### PR TITLE
fix: overlapped price on market screen

### DIFF
--- a/.changeset/quiet-coats-hang.md
+++ b/.changeset/quiet-coats-hang.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix overlapped price on the market screen

--- a/apps/ledger-live-mobile/src/screens/Market/MarketRowItem.tsx
+++ b/apps/ledger-live-mobile/src/screens/Market/MarketRowItem.tsx
@@ -73,8 +73,9 @@ function MarketRowItem({ item, index, counterCurrency, locale, t }: Props) {
         flexDirection="column"
         justifyContent="center"
         alignItems="flex-start"
+        flex={1}
       >
-        <Text variant="large" fontWeight="semiBold">
+        <Text variant="large" fontWeight="semiBold" numberOfLines={1}>
           {name}
         </Text>
         <Flex flexDirection="row" alignItems="center">
@@ -108,7 +109,6 @@ function MarketRowItem({ item, index, counterCurrency, locale, t }: Props) {
         flexDirection="column"
         justifyContent="center"
         alignItems="flex-end"
-        flex={1}
       >
         <Text variant="large" fontWeight="semiBold">
           {counterValueFormatter({
@@ -122,7 +122,7 @@ function MarketRowItem({ item, index, counterCurrency, locale, t }: Props) {
         {priceChangePercentage !== null && !isNaN(priceChangePercentage) ? (
           <DeltaVariation percent value={priceChangePercentage} />
         ) : (
-          <Text variant="body" height="50px" width="50px" color="neutral.c70">
+          <Text variant="body" color="neutral.c70">
             {" "}
             -
           </Text>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍

Please make sure to read the [Contributing guidelines](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md) if you have not already.

Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ❓ Context

- **Impacted projects**: ledger-live-mobile
  <!--
    If your PR is linked to a Github issue, post it below.
    For Ledger employees, post a link to the JIRA ticket if relevant.
  -->
- **Linked resource(s)**: [LIVE-1396]

On the market screen of ledger-live-mobile, when the currency name is too long the price is overlapped.

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [X] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [ ] **Breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo

<!--
  If relevant, add screenshots or video recordings to demonstrate the changes.
  For libraries, you can add a code sample.
-->
![Screenshot_20220517-172341_LL  DEV](https://user-images.githubusercontent.com/29443638/168856869-43efd97d-e138-4e64-a362-c3f560367a39.jpg)
![Screenshot_20220517-172356_LL  DEV](https://user-images.githubusercontent.com/29443638/168856878-03552e47-6d4c-437b-bf2d-436ee4e7a2d6.jpg)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-1396]: https://ledgerhq.atlassian.net/browse/LIVE-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ