### PR TITLE
Remove non-windows specific code from the extra metro config package

### DIFF
--- a/tools/metro-extra-config/duplicatesChecker.js
+++ b/tools/metro-extra-config/duplicatesChecker.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 function bold(str) {
   return "\033[1m" + str + "\033[0;0m";
 }
@@ -9,7 +11,7 @@ module.exports = () => {
     if (
       !resolution?.filePath ||
       moduleName.startsWith(".") ||
-      moduleName.startsWith("/")
+      path.isAbsolute("/")
     ) {
       return;
     }

--- a/tools/metro-extra-config/index.js
+++ b/tools/metro-extra-config/index.js
@@ -8,8 +8,8 @@
 /* eslint-disable no-console */
 
 const path = require("path");
-const defaultSourceExts =
-  require("metro-config/src/defaults/defaults").sourceExts;
+const defaultSourceExts = require("metro-config/src/defaults/defaults")
+  .sourceExts;
 const { makeMetroConfig } = require("@rnx-kit/metro-config");
 const MetroSymlinksResolver = require("@rnx-kit/metro-resolver-symlinks");
 const resolve = require("metro-resolver").resolve;
@@ -32,7 +32,7 @@ function forceDependency(moduleName, filters, nodeModulesPaths) {
   return null;
 }
 
-module.exports = function (options = {}, config = {}) {
+module.exports = function(options = {}, config = {}) {
   const {
     // Root of the project
     projectRoot,
@@ -151,7 +151,7 @@ module.exports = function (options = {}, config = {}) {
                 platform,
               });
             }
-            if (resolution.startsWith("/")) {
+            if (path.isAbsolute(resolution)) {
               return {
                 filePath: resolution,
                 type: "sourceFile",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍

Please make sure to read the [Contributing guidelines](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md) if you have not already.

Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ❓ Context

- **Impacted projects**: `tools/metro-extra-config` ,`live-mobile` (side-effect)
- **Linked resource(s)**: N/A

The `metro-extra-config` package contained platform specific code which made the node resolver fail on windows.
This issue made developing Ledger Live Mobile on windows quite impossible.

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [x] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [ ] **Breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
