### PR TITLE
Add --quiet on all eslint usage

### DIFF
--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -16,7 +16,7 @@
     "start": "cross-env NODE_ENV=development node ./tools/main.js",
     "build": "cross-env NODE_ENV=production node ./tools/main.js build",
     "build:testing": "cross-env NODE_ENV=production TESTING=1 node ./tools/main.js build",
-    "lint": "pnpm prettier:check && eslint src tools static --ext .js,.json,.ts,.tsx",
+    "lint": "pnpm prettier:check && eslint src tools static --ext .js,.json,.ts,.tsx --quiet",
     "lint:fix": "eslint src tools static --ext .js,.json,.ts,.tsx --fix",
     "prettier": "prettier --write \"{src,tools}/**/*.{js,json}\"",
     "prettier:check": "prettier -c \"{src,tools}/**/*.{js,json}\"",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -51,7 +51,7 @@
     "mock-android": "pnpm android:mock && pnpm android:install",
     "staging-android": "pnpm android:staging && pnpm android:install",
     "prettier": "prettier --write \"src/**/*.js\"",
-    "lint": "eslint src --ext .js,.json",
+    "lint": "eslint src --ext .js,.json --quiet",
     "lint:fix": "pnpm lint --fix",
     "flow": "flow",
     "typecheck": "node scripts/typecheck",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -17,7 +17,7 @@
     "watch": "bash ./scripts/watch-ts.sh",
     "updateAppSupportsQuitApp": "node scripts/updateAppSupportsQuitApp.js",
     "prettier": "prettier --write 'src/**/*.?s' 'cli/src/**/*.?s'",
-    "lint": "eslint src",
+    "lint": "eslint src --quiet",
     "lint:fix": "pnpm lint --fix",
     "jest": "rimraf libcoredb && mkdir libcoredb && cross-env TZ=America/New_York jest",
     "typecheck": "tsc --noEmit -p src/tsconfig.json",

--- a/libs/ledgerjs/packages/cryptoassets/package.json
+++ b/libs/ledgerjs/packages/cryptoassets/package.json
@@ -28,7 +28,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/devices/package.json
+++ b/libs/ledgerjs/packages/devices/package.json
@@ -34,7 +34,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/errors/package.json
+++ b/libs/ledgerjs/packages/errors/package.json
@@ -25,7 +25,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-algorand/package.json
+++ b/libs/ledgerjs/packages/hw-app-algorand/package.json
@@ -42,7 +42,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-btc/package.json
+++ b/libs/ledgerjs/packages/hw-app-btc/package.json
@@ -50,7 +50,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-cosmos/package.json
+++ b/libs/ledgerjs/packages/hw-app-cosmos/package.json
@@ -39,7 +39,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-eth/package.json
+++ b/libs/ledgerjs/packages/hw-app-eth/package.json
@@ -42,7 +42,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-helium/package.json
+++ b/libs/ledgerjs/packages/hw-app-helium/package.json
@@ -46,7 +46,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   }

--- a/libs/ledgerjs/packages/hw-app-polkadot/package.json
+++ b/libs/ledgerjs/packages/hw-app-polkadot/package.json
@@ -39,7 +39,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-solana/package.json
+++ b/libs/ledgerjs/packages/hw-app-solana/package.json
@@ -42,7 +42,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   }

--- a/libs/ledgerjs/packages/hw-app-str/package.json
+++ b/libs/ledgerjs/packages/hw-app-str/package.json
@@ -39,7 +39,7 @@
     "clean": "bash ../../script/clean.sh",
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-tezos/package.json
+++ b/libs/ledgerjs/packages/hw-app-tezos/package.json
@@ -40,7 +40,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-trx/package.json
+++ b/libs/ledgerjs/packages/hw-app-trx/package.json
@@ -38,7 +38,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-app-xrp/package.json
+++ b/libs/ledgerjs/packages/hw-app-xrp/package.json
@@ -38,7 +38,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-http/package.json
+++ b/libs/ledgerjs/packages/hw-transport-http/package.json
@@ -37,7 +37,7 @@
     "clean": "bash ../../script/clean.sh",
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-mocker/package.json
+++ b/libs/ledgerjs/packages/hw-transport-mocker/package.json
@@ -32,7 +32,7 @@
     "clean": "bash ../../script/clean.sh",
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-node-ble/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-ble/package.json
@@ -40,7 +40,7 @@
     "clean": "bash ../../script/clean.sh",
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/package.json
@@ -41,7 +41,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
@@ -41,7 +41,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-node-hid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/package.json
@@ -41,7 +41,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/package.json
@@ -38,7 +38,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-node-speculos/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos/package.json
@@ -38,7 +38,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-web-ble/package.json
+++ b/libs/ledgerjs/packages/hw-transport-web-ble/package.json
@@ -40,7 +40,7 @@
     "clean": "bash ../../script/clean.sh",
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-webhid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-webhid/package.json
@@ -40,7 +40,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport-webusb/package.json
+++ b/libs/ledgerjs/packages/hw-transport-webusb/package.json
@@ -40,7 +40,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/hw-transport/package.json
+++ b/libs/ledgerjs/packages/hw-transport/package.json
@@ -34,7 +34,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/logs/package.json
+++ b/libs/ledgerjs/packages/logs/package.json
@@ -25,7 +25,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/react-native-hid/package.json
+++ b/libs/ledgerjs/packages/react-native-hid/package.json
@@ -47,7 +47,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/package.json
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/package.json
@@ -38,7 +38,7 @@
     "clean": "bash ../../script/clean.sh",
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   },

--- a/libs/ledgerjs/packages/types-cryptoassets/package.json
+++ b/libs/ledgerjs/packages/types-cryptoassets/package.json
@@ -25,7 +25,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   }

--- a/libs/ledgerjs/packages/types-devices/package.json
+++ b/libs/ledgerjs/packages/types-devices/package.json
@@ -25,7 +25,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   }

--- a/libs/ledgerjs/packages/types-live/package.json
+++ b/libs/ledgerjs/packages/types-live/package.json
@@ -30,7 +30,7 @@
     "build": "bash ../../script/build.sh",
     "watch": "bash ../../script/watch.sh",
     "doc": "bash ../../script/doc.sh",
-    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --quiet",
     "lint:fix": "pnpm lint --fix",
     "test": "jest"
   }

--- a/libs/ui/packages/react/package.json
+++ b/libs/ui/packages/react/package.json
@@ -39,7 +39,7 @@
     "build:storybook": "build-storybook -s ./src",
     "watch": "tsc -p tsconfig.prod.json --watch",
     "clean": "rimraf lib",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --cache",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --cache --quiet",
     "lint:fix": "pnpm lint --fix",
     "typecheck": "tsc --p . --noEmit",
     "test": "pnpm -w -F ui test:react"


### PR DESCRIPTION
there are tons of warnings, it's too hard to see the actual errors
for instance on this run https://github.com/LedgerHQ/ledger-live/runs/6503636419?check_suite_focus=true
we are not even able to see in the logs the 1 error because there are 602 warnings
