### PR TITLE
Disable React Navigation sentry integration

### DIFF
--- a/.changeset/wild-papayas-bow.md
+++ b/.changeset/wild-papayas-bow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Disable React Navigation Sentry integration

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -21,7 +21,7 @@ import * as Sentry from "@sentry/react-native";
 import Config from "react-native-config";
 import VersionNumber from "react-native-version-number";
 
-import App, { routingInstrumentation } from "./src";
+import App from "./src";
 import { getEnabled } from "./src/components/HookSentry";
 import logReport from "./src/log-report";
 import pkg from "./package.json";
@@ -67,11 +67,7 @@ if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
     // dist: String(VersionNumber.buildVersion),
     sampleRate: 0.2,
     tracesSampleRate: 0.02,
-    integrations: [
-      new Sentry.ReactNativeTracing({
-        routingInstrumentation,
-      }),
-    ],
+    integrations: [],
     beforeSend(event: any) {
       if (!getEnabled()) return null;
       // If the error matches excludedErrorName or excludedErrorDescription,

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -12,7 +12,6 @@ import React, {
   useEffect,
 } from "react";
 import { connect, useDispatch, useSelector } from "react-redux";
-import * as Sentry from "@sentry/react-native";
 import {
   StyleSheet,
   View,
@@ -119,8 +118,6 @@ Text.defaultProps.allowFontScaling = false;
 type AppProps = {
   importDataString?: string,
 };
-
-export const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();
 
 function App({ importDataString }: AppProps) {
   useAppStateListener();
@@ -430,7 +427,6 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
         onReady={() => {
           isReadyRef.current = true;
           setTimeout(() => SplashScreen.hide(), 300);
-          routingInstrumentation.registerNavigationContainer(navigationRef);
         }}
       >
         {children}


### PR DESCRIPTION
### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2409

due to some recursive objects in our stack and passed in navigation, it makes Sentry crash when tracking the performance. problem was reported to https://github.com/getsentry/sentry-javascript/issues/2470 but in the meantime, we are disabling the feature for now.

### ✅ Checklist

- [ ] **Test coverage**: unfortunately can't be covered by tests easily, we'll look at better ways to split staging and production so we can evaluate that during staging phases in future.
- [x] **Atomic delivery**
- [x] **No breaking changes**


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
