### PR TITLE
Solana: downgrade web3 - RN doesnt support BigInt

### DIFF
--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -94,7 +94,7 @@
     "@polkadot/util": "9.1.1",
     "@polkadot/util-crypto": "9.1.1",
     "@solana/spl-token": "^0.2.0",
-    "@solana/web3.js": "^1.41.4",
+    "@solana/web3.js": "1.41.3",
     "@taquito/ledger-signer": "stablelib",
     "@taquito/taquito": "stablelib",
     "@taquito/utils": "stablelib",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,7 +843,7 @@ importers:
       '@polkadot/util': 9.1.1
       '@polkadot/util-crypto': 9.1.1
       '@solana/spl-token': ^0.2.0
-      '@solana/web3.js': ^1.41.4
+      '@solana/web3.js': 1.41.3
       '@svgr/core': ^5.5.0
       '@taquito/ledger-signer': stablelib
       '@taquito/taquito': stablelib
@@ -997,7 +997,7 @@ importers:
       '@polkadot/util': 9.1.1
       '@polkadot/util-crypto': 9.1.1
       '@solana/spl-token': 0.2.0
-      '@solana/web3.js': 1.41.4
+      '@solana/web3.js': 1.41.3
       '@taquito/ledger-signer': 11.1.0-stablelib.0
       '@taquito/taquito': 11.1.0-stablelib.0
       '@taquito/utils': 11.1.0-stablelib.0
@@ -12047,6 +12047,34 @@ packages:
       - utf-8-validate
     dev: false
 
+  /@solana/web3.js/1.41.3:
+    resolution: {integrity: sha512-H+zRDh7zpzma8fvA6S16DJY2sDemw4HHU/3WR9kXQG+3jsRtIJxhOD2NAwu1M2JrXoblyE2QYHWneLKDV2Bu6g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@ethersproject/sha2': 5.6.0
+      '@solana/buffer-layout': 4.0.0
+      bn.js: 5.2.0
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.1
+      cross-fetch: 3.1.5
+      fast-stable-stringify: 1.0.0
+      jayson: 3.6.6
+      js-sha3: 0.8.0
+      rpc-websockets: 7.4.18
+      secp256k1: 4.0.3
+      sinon-chai: 3.7.0
+      superstruct: 0.14.2
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - chai
+      - encoding
+      - sinon
+      - utf-8-validate
+    dev: false
+
   /@solana/web3.js/1.41.4:
     resolution: {integrity: sha512-2/mjqUcGsBkLEvKxA+rWFE1vODBycAMa62r3wm3Uzb6nmsXQQNTotB+6YoeLQmF0mxVoy8ZA+/QENzBkGkPzSg==}
     engines: {node: '>=12.20.0'}
@@ -19048,7 +19076,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
+      follow-redirects: 1.15.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -27697,6 +27725,16 @@ packages:
     resolution: {integrity: sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==}
     dependencies:
       tabbable: 5.3.2
+    dev: false
+
+  /follow-redirects/1.15.0:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: false
 
   /follow-redirects/1.15.0_debug@4.3.2:


### PR DESCRIPTION
### ❓ Context

- **Impacted projects**: [`live-desktop`, `@ledgerhq/live-common`, `live-mobile`]
  <!--
    If your PR is linked to a Github issue, post it below.
    For Ledger employees, post a link to the JIRA ticket if relevant.
  -->
- **Linked resource(s)**:

Solana `web3.js` library has recently switched to `BigInt`. But since `BigInt` is not supported in the current version of react native in `live-mobile` it's needed to downgrade `web3.js`.

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [ ] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [ ] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo

<!--
  If relevant, add screenshots or video recordings to demonstrate the changes.
  For libraries, you can add a code sample.
-->

### 🚀 Expectations to reach

No changes should be noticeable in any user facing project.

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
