### PR TITLE
LIVE-2356 - LIVE-2356-dependencies-update-s-5-1-2

### DIFF
--- a/.changeset/stale-llamas-cheer.md
+++ b/.changeset/stale-llamas-cheer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+upgrade dependencies

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -34,11 +34,11 @@
     "reactNative.js"
   ],
   "peerDependencies": {
+    "@types/react": "*",
     "react": ">=16",
     "react-dom": ">=16",
     "react-native": ">=0.65.1",
-    "react-native-svg": ">=12.1.1",
-    "@types/react": "*"
+    "react-native-svg": ">=12.1.1"
   },
   "peerDependenciesMeta": {
     "react-dom": {
@@ -156,14 +156,14 @@
     "semver": "^7.3.5",
     "sha.js": "^2.4.11",
     "source-map-support": "^0.5.21",
-    "stellar-sdk": "^10.1.0",
+    "stellar-sdk": "^10.1.1",
     "superstruct": "0.14.2",
     "tiny-secp256k1": "^1.1.6",
     "triple-beam": "^1.3.0",
     "utility-types": "^3.10.0",
     "varuint-bitcoin": "1.1.2",
     "winston": "^3.4.0",
-    "xstate": "^4.30.2",
+    "xstate": "^4.32.1",
     "zcash-bitcore-lib": "^0.13.20-rc3"
   },
   "devDependencies": {
@@ -171,7 +171,7 @@
     "@testing-library/react-hooks": "^4.0.1",
     "@types/bs58": "^4.0.1",
     "@types/cbor": "^6.0.0",
-    "@types/jest": "^27.5.0",
+    "@types/jest": "^27.5.1",
     "@types/lodash": "^4.14.179",
     "@types/node": "16.11.12",
     "@types/object-hash": "^2.1.0",
@@ -190,11 +190,11 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-prettier": "^3.4.0",
-    "eslint-plugin-react": "^7.29.2",
+    "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-typescript": "^0.14.0",
     "fs": "^0.0.1-security",
-    "glob": "^7.2.0",
+    "glob": "^7.2.3",
     "jest": "^27.5.1",
     "jest-file-snapshot": "^0.5.0",
     "prettier": "2.3.2",
@@ -205,8 +205,8 @@
     "react-test-renderer": "^17.0.2",
     "rimraf": "^3.0.2",
     "timemachine": "^0.3.2",
-    "ts-jest": "^27.1.3",
-    "ts-node": "^10.4.0",
+    "ts-jest": "^27.1.5",
+    "ts-node": "^10.8.0",
     "typescript": "^4.5.5",
     "typescript-eslint-parser": "^22.0.0",
     "ws": "7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,7 +853,7 @@ importers:
       '@types/bs58': ^4.0.1
       '@types/bs58check': ^2.1.0
       '@types/cbor': ^6.0.0
-      '@types/jest': ^27.5.0
+      '@types/jest': ^27.5.1
       '@types/lodash': ^4.14.179
       '@types/node': 16.11.12
       '@types/object-hash': ^2.1.0
@@ -901,7 +901,7 @@ importers:
       eslint-plugin-import: ^2.25.4
       eslint-plugin-jsx-a11y: ^6.5.1
       eslint-plugin-prettier: ^3.4.0
-      eslint-plugin-react: ^7.29.2
+      eslint-plugin-react: ^7.30.0
       eslint-plugin-react-hooks: ^4.3.0
       eslint-plugin-typescript: ^0.14.0
       eth-sig-util: 3.0.1
@@ -910,7 +910,7 @@ importers:
       expect: ^27.4.6
       fs: ^0.0.1-security
       generic-pool: ^3.8.2
-      glob: ^7.2.0
+      glob: ^7.2.3
       invariant: ^2.2.2
       isomorphic-ws: ^4.0.1
       jest: ^27.5.1
@@ -942,20 +942,20 @@ importers:
       semver: ^7.3.5
       sha.js: ^2.4.11
       source-map-support: ^0.5.21
-      stellar-sdk: ^10.1.0
+      stellar-sdk: ^10.1.1
       superstruct: 0.14.2
       timemachine: ^0.3.2
       tiny-secp256k1: ^1.1.6
       triple-beam: ^1.3.0
-      ts-jest: ^27.1.3
-      ts-node: ^10.4.0
+      ts-jest: ^27.1.5
+      ts-node: ^10.8.0
       typescript: ^4.5.5
       typescript-eslint-parser: ^22.0.0
       utility-types: ^3.10.0
       varuint-bitcoin: 1.1.2
       winston: ^3.4.0
       ws: '7'
-      xstate: ^4.30.2
+      xstate: ^4.32.1
       zcash-bitcore-lib: ^0.13.20-rc3
     dependencies:
       '@celo/base': 1.5.2
@@ -1004,7 +1004,7 @@ importers:
       '@types/bchaddrjs': 0.4.0
       '@types/bs58check': 2.1.0
       '@walletconnect/client': 1.7.3
-      '@xstate/react': 1.6.3_trxcr4ukgza3iqpu7qkdqadng4
+      '@xstate/react': 1.6.3_o6umqso4scogh3yesj77at2stm
       '@zondax/ledger-filecoin': 0.11.2
       algo-msgpack-with-bigint: 2.1.1
       algosdk: 1.13.0
@@ -1059,21 +1059,21 @@ importers:
       semver: 7.3.7
       sha.js: 2.4.11
       source-map-support: 0.5.21
-      stellar-sdk: 10.1.0
+      stellar-sdk: 10.1.1
       superstruct: 0.14.2
       tiny-secp256k1: 1.1.6
       triple-beam: 1.3.0
       utility-types: 3.10.0
       varuint-bitcoin: 1.1.2
       winston: 3.7.2
-      xstate: 4.32.0
+      xstate: 4.32.1
       zcash-bitcore-lib: 0.13.20-rc3
     devDependencies:
       '@svgr/core': 5.5.0
       '@testing-library/react-hooks': 4.0.1_rmfdlrtvj5fy7r2bxuk4wb2wvq
       '@types/bs58': 4.0.1
       '@types/cbor': 6.0.0
-      '@types/jest': 27.5.0
+      '@types/jest': 27.5.1
       '@types/lodash': 4.14.182
       '@types/node': 16.11.12
       '@types/object-hash': 2.2.1
@@ -1085,19 +1085,19 @@ importers:
       cross-env: 7.0.3
       env-cmd: 10.1.0
       eslint: 7.32.0
-      eslint-config-airbnb: 18.2.1_bm7p4wodtpvzs2p2gvb3dpoh6e
+      eslint-config-airbnb: 18.2.1_a3nm3qxvhzfwxf7foh47z5na3i
       eslint-config-prettier: 8.5.0_eslint@7.32.0
       eslint-config-typescript: 3.0.0_ydzymgcilm5bdawz4nkht27oxu
       eslint-formatter-pretty: 3.0.1
       eslint-plugin-import: 2.26.0_ffi3uiz42rv3jyhs6cr7p7qqry
       eslint-plugin-jsx-a11y: 6.5.1_eslint@7.32.0
       eslint-plugin-prettier: 3.4.1_24nbwbg7kfd7ynd7y3crveli54
-      eslint-plugin-react: 7.29.4_eslint@7.32.0
+      eslint-plugin-react: 7.30.0_eslint@7.32.0
       eslint-plugin-react-hooks: 4.5.0_eslint@7.32.0
       eslint-plugin-typescript: 0.14.0
       fs: 0.0.1-security
-      glob: 7.2.0
-      jest: 27.5.1_ts-node@10.7.0
+      glob: 7.2.3
+      jest: 27.5.1_ts-node@10.8.0
       jest-file-snapshot: 0.5.0
       prettier: 2.3.2
       react: 17.0.2
@@ -1107,8 +1107,8 @@ importers:
       react-test-renderer: 17.0.2_react@17.0.2
       rimraf: 3.0.2
       timemachine: 0.3.2
-      ts-jest: 27.1.4_3y7pzupgu3ueocdatbfldfrs3i
-      ts-node: 10.7.0_sihq2egcoz3xk6sc4vk74xvt4u
+      ts-jest: 27.1.5_ibhx3ehxrt2kgmkik4bkzmyeei
+      ts-node: 10.8.0_sihq2egcoz3xk6sc4vk74xvt4u
       typescript: 4.6.4
       typescript-eslint-parser: 22.0.0_e4zyhrvfnqudwdx5bevnvkluy4
       ws: 7.5.7
@@ -6841,6 +6841,19 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
+  /@cspotcode/source-map-support/0.8.1_source-map-support@0.5.21:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      source-map-support: '*'
+    peerDependenciesMeta:
+      source-map-support:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+      source-map-support: 0.5.21
+    dev: true
+
   /@csstools/convert-colors/1.4.0:
     resolution: {integrity: sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==}
     engines: {node: '>=4.0.0'}
@@ -8862,6 +8875,52 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@jest/core/27.5.1_ts-node@10.8.0:
+    resolution: {integrity: sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/console': 27.5.1
+      '@jest/reporters': 27.5.1
+      '@jest/test-result': 27.5.1
+      '@jest/transform': 27.5.1
+      '@jest/types': 27.5.1
+      '@types/node': 17.0.32
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.8.1
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      jest-changed-files: 27.5.1
+      jest-config: 27.5.1_ts-node@10.8.0
+      jest-haste-map: 27.5.1
+      jest-message-util: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-resolve-dependencies: 27.5.1
+      jest-runner: 27.5.1
+      jest-runtime: 27.5.1
+      jest-snapshot: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      jest-watcher: 27.5.1
+      micromatch: 4.0.5
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - metro
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /@jest/core/28.1.0:
     resolution: {integrity: sha512-/2PTt0ywhjZ4NwNO4bUqD9IVJfmFVhVKGlhvSpmEfUCuxYf/3NHcKmRFI+I71lYzbTT3wMuYpETDCTHo81gC/g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9142,7 +9201,7 @@ packages:
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
-      glob: 7.2.0
+      glob: 7.2.3
       graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.2.0
@@ -9602,6 +9661,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.0.7
       '@jridgewell/sourcemap-codec': 1.4.13
+
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.0.7
+      '@jridgewell/sourcemap-codec': 1.4.13
+    dev: true
 
   /@koa/cors/3.3.0:
     resolution: {integrity: sha512-lzlkqLlL5Ond8jb6JLnVVDmD2OPym0r5kvZlMgAWiS9xle+Q5ulw1T358oW+RVguxUkANquZQz82i/STIRmsqQ==}
@@ -11155,7 +11221,7 @@ packages:
       chalk: 4.1.2
       execa: 1.0.0
       fs-extra: 8.1.0
-      glob: 7.2.0
+      glob: 7.2.3
       jetifier: 1.6.8
       lodash: 4.17.21
       logkitty: 0.7.1
@@ -11183,7 +11249,7 @@ packages:
     dependencies:
       '@react-native-community/cli-tools': 6.2.0
       chalk: 4.1.2
-      glob: 7.2.0
+      glob: 7.2.3
       js-yaml: 3.14.1
       lodash: 4.17.21
       ora: 3.4.0
@@ -11463,7 +11529,7 @@ packages:
       execa: 1.0.0
       find-up: 4.1.0
       fs-extra: 8.1.0
-      glob: 7.2.0
+      glob: 7.2.3
       graceful-fs: 4.2.10
       joi: 17.6.0
       leven: 3.1.0
@@ -15759,7 +15825,7 @@ packages:
       '@ledgerhq/hw-transport': 5.51.1
       '@stablelib/blake2b': 1.0.1
       '@taquito/taquito': 11.1.0-stablelib.0
-      '@taquito/utils': 11.2.0
+      '@taquito/utils': 11.1.0-stablelib.0
       '@types/jest': 26.0.24
       buffer: 6.0.3
     dev: false
@@ -15797,7 +15863,7 @@ packages:
       '@taquito/michel-codec': 11.2.0
       '@taquito/michelson-encoder': 11.2.0
       '@taquito/rpc': 11.2.0
-      '@taquito/utils': 11.2.0
+      '@taquito/utils': 11.1.0-stablelib.0
       bignumber.js: 9.0.2
       rxjs: 6.6.7
     dev: false
@@ -18103,6 +18169,26 @@ packages:
       ws: 7.5.7
     dev: false
 
+  /@xstate/react/1.6.3_o6umqso4scogh3yesj77at2stm:
+    resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
+    peerDependencies:
+      '@xstate/fsm': ^1.0.0
+      react: ^16.8.0 || ^17.0.0
+      xstate: ^4.11.0
+    peerDependenciesMeta:
+      '@xstate/fsm':
+        optional: true
+      xstate:
+        optional: true
+    dependencies:
+      react: 17.0.2
+      use-isomorphic-layout-effect: 1.1.2_hx2b44akkvgcgvvtmk7ds2qk6q
+      use-subscription: 1.7.0_react@17.0.2
+      xstate: 4.32.1
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /@xstate/react/1.6.3_react@17.0.2+xstate@4.32.0:
     resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
     peerDependencies:
@@ -18117,26 +18203,6 @@ packages:
     dependencies:
       react: 17.0.2
       use-isomorphic-layout-effect: 1.1.2_react@17.0.2
-      use-subscription: 1.7.0_react@17.0.2
-      xstate: 4.32.0
-    transitivePeerDependencies:
-      - '@types/react'
-    dev: false
-
-  /@xstate/react/1.6.3_trxcr4ukgza3iqpu7qkdqadng4:
-    resolution: {integrity: sha512-NCUReRHPGvvCvj2yLZUTfR0qVp6+apc8G83oXSjN4rl89ZjyujiKrTff55bze/HrsvCsP/sUJASf2n0nzMF1KQ==}
-    peerDependencies:
-      '@xstate/fsm': ^1.0.0
-      react: ^16.8.0 || ^17.0.0
-      xstate: ^4.11.0
-    peerDependenciesMeta:
-      '@xstate/fsm':
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2_hx2b44akkvgcgvvtmk7ds2qk6q
       use-subscription: 1.7.0_react@17.0.2
       xstate: 4.32.0
     transitivePeerDependencies:
@@ -18914,6 +18980,17 @@ packages:
       es-array-method-boxes-properly: 1.0.0
       is-string: 1.0.7
     dev: true
+
+  /array.prototype.reduce/1.0.4:
+    resolution: {integrity: sha512-WnM+AjG/DvLRLo4DDl+r+SvCzYtD2Jd9oeBYMcEaI7t3fFrHY9M53/wdLcTvmZNQ70IU6Htj0emFkZ5TS+lrdw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.1
+      es-array-method-boxes-properly: 1.0.0
+      is-string: 1.0.7
+    dev: false
 
   /arrify/1.0.1:
     resolution: {integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=}
@@ -20081,7 +20158,7 @@ packages:
     dev: false
 
   /base32.js/0.1.0:
-    resolution: {integrity: sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=}
+    resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
     engines: {node: '>=0.12.0'}
     dev: false
 
@@ -20825,7 +20902,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    dev: false
 
   /buffer/5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -21009,7 +21085,7 @@ packages:
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
       p-map: 3.0.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 7.1.1
       unique-filename: 1.1.1
@@ -21499,7 +21575,7 @@ packages:
     engines: {node: '>=4.0.0', npm: '>=3.0.0'}
     deprecated: This module has been superseded by the multiformats module
     dependencies:
-      buffer: 5.7.1
+      buffer: 5.6.1
       class-is: 1.1.0
       multibase: 0.6.1
       multicodec: 1.0.4
@@ -22553,7 +22629,7 @@ packages:
   /crc/3.8.0:
     resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
     dependencies:
-      buffer: 5.7.1
+      buffer: 5.6.1
 
   /create-ecdh/4.0.4:
     resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
@@ -23241,7 +23317,7 @@ packages:
       supports-color:
         optional: true
     dependencies:
-      ms: 2.1.3
+      ms: 2.1.1
       supports-color: 6.0.0
     dev: false
 
@@ -24525,9 +24601,37 @@ packages:
       string.prototype.trimstart: 1.0.5
       unbox-primitive: 1.0.2
 
+  /es-abstract/1.20.1:
+    resolution: {integrity: sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      es-to-primitive: 1.2.1
+      function-bind: 1.1.1
+      function.prototype.name: 1.1.5
+      get-intrinsic: 1.1.1
+      get-symbol-description: 1.0.0
+      has: 1.0.3
+      has-property-descriptors: 1.0.0
+      has-symbols: 1.0.3
+      internal-slot: 1.0.3
+      is-callable: 1.2.4
+      is-negative-zero: 2.0.2
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.2
+      is-string: 1.0.7
+      is-weakref: 1.0.2
+      object-inspect: 1.12.1
+      object-keys: 1.1.1
+      object.assign: 4.1.2
+      regexp.prototype.flags: 1.4.3
+      string.prototype.trimend: 1.0.5
+      string.prototype.trimstart: 1.0.5
+      unbox-primitive: 1.0.2
+    dev: false
+
   /es-array-method-boxes-properly/1.0.0:
     resolution: {integrity: sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==}
-    dev: true
 
   /es-get-iterator/1.1.2:
     resolution: {integrity: sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==}
@@ -24846,6 +24950,26 @@ packages:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
       eslint-plugin-import: 2.26.0_ffi3uiz42rv3jyhs6cr7p7qqry
+      object.assign: 4.1.2
+      object.entries: 1.1.5
+    dev: true
+
+  /eslint-config-airbnb/18.2.1_a3nm3qxvhzfwxf7foh47z5na3i:
+    resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.22.1
+      eslint-plugin-jsx-a11y: ^6.4.1
+      eslint-plugin-react: ^7.21.5
+      eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
+    dependencies:
+      eslint: 7.32.0
+      eslint-config-airbnb-base: 14.2.1_hpmu7kn6tcn2vnxpfzvv33bxmy
+      eslint-plugin-import: 2.26.0_ffi3uiz42rv3jyhs6cr7p7qqry
+      eslint-plugin-jsx-a11y: 6.5.1_eslint@7.32.0
+      eslint-plugin-react: 7.30.0_eslint@7.32.0
+      eslint-plugin-react-hooks: 4.5.0_eslint@7.32.0
       object.assign: 4.1.2
       object.entries: 1.1.5
     dev: true
@@ -25748,6 +25872,29 @@ packages:
       array.prototype.flatmap: 1.3.0
       doctrine: 2.1.0
       eslint: 8.2.0
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.0
+      minimatch: 3.1.2
+      object.entries: 1.1.5
+      object.fromentries: 2.0.5
+      object.hasown: 1.1.1
+      object.values: 1.1.5
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.3
+      semver: 6.3.0
+      string.prototype.matchall: 4.0.7
+    dev: true
+
+  /eslint-plugin-react/7.30.0_eslint@7.32.0:
+    resolution: {integrity: sha512-RgwH7hjW48BleKsYyHK5vUAvxtE9SMPDKmcPRQgtRCYaZA0XQPt5FSkrU3nhz5ifzMZcA8opwmRJ2cmOO8tr5A==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
+    dependencies:
+      array-includes: 3.1.5
+      array.prototype.flatmap: 1.3.0
+      doctrine: 2.1.0
+      eslint: 7.32.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.0
       minimatch: 3.1.2
@@ -27793,8 +27940,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4_supports-color@6.1.0
-    dev: false
+      debug: 4.3.4
 
   /fontfaceobserver/2.1.0:
     resolution: {integrity: sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==}
@@ -28652,7 +28798,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -28669,6 +28815,16 @@ packages:
 
   /glob/7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  /glob/7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -29654,7 +29810,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -30630,7 +30786,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.20.0
+      es-abstract: 1.20.1
       foreach: 2.0.6
       has-tostringtag: 1.0.0
     dev: false
@@ -31226,6 +31382,37 @@ packages:
       - utf-8-validate
     dev: true
 
+  /jest-cli/27.5.1_ts-node@10.8.0:
+    resolution: {integrity: sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.5.1_ts-node@10.8.0
+      '@jest/test-result': 27.5.1
+      '@jest/types': 27.5.1
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.10
+      import-local: 3.1.0
+      jest-config: 27.5.1_ts-node@10.8.0
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      prompts: 2.4.2
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - metro
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
   /jest-cli/28.1.0_@types+node@14.18.17:
     resolution: {integrity: sha512-fDJRt6WPRriHrBsvvgb93OxgajHHsJbk4jZxiPqmZbMDRcHskfJBBfTyjFko0jjfprP544hOktdSi9HVgl4VUQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -31393,6 +31580,48 @@ packages:
       slash: 3.0.0
       strip-json-comments: 3.1.1
       ts-node: 10.7.0_33lso24kgdvwdhve7eirdtgycu
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - metro
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /jest-config/27.5.1_ts-node@10.8.0:
+    resolution: {integrity: sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    peerDependencies:
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.17.10
+      '@jest/test-sequencer': 27.5.1
+      '@jest/types': 27.5.1
+      babel-jest: 27.5.1_@babel+core@7.17.10
+      chalk: 4.1.2
+      ci-info: 3.3.0
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 27.5.1
+      jest-environment-jsdom: 27.5.1
+      jest-environment-node: 27.5.1
+      jest-get-type: 27.5.1
+      jest-jasmine2: 27.5.1
+      jest-regex-util: 27.5.1
+      jest-resolve: 27.5.1
+      jest-runner: 27.5.1
+      jest-util: 27.5.1
+      jest-validate: 27.5.1
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 27.5.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.8.0_sihq2egcoz3xk6sc4vk74xvt4u
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -32606,7 +32835,7 @@ packages:
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
-      glob: 7.2.0
+      glob: 7.2.3
       graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
@@ -33177,6 +33406,28 @@ packages:
       '@jest/core': 27.5.1_ts-node@10.7.0
       import-local: 3.1.0
       jest-cli: 27.5.1_ts-node@10.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - metro
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: true
+
+  /jest/27.5.1_ts-node@10.8.0:
+    resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
+    dependencies:
+      '@jest/core': 27.5.1_ts-node@10.8.0
+      import-local: 3.1.0
+      jest-cli: 27.5.1_ts-node@10.8.0
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -35402,24 +35653,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /metro-config/0.67.0_5rj3ktdhebdtkdjqejo5rbxriu:
-    resolution: {integrity: sha512-ThAwUmzZwTbKyyrIn2bKIcJDPDBS0LKAbqJZQioflvBGfcgA21h3fdL3IxRmvCEl6OnkEWI0Tn1Z9w2GLAjf2g==}
-    peerDependencies:
-      metro-transform-worker: '*'
-    peerDependenciesMeta:
-      metro-transform-worker:
-        optional: true
-    dependencies:
-      cosmiconfig: 5.2.1
-      jest-validate: 26.6.2
-      metro: 0.67.0
-      metro-cache: 0.67.0_metro@0.67.0
-      metro-core: 0.67.0_metro@0.67.0
-      metro-runtime: 0.67.0
-      metro-transform-worker: 0.67.0_metro-minify-uglify@0.67.0
-    transitivePeerDependencies:
-      - metro
-
   /metro-config/0.67.0_h77kaxayu5kga6qsud7rauzt6a:
     resolution: {integrity: sha512-ThAwUmzZwTbKyyrIn2bKIcJDPDBS0LKAbqJZQioflvBGfcgA21h3fdL3IxRmvCEl6OnkEWI0Tn1Z9w2GLAjf2g==}
     peerDependencies:
@@ -35693,7 +35926,7 @@ packages:
       '@babel/parser': 7.17.10
       '@babel/types': 7.17.10
       babel-preset-fbjs: 3.4.0_@babel+core@7.17.10
-      metro: 0.67.0_h77kaxayu5kga6qsud7rauzt6a
+      metro: 0.67.0
       metro-babel-transformer: 0.67.0
       metro-cache: 0.67.0_metro@0.67.0
       metro-cache-key: 0.67.0
@@ -35766,68 +35999,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
-      - utf-8-validate
-
-  /metro/0.67.0_h77kaxayu5kga6qsud7rauzt6a:
-    resolution: {integrity: sha512-DwuBGAFcAivoac/swz8Lp7Y5Bcge1tzT7T6K0nf1ubqJP8YzBUtyR4pkjEYVUzVu/NZf7O54kHSPVu1ibYzOBQ==}
-    hasBin: true
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/core': 7.17.10
-      '@babel/generator': 7.17.10
-      '@babel/parser': 7.17.10
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.17.10
-      '@babel/types': 7.17.10
-      absolute-path: 0.0.0
-      accepts: 1.3.8
-      async: 2.6.4
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 2.6.9
-      denodeify: 1.2.1
-      error-stack-parser: 2.0.7
-      fs-extra: 1.0.0
-      graceful-fs: 4.2.10
-      hermes-parser: 0.5.0
-      image-size: 0.6.3
-      invariant: 2.2.4
-      jest-haste-map: 27.5.1_metro@0.67.0
-      jest-worker: 26.6.2_metro@0.67.0
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.67.0
-      metro-cache: 0.67.0_metro@0.67.0
-      metro-cache-key: 0.67.0
-      metro-config: 0.67.0_5rj3ktdhebdtkdjqejo5rbxriu
-      metro-core: 0.67.0_metro@0.67.0
-      metro-hermes-compiler: 0.67.0
-      metro-inspector-proxy: 0.67.0
-      metro-minify-uglify: 0.67.0
-      metro-react-native-babel-preset: 0.67.0
-      metro-resolver: 0.67.0
-      metro-runtime: 0.67.0
-      metro-source-map: 0.67.0
-      metro-symbolicate: 0.67.0
-      metro-transform-plugins: 0.67.0
-      metro-transform-worker: 0.67.0_metro-minify-uglify@0.67.0
-      mime-types: 2.1.35
-      mkdirp: 0.5.6
-      node-fetch: 2.6.7
-      nullthrows: 1.1.1
-      rimraf: 2.7.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      strip-ansi: 6.0.1
-      temp: 0.8.3
-      throat: 5.0.0
-      ws: 7.5.7
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -36298,7 +36469,7 @@ packages:
     deprecated: This module has been superseded by the multiformats module
     dependencies:
       base-x: 3.0.9
-      buffer: 5.7.1
+      buffer: 5.6.1
     dev: false
 
   /multibase/0.7.0:
@@ -36306,7 +36477,7 @@ packages:
     deprecated: This module has been superseded by the multiformats module
     dependencies:
       base-x: 3.0.9
-      buffer: 5.7.1
+      buffer: 5.6.1
     dev: false
 
   /multicast-dns-service-types/1.1.0:
@@ -36330,7 +36501,7 @@ packages:
     resolution: {integrity: sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==}
     deprecated: This module has been superseded by the multiformats module
     dependencies:
-      buffer: 5.7.1
+      buffer: 5.6.1
       varint: 5.0.2
     dev: false
 
@@ -36341,7 +36512,7 @@ packages:
   /multihashes/0.4.21:
     resolution: {integrity: sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==}
     dependencies:
-      buffer: 5.7.1
+      buffer: 5.6.1
       multibase: 0.7.0
       varint: 5.0.2
     dev: false
@@ -36540,7 +36711,7 @@ packages:
   /node-environment-flags/1.0.5:
     resolution: {integrity: sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==}
     dependencies:
-      object.getownpropertydescriptors: 2.1.3
+      object.getownpropertydescriptors: 2.1.4
       semver: 5.7.1
     dev: false
 
@@ -36984,6 +37155,10 @@ packages:
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
 
+  /object-inspect/1.12.1:
+    resolution: {integrity: sha512-Y/jF6vnvEtOPGiKD1+q+X0CiUYRQtEHp89MLLUJ7TUivtH8Ugn2+3A7Rynqk7BRsAoqeOQWnFnjpDrKSxDgIGA==}
+    dev: false
+
   /object-is/1.1.5:
     resolution: {integrity: sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==}
     engines: {node: '>= 0.4'}
@@ -37057,6 +37232,16 @@ packages:
       call-bind: 1.0.2
       define-properties: 1.1.4
       es-abstract: 1.20.0
+
+  /object.getownpropertydescriptors/2.1.4:
+    resolution: {integrity: sha512-sccv3L/pMModT6dJAYF3fzGMVcb38ysQ0tEE6ixv2yXJDtEIPph268OlAdJj5/qZMZDq2g/jqvwppt36uS/uQQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      array.prototype.reduce: 1.0.4
+      call-bind: 1.0.2
+      define-properties: 1.1.4
+      es-abstract: 1.20.1
+    dev: false
 
   /object.hasown/1.1.1:
     resolution: {integrity: sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==}
@@ -39154,6 +39339,7 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
 
   /promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=}
@@ -42137,13 +42323,13 @@ packages:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
     hasBin: true
     dependencies:
-      glob: 7.2.0
+      glob: 7.2.3
 
   /rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
     dependencies:
-      glob: 7.2.0
+      glob: 7.2.3
 
   /ripemd160/2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
@@ -43506,8 +43692,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /stellar-base/8.0.0:
-    resolution: {integrity: sha512-MH0V94Hn/Ekq/yZxd+EQijkvfU+21zuqJAyEP8X+fhRR0IQYwGNByY003oLqIkgwqXotyofEQ76W5MoNFZmlpw==}
+  /stellar-base/8.0.1:
+    resolution: {integrity: sha512-IB7GxyAF59jHmY0jyX5vxzD5k7AJLTGSelRIcjJZwsENsqa7tNWEh9HpnmYGvCgdeG2D+MxaeR5fouEvElaH8A==}
     dependencies:
       base32.js: 0.1.0
       bignumber.js: 4.1.0
@@ -43520,8 +43706,8 @@ packages:
       sodium-native: 3.3.0
     dev: false
 
-  /stellar-sdk/10.1.0:
-    resolution: {integrity: sha512-8PTKuyrQ5bIbsyrLav+JE/c+rrLynBygiB4dpvG30ou7K8P6a5ainmGyVMbCzlz1OkKWoaAW5rJAkl3RhlTZkA==}
+  /stellar-sdk/10.1.1:
+    resolution: {integrity: sha512-PhSk+vdZdgUvK+gNWsO9O0AsksddvWurD+9HlNhnnlJJ7rrJ2/QVcOrKHfk+u9z74XOwsQylk+4CZGq/2sjkVw==}
     dependencies:
       '@types/eventsource': 1.1.8
       '@types/node': 17.0.32
@@ -43534,7 +43720,7 @@ packages:
       eventsource: 1.1.1
       lodash: 4.17.21
       randombytes: 2.1.0
-      stellar-base: 8.0.0
+      stellar-base: 8.0.1
       toml: 2.3.6
       tslib: 1.14.1
       urijs: 1.19.11
@@ -44262,7 +44448,7 @@ packages:
     resolution: {integrity: sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==}
     dependencies:
       bluebird: 3.7.2
-      buffer: 5.7.1
+      buffer: 5.6.1
       eth-lib: 0.1.29
       fs-extra: 4.0.3
       got: 7.1.0
@@ -44767,7 +44953,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 7.2.0
+      glob: 7.2.3
       minimatch: 3.1.2
     dev: true
 
@@ -45171,6 +45357,40 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
+  /ts-jest/27.1.5_ibhx3ehxrt2kgmkik4bkzmyeei:
+    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: '>=27.0.0 <28'
+      esbuild: '*'
+      jest: ^27.0.0
+      typescript: '>=3.8 <5.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@types/jest': 27.5.1
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 27.5.1_ts-node@10.8.0
+      jest-util: 27.5.1
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.6.4
+      yargs-parser: 20.2.9
+    dev: true
+
   /ts-jest/28.0.2_qy5m32hwmbz5mebulkdtchzcz4:
     resolution: {integrity: sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -45238,39 +45458,6 @@ packages:
       - source-map-support
     dev: true
 
-  /ts-node/10.7.0_sihq2egcoz3xk6sc4vk74xvt4u:
-    resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.7.0_source-map-support@0.5.21
-      '@tsconfig/node10': 1.0.8
-      '@tsconfig/node12': 1.0.9
-      '@tsconfig/node14': 1.0.1
-      '@tsconfig/node16': 1.0.2
-      '@types/node': 16.11.12
-      acorn: 8.7.1
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.6.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    transitivePeerDependencies:
-      - source-map-support
-    dev: true
-
   /ts-node/10.7.0_sm5zkxj4s52nbddwl76qwfh6ya:
     resolution: {integrity: sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==}
     hasBin: true
@@ -45291,6 +45478,39 @@ packages:
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
       '@types/node': 17.0.32
+      acorn: 8.7.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.6.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    transitivePeerDependencies:
+      - source-map-support
+    dev: true
+
+  /ts-node/10.8.0_sihq2egcoz3xk6sc4vk74xvt4u:
+    resolution: {integrity: sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1_source-map-support@0.5.21
+      '@tsconfig/node10': 1.0.8
+      '@tsconfig/node12': 1.0.9
+      '@tsconfig/node14': 1.0.1
+      '@tsconfig/node16': 1.0.2
+      '@types/node': 16.11.12
       acorn: 8.7.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -48137,7 +48357,7 @@ packages:
     dependencies:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
-      es-abstract: 1.20.0
+      es-abstract: 1.20.1
       foreach: 2.0.6
       has-tostringtag: 1.0.0
       is-typed-array: 1.1.8
@@ -48792,6 +49012,10 @@ packages:
 
   /xstate/4.32.0:
     resolution: {integrity: sha512-62gETqwnw4pBRe+tVWMt8hLgWEU8lq2qO8VN5PWmTELceRVt3I1bu1cwdraVRHUn4Bb2lnhNzn1A73oShuC+8g==}
+    dev: false
+
+  /xstate/4.32.1:
+    resolution: {integrity: sha512-QYUd+3GkXZ8i6qdixnOn28bL3EvA++LONYL/EMWwKlFSh/hiLndJ8YTnz77FDs+JUXcwU7NZJg7qoezoRHc4GQ==}
     dev: false
 
   /xstream/11.14.0:


### PR DESCRIPTION
Upgrade dependencies:

@types/jest (dev)              27.5.0 ❯ 27.5.1 
eslint-plugin-react (dev)      7.29.4 ❯ 7.30.0 
glob (dev)                      7.2.0 ❯ 7.2.3  
stellar-sdk                    10.1.0 ❯ 10.1.1 
ts-jest (dev)                  27.1.4 ❯ 27.1.5 
ts-node (dev)                  10.7.0 ❯ 10.8.0 
xstate                         4.32.0 ❯ 4.32.1 