### PR TITLE
LIVE-2279 -  post nano purchase state

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -78,6 +78,7 @@ import BuyDeviceScreen from "../../screens/BuyDeviceScreen";
 import { readOnlyModeEnabledSelector } from "../../reducers/settings";
 import Learn from "../../screens/Learn";
 import ManagerMain from "../../screens/Manager/Manager";
+import PostBuyDeviceScreen from "../../screens/PostBuyDeviceScreen";
 
 export default function BaseNavigator() {
   const { t } = useTranslation();
@@ -105,6 +106,14 @@ export default function BaseNavigator() {
         name={ScreenName.BuyDeviceScreen}
         component={BuyDeviceScreen}
         options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.PostBuyDeviceScreen}
+        component={PostBuyDeviceScreen}
+        options={{
+          title: t("postBuyDevice.headerTitle"),
+          headerLeft: null,
+        }}
       />
       <Stack.Screen
         name={NavigatorName.Settings}

--- a/apps/ledger-live-mobile/src/const/navigation.js
+++ b/apps/ledger-live-mobile/src/const/navigation.js
@@ -351,6 +351,7 @@ export const ScreenName = {
   SolanaEditMemo: "SolanaEditMemo",
 
   BuyDeviceScreen: "BuyDeviceScreen",
+  PostBuyDeviceScreen: "PostBuyDeviceScreen",
 
   DiscoverScreen: "DiscoverScreen",
   Learn: "Learn",

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -234,6 +234,7 @@ const linkingOptions = {
            * ie: "ledgerlive://wc?uri=wc:00e46b69-d0cc-4b3e-b6a2-cee442f97188@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=91303dedf64285cbbaf9120f6e9d160a5c8aa3deb67017a3874cd272323f48ae
            */
           [ScreenName.WalletConnectDeeplinkingSelectAccount]: "wc",
+          [ScreenName.PostBuyDeviceScreen]: "hw-purchase-success",
           [NavigatorName.Main]: {
             initialRouteName: ScreenName.Portfolio,
             screens: {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -808,6 +808,11 @@
     "cta": "Buy your Ledger now",
     "footer": "I already have a device, set it up now"
   },
+  "postBuyDevice": {
+    "headerTitle": "Purchase successful",
+    "title": "Congratulations",
+    "desc": "Your order is being processed.\nYou will receive your Ledger soon. Please check your email for your order confirmation.",
+  },
   "discover": {
     "title": "Discover",
     "desc": "Explore the world of web3 included in Ledger Live",

--- a/apps/ledger-live-mobile/src/screens/PostBuyDeviceScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostBuyDeviceScreen.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback, useEffect } from "react";
+import { Flex, Icons, Text, Box } from "@ledgerhq/native-ui";
+import styled from "styled-components/native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import { useTranslation } from "react-i18next";
+import Button from "../components/wrappedUi/Button";
+import { NavigatorName } from "../const";
+import { completeOnboarding, setReadOnlyMode } from "../actions/settings";
+import { useDispatch } from "react-redux";
+
+const StyledSafeAreaView = styled(SafeAreaView)`
+  flex: 1;
+  background-color: ${({ theme }) => theme.colors.background.main};
+`;
+
+export default function PostBuyDeviceScreen() {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const navigation = useNavigation();
+
+  const setupDevice = useCallback(() => {
+    navigation.navigate(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+    });
+  }, [navigation]);
+
+  useEffect(() => {
+    dispatch(setReadOnlyMode(true));
+    dispatch(completeOnboarding());
+  }, [dispatch]);
+
+  return (
+    <StyledSafeAreaView>
+      <Flex flex={1} justifyContent="center" alignItems="center" mx={6} my={6}>
+        <Flex justifyContent="center" alignItems="center">
+          <Box bg={"success.c30"} p={6} mb={7} borderRadius={999}>
+            <Box bg={"success.c50"} p={6} borderRadius={999}>
+              <Box
+                height={98}
+                width={98}
+                alignItems={"center"}
+                justifyContent={"center"}
+                bg={"success.c80"}
+                borderRadius={999}
+              >
+                <Icons.CheckAloneMedium size="48px" />
+              </Box>
+            </Box>
+          </Box>
+          <Text textAlign="center" variant="h4" mb={5}>
+            {t("postBuyDevice.title")}
+          </Text>
+          <Text
+            textAlign="center"
+            variant="bodyLineHeight"
+            color={"neutral.c80"}
+          >
+            {t("postBuyDevice.desc")}
+          </Text>
+        </Flex>
+      </Flex>
+      <Button
+        mx={6}
+        mb={8}
+        type="main"
+        outline={false}
+        event="BuyDeviceScreen - Buy Ledger"
+        onPress={setupDevice}
+        size="large"
+      >
+        {t("common.close")}
+      </Button>
+    </StyledSafeAreaView>
+  );
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍

Please make sure to read the [Contributing guidelines](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md) if you have not already.

Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ❓ Context

- **Impacted projects**: live-mobile
  <!--
    If your PR is linked to a Github issue, post it below.
    For Ledger employees, post a link to the JIRA ticket if relevant.
  -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2279

Add a new deeplink ledgerlive://hw-purchase-success used by ledger.com after a nano purchase, that will open a "successful buy" screen, removing the read only mode

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [ ] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [ ] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo


https://user-images.githubusercontent.com/89014981/169832979-0c3e00dc-0724-4529-adef-f09b3bb1d5b9.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
