### PR TITLE
Auto-increment android version code

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -25,36 +25,15 @@ IPA_DIRECTORY = "#{OUTPUT_DIRECTORY}/#{PROJECT_NAME}.ipa"
 default_platform(:ios)
 package = load_json(json_path: "./package.json")
 
-# Infers the build number / version code from the package.json version.
-def infer_build_number(version)
-  v = SemVer.parse version
-  # A build number is a 32 bits integer.
-  build_number = 0
-  # Bits 25 to 32 are mapped to the major version.
-  # Boundary is set to 32 because according to the android documentation the maximum value is 2100000000, which is between 2^30 and 2^31.
-  # It means that the upper 8 bits cannot be set higher than 118 (in base 10) otherwise the version code will be higher than the allowed max.
-  # See: https://developer.android.com/studio/publish/versioning#appversioning
-  build_number |= [v.major.to_i, 118].min << 24
-  # Bits 17 to 24 are mapped to the minor version.
-  build_number |= [v.minor.to_i, 255].min << 16
-  # Bits 9 to 16 are mapped to the patch version.
-  build_number |= [v.patch.to_i, 255].min << 8
-
-  if !v.special.empty?
-    # If there is a special suffix (like -next.1 or -nightly.10)
-    special_name, special_number = v.special.split "."
-    if(special_name === "next" || special_name === "hotfix")
-      # The lower 8 bits for a beta build should be higher than any nightly build.
-      build_number |= [126 + special_number.to_i, 254].min
-    else
-      build_number |= [special_number.to_i, 125].min
-    end
-  else
-    # Use 255 (11111111) as the lower 8 bits for true releases.
-    build_number |= 255
-  end
-
-  build_number
+def infer_android_version_code
+  # Checks all relevant tracks in the play console and take the highest (plus one).
+  ["Nightly", "internal", "beta", "alpha", "production"].map { |track|
+    google_play_track_version_codes(
+      package_name: "com.ledger.live",
+      track: track,
+      json_key_data: ENV["ANDROID_SERVICE_KEY_CONTENT"]
+    )[0].to_i
+  }.max + 1
 end
 
 def trim_version_number(version)
@@ -84,27 +63,6 @@ platform :ios do
       version_number: trim_version_number(package["version"]),
       xcodeproj: XCODE_PROJECT
     )
-  end
-
-  desc "private: bump build number"
-  private_lane :bump_build_number do
-    increment_build_number(
-      build_number: infer_build_number(package["version"]),
-      xcodeproj: "ios/ledgerlivemobile.xcodeproj"
-    )
-  end
-
-  desc "private: prepare iOS for beta release"
-  private_lane :prepare_ios_beta do |options|
-    bump_build_number
-    build_number = get_build_number(xcodeproj: "ios/ledgerlivemobile.xcodeproj")
-    # commit_version_bump(
-    #   message: "Bump iOS version to v#{package["version"]}-#{build_number}#{options[:nightly] ? " (nightly)" : ""}",
-    #   xcodeproj: XCODE_PROJECT
-    # )
-    # add_git_tag(
-    #   tag: "ios-v#{package["version"]}-#{build_number}"
-    # )
   end
 
   desc "private: setup ci for iOS build"
@@ -267,7 +225,6 @@ platform :ios do
 
   desc "build and push to TestFlight"
   lane :local_beta do
-    # prepare_ios_beta
     clean_beta
   end
 
@@ -278,7 +235,6 @@ platform :ios do
 
   desc "build nightly version"
   lane :local_nightly do
-    # prepare_ios_beta(nightly: true)
     build
     upload(nightly: true)
   end
@@ -288,7 +244,6 @@ platform :ios do
 
   desc "ci: create testflight version"
   lane :ci_testflight do |options|
-    # prepare_ios_beta
     setup_ios_ci
     build(ci: true)
     upload
@@ -296,7 +251,6 @@ platform :ios do
 
   desc "ci: create nightly version"
   lane :ci_nightly do |options|
-    # prepare_ios_beta(nightly: true)
     setup_ios_ci
     build(ci: true)
     upload(
@@ -350,7 +304,7 @@ platform :android do
   desc "private: bump version code"
   private_lane :bump_version_code do
     android_set_version_code(
-      version_code: infer_build_number(package["version"]),
+      version_code: infer_android_version_code,
       gradle_file: 'android/app/build.gradle'
     )
   end
@@ -358,7 +312,7 @@ platform :android do
   desc "private: prepare android for internal"
   private_lane :prepare_android_internal do |options|
     bump_version_code
-    version_code = android_get_version_code(gradle_file: 'android/app/build.gradle')
+    # version_code = android_get_version_code(gradle_file: 'android/app/build.gradle')
     # git_commit(
     #   path: [
     #     "android/app/build.gradle"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍

Please make sure to read the [Contributing guidelines](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md) if you have not already.

Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ❓ Context

- **Impacted projects**: `live-mobile`
  <!--
    If your PR is linked to a Github issue, post it below.
    For Ledger employees, post a link to the JIRA ticket if relevant.
  -->
- **Linked resource(s)**: N/A

The current state of affairs is that we use a [complex serialization function](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-mobile/fastlane/Fastfile#L29) during Fastlane builds to produce the [android version code](https://developer.android.com/studio/publish/versioning) from the version field inside package.json.

This is not good enough since it can become flaky when trying to release more than 2 tracks (nightly / prerelease (next) + potentially others).

**The solution:** query the google play console and take the highest version code, then just add one.

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [x] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [x] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo

<!--
  If relevant, add screenshots or video recordings to demonstrate the changes.
  For libraries, you can add a code sample.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
