### PR TITLE
Simplify the placeholder of the template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily 
 
 ### ❓ Context
 
-- **Impacted projects**: [e.g. `live-desktop`, `@ledgerhq/live-common`]
+- **Impacted projects**:
   <!--
     If your PR is linked to a Github issue, post it below.
     For Ledger employees, post a link to the JIRA ticket if relevant.


### PR DESCRIPTION
> META PR: updating the template of PRs 😆 

This PR suggests to remove this part

![Screenshot 2022-05-24 at 12 17 08](https://user-images.githubusercontent.com/211411/170009138-65d029e3-9328-4498-a2b7-c726228307fd.png)

because it is not clear for everyone that it's a placeholder to change. Lot of PR either keep it, or update just the right part and keep the "e.g.".. TLDR: it's not necessary to keep it in a template, especially you already have a big comment under it. Remove it will make it obvious if people forgot to set it too.

See 2 example out of numerous example from recent ongoing PRs:

![Screenshot 2022-05-24 at 12 08 12](https://user-images.githubusercontent.com/211411/170009424-ff32b424-9d5d-4e19-a16c-8083fd145e73.png)

![Screenshot 2022-05-24 at 12 06 13](https://user-images.githubusercontent.com/211411/170009467-197fc112-386d-434d-b3f2-5e32bfcdb09d.png)

