### PR TITLE
LLM: increase to iOS 13 minimum

### DIFF
--- a/.changeset/strong-penguins-chew.md
+++ b/.changeset/strong-penguins-chew.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LLM: increase to iOS 13 minimum

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -787,7 +787,7 @@
 					"$(SRCROOT)/../node_modules/@segment/analytics-react-native/ios/RNAnalytics",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -839,7 +839,7 @@
 					"$(SRCROOT)/../node_modules/@segment/analytics-react-native/ios/RNAnalytics",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -947,7 +947,7 @@
 					"$(SRCROOT)/../node_modules/@segment/analytics-react-native/ios/RNAnalytics",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) /usr/lib/swift @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",


### PR DESCRIPTION

### ❓ Context

- **Impacted projects**: ledger-live-mobile
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2493

This increases the minimum supported iOS version of Ledger Live Mobile from 12 to 13 due. It means that we will stop supporting iPhone 6 and below. 

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [x] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [x] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
