### PR TITLE
[LIVE-2492] - Bugfix: Preventing crash w/ offiline device action error

### DIFF
--- a/.changeset/silly-pots-clap.md
+++ b/.changeset/silly-pots-clap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Temporarily remove some device action error tracking due to it causing a crash on iOS while offline

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.js
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.js
@@ -223,7 +223,8 @@ export default function DeviceAction<R, H, P>({
   }
 
   if (!isLoading && error) {
-    track("DeviceActionError", error);
+    /** @TODO Put that back if the app is still crashing */
+    // track("DeviceActionError", error);
     onError && onError(error);
 
     // NB Until we find a better way, remap the error if it's 6d06 and we haven't fallen


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍

Please make sure to read the [Contributing guidelines](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md) if you have not already.

Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**:
https://ledgerhq.atlassian.net/browse/LIVE-2492

In production mode (so on TestFlight), we have a crash when a device is offline and trying to delegate with Cosmos and the Nano is on the dashboard. 
This PR prevents that by removing a new tracking that we have on Device Actions errors that is causing the crash (network call while offline + result of a device action)

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [x] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [x] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
