### PR TITLE
LLM Android: Sentry: Increase ANR timeout to 10s

### DIFF
--- a/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
@@ -63,6 +63,7 @@
       </activity>
       <activity android:taskAffinity="" android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
         android:exported="true"/>
+      <meta-data android:name="io.sentry.anr.timeout-interval-millis" android:value="10000" />
     </application>
 
 </manifest>


### PR DESCRIPTION
see https://docs.sentry.io/platforms/android/configuration/app-not-respond/

As we tend to see a bunch of 5s timeout, we're trying to be a bit more permissive in allowing slowness of 5s, now up to 10s to be a safe timeout to really detect possible "infinite loop" in case it happens in future.

### ❓ Context

- **Impacted projects**: llm
- **Linked resource(s)**: Sentry LEDGER-LIVE-MOBILE-5K

### ✅ Checklist

- [x] **Test coverage**: covered by building the app. then it's a parameter for Sentry lib itself.
- [x] **Atomic delivery**
- [x] **No breaking changes**


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
