### PR TITLE
Bugfix LIVE-2330  [BOT] Polygon NotEnoughBalance error

### DIFF
--- a/.changeset/lazy-pants-travel.md
+++ b/.changeset/lazy-pants-travel.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Use of the maxSpendable for bot testing instead of amount balance

--- a/libs/ledger-live-common/src/families/ethereum/specs.ts
+++ b/libs/ledger-live-common/src/families/ethereum/specs.ts
@@ -26,10 +26,10 @@ const ethereumBasicMutations = ({ maxAccount }) => [
   {
     name: "move 50%",
     maxRun: 2,
-    transaction: ({ account, siblings, bridge }) => {
+    transaction: ({ account, siblings, bridge, maxSpendable }) => {
       const sibling = pickSiblings(siblings, maxAccount);
       const recipient = sibling.freshAddress;
-      const amount = account.balance.div(2).integerValue();
+      const amount = maxSpendable.div(2).integerValue();
       return {
         transaction: bridge.createTransaction(account),
         updates: [


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍

Please make sure to read the [Contributing guidelines](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md) if you have not already.

Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ❓ Context

- **Impacted projects**: bot tests (ethereum)
  <!--
    [If your PR is linked to a Github issue, post it below.
    For Ledger employees, post a link to the JIRA ticket if relevant.]
  -->

- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2330

_Write a clear and concise description of what this pull request is about and why it is needed._
According to a Bot notEnoughBalance error on Polygon, maxSpendable replaces now the amount balance for testing

### ✅ Checklist

- [x] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [x] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [x] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo

<!--
  If relevant, add screenshots or video recordings to demonstrate the changes.
  For libraries, you can add a code sample.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
