### PR TITLE
trigger mobile build on prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -53,6 +53,12 @@ jobs:
         id: desktop-version
         with:
           path: ${{ github.workspace }}/apps/ledger-live-desktop
+
+      - uses: ledgerhq/ledger-live/tools/actions/get-package-infos@develop
+        id: mobile-version
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-mobile
+
       - name: install dependencies
         run: pnpm i -F "ledger-live" -F "{libs/**}..." --frozen-lockfile
       - name: build libs
@@ -97,6 +103,12 @@ jobs:
         id: post-desktop-version
         with:
           path: ${{ github.workspace }}/apps/ledger-live-desktop
+
+      - uses: ledgerhq/ledger-live/tools/actions/get-package-infos@develop
+        id: post-mobile-version
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-mobile
+
       - uses: actions/github-script@v6
         name: trigger prerelease build for desktop
         if: ${{ steps.desktop-version.outputs.version != steps.post-desktop-version.outputs.version }}
@@ -111,4 +123,17 @@ jobs:
               inputs: {
                 ref: "${{ github.event.push != '' && github.ref_name || steps.ref.outputs.ref }}"
               }
+            });
+
+      - uses: actions/github-script@v6
+        name: trigger prerelease build of mobile
+        if: ${{ steps.mobile-version.outputs.version != steps.post-mobile-version.outputs.version }}
+        with:
+          github-token: ${{ secrets.GH_PAT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: "ledgerhq",
+              repo: "ledger-live-build",
+              ref: "main",
+              workflow_id: "release-mobile.yml",
             });


### PR DESCRIPTION
### ❓ Context

- **Impacted projects**: `automation`, `llm`

With the voodoo we made last week, build number shouldn't be a problem anymore on either LLM iOS or LLM Android, allowing us to have unlimited builds on mobile as well, thus this PR aims to add a prerelease build of LLM during a `prerelease` workflow

### ✅ Checklist

- [ ] **Test coverage**: _Did you write any tests to cover the changes introduced by this pull request?_
- [x] **Atomic delivery**: _Is this pull request standalone? In order words, does it depend on nothing else?_
- [x] **No breaking changes**: _Does this pull request contain breaking changes of any kind? If so, please explain why._

### 📸 Demo

NO DEMO

### 🚀 Expectations to reach

it should build a LLM version on prerelease workflow

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
