### PR TITLE
dont display overlay on ci builds

### DIFF
--- a/apps/ledger-live-desktop/src/main/updater/init.js
+++ b/apps/ledger-live-desktop/src/main/updater/init.js
@@ -50,7 +50,7 @@ const init = () => {
   autoUpdater.autoInstallOnAppQuit = false;
   autoUpdater.autoDownload = false;
   autoUpdater.checkForUpdates();
-  if (__PRERELEASE__ && __CHANNEL__) {
+  if (__PRERELEASE__ && __CHANNEL__ && !__CHANNEL__.includes("sha")) {
     autoUpdater.channel = __CHANNEL__;
   }
 };

--- a/apps/ledger-live-desktop/src/renderer/Default.js
+++ b/apps/ledger-live-desktop/src/renderer/Default.js
@@ -229,7 +229,9 @@ export default function Default() {
                     <ToastOverlay />
                   </Box>
 
-                  {__PRERELEASE__ && __CHANNEL__ !== "next" ? <NightlyLayer /> : null}
+                  {__PRERELEASE__ && __CHANNEL__ !== "next" && !__CHANNEL__.includes("sha") ? (
+                    <NightlyLayer />
+                  ) : null}
 
                   <DeviceBusyIndicator />
                   <KeyboardContent sequence="BJBJBJ">


### PR DESCRIPTION
Since we rely on the `package.json` version to determine if we are in prerelease mode, and the CI now adds the `vX.Y.Z.sha.commithash` in our builds to better differenciate which ones we are currently testing, I've added a check to make sur those builds are not considered as prerelease

### ❓ Context

- **Impacted projects**: `ledger-live-desktop`


### ✅ Checklist

- [ ] **Test coverage**. <!-- Are your changes covered by tests? Features must be tested. bugfixes must bring the test that would have detected the bug. -->
- [x] **Atomic delivery**. <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes**. <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

NO DEMO

### 🚀 Expectations to reach

CI builds should not have the waternark anymore

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
