### PR TITLE
fix: Infinite Loading Spinner if no nano connected at start of funding flow [LIVE-2447]

### DIFF
--- a/.changeset/green-dodos-live.md
+++ b/.changeset/green-dodos-live.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix: Infinite Loading Spinner if no nano connected at start of funding flow [LIVE-2447]

--- a/libs/ledger-live-common/src/hw/actions/startExchange.ts
+++ b/libs/ledger-live-common/src/hw/actions/startExchange.ts
@@ -110,7 +110,8 @@ export const createAction = (
     const hasError = error || state.error;
     useEffect(() => {
       if (!opened || !device) {
-        setState({ ...initialState, isLoading: !hasError });
+        // isLoading should be false until we have a device to show the correct animation
+        setState({ ...initialState, isLoading: device ? !hasError : false });
         return;
       }
 
@@ -130,7 +131,7 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [device, opened, hasError, exchangeType]);
+    }, [device, opened, exchangeType, hasError]);
 
     return {
       ...appState,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The user has no indication that they need to connect a nano and unlock it when starting the funding flow. 

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-2447`](https://ledgerhq.atlassian.net/browse/LIVE-2447) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) --> 

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

https://user-images.githubusercontent.com/3009753/172213719-9fc108d9-bb71-4be6-8795-d3b9a112e5c0.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
