### PR TITLE
Update Github labeler path for screenshot label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,4 +27,4 @@ translations:
   - apps/ledger-live-mobile/src/locales/**/*
 
 screenshots:
-  - apps/ledger-live-desktop/tests/specs/**/*
+  - apps/ledger-live-desktop/tests/specs/*-snapshots/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,4 +27,4 @@ translations:
   - apps/ledger-live-mobile/src/locales/**/*
 
 screenshots:
-  - apps/ledger-live-desktop/tests/specs/*-snapshots/*
+  - apps/ledger-live-desktop/tests/specs/**/*.png


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The Github labeler add a `screenshots` tag whenever we modify the content of `desktop/tests/specs/**/*`, but sometime we modify or add tests without making changes to the snapshots. I updated the path to `desktop/tests/specs/*-snapshots/*` instead.

### ❓ Context

- **Impacted projects**: N/A <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: N/A <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
