### PR TITLE
Reborn - Improvements on how we handle the gestures on the carousel

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
@@ -136,6 +136,8 @@ function DiscoverLiveInfo() {
           width: "100%",
           px: 7,
         }}
+        scrollViewProps={{ scrollEnabled: false }}
+        maxDurationOfTap={700}
       >
         {slidesImages.map((image, index) => (
           <Item

--- a/libs/ui/packages/native/src/components/Carousel/index.tsx
+++ b/libs/ui/packages/native/src/components/Carousel/index.tsx
@@ -63,6 +63,11 @@ export type Props = React.PropsWithChildren<{
         duration?: number;
       }>
     | React.ReactElement;
+
+  /**
+   * Number of milliseconds a tap should not exceed to scroll to the netxt or precedent item.
+   */
+  maxDurationOfTap: number;
 }>;
 
 function Carousel({
@@ -76,6 +81,7 @@ function Carousel({
   onChange,
   onOverflow,
   IndicatorComponent = SlideIndicator,
+  maxDurationOfTap,
   children,
 }: Props) {
   const [init, setInit] = useState(false);
@@ -181,6 +187,21 @@ function Carousel({
     restartAfterEnd,
   ]);
 
+  // Timestamp of start of click on the Carrousel
+  const [tapTime, setTapTime] = useState<number>(0);
+  const onStartTap = useCallback(() => {
+    setTapTime(new Date().getTime());
+  }, []);
+  const onEndTap = useCallback(
+    (event) => {
+      const currentTime: number = new Date().getTime();
+      if (!maxDurationOfTap || currentTime - tapTime <= maxDurationOfTap) {
+        onTap(event);
+      }
+    },
+    [maxDurationOfTap, onTap, tapTime],
+  );
+
   return (
     <Flex flex={1} width="100%" alignItems="center" justifyContent="center" {...containerProps}>
       <HorizontalScrollView
@@ -198,7 +219,8 @@ function Carousel({
         scrollEventThrottle={200}
         contentContainerStyle={{ width: `${fullWidth}%` }}
         decelerationRate="fast"
-        onTouchEnd={scrollOnSidePress ? onTap : undefined}
+        onTouchStart={scrollOnSidePress ? onStartTap : undefined}
+        onTouchEnd={scrollOnSidePress ? onEndTap : undefined}
         {...scrollViewProps}
       >
         {React.Children.map(children, (child, index) => (


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

maxDurationTap parameter added to the carousel to be able to trigger only short taps
scroll disabled on the reborn carousel

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` `native-ui` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: 
   - JIRA : [LIVE-1813]
 
### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-1813]: https://ledgerhq.atlassian.net/browse/LIVE-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ