### PR TITLE
post libcore sunset, remove unecessary sqlite clean up

### DIFF
--- a/.changeset/dry-trains-drive.md
+++ b/.changeset/dry-trains-drive.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove unecessary 'sqlite' cleanup that no longer is needed after libcore sunset

--- a/apps/ledger-live-desktop/src/main/internal-lifecycle.js
+++ b/apps/ledger-live-desktop/src/main/internal-lifecycle.js
@@ -2,7 +2,6 @@
 
 import { app, ipcMain } from "electron";
 import path from "path";
-import rimraf from "rimraf";
 import { setEnvUnsafe, getAllEnvs } from "@ledgerhq/live-common/lib/env";
 import { isRestartNeeded } from "~/helpers/env";
 import logger from "~/logger";
@@ -16,13 +15,8 @@ const hydratedPerCurrency = {};
 // ~~~
 
 const LEDGER_CONFIG_DIRECTORY = app.getPath("userData");
-const LEDGER_LIVE_SQLITE_PATH = path.resolve(app.getPath("userData"), "sqlite");
 
 const internal = new InternalProcess({ timeout: 3000 });
-
-const cleanUpBeforeClosingSync = () => {
-  rimraf.sync(path.resolve(LEDGER_CONFIG_DIRECTORY, "sqlite/*.log"));
-};
 
 const sentryEnabled = false;
 const userId = "TODO";
@@ -34,7 +28,6 @@ const spawnCoreProcess = () => {
     ...process.env,
     IS_INTERNAL_PROCESS: 1,
     LEDGER_CONFIG_DIRECTORY,
-    LEDGER_LIVE_SQLITE_PATH,
     INITIAL_SENTRY_ENABLED: sentryEnabled,
     SENTRY_USER_ID: userId,
   };
@@ -61,7 +54,6 @@ app.on("window-all-closed", async () => {
   if (internal.active) {
     await internal.stop();
   }
-  cleanUpBeforeClosingSync();
   app.quit();
 });
 


### PR DESCRIPTION
### 📝 Description

a code was still there to remove the sqlite log files on app close. It's no longer needed as the app is no longer creating this sqlite folder: libcore is gone. On top of this, I believe these .log file creations were disabled more than a year ago, so it's long gone!

This will improve performance of closing the app, remove unnecessary access to filesystem (which was even done in sync!)

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** the electron automatic tests will cover the closing of the app
- [x] **Atomic delivery** 
- [x] **No breaking changes** 

### 📸 Demo

nothing to demo

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
