### PR TITLE
fix(LLM): platform manifest can be undefined when no network [LIVE-2571]

### DIFF
--- a/.changeset/unlucky-jars-speak.md
+++ b/.changeset/unlucky-jars-speak.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix(LLM): platform manifest can be undefined when no network [LIVE-2571]

--- a/apps/ledger-live-mobile/src/screens/Exchange/Buy.js
+++ b/apps/ledger-live-mobile/src/screens/Exchange/Buy.js
@@ -29,10 +29,12 @@ export default function Buy() {
 
   const navigateToMoonPay = useCallback(() => {
     const manifest = manifests.get("moonpay");
-    navigation.navigate(ScreenName.PlatformApp, {
-      platform: manifest.id,
-      name: manifest.name,
-    });
+    if (manifest) {
+      navigation.navigate(ScreenName.PlatformApp, {
+        platform: manifest.id,
+        name: manifest.name,
+      });
+    }
   }, [navigation, manifests]);
 
   const navigateToCoinify = useCallback(() => {

--- a/apps/ledger-live-mobile/src/screens/Platform/App.js
+++ b/apps/ledger-live-mobile/src/screens/Platform/App.js
@@ -14,7 +14,7 @@ const PlatformApp = ({ route }: StackScreenProps) => {
   const { manifests } = usePlatformApp();
   const manifest = manifests.get(appId);
   useEffect(() => {
-    manifest.name && setParams({ name: manifest.name });
+    manifest?.name && setParams({ name: manifest.name });
   }, [manifest, setParams]);
   const themeType = dark ? "dark" : "light";
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The platform manifest can be undefined when the user has no network.
Handling this simply because this code will change soon with multibuy 1.5.

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-2571`](https://ledgerhq.atlassian.net/browse/LIVE-2571) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
