### PR TITLE
Fix: native-ui ScrollListContainer forwardRef

### DIFF
--- a/.changeset/thin-bees-happen.md
+++ b/.changeset/thin-bees-happen.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Fix ScrollListContainer ref not being forwarded to FlatList

--- a/libs/ui/packages/native/src/components/Layout/ScrollListContainer/index.tsx
+++ b/libs/ui/packages/native/src/components/Layout/ScrollListContainer/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { View, FlatListProps, NativeSyntheticEvent, NativeScrollEvent } from "react-native";
 import Animated from "react-native-reanimated";
 import baseStyled, { BaseStyledProps } from "../../styled";
@@ -17,21 +17,22 @@ type ScrollListContainerProps = BaseStyledProps &
  ** This Layout is a wrapper for FlatList that accepts
  ** complex onScroll callback for react-native-reanimated.
  */
-const ScrollListContainer = ({
-  children,
-  onScroll,
-  horizontal = false,
-  ...props
-}: ScrollListContainerProps): JSX.Element => {
-  return (
-    <AnimatedFlatList
-      data={[...React.Children.toArray(children)]}
-      renderItem={({ item }: { item: React.ReactNode }) => <View>{item}</View>}
-      onScroll={onScroll}
-      horizontal={horizontal}
-      {...props}
-    />
-  );
-};
+const ScrollListContainer = forwardRef(
+  (
+    { children, onScroll, horizontal = false, ...props }: ScrollListContainerProps,
+    ref,
+  ): JSX.Element => {
+    return (
+      <AnimatedFlatList
+        ref={ref}
+        data={[...React.Children.toArray(children)]}
+        renderItem={({ item }: { item: React.ReactNode }) => <View>{item}</View>}
+        onScroll={onScroll}
+        horizontal={horizontal}
+        {...props}
+      />
+    );
+  },
+);
 
 export default ScrollListContainer;

--- a/libs/ui/packages/native/src/components/Layout/ScrollListContainer/index.tsx
+++ b/libs/ui/packages/native/src/components/Layout/ScrollListContainer/index.tsx
@@ -1,5 +1,11 @@
 import React, { forwardRef } from "react";
-import { View, FlatListProps, NativeSyntheticEvent, NativeScrollEvent } from "react-native";
+import {
+  View,
+  FlatListProps,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+  FlatList,
+} from "react-native";
 import Animated from "react-native-reanimated";
 import baseStyled, { BaseStyledProps } from "../../styled";
 
@@ -17,11 +23,8 @@ type ScrollListContainerProps = BaseStyledProps &
  ** This Layout is a wrapper for FlatList that accepts
  ** complex onScroll callback for react-native-reanimated.
  */
-const ScrollListContainer = forwardRef(
-  (
-    { children, onScroll, horizontal = false, ...props }: ScrollListContainerProps,
-    ref,
-  ): JSX.Element => {
+const ScrollListContainer = forwardRef<FlatList, ScrollListContainerProps>(
+  ({ children, onScroll, horizontal = false, ...props }, ref) => {
     return (
       <AnimatedFlatList
         ref={ref}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The ScrollListContainer component was not forwarding the ref being passed to it so 2 issues with that:
- in LLM we were passing a ref to a functional component so that was triggering a warning
- since the ref was not actually being passed, any imperative call on this ref (for instance to scroll the flatlist to the top) would not do anything.

### ❓ Context

- **Impacted projects**: `native-ui` `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: no ticket sorry just a message from @juan-cortes on Slack https://ledger.slack.com/archives/C0308JT8WS2/p1654850897917099

> <img width="355" alt="Screenshot 2022-06-10 at 11 42 54" src="https://user-images.githubusercontent.com/91890529/173038487-335f495c-348b-4817-8dba-5fb1c03e89f3.png">

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
