### PR TITLE
LIVE-2324 - Removing currency for Circulating supply

### DIFF
--- a/.changeset/funny-pianos-mix.md
+++ b/.changeset/funny-pianos-mix.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fixed issue on Circulating Supply, removed currency in front of the value

--- a/apps/ledger-live-desktop/README.md
+++ b/apps/ledger-live-desktop/README.md
@@ -71,7 +71,12 @@ pnpm dev:lld
 # Build & package the whole app
 # Creates a .dmg for Mac, .exe installer for Windows, or .AppImage for Linux
 # Output files will be created in dist/ folder
-pnpm desktop dist
+
+# build all the required dependencies
+pnpm build:lld:deps
+
+# alias to trigger the `dist` script in ledger-live-desktop project 
+pnpm desktop dist 
 ```
 
 ## Debug

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoinScreen/MarketInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoinScreen/MarketInfo.tsx
@@ -227,7 +227,6 @@ function MarketInfo({
             <LoadingLabel loading={loading}>
               {counterValueFormatter({
                 value: circulatingSupply,
-                currency: counterCurrency,
                 locale,
                 shorten: true,
               })}


### PR DESCRIPTION
Removed Currency from circulating supply in market/coin info

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

BUGFIX for LLD
In the currency's info under Circulating Supply was shown a currency which shouldn't be there. Removed it.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
