### PR TITLE
LIVE-2632 - Bugfix: WalletConnect error on disconnect

### DIFF
--- a/.changeset/silly-bulldogs-mate.md
+++ b/.changeset/silly-bulldogs-mate.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Fixing an issue with WalletConnect not accepting new connection after a first disconnection, resulting in an infite loading

--- a/apps/ledger-live-desktop/src/renderer/modals/WalletConnectPasteLink/Body.js
+++ b/apps/ledger-live-desktop/src/renderer/modals/WalletConnectPasteLink/Body.js
@@ -39,7 +39,7 @@ const steps: Array<St> = [
 
 const Body = ({ onClose, data }: Props) => {
   const { t } = useTranslation();
-  const [link, setLink] = useState();
+  const [link, setLink] = useState("");
   const [stepId, setStepId] = useState("paste");
 
   const handleStepChange = useCallback(e => setStepId(e.id), [setStepId]);

--- a/libs/ledger-live-common/src/walletconnect/Provider.tsx
+++ b/libs/ledger-live-common/src/walletconnect/Provider.tsx
@@ -161,9 +161,17 @@ const ProviderCommon = ({
     });
   };
 
-  disconnect = () => {
+  disconnect = async () => {
     if (state.connector) {
-      state.connector.killSession();
+      // Workaround for an error while trying to kill the session and it returns a error
+      // It lets the user in a state where he can't connect anymore even after relaunching the live
+      // See ref: https://github.com/WalletConnect/walletconnect-monorepo/issues/315#issuecomment-830695953
+      try {
+        await state.connector.killSession();
+      } catch (e) {
+        // using optional chaining to prevent it from crashing on mobile
+        window?.localStorage?.removeItem("walletconnect");
+      }
     }
 
     if (state.status !== STATUS.DISCONNECTED) {


### PR DESCRIPTION
### 📝 Description

Unfortunaltey I didn't find a good way to reproduce the bug yet. BUT, the explanation is:
- On unknown events, WalletConnect connexion is not closed correctly, therefore we never remove the `walletconnect` entry from the `localStorage`
- It results with the user never being able to use WalletConnect anymore
- Removing the entry allows for WalletConnect to work again

This PR adds a `catch` on the `WalletConnect.killSession` that can sometimes return this error: 

![wallet connect infinite loop connect](https://user-images.githubusercontent.com/44363395/173339310-611f3fc4-07ea-458a-a3d8-499e70dd67c9.png)

It probably is the culprit for never really removing the `localStorage` entry.

Result is: 
If you can kill the session properly, then do it (common case)
If you can't kill it, either because of the unkown event, or because you've touched by the bug before and your entry cannot be removed, then just force remove the entry.

That means that a user stuck with the bug, will see the modal opening, still be stuck in the infinite loading, but as soon as he closes the modal, he should be unstuck.

### ❓ Context

- **Impacted projects**: `live-common` `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-2632` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Proof of the bug existing and the solution being to remove the localStorage entry:

https://user-images.githubusercontent.com/44363395/173340034-bc77fec6-6b78-45fc-9863-7ab17d9ef300.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
