### PR TITLE
Bugfix - Allow pre-release tags in mustUpgrade or shouldUpgrade

### DIFF
--- a/.changeset/olive-camels-scream.md
+++ b/.changeset/olive-camels-scream.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Patching shouldUpgrade & mustUpgrade logic to allow for pre-release tags that were considered always considered as false before

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -21,7 +21,9 @@ export function shouldUpgrade(
     appName === "Bitcoin"
   ) {
     // https://donjon.ledger.com/lsb/010/
-    return !semver.satisfies(semver.coerce(appVersion) || "", ">= 1.4.0");
+    return !semver.satisfies(appVersion || "", ">= 1.4.0", {
+      includePrerelease: true, // this will allow pre-release tags that would otherwise return false. E.g. 1.0.0-dev
+    });
   }
 
   return false;
@@ -43,7 +45,9 @@ export function mustUpgrade(
   const range = appVersionsRequired[appName];
 
   if (range) {
-    return !semver.satisfies(appVersion, range);
+    return !semver.satisfies(appVersion || "", range, {
+      includePrerelease: true, // this will allow pre-release tags that would otherwise return false. E.g. 1.0.0-dev
+    });
   }
 
   return false;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR fixes an error being thrown for you to upgrade your app when using a pre-release version of a Nano App

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `None` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

#### **Before with the 1.9.19-dev Ethereum Nano app**

https://user-images.githubusercontent.com/44363395/173400026-631d82a9-6943-4c7e-8986-5b3815b97ba3.mov

#### **After with the 1.9.19-dev Ethereum Nano app**

https://user-images.githubusercontent.com/44363395/173400069-dffab49a-b6db-4523-92d3-a91cfaa296b8.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
