### PR TITLE
add ref on mobile prerelease job trigger

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -131,4 +131,7 @@ jobs:
               repo: "ledger-live-build",
               ref: "main",
               workflow_id: "release-mobile.yml",
+              inputs: {
+                ref: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref_name }}",
+              }
             });


### PR DESCRIPTION
### 📝 Description

Use the current ref to trigger the prerelease job on LLB for LLM prereleases

### ❓ Context

- **Impacted projects**: `automation` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

No Demo

### 🚀 Expectations to reach

Build from the correct branch

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
