### PR TITLE
LIVE-2634 support: add dep for L Market app for release

### DIFF
--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -56,6 +56,7 @@ export const whitelistDependencies = ["Decred", "Decred Testnet"];
   ["Ricochet", "Ethereum"],
   ["Kiln", "Ethereum"],
   ["Alkemi", "Ethereum"],
+  ["[ L ] Market", "Ethereum"],
 ].forEach(([name, dep]) => declareDep(name, dep));
 export const getDependencies = (appName: string): string[] =>
   directDep[appName] || [];


### PR DESCRIPTION
### 📝 Description

Add dep between plugin and Ethereum app
This PR is the equivalent of #334 for the release branch.

### ❓ Context

- **Impacted projects**: L Market
- **Linked resource(s)**: None

### ✅ Checklist

- [ ] **Test coverage**  n/a
- [x] **Atomic delivery** yes
- [x] **No breaking changes** no breaking changes

### 📸 Demo

n/a

### 🚀 Expectations to reach

n/a
