### PR TITLE
LIVE-2647 Remove useless if from custom hook

### DIFF
--- a/apps/ledger-live-mobile/src/hooks/useLatestFirmware.ts
+++ b/apps/ledger-live-mobile/src/hooks/useLatestFirmware.ts
@@ -8,8 +8,6 @@ import manager from "@ledgerhq/live-common/lib/manager";
 const useLatestFirmware: (
   deviceInfo?: DeviceInfo,
 ) => FirmwareUpdateContext | null | undefined = deviceInfo => {
-  if (!deviceInfo) return null;
-
   const [latestFirmware, setLatestFirmware] = useState<
     FirmwareUpdateContext | null | undefined
   >(null);


### PR DESCRIPTION
### 📝 Description
This is a bugfix. There's an useless if that does an early return before using a state and effect hook. This causes the app to crash due to the impossibility of conditionally using hooks. There should have been a linting warning for this, we'll check out how to add it.

### ❓ Context
[LIVE-2647]

### ✅ Checklist
- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

### 🚀 Expectations to reach

