### PR TITLE
LIVE-2664 Fix incremental sync for Cardano

### DIFF
--- a/.changeset/strong-buckets-listen.md
+++ b/.changeset/strong-buckets-listen.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Fix incremental sync for Cardano, use blockHeight from last operation instead of from account

--- a/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
@@ -153,10 +153,14 @@ export const getAccountShape: GetAccountShape = async (info) => {
   });
 
   const requiredConfirmations = 90;
+
+  const oldOperations = initialAccount?.operations || [];
+  const lastBlockHeight = oldOperations.length
+    ? (oldOperations[0].blockHeight || 0) + 1
+    : 0;
   const syncFromBlockHeight =
-    initialAccount?.blockHeight &&
-    initialAccount.blockHeight > requiredConfirmations
-      ? initialAccount.blockHeight - requiredConfirmations
+    lastBlockHeight > requiredConfirmations
+      ? lastBlockHeight - requiredConfirmations
       : 0;
 
   const {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Incremental sync for Cardano was based on `account.blockHeight` to know from which block to start sync. For some reason this field is not reset to 0 during clear cache (maybe it should?), which causes sync to only get data after this block height instead of 0.

The fix consists in using the blockHeight of the last operation, which unlike `account.blockHeight` is correctly 0 after a clear cache.


### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-2664


### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach


<!-- If any of the expectations are not met please explain the reason in detail. -->
