### PR TITLE
[live 2539] LLM - Back button in NftViewer

### DIFF
--- a/.changeset/shy-meals-yell.md
+++ b/.changeset/shy-meals-yell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add back navigation to NftViewer and fixed style issues on the view

--- a/apps/ledger-live-mobile/src/components/Nft/NftImage.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftImage.tsx
@@ -74,13 +74,10 @@ class NftImage extends React.PureComponent<Props, State> {
       toValue: 1,
       duration: 500,
       useNativeDriver: true,
-    }).start();
+    }).start(({ finished }) => {
+      finished && this.setState({ loading: false });
+    });
   };
-
-  onLoadEnd = () => {
-    this.setState({ loading: false });
-    this.startAnimation()
-  }
 
   onLoad = ({ nativeEvent }: OnLoadEvent) => {
     if (!nativeEvent) {
@@ -126,7 +123,7 @@ class NftImage extends React.PureComponent<Props, State> {
                 uri: src,
               }}
               onLoad={this.onLoad}
-              onLoadEnd={this.onLoadEnd}
+              onLoadEnd={this.startAnimation}
               onError={this.onError}
             />
           )}

--- a/apps/ledger-live-mobile/src/components/Nft/NftImage.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftImage.tsx
@@ -56,6 +56,7 @@ type Props = {
 
 type State = {
   loadError: boolean;
+  loading: boolean;
 };
 
 class NftImage extends React.PureComponent<Props, State> {
@@ -63,6 +64,7 @@ class NftImage extends React.PureComponent<Props, State> {
     beforeLoadDone: false,
     loadError: false,
     contentType: null,
+    loading: true,
   };
 
   opacityAnim = new Animated.Value(0);
@@ -75,9 +77,14 @@ class NftImage extends React.PureComponent<Props, State> {
     }).start();
   };
 
+  onLoadEnd = () => {
+    this.setState({ loading: false });
+    this.startAnimation()
+  }
+
   onLoad = ({ nativeEvent }: OnLoadEvent) => {
     if (!nativeEvent) {
-      this.setState({ loadError: true });
+      this.setState({ loading: true, loadError: true });
     }
   };
 
@@ -87,7 +94,7 @@ class NftImage extends React.PureComponent<Props, State> {
 
   render() {
     const { style, status, src, colors, resizeMode = "cover" } = this.props;
-    const { loadError } = this.state;
+    const { loadError, loading } = this.state;
 
     const noData = status === "nodata";
     const metadataError = status === "error";
@@ -95,7 +102,7 @@ class NftImage extends React.PureComponent<Props, State> {
 
     return (
       <View style={[style, styles.root]}>
-        <Skeleton style={styles.skeleton} loading={true} />
+        <Skeleton style={styles.skeleton} loading={loading} />
         <Animated.View
           style={[
             styles.imageContainer,
@@ -111,7 +118,7 @@ class NftImage extends React.PureComponent<Props, State> {
               style={[
                 styles.image,
                 {
-                  backgroundColor: colors.white,
+                  backgroundColor: colors.background.main,
                 },
               ]}
               resizeMode={resizeMode}
@@ -119,7 +126,7 @@ class NftImage extends React.PureComponent<Props, State> {
                 uri: src,
               }}
               onLoad={this.onLoad}
-              onLoadEnd={this.startAnimation}
+              onLoadEnd={this.onLoadEnd}
               onError={this.onError}
             />
           )}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/NftNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/NftNavigator.tsx
@@ -31,6 +31,7 @@ const NftNavigator = () => {
           title: null,
           headerRight: null,
           headerLeft: () => <BackButton navigation={navigation} />,
+          headerTransparent: true,
         })}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/NftNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/NftNavigator.tsx
@@ -5,7 +5,7 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import NftViewer from "../Nft/NftViewer";
 import NftImageViewer from "../Nft/NftImageViewer";
 import { ScreenName } from "../../const";
-import { CloseButton } from "../../screens/OperationDetails";
+import { CloseButton, BackButton } from "../../screens/OperationDetails";
 
 const NftNavigator = () => {
   const { colors } = useTheme();
@@ -27,10 +27,10 @@ const NftNavigator = () => {
       <Stack.Screen
         name={ScreenName.NftImageViewer}
         component={NftImageViewer}
-        options={() => ({
+        options={({ navigation }) => ({
           title: null,
           headerRight: null,
-          headerLeft: null,
+          headerLeft: () => <BackButton navigation={navigation} />,
         })}
       />
     </Stack.Navigator>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

LLM - Adding the back button to NFT Viewer and fixed background issue (the skeletton was still loading in the background. Passed the header to transparent so it has no background and is positionned to "absolute" preventing the image to get down in the view.

### ❓ Context

- **Impacted projects**: `LLM` 
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2539 https://www.figma.com/file/gmYzg5ekdRJ9tK3KuviFFu/LLM-%2F-NFT?node-id=211%3A560 

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

before : 
![Screenshot_20220530-122257-20220530-182437](https://user-images.githubusercontent.com/39890664/174047152-4b7f7f75-9355-47ff-a738-2e6c91e74cd3.png)
after :
<img width="432" alt="Screenshot 2022-06-16 at 12 04 18" src="https://user-images.githubusercontent.com/39890664/174047190-74b26926-b403-45b0-a491-d8522017c8fc.png">

Animation : 

https://user-images.githubusercontent.com/39890664/174078208-b2bc1423-4dae-4b18-8c6a-e5bbe2c7f0b3.mp4


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
