### PR TITLE
Fixed BuyDeviceBanner button that wasn't clickable anymore

### DIFF
--- a/apps/ledger-live-mobile/src/components/BuyDeviceBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/BuyDeviceBanner.tsx
@@ -124,7 +124,6 @@ export default function BuyDeviceBanner({
               eventProperties={eventProperties}
               type="main"
               flexShrink={0}
-              zIndex={1}
             >
               {buttonLabel ?? t("buyDevice.bannerButtonTitle")}
             </Button>
@@ -138,6 +137,7 @@ export default function BuyDeviceBanner({
           borderRadius={2}
           overflow="hidden"
           imageContainerStyle={imageContainerStyle}
+          pointerEvents="none"
         >
           <Image
             resizeMode="contain"

--- a/apps/ledger-live-mobile/src/components/BuyDeviceBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/BuyDeviceBanner.tsx
@@ -124,6 +124,7 @@ export default function BuyDeviceBanner({
               eventProperties={eventProperties}
               type="main"
               flexShrink={0}
+              zIndex={1}
             >
               {buttonLabel ?? t("buyDevice.bannerButtonTitle")}
             </Button>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The transparent background of the image on the right of the buy device banner card was overlapping on the button and we couldn't click on it anymore.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2681] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
