### PR TITLE
Set sampleRate to 100% on LLM + ignore 1 error

### DIFF
--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -49,6 +49,7 @@ const excludedErrorName = [
   "GetAppAndVersionUnsupportedFormat",
   // other
   "InvalidAddressError",
+  "SwapNoAvailableProviders",
 ];
 const excludedErrorDescription = [
   // networking
@@ -69,7 +70,7 @@ if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
     // NB we do not need to explicitly set the release. we let the native side infers it.
     // release: `com.ledger.live@${pkg.version}+${VersionNumber.buildVersion}`,
     // dist: String(VersionNumber.buildVersion),
-    sampleRate: 0.2,
+    sampleRate: 1,
     tracesSampleRate: 0.02,
     integrations: [],
     beforeSend(event: any) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We want to increase from 20% to 100% on the sampling rate of Sentry to have more events.
Also filtering out one frequent normal applicative issue.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
