### PR TITLE
Filter out 'prerelease' apps in speculos logic for the bot

### DIFF
--- a/libs/ledger-live-common/src/families/bitcoin/specs.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/specs.ts
@@ -289,7 +289,6 @@ const bitcoinTestnet: AppSpec<Transaction> = {
   appQuery: {
     model: DeviceModelId.nanoS,
     appName: "Bitcoin Test",
-    appVersion: "2.0.0-beta",
   },
   test: genericTest,
   mutations: bitcoinLikeMutations({

--- a/libs/ledger-live-common/src/load/speculos.ts
+++ b/libs/ledger-live-common/src/load/speculos.ts
@@ -316,8 +316,11 @@ export function appCandidatesMatches(
           hackBadSemver(appCandidate.firmware),
           searchFirmware
         ))) &&
-    (!search.appVersion ||
-      semver.satisfies(appCandidate.appVersion, search.appVersion))
+    ((!search.appVersion &&
+      !appCandidate.appVersion.includes("prerelease") &&
+      !appCandidate.appVersion.includes("rc")) ||
+      (search.appVersion &&
+        semver.satisfies(appCandidate.appVersion, search.appVersion)))
   );
 }
 export const findAppCandidate = (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes the bot to ignore the "prerelease" versions of coin-apps speculos bitcoin versions that would break.


### ❓ Context

- **Impacted projects**: `the bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2692 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

❌ Before fixing this:
```bash
pnpm run:cli sync --device 'speculos:nanoS:bitcoin'
debug: using app Bitcoin 2.0.99-prerelease on nanoS 2.1.0
```


✅ After fixing this: 
```bash
$ pnpm run:cli sync --device 'speculos:nanoS:bitcoin'
debug: using app Bitcoin 2.0.6 on nanoS 2.1.0
```

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
