### PR TITLE
Sentry: add more env context on errors

### DIFF
--- a/.changeset/shiny-swans-tickle.md
+++ b/.changeset/shiny-swans-tickle.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Log experimental and feature flags in Sentry error reports.

--- a/apps/ledger-live-desktop/src/renderer/App.jsx
+++ b/apps/ledger-live-desktop/src/renderer/App.jsx
@@ -33,6 +33,8 @@ import { ToastProvider } from "@ledgerhq/live-common/notifications/ToastProvider
 import { themeSelector } from "./actions/general";
 // $FlowFixMe
 import MarketDataProvider from "~/renderer/screens/market/MarketDataProviderWrapper";
+// $FlowFixMe
+import { ConnectEnvsToSentry } from "~/renderer/components/ConnectEnvsToSentry";
 
 const reloadApp = event => {
   if ((event.ctrlKey || event.metaKey) && event.key === "r") {
@@ -73,6 +75,7 @@ const InnerApp = ({ initialCountervalues }: { initialCountervalues: * }) => {
         <RemoteConfigProvider>
           <FirebaseRemoteConfigProvider>
             <FirebaseFeatureFlagsProvider>
+              <ConnectEnvsToSentry />
               <UpdaterProvider>
                 <CountervaluesProvider initialState={initialCountervalues}>
                   <ToastProvider>

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToSentry.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToSentry.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from "react";
+import { ipcRenderer } from "electron";
+import { EnvName, getEnv } from "@ledgerhq/live-common/env";
+import { defaultFeatures, useFeatureFlags } from "@ledgerhq/live-common/featureFlags/index";
+import { FeatureId } from "@ledgerhq/live-common/types";
+import { enabledExperimentalFeatures } from "../experimental";
+import { setTags } from "../../sentry/renderer";
+
+function setSentryTagsEverywhere(tags: { [_: string]: any }) {
+  ipcRenderer.invoke("set-sentry-tags", tags);
+  setTags(tags);
+}
+
+const MAX_KEYLEN = 32;
+function safekey(k: string) {
+  if (k.length > MAX_KEYLEN) {
+    const sep = "..";
+    const max = MAX_KEYLEN - sep.length;
+    const split1 = Math.floor(max / 2);
+    return k.slice(0, split1) + ".." + k.slice(k.length - (max - split1));
+  }
+  return k;
+}
+
+export const ConnectEnvsToSentry = () => {
+  const featureFlags = useFeatureFlags();
+  useEffect(() => {
+    // This sync the Sentry tags to include the extra information in context of events
+    const syncTheTags = () => {
+      const tags: { [_: string]: any } = {};
+      // if there are experimental on, we will add them in tags
+      enabledExperimentalFeatures().forEach((key: EnvName) => {
+        tags[safekey(key)] = getEnv(key);
+      });
+      // if there are features on, we will add them in tags
+      const features: { [key in FeatureId]: boolean } = {};
+      Object.keys(defaultFeatures).forEach(key => {
+        const value = featureFlags.getFeature(key);
+        if (value && value.enabled !== defaultFeatures[key].enabled) {
+          features[key] = value.enabled;
+        }
+      });
+
+      Object.keys(features).forEach(key => {
+        tags[safekey(`f_${key}`)] = features[key];
+      });
+
+      setSentryTagsEverywhere(tags);
+    };
+    // We need to wait firebase to load the data and then we set once for all the tags
+    setTimeout(syncTheTags, 5000);
+    // We also try to regularly update them so we are sure to get the correct tags (as these are dynamic)
+    setInterval(syncTheTags, 60000);
+  }, []);
+  return null;
+};

--- a/apps/ledger-live-desktop/src/sentry/internal.js
+++ b/apps/ledger-live-desktop/src/sentry/internal.js
@@ -17,3 +17,7 @@ export const captureException = (e: Error) => {
 export const captureBreadcrumb = (o: *) => {
   Sentry.addBreadcrumb(o);
 };
+
+export const setTags = (tags: *) => {
+  Sentry.setTags(tags);
+};

--- a/apps/ledger-live-desktop/src/sentry/main.js
+++ b/apps/ledger-live-desktop/src/sentry/main.js
@@ -17,3 +17,7 @@ export const captureException = (e: Error) => {
 export const captureBreadcrumb = (o: *) => {
   Sentry.addBreadcrumb(o);
 };
+
+export const setTags = (tags: *) => {
+  Sentry.setTags(tags);
+};

--- a/apps/ledger-live-desktop/src/sentry/renderer.js
+++ b/apps/ledger-live-desktop/src/sentry/renderer.js
@@ -20,3 +20,7 @@ export const captureException = (e: Error) => {
 export const captureBreadcrumb = (o: *) => {
   Sentry.addBreadcrumb(o);
 };
+
+export const setTags = (tags: *) => {
+  Sentry.setTags(tags);
+};

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -24,11 +24,14 @@ import * as Sentry from "@sentry/react-native";
 import Config from "react-native-config";
 import VersionNumber from "react-native-version-number";
 
+import { getEnv } from "@ledgerhq/live-common/lib/env";
 import BackgroundRunnerService from "./services/BackgroundRunnerService";
 import App, { routingInstrumentation } from "./src";
 import { getEnabled } from "./src/components/HookSentry";
 import logReport from "./src/log-report";
 import pkg from "./package.json";
+import { getAllDivergedFlags } from "./src/components/FirebaseFeatureFlags";
+import { enabledExperimentalFeatures } from "./src/experimental";
 
 // we exclude errors related to user's environment, not fixable by us
 const excludedErrorName = [
@@ -73,7 +76,7 @@ const excludedErrorDescription = [
   "Unable to open URL",
   "Received an invalid JSON-RPC message",
 ];
-if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
+if (Config.SENTRY_DSN && (!__DEV__ || Config.FORCE_SENTRY) && !Config.MOCK) {
   Sentry.init({
     dsn: Config.SENTRY_DSN,
     environment: Config.SENTRY_ENVIRONMENT,
@@ -116,6 +119,36 @@ if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
       return event;
     },
   });
+
+  const MAX_KEYLEN = 32;
+  const safekey = (k: string) => {
+    if (k.length > MAX_KEYLEN) {
+      const sep = "..";
+      const max = MAX_KEYLEN - sep.length;
+      const split1 = Math.floor(max / 2);
+      return k.slice(0, split1) + ".." + k.slice(k.length - (max - split1));
+    }
+    return k;
+  };
+
+  // This sync the Sentry tags to include the extra information in context of events
+  const syncTheTags = () => {
+    const tags = {};
+    // if there are experimental on, we will add them in tags
+    enabledExperimentalFeatures().forEach(key => {
+      tags[safekey(key)] = getEnv(key);
+    });
+    // if there are features on, we will add them in tags
+    const features = getAllDivergedFlags();
+    Object.keys(features).forEach(key => {
+      tags[safekey(`f_${key}`)] = features[key];
+    });
+    Sentry.setTags(tags);
+  };
+  // We need to wait firebase to load the data and then we set once for all the tags
+  setTimeout(syncTheTags, 5000);
+  // We also try to regularly update them so we are sure to get the correct tags (as these are dynamic)
+  setInterval(syncTheTags, 60000);
 }
 
 if (Config.DISABLE_YELLOW_BOX) {

--- a/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
@@ -1,6 +1,9 @@
 import React, { ReactNode } from "react";
 import remoteConfig from "@react-native-firebase/remote-config";
-import { FeatureFlagsProvider } from "@ledgerhq/live-common/featureFlags/index";
+import {
+  FeatureFlagsProvider,
+  defaultFeatures,
+} from "@ledgerhq/live-common/featureFlags/index";
 import { FeatureId } from "@ledgerhq/live-common/types/index";
 
 import { formatFeatureId } from "./FirebaseRemoteConfig";
@@ -9,22 +12,34 @@ type Props = {
   children?: ReactNode;
 };
 
-export const FirebaseFeatureFlagsProvider = ({ children }: Props) => {
-  const getFeature = (key: FeatureId) => {
-    try {
-      const value = remoteConfig().getValue(formatFeatureId(key));
-      const feature = JSON.parse(value.asString());
+const getFeature = (key: FeatureId) => {
+  try {
+    const value = remoteConfig().getValue(formatFeatureId(key));
+    const feature = JSON.parse(value.asString());
 
-      return feature;
-    } catch (error) {
-      console.error(`Failed to retrieve feature "${key}"`);
-      return null;
-    }
-  };
-
-  return (
-    <FeatureFlagsProvider getFeature={getFeature}>
-      {children}
-    </FeatureFlagsProvider>
-  );
+    return feature;
+  } catch (error) {
+    console.error(`Failed to retrieve feature "${key}"`);
+    return null;
+  }
 };
+
+/**
+ * @returns all flags that have different defaults are exported as a key value map
+ */
+export const getAllDivergedFlags = (): { [key in FeatureId]: boolean } => {
+  const res: { [key in FeatureId]: boolean } = {};
+  Object.keys(defaultFeatures).forEach(key => {
+    const value = getFeature(key);
+    if (value && value.enabled !== defaultFeatures[key].enabled) {
+      res[key] = value.enabled;
+    }
+  });
+  return res;
+};
+
+export const FirebaseFeatureFlagsProvider = ({ children }: Props) => (
+  <FeatureFlagsProvider getFeature={getFeature}>
+    {children}
+  </FeatureFlagsProvider>
+);

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -35,7 +35,6 @@ import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
 import { useCountervaluesExport } from "@ledgerhq/live-common/countervalues/react";
 import { pairId } from "@ledgerhq/live-common/countervalues/helpers";
-
 import { NftMetadataProvider } from "@ledgerhq/live-common/nft/index";
 import { ToastProvider } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import { GlobalCatalogProvider } from "@ledgerhq/live-common/platform/providers/GlobalCatalogProvider/index";


### PR DESCRIPTION
### 📝 Description

On Sentry, we currently don't know if any experimental OR feature flag has been enabled in context of an error, which is very valuable to know about.

Trade-off: this works with "polling". The current implementation will regularly sync the tags so they are always correct when an error arise.

This PR only do this on LLM as the LLD PR isn't merged there, but we'll eventually also apply the same idea to LLD.

### ❓ Context

- **Impacted projects**: LLM and LLD <!-- The list of end user projects impacted by the change. -->

### ✅ Checklist

- [ ] **Test coverage**: this is not automatically tested. I have manually tested on Mac and Android. This is the reference documentation to test: https://github.com/LedgerHQ/ledger-live/wiki/Manually-Test-Sentry-integration
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


We can see the env and the feature flags

![Screenshot 2022-07-04 at 19 15 01](https://user-images.githubusercontent.com/211411/177197233-b9c81bf1-5f67-427e-a708-0475bd7c40ef.png)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
