### PR TITLE
LIVE-1132 Fix Wrong Gas Price Polygon

### DIFF
--- a/.changeset/dull-timers-care.md
+++ b/.changeset/dull-timers-care.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix wrong gas Price Polygon

--- a/apps/ledger-live-mobile/src/families/ethereum/EditFeeUnitEthereum.js
+++ b/apps/ledger-live-mobile/src/families/ethereum/EditFeeUnitEthereum.js
@@ -83,7 +83,7 @@ export default function EditFeeUnitEthereum({
           >
             <LText style={[styles.currencyUnitText, { color: colors.live }]}>
               <CurrencyUnitValue
-                unit={feeCustomUnit || mainAccount.unit}
+                unit={mainAccount.unit || feeCustomUnit}
                 value={gasPrice}
               />
             </LText>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Display the right unit fee on mobile, the wrong one was Gwei and the right one is MATIC for Polygon

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-1132` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
[For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.]
-->
https://user-images.githubusercontent.com/103273462/165099973-16cb9fbc-648c-470c-8358-521634d27ecd.jpeg

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
