### PR TITLE
LIVE-2689 Fix empty params bug on manager screen

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Manager/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/index.tsx
@@ -154,7 +154,7 @@ class ChooseDevice extends Component<
   };
 
   componentDidMount() {
-    this.setState(state => ({ ...state, device: this.props.route.params.device }));
+    this.setState(state => ({ ...state, device: this.props.route.params?.device }));
   }
 
   render() {


### PR DESCRIPTION
### 📝 Description
There's a potential crashbug in the manager. If a navigation is triggered to this page without passing any parameters. The app crashes due to us trying to access a property from params. I could only find one accessible place where this can happen (the DebugHttpTransport functionality that is mostly used by devs), therefore the impact isn't very big.

In any case, this PR fixes the issue

### ❓ Context
[LIVE-2689]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->



[LIVE-2689]: https://ledgerhq.atlassian.net/browse/LIVE-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ