### PR TITLE
Reborn tabbar ledger button behavior fixed on readonly mode

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -106,13 +106,29 @@ export default function BaseNavigator() {
       <Stack.Screen
         name={NavigatorName.BuyDevice}
         component={BuyDeviceNavigator}
-        options={{ headerShown: false }}
+        options={{
+          headerShown: false,
+          cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+        }}
         {...noNanoBuyNanoWallScreenOptions}
       />
       <Stack.Screen
         name={ScreenName.PostBuyDeviceSetupNanoWallScreen}
         component={PostBuyDeviceSetupNanoWallScreen}
-        options={{ headerShown: false, presentation: "transparentModal" }}
+        options={{
+          headerShown: false,
+          presentation: "transparentModal",
+          headerMode: "none",
+          mode: "modal",
+          transparentCard: true,
+          cardStyle: { opacity: 1 },
+          gestureEnabled: true,
+          headerTitle: null,
+          headerRight: null,
+          headerBackTitleVisible: false,
+          title: null,
+          cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+        }}
       />
       <Stack.Screen
         name={ScreenName.PostBuyDeviceScreen}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
@@ -12,7 +12,10 @@ import Transfer, { TransferTabIcon } from "../TabBar/Transfer";
 import TabIcon from "../TabIcon";
 import MarketNavigator from "./MarketNavigator";
 import PortfolioNavigator from "./PortfolioNavigator";
-import { readOnlyModeEnabledSelector } from "../../reducers/settings";
+import {
+  hasOrderedNanoSelector,
+  readOnlyModeEnabledSelector,
+} from "../../reducers/settings";
 import ManagerNavigator, { ManagerTabIcon } from "./ManagerNavigator";
 import DiscoverNavigator from "./DiscoverNavigator";
 import customTabBar from "../TabBar/CustomTabBar";
@@ -29,6 +32,7 @@ export default function MainNavigator({
 }) {
   const { colors } = useTheme();
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
+  const hasOrderedNano = useSelector(hasOrderedNanoSelector);
 
   const { hideTabNavigation } = params || {};
 
@@ -150,17 +154,23 @@ export default function MainNavigator({
         listeners={({ navigation }) => ({
           tabPress: (e: any) => {
             e.preventDefault();
-            // NB The default behaviour is not reset route params, leading to always having the same
-            // search query or preselected tab after the first time (ie from Swap/Sell)
-            // https://github.com/react-navigation/react-navigation/issues/6674#issuecomment-562813152
-            navigation.navigate(NavigatorName.Manager, {
-              screen: ScreenName.Manager,
-              params: {
-                tab: undefined,
-                searchQuery: undefined,
-                updateModalOpened: undefined,
-              },
-            });
+            if (hasOrderedNano) {
+              navigation.navigate(ScreenName.PostBuyDeviceSetupNanoWallScreen);
+            } else if (readOnlyModeEnabled) {
+              navigation.navigate(NavigatorName.BuyDevice);
+            } else {
+              // NB The default behaviour is not reset route params, leading to always having the same
+              // search query or preselected tab after the first time (ie from Swap/Sell)
+              // https://github.com/react-navigation/react-navigation/issues/6674#issuecomment-562813152
+              navigation.navigate(NavigatorName.Manager, {
+                screen: ScreenName.Manager,
+                params: {
+                  tab: undefined,
+                  searchQuery: undefined,
+                  updateModalOpened: undefined,
+                },
+              });
+            }
           },
         })}
       />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ManagerNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ManagerNavigator.tsx
@@ -14,7 +14,6 @@ import styles from "../../navigation/styles";
 import TabIcon from "../TabIcon";
 import { useIsNavLocked } from "./CustomBlockRouterNavigator";
 import ManagerMain from "../../screens/Manager/Manager";
-import { useNoNanoBuyNanoWallScreenOptions } from "../../context/NoNanoBuyNanoWall";
 
 const BadgeContainer = styled(Flex).attrs({
   position: "absolute",
@@ -57,7 +56,6 @@ export default function ManagerNavigator() {
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors), [
     colors,
   ]);
-  const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
 
   return (
     <Stack.Navigator
@@ -78,7 +76,6 @@ export default function ManagerNavigator() {
           headerRight: null,
           gestureEnabled: false,
         }}
-        {...noNanoBuyNanoWallScreenOptions}
       />
       <Stack.Screen
         name={ScreenName.ManagerMain}


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Buy Ledger modal were not displayed properly when clicking on the 'My Ledger' button in the tabbar when on read only mode and when hasOrderedNano was set to true

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2690]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/17146928/174645143-2fcb73ad-4786-4bb5-a956-b192c3bb6375.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
