### PR TITLE
[LIVE-2497] - Bugfix: Handle reorg on Eth family sync

### DIFF
--- a/.changeset/tiny-roses-refuse.md
+++ b/.changeset/tiny-roses-refuse.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix reorg causing a failed incremental sync if latest stable operaton block hash doesn't exist on chain

--- a/libs/ledger-live-common/src/api/Ethereum.ts
+++ b/libs/ledger-live-common/src/api/Ethereum.ts
@@ -72,26 +72,38 @@ export type Tx = {
     time: string;
   };
 };
+
 export type ERC20BalancesInput = Array<{
   address: string;
   contract: string;
 }>;
+
 export type ERC20BalanceOutput = Array<{
   address: string;
   contract: string;
   balance: BigNumber;
 }>;
+
 export type NFTMetadataInput = Readonly<
   Array<{
     contract: string;
     tokenId: string;
   }>
 >;
+
 export type NFTCollectionMetadataInput = Readonly<
   Array<{
     contract: string;
   }>
 >;
+
+export type BlockByHashOutput = {
+  hash: string;
+  height: number;
+  time: string;
+  txs: string[];
+};
+
 export type API = {
   getTransactions: (
     address: string,
@@ -133,6 +145,7 @@ export type API = {
     medium: BigNumber;
     high: BigNumber;
   }>;
+  getBlockByHash: (blockHash: string) => Promise<BlockByHashOutput | undefined>;
 };
 export const apiForCurrency = (currency: CryptoCurrency): API => {
   const baseURL = blockchainBaseURL(currency);
@@ -328,5 +341,23 @@ export const apiForCurrency = (currency: CryptoCurrency): API => {
         maxAge: 30 * 1000,
       }
     ),
+
+    async getBlockByHash(blockHash) {
+      if (!blockHash) {
+        return undefined;
+      }
+
+      try {
+        const { data }: { data: BlockByHashOutput[] } = await network({
+          method: "GET",
+          url: `${baseURL}/blocks/${blockHash}`,
+          transformResponse: JSONBigNumber.parse,
+        });
+
+        return data[0];
+      } catch (e) {
+        return undefined;
+      }
+    },
   };
 };

--- a/libs/ledger-live-common/src/bridge/jsHelpers.ts
+++ b/libs/ledger-live-common/src/bridge/jsHelpers.ts
@@ -172,9 +172,11 @@ export const makeSync =
   ({
     getAccountShape,
     postSync = (_, a) => a,
+    shouldMergeOps = true,
   }: {
     getAccountShape: GetAccountShape;
     postSync?: (initial: Account, synced: Account) => Account;
+    shouldMergeOps?: boolean;
   }): AccountBridge<any>["sync"] =>
   (initial, syncConfig): Observable<AccountUpdater> =>
     Observable.create((o) => {
@@ -205,10 +207,14 @@ export const makeSync =
             },
             syncConfig
           );
+
           o.next((acc) => {
             const a = needClear ? clearAccount(acc) : acc;
             // FIXME reconsider doing mergeOps here. work is redundant for impl like eth
-            const operations = mergeOps(a.operations, shape.operations || []);
+            const operations = shouldMergeOps
+              ? mergeOps(a.operations, shape.operations || [])
+              : shape.operations || [];
+
             return recalculateAccountBalanceHistories(
               postSync(a, {
                 ...a,

--- a/libs/ledger-live-common/src/families/ethereum/bridge/js.ts
+++ b/libs/ledger-live-common/src/families/ethereum/bridge/js.ts
@@ -47,7 +47,11 @@ const broadcast = async ({
 };
 
 const scanAccounts = makeScanAccounts({ getAccountShape });
-const sync = makeSync({ getAccountShape, postSync: postSyncPatch });
+const sync = makeSync({
+  getAccountShape,
+  postSync: postSyncPatch,
+  shouldMergeOps: false,
+});
 
 const createTransaction = (): Transaction => ({
   family: "ethereum",

--- a/libs/ledger-live-common/src/families/ethereum/datasets/ethereum2.ts
+++ b/libs/ledger-live-common/src/families/ethereum/datasets/ethereum2.ts
@@ -1,0 +1,20 @@
+import { AccountRaw } from "../../../types";
+
+export const ethereum2: AccountRaw = {
+  id: "js:2:ethereum:0x789d2f10826BF8f3a56Ec524359bBA4e738Af5bF:",
+  seedIdentifier: "0x789d2f10826BF8f3a56Ec524359bBA4e738Af5bF",
+  name: "Ethereum legacy xpub6Bem...JyAdpYZy",
+  derivationMode: "",
+  index: 0,
+  freshAddress: "0x789d2f10826BF8f3a56Ec524359bBA4e738Af5bF",
+  freshAddressPath: "44'/60'/0'/0/0",
+  freshAddresses: [],
+  pendingOperations: [],
+  operations: [],
+  currencyId: "ethereum",
+  unitMagnitude: 18,
+  balance: "",
+  blockHeight: 0,
+  lastSyncDate: "",
+  xpub: "",
+};

--- a/libs/ledger-live-common/src/families/ethereum/synchronisation.integration.test.ts
+++ b/libs/ledger-live-common/src/families/ethereum/synchronisation.integration.test.ts
@@ -2,7 +2,7 @@ import "../../__tests__/test-helpers/setup";
 import { reduce } from "rxjs/operators";
 import { fromAccountRaw } from "../../account";
 import { getAccountCurrency } from "../../account/helpers";
-import type { Account, SubAccount } from "../../types";
+import type { Account, OperationRaw, SubAccount } from "../../types";
 import { getAccountBridge } from "../../bridge";
 import { makeBridgeCacheSystem } from "../../bridge/cache";
 import { ethereum1 } from "./datasets/ethereum1";
@@ -95,6 +95,7 @@ describe("sync on reorg", () => {
     const opHash = "NotImportant";
     const accountId = ethereum2.id;
     const opType = "OUT";
+    const opId = encodeOperationId(accountId, opHash, opType);
     const blockHeight = 10042069;
     const currency = getCryptoCurrencyById(ethereum2.currencyId);
     const syncHash =
@@ -104,40 +105,43 @@ describe("sync on reorg", () => {
         withDelisted: true,
       }).length;
 
+    const operation: OperationRaw = {
+      id: opId,
+      hash: opHash,
+      type: opType,
+      value: "1",
+      fee: "string",
+      senders: ["0x789d2f10826BF8f3a56Ec524359bBA4e738Af5bF"],
+      recipients: ["0xdA9EDcC3CF66bc18050dB55D376407Cf85e0617B"],
+      blockHeight: blockHeight - 81, // 80 is defined today as the threshold number of confirmation to be safe for a reorg. @see SAFE_REORG_THRESHOLD
+      blockHash:
+        "0x00000000000000000000000000000000000Th1sH4shSh0u1dN0t3x1sTOnCh4iN",
+      transactionSequenceNumber: 1,
+      date: "May-11-2020 01:50:10 UTC",
+      extra: {},
+      accountId,
+    };
+
     const account = fromAccountRaw({
       ...ethereum2,
       blockHeight,
       syncHash,
-      operations: [
-        {
-          id: encodeOperationId(accountId, opHash, opType),
-          hash: opHash,
-          type: opType,
-          value: "1",
-          fee: "string",
-          senders: ["0x0E3F0bb9516F01f2C34c25E0957518b8aC9414c5"],
-          recipients: ["0xdA9EDcC3CF66bc18050dB55D376407Cf85e0617B"],
-          blockHeight: blockHeight - 81, // 80 is defined today as the threshold number of confirmation to be safe for a reorg. @see SAFE_REORG_THRESHOLD
-          blockHash:
-            "0x00000000000000000000000000000000000Th1sH4shSh0u1dN0t3x1sTOnCh4iN",
-          transactionSequenceNumber: 1,
-          date: new Date(Date.now()).toISOString(),
-          extra: {},
-          accountId,
-        },
-      ],
+      operations: [operation],
       operationsCount: 1,
     });
     const bridge = getAccountBridge(account);
-
-    await expect(
-      bridge
-        .sync(account, {
-          paginationConfig: {},
-          blacklistedTokenIds: [],
-        })
-        .pipe(reduce((a, f: (arg0: Account) => Account) => f(a), account))
-        .toPromise()
-    ).rejects.toThrow();
+    const syncPromise = await bridge
+      .sync(account, {
+        paginationConfig: {},
+        blacklistedTokenIds: [],
+      })
+      .pipe(reduce((a, f: (arg0: Account) => Account) => f(a), account))
+      .toPromise();
+    // expect not to throw ok if you reach this point
+    // + expect operations to be from full sync instead of incremental
+    // so the fake op should be removed
+    expect(syncPromise.operations.map((o) => o.id)).not.toContain(opId);
+    // To this date (June 20th 2022) this account has 160 ops, we should at least get them all
+    expect(syncPromise.operations.length >= 160).toBe(true);
   });
 });

--- a/libs/ledger-live-common/src/families/ethereum/synchronisation.ts
+++ b/libs/ledger-live-common/src/families/ethereum/synchronisation.ts
@@ -20,7 +20,7 @@ import { API, apiForCurrency, Tx } from "../../api/Ethereum";
 import { digestTokenAccounts, prepareTokenAccounts } from "./modules";
 import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { encodeNftId, isNFTActive, nftsFromOperations } from "../../nft";
-import { encodeOperationId } from "../../operation";
+import { encodeOperationId, encodeSubOperationId } from "../../operation";
 import {
   encodeERC1155OperationId,
   encodeERC721OperationId,
@@ -282,7 +282,7 @@ const txToOps =
     // We are putting the sub operations in place for now, but they will later be exploded out of the operations back to their token accounts
     const subOperations = !transfer_events
       ? []
-      : flatMap(transfer_events.list, (event) => {
+      : flatMap(transfer_events.list, (event, i) => {
           const from = safeEncodeEIP55(event.from);
           const to = safeEncodeEIP55(event.to);
           const sending = addr === from;
@@ -304,7 +304,7 @@ const txToOps =
           if (sending) {
             const type = "OUT";
             all.push({
-              id: encodeOperationId(accountId, hash, type),
+              id: encodeSubOperationId(accountId, hash, type, i),
               hash,
               type,
               value,
@@ -323,7 +323,7 @@ const txToOps =
           if (receiving) {
             const type = "IN";
             all.push({
-              id: encodeOperationId(accountId, hash, type),
+              id: encodeSubOperationId(accountId, hash, type, i),
               hash,
               type,
               value,

--- a/libs/ledger-live-common/src/families/ethereum/synchronisation.ts
+++ b/libs/ledger-live-common/src/families/ethereum/synchronisation.ts
@@ -46,7 +46,13 @@ export const getAccountShape: GetAccountShape = async (
     : [];
   // fetch transactions, incrementally if possible
   const mostRecentStableOperation = initialStableOperations[0];
+  const currentBlockP = fetchCurrentBlock(currency);
+  const balanceP = api.getAccountBalance(address);
   // when new tokens are added / blacklist changes, we need to sync again because we need to go through all operations again
+  // Check if the block hash exists on chain to prevent reorg issue
+  const blockHashExistsOnChain = await api
+    .getBlockByHash(mostRecentStableOperation?.blockHash)
+    .then(Boolean);
   const syncHash =
     JSON.stringify(blacklistedTokenIds || []) +
     "_" +
@@ -58,12 +64,11 @@ export const getAccountShape: GetAccountShape = async (
     initialAccount &&
     areAllOperationsLoaded(initialAccount) &&
     mostRecentStableOperation &&
+    blockHashExistsOnChain &&
     !outdatedSyncHash
       ? mostRecentStableOperation.blockHash
       : undefined;
   const txsP = fetchAllTransactions(api, address, pullFromBlockHash);
-  const currentBlockP = fetchCurrentBlock(currency);
-  const balanceP = api.getAccountBalance(address);
   const [txs, currentBlock, balance] = await Promise.all([
     txsP,
     currentBlockP,
@@ -167,7 +172,10 @@ export const getAccountShape: GetAccountShape = async (
     ...o,
     subOperations: inferSubOperations(o.hash, subAccounts),
   }));
-  const operations = mergeOps(initialStableOperations, newOps);
+  const operations = mergeOps(
+    blockHashExistsOnChain ? initialStableOperations : [],
+    newOps
+  );
 
   const nfts = isNFTActive(currency)
     ? mergeNfts(

--- a/libs/ledger-live-common/src/operation.ts
+++ b/libs/ledger-live-common/src/operation.ts
@@ -87,6 +87,30 @@ export function decodeOperationId(id: string): {
   };
 }
 
+export function encodeSubOperationId(
+  accountId: string,
+  hash: string,
+  type: string,
+  index: string | number
+): string {
+  return `${accountId}-${hash}-${type}-i${index}`;
+}
+
+export function decodeSubOperationId(id: string): {
+  accountId: string;
+  hash: string;
+  type: string;
+  index: number;
+} {
+  const [accountId, hash, type, index] = id.split("-");
+  return {
+    accountId,
+    hash,
+    type,
+    index: Number(index),
+  };
+}
+
 export function patchOperationWithHash(
   operation: Operation,
   hash: string


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR adds a failsafe to Ethereum incremental synchronisation which is based on the latest "stable" block hash in the Account's operations history.
As of right now a block is considered safe based on an arbitrary value `SAFE_REORG_THRESHOLD` set at `80`, but it looks like even with this security we can end up with a block hash that doesn't exist on chain.
The failsafe will now make sure a block exists before trying an incremental sync from it, and if it doesn't it's going to do a full sync instead.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2497 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Can't really be demoed. But an integration test reproducing the issue has been added.

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
