### PR TITLE
chore: make pnpm lockfile deterministic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,11 +92,11 @@ jobs:
         run: pnpm i --filter="!./apps/**"
       - name: Build and Test affected libraries (Pull Request)
         if: ${{ github.event_name != 'push' }}
-        run: pnpm run test --continue --filter="!./apps/**" --filter="!live-common-tools" --filter="...[origin/${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.inputs.since_branch || 'develop' }}]" --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
+        run: pnpm run test --continue --filter="!./apps/**" --filter="!live-common-tools" --filter="!ledger-live...[origin/${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.event.inputs.since_branch || 'develop' }}]" --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
         shell: bash
       - name: Build and Test affected libraries (Pull Request)
         if: ${{ github.event_name == 'push' }}
-        run: pnpm run test --continue --filter="!./apps/**" --filter="!live-common-tools" --filter=[HEAD^1] --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
+        run: pnpm run test --continue --filter="!./apps/**" --filter="!live-common-tools" --filter="!ledger-live...[HEAD^1]" --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
         shell: bash
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@v3

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -15,6 +15,7 @@ const {
   addDependencies,
   addDevDependencies,
   addPeerDependencies,
+  removeDependencies,
 } = require("./tools/pnpm-utils");
 
 function readPackage(pkg, context) {
@@ -166,6 +167,10 @@ function readPackage(pkg, context) {
       addPeerDependencies("app-builder-lib", {
         "dmg-builder": "*",
         lodash: "*",
+      }),
+      // Try to prevent pnpm-lock.yaml flakiness
+      removeDependencies("follow-redirects", ["debug"], {
+        kind: "peerDependencies",
       }),
       /* Packages that are missing @types/* dependencies */
       addPeerDependencies("react-native-gesture-handler", {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "private": true,
-  "packageManager": "pnpm@7.1.0",
+  "packageManager": "pnpm@7.3.0",
   "scripts": {
     "clean": "git clean -fdX",
     "changelog": "changeset add",
@@ -88,7 +88,7 @@
     "create-release-hash": "workspace:*",
     "migrate-branch": "workspace:*",
     "pnpm-utils": "workspace:*",
-    "turbo": "1.2.17-canary.0"
+    "turbo": "1.3.1"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,7 +306,7 @@ importers:
       '@xstate/react': 1.6.3_react@17.0.2+xstate@4.32.0
       animated: 0.2.2_sfoxds7t5ydpegc3knd667wn6m
       async: 3.2.3
-      axios: 0.25.0_debug@4.3.4
+      axios: 0.25.0
       bignumber.js: 9.0.2
       canvas-confetti: 1.5.1
       chart.js: 2.9.4
@@ -7116,8 +7116,6 @@ packages:
       '@cosmjs/utils': 0.24.1
       axios: 0.21.4
       fast-deep-equal: 3.1.3
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /@cosmjs/math/0.23.1:
@@ -7160,8 +7158,6 @@ packages:
       '@cosmjs/utils': 0.24.1
       long: 4.0.0
       protobufjs: 6.10.2
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /@cosmjs/proto-signing/0.25.6:
@@ -7228,7 +7224,6 @@ packages:
       protobufjs: 6.10.2
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - utf-8-validate
     dev: false
 
@@ -7249,7 +7244,6 @@ packages:
       xstream: 11.14.0
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - utf-8-validate
     dev: false
 
@@ -7280,7 +7274,6 @@ packages:
       xstream: 11.14.0
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - utf-8-validate
     dev: false
 
@@ -7299,7 +7292,6 @@ packages:
       xstream: 11.14.0
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - utf-8-validate
     dev: false
 
@@ -7364,7 +7356,6 @@ packages:
       snakecase-keys: 3.2.1
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - utf-8-validate
     dev: false
 
@@ -19839,55 +19830,29 @@ packages:
   /axios/0.21.1:
     resolution: {integrity: sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
+      follow-redirects: 1.15.0
 
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /axios/0.21.4_debug@4.3.2:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-    dependencies:
-      follow-redirects: 1.15.0_debug@4.3.2
-    transitivePeerDependencies:
-      - debug
+      follow-redirects: 1.15.0
     dev: false
 
   /axios/0.25.0:
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
-
-  /axios/0.25.0_debug@4.3.4:
-    resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
-    dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
-    dev: false
+      follow-redirects: 1.15.0
 
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
-    transitivePeerDependencies:
-      - debug
+      follow-redirects: 1.15.0
 
   /axios/0.27.2:
     resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
+      follow-redirects: 1.15.0
       form-data: 4.0.0
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /axobject-query/0.1.0:
@@ -22763,7 +22728,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
   /concat-stream/1.5.2:
     resolution: {integrity: sha1-cIl4Yk2FavQaWnQd790mHadSwmY=}
@@ -27544,7 +27509,6 @@ packages:
     transitivePeerDependencies:
       - bluebird
       - bufferutil
-      - debug
       - encoding
       - eslint
       - metro
@@ -28645,28 +28609,9 @@ packages:
       tabbable: 5.3.2
     dev: false
 
-  /follow-redirects/1.15.0_debug@4.3.2:
+  /follow-redirects/1.15.0:
     resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
     engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.2
-    dev: false
-
-  /follow-redirects/1.15.0_debug@4.3.4:
-    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
 
   /fontfaceobserver/2.1.0:
     resolution: {integrity: sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==}
@@ -30495,27 +30440,24 @@ packages:
       - supports-color
     dev: true
 
-  /http-proxy-middleware/0.19.1_tmpgdztspuwvsxzgjkhoqk7duq:
+  /http-proxy-middleware/0.19.1_supports-color@6.1.0:
     resolution: {integrity: sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==}
     engines: {node: '>=4.0.0'}
     dependencies:
-      http-proxy: 1.18.1_debug@4.3.4
+      http-proxy: 1.18.1
       is-glob: 4.0.3
       lodash: 4.17.21
       micromatch: 3.1.10_supports-color@6.1.0
     transitivePeerDependencies:
-      - debug
       - supports-color
 
-  /http-proxy/1.18.1_debug@4.3.4:
+  /http-proxy/1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0_debug@4.3.4
+      follow-redirects: 1.15.0
       requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
 
   /http-signature/1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
@@ -44517,7 +44459,7 @@ packages:
       execa: 5.1.1
       lazy-ass: 1.6.0
       ps-tree: 1.2.0
-      wait-on: 6.0.0_debug@4.3.2
+      wait-on: 6.0.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -44591,8 +44533,6 @@ packages:
       tslib: 1.14.1
       urijs: 1.19.11
       utility-types: 3.10.0
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /store/2.0.12:
@@ -48172,18 +48112,16 @@ packages:
       xml-name-validator: 3.0.0
     dev: true
 
-  /wait-on/6.0.0_debug@4.3.2:
+  /wait-on/6.0.0:
     resolution: {integrity: sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     dependencies:
-      axios: 0.21.4_debug@4.3.2
+      axios: 0.21.4
       joi: 17.6.0
       lodash: 4.17.21
       minimist: 1.2.6
       rxjs: 7.5.5
-    transitivePeerDependencies:
-      - debug
     dev: false
 
   /walk-back/4.0.0:
@@ -48653,7 +48591,7 @@ packages:
       del: 4.1.1
       express: 4.18.1_supports-color@6.1.0
       html-entities: 1.4.0
-      http-proxy-middleware: 0.19.1_tmpgdztspuwvsxzgjkhoqk7duq
+      http-proxy-middleware: 0.19.1_supports-color@6.1.0
       import-local: 2.0.0
       internal-ip: 4.3.0
       ip: 1.1.8
@@ -48702,7 +48640,7 @@ packages:
       del: 4.1.1
       express: 4.18.1_supports-color@6.1.0
       html-entities: 1.4.0
-      http-proxy-middleware: 0.19.1_tmpgdztspuwvsxzgjkhoqk7duq
+      http-proxy-middleware: 0.19.1_supports-color@6.1.0
       import-local: 2.0.0
       internal-ip: 4.3.0
       ip: 1.1.8
@@ -49790,7 +49728,6 @@ packages:
     transitivePeerDependencies:
       - bluebird
       - bufferutil
-      - debug
       - encoding
       - eslint
       - metro

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,13 +20,13 @@ importers:
       create-release-hash: workspace:*
       migrate-branch: workspace:*
       pnpm-utils: workspace:*
-      turbo: 1.2.17-canary.0
+      turbo: 1.3.1
     devDependencies:
       '@changesets/cli': 2.23.0
       create-release-hash: link:tools/create-release-hash
       migrate-branch: link:tools/migrate-branch
       pnpm-utils: link:tools/pnpm-utils
-      turbo: 1.2.17-canary.0
+      turbo: 1.3.1
 
   apps/cli:
     specifiers:
@@ -46435,137 +46435,137 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  /turbo-android-arm64/1.2.17-canary.0:
-    resolution: {integrity: sha512-rp+ykBbW4GApeBDh3sjz5CqBlH7K3uZi+bkC0dqRF9abngGurZhGPoXEISiqCtR8KwyrvDoGOhAue8IR/icA8g==}
+  /turbo-android-arm64/1.3.1:
+    resolution: {integrity: sha512-JcnZh9tLbZDpKaXaao/s/k4qXt3TbNEc1xEYYXurVWnqiMueGeS7QAtThVB85ZSqzj7djk+ngSrZabPy5RG25Q==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-64/1.2.17-canary.0:
-    resolution: {integrity: sha512-KKF8Yr0d48dfrL+KB3ye1Yv6ebem4i2VouVm/J64ln/WoPYJ17jTzC9muan7QWzY4nktW0aIM4ZoMoHbyNB5UQ==}
+  /turbo-darwin-64/1.3.1:
+    resolution: {integrity: sha512-TIGDradVFoGck86VIuM38KaDeNxdKaP2ti93UpQeFw26ZhPIeTAa6wUgnz4DQP6bjIvQmXlYJ16ETZb4tFYygg==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.2.17-canary.0:
-    resolution: {integrity: sha512-2R8+gioDzElxXyP+7VqzlXwCeKVfq91xnS1Wa4gjgw0ozgeRnit4Re0nRSGdFh99LFGZAUMeRcgXMUEwrjuYMg==}
+  /turbo-darwin-arm64/1.3.1:
+    resolution: {integrity: sha512-aLBq8KiMMmop7uKBkvDt/y+eER2UzxZyUzh1KWcZ7DZB5tFZnknEUyf2qggY2vd2WcDVfQ1EUjZ0MFxhhVaVzA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-64/1.2.17-canary.0:
-    resolution: {integrity: sha512-yaOQWGvSH6+Lm3feHnwXWzytViAH9Fpgfj/WHwqUdNZ4YQ9HVp/hvPG4SuIIDuiT4UY5HNtqpuRKqE4wk5HUNw==}
+  /turbo-freebsd-64/1.3.1:
+    resolution: {integrity: sha512-BOr/ifmxjlBeuDkDQLUJtzqzXQ2zPHHcI14U9Ys+z4Mza1uzQn/oSJqQvU5RuyRBVai7noMrpPS7QuKtDz0Cyg==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-arm64/1.2.17-canary.0:
-    resolution: {integrity: sha512-Q8jqhGPfUSZeXy3cQ2mDFyrbiFVPadtKJ1kBjCx12m61ypVyvpV+QFFykcwoLd675052/G3tW3wheqUnKBoqZg==}
+  /turbo-freebsd-arm64/1.3.1:
+    resolution: {integrity: sha512-bHPZjK4xnGLz6/oxl5XmWhdYOdtBMSadrGhptWSZ0wBGNn/gQzDTeZAkQeqhh25AD0eM1hzDe8QUz8GlS43lrA==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-32/1.2.17-canary.0:
-    resolution: {integrity: sha512-qLDMnSjonYjiL/l9bu2iuxanSSOZxZ1ejg80+7IV/6nDoTw9EsPUlv+vk+ymFMZp7cOysXybaj/HC0aM+APlzw==}
+  /turbo-linux-32/1.3.1:
+    resolution: {integrity: sha512-c5okimusfvivu9wS8MKSr+rXpQAV+M4TyR9JX+spIK8B1I7AjfECAqiK2D5WFWO1bQ33bUAuxXOEpUuLpgEm+g==}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.2.17-canary.0:
-    resolution: {integrity: sha512-mSA48TohylsLRqddBFHT03dDQlApekmhKK7pDYoeoCTi+eqNUKOzq9DS4IWclH8nY2TgwSYrzPVchuf45GGGxQ==}
+  /turbo-linux-64/1.3.1:
+    resolution: {integrity: sha512-O0pNX+N5gbmRcyZT+jsCPUNCN3DpIZHqNN35j7MT5nr0IkZa83CGbZnrEc+7Qws//jFJ26EngqD/JyRB2E8nwQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm/1.2.17-canary.0:
-    resolution: {integrity: sha512-B41W3K6qf/V8W3RSzsumd8K0WKrUUfx/WDkf/Oemmk/6YRlg/amU1ppxqS6ZO7C0CR4rxYf5kGvhVVimmQjRcQ==}
+  /turbo-linux-arm/1.3.1:
+    resolution: {integrity: sha512-f+r6JIwv/7ylxxJtgVi8cVw+6oNoD/r1IMTU6ejH8bfyMZZko4kkNwH9VYribQ44KDkJEgzdltnzFG5f6Hz10g==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.2.17-canary.0:
-    resolution: {integrity: sha512-b+qi89glTMsDGsXOAe6Hhv2DwlrgoMebc1Lbv2BrDhSOZf1rcV/Ca0KpQ1aFMnqefLSTnLe5eUDbbyFDrPqeug==}
+  /turbo-linux-arm64/1.3.1:
+    resolution: {integrity: sha512-D6+1MeS/x+/VCCooHPU4NIpB8qI/eW70eMRA79bqTPaxxluP0g2CaxXgucco05P51YtNsSxeVcH7X76iadON6Q==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-mips64le/1.2.17-canary.0:
-    resolution: {integrity: sha512-s8zmzBPkJHqdtY/q75lcOqGyxQhw/Z0LfDsXHqHEGj/UHYItqfKHkfMG7l4iC/Gs8p/pWb8b8taJi+zNhsYaFQ==}
+  /turbo-linux-mips64le/1.3.1:
+    resolution: {integrity: sha512-yL64jgwVCziOpBcdpMxIsczkgwwOvmaqKObFKWyCNlk/LOl5NKODLwXEaryLaALtpwUAoS4ltMSI64gKqmLrOA==}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-ppc64le/1.2.17-canary.0:
-    resolution: {integrity: sha512-45Ry30rleAwTCum9Ro2pkFegkwmZVJSce6VXYCPWDwKoFn8hXkcDcRm3a0KxmbNNayHFLwoDikszwY5/57tZWQ==}
+  /turbo-linux-ppc64le/1.3.1:
+    resolution: {integrity: sha512-tjnM+8RosykS1lBpOPLDXGOz/Po2h796ty17uBd7IFslWPOI16a/akFOFoLH8PCiGGJMe3CYgRhEKn4sPWNxFA==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-32/1.2.17-canary.0:
-    resolution: {integrity: sha512-d+WB/DZNJjWb5ZiDDX7M2JJBPH6Ef46LDgOa3+8t4LMwTfxALYDCToMPHCp6PzYztBJCgW/rHJmBBJMGKjZ3ag==}
+  /turbo-windows-32/1.3.1:
+    resolution: {integrity: sha512-Snnv+TVigulqwK6guHKndMlrLw88NXj8BtHRGrEksPR0QkyuHlwLf+tHYB4HmvpUl4W9lnXQf4hsljWP64BEdw==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.2.17-canary.0:
-    resolution: {integrity: sha512-n3v/F0GlMkKwcWzGtXbLV0KPmjkDFEbDEZhyFssfP8jLckO27LIY6Vr3MhJPSRcym4pdh6l9UQeFnXczs6KVrw==}
+  /turbo-windows-64/1.3.1:
+    resolution: {integrity: sha512-gLeohHG07yIhON1Pp0YNE00i/yzip2GFhkA6HdJaK95uE5bKULpqxuO414hOS/WzGwrGVXBKCImfe24XXh5T+Q==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.2.17-canary.0:
-    resolution: {integrity: sha512-pdk4RPLMxkcEHBE4QTGp5fm/Xt2UtPaU+eVGRon80o/cB4kxy+NnAqPMPWBm5sfmAgeGCz/0x/gLUPrNc97Syw==}
+  /turbo-windows-arm64/1.3.1:
+    resolution: {integrity: sha512-0MWcHLvYgs/qdcoTFZ55nu8HhrpeiwXEMw9cbNfgqTlzy3OsrAsovYEJFyQ8KSxeploiD+QJlCdvhxx+5C0tlA==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.2.17-canary.0:
-    resolution: {integrity: sha512-0a21s0qeeFlyXXkt2QTXbc401RK46veHyvHAPDvT2cjvJWLJyHCAK3hH+/XIIeyufW5b77dZPP3KQs6IviJLsA==}
+  /turbo/1.3.1:
+    resolution: {integrity: sha512-DXckoGKlZgvTn/PrHpBI/57aeXR7tfyPf2dK+4LmBczt24ELA3o6eYHeA7KzfpSYhB2LE9qveYFQ6mJ1OzGjjg==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-android-arm64: 1.2.17-canary.0
-      turbo-darwin-64: 1.2.17-canary.0
-      turbo-darwin-arm64: 1.2.17-canary.0
-      turbo-freebsd-64: 1.2.17-canary.0
-      turbo-freebsd-arm64: 1.2.17-canary.0
-      turbo-linux-32: 1.2.17-canary.0
-      turbo-linux-64: 1.2.17-canary.0
-      turbo-linux-arm: 1.2.17-canary.0
-      turbo-linux-arm64: 1.2.17-canary.0
-      turbo-linux-mips64le: 1.2.17-canary.0
-      turbo-linux-ppc64le: 1.2.17-canary.0
-      turbo-windows-32: 1.2.17-canary.0
-      turbo-windows-64: 1.2.17-canary.0
-      turbo-windows-arm64: 1.2.17-canary.0
+      turbo-android-arm64: 1.3.1
+      turbo-darwin-64: 1.3.1
+      turbo-darwin-arm64: 1.3.1
+      turbo-freebsd-64: 1.3.1
+      turbo-freebsd-arm64: 1.3.1
+      turbo-linux-32: 1.3.1
+      turbo-linux-64: 1.3.1
+      turbo-linux-arm: 1.3.1
+      turbo-linux-arm64: 1.3.1
+      turbo-linux-mips64le: 1.3.1
+      turbo-linux-ppc64le: 1.3.1
+      turbo-windows-32: 1.3.1
+      turbo-windows-64: 1.3.1
+      turbo-windows-arm64: 1.3.1
     dev: true
 
   /turndown/7.0.0:

--- a/tools/pnpm-utils/index.js
+++ b/tools/pnpm-utils/index.js
@@ -92,7 +92,16 @@ function removeDependencies(
           );
           delete pkg[kind][dependency];
         }
-        if (pkg.peerDependenciesMeta && kind === "peerDependencies") {
+        if (
+          pkg.peerDependenciesMeta &&
+          kind === "peerDependencies" &&
+          pkg.peerDependenciesMeta[dependency]
+        ) {
+          console.log(
+            `${bold("[-]", 31)} ${field(dependency)} | ${field(
+              key
+            )} (peerDependenciesMeta)`
+          );
           delete pkg.peerDependenciesMeta[dependency];
         }
       });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### This PR attempts to fix the consistency issues with the pnpm lockfile.

`pnpm-lock.yaml` has been inconsistent for a while, and needed 2 passes of `pnpm i` to attain its final shape.
This is likely to be caused by `debug` being an optional peer dep of `follow-redirects`.

**Update:** There are still some checksum algorithm diffs from time to time (`concat-map` integrity is sometimes using `sha1`, other times `sha512`)… After investigating a bit is seems like this is unavoidable.

- Side effect: upgrades turborepo to 1.3.1

### ❓ Context

- **Impacted projects**: `ledger-live`
- **Linked resource(s)**: `N/A`

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
