### PR TITLE
Rounding the main value of AccountGraph when using counterValue

### DIFF
--- a/.changeset/fuzzy-lemons-breathe.md
+++ b/.changeset/fuzzy-lemons-breathe.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+AccountGraphCard : Add rounding when using counter value (to prevent too many decimals in crypto-value)

--- a/apps/ledger-live-mobile/src/components/AccountGraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/AccountGraphCard.tsx
@@ -252,7 +252,10 @@ const GraphCardHeader = ({
             numberOfLines={1}
             adjustsFontSizeToFit
           >
-            <CurrencyUnitValue {...items[0]} disableRounding />
+            <CurrencyUnitValue
+              disableRounding={shouldUseCounterValue}
+              {...items[0]}
+            />
           </Text>
           <Flex flexDirection="row" alignItems="center">
             <Delta percent valueChange={valueChange} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In account/AccountGraph, when switching to crypto as a main value, the crypto amount had too many decimals with specific cryptos (BTC, ETH...).
Rounding was disabled on that field. Enabling it only if we are in counterValue mode (aka when we use crypto as main value). Not enabling it all the time to prevent re-rounding the other value.

### ❓ Context

- **Impacted projects**: `LLM`
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-2271

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/39890664/174752512-43afea38-9aea-4f4f-9baa-0a85ab1fe53a.mp4

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
