### PR TITLE
LIVE-2730 - bugfix - LLM issue on webview reload crashes

### DIFF
--- a/.changeset/wise-bears-tease.md
+++ b/.changeset/wise-bears-tease.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/native-ui": patch
+"@ledgerhq/react-ui": patch
+"@ledgerhq/ui-shared": patch
+"@ledgerhq/icons-ui": patch
+---
+
+ui packages - release

--- a/.changeset/witty-dodos-drop.md
+++ b/.changeset/witty-dodos-drop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+bugfix - webview reload crash issue related to ui rendering layout shift bugs

--- a/apps/ledger-live-mobile/src/components/WebViewScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebViewScreen/index.tsx
@@ -88,11 +88,10 @@ const WebViewScreen = ({
     <SafeContainer>
       {renderHeader && renderHeader()}
       {trackEventName && <Track onMount event={trackEventName} />}
+
       <Flex flex={1}>
         {hasNetwork ? (
           <>
-            {loading &&
-              (renderLoading ? renderLoading() : defaultRenderLoading())}
             <StyledWebview
               ref={ref}
               source={{ uri }}
@@ -106,6 +105,18 @@ const WebViewScreen = ({
                 setCanGoBack(!navState.canGoBack);
               }}
             />
+            {loading ? (
+              <Flex
+                position="absolute"
+                width="100%"
+                height="100%"
+                top={0}
+                left={0}
+                bg="background.main"
+              >
+                {renderLoading ? renderLoading() : defaultRenderLoading()}
+              </Flex>
+            ) : null}
           </>
         ) : renderError ? (
           renderError()


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Bug issue when reloading webviews in LLM. the root cause was due to the native library not handling the layout shift correctly and messing up the rendering thus crashing.
We can fix that by not shift the layout of loading states but use a layered approach instead_

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2730] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2730]: https://ledgerhq.atlassian.net/browse/LIVE-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ