### PR TITLE
Fix opening external windows from a webview

### DIFF
--- a/.changeset/fair-seals-switch.md
+++ b/.changeset/fair-seals-switch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix regression when opening external windows from within a webview tag

--- a/apps/ledger-live-desktop/src/main/window-lifecycle.js
+++ b/apps/ledger-live-desktop/src/main/window-lifecycle.js
@@ -59,6 +59,8 @@ const defaultWindowOptions = {
     nodeIntegration: true,
     contextIsolation: false,
     spellcheck: false,
+    // Legacy - allows listening to the "new-window" even in webviews.
+    nativeWindowOpen: false,
   },
 };
 

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.js
@@ -495,6 +495,9 @@ const WebPlatformPlayer = ({ manifest, onClose, inputs, config }: Props) => {
     const webview = targetRef.current;
 
     if (webview) {
+      // For mysterious reasons, the webpreferences attribute does not
+      // pass through the styled component when added in the JSX.
+      webview.webpreferences = "nativeWindowOpen=no";
       webview.addEventListener("new-window", handleNewWindow);
       webview.addEventListener("did-finish-load", handleLoad);
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### Restore the ability to open external windows from a `<webview />` with the same API.

This bug was caused by a "kinda undocumented" electron 15 breaking change which impacted webviews indirectly.
`nativeWindowOpen` has been made `true` by default with electron 15, this PR restores the previous behaviour.

_Note:  both webviews and the api we use are marked as deprected by Chrome and Electron. It might be a good time to rewrite._

See:
- https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-150
- https://github.com/electron/electron/issues/31117
- https://github.com/electron/electron/issues/34678

### ❓ Context

- **Impacted projects**: `live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `N/A` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/3428394/174999359-465986ba-8947-4c18-8f53-a87ceeb87a74.mov

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
