### PR TITLE
[LIVE-2728][LIVE-2729] Bugfix - Fix usage of process.env instead of getEnv

### DIFF
--- a/.changeset/twelve-paws-whisper.md
+++ b/.changeset/twelve-paws-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix experimental EIP712 variable not working correctly

--- a/libs/ledger-live-common/src/families/ethereum/hw-signMessage.ts
+++ b/libs/ledger-live-common/src/families/ethereum/hw-signMessage.ts
@@ -2,6 +2,7 @@ import Eth from "@ledgerhq/hw-app-eth";
 import Transport from "@ledgerhq/hw-transport";
 import { TypedDataUtils } from "eth-sig-util";
 import { bufferToHex } from "ethereumjs-util";
+import { getEnv } from "../../env";
 import type { MessageData, Result } from "../../hw/signMessage/types";
 import type { TypedMessageData, TypedMessage } from "./types";
 type EthResolver = (
@@ -36,7 +37,7 @@ const resolver: EthResolver = async (
   if (typeof message === "string") {
     result = await eth.signPersonalMessage(path, rawMessage.slice(2));
   } else {
-    if (process.env.EXPERIMENTAL_EIP712) {
+    if (getEnv("EXPERIMENTAL_EIP712")) {
       result = await eth.signEIP712Message(path, message);
     } else {
       result = await eth.signEIP712HashedMessage(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR fixes the usage of process.env that parses everything as a string, which made the environment variable `EXPERIMENTAL_EIP712` always true. 

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-2729` `https://ledgerhq.atlassian.net/browse/LIVE-2728` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Before

https://user-images.githubusercontent.com/44363395/175046843-f6a45e2c-2ebe-44a8-8776-00bec1d3a941.mov

After

https://user-images.githubusercontent.com/44363395/175046882-483ae5ae-a0d7-41be-af34-89363062e0ab.mov



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
