### PR TITLE
Bugfix - LIVE-2741 - Fix hasOrderedNano state with Buy Nano screen

### DIFF
--- a/apps/ledger-live-mobile/src/components/ReadOnlyFabActions.tsx
+++ b/apps/ledger-live-mobile/src/components/ReadOnlyFabActions.tsx
@@ -5,7 +5,7 @@ import { useNavigation } from "@react-navigation/native";
 
 import Button from "./wrappedUi/Button";
 
-import { NavigatorName } from "../const";
+import { ScreenName } from "../const";
 
 const iconBuy = Icons.PlusMedium;
 const iconReceive = Icons.ArrowBottomMedium;
@@ -15,7 +15,7 @@ function ReadOnlyFabActions() {
   const { navigate } = useNavigation();
 
   const handleOnPress = useCallback(() => {
-    navigate(NavigatorName.BuyDevice);
+    navigate(ScreenName.NoDeviceWallScreen);
   }, [navigate]);
 
   return (

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -110,6 +110,10 @@ export default function BaseNavigator() {
           headerShown: false,
           cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
         }}
+      />
+      <Stack.Screen
+        name={ScreenName.NoDeviceWallScreen}
+        component={PostBuyDeviceSetupNanoWallScreen}
         {...noNanoBuyNanoWallScreenOptions}
       />
       <Stack.Screen
@@ -136,6 +140,7 @@ export default function BaseNavigator() {
         options={{
           title: t("postBuyDevice.headerTitle"),
           headerLeft: null,
+          headerRight: null,
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/const/navigation.js
+++ b/apps/ledger-live-mobile/src/const/navigation.js
@@ -355,6 +355,8 @@ export const ScreenName = {
   PostBuyDeviceScreen: "PostBuyDeviceScreen",
   PostBuyDeviceSetupNanoWallScreen: "PostBuyDeviceSetupNanoWallScreen",
 
+  NoDeviceWallScreen: "NoDeviceWallScreen",
+
   DiscoverScreen: "DiscoverScreen",
   Learn: "Learn",
 

--- a/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.tsx
+++ b/apps/ledger-live-mobile/src/context/NoNanoBuyNanoWall.tsx
@@ -31,7 +31,7 @@ export const useNoNanoBuyNanoWallScreenOptions = () => {
         headerRight: null,
         headerBackTitleVisible: false,
         title: null,
-        cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+        cardStyleInterpolator: CardStyleInterpolators.forFadeFromBottomAndroid,
       },
     };
   }

--- a/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccountHeaderRight.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccountHeaderRight.tsx
@@ -4,13 +4,13 @@ import { FiltersMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useNavigation } from "@react-navigation/native";
 
 import Touchable from "../../../components/Touchable";
-import { NavigatorName } from "../../../const";
+import { ScreenName } from "../../../const";
 
 export default function AccountHeaderRight() {
   const { navigate } = useNavigation();
 
   const handleOnPress = useCallback(() => {
-    navigate(NavigatorName.BuyDevice);
+    navigate(ScreenName.NoDeviceWallScreen);
   }, [navigate]);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/Accounts/AccountsNavigationHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/AccountsNavigationHeader.tsx
@@ -5,7 +5,7 @@ import { Box, Flex, Icons, Text } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import Touchable from "../../components/Touchable";
-import { NavigatorName } from "../../const";
+import { ScreenName } from "../../const";
 
 type Props = {
   readOnly?: boolean;
@@ -16,7 +16,7 @@ function AccountsNavigationHeader({ readOnly }: Props) {
   const { t } = useTranslation();
 
   const handleOnReadOnlyAddAccountPress = useCallback(() => {
-    navigation.navigate(NavigatorName.BuyDevice);
+    navigation.navigate(ScreenName.NoDeviceWallScreen);
   }, [navigation]);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/PostBuyDeviceScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostBuyDeviceScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Flex, Icons, Text, Box } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -6,6 +6,8 @@ import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import Button from "../components/wrappedUi/Button";
 import { NavigatorName } from "../const";
+import { setHasOrderedNano } from "../actions/settings";
+import { useDispatch } from "react-redux";
 
 const StyledSafeAreaView = styled(SafeAreaView)`
   flex: 1;
@@ -14,6 +16,7 @@ const StyledSafeAreaView = styled(SafeAreaView)`
 
 export default function PostBuyDeviceScreen() {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const navigation = useNavigation();
 
   const onClose = useCallback(() => {
@@ -21,6 +24,10 @@ export default function PostBuyDeviceScreen() {
       screen: NavigatorName.Main,
     });
   }, [navigation]);
+
+  useEffect(() => {
+    dispatch(setHasOrderedNano(true));
+  }, []);
 
   return (
     <StyledSafeAreaView>

--- a/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
@@ -15,11 +15,7 @@ import { PurchaseMessage } from "./types";
 import DebugMessageDrawer from "./DebugMessageDrawer";
 import WebViewScreen from "../../components/WebViewScreen";
 import { NavigatorName, ScreenName } from "../../const";
-import {
-  completeOnboarding,
-  setHasOrderedNano,
-  setReadOnlyMode,
-} from "../../actions/settings";
+import { completeOnboarding, setReadOnlyMode } from "../../actions/settings";
 import { urls } from "../../config/urls";
 
 const defaultURL = urls.buyNanoX;
@@ -80,7 +76,6 @@ const PurchaseDevice = () => {
       if (data.type === "ledgerLiveOrderSuccess") {
         dispatch(setReadOnlyMode(true));
         dispatch(completeOnboarding());
-        dispatch(setHasOrderedNano(true));
       }
     },
     [dispatch],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Delay set hasOrderedNano = true to the post buy device screen (called buy the deeplink called by the "Return to Ledger Live" on the e-commerce completed order summary)

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-2741

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/89014981/175330741-1dff745e-4602-4320-84da-9b62264622c1.mp4




### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
