### PR TITLE
Better icons-ui subpath exports compatibility

### DIFF
--- a/.changeset/hungry-queens-beg.md
+++ b/.changeset/hungry-queens-beg.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/icons-ui": patch
+---
+
+Enhance subpath exports to improve node17+ and jest compatibilty.

--- a/libs/ui/packages/icons/package.json
+++ b/libs/ui/packages/icons/package.json
@@ -9,15 +9,20 @@
     "index.js"
   ],
   "exports": {
-    "./react": {
-      "require": "./react/cjs/index.js",
-      "default": "./react/index.js"
-    },
     "./react/": {
       "require": "./react/cjs/",
       "default": "./react/"
     },
+    "./react/*": {
+      "require": "./react/cjs/*.js",
+      "default": "./react/*.js"
+    },
+    "./react": {
+      "require": "./react/cjs/index.js",
+      "default": "./react/index.js"
+    },
     "./native/": "./native/",
+    "./native/*": "./native/*.js",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Added the "star" kind of [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) to `@ledgerhq/icons-ui`. (`/path/*`)

The `/trailing-slash/` way of writing [subpath exports](https://nodejs.org/api/packages.html#subpath-exports) is deprecated and will not be supported in nodejs 17+. 

`jest-resolve` also has issues with the syntax, which impacts some of our external devs:
- https://github.com/LedgerHQ/buy-sell-live-app/pull/83

### ❓ Context

- **Impacted projects**: `@ledgerhq/icons-ui` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `N/A` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
