### PR TITLE
Simplify sentry logic and replace home paths into "." in sentry report

### DIFF
--- a/apps/ledger-live-desktop/src/logger/anonymizer.js
+++ b/apps/ledger-live-desktop/src/logger/anonymizer.js
@@ -1,8 +1,6 @@
 // @flow
 
 const configDir = (() => {
-  const { STORYBOOK_ENV } = process.env;
-  if (!STORYBOOK_ENV) return "__NOTHING_TO_REPLACE__";
   const { LEDGER_CONFIG_DIRECTORY } = process.env;
   if (LEDGER_CONFIG_DIRECTORY) return LEDGER_CONFIG_DIRECTORY;
   // $FlowFixMe
@@ -10,12 +8,18 @@ const configDir = (() => {
   return electron.app.getPath("userData") || "__NOTHING_TO_REPLACE__";
 })();
 
-const cwd = typeof process === "object" ? process.cwd() || "." : "__NOTHING_TO_REPLACE__";
+const homeDir = (() => {
+  const { HOME_DIRECTORY } = process.env;
+  if (HOME_DIRECTORY) return HOME_DIRECTORY;
+  // $FlowFixMe
+  const electron = process.type === "browser" ? require("electron") : require("@electron/remote");
+  return electron.app.getPath("home") || "__NOTHING_TO_REPLACE__";
+})();
 
 // all the paths the app will use. we replace them to anonymize
 const basePaths = {
   $USER_DATA: configDir,
-  ".": cwd,
+  ".": homeDir,
 };
 
 function filepathReplace(path: string) {
@@ -68,15 +72,6 @@ function filepathRecursiveReplacer(obj: mixed, seen: Array<*>) {
 }
 
 export default {
-  url: (url: ?string): ?string =>
-    url &&
-    url
-      .replace(/\/addresses\/[^/]+/g, "/addresses/<HIDDEN>")
-      .replace(/blockHash=[^&]+/g, "blockHash=<HIDDEN>"),
-
-  appURI: (uri: ?string): ?string => uri && uri.replace(/account\/[^/]+/g, "account/<HIDDEN>"),
-
   filepath: filepathReplace,
-
   filepathRecursiveReplacer: (obj: mixed) => filepathRecursiveReplacer(obj, []),
 };

--- a/apps/ledger-live-desktop/src/logger/logger.js
+++ b/apps/ledger-live-desktop/src/logger/logger.js
@@ -1,7 +1,6 @@
 // @flow
 import winston from "winston";
 import Transport from "winston-transport";
-import anonymizer from "./anonymizer";
 import pname from "./pname";
 
 const { format } = winston;
@@ -265,18 +264,10 @@ export default {
     status: number,
     responseTime: number,
   }) => {
-    const anonymURL = anonymizer.url(url);
-
     const log = `✔📡  HTTP ${status} ${method} ${url} – finished in ${responseTime.toFixed(0)}ms`;
     if (logNetwork) {
       logger.log("info", log, { type: "network-response" });
     }
-    captureBreadcrumb({
-      level: "debug",
-      category: "network",
-      message: "network success",
-      data: { url: anonymURL, status, method, responseTime },
-    });
   },
 
   networkError: ({
@@ -293,7 +284,6 @@ export default {
     error: string,
     responseTime: number,
   }) => {
-    const anonymURL = anonymizer.url(url);
     const log = `✖📡  HTTP ${status} ${method} ${url} – ${error} – failed after ${responseTime.toFixed(
       0,
     )}ms`;
@@ -301,12 +291,6 @@ export default {
       // $FlowFixMe
       logger.log("info", log, { type: "network-error", status, method, ...rest });
     }
-    captureBreadcrumb({
-      level: "debug",
-      category: "network",
-      message: "network error",
-      data: { url: anonymURL, status, method, responseTime },
-    });
   },
 
   networkDown: ({
@@ -322,11 +306,6 @@ export default {
     if (logNetwork) {
       logger.log("info", log, { type: "network-down" });
     }
-    captureBreadcrumb({
-      level: "error",
-      category: "network",
-      message: "network down",
-    });
   },
 
   analyticsStart: (id: string, props: Object) => {

--- a/apps/ledger-live-desktop/src/main/internal-lifecycle.js
+++ b/apps/ledger-live-desktop/src/main/internal-lifecycle.js
@@ -14,6 +14,7 @@ const hydratedPerCurrency = {};
 // ~~~
 
 const LEDGER_CONFIG_DIRECTORY = app.getPath("userData");
+const HOME_DIRECTORY = app.getPath("home");
 
 const internal = new InternalProcess({ timeout: 3000 });
 
@@ -35,6 +36,7 @@ const spawnCoreProcess = () => {
     ...process.env,
     IS_INTERNAL_PROCESS: 1,
     LEDGER_CONFIG_DIRECTORY,
+    HOME_DIRECTORY,
     INITIAL_SENTRY_ENABLED: String(!!sentryEnabled),
     SENTRY_USER_ID: userId,
   };

--- a/apps/ledger-live-desktop/src/sentry/install.js
+++ b/apps/ledger-live-desktop/src/sentry/install.js
@@ -54,21 +54,12 @@ export function init(Sentry: any) {
     beforeSend(data: any, hint: any) {
       if (__DEV__) console.log("before-send", { data, hint });
       if (!shouldSendCallback()) return null;
-
       if (typeof data !== "object" || !data) return data;
-
       // $FlowFixMe
       delete data.server_name; // hides the user machine name
-
-      if (typeof data.request === "object" && data.request) {
-        const { request } = data;
-        if (typeof request.url === "string") {
-          // $FlowFixMe not sure why
-          request.url = anonymizer.appURI(request.url);
-        }
-      }
-
       anonymizer.filepathRecursiveReplacer(data);
+
+      console.log("SENTRY REPORT", data);
       return data;
     },
 


### PR DESCRIPTION
### 📝 Description

- the $HOME of user is used instead of $PWD to anonymize the Sentry report of LLD and replace it with a "."
- remove the tracking of http in Sentry LLD because it's not useful enough to investigate problems (it can come back again in future) and remove the associated need to anonymize it.
- adding a console.log to always see when a Sentry report is sent, to help debugging this.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** Sentry integration can only be test manually at the time <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

to reproduce, I have used the same method as in #275 and I have run the app from `/` folder.

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
