### PR TITLE
use our own runners on macos for LLD build

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -209,7 +209,7 @@ jobs:
 
   build-desktop-app-macos:
     name: "Build Ledger Live Desktop (Mac OS X)"
-    runs-on: macos-latest
+    runs-on: [ledger-live, macos]
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:
@@ -244,8 +244,6 @@ jobs:
           os: mac
 
       - name: build the app
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: false
         run: |
           eval "$(rbenv init - bash)"
           pnpm build:lld --api="http://127.0.0.1:9080" --token="yolo" --team="foo"


### PR DESCRIPTION
### 📝 Description

Now that we can have 6 parallel jobs on our MacOS runner, let's resume first the LLD builds and monitor how is the queue handled by the workload of the PRs

### ❓ Context

- **Impacted projects**: `automation` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
