### PR TITLE
Fixes 'concurrency' of test-integration

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -16,7 +16,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}-${{ github.env.inputs.filter || "" }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The concurrency make sure it allows to let parallel runs to happen and not be cancelled into each other, as the goal of test-integration is to be run in parallel "on demand". e.g. running stellar tests on stellar PR and at same time running ethereum tests on another PR.

### ❓ Context

- **Impacted projects**: `none` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

showscase of the problem:

![Screenshot 2022-06-24 at 19 01 57](https://user-images.githubusercontent.com/211411/175608914-7d9afad0-a5c3-467f-ae0a-78ca39be8485.png)



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
