### PR TITLE
LIVE-2767 LLC - Countervalues API method change

### DIFF
--- a/.changeset/afraid-poets-trade.md
+++ b/.changeset/afraid-poets-trade.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+LLC - Countervalues API - updated pairs method to use new GET format

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -57,6 +57,7 @@ jobs:
         shell: bash
         env:
           FILTER: ${{ github.event.inputs.filter }}
+          VERBOSE_FILE: logs.txt
         run: |
           pnpm common ci-test-integration $FILTER
           git diff --exit-code libs/ledger-live-common/src
@@ -67,3 +68,9 @@ jobs:
           name: ${{ format('live-common-src-{0}', matrix.os) }}
           path: |
             libs/ledger-live-common/src
+      - name: (On Failure) Upload logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: logs.txt
+          path: logs.txt

--- a/libs/ledger-live-common/src/countervalues/api/api.ts
+++ b/libs/ledger-live-common/src/countervalues/api/api.ts
@@ -8,12 +8,14 @@ const baseURL = () => getEnv("LEDGER_COUNTERVALUES_API");
 
 const latest = async (pairs: TrackingPair[], direct?: boolean) => {
   const { data } = await network({
-    method: "POST",
-    url: `${baseURL()}/latest${direct ? "?method=direct" : ""}`,
-    data: pairs.map((p) => ({
-      from: p.from.countervalueTicker ?? p.from.ticker,
-      to: p.to.countervalueTicker ?? p.to.ticker,
-    })),
+    method: "GET",
+    url: `${baseURL()}/latest${direct ? "/direct" : "/indirect"}?pairs=${pairs
+      .map(
+        (p) =>
+          `${p.from.countervalueTicker ?? p.from.ticker}:${p.to.countervalueTicker ?? p.to.ticker
+          }`
+      )
+      .join(",")}`,
   });
   return data;
 };

--- a/libs/ledger-live-common/src/countervalues/api/api.ts
+++ b/libs/ledger-live-common/src/countervalues/api/api.ts
@@ -12,7 +12,8 @@ const latest = async (pairs: TrackingPair[], direct?: boolean) => {
     url: `${baseURL()}/latest${direct ? "/direct" : "/indirect"}?pairs=${pairs
       .map(
         (p) =>
-          `${p.from.countervalueTicker ?? p.from.ticker}:${p.to.countervalueTicker ?? p.to.ticker
+          `${p.from.countervalueTicker ?? p.from.ticker}:${
+            p.to.countervalueTicker ?? p.to.ticker
           }`
       )
       .join(",")}`,

--- a/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
@@ -83,6 +83,18 @@ describe("extreme cases", () => {
       })),
       autofillGaps: true,
     });
-    expect(state).not.toBe(initialState);
+
+    const currenciesWithCVs = currencies
+      .map((from) =>
+        calculate(state, {
+          date: new Date(),
+          from,
+          to: usd,
+          value: 1000000,
+        })
+      )
+      .filter((v) => v && v > 0);
+
+    expect(currenciesWithCVs.length).toBeGreaterThan(0);
   });
 });

--- a/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
@@ -25,6 +25,7 @@ describe("API sanity", () => {
         },
       ],
       autofillGaps: false,
+      disableAutoRecoverErrors: true,
     });
 
     for (let i = 0; i < 7; i++) {
@@ -48,6 +49,7 @@ describe("API sanity", () => {
         },
       ],
       autofillGaps: true,
+      disableAutoRecoverErrors: true,
     });
     const currentValue = calculate(state, {
       disableRounding: true,
@@ -82,6 +84,7 @@ describe("extreme cases", () => {
         startDate: new Date(),
       })),
       autofillGaps: true,
+      disableAutoRecoverErrors: true,
     });
 
     const currenciesWithCVs = currencies

--- a/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
@@ -72,7 +72,7 @@ describe("API sanity", () => {
 });
 
 describe("extreme cases", () => {
-  test("all tickers against BTC", async () => {
+  test("all tickers against USD", async () => {
     const currencies = Object.keys(getBTCValues())
       .filter((t) => t !== "USD")
       .map(findCurrencyByTicker)
@@ -93,6 +93,35 @@ describe("extreme cases", () => {
           date: new Date(),
           from,
           to: usd,
+          value: 1000000,
+        })
+      )
+      .filter((v) => v && v > 0);
+
+    expect(currenciesWithCVs.length).toBeGreaterThan(0);
+  });
+
+  test("all tickers against BTC", async () => {
+    const currencies = Object.keys(getBTCValues())
+      .filter((t) => t !== "BTC")
+      .map(findCurrencyByTicker)
+      .filter(Boolean) as Currency[];
+    const state = await loadCountervalues(initialState, {
+      trackingPairs: currencies.map((from) => ({
+        from,
+        to: bitcoin,
+        startDate: new Date(),
+      })),
+      autofillGaps: true,
+      disableAutoRecoverErrors: true,
+    });
+
+    const currenciesWithCVs = currencies
+      .map((from) =>
+        calculate(state, {
+          date: new Date(),
+          from,
+          to: bitcoin,
           value: 1000000,
         })
       )

--- a/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
@@ -1,5 +1,13 @@
+import "../__tests__/test-helpers/setup";
 import { initialState, loadCountervalues, calculate } from "./logic";
-import { getFiatCurrencyByTicker, getCryptoCurrencyById } from "../currencies";
+import {
+  getFiatCurrencyByTicker,
+  getCryptoCurrencyById,
+  findCurrencyByTicker,
+} from "../currencies";
+import { getBTCValues } from "../countervalues/mock";
+import { Currency } from "@ledgerhq/cryptoassets";
+
 const bitcoin = getCryptoCurrencyById("bitcoin");
 const usd = getFiatCurrencyByTicker("USD");
 const now = Date.now();
@@ -58,5 +66,23 @@ describe("API sanity", () => {
       });
       expect(value).not.toEqual(currentValue);
     }
+  });
+});
+
+describe("extreme cases", () => {
+  test("all tickers against BTC", async () => {
+    const currencies = Object.keys(getBTCValues())
+      .filter((t) => t !== "USD")
+      .map(findCurrencyByTicker)
+      .filter(Boolean) as Currency[];
+    const state = await loadCountervalues(initialState, {
+      trackingPairs: currencies.map((from) => ({
+        from,
+        to: usd,
+        startDate: new Date(),
+      })),
+      autofillGaps: true,
+    });
+    expect(state).not.toBe(initialState);
   });
 });

--- a/libs/ledger-live-common/src/countervalues/logic.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.ts
@@ -255,7 +255,7 @@ export async function loadCountervalues(
           return null;
         })
     ),
-    fetchLatest(latestToFetch)
+    fetchLatest(latestToFetch, settings.disableAutoRecoverErrors)
       .then((rates) => {
         const out = {};
         let hasData = false;

--- a/libs/ledger-live-common/src/countervalues/logic.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.ts
@@ -230,6 +230,7 @@ export async function loadCountervalues(
           };
         })
         .catch((e) => {
+          if (settings.disableAutoRecoverErrors) throw e;
           // TODO work on the semantic of failure.
           // do we want to opt-in for the 404 cases and make other fails it all?
           // do we want to be resilient on individual pulling / keep error somewhere?
@@ -271,6 +272,7 @@ export async function loadCountervalues(
         return out;
       })
       .catch((e) => {
+        if (settings.disableAutoRecoverErrors) throw e;
         log(
           "countervalues-error",
           "Failed to fetch latest for " +

--- a/libs/ledger-live-common/src/countervalues/modules/index.ts
+++ b/libs/ledger-live-common/src/countervalues/modules/index.ts
@@ -36,7 +36,8 @@ type CountervaluesJobs = {
 };
 
 export const fetchLatest = async (
-  pairs: TrackingPair[]
+  pairs: TrackingPair[],
+  disableAutoRecoverErrors?: boolean
 ): Promise<Array<number | null | undefined>> => {
   // a module can override as well. but as latest is a "one api" call,
   // we need to segment the pairs in diff modules
@@ -88,6 +89,7 @@ export const fetchLatest = async (
             }
           })
           .catch((e) => {
+            if (disableAutoRecoverErrors) throw e;
             log("error", "latest fetch issue: " + String(e));
           })
       )

--- a/libs/ledger-live-common/src/countervalues/types.ts
+++ b/libs/ledger-live-common/src/countervalues/types.ts
@@ -4,6 +4,8 @@ import type { Currency } from "../types";
 export type CountervaluesSettings = {
   trackingPairs: TrackingPair[];
   autofillGaps: boolean;
+  // throw exception in "loadCountervalues" if ANY error occurs (for test purpose)
+  disableAutoRecoverErrors?: boolean;
 };
 // This is the internal state of countervalues.
 export type CounterValuesState = {


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Updated LLC countervalues pair method from POST legacy format to GET format_

### ❓ Context

- **Impacted projects**: `ledger-live-common` affects -> `ledger-live-desktop`  `ledger-live-mobile`   <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2767] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->

To test:
check on LLD that theres no regression in countervalues shown and that the switch of countervalues is correct.
basically the goall is to have the same values before this update than after.

The impacted areas are all countervalues related to accounts imported by the nano (the market page is not impacted) 
you can check it on those sections but limited to:
- Portfolio page
- Operation details
- Accounts pages
- Send Flows countervalues
- Swap flows countervalues



[LIVE-2767]: https://ledgerhq.atlassian.net/browse/LIVE-2767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ