### PR TITLE
countervalues: Chunk batch the fetch of latest and improve tests

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -57,6 +57,7 @@ jobs:
         shell: bash
         env:
           FILTER: ${{ github.event.inputs.filter }}
+          VERBOSE_FILE: logs.txt
         run: |
           pnpm common ci-test-integration $FILTER
           git diff --exit-code libs/ledger-live-common/src
@@ -67,3 +68,9 @@ jobs:
           name: ${{ format('live-common-src-{0}', matrix.os) }}
           path: |
             libs/ledger-live-common/src
+      - name: (On Failure) Upload logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: logs.txt
+          path: logs.txt

--- a/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
@@ -25,6 +25,7 @@ describe("API sanity", () => {
         },
       ],
       autofillGaps: false,
+      disableAutoRecoverErrors: true,
     });
 
     for (let i = 0; i < 7; i++) {
@@ -48,6 +49,7 @@ describe("API sanity", () => {
         },
       ],
       autofillGaps: true,
+      disableAutoRecoverErrors: true,
     });
     const currentValue = calculate(state, {
       disableRounding: true,
@@ -82,6 +84,7 @@ describe("extreme cases", () => {
         startDate: new Date(),
       })),
       autofillGaps: true,
+      disableAutoRecoverErrors: true,
     });
 
     const currenciesWithCVs = currencies

--- a/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.integration.test.ts
@@ -72,7 +72,7 @@ describe("API sanity", () => {
 });
 
 describe("extreme cases", () => {
-  test("all tickers against BTC", async () => {
+  test("all tickers against USD", async () => {
     const currencies = Object.keys(getBTCValues())
       .filter((t) => t !== "USD")
       .map(findCurrencyByTicker)
@@ -93,6 +93,35 @@ describe("extreme cases", () => {
           date: new Date(),
           from,
           to: usd,
+          value: 1000000,
+        })
+      )
+      .filter((v) => v && v > 0);
+
+    expect(currenciesWithCVs.length).toBeGreaterThan(0);
+  });
+
+  test("all tickers against BTC", async () => {
+    const currencies = Object.keys(getBTCValues())
+      .filter((t) => t !== "BTC")
+      .map(findCurrencyByTicker)
+      .filter(Boolean) as Currency[];
+    const state = await loadCountervalues(initialState, {
+      trackingPairs: currencies.map((from) => ({
+        from,
+        to: bitcoin,
+        startDate: new Date(),
+      })),
+      autofillGaps: true,
+      disableAutoRecoverErrors: true,
+    });
+
+    const currenciesWithCVs = currencies
+      .map((from) =>
+        calculate(state, {
+          date: new Date(),
+          from,
+          to: bitcoin,
           value: 1000000,
         })
       )

--- a/libs/ledger-live-common/src/countervalues/logic.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.ts
@@ -255,7 +255,7 @@ export async function loadCountervalues(
           return null;
         })
     ),
-    fetchLatest(latestToFetch)
+    fetchLatest(latestToFetch, settings.disableAutoRecoverErrors)
       .then((rates) => {
         const out = {};
         let hasData = false;

--- a/libs/ledger-live-common/src/countervalues/logic.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.ts
@@ -230,6 +230,7 @@ export async function loadCountervalues(
           };
         })
         .catch((e) => {
+          if (settings.disableAutoRecoverErrors) throw e;
           // TODO work on the semantic of failure.
           // do we want to opt-in for the 404 cases and make other fails it all?
           // do we want to be resilient on individual pulling / keep error somewhere?
@@ -271,6 +272,7 @@ export async function loadCountervalues(
         return out;
       })
       .catch((e) => {
+        if (settings.disableAutoRecoverErrors) throw e;
         log(
           "countervalues-error",
           "Failed to fetch latest for " +

--- a/libs/ledger-live-common/src/countervalues/modules/index.ts
+++ b/libs/ledger-live-common/src/countervalues/modules/index.ts
@@ -36,7 +36,8 @@ type CountervaluesJobs = {
 };
 
 export const fetchLatest = async (
-  pairs: TrackingPair[]
+  pairs: TrackingPair[],
+  disableAutoRecoverErrors?: boolean
 ): Promise<Array<number | null | undefined>> => {
   // a module can override as well. but as latest is a "one api" call,
   // we need to segment the pairs in diff modules
@@ -88,6 +89,7 @@ export const fetchLatest = async (
             }
           })
           .catch((e) => {
+            if (disableAutoRecoverErrors) throw e;
             log("error", "latest fetch issue: " + String(e));
           })
       )

--- a/libs/ledger-live-common/src/countervalues/types.ts
+++ b/libs/ledger-live-common/src/countervalues/types.ts
@@ -4,6 +4,8 @@ import type { Currency } from "../types";
 export type CountervaluesSettings = {
   trackingPairs: TrackingPair[];
   autofillGaps: boolean;
+  // throw exception in "loadCountervalues" if ANY error occurs (for test purpose)
+  disableAutoRecoverErrors?: boolean;
 };
 // This is the internal state of countervalues.
 export type CounterValuesState = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- This improves the test of countervalues with a "strict mode" that disable recovering errors in the countervalues logic (only for test purpose).
- This improves work done at #486 (after having added there a test that reveal a problem) and implements chunking of 50 tickers max to fetch at once in "latest" API.

### ❓ Context

- **Impacted projects**: `LLM & LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-2767` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** https://github.com/LedgerHQ/ledger-live/actions/runs/2576619570
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

```
 PASS  src/countervalues/logic.integration.test.ts
  API sanity
    ✓ recent days have rate for BTC USD (197 ms)
    ✓ recent days have different rates for BTC USD (58 ms)
  extreme cases
    ✓ all tickers against BTC (507 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        4.001 s
```

console logging the chunked payloads before concat() them

![Screenshot 2022-06-28 at 15 12 11](https://user-images.githubusercontent.com/211411/176187184-8b89d7ea-4c40-4298-9246-d094eda9eda7.png)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
