### PR TITLE
modernize & simplify errors

### DIFF
--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import axios, { AxiosResponse } from "axios";
 import type { AxiosError, AxiosRequestConfig } from "axios";
 import { log } from "@ledgerhq/logs";
-import { NetworkDown, LedgerAPI5xx, LedgerAPI4xx } from "@ledgerhq/errors";
+import { NetworkDown } from "@ledgerhq/errors";
 import { retry } from "./promise";
 import { getEnv } from "./env";
 
@@ -49,36 +49,15 @@ export const errorInterceptor = (error: AxiosError<any>) => {
   if (!config) throw error;
   const { baseURL, url, method = "", metadata } = config;
   const { startTime = 0 } = metadata || {};
-
-  let errorToThrow;
   if (error.response) {
-    // The request was made and the server responded with a status code
-    // that falls out of the range of 2xx
     const { data, status } = error.response;
-    let msg;
-    try {
-      if (data && typeof data === "string") {
-        msg = extractErrorMessage(data);
-      } else if (data && typeof data === "object") {
-        msg = getErrorMessage(data);
-      }
-    } catch (e) {
-      log("warn", "can't parse server result " + String(e));
-    }
-
-    if (msg) {
-      errorToThrow = makeError(msg, status, url, method);
-    } else {
-      errorToThrow = makeError(`API HTTP ${status}`, status, url, method);
-    }
     log(
       "network-error",
       `${status} ${method} ${baseURL || ""}${url} (${(
         Date.now() - startTime
-      ).toFixed(0)}ms): ${errorToThrow.message}`,
+      ).toFixed(0)}ms)`,
       getEnv("DEBUG_HTTP_RESPONSE") ? { data: data } : {}
     );
-    throw errorToThrow;
   } else if (error.request) {
     log(
       "network-down",
@@ -95,52 +74,6 @@ axios.interceptors.request.use(requestInterceptor);
 
 // $FlowFixMe LLD raise issues here
 axios.interceptors.response.use(responseInterceptor, errorInterceptor);
-
-const makeError = (msg, status, url, method) => {
-  const obj = {
-    status,
-    url,
-    method,
-  };
-  return (status || "").toString().startsWith("4")
-    ? new LedgerAPI4xx(msg, obj)
-    : new LedgerAPI5xx(msg, obj);
-};
-
-const getErrorMessage = (
-  data: Record<string, any>
-): string | null | undefined => {
-  if (!data) return "";
-  if (typeof data === "string") return data;
-  if (data.errors) {
-    return getErrorMessage(data.errors[0]);
-  }
-  return data.message || data.error_message || data.error || data.msg;
-};
-
-const extractErrorMessage = (raw: string): string | undefined => {
-  let data = JSON.parse(raw);
-  if (data && Array.isArray(data)) data = data[0];
-  let msg = getErrorMessage(data);
-
-  if (typeof msg === "string") {
-    const m = msg.match(/^JsDefined\((.*)\)$/);
-    const innerPart = m ? m[1] : msg;
-
-    const r = JSON.parse(innerPart);
-    let message = r.message;
-    if (typeof message === "object") {
-      message = message.message;
-    }
-    if (typeof message === "string") {
-      msg = message;
-    }
-
-    return msg ? String(msg) : undefined;
-  }
-
-  return;
-};
 
 const implementation = (arg: any): Promise<any> => {
   invariant(typeof arg === "object", "network takes an object as parameter");


### PR DESCRIPTION
### 📝 Description

- network.ts is intercepting errors with too much intelligence today that does not apply to what we expect from a generic network utility. This removes this concept of `LedgerAPI4xx` and `LedgerAPI5xx`

- [ ] study the impact of this change on the whole project
- [ ] confirm there are no regression caused by this change
- [ ] get rid of the remaining usage of LedgerAPI* errors

### ❓ Context

- **Impacted projects**: `everything` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
