### PR TITLE
ci: attempt to reduce ram usage when running windows playwright tests

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -86,7 +86,9 @@ jobs:
       - name: Install playwright dependencies
         run: npx playwright install-deps
       - name: Build dependencies
-        run: pnpm turbo run ledger-live-desktop#build:testing --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
+        run: |
+          pnpm build:lld:deps --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
+          pnpm desktop build:testing
       - name: Run playwright tests [Linux => xvfb-run]
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm desktop test:playwright:update-snapshots

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Install playwright dependencies
         run: npx playwright install-deps
       - name: Build dependencies
+        env:
+          GOGC: 75
         run: |
           pnpm build:lld:deps --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
           pnpm desktop build:testing

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -121,7 +121,9 @@ jobs:
       - name: Install playwright dependencies
         run: npx @playwright/test install-deps
       - name: Build dependencies
-        run: pnpm turbo run ledger-live-desktop#build:testing --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
+        run: |
+          pnpm build:lld:deps --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
+          pnpm desktop build:testing
       - name: Run unit tests [Linux]
         if: matrix.os == 'ubuntu-latest'
         run: pnpm desktop test:jest

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -121,6 +121,8 @@ jobs:
       - name: Install playwright dependencies
         run: npx @playwright/test install-deps
       - name: Build dependencies
+        env:
+          GOGC: 75
         run: |
           pnpm build:lld:deps --api="http://127.0.0.1:9080" --token="yolo" --team="foo"
           pnpm desktop build:testing


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### Attempts to reduce memory usage during the dependencies build step when running the playwright tests on windows.

Splits `pnpm turbo run ledger-live-desktop#build:testing` into 2 steps: `pnpm build:lld:deps` then `pnpm desktop build:testing`.

Also decreased the memory pressure done by the go garbage collector.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `N/A` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
