### PR TITLE
Fixes autofocus on password field when Ledger Live Desktop is password protected

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.js
+++ b/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.js
@@ -120,6 +120,7 @@ export default function IsUnlocked({ children }: { children: any }) {
                   onChange={handleChangeInput("password")}
                   value={inputValue.password}
                   error={incorrectPassword}
+                  id="lockscreen-password-input"
                   data-test-id="lockscreen-password-input"
                 />
               </Box>


### PR DESCRIPTION
### 📝 Description

Fixes autofocus on password field when Ledger Live Desktop is password protected.
The code to do this exists, but is target ID `lockscreen-password-input` is missing in the view.

```
  useEffect(() => {
    let subscribed = false;
    const onKeyDown = () => {
      const input = document.getElementById("lockscreen-password-input");
      if (input) {
        input.focus();
      }
    };
    if (isLocked) {
      subscribed = true;
      window.addEventListener("keydown", onKeyDown);
    }
    return () => {
      if (subscribed) {
        window.removeEventListener("keydown", onKeyDown);
      }
    };
  }, [isLocked]);
```

### ❓ Context

N/A

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://youtu.be/pw8xn9YJhXk

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
