### PR TITLE
Improve custom errors stacktrace management

### DIFF
--- a/.changeset/odd-pigs-admire.md
+++ b/.changeset/odd-pigs-admire.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-libs": patch
+"@ledgerhq/errors": patch
+---
+
+Improve stacktrace in custom errors

--- a/libs/ledger-live-common/src/errors.test.ts
+++ b/libs/ledger-live-common/src/errors.test.ts
@@ -1,0 +1,21 @@
+import { AmountRequired } from "@ledgerhq/errors";
+
+function functionA() {
+  throw new AmountRequired();
+}
+
+describe("custom errors", () => {
+  test("error instanceof", () => {
+    try {
+      functionA();
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(AmountRequired);
+    }
+  });
+
+  test("promise error instanceof", () => {
+    expect(Promise.reject(new AmountRequired())).rejects.toBeInstanceOf(
+      AmountRequired
+    );
+  });
+});

--- a/libs/ledger-live-common/src/errors.test.ts
+++ b/libs/ledger-live-common/src/errors.test.ts
@@ -1,7 +1,7 @@
-import { AmountRequired } from "@ledgerhq/errors";
+import { AccessDeniedError } from "./errors";
 
 function functionA() {
-  throw new AmountRequired();
+  throw new AccessDeniedError();
 }
 
 describe("custom errors", () => {
@@ -9,13 +9,13 @@ describe("custom errors", () => {
     try {
       functionA();
     } catch (e: any) {
-      expect(e).toBeInstanceOf(AmountRequired);
+      expect(e).toBeInstanceOf(AccessDeniedError);
     }
   });
 
   test("promise error instanceof", () => {
-    expect(Promise.reject(new AmountRequired())).rejects.toBeInstanceOf(
-      AmountRequired
+    expect(Promise.reject(new AccessDeniedError())).rejects.toBeInstanceOf(
+      AccessDeniedError
     );
   });
 });

--- a/libs/ledgerjs/packages/errors/src/helpers.ts
+++ b/libs/ledgerjs/packages/errors/src/helpers.ts
@@ -13,22 +13,45 @@ export const addCustomErrorDeserializer = (
   deserializers[name] = deserializer;
 };
 
-type CustomErrorFunc = (
+export type CustomErrorFunc = (
   message?: string,
-  fields?: { [key: string]: any }
+  fields?: { [key: string]: any },
+  options?: any
 ) => void;
 
 export const createCustomErrorClass = (name: string): CustomErrorFunc => {
-  const C: CustomErrorFunc = function CustomError(message, fields): void {
-    Object.assign(this, fields);
-    this.name = name;
-    this.message = message || name;
-    this.stack = new Error().stack;
-  };
-  C.prototype = new Error();
-  errorClasses[name] = C;
-  return C;
+  class CustomErrorClass extends Error {
+    cause?: Error;
+    constructor(message, fields, options) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      super(message || name, options);
+      this.name = name;
+      for (const k in fields) {
+        this[k] = fields[k];
+      }
+      if (isObject(options) && "cause" in options && !("cause" in this)) {
+        // .cause was specified but the superconstructor
+        // did not create an instance property.
+        const cause = options.cause;
+        this.cause = cause;
+        if ("stack" in cause) {
+          this.stack = this.stack + "\nCAUSE: " + cause.stack;
+        }
+      }
+    }
+  }
+
+  errorClasses[name] = CustomErrorClass;
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return CustomErrorClass;
 };
+
+function isObject(value) {
+  return value !== null && typeof value === "object";
+}
 
 // inspired from https://github.com/programble/errio/blob/master/index.js
 export const deserializeError = (object: any): Error => {

--- a/libs/ledgerjs/packages/errors/src/helpers.ts
+++ b/libs/ledgerjs/packages/errors/src/helpers.ts
@@ -26,6 +26,8 @@ export const createCustomErrorClass = (name: string): CustomErrorFunc => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       super(message || name, options);
+      // Set the prototype explicitly. See https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+      Object.setPrototypeOf(this, CustomErrorClass.prototype);
       this.name = name;
       for (const k in fields) {
         this[k] = fields[k];

--- a/libs/ledgerjs/packages/errors/src/index.test.ts
+++ b/libs/ledgerjs/packages/errors/src/index.test.ts
@@ -1,0 +1,69 @@
+import { AmountRequired } from "./index";
+
+function functionA() {
+  throw new AmountRequired();
+}
+
+describe("custom errors", () => {
+  test("error name", () => {
+    try {
+      functionA();
+    } catch (e: any) {
+      expect(e.name).toEqual("AmountRequired");
+    }
+  });
+
+  test("error is correctly located at the functionA", () => {
+    try {
+      functionA();
+    } catch (e: any) {
+      const i = e.stack.indexOf("functionA");
+      expect(e.stack.slice(0, i + 9)).toEqual(
+        `AmountRequired: AmountRequired
+    at functionA`
+      );
+    }
+  });
+
+  test("error with custom message", () => {
+    try {
+      throw new AmountRequired("YO");
+    } catch (e: any) {
+      expect(e.message).toEqual("YO");
+    }
+  });
+
+  test("error with custom fields", () => {
+    try {
+      throw new AmountRequired("YO", { foo: 42 });
+    } catch (e: any) {
+      expect(e.foo).toEqual(42);
+    }
+  });
+
+  test("error.cause", () => {
+    try {
+      functionA();
+    } catch (cause: any) {
+      try {
+        throw new AmountRequired("YO", { foo: 42 }, { cause });
+      } catch (e: any) {
+        expect(e.cause).toMatchObject(new AmountRequired());
+      }
+    }
+  });
+
+  test("error instanceof", () => {
+    try {
+      functionA();
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(AmountRequired);
+    }
+  });
+
+  test("promise error instanceof", () => {
+    expect(Promise.reject(new AmountRequired())).rejects.toBeInstanceOf(
+      AmountRequired
+    );
+  });
+});


### PR DESCRIPTION
> NB: this PR includes part of the PR #509 (former PR is more acting as a playground)

### 📝 Description

We are often seeing these wrong stacktrace and location of the error:

<img width="611" alt="Screenshot 2022-06-28 at 16 20 24" src="https://user-images.githubusercontent.com/211411/176225740-820d0ab9-7203-4a76-8936-da4cabbe7806.png">

this is due to the usage of `new Error().stack`. We replace it with a more modern polyfill, inspired by https://exploringjs.com/impatient-js/ch_exception-handling.html#an-alternative-to-.cause-a-custom-error-class

Tests were added to confirm that we now have the properly location in the stacktrace.

this also introduces a 3rd parameter that will be passed to the second parameter of the Error constructor. This allows to pass in a `cause` field (which is also polyfilled). NB: this .cause usage is not yet getting used in our libraries, but if we ever have the need to "recover an error into another", this would be the pattern:

```js
try {
  something()
} catch (e) {
  if (e.something) throw new OneOfOurError(e.message, {}, { cause: e })
}
```

custom error stacktrace BEFORE the fix
```
AmountRequired
Error:
     at new CustomError (/Users/grenaudeau/dev/ledger-live/libs/ledgerjs/packages/errors/src/helpers.ts:27:18)
     at functionA ...
```

custom error stacktrace AFTER the fix

```
AmountRequired
Error:
     at functionA ...
```

### ❓ Context

- **Impacted projects**: `@ledgerhq/errors` but then by consequence, everything <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

```
@ledgerhq/errors:test:   custom errors
modernize & simplify errors helper
@ledgerhq/errors:test:     ✓ error name (3 ms)
@ledgerhq/errors:test:     ✓ error is correctly located at the functionA (6 ms)
@ledgerhq/errors:test:     ✓ error with custom message
@ledgerhq/errors:test:     ✓ error with custom fields (1 ms)
@ledgerhq/errors:test:     ✓ error.cause (1 ms)
```

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
