### PR TITLE
[LIVE-2748] fix crash when there is a transaction with no output for bitcoin

### DIFF
--- a/.changeset/popular-weeks-shake.md
+++ b/.changeset/popular-weeks-shake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix crash when there is a transaction with no input for bitcoin. LIVE-2748

--- a/libs/ledger-live-common/src/families/bitcoin/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/js-synchronisation.ts
@@ -1,26 +1,14 @@
-import { $Shape } from "utility-types";
-import type {
-  TX,
-  Currency,
-  Input as WalletInput,
-  Output as WalletOutput,
-} from "./wallet-btc";
+import type { Currency, Output as WalletOutput } from "./wallet-btc";
 import { DerivationModes as WalletDerivationModes } from "./wallet-btc";
 import { BigNumber } from "bignumber.js";
 import Btc from "@ledgerhq/hw-app-btc";
 import { log } from "@ledgerhq/logs";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import type {
-  Account,
-  Operation,
-  OperationType,
-  DerivationMode,
-} from "../../types";
+import type { Account, Operation, DerivationMode } from "../../types";
 import type { GetAccountShape } from "../../bridge/jsHelpers";
 import { makeSync, makeScanAccounts, mergeOps } from "../../bridge/jsHelpers";
 import { findCurrencyExplorer } from "../../api/Ledger";
 import { encodeAccountId } from "../../account";
-import { encodeOperationId } from "../../operation";
 import {
   isSegwitDerivationMode,
   isNativeSegwitDerivationMode,
@@ -30,6 +18,7 @@ import { BitcoinOutput } from "./types";
 import { perCoinLogic } from "./logic";
 import wallet from "./wallet-btc";
 import { getAddressWithBtcInstance } from "./hw-getAddress";
+import { mapTxToOperations } from "./logic";
 
 // Map LL's DerivationMode to wallet-btc's
 const toWalletDerivationMode = (
@@ -84,164 +73,6 @@ const deduplicateOperations = (
   }
 
   return out;
-};
-
-const mapTxToOperations = (
-  tx: TX,
-  currencyId: string,
-  accountId: string,
-  accountAddresses: Set<string>,
-  changeAddresses: Set<string>
-): $Shape<Operation[]> => {
-  const operations: Operation[] = [];
-  const txId = tx.id;
-  const fee = new BigNumber(tx.fees);
-  const blockHeight = tx.block?.height;
-  const blockHash = tx.block?.hash;
-  const date = new Date(tx.block?.time || tx.received_at);
-  const senders = new Set<string>();
-  const recipients: string[] = [];
-  let type: OperationType = "OUT";
-  let value = new BigNumber(0);
-  const hasFailed = false;
-  const accountInputs: WalletInput[] = [];
-  const accountOutputs: WalletOutput[] = [];
-  const syncReplaceAddress = perCoinLogic[currencyId]?.syncReplaceAddress;
-
-  for (const input of tx.inputs) {
-    if (input.address) {
-      senders.add(
-        syncReplaceAddress ? syncReplaceAddress(input.address) : input.address
-      );
-
-      if (input.value) {
-        if (accountAddresses.has(input.address)) {
-          // This address is part of the account
-          value = value.plus(input.value);
-          accountInputs.push(input);
-        }
-      }
-    }
-  }
-
-  // All inputs of a same transaction have the same sequence
-  const transactionSequenceNumber =
-    (accountInputs.length > 0 && accountInputs[0].sequence) || undefined;
-
-  const hasSpentNothing = value.eq(0);
-  // Change output is always the last one
-  const changeOutputIndex = tx.outputs
-    .map((o) => o.output_index)
-    .reduce((p, c) => (p > c ? p : c));
-
-  for (const output of tx.outputs) {
-    if (output.address) {
-      if (!accountAddresses.has(output.address)) {
-        // The output doesn't belong to this account
-        if (
-          accountInputs.length > 0 && // It's a SEND operation
-          (tx.outputs.length === 1 || // The transaction has only 1 output
-            output.output_index < changeOutputIndex) // The output isn't the change output
-        ) {
-          recipients.push(
-            syncReplaceAddress
-              ? syncReplaceAddress(output.address)
-              : output.address
-          );
-        }
-      } else {
-        // The output belongs to this account
-        accountOutputs.push(output);
-
-        if (!changeAddresses.has(output.address)) {
-          // The output isn't a change output of this account
-          recipients.push(
-            syncReplaceAddress
-              ? syncReplaceAddress(output.address)
-              : output.address
-          );
-        } else {
-          // The output is a change output of this account,
-          // we count it as a recipient only in some special cases
-          if (
-            (recipients.length === 0 &&
-              output.output_index >= changeOutputIndex) ||
-            hasSpentNothing
-          ) {
-            recipients.push(
-              syncReplaceAddress
-                ? syncReplaceAddress(output.address)
-                : output.address
-            );
-          }
-        }
-      }
-    }
-  }
-
-  if (accountInputs.length > 0) {
-    // It's a SEND operation
-    for (const output of accountOutputs) {
-      if (changeAddresses.has(output.address)) {
-        value = value.minus(output.value);
-      }
-    }
-
-    type = "OUT";
-    operations.push({
-      id: encodeOperationId(accountId, txId, type),
-      hash: txId,
-      type,
-      value,
-      fee,
-      senders: Array.from(senders),
-      recipients,
-      blockHeight,
-      blockHash,
-      transactionSequenceNumber,
-      accountId,
-      date,
-      hasFailed,
-      extra: {},
-    });
-  }
-
-  if (accountOutputs.length > 0) {
-    // It's a RECEIVE operation
-    const filterChangeAddresses = !!accountInputs.length;
-    let accountOutputCount = 0;
-    let finalAmount = new BigNumber(0);
-
-    for (const output of accountOutputs) {
-      if (!filterChangeAddresses || !changeAddresses.has(output.address)) {
-        finalAmount = finalAmount.plus(output.value);
-        accountOutputCount += 1;
-      }
-    }
-
-    if (accountOutputCount > 0) {
-      value = finalAmount;
-      type = "IN";
-      operations.push({
-        id: encodeOperationId(accountId, txId, type),
-        hash: txId,
-        type,
-        value,
-        fee,
-        senders: Array.from(senders),
-        recipients,
-        blockHeight,
-        blockHash,
-        transactionSequenceNumber,
-        accountId,
-        date,
-        hasFailed,
-        extra: {},
-      });
-    }
-  }
-
-  return operations;
 };
 
 const getAccountShape: GetAccountShape = async (info) => {

--- a/libs/ledger-live-common/src/families/bitcoin/logic.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/logic.ts
@@ -9,6 +9,15 @@ import type {
   NetworkInfo,
   UtxoStrategy,
 } from "./types";
+import { $Shape } from "utility-types";
+import type {
+  TX,
+  Input as WalletInput,
+  Output as WalletOutput,
+} from "./wallet-btc";
+import { BigNumber } from "bignumber.js";
+import { encodeOperationId } from "../../operation";
+import type { Operation, OperationType } from "../../types";
 
 // correspond ~ to min relay fees but determined empirically for a tx to be accepted by network
 const minFees = {
@@ -180,4 +189,164 @@ export const perCoinLogic: Record<
       forceFormat: "cashaddr",
     }),
   },
+};
+
+export const mapTxToOperations = (
+  tx: TX,
+  currencyId: string,
+  accountId: string,
+  accountAddresses: Set<string>,
+  changeAddresses: Set<string>
+): $Shape<Operation[]> => {
+  const operations: Operation[] = [];
+  const txId = tx.id;
+  const fee = new BigNumber(tx.fees);
+  const blockHeight = tx.block?.height;
+  const blockHash = tx.block?.hash;
+  const date = new Date(tx.block?.time || tx.received_at);
+  const senders = new Set<string>();
+  const recipients: string[] = [];
+  let type: OperationType = "OUT";
+  let value = new BigNumber(0);
+  const hasFailed = false;
+  const accountInputs: WalletInput[] = [];
+  const accountOutputs: WalletOutput[] = [];
+  const syncReplaceAddress = perCoinLogic[currencyId]?.syncReplaceAddress;
+
+  for (const input of tx.inputs) {
+    if (input.address) {
+      senders.add(
+        syncReplaceAddress ? syncReplaceAddress(input.address) : input.address
+      );
+
+      if (input.value) {
+        if (accountAddresses.has(input.address)) {
+          // This address is part of the account
+          value = value.plus(input.value);
+          accountInputs.push(input);
+        }
+      }
+    }
+  }
+
+  // All inputs of a same transaction have the same sequence
+  const transactionSequenceNumber =
+    (accountInputs.length > 0 && accountInputs[0].sequence) || undefined;
+
+  const hasSpentNothing = value.eq(0);
+
+  // Change output is always the last one
+  const changeOutputIndex =
+    tx.outputs.length === 0
+      ? 0
+      : tx.outputs.map((o) => o.output_index).reduce((p, c) => (p > c ? p : c));
+
+  for (const output of tx.outputs) {
+    if (output.address) {
+      if (!accountAddresses.has(output.address)) {
+        // The output doesn't belong to this account
+        if (
+          accountInputs.length > 0 && // It's a SEND operation
+          (tx.outputs.length === 1 || // The transaction has only 1 output
+            output.output_index < changeOutputIndex) // The output isn't the change output
+        ) {
+          recipients.push(
+            syncReplaceAddress
+              ? syncReplaceAddress(output.address)
+              : output.address
+          );
+        }
+      } else {
+        // The output belongs to this account
+        accountOutputs.push(output);
+
+        if (!changeAddresses.has(output.address)) {
+          // The output isn't a change output of this account
+          recipients.push(
+            syncReplaceAddress
+              ? syncReplaceAddress(output.address)
+              : output.address
+          );
+        } else {
+          // The output is a change output of this account,
+          // we count it as a recipient only in some special cases
+          if (
+            (recipients.length === 0 &&
+              output.output_index >= changeOutputIndex) ||
+            hasSpentNothing
+          ) {
+            recipients.push(
+              syncReplaceAddress
+                ? syncReplaceAddress(output.address)
+                : output.address
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (accountInputs.length > 0) {
+    // It's a SEND operation
+    for (const output of accountOutputs) {
+      if (changeAddresses.has(output.address)) {
+        value = value.minus(output.value);
+      }
+    }
+
+    type = "OUT";
+    operations.push({
+      id: encodeOperationId(accountId, txId, type),
+      hash: txId,
+      type,
+      value,
+      fee,
+      senders: Array.from(senders),
+      recipients,
+      blockHeight,
+      blockHash,
+      transactionSequenceNumber,
+      accountId,
+      date,
+      hasFailed,
+      extra: {},
+    });
+  }
+
+  if (accountOutputs.length > 0) {
+    // It's a RECEIVE operation
+    const filterChangeAddresses = !!accountInputs.length;
+    let accountOutputCount = 0;
+    let finalAmount = new BigNumber(0);
+
+    for (const output of accountOutputs) {
+      if (!filterChangeAddresses || !changeAddresses.has(output.address)) {
+        finalAmount = finalAmount.plus(output.value);
+        accountOutputCount += 1;
+      }
+    }
+
+    if (accountOutputCount > 0) {
+      value = finalAmount;
+      type = "IN";
+      operations.push({
+        id: encodeOperationId(accountId, txId, type),
+        hash: txId,
+        type,
+        value,
+        fee,
+        senders: Array.from(senders),
+        recipients,
+        blockHeight,
+        blockHash,
+        transactionSequenceNumber,
+        accountId,
+        date,
+        hasFailed,
+        extra: {},
+      });
+    }
+  }
+
+  return operations;
 };

--- a/libs/ledger-live-common/src/families/bitcoin/xpub.txs.txNoOutput.unit.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/xpub.txs.txNoOutput.unit.test.ts
@@ -1,0 +1,37 @@
+import { mapTxToOperations } from "./logic";
+
+describe("testing transaction without output", () => {
+  it("Parse zcash transaction without output", async () => {
+    const tx = {
+      id: "0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1",
+      inputs: [
+        {
+          output_hash:
+            "2772f3963856f3eb38cb706ec8c2b62fcdeb2ce10f32cf7160afb3873be6f60d",
+          output_index: 0,
+          value: "5000000000",
+          address: "2NCDBM9DAuMrD1T8XDHMxvbTmLutP7at4AB",
+          sequence: 4294967294,
+        },
+      ],
+      outputs: [],
+      block: {
+        hash: "305d4b8d4a6d6ecca0a3dd0216f8ecd090978ed346d1845883c8aa4529d72fc8",
+        height: 120,
+        time: "2021-07-28T13:34:38Z",
+      },
+      account: 0,
+      index: 0,
+      address: "mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb",
+      received_at: "2021-07-28T13:34:38Z",
+    };
+    const out = mapTxToOperations(
+      tx,
+      "zcash",
+      "zcash 1",
+      new Set<string>(),
+      new Set<string>()
+    );
+    expect(out.length).toEqual(0);
+  }, 30000);
+});


### PR DESCRIPTION
### 📝 Description

Crash fix for the case when  there is a transaction with no output for bitcoin family.
Here is an example for a transaction without output: https://zecblockexplorer.com/tx/d1c35527078ceaba10e0e7676aff760b34b419cf7504134e93519814582816dc

### ❓ Context

- **Impacted projects**: LLC
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2748

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

No demo as it is a bug fix

### 🚀 Expectations to reach

No crash