### PR TITLE
Bug fix - LIVE-2719 - Empty analytics overlay when activating it

### DIFF
--- a/.changeset/dirty-balloons-sort.md
+++ b/.changeset/dirty-balloons-sort.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Empty analytics overlay when activating it

--- a/apps/ledger-live-mobile/src/components/AnalyticsConsole.js
+++ b/apps/ledger-live-mobile/src/components/AnalyticsConsole.js
@@ -32,6 +32,10 @@ const AnalyticsConsole = () => {
   }, [addItem]);
   const render = useEnv("ANALYTICS_CONSOLE");
 
+  useEffect(() => {
+    setItems([]);
+  }, [render]);
+
   return render ? (
     <View style={styles.root} pointerEvents="none">
       {items.map((item, index) => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Empty the analytics overlay when activating it in debug settings, so there is no flooding of past events when you initialize it.

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-2719

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
