### PR TITLE
fix: connectApp add getVersion to wait when the device is not unlocked [LIVE-2611]

### DIFF
--- a/.changeset/wicked-pens-cheat.md
+++ b/.changeset/wicked-pens-cheat.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix: Improve locked device detection by sending getVersion first since it's blocking when locked [LIVE-2611]

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -26,6 +26,7 @@ import quitApp from "./quitApp";
 import { LatestFirmwareVersionRequired } from "../errors";
 import { mustUpgrade } from "../apps";
 import manager from "../manager";
+import getVersion from "./getVersion";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 
 export type RequiresDerivation = {
@@ -263,7 +264,8 @@ const cmd = ({
           dependencies,
           requireLatestFirmware,
         }: any) =>
-          defer(() => from(getAppAndVersion(transport))).pipe(
+          defer(() => from(getVersion(transport))).pipe(
+            concatMap(() => from(getAppAndVersion(transport))),
             concatMap((appAndVersion): Observable<ConnectAppEvent> => {
               timeoutSub.unsubscribe();
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When a Nano has been locked or connected while locked and a previous action had taken place, the ‘Connect and unlock your Nano’ modal changes to an infinite loading spinner with no prompt to the user to unlock the PIN of their Nano. By calling `getVersion` before `getAppAndVersion` we have the correct behaviour of sending an `unresponsiveDevice` event.

### ❓ Context

- **Impacted projects**: `live-common` impacts -> `live-desktop` and `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-2611`](https://ledgerhq.atlassian.net/browse/LIVE-2611) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### Tests scenarios

See the following scenarios for correct and incorrect behaviour (these were tested with the Funding flow in the Card app, but can also be verified with other SDK flows in the Debug app):

- Nano X
  - Turned off at start then connected - connect modal shows correctly throughout ✅
  - Connected, unlocked, Exchange app open - goes straight exchange app ✅
  - Connected, unlocked, Bitcoin app open - goes to exchange app ✅
  - Connected, unlocked, Main menu open - goes to exchange app ✅
  - Connected but locked - connect modal for a second then loading spinner ❌
  - Disconnect and locked - loading spinner (also if you are on settings on the Nano X you have to quit that before the app is asked to open) ❌
  - Connected and locked - loading spinner ❌
- Nano S
  - Disconnected - connect modal shows correctly throughout ✅
  - Connected, unlocked, Exchange app open - goes straight exchange app ✅
  - Connected, unlocked, Bitcoin app open - goes to exchange app ✅
  - Connected but locked - connect modal for a second then loading spinner ❌
- Nano S+
  - Disconnected - connect modal shows correctly throughout ✅
  - Connected, unlocked, Exchange app open - goes straight exchange app ✅
  - Connected, unlocked, Bitcoin app open - goes to exchange app ✅
  - Connected but locked - connect modal for a second then loading spinner ❌

### 📸 Demo


https://user-images.githubusercontent.com/3009753/177271289-40f2fe16-8e26-464e-9d97-bff7cce90260.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
