### PR TITLE
fix: imports should use /lib and not /src

### DIFF
--- a/.changeset/moody-moons-dance.md
+++ b/.changeset/moody-moons-dance.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: imports should use /lib and not /src

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -44,7 +44,7 @@ import {
   RemoteLiveAppProvider,
   useRemoteLiveAppContext,
 } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
-import { LocalLiveAppProvider } from "@ledgerhq/live-common/src/platform/providers/LocalLiveAppProvider";
+import { LocalLiveAppProvider } from "@ledgerhq/live-common/lib/platform/providers/LocalLiveAppProvider";
 
 import logger from "./logger";
 import { saveAccounts, saveBle, saveSettings, saveCountervalues } from "./db";

--- a/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/ReadOnlyAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/ReadOnlyAssets.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from "react";
 import { FlatList } from "react-native";
 import { useNavigation } from "@react-navigation/native";
+import { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 import ReadOnlyAccountRow from "../../Accounts/ReadOnly/ReadOnlyAccountRow";
 import { withDiscreetMode } from "../../../context/DiscreetModeContext";
-import { CryptoCurrency } from "@ledgerhq/live-common/src/types";
 
 type ListProps = {
   assets: CryptoCurrency[];

--- a/apps/ledger-live-mobile/src/screens/Settings/Developer/CustomManifest.js
+++ b/apps/ledger-live-mobile/src/screens/Settings/Developer/CustomManifest.js
@@ -2,7 +2,7 @@
 import React, { useState, useMemo, useCallback, useLayoutEffect } from "react";
 import { TextInput, StyleSheet, TouchableOpacity } from "react-native";
 import { useTheme, NavigationProp } from "@react-navigation/native";
-import { useLocalLiveAppContext } from "@ledgerhq/live-common/src/platform/providers/LocalLiveAppProvider";
+import { useLocalLiveAppContext } from "@ledgerhq/live-common/lib/platform/providers/LocalLiveAppProvider";
 import NavigationScrollView from "../../../components/NavigationScrollView";
 import Button from "../../../components/Button";
 import { ScreenName } from "../../../const";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We should import using `/lib` and not `/src`, this causes some global variables to be empty and was breaking adding a custom manifest.

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-2893`](https://ledgerhq.atlassian.net/browse/LIVE-2893) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
