### PR TITLE
Feat - LIVE-2362 - add satisfaction user property (analytics)

### DIFF
--- a/.changeset/soft-foxes-deny.md
+++ b/.changeset/soft-foxes-deny.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Refresh segment identify to take in account satisfaction user property change

--- a/apps/ledger-live-mobile/src/analytics/segment.js
+++ b/apps/ledger-live-mobile/src/analytics/segment.js
@@ -108,6 +108,25 @@ export const start = async (store: *) => {
   track("Start", extraProperties(store), true);
 };
 
+export const updateIdentify = async () => {
+  Sentry.addBreadcrumb({
+    category: "identify",
+    level: "debug",
+  });
+
+  if (!storeInstance || !analyticsEnabledSelector(storeInstance.getState())) {
+    return;
+  }
+
+  if (ANALYTICS_LOGS)
+    console.log("analytics:identify", extraProperties(storeInstance), {
+      context,
+    });
+  if (!token) return;
+  const { user } = await getOrCreateUser();
+  analytics.identify(user.id, extraProperties(storeInstance), { context });
+};
+
 export const stop = () => {
   if (ANALYTICS_LOGS) console.log("analytics:stop");
   storeInstance = null;

--- a/apps/ledger-live-mobile/src/screens/RatingsModal/Init.tsx
+++ b/apps/ledger-live-mobile/src/screens/RatingsModal/Init.tsx
@@ -28,7 +28,6 @@ const Init = ({ closeModal, setStep }: Props) => {
   const goToEnjoy = useCallback(() => {
     setStep("enjoy");
     handleSatisfied();
-    updateIdentify();
     track("button_clicked", {
       flow: "review",
       page: "review_step0",
@@ -36,6 +35,7 @@ const Init = ({ closeModal, setStep }: Props) => {
       source: ratingsHappyMoment?.route_name,
       params: ratingsFeatureParams,
     });
+    updateIdentify();
   }, [
     setStep,
     handleSatisfied,
@@ -44,7 +44,6 @@ const Init = ({ closeModal, setStep }: Props) => {
   ]);
   const goToDisappointed = useCallback(() => {
     setStep("disappointed");
-    updateIdentify();
     track("button_clicked", {
       flow: "review",
       page: "review_step0",
@@ -56,6 +55,7 @@ const Init = ({ closeModal, setStep }: Props) => {
       ratingsFeatureParams?.conditions?.disappointed_delay,
       { satisfaction: "disappointed" },
     );
+    updateIdentify();
   }, [
     setStep,
     ratingsHappyMoment?.route_name,

--- a/apps/ledger-live-mobile/src/screens/RatingsModal/Init.tsx
+++ b/apps/ledger-live-mobile/src/screens/RatingsModal/Init.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity } from "react-native";
 import { Trans } from "react-i18next";
 import styled from "styled-components/native";
 import { Flex, Text, Button } from "@ledgerhq/native-ui";
-import { track, TrackScreen } from "../../analytics";
+import { track, TrackScreen, updateIdentify } from "../../analytics";
 import useRatings from "../../logic/ratings";
 
 const NotNowButton = styled(TouchableOpacity)`
@@ -28,6 +28,7 @@ const Init = ({ closeModal, setStep }: Props) => {
   const goToEnjoy = useCallback(() => {
     setStep("enjoy");
     handleSatisfied();
+    updateIdentify();
     track("button_clicked", {
       flow: "review",
       page: "review_step0",
@@ -43,6 +44,7 @@ const Init = ({ closeModal, setStep }: Props) => {
   ]);
   const goToDisappointed = useCallback(() => {
     setStep("disappointed");
+    updateIdentify();
     track("button_clicked", {
       flow: "review",
       page: "review_step0",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Analytics : Add possibility to refresh segment user properties, otherwise it's updated only after app first launch.
Use it to update user with "satisfaction" property after user have rated the app.

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-2362

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
