### PR TITLE
fix: Inline app install not working [LIVE-2851]

### DIFF
--- a/.changeset/hot-avocados-dream.md
+++ b/.changeset/hot-avocados-dream.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: Inline app install not working [LIVE-2851]

--- a/apps/ledger-live-mobile/src/components/BottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/BottomModal.tsx
@@ -32,7 +32,7 @@ const BottomModal = ({
   const [open, setIsOpen] = useState(false);
   const modalLock = useSelector(isModalLockedSelector);
 
-  // workarround to make sure no double modal can be opened at same time
+  // workaround to make sure no double modal can be opened at same time
   useEffect(
     () => () => {
       isModalOpenedref = false;
@@ -48,7 +48,7 @@ const BottomModal = ({
     }
     isModalOpenedref = isOpened;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpened, modalLock]); // do not add onClose it might cause some issues on modals ie: filter manager modal
+  }, [isOpened]); // do not add onClose it might cause some issues on modals ie: filter manager modal
 
   const handleClose = useCallback(() => {
     if (modalLock) return;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Inline app install was not working because we lock the modal during the install and it was closing the modal instead.
By removing a dependency on `modalLock` in the `useEffect` we avoid to call `onClose` thinking this is a duplicate modal because of `isModalOpenedref` being `true`.

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-2851`](https://ledgerhq.atlassian.net/browse/LIVE-2851) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
