### PR TITLE
Improve InternalProcess stop() to not throw error if not running

### DIFF
--- a/apps/ledger-live-desktop/src/main/InternalProcess.js
+++ b/apps/ledger-live-desktop/src/main/InternalProcess.js
@@ -121,9 +121,9 @@ class InternalProcess {
   }
 
   stop() {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       if (!this.process) {
-        reject(new Error("Process not running"));
+        resolve(false);
         return;
       }
 
@@ -134,7 +134,7 @@ class InternalProcess {
       console.log(`ending process ${pid} ...`);
       this.active = false;
       this.process.once("exit", () => {
-        resolve();
+        resolve(true);
       });
       this.process.disconnect();
       setTimeout(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This change have no impact from the user perspective. However, on Sentry reporting side, we receive a bunch of `Process not running` error cases, which is useless and in that case, a stop() should have "no effect".

This PR changes the promise to not THROW an exception but simply have a boolean to know if the stop() effectively killed a process or not. This will make the `InternalProcess#restart()` method truly work too (even tho it's currently not used anywhere)

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://sentry.io/organizations/ledger/issues/3405017439

### ✅ Checklist

- [x] **Test coverage** this should be tested by automation as it's happening when the app is "closed"<!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
