### PR TITLE
Fix LLM cold start deeplinks to platform apps & deeplinks to platform apps for private & experimental apps

### DIFF
--- a/.changeset/nasty-crabs-lay.md
+++ b/.changeset/nasty-crabs-lay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix deeplinking logic to platform (experimental & private apps always accessible)

--- a/apps/ledger-live-mobile/deep-links-test-page.html
+++ b/apps/ledger-live-mobile/deep-links-test-page.html
@@ -94,7 +94,7 @@
           </p>
     </header>
     <div class="scrollContent">
-      <input type="text" value="" placeholder="Edit currency..." id="input">
+      <input type="text" value="" placeholder="Edit currency..." id="currencyInput">
       <button class="link" onclick="onClick('ledgerlive:\/\/')">
         <p>ledgerlive://</p> <p>🔗</p>
       </button>
@@ -158,8 +158,10 @@
         <p>🔗</p>
       </button>
 
-      <button class="link" onclick="onClick('ledgerlive:\/\/discover\/paraswap')">
-        <p>ledgerlive://discover/paraswap</p>
+      <input type="text" value="" placeholder="Edit platform app id..." id="platformAppInput">
+
+      <button class="link" onclick="onClick('ledgerlive:\/\/discover\/PLATFORM_APP_PARAM')">
+        <p>ledgerlive://discover/<b class="platformApp">paraswap</b></p>
         <p>🔗</p>
       </button>
 
@@ -178,8 +180,14 @@
     </div>
     <script>
       let currency = "bitcoin";
+      let platformApp = "paraswap"
       function onClick(url) {
-        window.open(url.replace(/CURRENCY_PARAM/, currency), "_blank");
+        window.open(
+          url
+            .replace(/CURRENCY_PARAM/, currency)
+            .replace(/PLATFORM_APP_PARAM/, platformApp),
+          "_blank"
+        );
       }
 
       function onChangeCurrency(evt) {
@@ -187,8 +195,14 @@
         Array.from(document.querySelectorAll("b.currencyName")).forEach(el => el.innerHTML = currency)
       }
 
+      function onChangePlatformApp(evt) {
+        platformApp = event.target.value.toLowerCase()
+        Array.from(document.querySelectorAll("b.platformApp")).forEach(el => el.innerHTML = platformApp)
+      }
+
       window.onload = () => {
-        document.getElementById("input").onchange = onChangeCurrency;
+        document.getElementById("currencyInput").onchange = onChangeCurrency;
+        document.getElementById("platformAppInput").onchange = onChangePlatformApp;
       }
     </script>
   </body>

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -13,7 +13,6 @@ import React, {
 } from "react";
 import { connect, useDispatch, useSelector } from "react-redux";
 import {
-  Alert,
   StyleSheet,
   View,
   Text,

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -388,7 +388,10 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const wcContext = useContext(_wcContext);
   const removeLiveAppState = useRemoteLiveAppContext();
-  const filteredManifests = useFilteredManifests();
+  const filteredManifests = useFilteredManifests({
+    private: true,
+    branches: undefined, // will override & having it to undefined makes all branches valid
+  });
 
   const linking = useMemo(
     () => ({

--- a/apps/ledger-live-mobile/src/index.js
+++ b/apps/ledger-live-mobile/src/index.js
@@ -13,6 +13,7 @@ import React, {
 } from "react";
 import { connect, useDispatch, useSelector } from "react-redux";
 import {
+  Alert,
   StyleSheet,
   View,
   Text,
@@ -383,15 +384,19 @@ const linkingOptionsOnboarding = {
   },
 };
 
+const platformManifestFilterParams = {
+  private: true,
+  branches: undefined, // will override & having it to undefined makes all branches valid
+};
+
 const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
   const dispatch = useDispatch();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const wcContext = useContext(_wcContext);
-  const removeLiveAppState = useRemoteLiveAppContext();
-  const filteredManifests = useFilteredManifests({
-    private: true,
-    branches: undefined, // will override & having it to undefined makes all branches valid
-  });
+  const { state: remoteLiveAppState } = useRemoteLiveAppContext();
+  const liveAppProviderInitialized =
+    !!remoteLiveAppState.value || !!remoteLiveAppState.error;
+  const filteredManifests = useFilteredManifests(platformManifestFilterParams);
 
   const linking = useMemo(
     () => ({
@@ -407,6 +412,16 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
            *  - checking that a manifest exists
            *  - adding "name" search param
            * */
+          if (!liveAppProviderInitialized) {
+            /**
+             * The provider isn't initialized yet so the manifest will possibly
+             * not be found.
+             * We redirect because this scenario happens when deep linking
+             * triggers a cold app start. The platform app screen will show an
+             * error in case the app isn't found.
+             */
+            return getStateFromPath(path, config);
+          }
           const manifest = filteredManifests.find(
             m => m.id.toLowerCase() === platform.toLowerCase(),
           );
@@ -423,33 +438,16 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
       wcContext.initDone,
       wcContext.session.session,
       filteredManifests,
+      liveAppProviderInitialized,
     ],
   );
 
   const [isReady, setIsReady] = React.useState(false);
 
   useEffect(() => {
-    if (!wcContext.initDone) {
-      return;
-    }
-    if (
-      removeLiveAppState.isLoading &&
-      !removeLiveAppState.lastUpdateTime &&
-      !removeLiveAppState.error
-    )
-      /**
-       * Ensure that the list of manifests has been loaded once so that the
-       * deep linking logic to platform apps works in the scenario where the app
-       * was not previously running.
-       *  */
-      return;
+    if (!wcContext.initDone) return;
     setIsReady(true);
-  }, [
-    wcContext.initDone,
-    removeLiveAppState.isLoading,
-    removeLiveAppState.lastUpdateTime,
-    removeLiveAppState.error,
-  ]);
+  }, [wcContext.initDone]);
 
   React.useEffect(
     () => () => {

--- a/apps/ledger-live-mobile/src/screens/Platform/App.js
+++ b/apps/ledger-live-mobile/src/screens/Platform/App.js
@@ -2,11 +2,18 @@
 
 import React, { useEffect } from "react";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/LocalLiveAppProvider";
-import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
+import {
+  useRemoteLiveAppContext,
+  useRemoteLiveAppManifest,
+} from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
 import type { StackScreenProps } from "@react-navigation/stack";
 import { useNavigation, useTheme } from "@react-navigation/native";
+import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
 import TrackScreen from "../../analytics/TrackScreen";
 import WebPlatformPlayer from "../../components/WebPlatformPlayer";
+import GenericErrorView from "../../components/GenericErrorView";
+
+const appManifestNotFoundError = new Error("App not found");
 
 const PlatformApp = ({ route }: StackScreenProps) => {
   const { dark } = useTheme();
@@ -14,6 +21,7 @@ const PlatformApp = ({ route }: StackScreenProps) => {
   const { setParams } = useNavigation();
   const localManifest = useLocalLiveAppManifest(appId);
   const remoteManifest = useRemoteLiveAppManifest(appId);
+  const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const manifest = localManifest || remoteManifest;
   useEffect(() => {
     manifest?.name && setParams({ name: manifest.name });
@@ -31,7 +39,15 @@ const PlatformApp = ({ route }: StackScreenProps) => {
         }}
       />
     </>
-  ) : null;
+  ) : (
+    <Flex flex={1} p={10} justifyContent="center" alignItems="center">
+      {remoteLiveAppState.isLoading ? (
+        <InfiniteLoader />
+      ) : (
+        <GenericErrorView error={appManifestNotFoundError} />
+      )}
+    </Flex>
+  );
 };
 
 export default PlatformApp;

--- a/apps/ledger-live-mobile/src/screens/Platform/shared.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/shared.tsx
@@ -1,13 +1,16 @@
 import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
-import { filterPlatformApps } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider/helpers";
+import {
+  FilterParams,
+  filterPlatformApps,
+} from "@ledgerhq/live-common/lib/platform/PlatformAppProvider/helpers";
 import { LiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/types";
 import { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
 import { useMemo } from "react";
 
 const defaultArray: LiveAppManifest[] = [];
 
-export const useFilteredManifests = () => {
+export const useFilteredManifests = (filterParamsOverride?: FilterParams) => {
   const { state } = useRemoteLiveAppContext();
   const manifests = state?.value?.liveAppByIndex || defaultArray;
   const experimental = useEnv("PLATFORM_EXPERIMENTAL_APPS");
@@ -24,6 +27,7 @@ export const useFilteredManifests = () => {
       version: "0.0.1",
       platform: "mobile",
       branches,
+      ...(filterParamsOverride ?? {}),
     });
-  }, [manifests, experimental]);
+  }, [manifests, experimental, filterParamsOverride]);
 };


### PR DESCRIPTION
### 📝 Description

#### Issue 1: deeplinking to private & experimental apps

Deeplinking to `ledgerlive://discover/lmarket-dev` was not working as it's a "private" app.

For deeplinking to platform apps, `private: true` apps were filtered out by default & `branch: "experimental"` were only accessible if experimental apps were enabled in the settings.

Now that we have a spec, spec defining that these apps should always be accessible through deeplinking (if they are fo), I added a way to override these default filters for deeplinking.

FYI the spec now is:

> - platform overrides all others (if mobile, only works on mobile, if desktop, only works on desktop)
> - Links work in any case if on the correct platform
> - private = true does not display in the catalog whatever the settings are - but links fork
> - branch=experimental : only displays if the experimental apps are activated, but links work in any case
> 

I tested on both platforms (iOS & Android), both for `private:true` apps and `branch:"experimental"` apps. It works.

#### Issue 2: deeplinking to platform apps with cold app start

Deep links to platform apps triggering a cold start of the app were not working as the list of manifests hasn't loaded yet.

The fix for that is to detect whether the list of manifests has had time to load once, and then if that's not the case, do an optimistic redirection to the PlatformApp screen (which will then dynamically load the manifest and if there is none, display an error message).

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2916] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Here's a demo with Market which is a `private: true` app.

https://user-images.githubusercontent.com/91890529/177744058-17862eea-ceb8-4d7d-9772-21647ce6b52b.mp4


https://user-images.githubusercontent.com/91890529/177744074-534ab747-01c5-42ac-ba45-329305f7a3bf.mp4

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2916]: https://ledgerhq.atlassian.net/browse/LIVE-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ