### PR TITLE
LIVE-2643 LIVE-2914 fix xpub null and "hash" to "id" migration

### DIFF
--- a/.changeset/lucky-bugs-shake.md
+++ b/.changeset/lucky-bugs-shake.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/live-common": major
+"@ledgerhq/live-common": minor
 ---
 
 Create index in real time instead of loading from app.json for btc wallet. Fix bug: https://ledgerhq.atlassian.net/browse/LIVE-2495

--- a/.changeset/lucky-bugs-shake.md
+++ b/.changeset/lucky-bugs-shake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": major
+---
+
+Create index in real time instead of loading from app.json for btc wallet. Fix bug: https://ledgerhq.atlassian.net/browse/LIVE-2495

--- a/libs/ledger-live-common/src/families/bitcoin/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/js-synchronisation.ts
@@ -259,7 +259,7 @@ const getAccountShape: GetAccountShape = async (info) => {
   const rootPath = derivationPath.split("/", 2).join("/");
   const accountPath = `${rootPath}/${index}'`;
 
-  const paramXpub = initialAccount?.xpub;
+  const paramXpub = initialAccount?.id.split(":")[3];
 
   let generatedXpub;
   if (!paramXpub) {

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -203,6 +203,12 @@ class BitcoinLikeStorage implements IStorage {
     this.accountIndex = {};
     this.unspentUtxos = {};
     this.spentUtxos = {};
+    data.txs.forEach((tx) => {
+      // migration from the field "hash" to "id" to adapt old data format
+      if (!tx.id && tx.hash) {
+        tx.id = tx.hash;
+      }
+    });
     this.appendTxs(data.txs);
     this.addressCache = data.addressCache;
     Base.addressCache = { ...Base.addressCache, ...this.addressCache };

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -78,13 +78,10 @@ class BitcoinLikeStorage implements IStorage {
       if (this.txs[this.primaryIndex[index]]) {
         return;
       }
-      if (
-        typeof this.accountIndex[`${tx.account}-${tx.index}`] === "undefined"
-      ) {
-        this.accountIndex[`${tx.account}-${tx.index}`] = [];
-      }
       const idx = this.txs.push(tx) - 1;
       this.primaryIndex[index] = idx;
+      this.accountIndex[`${tx.account}-${tx.index}`] =
+        this.accountIndex[`${tx.account}-${tx.index}`] || [];
       this.accountIndex[`${tx.account}-${tx.index}`].push(idx);
       this.unspentUtxos[indexAddress] = this.unspentUtxos[indexAddress] || [];
       this.spentUtxos[indexAddress] = this.spentUtxos[indexAddress] || [];
@@ -196,43 +193,26 @@ class BitcoinLikeStorage implements IStorage {
   exportSync() {
     return {
       txs: this.txs,
-      primaryIndex: this.primaryIndex,
-      accountIndex: this.accountIndex,
-      unspentUtxos: this.unspentUtxos,
       addressCache: this.addressCache,
     };
   }
 
-  loadSync(data: {
-    txs: TX[];
-    primaryIndex: { [key: string]: number };
-    accountIndex: { [key: string]: number[] };
-    unspentUtxos: { [key: string]: Output[] };
-    addressCache: { [key: string]: string };
-  }) {
-    this.txs = data.txs;
-    this.primaryIndex = data.primaryIndex;
-    this.accountIndex = data.accountIndex;
-    this.unspentUtxos = data.unspentUtxos;
+  loadSync(data: { txs: TX[]; addressCache: { [key: string]: string } }) {
+    this.txs = [];
+    this.primaryIndex = {};
+    this.accountIndex = {};
+    this.unspentUtxos = {};
+    this.spentUtxos = {};
+    this.appendTxs(data.txs);
     this.addressCache = data.addressCache;
     Base.addressCache = { ...Base.addressCache, ...this.addressCache };
-    if (!this.accountIndex || isEmpty(this.accountIndex)) {
-      this.accountIndex = {};
-      this.createAccountIndex();
-    }
   }
 
   async export() {
     return this.exportSync();
   }
 
-  async load(data: {
-    txs: TX[];
-    primaryIndex: { [key: string]: number };
-    accountIndex: { [key: string]: number[] };
-    unspentUtxos: { [key: string]: Output[] };
-    addressCache: { [key: string]: string };
-  }) {
+  async load(data: { txs: TX[]; addressCache: { [key: string]: string } }) {
     return this.loadSync(data);
   }
 

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -1,4 +1,4 @@
-import { findLast, filter, uniqBy, findIndex, isEmpty } from "lodash";
+import { findLast, filter, uniqBy, findIndex } from "lodash";
 import Base from "../crypto/base";
 import { Input, IStorage, Output, TX, Address } from "./types";
 

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/types.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/types.ts
@@ -1,5 +1,6 @@
 export interface TX {
   id: string;
+  hash?: string;
   account: number;
   index: number;
   received_at: string;

--- a/libs/ledger-live-common/src/families/bitcoin/xpub.txs.loadExport.unit.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/xpub.txs.loadExport.unit.test.ts
@@ -1,0 +1,101 @@
+import BitcoinLikeStorage from "./wallet-btc/storage";
+
+describe("testing transaction data load and export", () => {
+  it("testing transaction data load and export", async () => {
+    const storage = new BitcoinLikeStorage();
+    storage.appendTxs([
+      {
+        id: "9e1b337875c21f751e70ee2c2c6ee93d8a6733d0f3ba6d139ae6a0479ebcefb0",
+        inputs: [],
+        outputs: [
+          {
+            output_index: 0,
+            value: "5000000000",
+            address: "mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb",
+            output_hash:
+              "9e1b337875c21f751e70ee2c2c6ee93d8a6733d0f3ba6d139ae6a0479ebcefb0",
+            block_height: 1,
+            rbf: false,
+          },
+          {
+            output_index: 1,
+            value: "0",
+            address: "<unknown>",
+            output_hash:
+              "9e1b337875c21f751e70ee2c2c6ee93d8a6733d0f3ba6d139ae6a0479ebcefb0",
+            block_height: 1,
+            rbf: false,
+          },
+        ],
+        block: {
+          hash: "73c565a6f226978df23480e440b27eb02f307855f50aa3bc72ebb586938f23e0",
+          height: 1,
+          time: "2021-07-28T13:34:17Z",
+        },
+        account: 0,
+        index: 0,
+        address: "mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb",
+        received_at: "2021-07-28T13:34:17Z",
+      },
+      {
+        id: "0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1",
+        inputs: [
+          {
+            output_hash:
+              "2772f3963856f3eb38cb706ec8c2b62fcdeb2ce10f32cf7160afb3873be6f60d",
+            output_index: 0,
+            value: "5000000000",
+            address: "2NCDBM9DAuMrD1T8XDHMxvbTmLutP7at4AB",
+            sequence: 4294967294,
+          },
+        ],
+        outputs: [
+          {
+            output_index: 0,
+            value: "300000000",
+            address: "mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb",
+            output_hash:
+              "0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1",
+            block_height: 120,
+            rbf: false,
+          },
+          {
+            output_index: 1,
+            value: "4699983200",
+            address: "2MynSTpze5SDcuLr1DekSV7RVrFpQCo3LeP",
+            output_hash:
+              "0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1",
+            block_height: 120,
+            rbf: false,
+          },
+        ],
+        block: {
+          hash: "305d4b8d4a6d6ecca0a3dd0216f8ecd090978ed346d1845883c8aa4529d72fc8",
+          height: 120,
+          time: "2021-07-28T13:34:38Z",
+        },
+        account: 0,
+        index: 0,
+        address: "mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb",
+        received_at: "2021-07-28T13:34:38Z",
+      },
+    ]);
+    const primaryIndexCopy = Object.assign({}, storage.primaryIndex);
+    const accountIndexCopy = Object.assign({}, storage.accountIndex);
+    expect(Object.keys(primaryIndexCopy).length).toEqual(2);
+    expect(Object.keys(accountIndexCopy).length).toEqual(1);
+    /* primaryIndex:
+    {
+      'mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb-9e1b337875c21f751e70ee2c2c6ee93d8a6733d0f3ba6d139ae6a0479ebcefb0': 0,
+      'mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb-0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1': 1
+    }
+      accountIndex:
+      { '0-0': [ 0, 1 ] }
+    */
+    expect(Object.keys(accountIndexCopy["0-0"]).length).toEqual(2);
+    const txs = (await storage.export()).txs;
+    storage.load({ txs: txs, addressCache: {} });
+    expect(storage.primaryIndex).toMatchObject(primaryIndexCopy);
+    expect(storage.accountIndex).toMatchObject(accountIndexCopy);
+  }, 30000);
+});


### PR DESCRIPTION
### 📝 Description

1. When we did the migration from the field "hash" to "id", the bitcoin sync may be broken
2. xpub is undefined during sync from sentry report. we try to fix it in this PR

### ❓ Context

- **Impacted projects**: `` LLC
- **Linked resource(s)**: 
https://ledgerhq.atlassian.net/browse/LIVE-2643
https://ledgerhq.atlassian.net/browse/LIVE-2914

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

No demo for a bug fix

### 🚀 Expectations to reach

Bitcoin sync correctly