### PR TITLE
[LIVE-2943] Feat/add back forward buttons to web platform player

### DIFF
--- a/.changeset/tender-shrimps-refuse.md
+++ b/.changeset/tender-shrimps-refuse.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add navigation option to WebPlatformPlayer

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -12,6 +12,7 @@ import type { TopBarConfig } from "./type";
 
 import Box, { Tabbable } from "~/renderer/components/Box";
 
+import ArrowRight from "~/renderer/icons/ArrowRight";
 import IconClose from "~/renderer/icons/Cross";
 import IconInfoCircle from "~/renderer/icons/InfoCircle";
 import LightBulb from "~/renderer/icons/LightBulb";
@@ -22,6 +23,7 @@ import { enablePlatformDevToolsSelector } from "~/renderer/reducers/settings";
 import LiveAppIcon from "./LiveAppIcon";
 
 import { openPlatformAppInfoDrawer } from "~/renderer/actions/UI";
+
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
   horizontal: true,
   grow: 0,
@@ -162,10 +164,10 @@ const WebPlatformTopBar = ({
         </ItemContent>
       </ItemContainer>
       <ItemContainer isInteractive onClick={onGoBack}>
-        {"<-"}
+        <ArrowRight flipped size={16} />
       </ItemContainer>
       <ItemContainer isInteractive onClick={onGoForward}>
-        {"->"}
+        <ArrowRight size={16} />
       </ItemContainer>
       {enablePlatformDevTools && (
         <>

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -154,6 +154,20 @@ const WebPlatformTopBar = ({
   useEffect(() => {
     const webview = webviewRef.current;
 
+    /**
+     * Handle webview navigation events.
+     * The two events are complementary to enccompass the webview's navigation
+     *
+     * `did-navigate` is emitted when a navigation is done. But this event is not
+     * emitted for in-page navigations, such as clicking anchor links or updating
+     * the window.location.hash.
+     * That's why we use did-navigate-in-page event for this purpose.
+     * cf. doc bellow:
+     *
+     * https://www.electronjs.org/docs/latest/api/webview-tag#event-did-navigate
+     * https://www.electronjs.org/docs/latest/api/webview-tag#event-did-navigate-in-page
+     */
+
     if (webview && shouldDisplayNavigation) {
       webview.addEventListener("did-navigate", handleDidNavigate);
       webview.addEventListener("did-navigate-in-page", handleDidNavigate);

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import { WebviewTag } from "electron";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { RefObject, useCallback, useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 
@@ -117,7 +117,7 @@ export type Props = {
   onClose?: Function,
   onHelp?: Function,
   config?: TopBarConfig,
-  webviewRef: { current: null | WebviewTag },
+  webviewRef: RefObject<WebviewTag>,
 };
 
 const WebPlatformTopBar = ({
@@ -171,14 +171,12 @@ const WebPlatformTopBar = ({
     if (webview && shouldDisplayNavigation) {
       webview.addEventListener("did-navigate", handleDidNavigate);
       webview.addEventListener("did-navigate-in-page", handleDidNavigate);
-    }
 
-    return () => {
-      if (webview) {
+      return () => {
         webview.removeEventListener("did-navigate", handleDidNavigate);
         webview.removeEventListener("did-navigate-in-page", handleDidNavigate);
-      }
-    };
+      };
+    }
   }, [handleDidNavigate, webviewRef, shouldDisplayNavigation]);
 
   const onClick = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { useCallback, useEffect } from "react";
+import { WebviewTag } from "electron";
+import React, { useCallback, useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 
@@ -116,7 +117,7 @@ export type Props = {
   onClose?: Function,
   onHelp?: Function,
   config?: TopBarConfig,
-  webview: WebviewTag,
+  webviewRef: { current: null | WebviewTag },
 };
 
 const WebPlatformTopBar = ({
@@ -125,7 +126,7 @@ const WebPlatformTopBar = ({
   onHelp,
   onClose,
   config = {},
-  webview,
+  webviewRef,
 }: Props) => {
   const { name, icon } = manifest;
 
@@ -136,17 +137,23 @@ const WebPlatformTopBar = ({
     shouldDisplayNavigation = false,
   } = config;
 
-  const [canGoBack, setCanGoBack] = React.useState(false);
-  const [canGoForward, setCanGoForward] = React.useState(false);
+  const [canGoBack, setCanGoBack] = useState(false);
+  const [canGoForward, setCanGoForward] = useState(false);
   const enablePlatformDevTools = useSelector(enablePlatformDevToolsSelector);
   const dispatch = useDispatch();
 
   const handleDidNavigate = useCallback(() => {
-    setCanGoBack(webview.canGoBack());
-    setCanGoForward(webview.canGoForward());
-  }, [webview]);
+    const webview = webviewRef.current;
+
+    if (webview) {
+      setCanGoBack(webview.canGoBack());
+      setCanGoForward(webview.canGoForward());
+    }
+  }, [webviewRef]);
 
   useEffect(() => {
+    const webview = webviewRef.current;
+
     if (webview && shouldDisplayNavigation) {
       webview.addEventListener("did-navigate", handleDidNavigate);
       webview.addEventListener("did-navigate-in-page", handleDidNavigate);
@@ -158,29 +165,32 @@ const WebPlatformTopBar = ({
         webview.removeEventListener("did-navigate-in-page", handleDidNavigate);
       }
     };
-  }, [handleDidNavigate, webview, shouldDisplayNavigation]);
+  }, [handleDidNavigate, webviewRef, shouldDisplayNavigation]);
 
   const onClick = useCallback(() => {
     dispatch(openPlatformAppInfoDrawer({ manifest }));
   }, [manifest, dispatch]);
 
   const onOpenDevTools = useCallback(() => {
+    const webview = webviewRef.current;
     if (webview) {
       webview.openDevTools();
     }
-  }, [webview]);
+  }, [webviewRef]);
 
   const onGoBack = useCallback(() => {
+    const webview = webviewRef.current;
     if (webview) {
       webview.goBack();
     }
-  }, [webview]);
+  }, [webviewRef]);
 
   const onGoForward = useCallback(() => {
+    const webview = webviewRef.current;
     if (webview) {
       webview.goForward();
     }
-  }, [webview]);
+  }, [webviewRef]);
 
   return (
     <Container>

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -6,20 +6,20 @@ import styled from "styled-components";
 
 import type { AppManifest } from "@ledgerhq/live-common/platform/types";
 
-import type { TopBarConfig } from "./type";
-import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { rgba } from "~/renderer/styles/helpers";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import type { TopBarConfig } from "./type";
 
 import Box, { Tabbable } from "~/renderer/components/Box";
 
-import IconInfoCircle from "~/renderer/icons/InfoCircle";
-import IconReload from "~/renderer/icons/UpdateCircle";
-import LightBulb from "~/renderer/icons/LightBulb";
 import IconClose from "~/renderer/icons/Cross";
+import IconInfoCircle from "~/renderer/icons/InfoCircle";
+import LightBulb from "~/renderer/icons/LightBulb";
+import IconReload from "~/renderer/icons/UpdateCircle";
 
-import LiveAppIcon from "./LiveAppIcon";
-import { useSelector, useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { enablePlatformDevToolsSelector } from "~/renderer/reducers/settings";
+import LiveAppIcon from "./LiveAppIcon";
 
 import { openPlatformAppInfoDrawer } from "~/renderer/actions/UI";
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
@@ -114,6 +114,8 @@ export type Props = {
   onClose?: Function,
   onHelp?: Function,
   onOpenDevTools: Function,
+  onGoBack: Function,
+  onGoForward: Function,
   config?: TopBarConfig,
 };
 
@@ -123,6 +125,8 @@ const WebPlatformTopBar = ({
   onHelp,
   onClose,
   onOpenDevTools,
+  onGoBack,
+  onGoForward,
   config = {},
 }: Props) => {
   const { name, icon } = manifest;
@@ -156,6 +160,12 @@ const WebPlatformTopBar = ({
         <ItemContent>
           <Trans i18nKey="common.sync.refresh" />
         </ItemContent>
+      </ItemContainer>
+      <ItemContainer isInteractive onClick={onGoBack}>
+        {"<-"}
+      </ItemContainer>
+      <ItemContainer isInteractive onClick={onGoForward}>
+        {"->"}
       </ItemContainer>
       {enablePlatformDevTools && (
         <>

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -115,10 +115,8 @@ export type Props = {
   onReload: Function,
   onClose?: Function,
   onHelp?: Function,
-  onOpenDevTools: Function,
-  onGoBack: Function,
-  onGoForward: Function,
   config?: TopBarConfig,
+  webview: WebviewTag,
 };
 
 const WebPlatformTopBar = ({
@@ -126,10 +124,8 @@ const WebPlatformTopBar = ({
   onReload,
   onHelp,
   onClose,
-  onOpenDevTools,
-  onGoBack,
-  onGoForward,
   config = {},
+  webview,
 }: Props) => {
   const { name, icon } = manifest;
 
@@ -145,6 +141,24 @@ const WebPlatformTopBar = ({
   const onClick = useCallback(() => {
     dispatch(openPlatformAppInfoDrawer({ manifest }));
   }, [manifest, dispatch]);
+
+  const onOpenDevTools = useCallback(() => {
+    if (webview) {
+      webview.openDevTools();
+    }
+  }, [webview]);
+
+  const onGoBack = useCallback(() => {
+    if (webview) {
+      webview.goBack();
+    }
+  }, [webview]);
+
+  const onGoForward = useCallback(() => {
+    if (webview) {
+      webview.goForward();
+    }
+  }, [webview]);
 
   return (
     <Container>

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.jsx
@@ -133,6 +133,7 @@ const WebPlatformTopBar = ({
     shouldDisplayName = true,
     shouldDisplayInfo = true,
     shouldDisplayClose = !!onClose,
+    shouldDisplayNavigation = false,
   } = config;
 
   const [canGoBack, setCanGoBack] = React.useState(false);
@@ -146,7 +147,7 @@ const WebPlatformTopBar = ({
   }, [webview]);
 
   useEffect(() => {
-    if (webview) {
+    if (webview && shouldDisplayNavigation) {
       webview.addEventListener("did-navigate", handleDidNavigate);
       webview.addEventListener("did-navigate-in-page", handleDidNavigate);
     }
@@ -157,7 +158,7 @@ const WebPlatformTopBar = ({
         webview.removeEventListener("did-navigate-in-page", handleDidNavigate);
       }
     };
-  }, [handleDidNavigate, webview]);
+  }, [handleDidNavigate, webview, shouldDisplayNavigation]);
 
   const onClick = useCallback(() => {
     dispatch(openPlatformAppInfoDrawer({ manifest }));
@@ -198,12 +199,16 @@ const WebPlatformTopBar = ({
           <Trans i18nKey="common.sync.refresh" />
         </ItemContent>
       </ItemContainer>
-      <ItemContainer disabled={!canGoBack} isInteractive onClick={onGoBack}>
-        <ArrowRight flipped size={16} />
-      </ItemContainer>
-      <ItemContainer disabled={!canGoForward} isInteractive onClick={onGoForward}>
-        <ArrowRight size={16} />
-      </ItemContainer>
+      {shouldDisplayNavigation && (
+        <>
+          <ItemContainer disabled={!canGoBack} isInteractive onClick={onGoBack}>
+            <ArrowRight flipped size={16} />
+          </ItemContainer>
+          <ItemContainer disabled={!canGoForward} isInteractive onClick={onGoForward}>
+            <ArrowRight size={16} />
+          </ItemContainer>
+        </>
+      )}
       {enablePlatformDevTools && (
         <>
           <Separator />

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
@@ -288,7 +288,7 @@ export default function WebPlatformPlayer({ manifest, onClose, inputs = {}, conf
         manifest={manifest}
         onReload={handleReload}
         onClose={onClose}
-        webview={targetRef.current}
+        webviewRef={targetRef}
         config={config?.topBarConfig}
       />
 

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
@@ -281,30 +281,6 @@ export default function WebPlatformPlayer({ manifest, onClose, inputs = {}, conf
     };
   }, [handleLoad, handleNewWindow]);
 
-  const handleOpenDevTools = useCallback(() => {
-    const webview = targetRef.current;
-
-    if (webview) {
-      webview.openDevTools();
-    }
-  }, []);
-
-  const handleGoBack = useCallback(() => {
-    const webview = targetRef.current;
-
-    if (webview) {
-      webview.goBack();
-    }
-  }, []);
-
-  const handleGoForward = useCallback(() => {
-    const webview = targetRef.current;
-
-    if (webview) {
-      webview.goForward();
-    }
-  }, []);
-
   return (
     <Container>
       <TrackPage category="Platform" name="App" appId={manifest.id} params={inputs} />
@@ -312,9 +288,7 @@ export default function WebPlatformPlayer({ manifest, onClose, inputs = {}, conf
         manifest={manifest}
         onReload={handleReload}
         onClose={onClose}
-        onOpenDevTools={handleOpenDevTools}
-        onGoBack={handleGoBack}
-        onGoForward={handleGoForward}
+        webview={targetRef.current}
         config={config?.topBarConfig}
       />
 

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
@@ -289,6 +289,22 @@ export default function WebPlatformPlayer({ manifest, onClose, inputs = {}, conf
     }
   }, []);
 
+  const handleGoBack = useCallback(() => {
+    const webview = targetRef.current;
+
+    if (webview) {
+      webview.goBack();
+    }
+  }, []);
+
+  const handleGoForward = useCallback(() => {
+    const webview = targetRef.current;
+
+    if (webview) {
+      webview.goForward();
+    }
+  }, []);
+
   return (
     <Container>
       <TrackPage category="Platform" name="App" appId={manifest.id} params={inputs} />
@@ -297,6 +313,8 @@ export default function WebPlatformPlayer({ manifest, onClose, inputs = {}, conf
         onReload={handleReload}
         onClose={onClose}
         onOpenDevTools={handleOpenDevTools}
+        onGoBack={handleGoBack}
+        onGoForward={handleGoForward}
         config={config?.topBarConfig}
       />
 

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/type.js
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/type.js
@@ -10,4 +10,5 @@ export type TopBarConfig = {
   shouldDisplayName?: boolean,
   shouldDisplayInfo?: boolean,
   shouldDisplayClose?: boolean,
+  shouldDisplayNavigation?: boolean,
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/card/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/card/index.jsx
@@ -1,8 +1,8 @@
 // @flow
+import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import React from "react";
 import { useLocation } from "react-router-dom";
 import useTheme from "~/renderer/hooks/useTheme";
-import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 
 import { Card } from "~/renderer/components/Box";
 import WebPlatformPlayer from "~/renderer/components/WebPlatformPlayer";
@@ -33,6 +33,7 @@ export default function CardPlatformApp() {
               shouldDisplayName: false,
               shouldDisplayInfo: false,
               shouldDisplayClose: false,
+              shouldDisplayNavigation: true,
             },
           }}
           manifest={manifest}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add the back and forward buttons to the web platform player, allowing to easily back and forth in a Live app and also between live apps (like with the Buy / Sell live-app that redirect to other live apps) 

Possible to display or hide navigation through a new property in the `TopBarConfig` prop.

For now, only enables the navigation on the dedicated Ledger Card entry
The navigation on the Buy / Sell screen will be enabled by this PR -> https://github.com/LedgerHQ/ledger-live/pull/923


### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![a](https://user-images.githubusercontent.com/9203826/178308971-04ffdd9c-c1d1-45dd-abf0-2c051afb2a2c.png)

https://user-images.githubusercontent.com/9203826/178308976-f1d276d8-cf08-4e71-a35b-a938cd5d8e8a.mov


### 🚀 Expectations to reach

We can go back and forward on live apps.

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
