### PR TITLE
LIVE-2643 LIVE-2914 fix xpub null and "hash" to "id" migration

### DIFF
--- a/.changeset/curvy-walls-greet.md
+++ b/.changeset/curvy-walls-greet.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix undefined xpub bug and the field "hash" to "id" migration bug

--- a/libs/ledger-live-common/src/families/bitcoin/datasets/bitcoin.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/datasets/bitcoin.ts
@@ -134,7 +134,6 @@ const dataset: CurrenciesData<Transaction> = {
         balance: "2757",
         blockHeight: 0,
         lastSyncDate: "",
-        xpub: "xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn",
       },
     },
     {
@@ -160,7 +159,6 @@ const dataset: CurrenciesData<Transaction> = {
         unitMagnitude: 8,
         lastSyncDate: "",
         balance: "2717",
-        xpub: "xpub6DEHKg8fgKcb9at2u9Xhjtx4tXGyWqUPQAx2zNCzr41gQRyCqpCn7onSoJU4VS96GXyCtAhhFxErnG2pGVvVexaqF7DEfqGGnGk7Havn7C2",
       },
     },
   ],

--- a/libs/ledger-live-common/src/families/bitcoin/descriptor.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/descriptor.ts
@@ -13,6 +13,8 @@ import {
 } from "../../derivation";
 import { withDevice } from "../../hw/deviceAccess";
 import getAddress from "../../hw/getAddress";
+import { decodeAccountId } from "../../account/accountId";
+
 export type AccountDescriptor = {
   internal: string;
   external: string;
@@ -57,7 +59,8 @@ export function inferDescriptorFromAccount(
   account: Account
 ): AccountDescriptor | null | undefined {
   if (account.currency.family !== "bitcoin") return;
-  const { xpub, derivationMode, seedIdentifier, currency, index } = account;
+  const { id, derivationMode, seedIdentifier, currency, index } = account;
+  const xpub = decodeAccountId(id).xpubOrAddress;
   const fingerprint = makeFingerprint(
     compressPublicKeySECP256(Buffer.from(seedIdentifier, "hex"))
   );

--- a/libs/ledger-live-common/src/families/bitcoin/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/js-synchronisation.ts
@@ -19,6 +19,7 @@ import { perCoinLogic } from "./logic";
 import wallet from "./wallet-btc";
 import { getAddressWithBtcInstance } from "./hw-getAddress";
 import { mapTxToOperations } from "./logic";
+import { decodeAccountId } from "../../account/accountId";
 
 // Map LL's DerivationMode to wallet-btc's
 const toWalletDerivationMode = (
@@ -93,7 +94,9 @@ const getAccountShape: GetAccountShape = async (info) => {
   const rootPath = derivationPath.split("/", 2).join("/");
   const accountPath = `${rootPath}/${index}'`;
 
-  const paramXpub = initialAccount?.xpub;
+  const paramXpub = initialAccount
+    ? decodeAccountId(initialAccount.id).xpubOrAddress
+    : undefined;
 
   let generatedXpub;
   if (!paramXpub) {

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -203,6 +203,12 @@ class BitcoinLikeStorage implements IStorage {
     this.accountIndex = {};
     this.unspentUtxos = {};
     this.spentUtxos = {};
+    data.txs.forEach((tx) => {
+      // migration from the field "hash" to "id" to adapt old data format
+      if (!tx.id && tx.hash) {
+        tx.id = tx.hash;
+      }
+    });
     this.appendTxs(data.txs);
     this.addressCache = data.addressCache;
     Base.addressCache = { ...Base.addressCache, ...this.addressCache };

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/types.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/types.ts
@@ -1,5 +1,6 @@
 export interface TX {
   id: string;
+  hash?: string;
   account: number;
   index: number;
   received_at: string;


### PR DESCRIPTION
### 📝 Description

1. When we did the migration from the field "hash" to "id", the bitcoin sync may be broken
2. xpub is undefined during sync from sentry report. we try to fix it in this PR

### ❓ Context

- **Impacted projects**: `` LLC
- **Linked resource(s)**: 
https://ledgerhq.atlassian.net/browse/LIVE-2643
https://ledgerhq.atlassian.net/browse/LIVE-2914

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

No demo for a bug fix

### 🚀 Expectations to reach

Bitcoin sync correctly