### PR TITLE
bugfix/LIVE-2836-fix-ratings-drawer-conflict-with-receive-flow done

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
@@ -109,6 +109,7 @@ export default function ReceiveFundsNavigator() {
         component={ReceiveConfirmation}
         options={{
           headerTitle: "",
+          headerLeft: null,
         }}
       />
       {/* Receive Address Device Verification */}

--- a/apps/ledger-live-mobile/src/reducers/ratings.js
+++ b/apps/ledger-live-mobile/src/reducers/ratings.js
@@ -30,7 +30,7 @@ const handlers: Object = {
     ...state,
     isRatingsModalOpen,
   }),
-  RATINGS_SET_CURRENT_ROUTE: (
+  RATINGS_SET_CURRENT_ROUTE_NAME: (
     state: RatingsState,
     { currentRouteName }: { currentRouteName?: string },
   ) => ({

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -28,6 +28,7 @@ import ReceiveSecurityModal from "./ReceiveSecurityModal";
 import AdditionalInfoModal from "./AdditionalInfoModal";
 import { replaceAccounts } from "../../actions/accounts";
 import { ScreenName } from "../../const";
+import PreventNativeBack from "../../components/PreventNativeBack";
 
 type Props = {
   account?: (TokenAccount | Account),
@@ -126,6 +127,7 @@ export default function ReceiveConfirmation({ navigation, route }: Props) {
 
   return (
     <Flex flex={1} mb={9}>
+      <PreventNativeBack />
       <NavigationScrollView style={{ flex: 1 }}>
         <Flex p={6} alignItems="center" justifyContent="center">
           <Text color="neutral.c100" fontWeight="semiBold" variant="h4" mb={3}>


### PR DESCRIPTION


### 📝 Description

The ratings prompt now appears when leaving the screen in the case of the receive confirm address screen to avoid having two drawers displayed at the same time.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2836]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2836]: https://ledgerhq.atlassian.net/browse/LIVE-2836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ