### PR TITLE
Feat/live 2473 sign message

### DIFF
--- a/apps/ledger-live-mobile/src/components/HeaderRightClose.js
+++ b/apps/ledger-live-mobile/src/components/HeaderRightClose.js
@@ -34,22 +34,30 @@ export default function HeaderRightClose({
   const [onModalHide, setOnModalHide] = useState();
 
   function close(): void {
-    if (onClose) {
-      onClose();
-    }
-
     if (skipNavigation) {
+      // onClose should always be call at the end of the close method,
+      // so the callback will not interfere with the expected behavior of this component
+      if (onClose) {
+        onClose();
+      }
       return;
     }
 
     if (navigation.getParent().pop && preferDismiss) {
       navigation.getParent().pop();
+      if (onClose) {
+        onClose();
+      }
       return;
     }
 
     if (navigation.closeDrawer) navigation.closeDrawer();
 
     navigation.goBack();
+
+    if (onClose) {
+      onClose();
+    }
   }
 
   function onPress(): void {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SignMessageNavigator.js
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SignMessageNavigator.js
@@ -14,12 +14,13 @@ import StepHeader from "../StepHeader";
 
 const totalSteps = "3";
 
-export default function SignMessageNavigator() {
+export default function SignMessageNavigator({route}: {route: {params: Record<String, any>}}) {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors, true), [
-    colors,
-  ]);
+  const stackNavConfig = useMemo(
+    () => getStackNavigatorConfig(colors, true, route.params.onClose),
+    [colors],
+  );
   return (
     <Stack.Navigator screenOptions={stackNavConfig}>
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SignMessageNavigator.js
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SignMessageNavigator.js
@@ -14,7 +14,11 @@ import StepHeader from "../StepHeader";
 
 const totalSteps = "3";
 
-export default function SignMessageNavigator({route}: {route: {params: Record<String, any>}}) {
+export default function SignMessageNavigator({
+  route,
+}: {
+  route: { params: Record<String, any> },
+}) {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const stackNavConfig = useMemo(

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -48,6 +48,8 @@ import {
   serializePlatformSignedTransaction,
   deserializePlatformSignedTransaction,
 } from "@ledgerhq/live-common/platform/serializers";
+import { prepareMessageToSign } from "@ledgerhq/live-common/lib/hw/signMessage";
+
 import { NavigatorName, ScreenName } from "../../const";
 import { broadcastSignedTx } from "../../logic/screenTransactionHooks";
 import { accountsSelector } from "../../reducers/accounts";
@@ -56,7 +58,6 @@ import InfoIcon from "../../icons/Info";
 import InfoPanel from "./InfoPanel";
 
 import * as tracking from "./tracking";
-import { prepareMessageToSign, signMessageExec } from "@ledgerhq/live-common/lib/hw/signMessage";
 
 type Props = {
   manifest: AppManifest,

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -555,12 +555,23 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
         return Promise.reject(error);
       }
 
-      navigation.navigate(NavigatorName.SignMessage, {
-        screen: ScreenName.SignSummary,
-        params: {
-          message: formattedMessage,
-          accountId,
-        },
+      return new Promise((resolve, reject) => {
+        navigation.navigate(NavigatorName.SignMessage, {
+          screen: ScreenName.SignSummary,
+          params: {
+            message: formattedMessage,
+            accountId,
+            onConfirmationHandler: message => {
+              resolve(message);
+            },
+            onFailHandler: error => {
+              reject(error);
+            },
+          },
+          onClose: () => {
+            reject(new Error("Signature aborted by user"));
+          },
+        });
       });
     },
     [navigation, accounts],

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -18,9 +18,11 @@ import {
 import { WebView } from "react-native-webview";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import Color from "color";
+import invariant from "invariant";
 
 import { JSONRPCRequest } from "json-rpc-2.0";
 
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type {
   RawPlatformTransaction,
   RawPlatformSignedTransaction,
@@ -551,6 +553,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
 
       try {
         const account = accounts.find(account => account.id === accountId);
+        invariant(account, "account not found");
         formattedMessage = prepareMessageToSign(account, message);
       } catch (error) {
         return Promise.reject(error);
@@ -570,7 +573,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
             },
           },
           onClose: () => {
-            reject(new Error("Signature aborted by user"));
+            reject(new UserRefusedOnDevice());
           },
         });
       });

--- a/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
+++ b/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
@@ -12,7 +12,11 @@ export const defaultNavigationOptions = {
   headerTitleAllowFontScaling: false,
 };
 
-export const getStackNavigatorConfig = (c: any, closable: boolean = false) => ({
+export const getStackNavigatorConfig = (
+  c: any,
+  closable: boolean = false,
+  onClose?: Function,
+) => ({
   ...defaultNavigationOptions,
   cardStyle: { backgroundColor: c.background.main || c.background },
   headerStyle: {
@@ -26,5 +30,7 @@ export const getStackNavigatorConfig = (c: any, closable: boolean = false) => ({
   headerTitleStyle: {
     color: c.neutral?.c100 || c.darkBlue,
   },
-  headerRight: closable ? () => <HeaderRightClose /> : undefined,
+  headerRight: closable
+    ? () => <HeaderRightClose onClose={onClose} />
+    : undefined,
 });

--- a/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.js
@@ -30,7 +30,7 @@ export type RouteParams = {
   accountId: string,
   message: MessageData | TypedMessageData,
   onConfirmationHandler?: (MessageData | TypedMessageData) => void,
-  onFailHandler?: (Error) => void,
+  onFailHandler?: Error => void,
   currentNavigation?: string,
   nextNavigation?: string,
 };

--- a/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.js
@@ -29,6 +29,8 @@ type Props = {
 export type RouteParams = {
   accountId: string,
   message: MessageData | TypedMessageData,
+  onConfirmationHandler?: (MessageData | TypedMessageData) => void,
+  onFailHandler?: (Error) => void,
   currentNavigation?: string,
   nextNavigation?: string,
 };

--- a/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.js
@@ -29,8 +29,10 @@ type Props = {
 type RouteParams = {
   device: Device,
   accountId: string,
-  appName?: string,
   message: TypedMessageData | MessageData,
+  appName?: string,
+  onConfirmationHandler?: (MessageData | TypedMessageData) => void,
+  onFailHandler?: (Error) => void,
 };
 
 export default function ConnectDevice({ route, navigation }: Props) {

--- a/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.js
@@ -32,7 +32,7 @@ type RouteParams = {
   message: TypedMessageData | MessageData,
   appName?: string,
   onConfirmationHandler?: (MessageData | TypedMessageData) => void,
-  onFailHandler?: (Error) => void,
+  onFailHandler?: Error => void,
 };
 
 export default function ConnectDevice({ route, navigation }: Props) {

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.js
@@ -27,11 +27,12 @@ type RouteParams = {
   accountId: string,
   message: TypedMessageData | MessageData,
   error: Error,
+  onFailHandler?: (Error) => void,
 };
 
 export default function ValidationError({ navigation, route }: Props) {
   const { colors } = useTheme();
-  const error = route.params.error;
+  const { error, onFailHandler } = route.params;
   const wcContext = useContext(_wcContext);
   const [disableRetry, setDisableRetry] = useState(false);
 
@@ -39,6 +40,9 @@ export default function ValidationError({ navigation, route }: Props) {
     if (wcContext.currentCallRequestId) {
       setDisableRetry(true);
       setCurrentCallRequestError(error);
+      if (onFailHandler) {
+        onFailHandler(error);
+      }
     }
   }, []);
 

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.js
@@ -40,11 +40,11 @@ export default function ValidationError({ navigation, route }: Props) {
     if (wcContext.currentCallRequestId) {
       setDisableRetry(true);
       setCurrentCallRequestError(error);
-      if (onFailHandler) {
-        onFailHandler(error);
-      }
     }
-  }, []);
+    if (onFailHandler) {
+      onFailHandler(error);
+    }
+  }, [wcContext.currentCallRequestId, onFailHandler, error]);
 
   const onClose = useCallback(() => {
     navigation.getParent().pop();

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.js
@@ -27,7 +27,7 @@ type RouteParams = {
   accountId: string,
   message: TypedMessageData | MessageData,
   error: Error,
-  onFailHandler?: (Error) => void,
+  onFailHandler?: Error => void,
 };
 
 export default function ValidationError({ navigation, route }: Props) {

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationSuccess.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationSuccess.js
@@ -25,16 +25,21 @@ type RouteParams = {
   accountId: string,
   message: TypedMessageData | MessageData,
   signature: string,
+  onConfirmationHandler?: (MessageData | TypedMessageData) => void,
 };
 
 export default function ValidationSuccess({ navigation, route }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const { signature, onConfirmationHandler } = route.params;
   const wcContext = useContext(_wcContext);
 
   useEffect(() => {
     if (wcContext.currentCallRequestId) {
-      setCurrentCallRequestResult(route.params.signature);
+      setCurrentCallRequestResult(signature);
+    }
+    if (onConfirmationHandler) {
+      onConfirmationHandler(signature);
     }
   }, []);
 

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationSuccess.js
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationSuccess.js
@@ -41,7 +41,7 @@ export default function ValidationSuccess({ navigation, route }: Props) {
     if (onConfirmationHandler) {
       onConfirmationHandler(signature);
     }
-  }, []);
+  }, [wcContext.currentCallRequestId, onConfirmationHandler, signature]);
 
   const onClose = useCallback(() => {
     navigation.getParent().pop();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add signMessage call management in the mobile app.
Modification of the current management of the `onClose` callback of the `HeaderRightClose.js` component. This callback was not without some potential side effect. Therefore, its call has been moved at the end of the execution of the `HeaderRightClose::close` method.
The WalletConnect integration for the mobile has been slightly modified, due to this change.

### ❓ Context

- **Impacted projects**: `Mobile`, `WalletConnect`
- **Linked resource(s)**: 
  - [LIVE-2473](https://ledgerhq.atlassian.net/browse/LIVE-2473)
  - [EPIC](https://ledgerhq.atlassian.net/browse/LIVE-2463) related
  - Other PR related
    - https://github.com/LedgerHQ/live-app-sdk/pull/118
    - https://github.com/LedgerHQ/eth-dapp-browser/pull/9
    - https://github.com/LedgerHQ/platform-app-debug/pull/3

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

<!--  Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps). -->

No current behavior of the mobile application is expected with this sole PR.

<!-- If any of the expectations are not met please explain the reason in detail. -->
