### PR TITLE
Workaround to re-enable pnpm cache in the CI

### DIFF
--- a/.github/workflow-templates/bot-coin-family.yml
+++ b/.github/workflow-templates/bot-coin-family.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/backup/version-or-release.yml
+++ b/.github/workflows/backup/version-or-release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/bot-bitcoin-mooncake.yml
+++ b/.github/workflows/bot-bitcoin-mooncake.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/bot-cardano-silicium.yml
+++ b/.github/workflows/bot-cardano-silicium.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/bot-filecoin.yml
+++ b/.github/workflows/bot-filecoin.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/bot-phosphore.yml
+++ b/.github/workflows/bot-phosphore.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/bot-staging-explorer-btc.yml
+++ b/.github/workflows/bot-staging-explorer-btc.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/bot-transfer.yml
+++ b/.github/workflows/bot-transfer.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: TurboRepo local server
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: TurboRepo local server
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: TurboRepo local server

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: bump npm
         run: npm i -g npm@8.12.2
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: bump npm
         run: npm i -g npm@8.12.2
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: bump npm
         run: npm i -g npm@8.12.2

--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: install dependencies
         run: pnpm i -F "ledger-live"

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: install dependencies
         run: pnpm i -F "ledger-live"

--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
           registry-url: "https://registry.npmjs.org"
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
           registry-url: "https://registry.npmjs.org"
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-prepare-desktop.yml
+++ b/.github/workflows/release-prepare-desktop.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: install dependencies

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: install dependencies

--- a/.github/workflows/release-prepare-mobile.yml
+++ b/.github/workflows/release-prepare-mobile.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
 
       - name: install dependencies

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
           registry-url: "https://registry.npmjs.org"
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Bump npm to latest
         run: |

--- a/.github/workflows/test-mobile.yml
+++ b/.github/workflows/test-mobile.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - name: Install dependencies
         run: pnpm i --filter="!./apps/**" --frozen-lockfile
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          # cache: pnpm
+          cache: pnpm
           cache-dependency-path: "**/pnpm-lock.yaml"
       - uses: actions/setup-python@v2
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -2,6 +2,8 @@ shared-workspace-lockfile=true
 enable-pre-post-scripts=true
 hoist=false
 strict-peer-dependencies=false
+# See: https://github.com/actions/setup-node/issues/543#issuecomment-1182469390
+loglevel=warn
 # Disabled because it does not seem to be working and it regenerates the lockfile abusively
 side-effects-cache=false
 

--- a/tools/actions/composites/setup-test-desktop/action.yml
+++ b/tools/actions/composites/setup-test-desktop/action.yml
@@ -17,7 +17,7 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
-        # cache: pnpm
+        cache: pnpm
         cache-dependency-path: "**/pnpm-lock.yaml"
     - uses: actions/setup-python@v4
       if: ${{ !inputs.skip_python }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Setting `loglevel=warn` prevents `pnpm store` from outputting multiple lines instead of a single one.
Should fix the CI until pnpm publishes a fix.

### ❓ Context

- **Impacted projects**: `n/a` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://github.com/actions/setup-node/issues/543 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
