### PR TITLE
Add StyleProviderV3 to safely use UI lib in LLD

### DIFF
--- a/.changeset/friendly-clocks-begin.md
+++ b/.changeset/friendly-clocks-begin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-ui": patch
+---
+
+Fix background color of Popin & Drawer components

--- a/.changeset/stale-trains-sneeze.md
+++ b/.changeset/stale-trains-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-ui": patch
+---
+
+Fix overlay color of Popin component

--- a/apps/ledger-live-desktop/.flowconfig
+++ b/apps/ledger-live-desktop/.flowconfig
@@ -27,6 +27,9 @@ module.name_mapper='^@ledgerhq/live-common/\(.*\)' ->'<PROJECT_ROOT>/../../libs/
 munge_underscores=true
 esproposal.optional_chaining=enable
 
+module.file_ext=.tsx
+module.file_ext=.ts
+
 [strict]
 
 [untyped]

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.jsx
@@ -11,7 +11,7 @@ import TransactionsPendingConfirmationWarning from "~/renderer/components/Transa
 import { PlaceholderLine } from "./Placeholder";
 
 // $FlowFixMe
-import Button from "~/renderer/components/Button.ui.tsx";
+import Button from "~/renderer/components/ButtonV3";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { useHistory } from "react-router-dom";
 

--- a/apps/ledger-live-desktop/src/renderer/components/ButtonV3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ButtonV3.tsx
@@ -1,4 +1,3 @@
-// @flow
 import React from "react";
 import { Button as BaseButton, InvertTheme } from "@ledgerhq/react-ui";
 import { ButtonProps as BaseButtonProps } from "@ledgerhq/react-ui/components/cta/Button";

--- a/apps/ledger-live-desktop/src/renderer/components/Illustration.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Illustration.tsx
@@ -1,0 +1,25 @@
+import { ThemedComponent } from "renderer/styles/StyleProviderV3";
+import styled, { DefaultTheme, ThemeProps } from "styled-components";
+import { Box } from "@ledgerhq/react-ui";
+
+type Props = {
+  lightSource: string;
+  darkSource: string;
+  size: number;
+};
+
+const defineStyleFromTheme = (lightAsset: string, darkAsset: string) => (
+  p: ThemeProps<DefaultTheme>,
+) => (p.theme.colors.palette.type === "light" ? lightAsset : darkAsset);
+
+const Img: ThemedComponent<Props> = styled(Box).attrs((p: Props) => ({
+  width: `${p.size}px`,
+  height: `${p.size}px`,
+}))<Props>`
+  background: url(${(p: Props) => defineStyleFromTheme(p.lightSource, p.darkSource)(p)});
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center center;
+`;
+
+export default Img;

--- a/apps/ledger-live-desktop/src/renderer/modals/TermOfUseUpdate/TermOfUseUpdateBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/TermOfUseUpdate/TermOfUseUpdateBody.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
 import { ModalBody } from "~/renderer/components/Modal";
-import Button from "~/renderer/components/Button.ui";
+import Button from "~/renderer/components/ButtonV3";
 import { openURL } from "~/renderer/linking";
 import { useDynamicUrl } from "~/renderer/terms";
 

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountActionsDefault.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountActionsDefault.jsx
@@ -6,7 +6,7 @@ import IconSend from "~/renderer/icons/Send";
 import IconSwap from "~/renderer/icons/Swap";
 import IconExchange from "~/renderer/icons/Exchange";
 // $FlowFixMe
-import Button from "~/renderer/components/Button.ui.tsx";
+import Button from "~/renderer/components/ButtonV3";
 import { Flex } from "@ledgerhq/react-ui";
 type Props = {
   onClick: () => void,

--- a/apps/ledger-live-desktop/src/renderer/screens/asset/AssetBalanceSummaryHeader.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/asset/AssetBalanceSummaryHeader.jsx
@@ -21,7 +21,7 @@ import styled from "styled-components";
 import Swap from "~/renderer/icons/Swap";
 
 // $FlowFixMe
-import Button from "~/renderer/components/Button.ui.tsx";
+import Button from "~/renderer/components/ButtonV3";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { useHistory } from "react-router-dom";
 import { useTranslation } from "react-i18next";

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoinScreen/MarketCoinChart.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoinScreen/MarketCoinChart.tsx
@@ -1,4 +1,3 @@
-// @flow
 import React, { useMemo, memo, useCallback } from "react";
 import { Flex, Text, Bar } from "@ledgerhq/react-ui";
 import { SwitchTransition, Transition } from "react-transition-group";

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketDataProviderWrapper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketDataProviderWrapper.tsx
@@ -1,7 +1,5 @@
-// @flow
 import React, { ReactElement } from "react";
 import { useSelector } from "react-redux";
-// $FlowFixMe
 import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 import { MarketDataProvider } from "@ledgerhq/live-common/market/MarketDataProvider";
 import apiMock from "@ledgerhq/live-common/market/api/api.mock";

--- a/apps/ledger-live-desktop/src/renderer/styles/StyleProviderV3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/styles/StyleProviderV3.tsx
@@ -1,0 +1,58 @@
+import "@ledgerhq/react-ui/assets/fonts";
+import React, { useMemo } from "react";
+import { StyledComponent, ThemeProvider, useTheme } from "styled-components";
+import defaultTheme, { Theme } from "./theme";
+import palettes from "./palettes";
+
+import {
+  GlobalStyle,
+  defaultTheme as V3dDfaultTheme,
+  palettes as V3Palettes,
+} from "@ledgerhq/react-ui/styles/index";
+
+type Props = {
+  children: React.ReactNode;
+  selectedPalette: "light" | "dark";
+};
+
+export type ThemedComponent<T> = StyledComponent<T, Theme, any>;
+
+const StyleProviderV3 = ({ children, selectedPalette }: Props) => {
+  const palettesAny: any = palettes;
+  const v3SelectedPalettes = selectedPalette === "light" ? "light" : "dark";
+  const theme: Theme = useMemo(
+    () => ({
+      ...defaultTheme,
+      ...V3dDfaultTheme,
+      colors: {
+        ...defaultTheme.colors,
+        ...V3Palettes[v3SelectedPalettes],
+        palette: { ...palettesAny[v3SelectedPalettes], ...V3Palettes[v3SelectedPalettes] },
+      },
+      theme: v3SelectedPalettes,
+    }),
+    [palettesAny, v3SelectedPalettes],
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      {children}
+    </ThemeProvider>
+  );
+};
+
+export const withV3StyleProvider = (Component: React.ComponentType) => {
+  const WrappedComponent = props => {
+    const theme = useTheme();
+
+    return (
+      <StyleProviderV3 selectedPalette={theme.colors.type}>
+        <Component {...props} />
+      </StyleProviderV3>
+    );
+  };
+  return WrappedComponent;
+};
+
+export default StyleProviderV3;

--- a/libs/ui/packages/react/src/components/layout/Drawer/index.tsx
+++ b/libs/ui/packages/react/src/components/layout/Drawer/index.tsx
@@ -141,7 +141,7 @@ const DrawerContent = React.forwardRef(
             <Wrapper
               big={big}
               onClick={stopClickPropagation}
-              backgroundColor={backgroundColor ?? "neutral.c00"}
+              backgroundColor={backgroundColor ?? "background.main"}
             >
               <Container>
                 <FlexBox

--- a/libs/ui/packages/react/src/components/layout/Popin/index.tsx
+++ b/libs/ui/packages/react/src/components/layout/Popin/index.tsx
@@ -50,7 +50,7 @@ const Overlay = styled(Flex).attrs((p) => ({
   position: "fixed",
   top: 0,
   left: 0,
-  backgroundColor: p.theme.colors.neutral.c100a07,
+  backgroundColor: "constant.overlay",
 }))``;
 
 const Header = baseStyled.section`

--- a/libs/ui/packages/react/src/components/layout/Popin/index.tsx
+++ b/libs/ui/packages/react/src/components/layout/Popin/index.tsx
@@ -38,7 +38,7 @@ const Wrapper = styled(Flex).attrs<FlexBoxProps>((p) => ({
   zIndex: p.theme.zIndexes[8],
   p: p.p !== undefined ? p.p : p.theme.space[10],
   rowGap: 6,
-  backgroundColor: p.theme.colors.neutral.c00,
+  backgroundColor: "background.main",
 }))``;
 
 const Overlay = styled(Flex).attrs((p) => ({

--- a/libs/ui/packages/react/src/index.ts
+++ b/libs/ui/packages/react/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./components";
 export * from "./assets";
-export { StyleProvider, InvertTheme } from "./styles";
+export { StyleProvider, InvertTheme, InvertThemeV3 } from "./styles";

--- a/libs/ui/packages/react/src/styles/InvertTheme.tsx
+++ b/libs/ui/packages/react/src/styles/InvertTheme.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { ThemeProvider, useTheme } from "styled-components";
 import { defaultTheme } from ".";
 import { palettes } from "@ledgerhq/ui-shared";
-import { Theme } from "./theme";
+import V3dDfaultTheme, { Theme } from "./theme";
 
 export type Props = {
   if?: boolean;
@@ -24,4 +24,24 @@ export const InvertTheme = ({
   );
 
   return <ThemeProvider theme={condition ? newTheme : theme}>{children}</ThemeProvider>;
+};
+
+export const InvertThemeV3 = ({ children }: any): React.ReactElement => {
+  const theme = useTheme();
+
+  const v3RevertTheme = theme.theme === "light" ? "dark" : "light";
+  const newTheme: Theme = useMemo(
+    () => ({
+      ...defaultTheme,
+      ...V3dDfaultTheme,
+      colors: {
+        ...defaultTheme.colors,
+        ...palettes[v3RevertTheme],
+        palette: palettes[v3RevertTheme],
+      },
+      theme: v3RevertTheme,
+    }),
+    [v3RevertTheme],
+  );
+  return <ThemeProvider theme={newTheme}>{children}</ThemeProvider>;
 };

--- a/libs/ui/packages/react/src/styles/index.ts
+++ b/libs/ui/packages/react/src/styles/index.ts
@@ -2,6 +2,6 @@ export { default as defaultTheme } from "./theme";
 export * from "./helpers";
 export * from "./global";
 export * from "./StyleProvider";
-export { InvertTheme } from "./InvertTheme";
+export { InvertTheme, InvertThemeV3 } from "./InvertTheme";
 export type { ThemeNames, ColorPalette } from "@ledgerhq/ui-shared";
 export { palettes } from "@ledgerhq/ui-shared";


### PR DESCRIPTION
### 📝 Description

This PR adds `StyleProviderV3`, a wrapper component that can be used anywhere in the app to wrap components that are supposed to use the v3 styling & design system (`@ledgerhq/react-ui lib`).

The easy way to use this component is to use the associated HOC `withStyleProviderV3` and directly export your screen that uses v3 design like that: `export default withStyleProviderV3(MyComponent)`.

The PR also includes:
- some fixes on the `react-ui` lib regarding some colors that were outdated in the Popin & Drawer components.
- an `InvertThemeV3` wrapper

There are no user facing changes in this PR (the new stuff on LLD isn't used yet, the changes in react-ui either).

The changes in this PR are a subset of @pierrelouis-c 's work in https://github.com/LedgerHQ/ledger-live/pull/593 as this will PR here be easier to merge (it doesn't need a big QA round + it doesn't need to wait for a release to be merged) and are needed for other things.

### ❓ Context

- **Impacted projects**: `react-ui` `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-111] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-111]: https://ledgerhq.atlassian.net/browse/FAT-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ