### PR TITLE
remove wildcards bundle id for iOS

### DIFF
--- a/apps/ledger-live-mobile/fastlane/.env.adhoc
+++ b/apps/ledger-live-mobile/fastlane/.env.adhoc
@@ -1,5 +1,4 @@
 ENVFILE=.env.adhoc
 APP_IDENTIFIER="com.ledger.live.dev"
-MY_APP_BUNDLE_ID="com.ledger.live.dev.*"
-SHORT_BUNDLE_ID="com.ledger.live.dev"
+MY_APP_BUNDLE_ID="com.ledger.live.dev"
 APP_NAME="LL DEV"

--- a/apps/ledger-live-mobile/fastlane/.env.mock
+++ b/apps/ledger-live-mobile/fastlane/.env.mock
@@ -1,5 +1,4 @@
 ENVFILE=.env.mock
 APP_IDENTIFIER="com.ledger.live"
 MY_APP_BUNDLE_ID="com.ledger.live"
-SHORT_BUNDLE_ID="com.ledger.live"
 APP_NAME="LLmock"

--- a/apps/ledger-live-mobile/fastlane/.env.nightly
+++ b/apps/ledger-live-mobile/fastlane/.env.nightly
@@ -1,5 +1,4 @@
 ENVFILE=.env.adhoc
 APP_IDENTIFIER="com.ledger.live"
 MY_APP_BUNDLE_ID="com.ledger.live"
-SHORT_BUNDLE_ID="com.ledger.live"
 APP_NAME="LL NIGHTLY"

--- a/apps/ledger-live-mobile/fastlane/.env.production
+++ b/apps/ledger-live-mobile/fastlane/.env.production
@@ -1,5 +1,4 @@
 ENVFILE=.env.production
 APP_IDENTIFIER="com.ledger.live"
 MY_APP_BUNDLE_ID="com.ledger.live"
-SHORT_BUNDLE_ID="com.ledger.live"
 APP_NAME="Ledger Live"

--- a/apps/ledger-live-mobile/fastlane/.env.staging
+++ b/apps/ledger-live-mobile/fastlane/.env.staging
@@ -1,5 +1,4 @@
 ENVFILE=.env.staging
-APP_IDENTIFIER="com.ledger.live.dev.staging"
-MY_APP_BUNDLE_ID="com.ledger.live.dev.*"
-SHORT_BUNDLE_ID="com.ledger.live.dev"
+APP_IDENTIFIER="com.ledger.live.dev"
+MY_APP_BUNDLE_ID="com.ledger.live.dev"
 APP_NAME="LL DEV"

--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -92,7 +92,7 @@ platform :ios do
   private_lane :refresh_ios_profiles do
     match(
       type: "development",
-      app_identifier: ["com.ledger.live", "com.ledger.live.dev.*", "com.ledger.live.ledgerconnect"],
+      app_identifier: ["com.ledger.live", "com.ledger.live.dev", "com.ledger.live.ledgerconnect"],
       force_for_new_devices: true,
       git_url: ENV["GIT_REPO_URL"],
       username: ENV["APPLE_ID"],
@@ -103,8 +103,18 @@ platform :ios do
     )
     match(
       type: "adhoc",
-      app_identifier: ["com.ledger.live", "com.ledger.live.dev.*", "com.ledger.live.ledgerconnect"],
+      app_identifier: ["com.ledger.live", "com.ledger.live.dev", "com.ledger.live.ledgerconnect"],
       force_for_new_devices: true,
+      git_url: ENV["GIT_REPO_URL"],
+      username: ENV["APPLE_ID"],
+      team_id: ENV["DEVELOPER_TEAM_ID"],
+      keychain_name: ENV["CI_KEYCHAIN_NAME"],
+      keychain_password: ENV["CI_KEYCHAIN_PASSWORD"],
+      git_basic_authorization: Base64.strict_encode64("#{ENV["GIT_REPO_USER"]}:#{ENV["GH_TOKEN"]}"),
+    )
+    match(
+      type: "appstore",
+      app_identifier: "com.ledger.live",
       git_url: ENV["GIT_REPO_URL"],
       username: ENV["APPLE_ID"],
       team_id: ENV["DEVELOPER_TEAM_ID"],
@@ -119,7 +129,7 @@ platform :ios do
     export_options_method = options[:local] ? "development" : (options[:adhoc] ? "ad-hoc" : "app-store")
     code_sign_identity = "iPhone Distribution"
     MY_APP_BUNDLE_ID = ENV["MY_APP_BUNDLE_ID"]
-    MY_APP_ID = (options[:adhoc] ? "#{ENV["SHORT_BUNDLE_ID"]}.local" : "#{ENV["APP_IDENTIFIER"]}")
+    MY_APP_ID = ENV["APP_IDENTIFIER"]
 
     MY_PROFILE = (options[:adhoc] ? "match AdHoc #{MY_APP_BUNDLE_ID}" : "match AppStore #{MY_APP_BUNDLE_ID}")
     MY_TEAM = ENV["DEVELOPER_TEAM_ID"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21583,7 +21583,7 @@ packages:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 3.0.2
       ssri: 8.0.1
       tar: 6.1.11
@@ -35859,24 +35859,6 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /metro-config/0.67.0_5rj3ktdhebdtkdjqejo5rbxriu:
-    resolution: {integrity: sha512-ThAwUmzZwTbKyyrIn2bKIcJDPDBS0LKAbqJZQioflvBGfcgA21h3fdL3IxRmvCEl6OnkEWI0Tn1Z9w2GLAjf2g==}
-    peerDependencies:
-      metro-transform-worker: '*'
-    peerDependenciesMeta:
-      metro-transform-worker:
-        optional: true
-    dependencies:
-      cosmiconfig: 5.2.1
-      jest-validate: 26.6.2
-      metro: 0.67.0
-      metro-cache: 0.67.0_metro@0.67.0
-      metro-core: 0.67.0_metro@0.67.0
-      metro-runtime: 0.67.0
-      metro-transform-worker: 0.67.0_metro-minify-uglify@0.67.0
-    transitivePeerDependencies:
-      - metro
-
   /metro-config/0.67.0_h77kaxayu5kga6qsud7rauzt6a:
     resolution: {integrity: sha512-ThAwUmzZwTbKyyrIn2bKIcJDPDBS0LKAbqJZQioflvBGfcgA21h3fdL3IxRmvCEl6OnkEWI0Tn1Z9w2GLAjf2g==}
     peerDependencies:
@@ -36148,7 +36130,7 @@ packages:
       '@babel/parser': 7.18.5
       '@babel/types': 7.18.4
       babel-preset-fbjs: 3.4.0_@babel+core@7.18.5
-      metro: 0.67.0_h77kaxayu5kga6qsud7rauzt6a
+      metro: 0.67.0
       metro-babel-transformer: 0.67.0
       metro-cache: 0.67.0_metro@0.67.0
       metro-cache-key: 0.67.0
@@ -36221,68 +36203,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
-      - supports-color
-      - utf-8-validate
-
-  /metro/0.67.0_h77kaxayu5kga6qsud7rauzt6a:
-    resolution: {integrity: sha512-DwuBGAFcAivoac/swz8Lp7Y5Bcge1tzT7T6K0nf1ubqJP8YzBUtyR4pkjEYVUzVu/NZf7O54kHSPVu1ibYzOBQ==}
-    hasBin: true
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/core': 7.18.5
-      '@babel/generator': 7.18.2
-      '@babel/parser': 7.18.5
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.5
-      '@babel/types': 7.18.4
-      absolute-path: 0.0.0
-      accepts: 1.3.8
-      async: 2.6.4
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 2.6.9
-      denodeify: 1.2.1
-      error-stack-parser: 2.0.7
-      fs-extra: 1.0.0
-      graceful-fs: 4.2.10
-      hermes-parser: 0.5.0
-      image-size: 0.6.3
-      invariant: 2.2.4
-      jest-haste-map: 27.5.1_metro@0.67.0
-      jest-worker: 26.6.2_metro@0.67.0
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.67.0
-      metro-cache: 0.67.0_metro@0.67.0
-      metro-cache-key: 0.67.0
-      metro-config: 0.67.0_5rj3ktdhebdtkdjqejo5rbxriu
-      metro-core: 0.67.0_metro@0.67.0
-      metro-hermes-compiler: 0.67.0
-      metro-inspector-proxy: 0.67.0
-      metro-minify-uglify: 0.67.0
-      metro-react-native-babel-preset: 0.67.0
-      metro-resolver: 0.67.0
-      metro-runtime: 0.67.0
-      metro-source-map: 0.67.0
-      metro-symbolicate: 0.67.0
-      metro-transform-plugins: 0.67.0
-      metro-transform-worker: 0.67.0_metro-minify-uglify@0.67.0
-      mime-types: 2.1.35
-      mkdirp: 0.5.6
-      node-fetch: 2.6.7
-      nullthrows: 1.1.1
-      rimraf: 2.7.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      strip-ansi: 6.0.1
-      temp: 0.8.3
-      throat: 5.0.0
-      ws: 7.5.7
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -38545,7 +38465,7 @@ packages:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.6.4
+      ts-pnp: 1.2.0
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -39475,15 +39395,6 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-
-  /promise-inflight/1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dev: true
 
   /promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -45565,18 +45476,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  /ts-pnp/1.2.0_typescript@4.6.4:
-    resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      typescript: 4.6.4
-    dev: true
 
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

It seems using wildcards for bundle ids in iOS in conjunction with deeplinks actually breaks the build of iOS' .ipa. Removing the wildcard and moving back to "com.ledger.live.dev" for a simpler workflow

I've added to apple dev portal a new bundle id `com.ledger.live.dev` and will soon depreciate the old one. I've been using `fastlane match` to update the profiles accordingly. Nothing to do on ledger-live-build side as all the bundle ids are handled here

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

NO DEMO

### 🚀 Expectations to reach

Ledger Live Build repo is still able to produce adhoc .ipa 

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
