### PR TITLE
Improve robustness of Tezos impl with a way to set max iteration

### DIFF
--- a/.changeset/hot-singers-lick.md
+++ b/.changeset/hot-singers-lick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Introduce env TEZOS_MAX_TX_QUERIES to configure safe max amount of transaction http fetches for a tezos sync. Increase the default to 100.

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -549,6 +549,11 @@ const envDefinitions = {
     parser: intParser,
     desc: "version used for ledger status api",
   },
+  TEZOS_MAX_TX_QUERIES: {
+    def: 100,
+    parser: intParser,
+    desc: "safe max on maximum number of queries to synchronize a tezos account",
+  },
   PLATFORM_DEBUG: {
     def: false,
     parser: boolParser,

--- a/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
@@ -1,6 +1,8 @@
 import { getEnv, setEnv } from "../../env";
 import { fetchAllTransactions } from "./synchronisation";
 
+jest.setTimeout(60 * 1000);
+
 describe("TEZOS_MAX_TX_QUERIES", () => {
   const bigAccount = "tz1cgQAQfECg5bPASYTMyJ9QJQjSUi8rfL67";
   test("default have more than 100 txs", async () => {

--- a/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
@@ -1,7 +1,7 @@
 import { getEnv, setEnv } from "../../env";
 import { fetchAllTransactions } from "./synchronisation";
 
-jest.setTimeout(60 * 1000);
+jest.setTimeout(2 * 60 * 1000);
 
 describe("TEZOS_MAX_TX_QUERIES", () => {
   const bigAccount = "tz1cgQAQfECg5bPASYTMyJ9QJQjSUi8rfL67";

--- a/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
@@ -4,7 +4,7 @@ import { fetchAllTransactions } from "./synchronisation";
 jest.setTimeout(2 * 60 * 1000);
 
 describe("TEZOS_MAX_TX_QUERIES", () => {
-  const bigAccount = "tz1cgQAQfECg5bPASYTMyJ9QJQjSUi8rfL67";
+  const bigAccount = "tz1boBHAVpwcvKkNFAQHYr7mjxAz1PpVgKq7";
   test("default have more than 100 txs", async () => {
     const txs = await fetchAllTransactions(bigAccount);
     expect(txs.length).toBeGreaterThan(100);

--- a/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
+++ b/libs/ledger-live-common/src/families/tezos/synchronisation.integration.test.ts
@@ -1,0 +1,20 @@
+import { getEnv, setEnv } from "../../env";
+import { fetchAllTransactions } from "./synchronisation";
+
+describe("TEZOS_MAX_TX_QUERIES", () => {
+  const bigAccount = "tz1cgQAQfECg5bPASYTMyJ9QJQjSUi8rfL67";
+  test("default have more than 100 txs", async () => {
+    const txs = await fetchAllTransactions(bigAccount);
+    expect(txs.length).toBeGreaterThan(100);
+  });
+  test("lowering it to 1 will only fetch a few txs", async () => {
+    const cur = getEnv("TEZOS_MAX_TX_QUERIES");
+    setEnv("TEZOS_MAX_TX_QUERIES", 1);
+    try {
+      const txs = await fetchAllTransactions(bigAccount);
+      expect(txs.length).toBeLessThanOrEqual(100);
+    } finally {
+      setEnv("TEZOS_MAX_TX_QUERIES", cur);
+    }
+  });
+});

--- a/libs/ledger-live-common/src/families/tezos/synchronisation.ts
+++ b/libs/ledger-live-common/src/families/tezos/synchronisation.ts
@@ -12,6 +12,7 @@ import { areAllOperationsLoaded, decodeAccountId } from "../../account";
 import type { Operation, Account } from "../../types";
 import api from "./api/tzkt";
 import type { APIOperation } from "./api/tzkt";
+import { getEnv } from "../../env";
 
 function reconciliatePublicKey(
   publicKey: string | undefined,
@@ -272,14 +273,13 @@ const txToOp =
     };
   };
 
-const fetchAllTransactions = async (
+export const fetchAllTransactions = async (
   address: string,
   lastId?: number
 ): Promise<APIOperation[]> => {
   let txs: APIOperation[] = [];
-  let maxIteration = 20; // safe limit
+  let maxIteration = getEnv("TEZOS_MAX_TX_QUERIES");
   do {
-    // FIXME not sure what is going on here
     const r = await api.getAccountOperations(address, { lastId, sort: 0 });
     if (r.length === 0) return txs;
     txs = txs.concat(r);


### PR DESCRIPTION
### 📝 Description

currently, Ledger Live is not able to fetch more than ~1000ops on Tezos account. This increases the "safe max" limit to about 5 times more (this is a workaround until we can implement proper data pagination).
 
This is made as an env, so we have a technical workaround for us / users. A test was provided.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-2999 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
