### PR TITLE
bot: fixes ZCash

### DIFF
--- a/libs/ledger-live-common/src/load/speculos.ts
+++ b/libs/ledger-live-common/src/load/speculos.ts
@@ -316,9 +316,7 @@ export function appCandidatesMatches(
           hackBadSemver(appCandidate.firmware),
           searchFirmware
         ))) &&
-    ((!search.appVersion &&
-      !appCandidate.appVersion.includes("prerelease") &&
-      !appCandidate.appVersion.includes("rc")) ||
+    ((!search.appVersion && !appCandidate.appVersion.includes("-")) ||
       (search.appVersion &&
         semver.satisfies(appCandidate.appVersion, search.appVersion)))
   );


### PR DESCRIPTION
LIVE-3008

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the speculos coin apps search logic, we will filter out by default all app version that have a "-" in it.


### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:live-3008 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


I managed to fix the problem observed on #ledger-live-bot,

I can confirm my fix works by looking at it resolved using

```
VERBOSE=1 pnpm run:cli sync --device 'speculos:nanos:zcash'
```

which is now selecting :

```
debug: using app Zcash 2.0.6 on nanoS 2.1.0
```


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
