### PR TITLE
Specs without funds that are backed by testnet to no longer be warned

### DIFF
--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -194,12 +194,20 @@ export async function bot({ currency, family, mutation }: Arg = {}) {
     );
   }
 
-  const withoutFunds = results
+  const specsWithoutFunds = results.filter(
+    (s) =>
+      !s.fatalError &&
+      ((s.accountsBefore && s.accountsBefore.every(isAccountEmpty)) ||
+        (s.mutations && s.mutations.every((r) => !r.mutation)))
+  );
+
+  const withoutFunds = specsWithoutFunds
     .filter(
       (s) =>
-        !s.fatalError &&
-        ((s.accountsBefore && s.accountsBefore.every(isAccountEmpty)) ||
-          (s.mutations && s.mutations.every((r) => !r.mutation)))
+        // ignore coin that are backed by testnet that have funds
+        !specsWithoutFunds.some(
+          (o) => o.spec.currency.isTestnetFor === s.spec.currency.id
+        )
     )
     .map((s) => s.spec.name);
   const { GITHUB_RUN_ID, GITHUB_WORKFLOW } = process.env;
@@ -326,7 +334,9 @@ export async function bot({ currency, family, mutation }: Arg = {}) {
   if (withoutFunds.length) {
     const missingFundsWarn = `> ⚠️ ${
       withoutFunds.length
-    } specs don't have enough funds! (${withoutFunds.join(", ")})\n`;
+    } specs don't have enough funds! (${withoutFunds.join(
+      ", "
+    )})\n (and aren't covered by testnet)`;
     body += missingFundsWarn;
     slackBody += missingFundsWarn;
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

> 12 specs don't have enough funds! (Bitcoin, Dash, Qtum, ZCash, Decred, cardano, Cosmos, Crypto.org, Elrond, Ethereum, Ethereum Goerli, Tron)

bot is currently warning on coins that we are likely not going to funds (Bitcoin, Ethereum) because too expensive, **yet** they are backed up by Testnet. We assume here that testnet covered spec will be enough to not warn the missing funds problem.

### ❓ Context

- **Impacted projects**: `none` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none (support #ledger-live-bot)` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
