### PR TITLE
stop clogging up runners for 6 hours

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -270,7 +270,9 @@ platform :ios do
           app_version: package["version"],
           build_number: get_build_number(xcodeproj: "ios/ledgerlivemobile.xcodeproj"),
           notify_external_testers: true,
-          reject_build_waiting_for_review: !options[:ci]
+          reject_build_waiting_for_review: !options[:ci],
+          skip_waiting_for_build_processing: false,
+          wait_processing_timeout_duration: 1800, # 30mn
         )
       rescue => e
         raise unless e.message.include? "Another build is in review"


### PR DESCRIPTION
### 📝 Description

Another attempt to prevent CI runners from staying on for 6 hours. (LLB)

### ❓ Context

- **Impacted projects**: `CI` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Next nightly should not last 6h and then fail (LLM)

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
