### PR TITLE
use the commenter login instead of the PR creator

### DIFF
--- a/tools/github-bot/src/index.ts
+++ b/tools/github-bot/src/index.ts
@@ -19,7 +19,7 @@ export default (app: Probot) => {
       ref: "develop",
       inputs: {
         number: `${data.number}`,
-        login: `${payload.issue.user.login}`,
+        login: `${payload.comment.user.login}`,
       },
     });
   });


### PR DESCRIPTION
### 📝 Description

Missing input for the github bot to trigger the generate screenshots job

### ❓ Context

- **Impacted projects**: `ghbot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

NOPE

### 🚀 Expectations to reach

We use the correct user when checking org member now

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
