### PR TITLE
LIVE-2955 Fix wording for when user tries to update via Bluetooth

### DIFF
--- a/.changeset/afraid-moles-train.md
+++ b/.changeset/afraid-moles-train.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the error wording for users trying to update the firmware via bluetooth

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -69,7 +69,7 @@ const FirmwareUpdateBanner = () => {
       lastSeenDevice.deviceInfo,
       lastSeenDevice.modelId,
     );
-  const isDeviceConnectedViaUSB = lastConnectedDevice?.wired;
+  const isDeviceConnectedViaUSB = lastConnectedDevice?.wired === true;
   const usbFwUpdateActivated =
     usbFwUpdateFeatureFlag?.enabled &&
     Platform.OS === "android" &&

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -68,11 +68,14 @@ const FirmwareUpdateBanner = () => {
       lastSeenDevice.deviceInfo,
       lastSeenDevice.modelId,
     );
+  const isDeviceConnectedViaUSB = lastConnectedDevice?.wired;
   const usbFwUpdateActivated =
     usbFwUpdateFeatureFlag?.enabled &&
     Platform.OS === "android" &&
-    lastConnectedDevice?.wired &&
     isUsbFwVersionUpdateSupported;
+
+  const fwUpdateActivatedButNotWired =
+    usbFwUpdateActivated && !isDeviceConnectedViaUSB;
 
   return showBanner && hasCompletedOnboarding && hasConnectedDevice ? (
     <>
@@ -89,7 +92,9 @@ const FirmwareUpdateBanner = () => {
           type="color"
           title={t("FirmwareUpdate.update")}
           onPress={
-            usbFwUpdateActivated ? onExperimentalFirmwareUpdate : onPress
+            usbFwUpdateActivated && isDeviceConnectedViaUSB
+              ? onExperimentalFirmwareUpdate
+              : onPress
           }
           outline={false}
         />
@@ -99,15 +104,35 @@ const FirmwareUpdateBanner = () => {
         isOpen={showDrawer}
         onClose={onCloseDrawer}
         Icon={DownloadMedium}
-        title={t("FirmwareUpdate.drawerUpdate.title")}
-        description={t("FirmwareUpdate.drawerUpdate.description")}
+        title={
+          fwUpdateActivatedButNotWired
+            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle", {
+                deviceName: lastConnectedDevice?.deviceName,
+              })
+            : t("FirmwareUpdate.drawerUpdate.title")
+        }
+        description={
+          fwUpdateActivatedButNotWired
+            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbDescription", {
+                deviceName: lastConnectedDevice?.deviceName,
+              })
+            : t("FirmwareUpdate.drawerUpdate.description")
+        }
         noCloseButton
       >
-        <Button
-          type="primary"
-          title={t("common.close")}
-          onPress={onCloseDrawer}
-        />
+        {fwUpdateActivatedButNotWired ? (
+          <Button
+            type="primary"
+            title={t("common.retry")}
+            onPress={onExperimentalFirmwareUpdate}
+          />
+        ) : (
+          <Button
+            type="primary"
+            title={t("common.close")}
+            onPress={onCloseDrawer}
+          />
+        )}
       </BottomDrawer>
     </>
   ) : null;

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -7,6 +7,7 @@ import { useSelector } from "react-redux";
 import { ScreenName, NavigatorName } from "../const";
 import { Alert, BottomDrawer, Text } from "@ledgerhq/native-ui";
 import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
+import { getDeviceModel } from "@ledgerhq/devices";
 import {
   lastSeenDeviceSelector,
   hasCompletedOnboardingSelector,
@@ -77,13 +78,17 @@ const FirmwareUpdateBanner = () => {
   const fwUpdateActivatedButNotWired =
     usbFwUpdateActivated && !isDeviceConnectedViaUSB;
 
+  const deviceName = lastConnectedDevice
+    ? getDeviceModel(lastConnectedDevice.modelId).productName
+    : "";
+
   return showBanner && hasCompletedOnboarding && hasConnectedDevice ? (
     <>
       <Alert type="info" showIcon={false}>
         <Text flexShrink={1}>
           {t("FirmwareUpdate.newVersion", {
             version,
-            deviceName: lastConnectedDevice?.deviceName,
+            deviceName,
           })}
         </Text>
         <Button
@@ -112,19 +117,17 @@ const FirmwareUpdateBanner = () => {
         description={
           fwUpdateActivatedButNotWired
             ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbDescription", {
-                deviceName: lastConnectedDevice?.deviceName,
+                deviceName,
               })
             : t("FirmwareUpdate.drawerUpdate.description")
         }
         noCloseButton
       >
-        {!fwUpdateActivatedButNotWired && (
-          <Button
-            type="primary"
-            title={t("common.close")}
-            onPress={onCloseDrawer}
-          />
-        )}
+        <Button
+          type="primary"
+          title={t("common.close")}
+          onPress={onCloseDrawer}
+        />
       </BottomDrawer>
     </>
   ) : null;

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { ScreenName, NavigatorName } from "../const";
 import { Alert, BottomDrawer, Text } from "@ledgerhq/native-ui";
-import { DownloadMedium } from "@ledgerhq/native-ui/assets/icons";
+import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
 import {
   lastSeenDeviceSelector,
   hasCompletedOnboardingSelector,
@@ -103,12 +103,10 @@ const FirmwareUpdateBanner = () => {
       <BottomDrawer
         isOpen={showDrawer}
         onClose={onCloseDrawer}
-        Icon={DownloadMedium}
+        Icon={fwUpdateActivatedButNotWired ? UsbMedium : DownloadMedium}
         title={
           fwUpdateActivatedButNotWired
-            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle", {
-                deviceName: lastConnectedDevice?.deviceName,
-              })
+            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle")
             : t("FirmwareUpdate.drawerUpdate.title")
         }
         description={
@@ -120,13 +118,7 @@ const FirmwareUpdateBanner = () => {
         }
         noCloseButton
       >
-        {fwUpdateActivatedButNotWired ? (
-          <Button
-            type="primary"
-            title={t("common.retry")}
-            onPress={onExperimentalFirmwareUpdate}
-          />
-        ) : (
+        {!fwUpdateActivatedButNotWired && (
           <Button
             type="primary"
             title={t("common.close")}

--- a/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
@@ -60,6 +60,8 @@ export default function SelectDevice({
   const handleOnSelect = useCallback(
     deviceInfo => {
       const { modelId, wired } = deviceInfo;
+
+      dispatch(setLastConnectedDevice(deviceInfo));  
       if (wired) {
         track("Device selection", {
           modelId,
@@ -67,7 +69,6 @@ export default function SelectDevice({
         });
         // Nb consider a device selection enough to show the fw update banner in portfolio
         dispatch(setHasConnectedDevice(true));
-        dispatch(setLastConnectedDevice(deviceInfo));
         onSelect(deviceInfo);
         dispatch(setReadOnlyMode(false));
       } else {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3257,7 +3257,9 @@
     "newVersion": "Update {{version}} available for your {{deviceName}}",
     "drawerUpdate": {
       "title": "Firmware Update",
-      "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop"
+      "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop",
+      "pleaseConnectUsbTitle": "Connect your {{deviceName}}",
+      "pleaseConnectUsbDescription": "Plug your {{deviceName}} to your phone with a USB cable to start the firmware update."
     }
   },
   "FirmwareUpdateReleaseNotes": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3258,8 +3258,8 @@
     "drawerUpdate": {
       "title": "Firmware Update",
       "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop",
-      "pleaseConnectUsbTitle": "Connect your {{deviceName}}",
-      "pleaseConnectUsbDescription": "Plug your {{deviceName}} to your phone with a USB cable to start the firmware update."
+      "pleaseConnectUsbTitle": "USB cable needed",
+      "pleaseConnectUsbDescription": "To start the firmware update, plug your {{deviceName}} to your mobile phone using a USB cable."
     }
   },
   "FirmwareUpdateReleaseNotes": {

--- a/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
+++ b/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
@@ -12,7 +12,7 @@ export const isFirmwareUpdateVersionSupported = (
   deviceInfo: DeviceInfo,
   modelId: DeviceModelId,
 ) =>
-  deviceVersionRangesForUpdate[modelId] &&
+  Boolean(deviceVersionRangesForUpdate[modelId]) &&
   versionSatisfies(
     deviceInfo.version,
     deviceVersionRangesForUpdate[modelId] as string,


### PR DESCRIPTION
### 📝 Description
Use better wording for when the Firwmare update is available but the user is connected via Bluetooth instead of USB.


### ❓ Context
[LIVE-2955]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://user-images.githubusercontent.com/6013294/180246768-a2e85812-cfa8-4f81-b388-3807c809985f.png)



[LIVE-2955]: https://ledgerhq.atlassian.net/browse/LIVE-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ