### PR TITLE
Add a bridge test for AmountRequired

### DIFF
--- a/.changeset/weak-queens-shout.md
+++ b/.changeset/weak-queens-shout.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add a bridge test for AmountRequired error

--- a/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/bridge.ts
@@ -3,7 +3,11 @@ import { BigNumber } from "bignumber.js";
 import { reduce, filter, map } from "rxjs/operators";
 import flatMap from "lodash/flatMap";
 import omit from "lodash/omit";
-import { InvalidAddress, RecipientRequired } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  RecipientRequired,
+  AmountRequired,
+} from "@ledgerhq/errors";
 import type {
   Account,
   Transaction,
@@ -618,6 +622,13 @@ export function testBridge<T extends Transaction>(data: DatasetTest<T>): void {
             const status = await bridge.getTransactionStatus(account, t);
             expect(status.errors.recipient).toBeInstanceOf(InvalidAddress);
           });
+          makeTest("Default empty amount has an amount error", async () => {
+            const account = await getSynced();
+            const t = { ...bridge.createTransaction(account) };
+            const status = await bridge.getTransactionStatus(account, t);
+            expect(status.errors.amount).toBeInstanceOf(AmountRequired);
+          });
+
           const accountDataTest = accountData.test;
 
           if (accountDataTest) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->
?

### 📝 Description

Bridge integration tests didn't include a test of the `AmountRequired` error, i.e they were not testing that when the transaction amount is 0 or not provided we return an error.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: - <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Integration tests passing for all currencies (but currently broken for many other reasons)
