### PR TITLE
use same JAVA as we use locally

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -81,10 +81,10 @@ jobs:
           ruby-version: 2.7
         env:
           ImageOS: ubuntu20
-      - name: setup JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: "zulu" # See 'Supported distributions' for available options
+          java-version: "11"
       - name: setup Android SDK
         uses: android-actions/setup-android@v2.0.6
       - name: install dependencies
@@ -157,10 +157,10 @@ jobs:
           ruby-version: 2.7
         env:
           ImageOS: ubuntu20
-      - name: setup JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: "zulu" # See 'Supported distributions' for available options
+          java-version: "11"
       - name: setup Android SDK
         uses: android-actions/setup-android@v2.0.6
       - name: install dependencies


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

with RN update, we need to move to Java 11 and since most devs should have followed the install setup from React Native website, we should be using `zulu11`


### ❓ Context

- **Impacted projects**: `LLM` `automation` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

no demo

### 🚀 Expectations to reach

CI is not broken for LLM

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
