### PR TITLE
Remove global box-sizing setting for the ui lib

### DIFF
--- a/libs/ui/packages/react/src/styles/global.ts
+++ b/libs/ui/packages/react/src/styles/global.ts
@@ -19,10 +19,6 @@ export const GlobalStyle = createGlobalStyle<GlobalStyleProps>`
     font-size: 100%;
   }
 
-  *, *:before, *:after {
-    box-sizing: inherit;
-  }
-
   * {
     margin: 0;
     padding: 0;


### PR DESCRIPTION

### 📝 Description
This PR removes a global CSS setting on the box-sizing prop from the design system. This setting was affecting all elements of the page whenever the design system CSS was included, making it impossible to do a gradual migration to V3.

### ❓ Context
No JIRA ticket associated to this.

### ✅ Checklist

- [x] **Test coverage** already covered by the usual screenshot tests
- [x] **Atomic delivery** 
- [x] **No breaking changes**

### 📸 Demo
N/A

### 🚀 Expectations to reach
