### PR TITLE
Revert "LIVE-2955 Fix wording for when user tries to update via Bluet…

### DIFF
--- a/.changeset/afraid-moles-train.md
+++ b/.changeset/afraid-moles-train.md
@@ -1,5 +1,0 @@
----
-"live-mobile": patch
----
-
-Fix the error wording for users trying to update the firmware via bluetooth

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -6,8 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { ScreenName, NavigatorName } from "../const";
 import { Alert, BottomDrawer, Text } from "@ledgerhq/native-ui";
-import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { DownloadMedium } from "@ledgerhq/native-ui/assets/icons";
 import {
   lastSeenDeviceSelector,
   hasCompletedOnboardingSelector,
@@ -69,18 +68,11 @@ const FirmwareUpdateBanner = () => {
       lastSeenDevice.deviceInfo,
       lastSeenDevice.modelId,
     );
-  const isDeviceConnectedViaUSB = lastConnectedDevice?.wired === true;
   const usbFwUpdateActivated =
     usbFwUpdateFeatureFlag?.enabled &&
     Platform.OS === "android" &&
+    lastConnectedDevice?.wired &&
     isUsbFwVersionUpdateSupported;
-
-  const fwUpdateActivatedButNotWired =
-    usbFwUpdateActivated && !isDeviceConnectedViaUSB;
-
-  const deviceName = lastConnectedDevice
-    ? getDeviceModel(lastConnectedDevice.modelId).productName
-    : "";
 
   return showBanner && hasCompletedOnboarding && hasConnectedDevice ? (
     <>
@@ -88,7 +80,7 @@ const FirmwareUpdateBanner = () => {
         <Text flexShrink={1}>
           {t("FirmwareUpdate.newVersion", {
             version,
-            deviceName,
+            deviceName: lastConnectedDevice?.deviceName,
           })}
         </Text>
         <Button
@@ -97,9 +89,7 @@ const FirmwareUpdateBanner = () => {
           type="color"
           title={t("FirmwareUpdate.update")}
           onPress={
-            usbFwUpdateActivated && isDeviceConnectedViaUSB
-              ? onExperimentalFirmwareUpdate
-              : onPress
+            usbFwUpdateActivated ? onExperimentalFirmwareUpdate : onPress
           }
           outline={false}
         />
@@ -108,19 +98,9 @@ const FirmwareUpdateBanner = () => {
       <BottomDrawer
         isOpen={showDrawer}
         onClose={onCloseDrawer}
-        Icon={fwUpdateActivatedButNotWired ? UsbMedium : DownloadMedium}
-        title={
-          fwUpdateActivatedButNotWired
-            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle")
-            : t("FirmwareUpdate.drawerUpdate.title")
-        }
-        description={
-          fwUpdateActivatedButNotWired
-            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbDescription", {
-                deviceName,
-              })
-            : t("FirmwareUpdate.drawerUpdate.description")
-        }
+        Icon={DownloadMedium}
+        title={t("FirmwareUpdate.drawerUpdate.title")}
+        description={t("FirmwareUpdate.drawerUpdate.description")}
         noCloseButton
       >
         <Button

--- a/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
@@ -60,8 +60,6 @@ export default function SelectDevice({
   const handleOnSelect = useCallback(
     deviceInfo => {
       const { modelId, wired } = deviceInfo;
-
-      dispatch(setLastConnectedDevice(deviceInfo));  
       if (wired) {
         track("Device selection", {
           modelId,
@@ -69,6 +67,7 @@ export default function SelectDevice({
         });
         // Nb consider a device selection enough to show the fw update banner in portfolio
         dispatch(setHasConnectedDevice(true));
+        dispatch(setLastConnectedDevice(deviceInfo));
         onSelect(deviceInfo);
         dispatch(setReadOnlyMode(false));
       } else {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3257,9 +3257,7 @@
     "newVersion": "Update {{version}} available for your {{deviceName}}",
     "drawerUpdate": {
       "title": "Firmware Update",
-      "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop",
-      "pleaseConnectUsbTitle": "USB cable needed",
-      "pleaseConnectUsbDescription": "To start the firmware update, plug your {{deviceName}} to your mobile phone using a USB cable."
+      "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop"
     }
   },
   "FirmwareUpdateReleaseNotes": {

--- a/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
+++ b/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
@@ -12,7 +12,7 @@ export const isFirmwareUpdateVersionSupported = (
   deviceInfo: DeviceInfo,
   modelId: DeviceModelId,
 ) =>
-  Boolean(deviceVersionRangesForUpdate[modelId]) &&
+  deviceVersionRangesForUpdate[modelId] &&
   versionSatisfies(
     deviceInfo.version,
     deviceVersionRangesForUpdate[modelId] as string,


### PR DESCRIPTION
This reverts commit d9bc9eb20926f845b8186a91f892f7a8a51b5824.


### 📝 Description
I accidentatly merged https://github.com/LedgerHQ/ledger-live/pull/706 before I should have. There were missing translations and QA. This reverts it

### ❓ Context
https://github.com/LedgerHQ/ledger-live/pull/706

### ✅ Checklist

- [ ] **Test coverage** N/A
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
N/A

### 🚀 Expectations to reach

