### PR TITLE
LIVE-2955 Fix wording for when user tries to update via Bluetooth

### DIFF
--- a/.changeset/afraid-moles-train.md
+++ b/.changeset/afraid-moles-train.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the error wording for users trying to update the firmware via bluetooth

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -6,7 +6,8 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { ScreenName, NavigatorName } from "../const";
 import { Alert, BottomDrawer, Text } from "@ledgerhq/native-ui";
-import { DownloadMedium } from "@ledgerhq/native-ui/assets/icons";
+import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
+import { getDeviceModel } from "@ledgerhq/devices";
 import {
   lastSeenDeviceSelector,
   hasCompletedOnboardingSelector,
@@ -68,11 +69,18 @@ const FirmwareUpdateBanner = () => {
       lastSeenDevice.deviceInfo,
       lastSeenDevice.modelId,
     );
+  const isDeviceConnectedViaUSB = lastConnectedDevice?.wired === true;
   const usbFwUpdateActivated =
     usbFwUpdateFeatureFlag?.enabled &&
     Platform.OS === "android" &&
-    lastConnectedDevice?.wired &&
     isUsbFwVersionUpdateSupported;
+
+  const fwUpdateActivatedButNotWired =
+    usbFwUpdateActivated && !isDeviceConnectedViaUSB;
+
+  const deviceName = lastConnectedDevice
+    ? getDeviceModel(lastConnectedDevice.modelId).productName
+    : "";
 
   return showBanner && hasCompletedOnboarding && hasConnectedDevice ? (
     <>
@@ -80,7 +88,7 @@ const FirmwareUpdateBanner = () => {
         <Text flexShrink={1}>
           {t("FirmwareUpdate.newVersion", {
             version,
-            deviceName: lastConnectedDevice?.deviceName,
+            deviceName,
           })}
         </Text>
         <Button
@@ -89,7 +97,9 @@ const FirmwareUpdateBanner = () => {
           type="color"
           title={t("FirmwareUpdate.update")}
           onPress={
-            usbFwUpdateActivated ? onExperimentalFirmwareUpdate : onPress
+            usbFwUpdateActivated && isDeviceConnectedViaUSB
+              ? onExperimentalFirmwareUpdate
+              : onPress
           }
           outline={false}
         />
@@ -98,9 +108,19 @@ const FirmwareUpdateBanner = () => {
       <BottomDrawer
         isOpen={showDrawer}
         onClose={onCloseDrawer}
-        Icon={DownloadMedium}
-        title={t("FirmwareUpdate.drawerUpdate.title")}
-        description={t("FirmwareUpdate.drawerUpdate.description")}
+        Icon={fwUpdateActivatedButNotWired ? UsbMedium : DownloadMedium}
+        title={
+          fwUpdateActivatedButNotWired
+            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbTitle")
+            : t("FirmwareUpdate.drawerUpdate.title")
+        }
+        description={
+          fwUpdateActivatedButNotWired
+            ? t("FirmwareUpdate.drawerUpdate.pleaseConnectUsbDescription", {
+                deviceName,
+              })
+            : t("FirmwareUpdate.drawerUpdate.description")
+        }
         noCloseButton
       >
         <Button

--- a/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
@@ -60,6 +60,8 @@ export default function SelectDevice({
   const handleOnSelect = useCallback(
     deviceInfo => {
       const { modelId, wired } = deviceInfo;
+
+      dispatch(setLastConnectedDevice(deviceInfo));  
       if (wired) {
         track("Device selection", {
           modelId,
@@ -67,7 +69,6 @@ export default function SelectDevice({
         });
         // Nb consider a device selection enough to show the fw update banner in portfolio
         dispatch(setHasConnectedDevice(true));
-        dispatch(setLastConnectedDevice(deviceInfo));
         onSelect(deviceInfo);
         dispatch(setReadOnlyMode(false));
       } else {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3257,7 +3257,9 @@
     "newVersion": "Update {{version}} available for your {{deviceName}}",
     "drawerUpdate": {
       "title": "Firmware Update",
-      "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop"
+      "description": "Update your Ledger Nano firmware by connecting it to the Ledger Live application on desktop",
+      "pleaseConnectUsbTitle": "USB cable needed",
+      "pleaseConnectUsbDescription": "To start the firmware update, plug your {{deviceName}} to your mobile phone using a USB cable."
     }
   },
   "FirmwareUpdateReleaseNotes": {

--- a/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
+++ b/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
@@ -12,7 +12,7 @@ export const isFirmwareUpdateVersionSupported = (
   deviceInfo: DeviceInfo,
   modelId: DeviceModelId,
 ) =>
-  deviceVersionRangesForUpdate[modelId] &&
+  Boolean(deviceVersionRangesForUpdate[modelId]) &&
   versionSatisfies(
     deviceInfo.version,
     deviceVersionRangesForUpdate[modelId] as string,


### PR DESCRIPTION
### 📝 Description
Use better wording for when the Firwmare update is available but the user is connected via Bluetooth instead of USB.


### ❓ Context
[LIVE-2955]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://user-images.githubusercontent.com/6013294/180246768-a2e85812-cfa8-4f81-b388-3807c809985f.png)



[LIVE-2955]: https://ledgerhq.atlassian.net/browse/LIVE-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ