### PR TITLE
LIVE-2935 LIVE-2936 - LLM - redirect buy sell links to live app

### DIFF
--- a/.changeset/stale-dancers-beam.md
+++ b/.changeset/stale-dancers-beam.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+update ptx smart routing feature flag and live app web player undefined uri params

--- a/.changeset/violet-yaks-tan.md
+++ b/.changeset/violet-yaks-tan.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LLM - Redirect buy sell in app links to live app implementation if feature flag is activated

--- a/apps/ledger-live-mobile/src/components/FabActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions.tsx
@@ -203,6 +203,7 @@ const FabMarketActionsComponent: React.FC<Props> = ({
                       currency &&
                       currency.ticker &&
                       currency.ticker.toUpperCase(),
+                    defaultCurrencyId: currency && currency.id,
                   },
                 },
               ],
@@ -224,6 +225,7 @@ const FabMarketActionsComponent: React.FC<Props> = ({
                       currency &&
                       currency.ticker &&
                       currency.ticker.toUpperCase(),
+                    defaultCurrencyId: currency && currency.id,
                   },
                 },
               ],

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -91,7 +91,7 @@ export default function BaseNavigator() {
   );
   const learn = useFeature("learn");
   // PTX smart routing feature flag - buy sell live app flag
-  const ptxSmartRouting = useFeature("ptxSmartRouting");
+  const ptxSmartRoutingMobile = useFeature("ptxSmartRoutingMobile");
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
 
   return (
@@ -357,10 +357,12 @@ export default function BaseNavigator() {
       <Stack.Screen
         name={NavigatorName.Exchange}
         component={
-          ptxSmartRouting.enabled ? ExchangeLiveAppNavigator : ExchangeNavigator
+          ptxSmartRoutingMobile?.enabled
+            ? ExchangeLiveAppNavigator
+            : ExchangeNavigator
         }
         options={
-          ptxSmartRouting.enabled
+          ptxSmartRoutingMobile?.enabled
             ? { headerShown: false }
             : { headerStyle: styles.headerNoShadow, headerLeft: null }
         }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -34,6 +34,7 @@ import UnfreezeNavigator from "./UnfreezeNavigator";
 import ClaimRewardsNavigator from "./ClaimRewardsNavigator";
 import AddAccountsNavigator from "./AddAccountsNavigator";
 import ExchangeNavigator from "./ExchangeNavigator";
+import ExchangeLiveAppNavigator from "./ExchangeLiveAppNavigator";
 import PlatformExchangeNavigator from "./PlatformExchangeNavigator";
 import FirmwareUpdateNavigator from "./FirmwareUpdateNavigator";
 import AccountSettingsNavigator from "./AccountSettingsNavigator";
@@ -89,6 +90,8 @@ export default function BaseNavigator() {
     [colors],
   );
   const learn = useFeature("learn");
+  // PTX smart routing feature flag - buy sell live app flag
+  const ptxSmartRouting = useFeature("ptxSmartRouting");
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
 
   return (
@@ -353,8 +356,14 @@ export default function BaseNavigator() {
       />
       <Stack.Screen
         name={NavigatorName.Exchange}
-        component={ExchangeNavigator}
-        options={{ headerStyle: styles.headerNoShadow, headerLeft: null }}
+        component={
+          ptxSmartRouting.enabled ? ExchangeLiveAppNavigator : ExchangeNavigator
+        }
+        options={
+          ptxSmartRouting.enabled
+            ? { headerShown: false }
+            : { headerStyle: styles.headerNoShadow, headerLeft: null }
+        }
         {...noNanoBuyNanoWallScreenOptions}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -13,7 +13,7 @@ export default function ExchangeLiveAppNavigator({ route }: any) {
   const { colors } = useTheme();
 
   // PTX smart routing feature flag - buy sell live app flag
-  const ptxSmartRouting = useFeature("ptxSmartRouting");
+  const ptxSmartRoutingMobile = useFeature("ptxSmartRoutingMobile");
 
   const stackNavigationConfig = useMemo(
     () => getStackNavigatorConfig(colors, true),
@@ -43,8 +43,8 @@ export default function ExchangeLiveAppNavigator({ route }: any) {
             route={{
               ..._props.route,
               params: {
-                ..._props.route.params,
-                platform: ptxSmartRouting?.params?.liveAppId || "multibuy",
+                platform:
+                  ptxSmartRoutingMobile?.params?.liveAppId || "multibuy",
                 mode: "buy",
                 currency: _props.route.params?.defaultCurrencyId,
                 account: _props.route.params?.defaultAccountId,
@@ -72,8 +72,8 @@ export default function ExchangeLiveAppNavigator({ route }: any) {
             route={{
               ..._props.route,
               params: {
-                ..._props.route.params,
-                platform: ptxSmartRouting?.params?.liveAppId || "multibuy",
+                platform:
+                  ptxSmartRoutingMobile?.params?.liveAppId || "multibuy",
                 mode: "sell",
                 currency: _props.route.params?.defaultCurrencyId,
                 account: _props.route.params?.defaultAccountId,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo } from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+import { useTheme } from "styled-components/native";
+import { Icons, Flex } from "@ledgerhq/native-ui";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { ScreenName } from "../../const";
+import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
+
+import PlatformApp from "../../screens/Platform/App";
+import styles from "../../navigation/styles";
+
+export default function ExchangeLiveAppNavigator({ route }: any) {
+  const { colors } = useTheme();
+
+  // PTX smart routing feature flag - buy sell live app flag
+  const ptxSmartRouting = useFeature("ptxSmartRouting");
+
+  const stackNavigationConfig = useMemo(
+    () => getStackNavigatorConfig(colors, true),
+    [colors],
+  );
+
+  const { params: routeParams } = route;
+
+  return (
+    <Stack.Navigator {...stackNavigationConfig}>
+      <Stack.Screen
+        name={ScreenName.ExchangeBuy}
+        options={{
+          headerBackImage: () => (
+            <Flex pl="16px">
+              <Icons.CloseMedium color="neutral.c100" size="20px" />
+            </Flex>
+          ),
+          headerStyle: styles.headerNoShadow,
+          headerTitle: () => null,
+        }}
+      >
+        {(_props: any) => (
+          <PlatformApp
+            {..._props}
+            {...routeParams}
+            route={{
+              ..._props.route,
+              params: {
+                ..._props.route.params,
+                platform: ptxSmartRouting?.params?.liveAppId || "multibuy",
+                mode: "buy",
+                currency: _props.route.params?.defaultCurrencyId,
+                account: _props.route.params?.defaultAccountId,
+              },
+            }}
+          />
+        )}
+      </Stack.Screen>
+      <Stack.Screen
+        name={ScreenName.ExchangeSell}
+        options={{
+          headerBackImage: () => (
+            <Flex pl="16px">
+              <Icons.CloseMedium color="neutral.c100" size="20px" />
+            </Flex>
+          ),
+          headerStyle: styles.headerNoShadow,
+          headerTitle: () => null,
+        }}
+      >
+        {(_props: any) => (
+          <PlatformApp
+            {..._props}
+            {...routeParams}
+            route={{
+              ..._props.route,
+              params: {
+                ..._props.route.params,
+                platform: ptxSmartRouting?.params?.liveAppId || "multibuy",
+                mode: "sell",
+                currency: _props.route.params?.defaultCurrencyId,
+                account: _props.route.params?.defaultAccountId,
+              },
+            }}
+          />
+        )}
+      </Stack.Screen>
+    </Stack.Navigator>
+  );
+}
+
+const Stack = createStackNavigator();

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/InfoPanel.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/InfoPanel.js
@@ -19,6 +19,7 @@ type Props = {
   icon?: string | null,
   description: TranslatableString,
   url?: string | null,
+  uri?: string | null,
   isOpened: boolean,
   setIsOpened: (isOpened: boolean) => void,
 };
@@ -28,6 +29,7 @@ const InfoPanel = ({
   icon,
   description,
   url,
+  uri,
   isOpened,
   setIsOpened,
 }: Props) => {
@@ -91,6 +93,28 @@ const InfoPanel = ({
               style={{ ...styles.basicFontStyle, color: colors.live }}
             >
               {url}
+            </LText>
+            <View style={styles.externalLinkIcon}>
+              <ExternalLinkIcon size={14} color={colors.live} />
+            </View>
+          </TouchableOpacity>
+        </>
+      ) : null}
+      {__DEV__ && uri ? (
+        <>
+          <View style={styles.hr} />
+          <LText semibold style={styles.subSectionTitle}>
+            URI:
+          </LText>
+          <TouchableOpacity
+            style={styles.flexRow}
+            onPress={() => onLinkPress(uri)}
+          >
+            <LText
+              semibold
+              style={{ ...styles.basicFontStyle, color: colors.live }}
+            >
+              {uri}
             </LText>
             <View style={styles.externalLinkIcon}>
               <ExternalLinkIcon size={14} color={colors.live} />

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -124,7 +124,6 @@ const InfoPanelButton = ({
 const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const targetRef: { current: null | WebView } = useRef(null);
   const accounts = flattenAccounts(useSelector(accountsSelector));
-  const theme = useTheme();
   const navigation = useNavigation();
   const { locale } = useLocale();
 
@@ -139,11 +138,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
     {
       loadDate,
     },
-    {
-      ...inputs,
-      lang: locale,
-      theme: theme.theme,
-    },
+    inputs,
   );
 
   const listAccounts = useListPlatformAccounts(accounts);

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -137,11 +137,13 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const uri = usePlatformUrl(
     manifest,
     {
-      lang: locale,
-      theme: theme.theme,
       loadDate,
     },
-    inputs,
+    {
+      ...inputs,
+      lang: locale,
+      theme: theme.theme,
+    },
   );
 
   const listAccounts = useListPlatformAccounts(accounts);

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -69,7 +69,6 @@ import InfoIcon from "../../icons/Info";
 import InfoPanel from "./InfoPanel";
 
 import { track } from "../../analytics/segment";
-import { useLocale } from "../../context/Locale";
 
 const tracking = trackingWrapper(track);
 type Props = {
@@ -125,7 +124,6 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const targetRef: { current: null | WebView } = useRef(null);
   const accounts = flattenAccounts(useSelector(accountsSelector));
   const navigation = useNavigation();
-  const { locale } = useLocale();
 
   const [loadDate, setLoadDate] = useState(Date.now());
   const [widgetLoaded, setWidgetLoaded] = useState(false);

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.js
@@ -15,8 +15,7 @@ import {
   SafeAreaView,
 } from "react-native";
 import { WebView } from "react-native-webview";
-import { useNavigation, useTheme } from "@react-navigation/native";
-import Color from "color";
+import { useNavigation } from "@react-navigation/native";
 import invariant from "invariant";
 
 import { JSONRPCRequest } from "json-rpc-2.0";
@@ -61,6 +60,7 @@ import {
 } from "@ledgerhq/live-common/platform/react";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
 
+import { useTheme } from "styled-components/native";
 import { NavigatorName, ScreenName } from "../../const";
 import { broadcastSignedTx } from "../../logic/screenTransactionHooks";
 import { accountsSelector } from "../../reducers/accounts";
@@ -69,6 +69,7 @@ import InfoIcon from "../../icons/Info";
 import InfoPanel from "./InfoPanel";
 
 import { track } from "../../analytics/segment";
+import { useLocale } from "../../context/Locale";
 
 const tracking = trackingWrapper(track);
 type Props = {
@@ -91,7 +92,7 @@ const ReloadButton = ({
       disabled={loading}
       onPress={() => !loading && onReload()}
     >
-      <UpdateIcon size={18} color={colors.grey} />
+      <UpdateIcon size={18} color={colors.neutral.c70} />
     </TouchableOpacity>
   );
 };
@@ -115,7 +116,7 @@ const InfoPanelButton = ({
       disabled={loading}
       onPress={onPress}
     >
-      <InfoIcon size={18} color={colors.grey} />
+      <InfoIcon size={18} color={colors.neutral.c70} />
     </TouchableOpacity>
   );
 };
@@ -125,6 +126,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const accounts = flattenAccounts(useSelector(accountsSelector));
   const theme = useTheme();
   const navigation = useNavigation();
+  const { locale } = useLocale();
 
   const [loadDate, setLoadDate] = useState(Date.now());
   const [widgetLoaded, setWidgetLoaded] = useState(false);
@@ -135,8 +137,8 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const uri = usePlatformUrl(
     manifest,
     {
-      background: new Color(theme.colors.card).hex(),
-      text: new Color(theme.colors.text).hex(),
+      lang: locale,
+      theme: theme.theme,
       loadDate,
     },
     inputs,
@@ -703,6 +705,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
         name={manifest.name}
         icon={manifest.icon}
         url={manifest.homepageUrl}
+        uri={uri.toString()}
         description={manifest.content.description}
         isOpened={isInfoPanelOpened}
         setIsOpened={setIsInfoPanelOpened}

--- a/apps/ledger-live-mobile/src/screens/Platform/App.js
+++ b/apps/ledger-live-mobile/src/screens/Platform/App.js
@@ -7,26 +7,28 @@ import {
   useRemoteLiveAppManifest,
 } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
 import type { StackScreenProps } from "@react-navigation/stack";
-import { useNavigation, useTheme } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
+import { useTheme } from "styled-components/native";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
 import TrackScreen from "../../analytics/TrackScreen";
 import WebPlatformPlayer from "../../components/WebPlatformPlayer";
 import GenericErrorView from "../../components/GenericErrorView";
+import { useLocale } from "../../context/Locale";
 
 const appManifestNotFoundError = new Error("App not found");
 
 const PlatformApp = ({ route }: StackScreenProps) => {
-  const { dark } = useTheme();
+  const { theme } = useTheme();
   const { platform: appId, ...params } = route.params;
   const { setParams } = useNavigation();
   const localManifest = useLocalLiveAppManifest(appId);
   const remoteManifest = useRemoteLiveAppManifest(appId);
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
+  const { locale } = useLocale();
   const manifest = localManifest || remoteManifest;
   useEffect(() => {
     manifest?.name && setParams({ name: manifest.name });
   }, [manifest, setParams]);
-  const themeType = dark ? "dark" : "light";
 
   return manifest ? (
     <>
@@ -34,7 +36,8 @@ const PlatformApp = ({ route }: StackScreenProps) => {
       <WebPlatformPlayer
         manifest={manifest}
         inputs={{
-          theme: themeType,
+          theme,
+          lang: locale,
           ...params,
         }}
       />

--- a/libs/ledger-live-common/src/platform/react.ts
+++ b/libs/ledger-live-common/src/platform/react.ts
@@ -30,14 +30,18 @@ export function usePlatformUrl(
 
     if (inputs) {
       for (const key in inputs) {
-        if (Object.prototype.hasOwnProperty.call(inputs, key)) {
+        if (
+          Object.prototype.hasOwnProperty.call(inputs, key) &&
+          inputs[key] !== undefined
+        ) {
           url.searchParams.set(key, inputs[key]);
         }
       }
     }
 
-    url.searchParams.set("backgroundColor", params.background);
-    url.searchParams.set("textColor", params.text);
+    if (params.background)
+      url.searchParams.set("backgroundColor", params.background);
+    if (params.text) url.searchParams.set("textColor", params.text);
     if (params.loadDate) {
       url.searchParams.set("loadDate", params.loadDate.valueOf().toString());
     }

--- a/libs/ledgerjs/packages/types-live/README.md
+++ b/libs/ledgerjs/packages/types-live/README.md
@@ -455,7 +455,7 @@ Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 
 Add others with union (e.g. "learn" | "market" | "foo")
 
-Type: (`"learn"` | `"pushNotifications"` | `"llmUsbFirmwareUpdate"` | `"ratings"` | `"counterValue"` | `"buyDeviceFromLive"` | `"ptxSmartRouting"` | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))
+Type: (`"learn"` | `"pushNotifications"` | `"llmUsbFirmwareUpdate"` | `"ratings"` | `"counterValue"` | `"buyDeviceFromLive"` | `"ptxSmartRouting"` | `"ptxSmartRoutingMobile"` | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))
 
 ### Feature
 

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -7,6 +7,7 @@ export type FeatureId =
   | "counterValue"
   | "buyDeviceFromLive"
   | "ptxSmartRouting"
+  | "ptxSmartRoutingMobile"
   | string;
 
 /**  We use objects instead of direct booleans for potential future improvements


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_LLM - Buy Sell in app links should redirect to live app implementation if feature flag is activated_

Redirection is handled at the router level using a specific for this case router to route all exchange buy/sell previous routes to live app

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2935] [LIVE-2936] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2935]: https://ledgerhq.atlassian.net/browse/LIVE-2935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-2936]: https://ledgerhq.atlassian.net/browse/LIVE-2936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ