### PR TITLE
feat/Live-2864 Update the UI of app buttons in manager

### DIFF
--- a/.changeset/slow-trainers-fry.md
+++ b/.changeset/slow-trainers-fry.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Update UI for manager app install/uninstall buttons

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppInstallButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppInstallButton.tsx
@@ -79,7 +79,7 @@ export default function AppInstallButton({
 
   return (
     <TouchableOpacity onPress={installApp}>
-      <ButtonContainer borderColor="neutral.c40">
+      <ButtonContainer borderColor="neutral.c30">
         <Icons.PlusMedium size={18} color="neutral.c100"/>
       </ButtonContainer>
     </TouchableOpacity>

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppProgressButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppProgressButton.tsx
@@ -1,26 +1,16 @@
 import React from "react";
 
-import type { State } from "@ledgerhq/live-common/apps/index";
-import styled, { useTheme } from "styled-components/native";
-
-import { Box, ProgressLoader, Icons } from "@ledgerhq/native-ui";
-
+import { useTheme } from "styled-components/native";
+import { ProgressLoader } from "@ledgerhq/native-ui";
 import { useAppInstallProgress } from "@ledgerhq/live-common/apps/react";
 
 type Props = {
-  state: State,
-  name: string,
-  installing: boolean,
-  updating: boolean,
-  size: number,
+  state: State;
+  name: string;
+  installing: boolean;
+  updating: boolean;
+  size: number;
 };
-
-const StopIcon = styled(Box).attrs((p: {size: number; color: string}) => ({
-  width: p.size,
-  height: p.size,
-  borderRadius: p.size / 20,
-  backgroundColor: p.color,
-}))``;
 
 export default function AppProgressButton({
   state,
@@ -31,23 +21,22 @@ export default function AppProgressButton({
 }: Props) {
   const { colors } = useTheme();
   const progress = useAppInstallProgress(state, name);
+  const { currentAppOp } = state;
+  const isPrimary = updating || installing;
+  const isCurrentAppOp = currentAppOp?.name === name;
 
-  const color = updating || installing ? colors.primary.c80 : colors.error.c100;
+  const mainColor = isPrimary ? colors.primary.c80 : colors.error.c100;
+  const secondaryColor = isPrimary ? colors.primary.c30 : colors.error.c30;
 
   return (
     <ProgressLoader
       onPress={() => {}}
       progress={progress}
-      infinite={!installing && !updating}
+      infinite={!progress && isCurrentAppOp}
       radius={size / 2}
       strokeWidth={2}
-      mainColor={color}
-    >
-      {installing || updating ? (
-        <StopIcon size={size / 4.8} color={color} />
-      ) : (
-        <Icons.TrashMedium size={size * 0.375} color={color} />
-      )}
-    </ProgressLoader>
+      mainColor={mainColor}
+      secondaryColor={secondaryColor}
+    />
   );
 }

--- a/libs/ledger-live-common/src/apps/react.test.ts
+++ b/libs/ledger-live-common/src/apps/react.test.ts
@@ -57,7 +57,7 @@ test("Apps hooks - useAppInstallProgress - Queued or unknown app", () => {
   const { result } = renderHook(() =>
     useAppInstallProgress(mockedState, "not_in_queue")
   );
-  expect(result.current).toBe(1);
+  expect(result.current).toBe(0);
 });
 test("Apps hooks - useAppInstallProgress - Current app", () => {
   const currentProgressSubject: Subject<number> = new Subject();

--- a/libs/ledger-live-common/src/apps/react.ts
+++ b/libs/ledger-live-common/src/apps/react.ts
@@ -151,7 +151,7 @@ export function useAppInstallProgress(state: State, name: string): number {
     return progress;
   }
 
-  return 1;
+  return 0;
 }
 
 // if the app needs deps to be installed, we want to display a modal


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adapt the UI to the new design proposed where we remove the stop icon from queued installs, and adapt the colors to match the figma linked. Can barely call this a feature, but it's an iteration over the current design, not a fix so 🤷🏼‍♂️ I guess it is.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile, ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-2864` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://user-images.githubusercontent.com/4631227/180757130-a211d195-66fa-4526-bfe5-dd113dd43dab.mov

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

There are essentially six states for these buttons:

- Not installed:  It should offer the plus icon, to queue installation
- Queued install: Purple ring, no icon, no animation
- Installing: Active element, Purple spinning ring before we have any progress, then percentage progress no spin
- Installed: It should offer the bucket, to queue uninstallation
- Queued uninstall: Red ring, no icon, no animation
- Uninstalling: Active element, Red spinning ring before we have any progress, then it finishes because there's no partial progress on uninstalls.
