### PR TITLE
Bugfix/live 3027

### DIFF
--- a/.changeset/cold-suns-stare.md
+++ b/.changeset/cold-suns-stare.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fixed incorrect value for used space in Manager

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
@@ -31,7 +31,13 @@ const StorageRepartition = styled(Box)`
 const DeviceAppStorage = ({
   deviceModel,
   deviceInfo,
-  distribution: { freeSpaceBytes, appsSpaceBytes, shouldWarnMemory, apps },
+  distribution: {
+    totalAppsBytes,
+    freeSpaceBytes,
+    appsSpaceBytes,
+    shouldWarnMemory,
+    apps,
+  },
 }: Props) => {
   const appSizes = useMemo(
     () =>
@@ -68,7 +74,7 @@ const DeviceAppStorage = ({
               <Trans i18nKey="manager.storage.used" />
             </Text>{" "}
             <ByteSize
-              value={appsSpaceBytes}
+              value={totalAppsBytes}
               deviceModel={deviceModel}
               firmwareVersion={deviceInfo.version}
             />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We are incorrectly showing the wrong value for the used app data space in the manager for LLM, it's showing the total maximum available data instead of the used one. This address that.

### ❓ Context

- **Impacted projects**: `` ledger-live-mobile
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="550" alt="image" src="https://user-images.githubusercontent.com/4631227/181003276-136fba4f-926b-415b-8c59-47c42fe7a912.png">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

`Used` should reflect the total app size data, not the total size as it did before.