### PR TITLE
Add help drawer to desktop sync onboarding

### DIFF
--- a/.changeset/modern-years-relate.md
+++ b/.changeset/modern-years-relate.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/react-ui": minor
+---
+
+Add a new help drawer in the new synchronous onboarding screen. Also update the drawer component from UI library to comply with recent designs.

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/HelpDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/HelpDrawer.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Drawer, Flex, Text, Button, Link } from "@ledgerhq/react-ui";
+import { useTranslation } from "react-i18next";
+import { ExternalLinkMedium } from "@ledgerhq/react-ui/assets/icons";
+
+export type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const HelpDrawer = ({ isOpen, onClose }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <Drawer big isOpen={isOpen} onClose={onClose}>
+      <Flex position="relative" flexDirection="column" height="100%" px={6}>
+        <Flex flexDirection="column" flex={1}>
+          <Text variant="h4" fontSize={24} fontWeight="semiBold">
+            {t("syncOnboarding.manual.helpDrawer.title")}
+          </Text>
+          <Text variant="body" mt={8}>
+            {t("syncOnboarding.manual.helpDrawer.description")}
+          </Text>
+        </Flex>
+        <Flex flexDirection="column">
+          <Button variant="main" Icon={ExternalLinkMedium} iconSize={18}>
+            {t("syncOnboarding.manual.helpDrawer.docButton")}
+          </Button>
+          <Link Icon={ExternalLinkMedium} mt={8}>
+            {t("syncOnboarding.manual.helpDrawer.supportButton")}
+          </Link>
+        </Flex>
+      </Flex>
+    </Drawer>
+  );
+};
+
+export default HelpDrawer;

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -1,16 +1,15 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button, Flex, Text, VerticalTimeline } from "@ledgerhq/react-ui";
-import { CloseMedium } from "@ledgerhq/react-ui/assets/icons";
+import { CloseMedium, HelpMedium } from "@ledgerhq/react-ui/assets/icons";
 import { useTranslation } from "react-i18next";
 import LangSwitcher from "~/renderer/components/Onboarding/LangSwitcher";
 
 import nanoX from "~/renderer/images/nanoX.v3.svg";
 import nanoXDark from "~/renderer/images/nanoXDark.v3.svg";
 import Illustration from "~/renderer/components/Illustration";
+import HelpDrawer from "./HelpDrawer";
 
 const SyncOnboardingManual = () => {
-  const { t } = useTranslation();
-
   const steps = [
     {
       status: "active",
@@ -57,17 +56,28 @@ const SyncOnboardingManual = () => {
     },
   ];
 
+  const { t } = useTranslation();
+  const [isHelpDrawerOpen, setHelpDrawerOpen] = useState<boolean>(false);
+
   return (
     <Flex bg="background.main" width="100%" height="100%" flexDirection="column">
+      <HelpDrawer isOpen={isHelpDrawerOpen} onClose={() => setHelpDrawerOpen(false)} />
       <Flex width="100%" justifyContent="flex-end" mt={4} px={4}>
         <LangSwitcher />
         <Button ml={4} Icon={CloseMedium} />
       </Flex>
       <Flex flex={1} px={8} py={4}>
-        <Flex flex={1} flexDirection="column" justifyContent="center">
-          <Text variant="h1" fontSize="24px" mb="50px">
-            Setup your Nano
-          </Text>
+        <Flex flex={1} flexDirection="column">
+          <Flex alignItems="center" mb={8}>
+            <Text variant="h4" fontSize="24px" fontWeight="semiBold">
+              Setup Manual
+            </Text>
+            <Button
+              ml={4}
+              Icon={() => <HelpMedium color="neutral.c80" size={24} />}
+              onClick={() => setHelpDrawerOpen(true)}
+            />
+          </Flex>
           <VerticalTimeline steps={steps as any} />
         </Flex>
         <Flex flex={1} justifyContent="center" alignItems="center">

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Flex } from "@ledgerhq/react-ui";
 import { Redirect, Route, Switch, useRouteMatch } from "react-router-dom";
 
+import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import SyncOnboardingPairing from "./Pairing";
 import SyncOnboardingManual from "./Manual";
 
@@ -23,4 +24,4 @@ const SyncOnboarding = () => {
   );
 };
 
-export default SyncOnboarding;
+export default withV3StyleProvider(SyncOnboarding);

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1071,6 +1071,16 @@
     "desc": "This action will hide all <1><0>{{tokenName}}</0></1> accounts, you can show them again using <3>Settings</3>",
     "hideCTA": "Hide token"
   },
+  "syncOnboarding": {
+    "manual": {
+      "helpDrawer": {
+        "title": "Need some help with your setup manual?",
+        "description": "Lorem Elsass ipsum aliquam bissame Oberschaeffolsheim geht's messti de Bischheim tellus blottkopf, dui sed libero. hopla libero, placerat leo eget Gal.",
+        "docButton": "Go to FAQ",
+        "supportButton": "Speak to a human"
+      }
+    }
+  },
   "hideNftCollection": {
     "title": "Hide NFT Collection",
     "desc": "This action will hide all NFTs from the <1><0>{{collectionName}}</0></1> collection, you can show them again using <3>Settings</3>",

--- a/libs/ui/packages/react/src/components/asorted/Text/styles.ts
+++ b/libs/ui/packages/react/src/components/asorted/Text/styles.ts
@@ -79,19 +79,16 @@ export const textVariantStyle: Record<
     "text-transform": "uppercase",
   },
   h3: {
-    fontFamily: "Alpha, Inter, Sans",
+    fontFamily: "Inter, Sans",
     fontWeight: 500,
-    "text-transform": "uppercase",
   },
   h4: {
-    fontFamily: "Alpha, Inter, Sans",
+    fontFamily: "Inter, Sans",
     fontWeight: 500,
-    "text-transform": "uppercase",
   },
   h5: {
-    fontFamily: "Alpha, Inter, Sans",
+    fontFamily: "Inter, Sans",
     fontWeight: 500,
-    "text-transform": "uppercase",
   },
   large: {
     fontFamily: "Inter, Sans",

--- a/libs/ui/packages/react/src/components/layout/Drawer/index.tsx
+++ b/libs/ui/packages/react/src/components/layout/Drawer/index.tsx
@@ -8,6 +8,7 @@ import ArrowLeft from "@ledgerhq/icons-ui/react/ArrowLeftRegular";
 import TransitionSlide from "../../transitions/TransitionSlide";
 import TransitionInOut from "../../transitions/TransitionInOut";
 import Text from "../../asorted/Text";
+import Button from "../../cta/Button";
 
 export enum Direction {
   Left = "left",
@@ -31,6 +32,7 @@ const Wrapper = styled(FlexBox)<{
   justify-content: space-between;
   z-index: ${(p) => p.theme.zIndexes[8]};
 `;
+
 const Overlay = styled.div<{ direction: Direction }>`
   display: flex;
   position: fixed;
@@ -42,19 +44,19 @@ const Overlay = styled.div<{ direction: Direction }>`
   z-index: 999;
   background-color: ${(p) => p.theme.colors.constant.overlay};
 `;
+
 const ScrollWrapper = styled(FlexBox)`
   &::-webkit-scrollbar {
     display: none;
   }
 `;
+
 const ButtonPlaceholder = styled.div`
   min-width: ${(p) => p.theme.space[13]}px;
 `;
-const Button = styled.button`
-  background: unset;
-  border: unset;
-  cursor: pointer;
-  color: ${(p) => p.theme.colors.neutral.c100};
+
+const IconButton = styled(Button)`
+  background-color: ${(p) => p.theme.colors.neutral.c30};
 `;
 
 export interface DrawerProps {
@@ -154,9 +156,7 @@ const DrawerContent = React.forwardRef(
                   {!hideNavigation && (
                     <>
                       {onBack != null ? (
-                        <Button onClick={onBack}>
-                          <ArrowLeft size={21} />
-                        </Button>
+                        <IconButton onClick={onBack} Icon={ArrowLeft} />
                       ) : (
                         <ButtonPlaceholder />
                       )}
@@ -168,9 +168,7 @@ const DrawerContent = React.forwardRef(
                     </Text>
                   ) || <div />}
                   <FlexBox alignSelf="flex-start">
-                    <Button onClick={onClose}>
-                      <Close />
-                    </Button>
+                    <IconButton onClick={onClose} Icon={Close} />
                   </FlexBox>
                 </FlexBox>
                 <ScrollWrapper


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add a drawer displaying help to the sync onboarding page on desktop. The content is still a placeholder for now, waiting for final designs. The drawer can be opened from clicking on the help icon near the manual title.

Update some styles from React UI lib that weren't finalized.

### ❓ Context

- **Impacted projects**: `react-ui`, `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-150] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** -> will be done as part of the sync onboarding playwright test suite <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** -> will be completed in the sync onboarding PR when final designs are ready <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

https://user-images.githubusercontent.com/23487649/181051709-18e10e4a-e18b-4284-89d1-fa5c29609434.mp4

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-150]: https://ledgerhq.atlassian.net/browse/FAT-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ