### PR TITLE
[LIVE-2953] - Bugfix: Fix ethereum signMessage for EIP-712

### DIFF
--- a/.changeset/seven-humans-sip.md
+++ b/.changeset/seven-humans-sip.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fixing support for EIP-712 in hw-signMessage for walletconnect and SDK

--- a/libs/ledger-live-common/src/families/ethereum/hw-signMessage.test.ts
+++ b/libs/ledger-live-common/src/families/ethereum/hw-signMessage.test.ts
@@ -1,0 +1,110 @@
+import "../../__tests__/test-helpers/setup";
+
+import EIP712Message from "@ledgerhq/hw-app-eth/tests/sample-messages/0.json";
+import hwSignMessage from "./hw-signMessage";
+import { setEnv } from "../../env";
+
+const signPersonalMessage = jest.fn(() =>
+  Promise.resolve({
+    r: "r",
+    s: "s",
+    v: 28,
+  })
+);
+const signEIP712HashedMessage = jest.fn(() =>
+  Promise.resolve({
+    r: "r",
+    s: "s",
+    v: 28,
+  })
+);
+const signEIP712Message = jest.fn(() =>
+  Promise.resolve({
+    r: "r",
+    s: "s",
+    v: 28,
+  })
+);
+jest.mock("@ledgerhq/hw-app-eth", () => {
+  return class {
+    signPersonalMessage = signPersonalMessage;
+    signEIP712HashedMessage = signEIP712HashedMessage;
+    signEIP712Message = signEIP712Message;
+  };
+});
+
+describe("Eth hw-signMessage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("parsing", () => {
+    it("should be using the signPersonalMessage method with string message", async () => {
+      await hwSignMessage({} as any, {
+        path: "",
+        message: "test",
+        rawMessage: "0xtest",
+      });
+
+      expect(signPersonalMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("should be using the signEIP712HashedMessage method with stringified message", async () => {
+      await hwSignMessage({} as any, {
+        path: "",
+        message: JSON.stringify(EIP712Message),
+        rawMessage: "0xtest",
+      });
+
+      expect(signEIP712HashedMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("should be using the signEIP712Message method with stringified message", async () => {
+      setEnv("EXPERIMENTAL_EIP712", true);
+
+      await hwSignMessage({} as any, {
+        path: "",
+        message: EIP712Message,
+        rawMessage: "0xtest",
+      });
+
+      expect(signEIP712Message).toHaveBeenCalledTimes(1);
+      setEnv("EXPERIMENTAL_EIP712", false);
+    });
+  });
+
+  describe("value of v", () => {
+    it("should returning parity for signPersonalMessage", async () => {
+      const { rsv } = await hwSignMessage({} as any, {
+        path: "",
+        message: "test",
+        rawMessage: "0xtest",
+      });
+
+      expect(rsv.v).toBe(1);
+    });
+
+    it("should not be returning parity for signEIP712HashedMessage", async () => {
+      const { rsv } = await hwSignMessage({} as any, {
+        path: "",
+        message: JSON.stringify(EIP712Message),
+        rawMessage: "0xtest",
+      });
+
+      expect(rsv.v).toBe(28);
+    });
+
+    it("should not be returning parity for signEIP712Message", async () => {
+      setEnv("EXPERIMENTAL_EIP712", true);
+
+      const { rsv } = await hwSignMessage({} as any, {
+        path: "",
+        message: EIP712Message,
+        rawMessage: "0xtest",
+      });
+
+      expect(rsv.v).toBe(28);
+      setEnv("EXPERIMENTAL_EIP712", false);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/ethereum/hw-signMessage.ts
+++ b/libs/ledger-live-common/src/families/ethereum/hw-signMessage.ts
@@ -1,15 +1,18 @@
+import { EIP712Message } from "@ledgerhq/hw-app-eth/lib/modules/EIP712/EIP712.types";
 import Eth from "@ledgerhq/hw-app-eth";
 import Transport from "@ledgerhq/hw-transport";
 import { TypedDataUtils } from "eth-sig-util";
 import { bufferToHex } from "ethereumjs-util";
 import { getEnv } from "../../env";
 import type { MessageData, Result } from "../../hw/signMessage/types";
-import type { TypedMessageData, TypedMessage } from "./types";
+import type { TypedMessageData } from "./types";
 type EthResolver = (
   arg0: Transport,
-  arg1: MessageData | TypedMessageData
+  arg1: Pick<MessageData | TypedMessageData, "path" | "message"> &
+    Partial<Pick<MessageData, "rawMessage">>
 ) => Promise<Result>;
-export const domainHash = (message: TypedMessage) => {
+
+export const domainHash = (message: EIP712Message): Buffer => {
   return TypedDataUtils.hashStruct(
     "EIP712Domain",
     message.domain,
@@ -17,7 +20,7 @@ export const domainHash = (message: TypedMessage) => {
     true
   );
 };
-export const messageHash = (message: TypedMessage) => {
+export const messageHash = (message: EIP712Message): Buffer => {
   return TypedDataUtils.hashStruct(
     message.primaryType,
     message.message,
@@ -28,29 +31,34 @@ export const messageHash = (message: TypedMessage) => {
 
 const resolver: EthResolver = async (
   transport,
-  // @ts-expect-error only available on MessageData. (type guard)
   { path, message, rawMessage }
 ) => {
   const eth = new Eth(transport);
-  let result;
-
-  if (typeof message === "string") {
-    result = await eth.signPersonalMessage(path, rawMessage.slice(2));
-  } else {
-    if (getEnv("EXPERIMENTAL_EIP712")) {
-      result = await eth.signEIP712Message(path, message);
-    } else {
-      result = await eth.signEIP712HashedMessage(
-        path,
-        bufferToHex(domainHash(message)),
-        bufferToHex(messageHash(message))
-      );
+  const parsedMessage = (() => {
+    try {
+      return JSON.parse(message as string);
+    } catch (e) {
+      return message;
     }
+  })();
+
+  let result: Awaited<ReturnType<typeof eth.signPersonalMessage>>;
+  if (typeof parsedMessage === "string") {
+    result = await eth.signPersonalMessage(path, rawMessage?.slice(2) || "");
+    result.v -= 27;
+    // here the expected v is the parity/recoveryId, so we need to remove 27 (v is either 27 or 28)
+  } else {
+    result = getEnv("EXPERIMENTAL_EIP712")
+      ? await eth.signEIP712Message(path, parsedMessage)
+      : await eth.signEIP712HashedMessage(
+          path,
+          bufferToHex(domainHash(parsedMessage)),
+          bufferToHex(messageHash(parsedMessage))
+        );
+    // result.v stays untouched for EIP712 as the expected v is already good (27 or 28)
   }
 
-  let v: string | number = result["v"] - 27;
-  v = v.toString(16);
-
+  let v = result.v.toString(16);
   if (v.length < 2) {
     v = "0" + v;
   }

--- a/libs/ledger-live-common/src/families/ethereum/types.ts
+++ b/libs/ledger-live-common/src/families/ethereum/types.ts
@@ -1,3 +1,4 @@
+import { EIP712Message } from "@ledgerhq/hw-app-eth/lib/modules/EIP712/EIP712.types";
 import type { BigNumber } from "bignumber.js";
 import type { Unit } from "../../types";
 import type {
@@ -59,35 +60,12 @@ export type TransactionRaw = TransactionCommonRaw & {
   collectionName?: string;
   quantities?: string[];
 };
-export type TypedMessage = {
-  types: {
-    EIP712Domain: [
-      {
-        type: string;
-        name: string;
-      }
-    ];
-    [key: string]: [
-      {
-        type: string;
-        name: string;
-      }
-    ];
-  };
-  primaryType: string;
-  domain: any;
-  message: any;
-  hashes: {
-    domainHash: string;
-    messageHash: string;
-  };
-};
 export type TypedMessageData = {
   currency: CryptoCurrency;
   path: string;
   verify?: boolean;
   derivationMode: DerivationMode;
-  message: TypedMessage;
+  message: EIP712Message;
   hashes: {
     stringHash: string;
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Until now, we had 2 issues with our message signatures with ethereum:
- The `v` of the signature was wrong for the EIP-712. The parity was used instead of the normal result.
- The signMessage method of the SDK was always returning a stringified message preventing from ever using the`signEIP721Message` method which was triggered by a JSON message.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2953 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Before:
<img width="927" alt="Screenshot 2022-07-26 at 18 51 18" src="https://user-images.githubusercontent.com/44363395/181064749-e03926bf-cb41-46cd-a190-9ef723150612.png">

After:
<img width="939" alt="Screenshot 2022-07-26 at 18 51 25" src="https://user-images.githubusercontent.com/44363395/181064776-1eaf9efa-bbf9-40d9-8e2e-3dd72d784880.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
