### PR TITLE
Translation Fehler at line 1572.

### DIFF
--- a/apps/ledger-live-desktop/static/i18n/de/app.json
+++ b/apps/ledger-live-desktop/static/i18n/de/app.json
@@ -1569,7 +1569,7 @@
       "ctaPortfolio" : "Zurück zum Portfolio"
     },
     "deviceStorage" : {
-      "freeSpace" : "<0>{{space}}</0>kostenlos",
+      "freeSpace" : "<0>{{space}}</0> frei",
       "noFreeSpace" : "Kein Speicher mehr frei",
       "installed" : "Apps",
       "capacity" : "Kapazität",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_An incorrect translation into German was corrected in line 1572. The word "free" was translated to kostenlos. The correct translation for free in this case would be free._


### ❓ Context

- **Impacted projects**: `` Ledger Live 2.44.0 for MacOS ARM
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

From this : `"freeSpace" : "<0>{{space}}</0>kostenlos",`
to this : `"freeSpace" : "<0>{{space}}</0> frei",`
<img width="727" alt="Bildschirmfoto 2022-07-26 um 20 03 05" src="https://user-images.githubusercontent.com/100293065/181087191-fb5974d6-27f1-4a04-89a4-6eb9ae0ad87f.png">


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_To change the mistake._

<!-- If any of the expectations are not met please explain the reason in detail. -->
