### PR TITLE
LIVE-2881 - Fix redirection from upsell screen

### DIFF
--- a/.changeset/smart-shoes-shake.md
+++ b/.changeset/smart-shoes-shake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix redirection from upsell screen

--- a/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PurchaseDevice/index.tsx
@@ -32,12 +32,7 @@ const PurchaseDevice = () => {
   const [message, setMessage] = useState<PurchaseMessage | null>(null);
 
   const handleBack = useCallback(() => {
-    navigation.navigate(
-      NavigatorName.BuyDevice as never,
-      {
-        screen: ScreenName.GetDevice,
-      } as never,
-    );
+    navigation.goBack();
   }, [navigation]);
 
   const handleOpenDrawer = useCallback(() => {


### PR DESCRIPTION
### 📝 Description

This PR fixes the bug causing users to be stuck between the upsell screen and the purchase device web view

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-2881](https://ledgerhq.atlassian.net/browse/LIVE-2881)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
