### PR TITLE
bugfix/LIVE-2739 Prevent navigation with ongoing installs/uninstalls

### DIFF
--- a/.changeset/breezy-hairs-bathe.md
+++ b/.changeset/breezy-hairs-bathe.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Prevent navigation without user confirmation with ongoing installs/uninstalls


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We have a bug in production that allows users to navigate away from the manager while there are ongoing app operations by using the bottom tab buttons. We ask for confirmation if the user uses the back key or the top left button to navigate back, in this case we show a confirmation modal such as the attached screenshot. This pr introduces the same behaviour to the bottom tab buttons (except the Transfer one which remains disabled as in production).

The same way we are exposing whether the navigation should be locked or not, we now expose the callback from the manager when trying to navigate away. This callback will either be called directly if the navigation is not locked, deferred called if the navigation is locked and the user confirms on the modal, or not called at all if the user cancels the modal prompt.


### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->


### 📸 Demo

<img width="550" alt="image" src="https://user-images.githubusercontent.com/4631227/181276854-9628e267-4675-47be-a869-f5485bfdbec4.png">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Since this includes some changes to the navigation stack I would suggest testing for unexpected behaviour when navigating between sections of the application. It is expected that if we confirm navigation during an ongoing app transfer the device may become unresponsive, when in doubt please compare with production in case it's already like that.
