### PR TITLE
chore: stop cascade trigger after doing a release preprare

### DIFF
--- a/.github/workflows/release-prepare-desktop.yml
+++ b/.github/workflows/release-prepare-desktop.yml
@@ -51,7 +51,7 @@ jobs:
       - name: commit
         run: |
           git add .
-          git commit -m ":rocket: prepare release"
+          git commit -m ":rocket: prepare release [skip ci]"
 
       - name: push changes
         run: |

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -51,7 +51,7 @@ jobs:
       - name: commit
         run: |
           git add .
-          git commit -m ":fire: hotfix release"
+          git commit -m ":fire: hotfix release [skip ci]"
 
       - name: push changes
         run: |

--- a/.github/workflows/release-prepare-mobile.yml
+++ b/.github/workflows/release-prepare-mobile.yml
@@ -51,7 +51,7 @@ jobs:
       - name: commit
         run: |
           git add .
-          git commit -m ":rocket: prepare release"
+          git commit -m ":rocket: prepare release [skip ci]"
 
       - name: push changes
         run: |


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Prevent CI from triggering unexpected workflow after a prepare-{desktop|mobile|hotfix} workflow

### ❓ Context

- **Impacted projects**: `automation` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

No demo

### 🚀 Expectations to reach

Stop triggering prerelease CI after a release prepare

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
