### PR TITLE
Add missing "size" property to React UI buttons

### DIFF
--- a/.changeset/tender-mirrors-guess.md
+++ b/.changeset/tender-mirrors-guess.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-ui": patch
+---
+
+Add optional size prop to button

--- a/libs/ui/packages/react/src/components/cta/Button/Button.stories.tsx
+++ b/libs/ui/packages/react/src/components/cta/Button/Button.stories.tsx
@@ -48,7 +48,7 @@ export default {
   },
 };
 
-export const Overview = ((args: StoryTemplate<ButtonProps>) => {
+export const Overview = ((args: ButtonProps) => {
   const templateProps = { Icon: PlusMedium, children: "Try me", onClick: () => {} };
   const propsArr = [
     { ...templateProps, Icon: undefined },

--- a/libs/ui/packages/react/src/components/cta/Button/Button.stories.tsx
+++ b/libs/ui/packages/react/src/components/cta/Button/Button.stories.tsx
@@ -20,6 +20,10 @@ export default {
         type: "radio",
       },
     },
+    size: {
+      options: [undefined, "small", "medium", "large"],
+      control: { type: "radio" },
+    },
     fontSize: {
       options: [undefined, 0, 1, 2, 3, 4, 5, 6, 7, 8],
       control: {
@@ -44,7 +48,7 @@ export default {
   },
 };
 
-export const Overview = (() => {
+export const Overview = ((args) => {
   const templateProps = { Icon: PlusMedium, children: "Try me", onClick: () => {} };
   const propsArr = [
     { ...templateProps, Icon: undefined },
@@ -65,6 +69,7 @@ export const Overview = (() => {
               <Flex flex={1} columnGap={4}>
                 {[false, true].map((disabled) => (
                   <Button
+                    size={args.size}
                     variant={buttonType}
                     outline={outline}
                     disabled={disabled}

--- a/libs/ui/packages/react/src/components/cta/Button/Button.stories.tsx
+++ b/libs/ui/packages/react/src/components/cta/Button/Button.stories.tsx
@@ -48,7 +48,7 @@ export default {
   },
 };
 
-export const Overview = ((args) => {
+export const Overview = ((args: StoryTemplate<ButtonProps>) => {
   const templateProps = { Icon: PlusMedium, children: "Try me", onClick: () => {} };
   const propsArr = [
     { ...templateProps, Icon: undefined },

--- a/libs/ui/packages/react/src/components/cta/Button/index.tsx
+++ b/libs/ui/packages/react/src/components/cta/Button/index.tsx
@@ -14,6 +14,7 @@ interface BaseProps extends BaseStyledProps, BordersProps {
   ff?: string;
   color?: string;
   backgroundColor?: string;
+  size?: "small" | "medium" | "large";
   fontSize?: number;
   variant?: ButtonVariants;
   outline?: boolean;
@@ -155,14 +156,13 @@ export const Base = baseStyled.button.attrs((p: BaseProps) => ({
   border-width: ${(p) => (p.outline || p.variant === "shade" ? 1 : 0)}px;
   font-weight: 600;
   ${compose(fontFamily, fontSize, border)};
-  height: ${(p) => p.theme.space[13]}px;
   line-height: ${(p) => p.theme.fontSizes[p.fontSize]}px;
   text-align: center;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 2em;
   overflow: hidden;
+  ${(p) => buttonSizeStyle[p.size || "medium"]}
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
@@ -280,6 +280,26 @@ export function ButtonExpand(
     />
   );
 }
+
+export const buttonSizeStyle: {
+  [index: string]: {
+    padding: string;
+    height: string;
+  };
+} = {
+  small: {
+    padding: "0 20px",
+    height: "40px",
+  },
+  medium: {
+    padding: "0 24px",
+    height: "48px",
+  },
+  large: {
+    padding: "0 28px",
+    height: "56px",
+  },
+};
 
 Button.Unstyled = ButtonUnstyled;
 Button.Expand = React.forwardRef(ButtonExpand);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR add a missing optional "size" prop to button in React UI, like it is in Native UI

### ❓ Context

- **Impacted projects**: `react-ui`
- **Linked resource(s)**: [FAT-243]

### ✅ Checklist

- [ ] ~**Test coverage**~ - No testing setup in UI library <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

https://user-images.githubusercontent.com/29443638/181470171-03c650c1-9ddf-4879-8b23-9a6e1654c88a.mp4


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-243]: https://ledgerhq.atlassian.net/browse/FAT-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ