### PR TITLE
Disable ftx ftxus temporary as a swap provider before official mobile release

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Swap/SwapEntry.js
+++ b/apps/ledger-live-mobile/src/screens/Swap/SwapEntry.js
@@ -22,7 +22,7 @@ export const useProviders = () => {
   useEffect(() => {
     getProviders().then((providers: any) => {
       let resultProvider;
-      const disabledProviders = Config.SWAP_DISABLED_PROVIDERS || "";
+      const disabledProviders = Config.SWAP_DISABLED_PROVIDERS || "ftx,ftxus";
       const providersByName = providers.reduce((acc, providerData) => {
         if (!disabledProviders.includes(providerData.provider)) {
           acc[providerData.provider] = providerData;


### PR DESCRIPTION
### 📝 Description
FTX and FTX.US shows up on mobile even we haven't officially release. Currently there's a workaround in place provided by backend team based on User-Agent filter. This PR would directly hide them on the client side.
When new mobile swap version land in the next release, this change would be no longer necessary. This is a temporary solution.

close #765

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
  - mobile swap
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->
  - [LIVE-3140](https://ledgerhq.atlassian.net/browse/LIVE-3140)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

If you don't see FTX and FTX.US anymore from mobile even without backend workaround then that's the success.

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
