### PR TITLE
fix: use getMainAccount in broadcastTransaction [LIVE-3142]

### DIFF
--- a/.changeset/silly-oranges-begin.md
+++ b/.changeset/silly-oranges-begin.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: use getMainAccount in broadcastTransaction [LIVE-3142]

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/LiveAppSDKLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/LiveAppSDKLogic.ts
@@ -219,7 +219,7 @@ export const broadcastTransactionLogic = async (
       setDrawer(OperationDetails, {
         operationId: optimisticOperation.id,
         accountId: account.id,
-        parentId: parentAccount && parentAccount.id,
+        parentId: parentAccount?.id,
       });
     },
   });

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/LiveAppSDKLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/LiveAppSDKLogic.ts
@@ -36,6 +36,8 @@ import { track } from "~/renderer/analytics/segment";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
 import { MessageData } from "@ledgerhq/live-common/hw/signMessage/types";
 import { prepareMessageToSign } from "@ledgerhq/live-common/hw/signMessage/index";
+import { OperationDetails } from "~/renderer/drawers/OperationDetails";
+import { setDrawer } from "~/renderer/drawers/Provider";
 
 const tracking = trackingWrapper(track);
 
@@ -214,13 +216,11 @@ export const broadcastTransactionLogic = async (
     icon: "info",
     callback: () => {
       tracking.platformBroadcastOperationDetailsClick(manifest);
-      dispatch(
-        openModal("MODAL_OPERATION_DETAILS", {
-          operationId: optimisticOperation.id,
-          accountId: account.id,
-          parentId: null,
-        }),
-      );
+      setDrawer(OperationDetails, {
+        operationId: optimisticOperation.id,
+        accountId: account.id,
+        parentId: parentAccount && parentAccount.id,
+      });
     },
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes the support of ERC20 tokens in broadcastTransaction for LLD

### ❓ Context

- **Impacted projects**: `live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-3142`](https://ledgerhq.atlassian.net/browse/LIVE-3142) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage**: We found the issue when migrating to typescript which covers that case instead of a test <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
