### PR TITLE
Refactoring: FAT-82 & 99 Onboarding polling hook refactor

### DIFF
--- a/.changeset/twelve-oranges-play.md
+++ b/.changeset/twelve-oranges-play.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Refactoring of useOnboardingStatePolling bringing 2 changes:
+
+- avoid re-rendering: the hook only updates its result on a new onboardingState or new allowedError, not at every run
+- update of useOnboardingStatePolling args: getOnboardingStatePolling as an optional injected dependency to the hook. It is needed for LLD to have the polling working on the internal thread. It is set by default to live-common/hw/getOnboardingStatePolling so it is not needed to pass it as an arg to use the hook on LLM.

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -28,6 +28,15 @@ export type OnboardingStatePollingResult = {
   allowedError: Error | null;
 };
 
+export type GetOnboardingStatePollingResult =
+  Observable<OnboardingStatePollingResult>;
+
+export type GetOnboardingStatePollingArgs = {
+  deviceId: string;
+  pollingPeriodMs: number;
+  fetchingTimeoutMs?: number;
+};
+
 /**
  * Polls the device onboarding state at a given frequency
  * @param deviceId A device id
@@ -39,11 +48,7 @@ export const getOnboardingStatePolling = ({
   deviceId,
   pollingPeriodMs,
   fetchingTimeoutMs = pollingPeriodMs,
-}: {
-  deviceId: string;
-  pollingPeriodMs: number;
-  fetchingTimeoutMs?: number;
-}): Observable<OnboardingStatePollingResult> => {
+}: GetOnboardingStatePollingArgs): GetOnboardingStatePollingResult => {
   let firstRun = true;
 
   const delayedOnceOnboardingStateObservable: Observable<OnboardingStatePollingResult> =

--- a/libs/ledger-live-common/src/onboarding/hooks/useOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/onboarding/hooks/useOnboardingStatePolling.ts
@@ -49,11 +49,35 @@ export const useOnboardingStatePolling = ({
         next: (onboardingStatePollingResult: OnboardingStatePollingResult) => {
           if (onboardingStatePollingResult) {
             setFatalError(null);
-            setAllowedError(onboardingStatePollingResult.allowedError);
+            setAllowedError((prevAllowedError) => {
+              // Only updates if the new allowedError is different
+              if (
+                isDifferentError(
+                  prevAllowedError,
+                  onboardingStatePollingResult.allowedError
+                )
+              ) {
+                return onboardingStatePollingResult.allowedError;
+              }
+
+              return prevAllowedError;
+            });
 
             // Does not update the onboarding state if an allowed error occurred
             if (!onboardingStatePollingResult.allowedError) {
-              setOnboardingState(onboardingStatePollingResult.onboardingState);
+              setOnboardingState((prevOnboardingState) => {
+                // Only updates if the new onboardingState is different
+                if (
+                  isDifferentOnboardingState(
+                    prevOnboardingState,
+                    onboardingStatePollingResult.onboardingState
+                  )
+                ) {
+                  return onboardingStatePollingResult.onboardingState;
+                }
+
+                return prevOnboardingState;
+              });
             }
           }
         },
@@ -83,4 +107,22 @@ export const useOnboardingStatePolling = ({
   ]);
 
   return { onboardingState, allowedError, fatalError };
+};
+
+const isDifferentOnboardingState = (
+  prevOnboardingState: OnboardingState | null,
+  newOnboardingState: OnboardingState | null
+): boolean => {
+  // OnboardingState are simple JSON-style objects, without methods
+  return (
+    JSON.stringify(prevOnboardingState) !== JSON.stringify(newOnboardingState)
+  );
+};
+
+const isDifferentError = (
+  prevError: Error | null,
+  newError: Error | null
+): boolean => {
+  // Only interested if the errors are instances of the same Error class
+  return prevError?.constructor !== newError?.constructor;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Refactoring of the useOnboardingStatePolling that has no impact on current develop/production projects. This PR merged on `develop` will make our work easier on both LLD and LLM.

This refactoring brings 2 changes:
- avoid re-rendering: the hook only updates its result on a new onboardingState or new allowedError, not at every run
- update of `useOnboardingStatePolling args`: `getOnboardingStatePolling` as an optional injected dependency to the hook. It is needed for LLD to have the polling working on the **internal thread**. It is set by default to `live-common/hw/getOnboardingStatePolling` so it is not needed to pass it as an arg to use the hook on LLM.

Note: you can see a usage of the "dependency injection"/LLD on commit [371ada8c5f7c8d3cf63f9974d1756933d671e21a](https://github.com/LedgerHQ/ledger-live/pull/770/commits/371ada8c5f7c8d3cf63f9974d1756933d671e21a).

### ❓ Context

- **Impacted projects**: live-common
- **Linked resource(s)**: Will be used by [FAT-82 on LLM](https://ledgerhq.atlassian.net/browse/FAT-82?atlOrigin=eyJpIjoiMzllODNlOTNmYTVjNDdiZTkwZDUxYjkyYWU0ZWZkNGYiLCJwIjoiaiJ9) and [FAT-99 on LLD](https://ledgerhq.atlassian.net/browse/FAT-99?atlOrigin=eyJpIjoiYWM1NTc0YTVlMmVkNGIxOTgyMzIxNWYyN2M2NGY3Y2EiLCJwIjoiaiJ9)

### ✅ Checklist

- [x] **Test coverage** : unit tested
- [x] **Atomic delivery** 
- [x] **No breaking changes** : no impact on current develop/production projects

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
