### PR TITLE
LIVE-3025 - Fix redirection to stories from device selection screen

### DIFF
--- a/.changeset/cold-clocks-travel.md
+++ b/.changeset/cold-clocks-travel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": major
+---
+
+Fix redirection to stories from device selection screen

--- a/.changeset/cold-clocks-travel.md
+++ b/.changeset/cold-clocks-travel.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": major
+"live-mobile": patch
 ---
 
 Fix redirection to stories from device selection screen

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
@@ -74,11 +74,9 @@ const Item = ({
     dispatch(setReadOnlyMode(true));
     onClick("Explore without a device");
 
-    // Fixme: Navigate to read only page ?
-    // TODO: FIX @react-navigation/native using Typescript
-    // @ts-ignore next-line
-    navigation.navigate(NavigatorName.Base, {
-      screen: NavigatorName.Main,
+    navigation.reset({
+      index: 0,
+      routes: [{ name: NavigatorName.Base } as never],
     });
   }, [dispatch, navigation, onClick]);
 


### PR DESCRIPTION
### 📝 Description

Fix the bug causing users to go back to the stories from the device selection screen

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-3025](https://ledgerhq.atlassian.net/browse/LIVE-3025)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
