### PR TITLE
Update ZIL&TT explorer and color

### DIFF
--- a/.changeset/tender-dingos-jump.md
+++ b/.changeset/tender-dingos-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+Update ZIL&TT explorer and color

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -2617,7 +2617,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     managerAppName: "Thundercore",
     ticker: "TT",
     scheme: "thundercore",
-    color: "#000",
+    color: "#0844D2",
     family: "ethereum",
     ethereumLikeInfo: {
       chainId: 108,
@@ -2629,7 +2629,12 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
         magnitude: 18,
       },
     ],
-    explorerViews: [],
+    explorerViews: [
+      {
+        tx: "https://viewblock.io/thundercore/tx/$hash",
+        address: "https://viewblock.io/thundercore/address/$address",
+      },
+    ],
   },
   tomo: {
     type: "CryptoCurrency",
@@ -3002,7 +3007,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     managerAppName: "Zilliqa",
     ticker: "ZIL",
     scheme: "zilliqa",
-    color: "#000",
+    color: "#2CC0BE",
     family: "zilliqa",
     units: [
       {
@@ -3011,7 +3016,12 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
         magnitude: 12,
       },
     ],
-    explorerViews: [],
+    explorerViews: [
+      {
+        tx: "https://viewblock.io/zilliqa/tx/$hash",
+        address: "https://viewblock.io/zilliqa/address/$address",
+      },
+    ],
   },
   crypto_org: {
     type: "CryptoCurrency",


### PR DESCRIPTION
### 📝 Description

Adds explorers links to Zilliqa & Thundercore chains + updates their primary colors.

### ❓ Context

- **Impacted projects**: `Zilliqa`, `Thundercore`

### ✅ Checklist

- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->
