### PR TITLE
LIVE-3203 - LLM - market backarrow button touch highlight color issue

### DIFF
--- a/.changeset/shiny-pens-flow.md
+++ b/.changeset/shiny-pens-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Button component uses correct TouchableOpacity instead of Highlight

--- a/.changeset/thin-tomatoes-poke.md
+++ b/.changeset/thin-tomatoes-poke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - fixes issue on market header button touch highlight color

--- a/libs/ui/packages/native/src/components/cta/Button/index.tsx
+++ b/libs/ui/packages/native/src/components/cta/Button/index.tsx
@@ -1,14 +1,14 @@
 import React, { useCallback, useState, useMemo } from "react";
 import styled, { useTheme } from "styled-components/native";
 
-import { ActivityIndicator, TouchableHighlight, TouchableHighlightProps, View } from "react-native";
+import { ActivityIndicator, TouchableOpacity, TouchableOpacityProps, View } from "react-native";
 import { buttonSizeStyle, getButtonColorStyle } from "../../cta/Button/getButtonStyle";
 import { ctaIconSize, ctaTextType } from "../../cta/getCtaStyle";
 import Text from "../../Text";
 import { Icon as IconComponent } from "../../Icon";
 import baseStyled, { BaseStyledProps } from "../../styled";
 
-export type ButtonProps = TouchableHighlightProps &
+export type ButtonProps = TouchableOpacityProps &
   BaseStyledProps & {
     Icon?: React.ComponentType<{ size: number; color: string }> | null;
     iconName?: string;
@@ -31,7 +31,7 @@ const IconContainer = styled.View<{
     p.iconButton ? "" : p.iconPosition === "left" ? `margin-right: 10px;` : `margin-left: 10px;`}
 `;
 
-export const Base = baseStyled(TouchableHighlight).attrs<ButtonProps>((p) => ({
+export const Base = baseStyled(TouchableOpacity).attrs<ButtonProps>((p) => ({
   ...getButtonColorStyle(p.theme.colors, p).button,
   // Avoid conflict with styled-system's size property by nulling size and renaming it
   size: undefined,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Fixes issue on market header back button arrow being the incorrect color when tapped_

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3203] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3203]: https://ledgerhq.atlassian.net/browse/LIVE-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ