### PR TITLE
bugfix: check that Celo bot account is registered before locking tokens

### DIFF
--- a/libs/ledger-live-common/src/families/celo/specs/createLockMutation.ts
+++ b/libs/ledger-live-common/src/families/celo/specs/createLockMutation.ts
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import { getCryptoCurrencyById, parseCurrencyUnit } from "../../../currencies";
 import { MutationSpec } from "../../../bot/types";
-import type { Transaction } from "../types";
+import type { CeloAccount, Transaction } from "../types";
 
 const currency = getCryptoCurrencyById("celo");
 const minimalAmount = parseCurrencyUnit(currency.units[0], "0.005");
@@ -10,6 +10,12 @@ export const createLockMutation = (): MutationSpec<Transaction> => ({
   name: "Celo: Lock",
   maxRun: 1,
   transaction: ({ account, bridge, maxSpendable }) => {
+    const { celoResources } = account as CeloAccount;
+    invariant(
+      celoResources?.registrationStatus,
+      "Celo: Lock Vote | Account is not registered"
+    );
+
     invariant(
       maxSpendable.gt(minimalAmount),
       "Celo:  Lock | balance is too low"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Before attempting to lock funds, we need to ensure that the Celo account is registered.  

### ❓ Context

- **Impacted projects**: `Bot tests` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
