### PR TITLE
fix: bump platform API version [LIVE-3181]

### DIFF
--- a/.changeset/empty-seals-bow.md
+++ b/.changeset/empty-seals-bow.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-common": patch
+---
+
+fix: bump platform API version [LIVE-3181]

--- a/.changeset/great-waves-kiss.md
+++ b/.changeset/great-waves-kiss.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: bump platform API version [LIVE-3181]

--- a/.changeset/slimy-chicken-act.md
+++ b/.changeset/slimy-chicken-act.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: bump platform API version [LIVE-3181]

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -6,7 +6,7 @@ import { listen } from "@ledgerhq/logs";
 import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { setPlatformVersion } from "@ledgerhq/live-common/platform/version";
 
-setPlatformVersion("1.0.0");
+setPlatformVersion("1.1.0");
 
 setSupportedCurrencies([
   "bitcoin",

--- a/apps/ledger-live-desktop/src/live-common-set-supported-currencies.js
+++ b/apps/ledger-live-desktop/src/live-common-set-supported-currencies.js
@@ -2,7 +2,7 @@
 import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
 import { setPlatformVersion } from "@ledgerhq/live-common/platform/version";
 
-setPlatformVersion("1.0.0");
+setPlatformVersion("1.1.0");
 
 setSupportedCurrencies([
   "bitcoin",

--- a/apps/ledger-live-mobile/src/live-common-setup.js
+++ b/apps/ledger-live-mobile/src/live-common-setup.js
@@ -25,7 +25,7 @@ setGlobalOnBridgeError(e => logger.critical(e));
 
 setDeviceMode("polling");
 
-setPlatformVersion("1.0.0");
+setPlatformVersion("1.1.0");
 
 setSupportedCurrencies([
   "bitcoin",

--- a/libs/ledger-live-common/src/__tests__/accounts/importAccounts.ts
+++ b/libs/ledger-live-common/src/__tests__/accounts/importAccounts.ts
@@ -7,7 +7,7 @@ import {
 import { setSupportedCurrencies } from "../../currencies";
 import { setPlatformVersion } from "../../platform/version";
 
-setPlatformVersion("1.0.0");
+setPlatformVersion("1.1.0");
 
 setSupportedCurrencies(["ethereum"]);
 describe("importAccountsMakeItems", () => {

--- a/libs/ledger-live-common/src/__tests__/test-helpers/setup.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/setup.ts
@@ -18,7 +18,7 @@ expect.extend({
   },
 });
 
-setPlatformVersion("1.0.0");
+setPlatformVersion("1.1.0");
 
 setSupportedCurrencies([
   "bitcoin",

--- a/libs/ledger-live-common/src/apps/filtering.test.ts
+++ b/libs/ledger-live-common/src/apps/filtering.test.ts
@@ -5,7 +5,7 @@ import { sortFilterApps } from "./filtering";
 import { setSupportedCurrencies } from "../currencies/support";
 import { setPlatformVersion } from "../platform/version";
 
-setPlatformVersion("1.0.0");
+setPlatformVersion("1.1.0");
 
 type FilteringScenario = {
   name: string;

--- a/libs/ledger-live-common/src/platform/version.test.ts
+++ b/libs/ledger-live-common/src/platform/version.test.ts
@@ -1,5 +1,5 @@
 import "../__tests__/test-helpers/setup";
 import { getPlatformVersion } from "./version";
 test("version is defined by setup", () => {
-  expect(getPlatformVersion()).toBe("1.0.0");
+  expect(getPlatformVersion()).toBe("1.1.0");
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Bump the platform API version to reflect the addition of `signMessage`

### ❓ Context

- **Impacted projects**: `live-mobile`, `live-desktop`, `cli` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-3181`](https://ledgerhq.atlassian.net/browse/LIVE-3181) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** You can check that apps are still available in the discover section of the apps <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
