### PR TITLE
ci: attempt to fix the flaky node-gyp errors in the windows ci

### DIFF
--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -100,6 +100,10 @@ jobs:
           ref: ${{ github.event.inputs.ref || github.ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
+      - name: Install node-gyp globally
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          pnpm add -g node-gyp
       - name: TurboRepo local server
         uses: felixmosh/turborepo-gh-artifacts@v1
         with:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Trying to fix these errors appearing  **randomly** during the windows playwright tests running on the Github hosted runners:

```
.../node_modules/tiny-secp256k1 install: D:\a\ledger-live\ledger-live\node_modules\.pnpm\nan@2.15.0\node_modules\nan\nan.h(57,10): fatal error C1083: Cannot open include file: 'uv.h': No such file or directory [D:\a\ledger-live\ledger-live\node_modules\.pnpm\tiny-secp256k1@1.1.6\node_modules\tiny-secp256k1\build\secp256k1.vcxproj]
.../blake2@4.1.1/node_modules/blake2 install: C:\Users\runneradmin\AppData\Local\node-gyp\Cache\16.16.0\include\node\node.h(63,10): fatal error C1083: Cannot open include file: 'v8.h': No such file or directory [D:\a\ledger-live\ledger-live\node_modules\.pnpm\blake2@4.1.1\node_modules\blake2\build\binding.vcxproj]
.../keccak@1.4.0/node_modules/keccak install: C:\Users\runneradmin\AppData\Local\node-gyp\Cache\16.16.0\include\node\node.h(63,10): fatal error C1083: Cannot open include file: 'v8.h': No such file or directory [D:\a\ledger-live\ledger-live\node_modules\.pnpm\keccak@1.4.0\node_modules\keccak\build\keccak.vcxproj]
```

It is certainly related to `node-gyp` not downloading the node header files because it expects them from a local cache folder (which is missing).

From what I saw when `node-gyp` downloads the `.h` files the action runs successfully.

```
.../node_modules/tiny-secp256k1 install: gyp http GET https://nodejs.org/download/release/v16.16.0/node-v16.16.0-headers.tar.gz
.../node_modules/tiny-secp256k1 install: gyp http 200 https://nodejs.org/download/release/v16.16.0/node-v16.16.0-headers.tar.gz
(and so on…)
```

#### So how to force the download?

This pr installs `node-gyp` globally, maybe it will do the trick.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

Testing is tricky because the issue is random.

I ran the `Ledger Live Desktop Tests (windows-latest)` workflow **10 times** successfully, so we can hope I did not get a lucky streak and it fixes the header not found problem 🍀 .

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
