### PR TITLE
native-ui: "h1Inter" text variant (h1 with Inter font family)

### DIFF
--- a/.changeset/hip-readers-enjoy.md
+++ b/.changeset/hip-readers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Add h1Inter text variant (h1 with Inter font)

--- a/libs/ui/packages/native/src/components/Text/getTextStyle.ts
+++ b/libs/ui/packages/native/src/components/Text/getTextStyle.ts
@@ -3,8 +3,11 @@ import { BaseTextProps } from "./index";
 
 export type FontWeightTypes = "medium" | "semiBold" | "bold";
 
+export const fontWeightTypes: FontWeightTypes[] = ["medium", "semiBold", "bold"];
+
 const bracketSizes: Record<TextVariants, number> = {
   h1: 32,
+  h1Inter: 32,
   h2: 28,
   h3: 20,
   h4: 18,
@@ -30,6 +33,7 @@ export function getTextTypeStyle({ bracket }: { bracket?: boolean }): Record<
     lineHeight?: string;
     paddingTop?: number;
     textTransform?: string;
+    letterSpacing?: number;
   }
 > {
   return {
@@ -38,6 +42,11 @@ export function getTextTypeStyle({ bracket }: { bracket?: boolean }): Record<
       lineHeight: "32px",
       paddingTop: bracket ? 5 : 0,
       textTransform: "uppercase",
+    },
+    h1Inter: {
+      fontFamily: "Inter",
+      lineHeight: "42px",
+      letterSpacing: -1,
     },
     h2: {
       fontFamily: "Alpha",

--- a/libs/ui/packages/native/src/styles/theme.ts
+++ b/libs/ui/packages/native/src/styles/theme.ts
@@ -3,25 +3,32 @@ import { ColorPalette, palettes } from "@ledgerhq/ui-shared";
 //                    0  1  2  3  4   5   6   7   8   9   10  11  12  13  14
 export const space = [0, 2, 4, 8, 12, 14, 16, 24, 32, 40, 48, 64, 80, 96, 120];
 
-export type TextVariants =
-  | "h1"
-  | "h2"
-  | "h3"
-  | "h4"
-  | "h5"
-  | "large"
-  | "body"
-  | "bodyLineHeight"
-  | "paragraph"
-  | "paragraphLineHeight"
-  | "small"
-  | "subtitle"
-  | "tiny";
+export const textVariants = [
+  "h1",
+  "h1Inter",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "large",
+  "body",
+  "bodyLineHeight",
+  "paragraph",
+  "paragraphLineHeight",
+  "small",
+  "subtitle",
+  "tiny",
+] as const;
+
+export type TextVariants = typeof textVariants[number];
 
 export type ThemeScale<Type, Aliases extends string> = Array<Type> & Record<Aliases, Type>;
 
-//                        0   1   2   3   4   5   6   7   8
-export const fontSizes = [10, 11, 12, 13, 14, 16, 18, 24, 28] as ThemeScale<number, TextVariants>;
+//                        0   1   2   3   4   5   6   7   8   9
+export const fontSizes = [10, 11, 12, 13, 14, 16, 18, 24, 28, 32] as ThemeScale<
+  number,
+  TextVariants
+>;
 
 [
   fontSizes.tiny,
@@ -33,6 +40,7 @@ export const fontSizes = [10, 11, 12, 13, 14, 16, 18, 24, 28] as ThemeScale<numb
   fontSizes.h3,
   fontSizes.h2,
   fontSizes.h1,
+  fontSizes.h1Inter,
 ] = fontSizes;
 fontSizes.bodyLineHeight = fontSizes.body;
 fontSizes.paragraphLineHeight = fontSizes.paragraph;

--- a/libs/ui/packages/native/storybook/stories/Text/Text.stories.tsx
+++ b/libs/ui/packages/native/storybook/stories/Text/Text.stories.tsx
@@ -3,29 +3,12 @@ import { text } from "@storybook/addon-knobs";
 import { storiesOf } from "../storiesOf";
 import { select, boolean } from "@storybook/addon-knobs";
 import Text from "../../../src/components/Text";
+import { textVariants } from "../../../src/styles/theme";
 
 storiesOf((story) =>
   story("Text", module).add("Text", () => (
     <Text
-      variant={select(
-        "variant",
-        [
-          "h1",
-          "h2",
-          "h3",
-          "h4",
-          "h5",
-          "large",
-          "body",
-          "bodyLineHeight",
-          "paragraph",
-          "paragraphLineHeight",
-          "small",
-          "subtitle",
-          "tiny",
-        ],
-        "h1",
-      )}
+      variant={select("variant", textVariants, "h1")}
       fontWeight={select("fontWeight", ["medium", "semiBold", "bold"], "medium")}
       color={select("color", ["primary.c100", "neutral.c100"], "neutral.c100")}
       bracket={boolean("bracket", false)}

--- a/libs/ui/packages/native/storybook/stories/Text/TextOverview.stories.tsx
+++ b/libs/ui/packages/native/storybook/stories/Text/TextOverview.stories.tsx
@@ -1,49 +1,44 @@
 import React from "react";
 import { ScrollView } from "react-native";
-import { FontWeightTypes } from "src/components/Text/getTextStyle";
+import proxyStyled from "../../../src/components/styled";
+import { fontWeightTypes, FontWeightTypes } from "../../../src/components/Text/getTextStyle";
 import { Flex } from "../../../src/components/Layout";
 import Text from "../../../src/components/Text";
-import { TextVariants } from "../../../src/styles/theme";
+import { textVariants, TextVariants } from "../../../src/styles/theme";
 import { storiesOf } from "../storiesOf";
 
-const headerVariants: TextVariants[] = ["h1", "h2", "h3", "h4", "h5"];
+const HorizontalScroll = proxyStyled(ScrollView).attrs({
+  horizontal: true,
+  flex: 1,
+  width: "100%",
+})``;
 
-const mainVariants: TextVariants[] = [
-  "large",
-  "body",
-  "bodyLineHeight",
-  "paragraph",
-  "paragraphLineHeight",
-  "small",
-  "tiny",
-];
-
+const headerVariants: TextVariants[] = ["h1", "h1Inter", "h2", "h3", "h4", "h5"];
+const headerInterVariants: TextVariants[] = ["h1Inter", "h4", "h5"];
 const subtitleVariants: TextVariants[] = ["subtitle"];
-
-const variants: TextVariants[] = [...headerVariants, ...mainVariants, ...subtitleVariants];
 
 const makeIsInCategory = (variantsArray: TextVariants[]) => (variant: TextVariants) =>
   variantsArray.includes(variant);
 const isHeader = makeIsInCategory(headerVariants);
 const isSubtitle = makeIsInCategory(subtitleVariants);
-
-const mainFontWeights: FontWeightTypes[] = ["medium", "semiBold", "bold"];
+const isHeaderInter = makeIsInCategory(headerInterVariants);
 
 const Overview = () => {
   return (
-    <ScrollView horizontal contentContainerStyle={{ padding: 20 }}>
+    <HorizontalScroll>
       <ScrollView>
-        <Flex flexDirection="column">
-          {variants.map((variant) => {
-            const fontWeightsToShow: FontWeightTypes[] = isHeader(variant)
-              ? ["medium"]
-              : isSubtitle(variant)
-              ? ["semiBold"]
-              : mainFontWeights;
+        <Flex flexDirection="column" padding={7}>
+          {textVariants.map((variant) => {
+            const fontWeightsToShow: FontWeightTypes[] =
+              isHeader(variant) && !isHeaderInter(variant)
+                ? ["medium"]
+                : isSubtitle(variant)
+                ? ["semiBold"]
+                : fontWeightTypes;
             const decorationsToShow: ("none" | "underline")[] =
               isHeader(variant) || isSubtitle(variant) ? ["none"] : ["none", "underline"];
             return (
-              <Flex flexDirection="row" mb={8}>
+              <Flex key={variant} flexDirection="row" mb={8}>
                 <Flex style={{ minWidth: 250 }}>
                   <Text variant="small" mt={6} color="neutral.c90">
                     variant="{variant}"
@@ -54,7 +49,7 @@ const Overview = () => {
                 </Flex>
                 {fontWeightsToShow.flatMap((fontWeight) =>
                   decorationsToShow.map((textDecorationLine) => (
-                    <Flex maxWidth={270} mx={4}>
+                    <Flex key={fontWeight + textDecorationLine} maxWidth={270} mx={4}>
                       <Text
                         variant={variant}
                         fontWeight={fontWeight}
@@ -70,7 +65,7 @@ const Overview = () => {
           })}
         </Flex>
       </ScrollView>
-    </ScrollView>
+    </HorizontalScroll>
   );
 };
 


### PR DESCRIPTION
### 📝 Description

- Adding `"h1Inter"` text variant [Figma for reference](https://www.figma.com/file/wGzwuUVo0rkCJ3sM8cpbDY/%F0%9F%93%B1-LLM-%2F-Library?node-id=1137%3A16)
- Fix a layout issue on the web native-ui storybook

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [Figma](https://www.figma.com/file/wGzwuUVo0rkCJ3sM8cpbDY/%F0%9F%93%B1-LLM-%2F-Library?node-id=1137%3A16) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1074" alt="Screenshot 2022-08-09 at 17 26 33" src="https://user-images.githubusercontent.com/91890529/183693190-7806f22e-c0b9-46ef-ad97-a3397e0fcb5f.png">

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
