### PR TITLE
add: recovery content sync onboarding

### DIFF
--- a/.changeset/big-carpets-sniff.md
+++ b/.changeset/big-carpets-sniff.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add debug screen for storyly

--- a/apps/ledger-live-desktop/src/renderer/Default.jsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.jsx
@@ -51,6 +51,7 @@ import DebugSkeletons from "~/renderer/components/debug/DebugSkeletons";
 import { DisableTransactionBroadcastWarning } from "~/renderer/components/debug/DisableTransactionBroadcastWarning";
 import { DebugWrapper } from "~/renderer/components/debug/shared";
 import useDeeplink from "~/renderer/hooks/useDeeplinking";
+import useStoryly from "~/renderer/hooks/useStoryly";
 import useUSBTroubleshooting from "~/renderer/hooks/useUSBTroubleshooting";
 import ModalsLayer from "./ModalsLayer";
 import { ToastOverlay } from "~/renderer/components/ToastOverlay";
@@ -149,6 +150,7 @@ export default function Default() {
 
   useDeeplink();
   useUSBTroubleshooting();
+  useStoryly();
 
   // PTX smart routing feature flag - buy sell live app flag
   const ptxSmartRouting = useFeature("ptxSmartRouting");
@@ -167,20 +169,6 @@ export default function Default() {
       history.push("/onboarding");
     }
   }, [history, hasCompletedOnboarding]);
-
-  useEffect(() => {
-    const script = document.createElement("script");
-
-    script.src = "https://web-story.storyly.io/v2/storyly-web.js";
-    script["custom-element"] = "storyly-web";
-    script.async = true;
-
-    document.body.appendChild(script);
-
-    return () => {
-      document.body.removeChild(script);
-    };
-  }, []);
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/Default.jsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.jsx
@@ -168,6 +168,20 @@ export default function Default() {
     }
   }, [history, hasCompletedOnboarding]);
 
+  useEffect(() => {
+    const script = document.createElement("script");
+
+    script.src = "https://web-story.storyly.io/v2/storyly-web.js";
+    script["custom-element"] = "storyly-web";
+    script.async = true;
+
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
   return (
     <>
       <TriggerAppReady />

--- a/apps/ledger-live-desktop/src/renderer/components/Storyly/StorylyWrapper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Storyly/StorylyWrapper.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useLayoutEffect, useState, useRef } from "react";
+import React, { useMemo, useLayoutEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import { languageSelector } from "~/renderer/reducers/settings";
+import { useTheme } from "styled-components";
 
 import { StorylyInstanceID } from "./types";
 
@@ -12,11 +13,13 @@ type Props = {
 export const StorylyWrapper = ({ instanceID, storylySegments }: Props) => {
   const storylyRef = useRef();
   const language = useSelector(languageSelector);
+  const theme = useTheme();
 
   const segments = useMemo(() => {
-    const languageSegments = [language, ...(true && language !== "en" ? ["en"] : [])].map(
-      l => `lang_${l}`,
-    );
+    const languageSegments = [
+      language,
+      ...(((language as unknown) as string) !== "en" ? ["en"] : []),
+    ].map(l => `lang_${l}`);
     return [...languageSegments, ...(storylySegments ?? [])];
   }, [language, storylySegments]);
 
@@ -25,18 +28,26 @@ export const StorylyWrapper = ({ instanceID, storylySegments }: Props) => {
      * You can customize Storyly web, here is the documentation
      * https://integration.storyly.io/web/ui-customizations.html#story-group-text-color
      */
-    storylyRef.current.init({
-      token: instanceID,
-      layout: "classic",
-      segments: segments,
-      props: {
-        storyGroupAlign: "left",
-        storyGroupBorderRadius: "35",
-        storyGroupTextColor: "#FFFFFF",
-        storyGroupTextSeenColor: "#FFFFFF",
-        storyGroupIconBorderColorSeen: ["#461AF7", "#FF6E33"],
-      },
-    });
-  }, []);
+    storylyRef.current &&
+      storylyRef.current.init({
+        token: instanceID,
+        layout: "classic",
+        segments: segments,
+        props: {
+          storyGroupAlign: "left",
+          storyGroupBorderRadius: "35",
+          /**
+           * Story title color for not seen story
+           */
+          storyGroupTextColor: theme.colors.neutral.c100,
+          /**
+           * Story title color for already seen story
+           */
+          storyGroupTextSeenColor: theme.colors.neutral.c100,
+          storyGroupIconBorderColorNotSeen: [theme.colors.primary.c80, theme.colors.primary.c80],
+          storyGroupIconBorderColorSeen: [theme.colors.primary.c80, theme.colors.primary.c80],
+        },
+      });
+  }, [instanceID, segments, theme.colors]);
   return <storyly-web ref={storylyRef} />;
 };

--- a/apps/ledger-live-desktop/src/renderer/components/Storyly/StorylyWrapper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Storyly/StorylyWrapper.tsx
@@ -1,0 +1,42 @@
+import React, { useMemo, useLayoutEffect, useState, useRef } from "react";
+import { useSelector } from "react-redux";
+import { languageSelector } from "~/renderer/reducers/settings";
+
+import { StorylyInstanceID } from "./types";
+
+type Props = {
+  instanceID: StorylyInstanceID;
+  storylySegments?: string[];
+};
+
+export const StorylyWrapper = ({ instanceID, storylySegments }: Props) => {
+  const storylyRef = useRef();
+  const language = useSelector(languageSelector);
+
+  const segments = useMemo(() => {
+    const languageSegments = [language, ...(true && language !== "en" ? ["en"] : [])].map(
+      l => `lang_${l}`,
+    );
+    return [...languageSegments, ...(storylySegments ?? [])];
+  }, [language, storylySegments]);
+
+  useLayoutEffect(() => {
+    /**
+     * You can customize Storyly web, here is the documentation
+     * https://integration.storyly.io/web/ui-customizations.html#story-group-text-color
+     */
+    storylyRef.current.init({
+      token: instanceID,
+      layout: "classic",
+      segments: segments,
+      props: {
+        storyGroupAlign: "left",
+        storyGroupBorderRadius: "35",
+        storyGroupTextColor: "#FFFFFF",
+        storyGroupTextSeenColor: "#FFFFFF",
+        storyGroupIconBorderColorSeen: ["#461AF7", "#FF6E33"],
+      },
+    });
+  }, []);
+  return <storyly-web ref={storylyRef} />;
+};

--- a/apps/ledger-live-desktop/src/renderer/components/Storyly/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Storyly/index.tsx
@@ -1,3 +1,3 @@
 export { testStoryInstanceID, onboardingTipsStoryInstanceID, storyInstancesIDs, storyInstancesIDsMap } from "./types"
 export type { StorylyInstanceID } from "./types"
-export {StorylyWrapper} from "./StorylyWrapper"
+export { StorylyWrapper } from "./StorylyWrapper"

--- a/apps/ledger-live-desktop/src/renderer/components/Storyly/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Storyly/index.tsx
@@ -1,0 +1,3 @@
+export { testStoryInstanceID, onboardingTipsStoryInstanceID, storyInstancesIDs, storyInstancesIDsMap } from "./types"
+export type { StorylyInstanceID } from "./types"
+export {StorylyWrapper} from "./StorylyWrapper"

--- a/apps/ledger-live-desktop/src/renderer/components/Storyly/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Storyly/index.tsx
@@ -1,3 +1,2 @@
-export { testStoryInstanceID, onboardingTipsStoryInstanceID, storyInstancesIDs, storyInstancesIDsMap } from "./types"
-export type { StorylyInstanceID } from "./types"
-export { StorylyWrapper } from "./StorylyWrapper"
+export * from "./types";
+export { StorylyWrapper } from "./StorylyWrapper";

--- a/apps/ledger-live-desktop/src/renderer/components/Storyly/types.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Storyly/types.tsx
@@ -1,0 +1,13 @@
+export const testStoryInstanceID =
+  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjY5NDgsImFwcF9pZCI6MTE0MjIsImluc19pZCI6MTIxOTh9.XqNitheri5VPDqebtA4JFu1VucVOHYlryki2TqCb1DQ";
+export const onboardingTipsStoryInstanceID =
+  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjY5NDgsImFwcF9pZCI6MTE0MjIsImluc19pZCI6MTI0ODh9.gFt9c5R8rLsnYpZfoBBchKqo9nEJJs5_G3-i215mTlU";
+
+export const storyInstancesIDs = [onboardingTipsStoryInstanceID, testStoryInstanceID] as const;
+
+export const storyInstancesIDsMap: Record<string, StorylyInstanceID> = {
+  onboarding_tips: onboardingTipsStoryInstanceID,
+  test_story: testStoryInstanceID,
+};
+
+export type StorylyInstanceID = typeof storyInstancesIDs[number];

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/RecoveryContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/RecoveryContent.tsx
@@ -1,30 +1,15 @@
-import React, { useLayoutEffect, useRef } from "react";
+import React from "react";
 import { Text } from "@ledgerhq/react-ui";
 import { useTranslation } from "react-i18next";
+import { StorylyWrapper } from "~/renderer/components/Storyly";
 
 const RecoveryContent = () => {
   const { t } = useTranslation();
 
-  const storylyRef = useRef();
-  useLayoutEffect(() => {
-    storylyRef.current.init({
-      token:
-        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjY5NDgsImFwcF9pZCI6MTE0MjIsImluc19pZCI6MTIxOTh9.XqNitheri5VPDqebtA4JFu1VucVOHYlryki2TqCb1DQ",
-      layout: "classic",
-      props: {
-        storyGroupAlign: "left",
-        storyGroupBorderRadius: "35",
-        storyGroupTextColor: "#FFFFFF",
-        storyGroupTextSeenColor: "#FFFFFF",
-        storyGroupIconBorderColorSeen: ["#461AF7", "#FF6E33"],
-      },
-    });
-  }, []);
-
   return (
     <>
       <Text>{t("syncOnboarding.manual.recoveryContent.content")}</Text>
-      <storyly-web ref={storylyRef} />
+      <StorylyWrapper instanceID="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjY5NDgsImFwcF9pZCI6MTE0MjIsImluc19pZCI6MTI0ODh9.gFt9c5R8rLsnYpZfoBBchKqo9nEJJs5_G3-i215mTlU" />
     </>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/RecoveryContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/RecoveryContent.tsx
@@ -1,0 +1,32 @@
+import React, { useLayoutEffect, useRef } from "react";
+import { Text } from "@ledgerhq/react-ui";
+import { useTranslation } from "react-i18next";
+
+const RecoveryContent = () => {
+  const { t } = useTranslation();
+
+  const storylyRef = useRef();
+  useLayoutEffect(() => {
+    storylyRef.current.init({
+      token:
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjY5NDgsImFwcF9pZCI6MTE0MjIsImluc19pZCI6MTIxOTh9.XqNitheri5VPDqebtA4JFu1VucVOHYlryki2TqCb1DQ",
+      layout: "classic",
+      props: {
+        storyGroupAlign: "left",
+        storyGroupBorderRadius: "35",
+        storyGroupTextColor: "#FFFFFF",
+        storyGroupTextSeenColor: "#FFFFFF",
+        storyGroupIconBorderColorSeen: ["#461AF7", "#FF6E33"],
+      },
+    });
+  }, []);
+
+  return (
+    <>
+      <Text>{t("syncOnboarding.manual.recoveryContent.content")}</Text>
+      <storyly-web ref={storylyRef} />
+    </>
+  );
+};
+
+export default RecoveryContent;

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/RecoveryContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/RecoveryContent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "@ledgerhq/react-ui";
 import { useTranslation } from "react-i18next";
-import { StorylyWrapper } from "~/renderer/components/Storyly";
+import { StorylyWrapper, storyInstancesIDsMap } from "~/renderer/components/Storyly";
 
 const RecoveryContent = () => {
   const { t } = useTranslation();
@@ -9,7 +9,7 @@ const RecoveryContent = () => {
   return (
     <>
       <Text>{t("syncOnboarding.manual.recoveryContent.content")}</Text>
-      <StorylyWrapper instanceID="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NfaWQiOjY5NDgsImFwcF9pZCI6MTE0MjIsImluc19pZCI6MTI0ODh9.gFt9c5R8rLsnYpZfoBBchKqo9nEJJs5_G3-i215mTlU" />
+      <StorylyWrapper instanceID={storyInstancesIDsMap.onboarding_tips} />
     </>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -69,7 +69,7 @@ const SyncOnboardingManual = () => {
     },
     {
       key: StepKey.Seed,
-      status: "active",
+      status: "inactive",
       title: t("syncOnboarding.manual.recoveryContent.title"),
       renderBody: () => <RecoveryContent />,
       estimatedTime: 300,

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -17,6 +17,7 @@ import HelpDrawer from "./HelpDrawer";
 import TroubleshootingDrawer from "./TroubleshootingDrawer";
 import GenuineCheckModal from "./GenuineCheckModal";
 import SoftwareCheckContent from "./SoftwareCheckContent";
+import RecoveryContent from "./RecoveryContent";
 
 const readyRedirectDelay = 2500;
 
@@ -68,17 +69,15 @@ const SyncOnboardingManual = () => {
     },
     {
       key: StepKey.Seed,
-      status: "inactive",
-      title: "Recovery phrase",
-      renderBody: () => (
-        <Text>{`Tap on the videos below to learn more about your secret recovery phrase`}</Text>
-      ),
+      status: "active",
+      title: t("syncOnboarding.manual.recoveryContent.title"),
+      renderBody: () => <RecoveryContent />,
       estimatedTime: 300,
     },
     {
       key: StepKey.SoftwareCheck,
       status: "inactive",
-      title: "Software check",
+      title: t("syncOnboarding.manual.softwareCheckContent.title"),
       renderBody: () => (
         <SoftwareCheckContent genuineCheckStatus="active" firmwareUpdateStatus="inactive" />
       ),

--- a/apps/ledger-live-desktop/src/renderer/hooks/useStoryly.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useStoryly.tsx
@@ -1,15 +1,19 @@
+import { useEffect } from "react";
+
 function useStoryly() {
-  const script = document.createElement("script");
+  useEffect(() => {
+    const script = document.createElement("script");
 
-  script.src = "https://web-story.storyly.io/v2/storyly-web.js";
-  script["custom-element"] = "storyly-web";
-  script.async = true;
+    script.src = "https://web-story.storyly.io/v2/storyly-web.js";
+    script["custom-element"] = "storyly-web";
+    script.async = true;
 
-  document.body.appendChild(script);
+    document.body.appendChild(script);
 
-  return () => {
-    document.body.removeChild(script);
-  };
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
 }
 
 export default useStoryly;

--- a/apps/ledger-live-desktop/src/renderer/hooks/useStoryly.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useStoryly.tsx
@@ -1,0 +1,15 @@
+function useStoryly() {
+  const script = document.createElement("script");
+
+  script.src = "https://web-story.storyly.io/v2/storyly-web.js";
+  script["custom-element"] = "storyly-web";
+  script.async = true;
+
+  document.body.appendChild(script);
+
+  return () => {
+    document.body.removeChild(script);
+  };
+}
+
+export default useStoryly;

--- a/apps/ledger-live-desktop/src/renderer/modals/LottieDebugger/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/LottieDebugger/index.jsx
@@ -268,10 +268,11 @@ const LottieDebugger = ({ name }: { name: string }) => {
     <Modal
       name={name}
       centered
-      render={() => (
+      render={({ onClose }: { onClose: void }) => (
         <ModalBody
+          onClose={onClose}
           onBack={undefined}
-          title={<Trans i18nKey="tron.manage.title" />}
+          title={<Trans i18nKey="settings.experimental.features.testAnimations.title" />}
           noScroll
           render={() => (
             <ScrollArea>

--- a/apps/ledger-live-desktop/src/renderer/modals/StorylyDebugger/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/StorylyDebugger/index.tsx
@@ -11,10 +11,11 @@ const StorylyDebugger = ({ name }: { name: string }) => {
     <Modal
       name={name}
       centered
-      render={() => (
+      render={({ onClose }: { onClose: void }) => (
         <ModalBody
+          onClose={onClose}
           onBack={undefined}
-          title={<Trans i18nKey="tron.manage.title" />}
+          title={<Trans i18nKey="settings.experimental.features.testStories.title" />}
           noScroll
           render={() => (
             <ScrollArea>

--- a/apps/ledger-live-desktop/src/renderer/modals/StorylyDebugger/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/StorylyDebugger/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { StorylyWrapper, storyInstancesIDsMap } from "~/renderer/components/Storyly";
+import { Text } from "@ledgerhq/react-ui";
+import Alert from "~/renderer/components/Alert";
+import Modal, { ModalBody } from "~/renderer/components/Modal";
+import { ScrollArea } from "~/renderer/components/Onboarding/ScrollArea";
+
+const StorylyDebugger = ({ name }: { name: string }) => {
+  return (
+    <Modal
+      name={name}
+      centered
+      render={() => (
+        <ModalBody
+          onBack={undefined}
+          title={<Trans i18nKey="tron.manage.title" />}
+          noScroll
+          render={() => (
+            <ScrollArea>
+              <Alert type="warning">
+                {
+                  "This is a tool provided as-is for the team to validate storyly stories used in the app."
+                }
+              </Alert>
+              {Object.keys(storyInstancesIDsMap).map(key => (
+                <>
+                  <Text variant="paragraph">{key}</Text>
+                  <StorylyWrapper key={key} instanceID={storyInstancesIDsMap[key]} />
+                </>
+              ))}
+            </ScrollArea>
+          )}
+        />
+      )}
+    />
+  );
+};
+
+export default StorylyDebugger;

--- a/apps/ledger-live-desktop/src/renderer/modals/StorylyDebugger/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/StorylyDebugger/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import { StorylyWrapper, storyInstancesIDsMap } from "~/renderer/components/Storyly";
-import { Text } from "@ledgerhq/react-ui";
+import { Box, Text } from "@ledgerhq/react-ui";
 import Alert from "~/renderer/components/Alert";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { ScrollArea } from "~/renderer/components/Onboarding/ScrollArea";
@@ -24,10 +24,10 @@ const StorylyDebugger = ({ name }: { name: string }) => {
                 }
               </Alert>
               {Object.keys(storyInstancesIDsMap).map(key => (
-                <>
+                <Box key={key}>
                   <Text variant="paragraph">{key}</Text>
-                  <StorylyWrapper key={key} instanceID={storyInstancesIDsMap[key]} />
-                </>
+                  <StorylyWrapper instanceID={storyInstancesIDsMap[key]} />
+                </Box>
               ))}
             </ScrollArea>
           )}

--- a/apps/ledger-live-desktop/src/renderer/modals/index.js
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.js
@@ -32,6 +32,7 @@ import MODAL_PLATFORM_EXCHANGE_COMPLETE from "./Platform/Exchange/CompleteExchan
 
 import MODAL_FULL_NODE from "./FullNode";
 import MODAL_LOTTIE_DEBUGGER from "./LottieDebugger";
+import MODAL_STORYLY_DEBUGGER from "./StorylyDebugger";
 import MODAL_RECOVERY_SEED_WARNING from "./RecoverySeedWarning";
 
 import MODAL_CLAIM_REWARDS from "./ClaimRewards";
@@ -137,6 +138,7 @@ const modals: { [_: string]: React$ComponentType<any> } = {
   MODAL_SOLANA_DELEGATION_WITHDRAW,
   MODAL_FULL_NODE,
   MODAL_LOTTIE_DEBUGGER,
+  MODAL_STORYLY_DEBUGGER,
   MODAL_RECOVERY_SEED_WARNING,
   // Lending
   MODAL_LEND_MANAGE,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/StorylyTester.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/StorylyTester.tsx
@@ -1,0 +1,22 @@
+import React, { useCallback } from "react";
+import { useTranslation, Trans } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+import Button from "~/renderer/components/Button";
+import { openModal } from "~/renderer/actions/modals";
+
+const LottieTester = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const onOpenModal = useCallback(() => dispatch(openModal("MODAL_STORYLY_DEBUGGER")), [dispatch]);
+
+  return (
+    <SettingsSectionRow title={t("settings.experimental.features.testStories.title")} desc="">
+      <Button onClick={onOpenModal} primary>
+        <Trans i18nKey={"storylyDebugger.buttonTitle"} />
+      </Button>
+    </SettingsSectionRow>
+  );
+};
+
+export default LottieTester;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/StorylyTester.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/StorylyTester.tsx
@@ -5,7 +5,7 @@ import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection"
 import Button from "~/renderer/components/Button";
 import { openModal } from "~/renderer/actions/modals";
 
-const LottieTester = () => {
+const StorylyTester = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const onOpenModal = useCallback(() => dispatch(openModal("MODAL_STORYLY_DEBUGGER")), [dispatch]);
@@ -19,4 +19,4 @@ const LottieTester = () => {
   );
 };
 
-export default LottieTester;
+export default StorylyTester;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.jsx
@@ -18,6 +18,7 @@ import ExperimentalSwitch from "./ExperimentalSwitch";
 import ExperimentalInteger from "./ExperimentalInteger";
 import FullNode from "~/renderer/screens/settings/sections/Accounts/FullNode";
 import LottieTester from "./LottieTester";
+import StorylyTester from "./StorylyTester";
 
 const experimentalTypesMap = {
   toggle: ExperimentalSwitch,
@@ -113,6 +114,7 @@ const SectionExperimental = () => {
         )}
         {process.env.SHOW_ETHEREUM_BRIDGE ? <EthereumBridgeRow /> : null}
         {process.env.DEBUG_LOTTIE ? <LottieTester /> : null}
+        {process.env.DEBUG_STORYLY ? <StorylyTester /> : null}
         <FullNode />
       </Body>
     </div>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1081,7 +1081,12 @@
       }
     },
     "manual": {
+      "recoveryContent": {
+        "title": "Recovery phrase",
+        "content": "Tap on the videos below to learn more about your secret recovery phrase"
+      },
       "softwareCheckContent": {
+        "title": "Software check",
         "genuineCheck": {
           "active": "Checking Nano",
           "completed": "Nano is authentic"

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -568,6 +568,9 @@
   "lottieDebugger": {
     "buttonTitle": "Test"
   },
+  "storylyDebugger": {
+    "buttonTitle": "Test"
+  },
   "fullNode": {
     "status": "Status",
     "connect": "Connect",
@@ -3017,6 +3020,10 @@
         "testAnimations": {
           "title": "Test Lottie animations",
           "description": "Test all animations used in Ledger Live"
+        },
+        "testStories": {
+          "title": "Test Storyly stories",
+          "description": "Test all stories used in Ledger Live"
         }
       }
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR add the recovery content in the vertical timeline of the sync onboarding along with stories

It also add a debugger screen for Storyly

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-155] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->
![Screenshot from 2022-08-17 11-12-52](https://user-images.githubusercontent.com/29443638/185082600-87332eee-f24a-4caf-8cab-04c7c248db89.png)
![Screenshot from 2022-08-17 11-20-46](https://user-images.githubusercontent.com/29443638/185083593-f0c5bc97-04b8-4103-9525-0b6a717ba1b7.png)

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-155]: https://ledgerhq.atlassian.net/browse/FAT-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ