### PR TITLE
Filecoin bot spec: increase the max account from 2 to 5

### DIFF
--- a/.github/workflows/bot-filecoin.yml
+++ b/.github/workflows/bot-filecoin.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - feat/filecoin
+      - support/filecoin-*
 
 concurrency:
   group: bot-seed4

--- a/libs/ledger-live-common/src/families/filecoin/specs.ts
+++ b/libs/ledger-live-common/src/families/filecoin/specs.ts
@@ -8,6 +8,8 @@ import { pickSiblings } from "../../bot/specs";
 import type { AppSpec } from "../../bot/types";
 
 const MIN_SAFE = new BigNumber(100000);
+const maxAccount = 6;
+
 const filecoinSpecs: AppSpec<Transaction> = {
   name: "Filecoin",
   currency: getCryptoCurrencyById("filecoin"),
@@ -42,7 +44,7 @@ const filecoinSpecs: AppSpec<Transaction> = {
           transaction: bridge.createTransaction(account),
           updates: [
             {
-              recipient: pickSiblings(siblings, 2).freshAddress,
+              recipient: pickSiblings(siblings, maxAccount).freshAddress,
             },
             {
               amount,
@@ -59,7 +61,7 @@ const filecoinSpecs: AppSpec<Transaction> = {
           transaction: bridge.createTransaction(account),
           updates: [
             {
-              recipient: pickSiblings(siblings, 2).freshAddress,
+              recipient: pickSiblings(siblings, maxAccount).freshAddress,
             },
             {
               useAllAmount: true,

--- a/libs/ledger-live-common/src/families/filecoin/specs.ts
+++ b/libs/ledger-live-common/src/families/filecoin/specs.ts
@@ -27,7 +27,7 @@ const filecoinSpecs: AppSpec<Transaction> = {
       name: "Send 50%~",
       maxRun: 1,
       transaction: ({ account, siblings, bridge }) => {
-        const sibling = pickSiblings(siblings, 2);
+        const sibling = pickSiblings(siblings, maxAccount);
         let amount = account.spendableBalance
           .div(1.9 + 0.2 * Math.random())
           .integerValue();
@@ -44,7 +44,7 @@ const filecoinSpecs: AppSpec<Transaction> = {
           transaction: bridge.createTransaction(account),
           updates: [
             {
-              recipient: pickSiblings(siblings, maxAccount).freshAddress,
+              recipient: sibling.freshAddress,
             },
             {
               amount,


### PR DESCRIPTION

### 📝 Description

Filecoin bot spec: increase the max account from 2 to 5 in the bot runs

today the bot is generating only 2 accounts which is too limited to detect all problems ⚠️ 

this lead to a situation where we only start to detect now some problems on the Send Max when account have low balance (case that wouldn't easily be reached with a funds rotation between 2 accounts)

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
