### PR TITLE
fix useAllAmount flow when fees are higher than balance

### DIFF
--- a/.changeset/polite-phones-roll.md
+++ b/.changeset/polite-phones-roll.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": major
+---
+
+fix useAllAmount usage when fees are higher than balance

--- a/libs/ledger-live-common/src/families/filecoin/bridge/account.ts
+++ b/libs/ledger-live-common/src/families/filecoin/bridge/account.ts
@@ -83,12 +83,19 @@ const getTransactionStatus = async (
   // This is the worst case scenario (the tx won't cost more than this value)
   const estimatedFees = calculateEstimatedFees(gasFeeCap, gasLimit);
 
-  const totalSpent = useAllAmount ? balance : amount.plus(estimatedFees);
-  if (totalSpent.gt(a.spendableBalance)) {
-    errors.amount = new NotEnoughBalance();
+  let totalSpent;
+  if (useAllAmount) {
+    totalSpent = a.spendableBalance;
+    amount = totalSpent.minus(estimatedFees);
+    if (amount.lte(0) || totalSpent.gt(balance)) {
+      errors.amount = new NotEnoughBalance();
+    }
   } else {
-    amount = useAllAmount ? balance.minus(estimatedFees) : amount;
-    if (amount.lte(0)) errors.amount = new AmountRequired();
+    totalSpent = amount.plus(estimatedFees);
+    if (amount.eq(0)) {
+      errors.amount = new AmountRequired();
+    } else if (totalSpent.gt(a.spendableBalance))
+      errors.amount = new NotEnoughBalance();
   }
 
   // log("debug", "[getTransactionStatus] finish fn");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixing a bug reported by the bot, involving usage of useAllAmount when fees are higher than balance on Filecoin integration

### ❓ Context

- **Impacted projects**: `common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
