### PR TITLE
bot: pickSiblings must be used once in spec

### DIFF
--- a/libs/ledger-live-common/src/families/elrond/specs.ts
+++ b/libs/ledger-live-common/src/families/elrond/specs.ts
@@ -54,7 +54,7 @@ const elrondSpec: AppSpec<Transaction> = {
           transaction: bridge.createTransaction(account),
           updates: [
             {
-              recipient: pickSiblings(siblings, 1).freshAddress,
+              recipient: sibling.freshAddress,
             },
             {
               amount,

--- a/libs/ledger-live-common/src/families/polkadot/specs.ts
+++ b/libs/ledger-live-common/src/families/polkadot/specs.ts
@@ -74,7 +74,7 @@ const polkadot: AppSpec<Transaction> = {
           transaction: bridge.createTransaction(account),
           updates: [
             {
-              recipient: pickSiblings(siblings, 1).freshAddress,
+              recipient: sibling.freshAddress,
             },
             {
               amount,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

there seemed to be a shared mistake done across different coins in the bot spec that was using `pickSiblings` twice in a row in a mutation spec,

this is likely to create a flaky bug where we would check if an account have enough funds to send a tx to it but where we would actually pick **another** account to send to, making the check useless.

the fix is to share the same `sibling`

### ❓ Context

- **Impacted projects**: `n/a` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
