### PR TITLE
bugfix/LIVE-3250: Fix multibuy access from token account

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.jsx
@@ -189,7 +189,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
       if (ptxSmartRouting?.enabled) {
         const params = {
           currency: currency?.id,
-          account: mainAccount?.id,
+          account: account?.id,
           mode, // buy or sell
         };
 
@@ -204,12 +204,12 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
           state: {
             mode: "onRamp",
             currencyId: currency.id,
-            accountId: mainAccount.id,
+            accountId: account.id,
           },
         });
       }
     },
-    [currency, history, mainAccount, ptxSmartRouting],
+    [currency, history, account, ptxSmartRouting],
   );
 
   const onLend = useCallback(() => {


### PR DESCRIPTION
### 📝 Description

Accessing the multibuy live app from a token account would send the parent account id instead of the token account's, resulting in the wrong account to be initially selected in multibuy.

### ❓ Context

- **Impacted projects**: `multibuy live app` 
- LIVE-3250:

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->
