### PR TITLE
Bot: Polkadot: fixes spec to generate more than 2 accounts

### DIFF
--- a/libs/ledger-live-common/src/families/polkadot/specs.ts
+++ b/libs/ledger-live-common/src/families/polkadot/specs.ts
@@ -21,7 +21,7 @@ import {
 } from "../../families/polkadot/logic";
 import { DeviceModelId } from "@ledgerhq/devices";
 
-const maxAccounts = 8;
+const maxAccounts = 32;
 const currency = getCryptoCurrencyById("polkadot");
 // FIXME Should be replaced with EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN in logic.ts
 const POLKADOT_MIN_SAFE = parseCurrencyUnit(currency.units[0], "0.1");

--- a/libs/ledger-live-common/src/families/polkadot/specs.ts
+++ b/libs/ledger-live-common/src/families/polkadot/specs.ts
@@ -21,6 +21,7 @@ import {
 } from "../../families/polkadot/logic";
 import { DeviceModelId } from "@ledgerhq/devices";
 
+const maxAccounts = 8;
 const currency = getCryptoCurrencyById("polkadot");
 // FIXME Should be replaced with EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN in logic.ts
 const POLKADOT_MIN_SAFE = parseCurrencyUnit(currency.units[0], "0.1");
@@ -52,10 +53,10 @@ const polkadot: AppSpec<Transaction> = {
   mutations: [
     {
       name: "send 50%~",
-      maxRun: 2,
+      maxRun: 4,
       transaction: ({ account, siblings, bridge }) => {
         invariant((account as PolkadotAccount).polkadotResources, "polkadot");
-        const sibling = pickSiblings(siblings, 2);
+        const sibling = pickSiblings(siblings, maxAccounts);
         let amount = account.spendableBalance
           .div(1.9 + 0.2 * Math.random())
           .integerValue();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Apparently, polkadot running on the bot never had more than 2 accounts which can be limiting the coverage. Today it's a problem because 2 accounts isn't enough to cover all the features we want to cover here (delegation,..)

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
