### PR TITLE
Bot: Cosmos: reduce the chance to get amount delegated by half

### DIFF
--- a/libs/ledger-live-common/src/families/cosmos/specs.ts
+++ b/libs/ledger-live-common/src/families/cosmos/specs.ts
@@ -154,7 +154,7 @@ const cosmos: AppSpec<Transaction> = {
           count
         )
           .minus(minAmount.times(2))
-          .times(0.5 * Math.random());
+          .times(0.25 * Math.random());
         invariant(remaining.gt(0), "not enough funds in account for delegate");
         const all = data.validators.filter(
           (v) =>
@@ -298,7 +298,7 @@ const cosmos: AppSpec<Transaction> = {
         const amount = (sourceDelegation as CosmosDelegation).amount
           .times(
             // most of the time redelegate all
-            Math.random() > 0.3 ? 1 : Math.random()
+            Math.random() > 0.2 ? 1 : Math.random()
           )
           .integerValue();
         invariant(amount.gt(0), "random amount to be positive");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Too much funds is locked in delegation of cosmos even with the current settings that target 32 accounts! 

This PR reduces by half the chance to get part of the delegatable amount delegated.

we'll still need to send some ATOM to the bot meanwhile.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
