### PR TITLE
LIVE-3364 Disable Filecoin in LLM

### DIFF
--- a/apps/ledger-live-mobile/src/live-common-setup.js
+++ b/apps/ledger-live-mobile/src/live-common-setup.js
@@ -67,7 +67,6 @@ setSupportedCurrencies([
   "hedera",
   "cardano",
   "osmosis",
-  "filecoin",
 ]);
 
 if (Config.VERBOSE) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

https://github.com/LedgerHQ/ledger-live/pull/846 which was tested and targeted for LLD, optimistically enabled Filecoin on LLM too.
But then this issue was found https://ledgerhq.atlassian.net/browse/LIVE-3331 which is a blocker for iOS.
This PR disables Filecoin on LLM, which is safe and enough as the blocker only happens while using Filecoin. Zero impact when Filecoin disabled.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3364 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

<!-- If any of the expectations are not met please explain the reason in detail. -->
