### PR TITLE
FAT-253 Analytics for device localization

### DIFF
--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -33,6 +33,7 @@ import { knownDevicesSelector } from "../reducers/ble";
 import { satisfactionSelector } from "../reducers/ratings";
 import type { State } from "../reducers";
 import { NavigatorName } from "../const";
+import { idsToLanguage } from "@ledgerhq/types-live";
 
 const sessionId = uuid();
 const appVersion = `${VersionNumber.appVersion || ""} (${
@@ -55,6 +56,9 @@ const extraProperties = store => {
   const deviceInfo = lastDevice
     ? {
         deviceVersion: lastDevice.deviceInfo?.version,
+        deviceLanguage:
+          lastDevice.deviceInfo?.languageId &&
+          idsToLanguage[lastDevice.deviceInfo?.languageId],
         appLength: lastDevice?.appsInstalled,
         modelId: lastDevice.modelId,
       }

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdate/DeviceLanguageStep.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdate/DeviceLanguageStep.tsx
@@ -148,6 +148,11 @@ const DeviceLanguageStep = ({
         <ChangeDeviceLanguageAction
           device={deviceForAction}
           language={languageToInstall}
+          onError={(error: any) => {
+            track("Page Manager FwUpdateLanguageInstallError", {
+              error,
+            });
+          }}
           onResult={() =>
             track("Page Manager FwUpdateLanguageInstalled", {
               selectedLanguage: languageToInstall,

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdate/DeviceLanguageStep.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdate/DeviceLanguageStep.tsx
@@ -21,6 +21,7 @@ import { localeIdToDeviceLanguage } from "../../languages";
 import ChangeDeviceLanguageAction from "../ChangeDeviceLanguageAction";
 import ChangeDeviceLanguagePrompt from "../ChangeDeviceLanguagePrompt";
 import DeviceActionProgress from "../DeviceActionProgress";
+import { track } from "../../analytics";
 
 type Props = {
   oldDeviceInfo?: DeviceInfo;
@@ -89,6 +90,7 @@ const DeviceLanguageStep = ({
         oldDeviceInfo?.languageId !== undefined &&
         oldDeviceInfo?.languageId !== languageIds["english"]
       ) {
+        track("Page Manager FwUpdateReinstallLanguage");
         installLanguage(idsToLanguage[oldDeviceInfo.languageId]);
       } else {
         dispatchEvent({ type: "languagePromptDismissed" });
@@ -106,14 +108,13 @@ const DeviceLanguageStep = ({
     installLanguage,
   ]);
 
-
   const deviceName = getDeviceModel(device.modelId).productName;
 
   return (
     <Flex alignItems="center">
       {isLanguagePromptOpen && deviceForAction === null && (
         <>
-          <Track event="FirmwareUpdateFirstDeviceLanguagePrompt" onMount />
+          <Track event="Page Manager FwUpdateDeviceLanguagePrompt" onMount />
           <ChangeDeviceLanguagePrompt
             titleWording={t("deviceLocalization.firmwareUpdatePrompt.title", {
               language: t(
@@ -131,7 +132,10 @@ const DeviceLanguageStep = ({
               },
             )}
             canSkip
-            onSkip={() => dispatchEvent({ type: "languagePromptDismissed" })}
+            onSkip={() => {
+              track("Page Manager FwUpdateDeviceLanguagePromptDismissed");
+              dispatchEvent({ type: "languagePromptDismissed" });
+            }}
             onConfirm={() =>
               installLanguage(
                 localeIdToDeviceLanguage[currentLocale] as Language,
@@ -144,6 +148,11 @@ const DeviceLanguageStep = ({
         <ChangeDeviceLanguageAction
           device={deviceForAction}
           language={languageToInstall}
+          onResult={() =>
+            track("Page Manager FwUpdateLanguageInstalled", {
+              selectedLanguage: languageToInstall,
+            })
+          }
           onContinue={() => {
             setDeviceForAction(null);
             dispatchEvent({ type: "languagePromptDismissed" });

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -7,6 +7,7 @@ import DeviceLanguageSelection from "./DeviceLanguageSelection";
 import ChangeDeviceLanguageActionModal from "../../../components/ChangeDeviceLanguageActionModal";
 import { useAvailableLanguagesForDevice } from "@ledgerhq/live-common/lib/manager/hooks";
 import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
+import { track } from "../../../analytics";
 
 type Props = {
   pendingInstalls: boolean;
@@ -44,15 +45,16 @@ const DeviceLanguage: React.FC<Props> = ({
     () => setIsChangeLanguageOpen(false),
     [setIsChangeLanguageOpen],
   );
-  const openChangeLanguageModal = useCallback(
-    () => setIsChangeLanguageOpen(true),
-    [setIsChangeLanguageOpen],
-  );
+  const openChangeLanguageModal = useCallback(() => {
+    track("Page Manager ChangeLanguageEntered");
+    setIsChangeLanguageOpen(true);
+  }, [setIsChangeLanguageOpen]);
 
   const confirmInstall = useCallback(() => {
+    track("Page Manager LanguageInstallTriggered", { selectedLanguage });
     setShouldInstallLanguage(true);
     closeChangeLanguageModal();
-  }, [setShouldInstallLanguage, closeChangeLanguageModal]);
+  }, [setShouldInstallLanguage, closeChangeLanguageModal, selectedLanguage]);
   // this has to be done in two steps because we can only open the second modal after the first
   // one has been hidden. So we need to put this function attached to the onModalHide prop of the first
   // see https://github.com/react-native-modal/react-native-modal/issues/30
@@ -68,6 +70,7 @@ const DeviceLanguage: React.FC<Props> = ({
   }, [setShouldInstallLanguage, setDeviceForActionModal]);
 
   const refreshDeviceLanguage = useCallback(() => {
+    track("Page Manager LanguageInstalled", { language: selectedLanguage });
     onLanguageChange();
   }, [selectedLanguage]);
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -118,7 +118,10 @@ const DeviceLanguage: React.FC<Props> = ({
         onClose={closeDeviceActionModal}
         device={deviceForActionModal}
         language={selectedLanguage}
-        onError={refreshDeviceLanguage}
+        onError={error => {
+          track("Page Manager LanguageInstallError", { error });
+          refreshDeviceLanguage();
+        }}
         onResult={refreshDeviceLanguage}
       />
     </>

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -70,7 +70,7 @@ const DeviceLanguage: React.FC<Props> = ({
   }, [setShouldInstallLanguage, setDeviceForActionModal]);
 
   const refreshDeviceLanguage = useCallback(() => {
-    track("Page Manager LanguageInstalled", { language: selectedLanguage });
+    track("Page Manager LanguageInstalled", { selectedLanguage });
     onLanguageChange();
   }, [selectedLanguage]);
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
@@ -34,6 +34,7 @@ import { DeviceModelInfo, idsToLanguage, Language } from "@ledgerhq/types-live";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
 import { setLastSeenDevice } from "../../../actions/settings";
+import { track } from "../../../analytics";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
@@ -105,6 +106,9 @@ function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
         idsToLanguage[deviceLanguageId] !== potentialDeviceLanguage &&
         deviceLocalizationFeatureFlag.enabled
       ) {
+        track("Page LiveLanguageChange DeviceLanguagePrompt", {
+          selectedLanguage: potentialDeviceLanguage,
+        });
         setIsDeviceLanguagePromptOpen(true);
       } else {
         next();
@@ -149,6 +153,11 @@ function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
               device={deviceForChangeLanguageAction}
               onStart={() => setPreventPromptBackdropClick(true)}
               language={localeIdToDeviceLanguage[currentLocale] as Language}
+              onResult={() =>
+                track("Page LiveLanguageChange LanguageInstalled", {
+                  selectedLanguage: localeIdToDeviceLanguage[currentLocale],
+                })
+              }
               onContinue={() => {
                 setDeviceForChangeLanguageAction(null);
                 closeDeviceLanguagePrompt();
@@ -165,9 +174,12 @@ function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
                   ),
                 },
               )}
-              onConfirm={() =>
-                setDeviceForChangeLanguageAction(lastConnectedDevice)
-              }
+              onConfirm={() => {
+                track("Page LiveLanguageChange LanguageInstallTriggered", {
+                  selectedLanguage: localeIdToDeviceLanguage[currentLocale],
+                });
+                setDeviceForChangeLanguageAction(lastConnectedDevice);
+              }}
             />
           )}
         </Flex>

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
@@ -148,16 +148,19 @@ function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
         <Flex alignItems="center">
           {deviceForChangeLanguageAction ? (
             <ChangeDeviceLanguageAction
-              onResult={onActionFinished}
-              onError={onActionFinished}
+              onError={(error: any) => {
+                refreshDeviceInfo();
+                track("Page LiveLanguageChange LanguageInstallError", { error });
+              }}
               device={deviceForChangeLanguageAction}
               onStart={() => setPreventPromptBackdropClick(true)}
               language={localeIdToDeviceLanguage[currentLocale] as Language}
-              onResult={() =>
+              onResult={() => {
+                refreshDeviceInfo();
                 track("Page LiveLanguageChange LanguageInstalled", {
                   selectedLanguage: localeIdToDeviceLanguage[currentLocale],
-                })
-              }
+                });
+              }}
               onContinue={() => {
                 setDeviceForChangeLanguageAction(null);
                 closeDeviceLanguagePrompt();


### PR DESCRIPTION
### 📝 Description
This PRs adds analytics events concerning the device localization feature on LLM. All prompts and manual language changes now have tracking events associated to them
List of added events:
`Page Manager FwUpdateReinstallLanguage`
`Page Manager FwUpdateDeviceLanguagePromptDismissed`
`Page Manager FwUpdateLanguageInstalled`
`Page Manager FwUpdateDeviceLanguagePrompt`
`Page Manager ChangeLanguageEntered`
`Page Manager LanguageInstallTriggered`
`Page Manager LanguageInstalled`
`Page LiveLanguageChange DeviceLanguagePrompt`
`Page LiveLanguageChange LanguageInstalled`
`Page LiveLanguageChange LanguageInstallTriggered`

### ❓ Context
[FAT-253]

### ✅ Checklist

- [N/A] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
N/A

### 🚀 Expectations to reach


[FAT-253]: https://ledgerhq.atlassian.net/browse/FAT-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ