### PR TITLE
Fix LLM react warning - key prop missing in lists of components in CustomTabBar

### DIFF
--- a/apps/ledger-live-mobile/src/components/TabBar/CustomTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/CustomTabBar.tsx
@@ -63,16 +63,16 @@ const darkGradients = [
     height: GRADIENT_HEIGHT,
     opacity: 0.8,
     stops: [
-      <Stop offset="0%" stopOpacity={0} stopColor="#131214" />,
-      <Stop offset="100%" stopOpacity={1} stopColor="#131214" />,
+      <Stop key="0%" offset="0%" stopOpacity={0} stopColor="#131214" />,
+      <Stop key="100%" offset="100%" stopOpacity={1} stopColor="#131214" />,
     ],
   },
   {
     height: 85,
     opacity: 0.8,
     stops: [
-      <Stop offset="0%" stopOpacity={0} stopColor="#131214" />,
-      <Stop offset="100%" stopOpacity={1} stopColor="#131214" />,
+      <Stop key="0%" offset="0%" stopOpacity={0} stopColor="#131214" />,
+      <Stop key="100%" offset="100%" stopOpacity={1} stopColor="#131214" />,
     ],
   },
 ];
@@ -91,7 +91,7 @@ const lightGradients = [
     opacity: 0.8,
     stops: [
       <Stop key="0%" offset="0" stopOpacity={0} stopColor="#ffffff" />,
-      <Stop offset="57%" stopOpacity={0.15} stopColor="#000000" />,
+      <Stop key="57%" offset="57%" stopOpacity={0.15} stopColor="#000000" />,
       <Stop key="100%" offset="100%" stopOpacity={0.15} stopColor="#000000" />,
     ],
   },
@@ -159,7 +159,7 @@ export default function CustomTabBar({
 
         if (index === 2) {
           return (
-            <>
+            <React.Fragment key={index}>
               <Flex flex={1} />
               <MiddleIconContainer
                 pointerEvents="box-none"
@@ -172,12 +172,13 @@ export default function CustomTabBar({
                   color={isFocused ? colors.primary.c80 : colors.neutral.c80}
                 />
               </MiddleIconContainer>
-            </>
+            </React.Fragment>
           );
         }
 
         return (
           <Touchable
+            key={index}
             accessibilityRole="button"
             accessibilityState={isFocused ? { selected: true } : {}}
             accessibilityLabel={options.tabBarAccessibilityLabel}


### PR DESCRIPTION
### 📝 Description

Keys were missing in list of components being rendered, so there was a warning.

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
