### PR TITLE
ci: prevent reporting on fork PR as token does not have permission

### DIFF
--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -153,9 +153,9 @@ jobs:
           os: ${{ steps.os.outputs.result }}
 
   report:
-    needs: [test-desktop-app, test-desktop-app-mac-internal]
+    needs: [pr-is-fork, test-desktop-app, test-desktop-app-mac-internal]
     runs-on: ubuntu-latest
-    if: ${{ always()  && !cancelled() && github.event.pull_request != '' }}
+    if: ${{ always()  && !cancelled() && github.event.pull_request != '' && !fromJSON(needs.pr-is-fork.outputs.pr-is-fork) }}
     steps:
       - uses: actions/checkout@v3
       - name: check if comment already exists exists


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

prevent CI from trying to post report comment on fork PR as the gha token doesn't 
have permissions to do so

### ❓ Context

- **Impacted projects**: `automation` <!-- The list of end user projects impacted 
by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, 
does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain 
why. -->

### 📸 Demo

No Demo

### 🚀 Expectations to reach

Green CI on external PR after test desktop

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
