### PR TITLE
Feat/native UI tags redesign

### DIFF
--- a/.changeset/afraid-needles-own.md
+++ b/.changeset/afraid-needles-own.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": minor
+---
+
+Tag component: change appearance (new design)

--- a/.changeset/young-ads-mate.md
+++ b/.changeset/young-ads-mate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": minor
+---
+
+Tag component: remove "active" prop

--- a/libs/ui/packages/native/src/components/tags/Tag/index.tsx
+++ b/libs/ui/packages/native/src/components/tags/Tag/index.tsx
@@ -2,31 +2,56 @@ import React from "react";
 
 import Flex, { FlexBoxProps } from "../../Layout/Flex";
 import Text from "../../Text";
+import { IconType } from "../../Icon/type";
+import { Box } from "../../Layout";
 
 export interface TagProps extends FlexBoxProps {
-  active?: boolean;
+  type?: "shade" | "color" | "warning";
+  size?: "small" | "medium";
+  Icon?: IconType;
   uppercase?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-export default function Tag({ active, uppercase, children, ...props }: TagProps): JSX.Element {
+const typeColor = {
+  color: "primary.c80",
+  shade: "neutral.c30",
+  warning: "warning.c100",
+};
+
+export default function Tag({
+  type = "shade",
+  size = "small",
+  uppercase,
+  Icon,
+  children,
+  ...props
+}: TagProps): JSX.Element {
   return (
     <Flex
-      px={2}
+      px={size === "small" ? "6px" : 3}
       alignItems="center"
       justifyContent="center"
-      borderRadius={4}
-      borderWidth={1}
-      borderColor={active ? "primary.c50" : "neutral.c40"}
+      flexDirection="row"
+      borderRadius={6}
+      bg={typeColor[type]}
+      height={size === "small" ? "18px" : "28px"}
       {...props}
     >
+      {Icon && (
+        <Box pr={2}>
+          <Icon
+            size={size === "small" ? 16 : 20}
+            color={type === "shade" ? "neutral.c90" : "neutral.c00"}
+          />
+        </Box>
+      )}
       <Text
-        variant="tiny"
-        fontWeight="semiBold"
-        lineHeight="16px"
+        variant={size === "small" ? "subtitle" : "small"}
+        fontWeight="bold"
         uppercase={uppercase !== false}
         textAlign="center"
-        color={active ? "primary.c70" : "neutral.c80"}
+        color={type === "shade" ? "neutral.c90" : "neutral.c00"}
       >
         {children}
       </Text>

--- a/libs/ui/packages/native/storybook/stories/Tag/Tag.stories.tsx
+++ b/libs/ui/packages/native/storybook/stories/Tag/Tag.stories.tsx
@@ -1,11 +1,17 @@
 import React from "react";
-import { boolean, text } from "@storybook/addon-knobs";
+import { boolean, select, text } from "@storybook/addon-knobs";
 
 import Tag from "../../../src/components/tags/Tag";
 import { storiesOf } from "../storiesOf";
+import { Icons } from "../../../src/assets";
 
 const TagSample = () => (
-  <Tag active={boolean("active", false)} uppercase={boolean("uppercase", true)}>
+  <Tag
+    type={select("type", ["color", "shade", "warning"], "shade")}
+    size={select("size", ["small", "medium"], "small")}
+    Icon={boolean("icon", false) ? Icons.CircledCheckSolidMedium : undefined}
+    uppercase={boolean("uppercase", false)}
+  >
     {text("children", "Label")}
   </Tag>
 );


### PR DESCRIPTION
### 📝 Description

I'm just co-authoring the work of @nparigi-ledger here

The design of the `Tag` component has changed:
- there are now 3 types (`type` prop): `"color"` `"shade"` `"warning"`
- there are 2 sizes (`size` prop): `"small"` `"medium"`
- there is a possibility to add an icon with the `Icon` prop.
- the `active` prop is gone

#### new design (Figma):
<img width="423" alt="Screenshot 2022-08-18 at 10 56 32" src="https://user-images.githubusercontent.com/91890529/185354587-98be2d0d-3e7d-485b-aec7-e38b060d8efb.png">


### ❓ Context

- **Impacted projects**: `ledger-live-mobile` `native-ui` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [Figma]()

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/91890529/185353994-cd4678ce-0566-4314-b2cd-bc44b14153c2.mov



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
