### PR TITLE
[LIVE-2722] Stellar sync error instead of 0 balance fallback (#909)

### DIFF
--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4067,6 +4067,10 @@
       "title": "Sorry, internet seems to be down",
       "description": "Please check your internet connection."
     },
+    "NetworkError": {
+      "title": "An error occurred during synchronization",
+      "description": "Please check your internet connection."
+    },
     "NoAddressesFound": {
       "title": "Sorry, no accounts were found",
       "description": "Something went wrong with the address calculation, try again or contact Ledger Support"

--- a/libs/ledger-live-common/src/families/stellar/api/horizon.ts
+++ b/libs/ledger-live-common/src/families/stellar/api/horizon.ts
@@ -3,7 +3,7 @@ import StellarSdk, {
   // @ts-expect-error stellar-sdk ts definition missing?
   AccountRecord,
   NotFoundError,
-  NetworkError,
+  NetworkError as StellarSdkNetworkError,
 } from "stellar-sdk";
 import { getEnv } from "../../../env";
 import { getCryptoCurrencyById, parseCurrencyUnit } from "../../../currencies";
@@ -14,7 +14,7 @@ import {
   rawOperationsToOperations,
   getReservedBalance,
 } from "../logic";
-import { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx, LedgerAPI5xx, NetworkError } from "@ledgerhq/errors";
 import { requestInterceptor, responseInterceptor } from "../../../network";
 import type { BalanceAsset } from "../types";
 import { NetworkCongestionLevel, Signer } from "../types";
@@ -127,8 +127,12 @@ export const fetchAccount = async (
     assets = account.balances?.filter((balance) => {
       return balance.asset_type !== "native";
     });
-  } catch (e) {
-    balance.balance = "0";
+  } catch (e: any) {
+    if (e instanceof NotFoundError || e?.response?.status === 400) {
+      balance.balance = "0";
+    } else {
+      throw new NetworkError();
+    }
   }
 
   const formattedBalance = parseCurrencyUnit(
@@ -205,11 +209,11 @@ export const fetchOperations = async ({
     }
 
     if (
-      e instanceof NetworkError ||
+      e instanceof StellarSdkNetworkError ||
       errorMsg.match(/ECONNRESET|ECONNREFUSED|ENOTFOUND|EPIPE|ETIMEDOUT/) ||
       errorMsg.match(/undefined is not an object/)
     ) {
-      throw new NetworkDown();
+      throw new NetworkError();
     }
 
     throw e;

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -111,6 +111,7 @@ export const ManagerUninstallBTCDep = createCustomErrorClass(
   "ManagerUninstallBTCDep"
 );
 export const NetworkDown = createCustomErrorClass("NetworkDown");
+export const NetworkError = createCustomErrorClass("NetworkError");
 export const NoAddressesFound = createCustomErrorClass("NoAddressesFound");
 export const NotEnoughBalance = createCustomErrorClass("NotEnoughBalance");
 export const NotEnoughBalanceToDelegate = createCustomErrorClass(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Network error instead of (scary) fallback to 0 for Stellar balance

### ❓ Context

- **Impacted projects**: `LLC` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-2722 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2722]: https://ledgerhq.atlassian.net/browse/LIVE-2722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ