### PR TITLE
Bugfix/LIVE-3407 Fix rendering of last item in manager app list

### DIFF
--- a/.changeset/rare-guests-cheer.md
+++ b/.changeset/rare-guests-cheer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix rendering of last app item in manager

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
@@ -30,6 +30,7 @@ import AppUpdateAll from "./AppsList/AppUpdateAll";
 import Search from "../../components/Search";
 import FirmwareUpdateBanner from "../../components/FirmwareUpdateBanner";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
+import { TAB_BAR_SAFE_HEIGHT } from "../../components/TabBar/shared";
 
 type Props = {
   state: State;
@@ -352,7 +353,7 @@ const AppsScreen = ({
 
 const styles = StyleSheet.create({
   list: {
-    paddingBottom: 55,
+    paddingBottom: TAB_BAR_SAFE_HEIGHT,
   },
 });
 

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { useState, useCallback, useMemo, memo } from "react";
-import { FlatList } from "react-native";
+import { FlatList, StyleSheet } from "react-native";
 import {
   listTokens,
   isCurrencySupported,
@@ -303,6 +303,7 @@ const AppsScreen = ({
         ListEmptyComponent={renderNoResults}
         keyExtractor={item => item.name}
         showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.list}
       />
     ),
     [
@@ -348,5 +349,11 @@ const AppsScreen = ({
     </Flex>
   );
 };
+
+const styles = StyleSheet.create({
+  list: {
+    paddingBottom: 55,
+  },
+});
 
 export default memo<Props>(AppsScreen);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
A bug that has been present for quite some time but we just never noticed it, the last application in the manager was hidden by the tab bar at the bottom of the UI. Adding a little padding to the FlatList makes it visible. This was made obvious when we introduced the [L] Market app since it's rendered last due to the sorting.





### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-3407` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://user-images.githubusercontent.com/4631227/185884417-556a88f5-d78d-4e45-9dea-ac5d4a5f224d.mov

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Access the manager and make sure you can see the last item. You should also be able to see it through the tab bar space between the purple button and the tab bar, so it's prettier than just cutting it off.
