### PR TITLE
LIVE-3422 Fix file name of generated Tezos custom component

### DIFF
--- a/.changeset/fluffy-hairs-promise.md
+++ b/.changeset/fluffy-hairs-promise.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix one incorrect filename in custom component generation mechanism

--- a/apps/ledger-live-desktop/scripts/sync-families-dispatch.mjs
+++ b/apps/ledger-live-desktop/scripts/sync-families-dispatch.mjs
@@ -21,7 +21,7 @@ const targets = [
   "AccountSubHeader.jsx",
   "SendAmountFields.jsx",
   "SendRecipientFields.jsx",
-  "SendWarning.js",
+  "SendWarning.jsx",
   "ReceiveWarning.jsx",
   "AccountBalanceSummaryFooter.jsx",
   "TokenList.jsx",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There was a mismatch between the file name of a Tezos custom component (`SendWarning.jsx`) and the expected file name in the component generation mechanism (`SendWarning.js`)

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3422 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
#### Before
![image](https://user-images.githubusercontent.com/59644786/185959790-368fc84d-15d4-46fa-800b-44b12c2c841d.png)

#### After
![image](https://user-images.githubusercontent.com/59644786/185959627-7c6e5228-4501-4b64-9416-1b0a36294ae0.png)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach


<!-- If any of the expectations are not met please explain the reason in detail. -->
