### PR TITLE
ci: add /regen-pods bot command and action

### DIFF
--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -228,5 +228,13 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - name: Cache LLM pods
+        uses: actions/cache@v3
+        with:
+          path: |
+            apps/ledger-live-mobile/ios/Pods
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
       - name: install dependencies
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v3
         if: ${{ github.event.inputs.ref != null }}
         with:
+          ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
       - uses: actions/checkout@v3
         if: ${{ !github.event.inputs.ref }}

--- a/.github/workflows/regen-pods.yml
+++ b/.github/workflows/regen-pods.yml
@@ -1,0 +1,92 @@
+name: "Mobile App - Regen Pods"
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The branch to generate pods for.
+        required: false
+      number:
+        description: The pull request number.
+        required: false
+      login:
+        description: The GitHub username that triggered the workflow
+        required: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regen-pods:
+    runs-on: macos-latest
+    name: "Regenerate Podfile"
+    env:
+      SKIP_BUNDLE_CHECK: 1
+    steps:
+      - uses: actions/checkout@v3
+        if: ${{ github.event.inputs.ref != null }}
+        with:
+          ref: ${{ github.event.inputs.ref }}
+      - uses: actions/checkout@v3
+        if: ${{ !github.event.inputs.ref }}
+      - name: Checkout PR
+        if: ${{ github.event.inputs.number != null }}
+        run: gh pr checkout ${{ github.event.inputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: set git user
+        run: |
+          git config user.email "team-live@ledger.fr"
+          git config user.name "Team Live"
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: pnpm
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: bump npm
+        run: npm i -g npm@8.12.2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: install dependencies
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
+      - name: regenerate pods
+        run: pnpm mobile pod
+      - name: status
+        id: check-status
+        run: echo "::set-output name=status::$(git status --porcelain | wc -l)"
+      - name: commit and push changes
+        if: steps.check-status.outputs.status != 0
+        run: >
+          git add ./apps/ledger-live-mobile/ios &&
+          git commit -m 'chore(🍏): regenerate podfile' &&
+          git restore . &&
+          git pull --rebase &&
+          git push
+      - uses: ./tools/actions/composites/pr-comment
+        if: failure() && github.event.inputs.number != null
+        with:
+          number: ${{ github.event.inputs.number }}
+          body: |
+            #### ❌ Podfile regeneration failed
+
+            @${{ github.event.inputs.login }}: you can check [the action logs](https://github.com/LedgerHQ/ledger-live/runs/${{ github.run_id }}) for more information.
+      - uses: ./tools/actions/composites/pr-comment
+        if: github.event.inputs.number != null && steps.check-status.outputs.status != 0
+        with:
+          number: ${{ github.event.inputs.number }}
+          body: |
+            #### 🚀 Podfile regenerated
+
+            @${{ github.event.inputs.login }}: the podfile has been regenerated and a commit has been pushed to your branch.
+      - uses: ./tools/actions/composites/pr-comment
+        if: github.event.inputs.number != null && steps.check-status.outputs.status == 0
+        with:
+          number: ${{ github.event.inputs.number }}
+          body: |
+            #### ✨ No changes detected
+
+            @${{ github.event.inputs.login }}: the podfile is already up to date.

--- a/.github/workflows/regen-pods.yml
+++ b/.github/workflows/regen-pods.yml
@@ -51,6 +51,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+      - name: Cache LLM pods
+        uses: actions/cache@v3
+        with:
+          path: |
+            apps/ledger-live-mobile/ios/Pods
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
       - name: install dependencies
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
       - name: regenerate pods

--- a/apps/ledger-live-mobile/scripts/post.mjs
+++ b/apps/ledger-live-mobile/scripts/post.mjs
@@ -43,7 +43,7 @@ const final = async () => {
     );
   }
 
-  if (os.platform() === "darwin") {
+  if (os.platform() === "darwin" && !process.env["SKIP_BUNDLE_CHECK"]) {
     cd("ios");
     try {
       await $`bundle exec pod install --deployment --repo-update`;

--- a/tools/actions/composites/pr-comment/action.yml
+++ b/tools/actions/composites/pr-comment/action.yml
@@ -1,0 +1,22 @@
+name: "Add a comment in a PR"
+description: "Composite job to easily comment a pull request"
+inputs:
+  number:
+    description: The pull request number.
+    required: true
+  body:
+    description: Body of the comment
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          github.rest.issues.createComment({
+            issue_number: ${{ inputs.number }},
+            owner: "LedgerHQ",
+            repo: "ledger-live",
+            body: `${{ inputs.body }}`
+          })

--- a/tools/github-bot/src/index.ts
+++ b/tools/github-bot/src/index.ts
@@ -24,6 +24,28 @@ export default (app: Probot) => {
     });
   });
 
+  commands(app, "regen-pods", async (context, data) => {
+    const { octokit, payload } = context;
+
+    if (context.isBot) return;
+
+    await octokit.rest.reactions.createForIssueComment({
+      ...context.repo(),
+      comment_id: context.payload.comment.id,
+      content: "rocket",
+    });
+
+    await octokit.actions.createWorkflowDispatch({
+      ...context.repo(),
+      workflow_id: "regen-pods.yml",
+      ref: "develop",
+      inputs: {
+        number: `${data.number}`,
+        login: `${payload.comment.user.login}`,
+      },
+    });
+  });
+
   // trigger to autoclose PR when not respecting guidelines
   app.on(["pull_request.opened", "pull_request.reopened"], async (context) => {
     const { payload, octokit } = context;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### Add `/regen-pods` command

Adds a `/regen-pods` command to regenerate podfiles for users that do not have access to mac hardware.

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `N/A` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
