### PR TITLE
chore: add changelog + prevent CI from failing on iOS nightly

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -263,8 +263,8 @@ platform :ios do
         pilot(
           skip_submission: false,
           app_identifier: "com.ledger.live",
-          skip_waiting_for_build_processing: false,
-          wait_processing_timeout_duration: 1800, # 30mn
+          skip_waiting_for_build_processing: true,
+          # wait_processing_timeout_duration: 1800, # 30mn
           ipa: IPA_DIRECTORY,
           changelog: "Nightly Build v#{package['version']} (#{build_number})",
           beta_app_review_info: {
@@ -274,19 +274,19 @@ platform :ios do
           }
         )
 
-        pilot(
-          distribute_only: true,
-          groups: ["External Nightly"],
-          distribute_external: true,
-          app_identifier: "com.ledger.live",
-          app_platform: 'ios',
-          app_version: package["version"],
-          build_number: get_build_number(xcodeproj: "ios/ledgerlivemobile.xcodeproj"),
-          notify_external_testers: true,
-          reject_build_waiting_for_review: !options[:ci],
-          skip_waiting_for_build_processing: false,
-          wait_processing_timeout_duration: 1800, # 30mn
-        )
+        # pilot(
+        #   distribute_only: true,
+        #   groups: ["External Nightly"],
+        #   distribute_external: true,
+        #   app_identifier: "com.ledger.live",
+        #   app_platform: 'ios',
+        #   app_version: package["version"],
+        #   build_number: get_build_number(xcodeproj: "ios/ledgerlivemobile.xcodeproj"),
+        #   notify_external_testers: true,
+        #   reject_build_waiting_for_review: !options[:ci],
+        #   skip_waiting_for_build_processing: false,
+        #   wait_processing_timeout_duration: 1800, # 30mn
+        # )
       rescue => e
         raise unless e.message.include? "Another build is in review"
 
@@ -297,7 +297,8 @@ platform :ios do
         skip_submission: true,
         app_identifier: "com.ledger.live",
         skip_waiting_for_build_processing: true,
-        ipa: IPA_DIRECTORY
+        ipa: IPA_DIRECTORY,
+        changelog: "v#{package['version']} (#{build_number})",
       )
     end
   end

--- a/libs/ledger-live-common/scripts/watch-ts.mjs
+++ b/libs/ledger-live-common/scripts/watch-ts.mjs
@@ -2,19 +2,24 @@
 import "zx/globals";
 import rimraf from "rimraf";
 
-cd(path.join(__dirname, ".."));
+try {
+  cd(path.join(__dirname, ".."));
 
-const remover = async () => {
-  await rimraf("src/data/icons/react*", (e) => {
-    if (e) echo(chalk.red(e));
-  });
-};
+  const remover = async () => {
+    await rimraf("src/data/icons/react*", (e) => {
+      if (e) echo(chalk.red(e));
+    });
+  };
 
-await remover();
+  await remover();
 
-await $`zx ./scripts/sync-families-dispatch.mjs`;
+  await $`zx ./scripts/sync-families-dispatch.mjs`;
 
-await $`node ./scripts/buildReactIcons.js`;
-await $`node ./scripts/buildReactFlags.js`;
+  await $`node ./scripts/buildReactIcons.js`;
+  await $`node ./scripts/buildReactFlags.js`;
 
-await $`pnpm tsc --project src/tsconfig.json --watch`;
+  await $`pnpm tsc --project src/tsconfig.json --watch`;
+} catch (error) {
+  console.log(chalk.red(error));
+  process.exit(1);
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

iOS nightly were trying to wait for builds to be validate by apple to then distribute the build into the correct test group.
In the past we've had 6h timeout (whenever a job stops because it's too long), and I experimented with a timeout on 30mn.
Unfortunately, we never had a submission happen this fast, so I just removed the distribution to the tester group (has to be done manually from the apple dev center).

Also add the version on the changelog when pushing .ipa so we have it displayed in the metadata (easier to know version + build)

### ❓ Context

- **Impacted projects**: `automation` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

No Demo


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
