### PR TITLE
feat/LIVE-3016-improve-explore-with-device

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
@@ -157,7 +157,7 @@ function PostWelcomeSelection({
 
   const pressExplore = useCallback(
     (data: DataType) => {
-      dispatch(setHasOrderedNano(userHasDevice ? true : false));
+      dispatch(setHasOrderedNano(!!userHasDevice));
 
       onCardClick(data, "Explore LL");
     },

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import { Text, Button, Flex } from "@ledgerhq/native-ui";
+import { useDispatch } from "react-redux";
 import { track, TrackScreen } from "../../../analytics";
 import { NavigatorName, ScreenName } from "../../../const";
 import OnboardingView from "../OnboardingView";
@@ -11,6 +12,7 @@ import Illustration from "../../../images/illustration/Illustration";
 import DiscoverCard from "../../Discover/DiscoverCard";
 // eslint-disable-next-line import/no-cycle
 import { AnalyticsContext } from "../../../components/RootNavigator";
+import { setHasOrderedNano } from "../../../actions/settings";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const setupLedgerImg = require("../../../images/illustration/Shared/_SetupLedger.png");
@@ -91,6 +93,8 @@ function PostWelcomeSelection({
   route: RouteProp<{ params: { userHasDevice: boolean } }, "params">;
 }) {
   const { userHasDevice } = route.params;
+  const dispatch = useDispatch();
+
   const screenName = `Onboarding Choice ${
     userHasDevice ? "With Device" : "No Device"
   }`;
@@ -152,7 +156,11 @@ function PostWelcomeSelection({
   );
 
   const pressExplore = useCallback(
-    (data: DataType) => onCardClick(data, "Explore LL"),
+    (data: DataType) => {
+      dispatch(setHasOrderedNano(userHasDevice ? true : false));
+
+      onCardClick(data, "Explore LL");
+    },
     [onCardClick],
   );
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/postWelcomeSelection.tsx
@@ -161,7 +161,7 @@ function PostWelcomeSelection({
 
       onCardClick(data, "Explore LL");
     },
-    [onCardClick],
+    [dispatch, onCardClick, userHasDevice],
   );
 
   const pressBuy = useCallback(


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Explore the app when user already has a device now uses the hasOrderedNano state

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3016] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3016]: https://ledgerhq.atlassian.net/browse/LIVE-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ