### PR TITLE
feat: remove 'any' type from getAccountBridge to avoid type lose

### DIFF
--- a/libs/ledger-live-common/src/bridge/index.ts
+++ b/libs/ledger-live-common/src/bridge/index.ts
@@ -6,6 +6,7 @@ import type {
   CurrencyBridge,
   ScanAccountEvent,
   ScanAccountEventRaw,
+  TransactionCommon,
 } from "@ledgerhq/types-live";
 import { fromAccountRaw, toAccountRaw } from "../account";
 import * as impl from "./impl";
@@ -25,11 +26,13 @@ export const setBridgeProxy = (p: Proxy | null | undefined) => {
 };
 export const getCurrencyBridge = (currency: CryptoCurrency): CurrencyBridge =>
   (proxy || impl).getCurrencyBridge(currency);
-export const getAccountBridge = (
+export function getAccountBridge<T extends TransactionCommon>(
   account: AccountLike,
   parentAccount?: Account | null | undefined
-): AccountBridge<any> =>
-  (proxy || impl).getAccountBridge(account, parentAccount);
+): AccountBridge<T> {
+  return (proxy || impl).getAccountBridge(account, parentAccount);
+}
+
 export function fromScanAccountEventRaw(
   raw: ScanAccountEventRaw
 ): ScanAccountEvent {


### PR DESCRIPTION
Signed-off-by: Stéphane Prohaszka <stephane.prohaszka@ledger.fr>

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Small update to remove the `any` type that is returned from calling `getAccountBridge`

### ❓ Context

- **Impacted projects**: `Common`
- **Linked resource(s)**: `none`

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

The goal is to enforce type safety.

<!-- If any of the expectations are not met please explain the reason in detail. -->
