### PR TITLE
Osmosis bot - Change the max nb of accounts from 3 to 16

### DIFF
--- a/libs/ledger-live-common/src/families/osmosis/specs.ts
+++ b/libs/ledger-live-common/src/families/osmosis/specs.ts
@@ -22,7 +22,7 @@ import { BigNumber } from "bignumber.js";
 
 const currency = getCryptoCurrencyById("osmosis");
 const minimalAmount = parseCurrencyUnit(currency.units[0], "0.00001");
-const maxAccount = 3;
+const maxAccount = 16;
 // amounts of delegation are not exact so we are applying an approximation
 function approximateValue(value) {
   return "~" + value.div(100).integerValue().times(100).toString();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Osmosis bot was initially setup to use only 3 accounts. Since Osmosis has staking implemented, and the unlocking period is 14 days, it makes sense to use more accounts than the unlocking period to mitigate and hopefully avoid the situation where all accounts have funds locked waiting to be unlocked.
(For the same reason, the Cosmos bot was set to use 32 accounts because Cosmos has an unlocking delay of 21 days).

### ❓ Context

- **Impacted projects**: `none` (bot config only) <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: N/A <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach



<!-- If any of the expectations are not met please explain the reason in detail. -->
