### PR TITLE
Asset centric wallet - bugfix/LIVE-3436-added-crypto-quantity-in-asset-page

### DIFF
--- a/apps/ledger-live-mobile/src/components/AssetCentricGraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/AssetCentricGraphCard.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, memo } from "react";
 import styled, { useTheme } from "styled-components/native";
 import { Flex, Text, GraphTabs } from "@ledgerhq/native-ui";
-import { useTranslation } from "react-i18next";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import Animated, {
   Extrapolate,
@@ -43,6 +42,7 @@ type Props = {
   graphCardEndPosition: number;
   currency: Currency;
   areAccountsEmpty: boolean;
+  currencyBalance: number;
 };
 
 function AssetCentricGraphCard({
@@ -52,19 +52,18 @@ function AssetCentricGraphCard({
   graphCardEndPosition,
   currency,
   areAccountsEmpty,
+  currencyBalance,
 }: Props) {
   const { colors } = useTheme();
-  const { t } = useTranslation();
   const currentScreen = useCurrentRouteName();
   const [itemRange, setTimeRange, timeRangeItems] = useTimeRange();
-  const [loading, setLoading] = useState(false);
   const {
     countervalueChange,
     balanceAvailable,
     balanceHistory,
   } = assetPortfolio;
 
-  const item = balanceHistory[balanceHistory.length - 1];
+  const currencyUnitValue = balanceHistory[balanceHistory.length - 1];
 
   const unit = counterValueCurrency.units[0];
 
@@ -143,21 +142,20 @@ function AssetCentricGraphCard({
                   {!balanceAvailable ? (
                     <BigPlaceholder mt="8px" />
                   ) : (
-                    <>
+                    <Flex alignItems="center">
                       <Text
                         variant={"large"}
                         fontWeight={"medium"}
                         color={"neutral.c80"}
+                        mt={3}
                       >
-                        <CurrencyUnitValue
-                          unit={unit}
-                          value={
-                            hoveredItem
-                              ? hoveredItem.countervalue
-                              : item.countervalue
-                          }
-                          joinFragmentsSeparator=" "
-                        />
+                        {!hoveredItem ? (
+                          <CurrencyUnitValue
+                            unit={currency.units[0]}
+                            value={currencyBalance}
+                            joinFragmentsSeparator=""
+                          />
+                        ) : null}
                       </Text>
                       <Text
                         fontFamily="Inter"
@@ -169,11 +167,15 @@ function AssetCentricGraphCard({
                       >
                         <CurrencyUnitValue
                           unit={unit}
-                          value={hoveredItem ? hoveredItem.value : item.value}
-                          joinFragmentsSeparator=" "
+                          value={
+                            hoveredItem
+                              ? hoveredItem.value
+                              : currencyUnitValue.value
+                          }
+                          joinFragmentsSeparator=""
                         />
                       </Text>
-                    </>
+                    </Flex>
                   )}
                   <TransactionsPendingConfirmationWarning />
                 </Flex>
@@ -196,6 +198,7 @@ function AssetCentricGraphCard({
                             valueChange={countervalueChange}
                             // range={portfolio.range}
                           />
+                          <Text> </Text>
                           <Delta unit={unit} valueChange={countervalueChange} />
                         </>
                       )}

--- a/apps/ledger-live-mobile/src/components/GraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/GraphCard.tsx
@@ -141,7 +141,7 @@ function GraphCard({
                       <CurrencyUnitValue
                         unit={unit}
                         value={hoveredItem ? hoveredItem.value : item.value}
-                        joinFragmentsSeparator=" "
+                        joinFragmentsSeparator=""
                       />
                     </Text>
                   )}
@@ -170,6 +170,7 @@ function GraphCard({
                             valueChange={countervalueChange}
                             // range={portfolio.range}
                           />
+                          <Text> </Text>
                           <Delta unit={unit} valueChange={countervalueChange} />
                         </>
                       )}

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -153,9 +153,6 @@ function PortfolioScreen({ navigation }: Props) {
       </Box>,
       ...(showAssets
         ? [
-            <Box pt={6} background={colors.background.main}>
-              <FabActions areAccountsEmpty={areAccountsEmpty} />
-            </Box>,
             <Box background={colors.background.main} px={6} mt={6}>
               <Assets assets={assetsToDisplay} />
               {distribution.list.length < maxAssetsToDisplay ? (

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
@@ -68,7 +68,7 @@ function Header({
         currencyId: currency.id,
       },
     });
-  }, [currency.id, navigation]);
+  }, [currency.id, currentRoute, navigation]);
 
   return (
     <CurrencyHeaderLayout
@@ -109,7 +109,7 @@ function Header({
                 <CurrencyUnitValue
                   unit={unit}
                   value={item.value}
-                  joinFragmentsSeparator=" "
+                  joinFragmentsSeparator=""
                 />
               </Text>
             </>

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
@@ -82,6 +82,11 @@ const AssetScreen = ({ route }: Props) => {
     currentPositionY.value = event.contentOffset.y;
   });
 
+  const currencyBalance = useMemo(
+    () => cryptoAccounts.reduce((acc, val) => acc + val.balance.toNumber(), 0),
+    [cryptoAccounts],
+  );
+
   const onAssetCardLayout = useCallback((event: LayoutChangeEvent) => {
     const { y, height } = event.nativeEvent.layout;
     setGraphCardEndPosition(y + height / 10);
@@ -112,6 +117,7 @@ const AssetScreen = ({ route }: Props) => {
           currentPositionY={currentPositionY}
           graphCardEndPosition={graphCardEndPosition}
           currency={currency}
+          currencyBalance={currencyBalance}
           areAccountsEmpty={areCryptoAccountsEmpty}
         />
       </Box>,


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Two bugs fixed :
- LLM - Individual Asset page - Crypto quantity is missing for balance 
- LLM - Active wallet page - New design should not display quick action button 

A few pixel polish feedbacks also implemented

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3236] [LIVE-3413] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3236]: https://ledgerhq.atlassian.net/browse/LIVE-3236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-3413]: https://ledgerhq.atlassian.net/browse/LIVE-3413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ