### PR TITLE
LIVE-2105 Move coin-specific logic to families when importing accounts in LLM

### DIFF
--- a/.changeset/olive-laws-smash.md
+++ b/.changeset/olive-laws-smash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Use CurrencyBridge.importAccountData function to handle coin-specific logic when importing accounts into LLM

--- a/.changeset/tough-eyes-remain.md
+++ b/.changeset/tough-eyes-remain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/types-live": minor
+---
+
+Add an optional CurrencyBridge.importAccountData function

--- a/libs/ledger-live-common/scripts/sync-families-dispatch.mjs
+++ b/libs/ledger-live-common/scripts/sync-families-dispatch.mjs
@@ -94,19 +94,41 @@ ${exprts};
   await fs.promises.appendFile(outpath, str, "utf8");
 }
 
+function toPascalCase(s) {
+  return (
+    s[0].toUpperCase() +
+    s.substring(1).replace(/([-_][a-z])/gi, ($1) => {
+      return $1.toUpperCase().replace("-", "").replace("_", "");
+    })
+  );
+}
+
 async function genTypesFile(families) {
   const outpath = path.join("generated", "types.ts");
   let imprts = ``;
+  let exprtsA = `export type CoinAccount =`;
+  let exprtsARaw = `export type CoinAccountRaw =`;
   let exprtsT = `export type Transaction =`;
   let exprtsTRaw = `export type TransactionRaw =`;
   let exprtsStatus = `export type TransactionStatus =`;
   let exprtsStatusRaw = `export type TransactionStatusRaw =`;
   for (const family of families) {
-    imprts += `import { Transaction as ${family}Transaction } from "../families/${family}/types";
+    const familyCaps = toPascalCase(family);
+
+    imprts += `import { ${familyCaps}Account } from "../families/${family}/types";
+import { ${familyCaps}AccountRaw } from "../families/${family}/types";
+import { Transaction as ${family}Transaction } from "../families/${family}/types";
 import { TransactionRaw as ${family}TransactionRaw } from "../families/${family}/types";
 import { TransactionStatus as ${family}TransactionStatus } from "../families/${family}/types";
 import { TransactionStatusRaw as ${family}TransactionStatusRaw } from "../families/${family}/types";
 `;
+
+    exprtsA += `
+  | ${familyCaps}Account`;
+
+    exprtsARaw += `
+  | ${familyCaps}AccountRaw`;
+
     exprtsT += `
   | ${family}Transaction`;
 
@@ -120,6 +142,10 @@ import { TransactionStatusRaw as ${family}TransactionStatusRaw } from "../famili
   | ${family}TransactionStatusRaw`;
   }
 
+  exprtsA += `;
+`;
+  exprtsARaw += `;
+`;
   exprtsT += `;
 `;
   exprtsTRaw += `;
@@ -130,6 +156,8 @@ import { TransactionStatusRaw as ${family}TransactionStatusRaw } from "../famili
 `;
 
   const str = `${imprts}
+${exprtsA}
+${exprtsARaw}
 ${exprtsT}
 ${exprtsTRaw}
 ${exprtsStatus}

--- a/libs/ledger-live-common/src/families/celo/types.ts
+++ b/libs/ledger-live-common/src/families/celo/types.ts
@@ -1,4 +1,6 @@
 import type {
+  Account,
+  AccountRaw,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -18,3 +20,7 @@ export type TransactionRaw = TransactionCommonRaw & {
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type CeloAccount = Account;
+
+export type CeloAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/families/ethereum/types.ts
+++ b/libs/ledger-live-common/src/families/ethereum/types.ts
@@ -4,6 +4,8 @@ import type { TransactionMode, ModeModule } from "./modules";
 import type { Range, RangeRaw } from "../../range";
 import type { DerivationMode } from "../../derivation";
 import type {
+  Account,
+  AccountRaw,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -75,3 +77,7 @@ export type TypedMessageData = {
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type EthereumAccount = Account;
+
+export type EthereumAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/families/filecoin/types.ts
+++ b/libs/ledger-live-common/src/families/filecoin/types.ts
@@ -1,4 +1,6 @@
 import {
+  Account,
+  AccountRaw,
   BroadcastArg0,
   Operation,
   TransactionCommon,
@@ -44,3 +46,7 @@ export type BroadcastFnSignature = (arg0: BroadcastArg0) => Promise<Operation>;
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type FilecoinAccount = Account;
+
+export type FilecoinAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/families/hedera/types.ts
+++ b/libs/ledger-live-common/src/families/hedera/types.ts
@@ -1,4 +1,6 @@
 import type {
+  Account,
+  AccountRaw,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -29,3 +31,7 @@ export const reflect = (_declare: any) => {};
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type HederaAccount = Account;
+
+export type HederaAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/families/neo/types.ts
+++ b/libs/ledger-live-common/src/families/neo/types.ts
@@ -1,4 +1,6 @@
 import type {
+  Account,
+  AccountRaw,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -19,3 +21,6 @@ export type TransactionRaw = TransactionCommonRaw & {
 };
 export type TransactionStatus = TransactionStatusCommon;
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type NeoAccount = Account;
+export type NeoAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/families/osmosis/types.ts
+++ b/libs/ledger-live-common/src/families/osmosis/types.ts
@@ -1,5 +1,7 @@
 import type { BigNumber } from "bignumber.js";
 import {
+  Account,
+  AccountRaw,
   TransactionStatusCommon,
   TransactionStatusCommonRaw,
 } from "@ledgerhq/types-live";
@@ -46,3 +48,7 @@ export type OsmosisRewardsState = {
   averageDailyFees: number;
   currentValueInflation: number;
 };
+
+export type OsmosisAccount = Account;
+
+export type OsmosisAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/families/ripple/types.ts
+++ b/libs/ledger-live-common/src/families/ripple/types.ts
@@ -1,6 +1,8 @@
 import type { BigNumber } from "bignumber.js";
 import type { Unit } from "@ledgerhq/types-cryptoassets";
 import type {
+  Account,
+  AccountRaw,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -33,3 +35,6 @@ export type TransactionRaw = TransactionCommonRaw & {
 };
 export type TransactionStatus = TransactionStatusCommon;
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type RippleAccount = Account;
+export type RippleAccountRaw = Account;

--- a/libs/ledger-live-common/src/families/stellar/types.ts
+++ b/libs/ledger-live-common/src/families/stellar/types.ts
@@ -1,6 +1,8 @@
 import { ServerApi } from "stellar-sdk";
 import type { BigNumber } from "bignumber.js";
 import type {
+  Account,
+  AccountRaw,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -97,3 +99,7 @@ export type Signer = {
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type StellarAccount = Account;
+
+export type StellarAccountRaw = AccountRaw;

--- a/libs/ledger-live-common/src/generated/types.ts
+++ b/libs/ledger-live-common/src/generated/types.ts
@@ -1,75 +1,151 @@
+import { AlgorandAccount } from "../families/algorand/types";
+import { AlgorandAccountRaw } from "../families/algorand/types";
 import { Transaction as algorandTransaction } from "../families/algorand/types";
 import { TransactionRaw as algorandTransactionRaw } from "../families/algorand/types";
 import { TransactionStatus as algorandTransactionStatus } from "../families/algorand/types";
 import { TransactionStatusRaw as algorandTransactionStatusRaw } from "../families/algorand/types";
+import { BitcoinAccount } from "../families/bitcoin/types";
+import { BitcoinAccountRaw } from "../families/bitcoin/types";
 import { Transaction as bitcoinTransaction } from "../families/bitcoin/types";
 import { TransactionRaw as bitcoinTransactionRaw } from "../families/bitcoin/types";
 import { TransactionStatus as bitcoinTransactionStatus } from "../families/bitcoin/types";
 import { TransactionStatusRaw as bitcoinTransactionStatusRaw } from "../families/bitcoin/types";
+import { CardanoAccount } from "../families/cardano/types";
+import { CardanoAccountRaw } from "../families/cardano/types";
 import { Transaction as cardanoTransaction } from "../families/cardano/types";
 import { TransactionRaw as cardanoTransactionRaw } from "../families/cardano/types";
 import { TransactionStatus as cardanoTransactionStatus } from "../families/cardano/types";
 import { TransactionStatusRaw as cardanoTransactionStatusRaw } from "../families/cardano/types";
+import { CeloAccount } from "../families/celo/types";
+import { CeloAccountRaw } from "../families/celo/types";
 import { Transaction as celoTransaction } from "../families/celo/types";
 import { TransactionRaw as celoTransactionRaw } from "../families/celo/types";
 import { TransactionStatus as celoTransactionStatus } from "../families/celo/types";
 import { TransactionStatusRaw as celoTransactionStatusRaw } from "../families/celo/types";
+import { CosmosAccount } from "../families/cosmos/types";
+import { CosmosAccountRaw } from "../families/cosmos/types";
 import { Transaction as cosmosTransaction } from "../families/cosmos/types";
 import { TransactionRaw as cosmosTransactionRaw } from "../families/cosmos/types";
 import { TransactionStatus as cosmosTransactionStatus } from "../families/cosmos/types";
 import { TransactionStatusRaw as cosmosTransactionStatusRaw } from "../families/cosmos/types";
+import { CryptoOrgAccount } from "../families/crypto_org/types";
+import { CryptoOrgAccountRaw } from "../families/crypto_org/types";
 import { Transaction as crypto_orgTransaction } from "../families/crypto_org/types";
 import { TransactionRaw as crypto_orgTransactionRaw } from "../families/crypto_org/types";
 import { TransactionStatus as crypto_orgTransactionStatus } from "../families/crypto_org/types";
 import { TransactionStatusRaw as crypto_orgTransactionStatusRaw } from "../families/crypto_org/types";
+import { ElrondAccount } from "../families/elrond/types";
+import { ElrondAccountRaw } from "../families/elrond/types";
 import { Transaction as elrondTransaction } from "../families/elrond/types";
 import { TransactionRaw as elrondTransactionRaw } from "../families/elrond/types";
 import { TransactionStatus as elrondTransactionStatus } from "../families/elrond/types";
 import { TransactionStatusRaw as elrondTransactionStatusRaw } from "../families/elrond/types";
+import { EthereumAccount } from "../families/ethereum/types";
+import { EthereumAccountRaw } from "../families/ethereum/types";
 import { Transaction as ethereumTransaction } from "../families/ethereum/types";
 import { TransactionRaw as ethereumTransactionRaw } from "../families/ethereum/types";
 import { TransactionStatus as ethereumTransactionStatus } from "../families/ethereum/types";
 import { TransactionStatusRaw as ethereumTransactionStatusRaw } from "../families/ethereum/types";
+import { FilecoinAccount } from "../families/filecoin/types";
+import { FilecoinAccountRaw } from "../families/filecoin/types";
 import { Transaction as filecoinTransaction } from "../families/filecoin/types";
 import { TransactionRaw as filecoinTransactionRaw } from "../families/filecoin/types";
 import { TransactionStatus as filecoinTransactionStatus } from "../families/filecoin/types";
 import { TransactionStatusRaw as filecoinTransactionStatusRaw } from "../families/filecoin/types";
+import { HederaAccount } from "../families/hedera/types";
+import { HederaAccountRaw } from "../families/hedera/types";
 import { Transaction as hederaTransaction } from "../families/hedera/types";
 import { TransactionRaw as hederaTransactionRaw } from "../families/hedera/types";
 import { TransactionStatus as hederaTransactionStatus } from "../families/hedera/types";
 import { TransactionStatusRaw as hederaTransactionStatusRaw } from "../families/hedera/types";
+import { NeoAccount } from "../families/neo/types";
+import { NeoAccountRaw } from "../families/neo/types";
 import { Transaction as neoTransaction } from "../families/neo/types";
 import { TransactionRaw as neoTransactionRaw } from "../families/neo/types";
 import { TransactionStatus as neoTransactionStatus } from "../families/neo/types";
 import { TransactionStatusRaw as neoTransactionStatusRaw } from "../families/neo/types";
+import { OsmosisAccount } from "../families/osmosis/types";
+import { OsmosisAccountRaw } from "../families/osmosis/types";
 import { Transaction as osmosisTransaction } from "../families/osmosis/types";
 import { TransactionRaw as osmosisTransactionRaw } from "../families/osmosis/types";
 import { TransactionStatus as osmosisTransactionStatus } from "../families/osmosis/types";
 import { TransactionStatusRaw as osmosisTransactionStatusRaw } from "../families/osmosis/types";
+import { PolkadotAccount } from "../families/polkadot/types";
+import { PolkadotAccountRaw } from "../families/polkadot/types";
 import { Transaction as polkadotTransaction } from "../families/polkadot/types";
 import { TransactionRaw as polkadotTransactionRaw } from "../families/polkadot/types";
 import { TransactionStatus as polkadotTransactionStatus } from "../families/polkadot/types";
 import { TransactionStatusRaw as polkadotTransactionStatusRaw } from "../families/polkadot/types";
+import { RippleAccount } from "../families/ripple/types";
+import { RippleAccountRaw } from "../families/ripple/types";
 import { Transaction as rippleTransaction } from "../families/ripple/types";
 import { TransactionRaw as rippleTransactionRaw } from "../families/ripple/types";
 import { TransactionStatus as rippleTransactionStatus } from "../families/ripple/types";
 import { TransactionStatusRaw as rippleTransactionStatusRaw } from "../families/ripple/types";
+import { SolanaAccount } from "../families/solana/types";
+import { SolanaAccountRaw } from "../families/solana/types";
 import { Transaction as solanaTransaction } from "../families/solana/types";
 import { TransactionRaw as solanaTransactionRaw } from "../families/solana/types";
 import { TransactionStatus as solanaTransactionStatus } from "../families/solana/types";
 import { TransactionStatusRaw as solanaTransactionStatusRaw } from "../families/solana/types";
+import { StellarAccount } from "../families/stellar/types";
+import { StellarAccountRaw } from "../families/stellar/types";
 import { Transaction as stellarTransaction } from "../families/stellar/types";
 import { TransactionRaw as stellarTransactionRaw } from "../families/stellar/types";
 import { TransactionStatus as stellarTransactionStatus } from "../families/stellar/types";
 import { TransactionStatusRaw as stellarTransactionStatusRaw } from "../families/stellar/types";
+import { TezosAccount } from "../families/tezos/types";
+import { TezosAccountRaw } from "../families/tezos/types";
 import { Transaction as tezosTransaction } from "../families/tezos/types";
 import { TransactionRaw as tezosTransactionRaw } from "../families/tezos/types";
 import { TransactionStatus as tezosTransactionStatus } from "../families/tezos/types";
 import { TransactionStatusRaw as tezosTransactionStatusRaw } from "../families/tezos/types";
+import { TronAccount } from "../families/tron/types";
+import { TronAccountRaw } from "../families/tron/types";
 import { Transaction as tronTransaction } from "../families/tron/types";
 import { TransactionRaw as tronTransactionRaw } from "../families/tron/types";
 import { TransactionStatus as tronTransactionStatus } from "../families/tron/types";
 import { TransactionStatusRaw as tronTransactionStatusRaw } from "../families/tron/types";
+
+export type CoinAccount =
+  | AlgorandAccount
+  | BitcoinAccount
+  | CardanoAccount
+  | CeloAccount
+  | CosmosAccount
+  | CryptoOrgAccount
+  | ElrondAccount
+  | EthereumAccount
+  | FilecoinAccount
+  | HederaAccount
+  | NeoAccount
+  | OsmosisAccount
+  | PolkadotAccount
+  | RippleAccount
+  | SolanaAccount
+  | StellarAccount
+  | TezosAccount
+  | TronAccount;
+
+export type CoinAccountRaw =
+  | AlgorandAccountRaw
+  | BitcoinAccountRaw
+  | CardanoAccountRaw
+  | CeloAccountRaw
+  | CosmosAccountRaw
+  | CryptoOrgAccountRaw
+  | ElrondAccountRaw
+  | EthereumAccountRaw
+  | FilecoinAccountRaw
+  | HederaAccountRaw
+  | NeoAccountRaw
+  | OsmosisAccountRaw
+  | PolkadotAccountRaw
+  | RippleAccountRaw
+  | SolanaAccountRaw
+  | StellarAccountRaw
+  | TezosAccountRaw
+  | TronAccountRaw;
 
 export type Transaction =
   | algorandTransaction

--- a/libs/ledgerjs/packages/types-live/src/account.ts
+++ b/libs/ledgerjs/packages/types-live/src/account.ts
@@ -289,3 +289,18 @@ export type AccountIdParams = {
   xpubOrAddress: string;
   derivationMode: DerivationMode;
 };
+
+/**
+ * Minimal amount of account data transferred during
+ * export/import of accounts from live-desktop to live-mobile
+ */
+export type AccountData = {
+  id: string;
+  currencyId: string;
+  freshAddress?: string;
+  seedIdentifier: string;
+  derivationMode: string;
+  name: string;
+  index: number;
+  balance: string;
+};

--- a/libs/ledgerjs/packages/types-live/src/bridge.ts
+++ b/libs/ledgerjs/packages/types-live/src/bridge.ts
@@ -6,7 +6,7 @@
 import { BigNumber } from "bignumber.js";
 import type { Observable } from "rxjs";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import type { AccountLike, Account, AccountRaw } from "./account";
+import type { AccountLike, Account, AccountRaw, AccountData } from "./account";
 import type {
   SignOperationEvent,
   SignedOperation,
@@ -83,6 +83,7 @@ export interface CurrencyBridge {
   // returned value is a serializable object
   // fail if data was not able to load.
   preload(currency: CryptoCurrency): Promise<Record<string, any>>;
+  getPreloadStrategy?: (currency: CryptoCurrency) => PreloadStrategy;
   // reinject the preloaded data (typically if it was cached)
   // method need to treat the data object as unsafe and validate all fields / be backward compatible.
   hydrate(data: unknown, currency: CryptoCurrency): void;
@@ -94,7 +95,9 @@ export interface CurrencyBridge {
     syncConfig: SyncConfig;
     preferredNewAccountScheme?: DerivationMode;
   }): Observable<ScanAccountEvent>;
-  getPreloadStrategy?: (currency: CryptoCurrency) => PreloadStrategy;
+  // Optional logic to apply to complete missing data,
+  // when importing accounts from live-desktop to live-mobile
+  importAccountData?: (accountData: AccountData) => Partial<Account>;
   nftResolvers?: {
     nftMetadata: (arg: {
       contract: string;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently, some coin-specific logic lives in the generic code that creates `Account`s from account data imported from LLD.
This PR moves the coin-specific logic back to coin families.

To do so it adds a `CurrencyBridge.importAccountData` function, that is in charge of extending the default logic to create the `Account` object in cross.ts, with any custom logic relevant for the family.

### ❓ Context

- **Impacted projects**: `types-live` `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2105 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach


<!-- If any of the expectations are not met please explain the reason in detail. -->
