### PR TITLE
LIVE-2641 Prevent emitting an event when device descriptor is null

### DIFF
--- a/.changeset/rotten-seals-mix.md
+++ b/.changeset/rotten-seals-mix.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+Fix crash when scanning for bluetooth devices

--- a/apps/ledger-live-mobile/src/react-native-hw-transport-ble/makeMock.ts
+++ b/apps/ledger-live-mobile/src/react-native-hw-transport-ble/makeMock.ts
@@ -1,14 +1,14 @@
 import Transport from "@ledgerhq/hw-transport";
 import { from } from "rxjs";
 import { take, first, filter } from "rxjs/operators";
-import type { ApduMock } from "../logic/createAPDUMock";
-import { hookRejections } from "../logic/debugReject";
-import { e2eBridgeSubject } from "../../e2e/bridge/client";
 import type { Device } from "@ledgerhq/react-native-hw-transport-ble/lib/types";
 import type {
   Observer as TransportObserver,
   DescriptorEvent,
 } from "@ledgerhq/hw-transport";
+import type { ApduMock } from "../logic/createAPDUMock";
+import { hookRejections } from "../logic/debugReject";
+import { e2eBridgeSubject } from "../../e2e/bridge/client";
 
 export type DeviceMock = {
   id: string;

--- a/apps/ledger-live-mobile/src/react-native-hw-transport-ble/makeMock.ts
+++ b/apps/ledger-live-mobile/src/react-native-hw-transport-ble/makeMock.ts
@@ -4,6 +4,11 @@ import { take, first, filter } from "rxjs/operators";
 import type { ApduMock } from "../logic/createAPDUMock";
 import { hookRejections } from "../logic/debugReject";
 import { e2eBridgeSubject } from "../../e2e/bridge/client";
+import type { Device } from "@ledgerhq/react-native-hw-transport-ble/lib/types";
+import type {
+  Observer as TransportObserver,
+  DescriptorEvent,
+} from "@ledgerhq/hw-transport";
 
 export type DeviceMock = {
   id: string;
@@ -36,7 +41,7 @@ export default (opts: Opts) => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     static setLogLevel = (_param: string) => {};
 
-    static listen(observer: any) {
+    static listen(observer: TransportObserver<DescriptorEvent<Device>>) {
       return e2eBridgeSubject
         .pipe(
           filter(msg => msg.type === "add"),

--- a/apps/ledger-live-mobile/src/screens/PairDevices/Scanning.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/Scanning.tsx
@@ -12,6 +12,7 @@ import TransportBLE from "../../react-native-hw-transport-ble";
 import { TrackScreen } from "../../analytics";
 import DeviceItem from "../../components/SelectDevice/DeviceItem";
 import ScanningHeader from "./ScanningHeader";
+import { DescriptorEvent } from "@ledgerhq/hw-transport";
 
 type Props = {
   // eslint-disable-next-line no-unused-vars
@@ -61,7 +62,7 @@ export default function Scanning({ onTimeout, onError, onSelect }: Props) {
     }, BLE_SCANNING_NOTHING_TIMEOUT);
 
     const sub = Observable.create(TransportBLE.listen).subscribe({
-      next: (e: { type: string; descriptor: any }) => {
+      next: (e: DescriptorEvent<Device>) => {
         if (e.type === "add") {
           clearTimeout(timeout);
           const device = e.descriptor;

--- a/apps/ledger-live-mobile/src/screens/PairDevices/Scanning.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/Scanning.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Observable } from "rxjs";
 import { InfiniteLoader } from "@ledgerhq/native-ui";
 import { getInfosForServiceUuid, DeviceModelId } from "@ledgerhq/devices";
+import { DescriptorEvent } from "@ledgerhq/hw-transport";
 import logger from "../../logger";
 import { BLE_SCANNING_NOTHING_TIMEOUT } from "../../constants";
 import { knownDevicesSelector } from "../../reducers/ble";
@@ -12,7 +13,6 @@ import TransportBLE from "../../react-native-hw-transport-ble";
 import { TrackScreen } from "../../analytics";
 import DeviceItem from "../../components/SelectDevice/DeviceItem";
 import ScanningHeader from "./ScanningHeader";
-import { DescriptorEvent } from "@ledgerhq/hw-transport";
 
 type Props = {
   // eslint-disable-next-line no-unused-vars

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -339,7 +339,7 @@ export default class BluetoothTransport extends Transport {
    * Scan for bluetooth Ledger devices
    */
   static listen(
-    observer: TransportObserver<DescriptorEvent<Device | null>>
+    observer: TransportObserver<DescriptorEvent<Device>>
   ): TransportSubscription {
     log("ble-verbose", "listen...");
     let unsubscribed;
@@ -369,11 +369,14 @@ export default class BluetoothTransport extends Transport {
 
             const res = retrieveInfos(device);
             const deviceModel = res && res.deviceModel;
-            observer.next({
-              type: "add",
-              descriptor: device,
-              deviceModel,
-            });
+
+            if(device) {
+              observer.next({
+                type: "add",
+                descriptor: device,
+                deviceModel,
+              });
+            }
           }
         );
       }

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -370,7 +370,7 @@ export default class BluetoothTransport extends Transport {
             const res = retrieveInfos(device);
             const deviceModel = res && res.deviceModel;
 
-            if(device) {
+            if (device) {
               observer.next({
                 type: "add",
                 descriptor: device,


### PR DESCRIPTION
### 📝 Description
This is a fix for an error that was found in Sentry.
While scanning devices, if there was a device for which the scan failed, we emitted is as a `null` device. However this broke on React end since we were trying to access infos from this null value as if it were an object.
See associated JIRA task for more info on the error.

The PR prevents the emission of an event in this case, fixing the issue directly in the scanning logic. This could have been prevented if we had a stricter typing, so I've also added some typing to the logic.

### ❓ Context
- **Impacted projects**: `ledgerjs/react-native-hw-transport-ble`, `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-2641]

### ✅ Checklist

- [N/A] **Test coverage** -- this was more a question of proper typing rather than tests
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
N/A


[LIVE-2641]: https://ledgerhq.atlassian.net/browse/LIVE-2641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ