### PR TITLE
Fixes Algo bot failure

### DIFF
--- a/libs/ledger-live-common/src/families/algorand/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/algorand/speculos-deviceActions.ts
@@ -32,6 +32,7 @@ const acceptTransaction: DeviceAction<AlgorandTransaction, any> =
         title: "Fee",
         button: "Rr",
         expectedValue: ({ account, status }) =>
+          "ALGO " +
           formatCurrencyUnit(account.unit, status.estimatedFees, {
             disableRounding: true,
           }),


### PR DESCRIPTION


### 📝 Description

fixes this problem

```
⚠️ TEST deviceAction confirm step 'Fee'
Error: expect(received).toMatchObject(expected)

- Expected  - 1
+ Received  + 1

  Object {
-   "Fee": "0.001",
+   "Fee": "ALGO 0.001",
  }
  ```

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:  <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
