### PR TITLE
[HOTFIX][LIVE-3524] fix handle new window event

### DIFF
--- a/.changeset/tiny-kangaroos-type.md
+++ b/.changeset/tiny-kangaroos-type.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix handle new-window event in WebPlatformPlayer

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx
@@ -269,6 +269,9 @@ export default function WebPlatformPlayer({ manifest, onClose, inputs = {}, conf
     const webview = targetRef.current;
 
     if (webview) {
+      // For mysterious reasons, the webpreferences attribute does not
+      // pass through the styled component when added in the JSX.
+      webview.webpreferences = "nativeWindowOpen=no";
       webview.addEventListener("new-window", handleNewWindow);
       webview.addEventListener("did-finish-load", handleLoad);
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Following a refacto of the WebPlatformPlayer component, a line enabling opening of external links was removed. Adding this line back to allow opening new window (external links) again

### ❓ Context

- **Impacted projects**: LLD
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3524

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->

Open Moonpay in Discover and try to open their Twitter account from the link bottom left. The link should be opened on an external browser window.