### PR TITLE
LIVE-3519 Add missing safety check on bitcoinResources

### DIFF
--- a/libs/ledger-live-common/src/account/serialization.ts
+++ b/libs/ledger-live-common/src/account/serialization.ts
@@ -777,90 +777,76 @@ export function fromAccountRaw(rawAccount: AccountRaw): Account {
   }
 
   switch (res.currency.family) {
-    case "tron": {
+    case "tron":
       const tronResourcesRaw = (rawAccount as TronAccountRaw).tronResources;
       if (tronResourcesRaw) {
         (res as TronAccount).tronResources =
           fromTronResourcesRaw(tronResourcesRaw);
       }
       break;
-    }
     case "osmosis":
-    case "cosmos": {
+    case "cosmos":
       const cosmosResourcesRaw = (rawAccount as CosmosAccountRaw)
         .cosmosResources;
       if (cosmosResourcesRaw)
         (res as CosmosAccount).cosmosResources =
           fromCosmosResourcesRaw(cosmosResourcesRaw);
       break;
-    }
     case "tezos":
-      {
-        const tezosResourcesRaw = (rawAccount as TezosAccountRaw)
-          .tezosResources;
-        if (tezosResourcesRaw)
-          (res as TezosAccount).tezosResources =
-            fromTezosResourcesRaw(tezosResourcesRaw);
-      }
+      const tezosResourcesRaw = (rawAccount as TezosAccountRaw).tezosResources;
+      if (tezosResourcesRaw)
+        (res as TezosAccount).tezosResources =
+          fromTezosResourcesRaw(tezosResourcesRaw);
       break;
-    case "bitcoin": {
+    case "bitcoin":
       const bitcoinResourcesRaw = (rawAccount as BitcoinAccountRaw)
         .bitcoinResources;
-      (res as BitcoinAccount).bitcoinResources =
-        fromBitcoinResourcesRaw(bitcoinResourcesRaw);
+      if (bitcoinResourcesRaw)
+        (res as BitcoinAccount).bitcoinResources =
+          fromBitcoinResourcesRaw(bitcoinResourcesRaw);
       break;
-    }
-    case "algorand": {
+    case "algorand":
       const algoResourcesRaw = (rawAccount as AlgorandAccountRaw)
         .algorandResources;
       if (algoResourcesRaw)
         (res as AlgorandAccount).algorandResources =
           fromAlgorandResourcesRaw(algoResourcesRaw);
       break;
-    }
     case "polkadot":
-      {
-        const polkadotResourcesRaw = (rawAccount as PolkadotAccountRaw)
-          .polkadotResources;
-
-        if (polkadotResourcesRaw)
-          (res as PolkadotAccount).polkadotResources =
-            fromPolkadotResourcesRaw(polkadotResourcesRaw);
-      }
+      const polkadotResourcesRaw = (rawAccount as PolkadotAccountRaw)
+        .polkadotResources;
+      if (polkadotResourcesRaw)
+        (res as PolkadotAccount).polkadotResources =
+          fromPolkadotResourcesRaw(polkadotResourcesRaw);
       break;
-    case "elrond": {
+    case "elrond":
       const elrondResourcesRaw = (rawAccount as ElrondAccountRaw)
         .elrondResources;
-
       if (elrondResourcesRaw)
         (res as ElrondAccount).elrondResources =
           fromElrondResourcesRaw(elrondResourcesRaw);
       break;
-    }
-    case "cardano": {
+    case "cardano":
       const cardanoResourcesRaw = (rawAccount as CardanoAccountRaw)
         .cardanoResources;
       if (cardanoResourcesRaw)
         (res as CardanoAccount).cardanoResources =
           fromCardanoResourceRaw(cardanoResourcesRaw);
       break;
-    }
-    case "solana": {
+    case "solana":
       const solanaResourcesRaw = (rawAccount as SolanaAccountRaw)
         .solanaResources;
       if (solanaResourcesRaw)
         (res as SolanaAccount).solanaResources =
           fromSolanaResourcesRaw(solanaResourcesRaw);
       break;
-    }
-    case "crypto_org": {
+    case "crypto_org":
       const cryptoOrgResourcesRaw = (rawAccount as CryptoOrgAccountRaw)
         .cryptoOrgResources;
       if (cryptoOrgResourcesRaw)
         (res as CryptoOrgAccount).cryptoOrgResources =
           fromCryptoOrgResourcesRaw(cryptoOrgResourcesRaw);
       break;
-    }
   }
 
   if (swapHistory) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Following recent types rework, a number of safety check had to be put on coin-specific account fields (`xxxResources`), that are no longer guaranteed to exist.
For some unknown reason a safety-check was missing for bitcoin in the fromAccountRaw function, while it was done for all other coins. This PR just adds the safety-check for bitcoin as well.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3519 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
