### PR TITLE
Fixes botTransfer + make CI test cli compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,26 @@ jobs:
       - name: check if diff
         run: git diff --exit-code || exit 1
 
+  test-cli:
+    name: "Test CLI"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: pnpm
+          cache-dependency-path: "**/pnpm-lock.yaml"
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+      - name: build cli
+        run: pnpm build:cli
+      - name: check if diff
+        run: git diff --exit-code || exit 1
+
   test-libraries:
     name: "Test Libraries"
     env:


### PR DESCRIPTION


### 📝 Description

- quick fix that solves the CLI compilation issue due to the drop of getImplicitDeviceAction.
- also make the CI run the build:cli

**Note for future:**

in future we will also make the "botTransfer" more **explicit** by defining on each spec a "transferMutation" that would define how to "cash out" from the bot to another bot, meaning that it would also prioritize the "unfreeze" of assets first before moving out, so it could be pretty handy to tackle next time we need that.

### ❓ Context

- **Impacted projects**: `cli` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
