### PR TITLE
Chore: LLM eslint rule no-unused-vars only from TS

### DIFF
--- a/apps/ledger-live-mobile/.eslintrc.js
+++ b/apps/ledger-live-mobile/.eslintrc.js
@@ -41,15 +41,6 @@ module.exports = {
         allow: ["warn", "error"],
       },
     ],
-    "no-unused-vars": [
-      "error",
-      {
-        argsIgnorePattern: "^_",
-        vars: "all",
-        args: "after-used",
-        ignoreRestSiblings: true,
-      },
-    ],
     "lines-between-class-members": 0,
     "flowtype/space-after-type-colon": 0,
     "no-continue": 0,
@@ -107,6 +98,9 @@ module.exports = {
     "react-native/no-inline-styles": "warn",
     "react/jsx-fragments": "warn",
     "react/no-deprecated": "warn",
+
+    // Enables no-unused-vars only from TypeScript
+    "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error"],
   },
   globals: {

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -38,9 +38,7 @@ export const setAccounts = (accounts: Account[]) => ({
   },
 });
 export type UpdateAccountWithUpdater = (
-  // eslint-disable-next-line no-unused-vars
   accountId: string,
-  // eslint-disable-next-line no-unused-vars
   arg1: (arg0: Account) => Account,
 ) => never;
 

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -7,9 +7,7 @@ import type { State } from "../reducers";
 type Props<Data, Stats> = {
   throttle: number;
   lense: (_: State) => Data;
-  // eslint-disable-next-line no-unused-vars
   getChangesStats: (next: State, prev: State) => Stats;
-  // eslint-disable-next-line no-unused-vars
   save: (data: Data, changedStats: Stats) => Promise<void>;
 };
 export default function useDBSaveEffect<D, S>({

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -108,7 +108,6 @@ const ConnectDeviceExtraContentWrapper = styled(Flex).attrs({
 })``;
 
 type RawProps = {
-  // eslint-disable-next-line no-unused-vars
   t: (key: string, options?: { [key: string]: string | number }) => string;
   colors?: any;
   theme?: "light" | "dark";

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -19,7 +19,6 @@ type Props = {
   request?: any;
   onClose?: () => void;
   onModalHide?: () => void;
-  // eslint-disable-next-line no-unused-vars
   onResult?: (payload: any) => Promise<void> | void;
   renderOnResult?: (_: any) => React.ReactNode;
   onSelectDeviceLink?: () => void;

--- a/apps/ledger-live-mobile/src/components/DeviceJob/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceJob/index.tsx
@@ -76,12 +76,10 @@ class DeviceJob extends Component<
     // as soon as meta is set, the DeviceJob starts
     meta: Device | null | undefined;
     steps: Step[];
-    // eslint-disable-next-line no-unused-vars
     onDone: (arg0: Record<string, any>) => void;
     onCancel: () => void;
     editMode?: boolean;
     deviceModelId: DeviceNames;
-    // eslint-disable-next-line no-unused-vars
     onStepEntered?: (arg0: number, arg1: Record<string, any>) => void;
   },
   {

--- a/apps/ledger-live-mobile/src/components/DeviceJob/types.ts
+++ b/apps/ledger-live-mobile/src/components/DeviceJob/types.ts
@@ -12,9 +12,7 @@ export type Step = {
     onRetry: () => void;
   }>;
   run: (
-    // eslint-disable-next-line no-unused-vars
     meta: Record<string, any>,
-    // eslint-disable-next-line no-unused-vars
     onDoneO: Observable<any>,
   ) => Observable<Record<string, any>>;
 };

--- a/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
@@ -18,7 +18,6 @@ type Props = PropsWithChildren<{}>;
 const getFeature = (
   key: FeatureId,
   appLanguage: string,
-  // eslint-disable-next-line no-unused-vars
   localOverrides?: { [key in FeatureId]?: Feature },
 ) => {
   try {
@@ -56,9 +55,7 @@ const getFeature = (
  */
 export const getAllDivergedFlags = (
   appLanguage: string,
-  // eslint-disable-next-line no-unused-vars
 ): { [key in FeatureId]: boolean } => {
-  // eslint-disable-next-line no-unused-vars
   const res: { [key in FeatureId]: boolean } = {};
   Object.keys(defaultFeatures).forEach(key => {
     const value = getFeature(key, appLanguage);

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdate/index.tsx
@@ -34,7 +34,6 @@ type Props = {
   device: Device;
   deviceInfo: DeviceInfo;
   isOpen: boolean;
-  // eslint-disable-next-line no-unused-vars
   onClose: (restoreApps?: boolean) => void;
   hasAppsToRestore: boolean;
 };

--- a/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
@@ -50,7 +50,6 @@ type Props = FlexBoxProps & {
   style?: any;
   index: number;
   showHint: boolean;
-  // eslint-disable-next-line no-unused-vars
   onAccountNameChange?: (name: string, changedAccount: Account) => void;
   useFullBalance?: boolean;
 };
@@ -129,7 +128,6 @@ type SelectableAccountProps = {
   rowIndex: number;
   listIndex: number;
   navigation: any;
-  // eslint-disable-next-line no-unused-vars
   onAccountNameChange?: (name: string, changedAccount: Account) => void;
   colors: any;
   useFullBalance?: boolean;

--- a/apps/ledger-live-mobile/src/components/SubAccountRow.tsx
+++ b/apps/ledger-live-mobile/src/components/SubAccountRow.tsx
@@ -24,9 +24,7 @@ import Delta from "./Delta";
 type Props = {
   account: SubAccount;
   parentAccount: Account;
-  // eslint-disable-next-line no-unused-vars
   onSubAccountPress: (subAccount: SubAccount) => any;
-  // eslint-disable-next-line no-unused-vars
   onSubAccountLongPress: (tokenAccount: TokenAccount, account: Account) => any;
   useCounterValue?: boolean;
 };

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -22,7 +22,6 @@ export const store = createStore(
 export default class LedgerStoreProvider extends Component<
   {
     onInitFinished: () => void;
-    // eslint-disable-next-line no-unused-vars
     children: (ready: boolean, store: any, initialCountervalues: any) => any;
   },
   {

--- a/apps/ledger-live-mobile/src/families/cosmos/shared/Item.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/shared/Item.tsx
@@ -21,9 +21,7 @@ type Props = {
   value: BigNumber | null | undefined;
   showVal?: boolean;
   onSelect: (
-    // eslint-disable-next-line no-unused-vars
     validator: CosmosValidatorItem,
-    // eslint-disable-next-line no-unused-vars
     value: BigNumber | null | undefined,
   ) => void;
   unit: Unit;

--- a/apps/ledger-live-mobile/src/families/hedera/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Confirmation.tsx
@@ -53,7 +53,6 @@ type RouteParams = {
   modelId: DeviceModelId;
   wired: boolean;
   device?: Device;
-  // eslint-disable-next-line no-unused-vars
   onSuccess?: (address?: string) => void;
   onError?: () => void;
 };

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/ValidatorItem.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/ValidatorItem.tsx
@@ -11,9 +11,7 @@ import Touchable from "../../../components/Touchable";
 type Props = {
   item: PolkadotValidator;
   disabled: boolean;
-  // eslint-disable-next-line no-unused-vars
   onSelect: (item: PolkadotValidator, selected: boolean) => void;
-  // eslint-disable-next-line no-unused-vars
   onClick: (address: string) => void;
   selected: boolean;
 };

--- a/apps/ledger-live-mobile/src/families/polkadot/Nominations/NominationRow.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/Nominations/NominationRow.tsx
@@ -24,7 +24,6 @@ type Props = {
   nomination: PolkadotNomination;
   validator?: PolkadotValidator;
   account: Account;
-  // eslint-disable-next-line no-unused-vars
   onPress: (nomination: PolkadotNomination) => void;
   isLast?: boolean;
 };

--- a/apps/ledger-live-mobile/src/families/polkadot/components/CollapsibleList.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/components/CollapsibleList.tsx
@@ -8,9 +8,7 @@ type Props = {
   children?: React.ReactNode;
   uncollapsedItems: Array<any>;
   collapsedItems: Array<any>;
-  // eslint-disable-next-line no-unused-vars
   renderItem: (item: any, index: number, isLast: boolean) => React.ReactNode;
-  // eslint-disable-next-line no-unused-vars
   renderShowMore: (collapsed: boolean) => React.ReactNode;
 };
 

--- a/apps/ledger-live-mobile/src/families/polkadot/components/NominationInfo.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/components/NominationInfo.tsx
@@ -6,7 +6,6 @@ import LText from "../../../components/LText";
 type Props = {
   address: string;
   identity: string | null | undefined;
-  // eslint-disable-next-line no-unused-vars
   onPress: (address: string) => void;
 };
 export default function NominationInfo({ address, identity, onPress }: Props) {

--- a/apps/ledger-live-mobile/src/families/stellar/StellarFeeRow.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/StellarFeeRow.tsx
@@ -81,7 +81,6 @@ export default function StellarFeeRow({
     label: React.ReactNode;
     isSelected: boolean;
     fee: BigNumber | null;
-    // eslint-disable-next-line no-unused-vars
     onSelect: (isCustom: boolean) => void;
   }) => (
     <TouchableOpacity

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -80,7 +80,6 @@ const BakerRow = ({
   onPress,
   baker,
 }: {
-  // eslint-disable-next-line no-unused-vars
   onPress: (arg0: Baker) => void;
   baker: Baker;
 }) => {

--- a/apps/ledger-live-mobile/src/families/tron/VoteFlow/01-SelectValidator/Item.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/VoteFlow/01-SelectValidator/Item.tsx
@@ -22,7 +22,6 @@ type ItemProp = {
 type Props = {
   item: ItemProp;
   disabled: boolean;
-  // eslint-disable-next-line no-unused-vars
   onSelectSuperRepresentative: (item: ItemProp, selected: boolean) => void;
   selected: boolean;
 };

--- a/apps/ledger-live-mobile/src/families/tron/VoteFlow/02-VoteModal.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/VoteFlow/02-VoteModal.tsx
@@ -21,9 +21,7 @@ type Props = {
   vote: Vote;
   name: string;
   tronPower: number;
-  // eslint-disable-next-line no-unused-vars
   onChange: (vote: Vote) => void;
-  // eslint-disable-next-line no-unused-vars
   onRemove: (vote: Vote) => void;
   onClose: () => void;
   votes: Vote[];

--- a/apps/ledger-live-mobile/src/families/tron/VoteFlow/02-VoteRow.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/VoteFlow/02-VoteRow.tsx
@@ -61,12 +61,9 @@ type VoteRowProps = {
     rank: number;
     validator?: SuperRepresentative;
   };
-  // eslint-disable-next-line no-unused-vars
   onEdit: (vote: Vote, name: string) => void;
-  // eslint-disable-next-line no-unused-vars
   onRemove: (vote: Vote) => void;
   index: number;
-  // eslint-disable-next-line no-unused-vars
   onOpen: (i: number) => void;
   openIndex: number;
 };

--- a/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
+++ b/apps/ledger-live-mobile/src/logic/firmwareUpdate.ts
@@ -2,7 +2,6 @@ import { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceInfo } from "@ledgerhq/types-live";
 import { satisfies as versionSatisfies } from "semver";
 
-// eslint-disable-next-line no-unused-vars
 const deviceVersionRangesForUpdate: { [key in DeviceModelId]?: string } = {
   nanoS: ">=1.6.1",
   nanoX: ">=1.2.4-6",

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -51,9 +51,7 @@ export const useSignWithDevice = ({
   account: AccountLike;
   parentAccount: Account | null | undefined;
   updateAccountWithUpdater: (
-    // eslint-disable-next-line no-unused-vars
     arg0: string,
-    // eslint-disable-next-line no-unused-vars
     arg1: (arg0: Account) => Account,
   ) => void;
 }) => {
@@ -278,7 +276,6 @@ export function useSignedTxHandler({
 export function useSignedTxHandlerWithoutBroadcast({
   onSuccess,
 }: {
-  // eslint-disable-next-line no-unused-vars
   onSuccess: (signedOp: any) => void;
 }) {
   const navigation = useNavigation();

--- a/apps/ledger-live-mobile/src/react-native-hw-transport-ble/makeMock.ts
+++ b/apps/ledger-live-mobile/src/react-native-hw-transport-ble/makeMock.ts
@@ -16,7 +16,6 @@ export type DeviceMock = {
   apduMock: ApduMock;
 };
 type Opts = {
-  // eslint-disable-next-line no-unused-vars
   createTransportDeviceMock: (id: string, name: string) => DeviceMock;
 };
 const defaultOpts = {

--- a/apps/ledger-live-mobile/src/screens/AccountSettings/EditAccountName.tsx
+++ b/apps/ledger-live-mobile/src/screens/AccountSettings/EditAccountName.tsx
@@ -31,7 +31,6 @@ type RouteParams = {
   account: any;
   accountId?: string;
   accountName?: string;
-  // eslint-disable-next-line no-unused-vars
   onAccountNameChange: (name: string, changedAccount: Account) => void;
 };
 

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -35,9 +35,7 @@ type RouteParams = {
   status: TransactionStatus;
   appName?: string;
   selectDeviceLink?: boolean;
-  // eslint-disable-next-line no-unused-vars
   onSuccess?: (payload: any) => void;
-  // eslint-disable-next-line no-unused-vars
   onError?: (error: any) => void;
   analyticsPropertyFlow?: string;
 };

--- a/apps/ledger-live-mobile/src/screens/DebugFeatureFlags.tsx
+++ b/apps/ledger-live-mobile/src/screens/DebugFeatureFlags.tsx
@@ -80,12 +80,10 @@ export default function DebugPlayground() {
     null,
   );
   const [inputValues, setInputValues] = useState<{
-    // eslint-disable-next-line no-unused-vars
     [key in FeatureId]?: string | undefined;
   }>({});
 
   const featureFlags = useMemo(() => {
-    // eslint-disable-next-line no-unused-vars
     const features: { [key in FeatureId]: Feature } = {};
     Object.keys(defaultFeatures).forEach((key: FeatureId) => {
       const value = featureFlagsProvider.getFeature(key);

--- a/apps/ledger-live-mobile/src/screens/DebugHttpTransport.tsx
+++ b/apps/ledger-live-mobile/src/screens/DebugHttpTransport.tsx
@@ -23,7 +23,6 @@ const forceInset = {
 type OwnProps = {};
 type Props = OwnProps & {
   navigation: any;
-  // eslint-disable-next-line no-unused-vars
   addKnownDevice: (arg0: any) => void;
   colors: any;
 };

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -30,7 +30,6 @@ const mapDispatchToProps = {
 type Props = {
   navigation: any;
   route: { params: RouteParams };
-  // eslint-disable-next-line no-unused-vars
   saveBleDeviceName: (d: string, v: string) => void;
 };
 

--- a/apps/ledger-live-mobile/src/screens/Exchange/ProviderList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Exchange/ProviderList.tsx
@@ -45,11 +45,8 @@ const assetMap = {
 type ProviderItemProps = {
   provider: RampLiveAppCatalogEntry;
   onClick: (
-    // eslint-disable-next-line no-unused-vars
     provider: RampLiveAppCatalogEntry,
-    // eslint-disable-next-line no-unused-vars
     icon: string,
-    // eslint-disable-next-line no-unused-vars
     name: string,
   ) => void;
 };

--- a/apps/ledger-live-mobile/src/screens/Exchange/hooks.ts
+++ b/apps/ledger-live-mobile/src/screens/Exchange/hooks.ts
@@ -78,9 +78,7 @@ export type UseCurrencyAccountSelectReturnType = {
   account: (Account | null | undefined) | any;
   subAccount: (SubAccount | null | undefined) | any;
   setAccount: (
-    // eslint-disable-next-line no-unused-vars
     account: Account | null | undefined,
-    // eslint-disable-next-line no-unused-vars
     subAccount: SubAccount | null | undefined,
   ) => void;
   setCurrency: (_: (CryptoCurrency | TokenCurrency) | null | undefined) => void;

--- a/apps/ledger-live-mobile/src/screens/ImportAccounts/DisplayResultItem.tsx
+++ b/apps/ledger-live-mobile/src/screens/ImportAccounts/DisplayResultItem.tsx
@@ -13,7 +13,6 @@ export default class DisplayResultItem extends Component<{
   mode: any;
   checked: boolean;
   importing: boolean;
-  // eslint-disable-next-line no-unused-vars
   onSwitch: (boolean, Account) => void;
 }> {
   onSwitch = () => {

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppStateButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppStateButton.tsx
@@ -18,7 +18,6 @@ type Props = {
   isInstalled: boolean;
   setAppInstallWithDependencies: (_: { app: App; dependencies: App[] }) => void;
   setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
-  // eslint-disable-next-line no-unused-vars
   storageWarning: (appName: string) => void;
 };
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
@@ -38,7 +38,6 @@ type Props = {
   blockNavigation: boolean;
   deviceInfo: any;
   setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
-  // eslint-disable-next-line no-unused-vars
   dispatch: (action: any) => void;
   appList: App[];
 };

--- a/apps/ledger-live-mobile/src/screens/Market/SearchHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Market/SearchHeader.tsx
@@ -6,7 +6,6 @@ import { track } from "../../analytics";
 
 type Props = {
   search?: string;
-  // eslint-disable-next-line no-unused-vars
   refresh: (params: any) => void;
 };
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/OnboardingQuizItem.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/OnboardingQuizItem.tsx
@@ -20,7 +20,6 @@ type Props = {
     image: any;
     answers: Answer[];
   };
-  // eslint-disable-next-line no-unused-vars
   onNext: (correct: boolean) => void;
   setBg: (_: string) => void;
   cta: string;

--- a/apps/ledger-live-mobile/src/screens/Onboarding/shared/infoPagesData.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/shared/infoPagesData.tsx
@@ -527,9 +527,7 @@ const pinCodeScenes = (deviceModelId, theme: "dark" | "light") => [
 ];
 
 const getSetupDeviceScenes: (
-  // eslint-disable-next-line no-unused-vars
   deviceModelId: "nanoS" | "nanoSP" | "nanoX" | "blue" | "nanoFTS",
-  // eslint-disable-next-line no-unused-vars
   theme: "dark" | "light",
 ) => OnboardingScene[] = (deviceModelId, theme) => [
   {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/types.ts
@@ -37,6 +37,5 @@ export type OnboardingContextProviderProps = {
 };
 type OnboardingMode = "full" | "alreadyInitialized" | "restore" | "qr";
 export type DeviceNames = "nanoS" | "nanoX" | "blue";
-// eslint-disable-next-line no-unused-vars
 type StepNavigateType = (arg0: any, arg1: any) => void;
 type Noop = (_: any) => any;

--- a/apps/ledger-live-mobile/src/screens/PairDevices/Scanning.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/Scanning.tsx
@@ -15,7 +15,6 @@ import DeviceItem from "../../components/SelectDevice/DeviceItem";
 import ScanningHeader from "./ScanningHeader";
 
 type Props = {
-  // eslint-disable-next-line no-unused-vars
   onSelect: (device: Device, deviceMeta: any) => Promise<void>;
   onError: (_: Error) => void;
   onTimeout: () => void;

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
@@ -57,7 +57,6 @@ type RouteParams = {
   device?: Device;
   currency?: Currency;
   createTokenAccount?: boolean;
-  // eslint-disable-next-line no-unused-vars
   onSuccess?: (address?: string) => void;
   onError?: () => void;
 };

--- a/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
@@ -40,7 +40,6 @@ type RouteParams = {
   currencies: string[];
   currency: CryptoCurrency | TokenCurrency;
   allowAddAccount?: boolean;
-  // eslint-disable-next-line no-unused-vars
   onSuccess: (account: AccountLike, parentAccount: Account) => void;
   onError: (_: Error) => void;
 };
@@ -52,7 +51,6 @@ const Item = ({
   onSelect,
 }: {
   item: SearchResult;
-  // eslint-disable-next-line no-unused-vars
   onSelect: (account: AccountLike, parentAccount: Account) => void;
 }) => {
   const { account, parentAccount, match } = result;

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureInteger.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureInteger.tsx
@@ -11,7 +11,6 @@ import getFontStyle from "../../../components/LText/getFontStyle";
 type Props = {
   name: any;
   readOnly: boolean;
-  // eslint-disable-next-line no-unused-vars
   onChange: (name: string, val: any) => boolean;
   value: number;
   minValue: number;

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureSwitch.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureSwitch.tsx
@@ -9,7 +9,6 @@ type Props = {
   valueOff: any;
   checked?: boolean;
   readOnly?: boolean;
-  // eslint-disable-next-line no-unused-vars
   onChange: (name: string, val: any) => boolean;
 };
 

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -33,7 +33,6 @@ type RouteParams = {
   transaction: Transaction;
   status: TransactionStatus;
   appName?: string;
-  // eslint-disable-next-line no-unused-vars
   onSuccess: (payload: any) => void;
   onError: (_: Error) => void;
 };

--- a/apps/ledger-live-mobile/src/screens/SkipSelectDevice.ts
+++ b/apps/ledger-live-mobile/src/screens/SkipSelectDevice.ts
@@ -6,7 +6,6 @@ import { lastConnectedDeviceSelector } from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
 
 type Props = {
-  // eslint-disable-next-line no-unused-vars
   onResult: (device: any) => void;
   route?: {
     params: any;

--- a/apps/ledger-live-mobile/src/screens/Swap/FormSelection/AccountAmountRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/FormSelection/AccountAmountRow.tsx
@@ -29,11 +29,8 @@ type Props = {
     params: SwapRouteParams;
   };
   swap: SwapDataType;
-  // eslint-disable-next-line no-unused-vars
   setFromAccount: (account?: Account | TokenAccount) => void;
-  // eslint-disable-next-line no-unused-vars
   setFromAmount: (amount: BigNumber) => void;
-  // eslint-disable-next-line no-unused-vars
   setToCurrency: (currency?: TokenCurrency | CryptoCurrency) => void;
   useAllAmount: boolean;
   transaction: SwapTransaction;

--- a/apps/ledger-live-mobile/src/screens/Swap/FormSelection/AccountSelect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/FormSelection/AccountSelect.tsx
@@ -22,7 +22,6 @@ type Props = {
     params: SwapRouteParams;
   };
   swap: SwapDataType;
-  // eslint-disable-next-line no-unused-vars
   setFromAccount: (account?: Account | TokenAccount) => void;
   providers: any;
   provider: any;

--- a/apps/ledger-live-mobile/src/screens/Swap/FormSelection/CurrencyTargetSelect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/FormSelection/CurrencyTargetSelect.tsx
@@ -20,7 +20,6 @@ type Props = {
     params: SwapRouteParams;
   };
   swap: SwapDataType;
-  // eslint-disable-next-line no-unused-vars
   setToCurrency: (currency?: TokenCurrency | CryptoCurrency) => void;
   providers: any;
   provider: any;

--- a/apps/ledger-live-mobile/src/screens/Swap/FormSelection/RatesSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/FormSelection/RatesSection.tsx
@@ -49,11 +49,8 @@ type Props = {
   status: any;
   rate: ExchangeRate;
   setToAccount: (
-    // eslint-disable-next-line no-unused-vars
     currency: TokenCurrency | CryptoCurrency,
-    // eslint-disable-next-line no-unused-vars
     account: Account | TokenAccount,
-    // eslint-disable-next-line no-unused-vars
     parentAccount?: Account | TokenAccount,
   ) => void;
   providers: any;

--- a/apps/ledger-live-mobile/src/screens/Swap/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/index.tsx
@@ -62,9 +62,7 @@ export type SwapRouteParams = {
   rate?: ExchangeRate;
   rates?: ExchangeRate[];
   tradeMethod?: string;
-  // eslint-disable-next-line no-unused-vars
   setAccount?: (account?: Account | TokenAccount) => void;
-  // eslint-disable-next-line no-unused-vars
   setCurrency?: (currency?: TokenCurrency | CryptoCurrency) => void;
 };
 export const ratesExpirationThreshold = 60000;

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/VerifyAddress.ts
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/VerifyAddress.ts
@@ -14,7 +14,6 @@ function VerifyAddress({
 }: {
   account: Account;
   device: Device | null | undefined;
-  // eslint-disable-next-line no-unused-vars
   onResult: (confirmed: boolean, error?: Error) => void;
 }) {
   const { theme } = useTheme();

--- a/apps/ledger-live-mobile/src/screens/makeGenericSelectScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/makeGenericSelectScreen.tsx
@@ -6,7 +6,6 @@ import SettingsRow from "../components/SettingsRow";
 
 type EntryProps<Item> = {
   item: Item;
-  // eslint-disable-next-line no-unused-vars
   onPress: (value: Item) => void;
   selected: boolean;
 };
@@ -62,7 +61,6 @@ export default function makeGenericSelectScreen<Item>(opts: Opts<Item>) {
   return class GenericSelectScreen extends Component<{
     selectedKey?: string;
     items: Item[];
-    // eslint-disable-next-line no-unused-vars
     onValueChange: (items: Item, props: any) => void;
     navigation: any;
     cancelNavigateBack?: boolean;

--- a/apps/ledger-live-mobile/src/snoopy.ts
+++ b/apps/ledger-live-mobile/src/snoopy.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable no-unused-vars */
 // The code here is only enabled in development and allows to investigate performance
 // https://github.com/jondot/rn-snoopy
 // core Snoopy

--- a/apps/ledger-live-mobile/src/types/common.ts
+++ b/apps/ledger-live-mobile/src/types/common.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 // TODO should drop this file!,
 // FIXME then drop it, i'm not here for that.
 export type T = (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

On LLM, only using the eslint rule `no-unused-vars` from TypeScript

Also cleaned all unnecessary all unused "eslint-disable no-unused-vars" 

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
