### PR TITLE
FAT-356 Update onboarding states according to the new firmware definitions

### DIFF
--- a/.changeset/shy-feet-appear.md
+++ b/.changeset/shy-feet-appear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Update the onboarding states according to the new firmware definitons

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
@@ -44,23 +44,40 @@ describe("@hw/extractOnboardingState", () => {
       });
 
       describe("and the user is on the welcome screen", () => {
-        beforeEach(() => {
-          flagsBytes[3] = 0;
-        });
-
         it("should return an onboarding step that is set at the welcome screen", () => {
-          const onboardingState = extractOnboardingState(flagsBytes);
-
+          flagsBytes[3] = 0;
+          let onboardingState = extractOnboardingState(flagsBytes);
           expect(onboardingState).not.toBeNull();
           expect(onboardingState?.currentOnboardingStep).toBe(
-            OnboardingStep.WelcomeScreen
+            OnboardingStep.WelcomeScreen1
+          );
+
+          flagsBytes[3] = 1;
+          onboardingState = extractOnboardingState(flagsBytes);
+          expect(onboardingState).not.toBeNull();
+          expect(onboardingState?.currentOnboardingStep).toBe(
+            OnboardingStep.WelcomeScreen2
+          );
+
+          flagsBytes[3] = 2;
+          onboardingState = extractOnboardingState(flagsBytes);
+          expect(onboardingState).not.toBeNull();
+          expect(onboardingState?.currentOnboardingStep).toBe(
+            OnboardingStep.WelcomeScreen3
+          );
+
+          flagsBytes[3] = 3;
+          onboardingState = extractOnboardingState(flagsBytes);
+          expect(onboardingState).not.toBeNull();
+          expect(onboardingState?.currentOnboardingStep).toBe(
+            OnboardingStep.WelcomeScreen4
           );
         });
       });
 
       describe("and the user is choosing what kind of setup they want", () => {
         beforeEach(() => {
-          flagsBytes[3] = 1;
+          flagsBytes[3] = 5;
         });
 
         it("should return an onboarding step that is set at the setup choice", () => {
@@ -75,7 +92,7 @@ describe("@hw/extractOnboardingState", () => {
 
       describe("and the user is setting their pin", () => {
         beforeEach(() => {
-          flagsBytes[3] = 2;
+          flagsBytes[3] = 6;
         });
 
         it("should return an onboarding step that is set at setting the pin", () => {
@@ -104,7 +121,7 @@ describe("@hw/extractOnboardingState", () => {
 
           describe("and the user is writing the seed word i", () => {
             beforeEach(() => {
-              flagsBytes[3] = 3;
+              flagsBytes[3] = 7;
             });
 
             it("should return an onboarding step that is set at writting the seed phrase", () => {
@@ -131,7 +148,7 @@ describe("@hw/extractOnboardingState", () => {
 
           describe("and the user is confirming the seed word i", () => {
             beforeEach(() => {
-              flagsBytes[3] = 4;
+              flagsBytes[3] = 8;
             });
 
             it("should return an onboarding step that is set at confirming the seed phrase", () => {
@@ -190,7 +207,7 @@ describe("@hw/extractOnboardingState", () => {
               // 24-words seed
               flagsBytes[2] |= 0 << 5;
 
-              flagsBytes[3] = 5;
+              flagsBytes[3] = 9;
             });
 
             it("should return an onboarding step that is set at confirming the restored seed phrase", () => {
@@ -219,7 +236,7 @@ describe("@hw/extractOnboardingState", () => {
 
       describe("and the user is on the safety warning screen", () => {
         beforeEach(() => {
-          flagsBytes[3] = 6;
+          flagsBytes[3] = 10;
         });
 
         it("should return an onboarding step that is set at the safety warning screen", () => {
@@ -234,7 +251,7 @@ describe("@hw/extractOnboardingState", () => {
 
       describe("and the user finished the onboarding process", () => {
         beforeEach(() => {
-          flagsBytes[3] = 7;
+          flagsBytes[3] = 11;
         });
 
         it("should return an onboarding step that is set at ready", () => {

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.ts
@@ -16,7 +16,11 @@ const fromBitsToSeedPhraseType = new Map<number, SeedPhraseType>([
 ]);
 
 export enum OnboardingStep {
-  WelcomeScreen = "WELCOME_SCREEN",
+  WelcomeScreen1 = "WELCOME_SCREEN_1",
+  WelcomeScreen2 = "WELCOME_SCREEN_2",
+  WelcomeScreen3 = "WELCOME_SCREEN_3",
+  WelcomeScreen4 = "WELCOME_SCREEN_4",
+  WelcomeScreenReminder = "WELCOME_SCREEN_REMINDER",
   SetupChoice = "SETUP_CHOICE",
   Pin = "PIN",
   NewDevice = "NEW_DEVICE", // path "new device" & currentSeedWordIndex available
@@ -27,14 +31,18 @@ export enum OnboardingStep {
 }
 
 const fromBitsToOnboardingStep = new Map<number, OnboardingStep>([
-  [0, OnboardingStep.WelcomeScreen],
-  [1, OnboardingStep.SetupChoice],
-  [2, OnboardingStep.Pin],
-  [3, OnboardingStep.NewDevice],
-  [4, OnboardingStep.NewDeviceConfirming],
-  [5, OnboardingStep.RestoreSeed],
-  [6, OnboardingStep.SafetyWarning],
-  [7, OnboardingStep.Ready],
+  [0, OnboardingStep.WelcomeScreen1],
+  [1, OnboardingStep.WelcomeScreen2],
+  [2, OnboardingStep.WelcomeScreen3],
+  [3, OnboardingStep.WelcomeScreen4],
+  [4, OnboardingStep.WelcomeScreenReminder],
+  [5, OnboardingStep.SetupChoice],
+  [6, OnboardingStep.Pin],
+  [7, OnboardingStep.NewDevice],
+  [8, OnboardingStep.NewDeviceConfirming],
+  [9, OnboardingStep.RestoreSeed],
+  [10, OnboardingStep.SafetyWarning],
+  [11, OnboardingStep.Ready],
 ]);
 
 export type OnboardingState = {


### PR DESCRIPTION
### 📝 Description
Recently, new onboarding states were added to the firmware. This PR updates the definition of the states and the associated tests for those. It was tested using a 2.1.0-lo5 firmware on a Nano X using the CLI, since it's not yet used in Live itself.

### ❓ Context

- **Impacted projects**: `ledger-live-common`
- **Linked resource(s)**: [FAT-356]

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** 
Technically, these are breaking changes on the LLC lib. But since this is not yet used anywhere in LIVE. It doesn't break anything.

### 📸 Demo
N/A

[FAT-356]: https://ledgerhq.atlassian.net/browse/FAT-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ