### PR TITLE
Switch Ethereum Goerli explorer env from staging to prod

### DIFF
--- a/.changeset/three-panthers-peel.md
+++ b/.changeset/three-panthers-peel.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Switch Ethereum Goerli explorer env from staging to prod

--- a/libs/ledger-live-common/src/api/explorerConfig/index.ts
+++ b/libs/ledger-live-common/src/api/explorerConfig/index.ts
@@ -192,7 +192,7 @@ const initialExplorerConfig: FullConfig = {
   ethereum_goerli: {
     id: "eth_goerli",
     stable: {
-      base: "EXPLORER_STAGING",
+      base: "EXPLORER",
       version: "v3",
     },
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When Ethereum Goerli testnet support was added to Live, prod explorer env was not available yet.
Backend team confirms Goerli is now available on prod env, so this PR makes the switch.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: N/A <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
