### PR TITLE
LIVE-3570: Switch to swap backend API v4

### DIFF
--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -500,7 +500,7 @@ const envDefinitions = {
     desc: "dev flag to skip onboarding flow",
   },
   SWAP_API_BASE: {
-    def: "https://swap.ledger.com/v3",
+    def: "https://swap.ledger.com/v4",
     parser: stringParser,
     desc: "Swap API base",
   },

--- a/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
@@ -13,7 +13,12 @@ import {
 } from "../../errors";
 import network from "../../network";
 import type { Transaction } from "../../generated/types";
-import { getAvailableProviders, getSwapAPIBaseURL, getSwapAPIError } from "./";
+import {
+  getAvailableProviders,
+  getSwapAPIBaseURL,
+  getSwapAPIError,
+  getSwapAPIVersion,
+} from "./";
 import { mockGetExchangeRates } from "./mock";
 import type { CustomMinOrMaxError, Exchange, GetExchangeRates } from "./types";
 
@@ -26,8 +31,7 @@ const getExchangeRates: GetExchangeRates = async (
   if (getEnv("MOCK"))
     return mockGetExchangeRates(exchange, transaction, currencyTo);
 
-  // Rely on the api base to determine the version logic
-  const usesV3 = getSwapAPIBaseURL().endsWith("v3");
+  const usesV3 = getSwapAPIVersion() >= 3;
   const from = getAccountCurrency(exchange.fromAccount).id;
   const unitFrom = getAccountUnit(exchange.fromAccount);
   const unitTo =

--- a/libs/ledger-live-common/src/exchange/swap/getProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getProviders.ts
@@ -2,29 +2,52 @@ import qs from "qs";
 import { getEnv } from "../../env";
 import { SwapNoAvailableProviders } from "../../errors";
 import network from "../../network";
-import { getAvailableProviders, getSwapAPIBaseURL } from "./";
+import {
+  getAvailableProviders,
+  getSwapAPIBaseURL,
+  getSwapAPIVersion,
+} from "./";
 import { mockGetProviders } from "./mock";
-import type { GetProviders } from "./types";
+import type { GetProviders, ProvidersResponseV4 } from "./types";
 
 const getProviders: GetProviders = async () => {
   if (getEnv("MOCK")) return mockGetProviders();
 
-  // Rely on the api base to determine the version logic
-  const usesV3 = getSwapAPIBaseURL().endsWith("v3");
+  const version = getSwapAPIVersion();
 
   const res = await network({
     method: "GET",
     url: `${getSwapAPIBaseURL()}/providers`,
-    params: usesV3 ? { whitelist: getAvailableProviders() } : undefined,
+    params: version >= 3 ? { whitelist: getAvailableProviders() } : undefined,
     paramsSerializer: (params) =>
       qs.stringify(params, { arrayFormat: "comma" }),
   });
 
-  if (!res.data.length) {
-    throw new SwapNoAvailableProviders();
+  if (version < 4) {
+    if (!res.data.length) {
+      throw new SwapNoAvailableProviders();
+    }
+    return res.data;
   }
 
-  return res.data;
+  const responseV4 = res.data as ProvidersResponseV4;
+  if (responseV4.providers.size == 0) {
+    throw new SwapNoAvailableProviders();
+  }
+  return Object.entries(responseV4.providers).flatMap(([provider, groups]) => ({
+    provider: provider,
+    pairs: groups.flatMap((group) =>
+      group.methods.flatMap((tradeMethod) =>
+        Object.entries(group.pairs).flatMap(([from, toArray]) =>
+          (toArray as number[]).map((to) => ({
+            from: responseV4.currencies[from],
+            to: responseV4.currencies[to.toString()],
+            tradeMethod,
+          }))
+        )
+      )
+    ),
+  }));
 };
 
 export default getProviders;

--- a/libs/ledger-live-common/src/exchange/swap/index.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.ts
@@ -11,6 +11,7 @@ import {
   JSONRPCResponseError,
   NoIPHeaderError,
   NotImplementedError,
+  SwapGenericAPIError,
   TradeMethodNotSupportedError,
   UnexpectedError,
   ValidationError,
@@ -35,6 +36,19 @@ export const isSwapOperationPending: (status: string) => boolean = (status) =>
   !operationStatusList.finishedKO.includes(status);
 
 const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");
+
+const SWAP_API_BASE_PATTERN = /.*\/v(?<version>\d+)\/*$/;
+const getSwapAPIVersion: () => number = () => {
+  const version = Number(
+    getSwapAPIBaseURL().match(SWAP_API_BASE_PATTERN)?.groups?.version
+  );
+  if (version == null || isNaN(version)) {
+    throw new SwapGenericAPIError(
+      "Configured swap API base URL is invalid, should end with /v<number>"
+    );
+  }
+  return version;
+};
 
 const ftx = {
   nameAndPubkey: Buffer.concat([
@@ -179,6 +193,7 @@ export const getSwapAPIError = (errorCode: number, errorMessage?: string) => {
 
 export {
   getSwapAPIBaseURL,
+  getSwapAPIVersion,
   getProviderConfig,
   getProviders,
   getExchangeRates,

--- a/libs/ledger-live-common/src/exchange/swap/mock.ts
+++ b/libs/ledger-live-common/src/exchange/swap/mock.ts
@@ -7,7 +7,7 @@ import {
   SwapExchangeRateAmountTooHigh,
   SwapExchangeRateAmountTooLow,
 } from "../../errors";
-import { getSwapAPIBaseURL } from "./";
+import { getSwapAPIVersion } from "./";
 import type {
   CheckQuote,
   Exchange,
@@ -129,7 +129,7 @@ export const mockInitSwap = (
 export const mockGetProviders: GetProviders = async () => {
   //Fake delay to show loading UI
   await new Promise((r) => setTimeout(r, 800));
-  const usesV3 = getSwapAPIBaseURL().endsWith("v3");
+  const usesV3 = getSwapAPIVersion() >= 3;
 
   return usesV3
     ? [

--- a/libs/ledger-live-common/src/exchange/swap/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/types.ts
@@ -82,6 +82,14 @@ export type AvailableProviderV3 = {
   provider: string;
   pairs: Array<{ from: string; to: string; tradeMethod: string }>;
 };
+export type TradeMethodGroup = {
+  methods: TradeMethod[];
+  pairs: Map<string, number[]>;
+};
+export type ProvidersResponseV4 = {
+  currencies: Map<string, string>;
+  providers: Map<string, TradeMethodGroup[]>;
+};
 
 type CheckQuoteOkStatus = {
   codeName: "RATE_VALID";


### PR DESCRIPTION
### 📝 Description

This switches to swap backend API v4, which drastically reduces size of `/providers` endpoint response.

Note: this PR only converts response back to v3 flattened format of pairs, deeper changes are required to get full benefit of it:

- for swap pane, the response can be intersected with list of accounts instead of full decoding
- for swap button in market/portfolio pages, only a few lookups are sufficient instead of full decoding

### ❓ Context

- **Impacted projects**: swap, market page, portfolio, account pages
- **Linked resource(s)**: ``
   - https://ledgerhq.atlassian.net/browse/LIVE-3570
   - https://ledgerhq.atlassian.net/browse/BACK-3654
   - https://ledgerhq.atlassian.net/wiki/spaces/BE/pages/3753050176

### ✅ Checklist

- [ ] **Test coverage** only existing tests :warning: 
- [x] **Atomic delivery** 
- [ ] **No breaking changes** 

### 📸 Demo
[live-api-v4.webm](https://user-images.githubusercontent.com/102984500/187739589-0fcd4f9a-2468-4e45-bd48-18ee03770147.webm)
