### PR TITLE
LIVE-3570: Switch to swap backend API v4

### DIFF
--- a/.changeset/small-eggs-sip.md
+++ b/.changeset/small-eggs-sip.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Switch to swap backend API v4

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -500,7 +500,7 @@ const envDefinitions = {
     desc: "dev flag to skip onboarding flow",
   },
   SWAP_API_BASE: {
-    def: "https://swap.ledger.com/v3",
+    def: "https://swap.ledger.com/v4",
     parser: stringParser,
     desc: "Swap API base",
   },

--- a/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
@@ -13,7 +13,12 @@ import {
 } from "../../errors";
 import network from "../../network";
 import type { Transaction } from "../../generated/types";
-import { getAvailableProviders, getSwapAPIBaseURL, getSwapAPIError } from "./";
+import {
+  getAvailableProviders,
+  getSwapAPIBaseURL,
+  getSwapAPIError,
+  getSwapAPIVersion,
+} from "./";
 import { mockGetExchangeRates } from "./mock";
 import type { CustomMinOrMaxError, Exchange, GetExchangeRates } from "./types";
 
@@ -26,8 +31,7 @@ const getExchangeRates: GetExchangeRates = async (
   if (getEnv("MOCK"))
     return mockGetExchangeRates(exchange, transaction, currencyTo);
 
-  // Rely on the api base to determine the version logic
-  const usesV3 = getSwapAPIBaseURL().endsWith("v3");
+  const usesV3 = getSwapAPIVersion() >= 3;
   const from = getAccountCurrency(exchange.fromAccount).id;
   const unitFrom = getAccountUnit(exchange.fromAccount);
   const unitTo =

--- a/libs/ledger-live-common/src/exchange/swap/getProviders.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getProviders.test.ts
@@ -1,0 +1,450 @@
+import axios from "axios";
+import getProviders from "./getProviders";
+import { getEnv, setEnv } from "../../env";
+
+const EXPECTED_RESULT_V4 = [
+  {
+    provider: "changelly",
+    pairs: [
+      {
+        from: "bitcoin",
+        to: "ethereum",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "ethereum",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "zcash",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "zcash",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum_classic",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum_classic",
+        to: "ethereum",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "ethereum",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "bitcoin",
+        to: "zcash",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "bitcoin",
+        to: "ethereum_classic",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum",
+        to: "bitcoin",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum",
+        to: "zcash",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum",
+        to: "ethereum_classic",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "zcash",
+        to: "bitcoin",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "zcash",
+        to: "ethereum_classic",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum_classic",
+        to: "bitcoin",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum_classic",
+        to: "ethereum",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "zcash",
+        to: "bitcoin",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "zcash",
+        to: "ethereum_classic",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum_classic",
+        to: "bitcoin",
+        tradeMethod: "fixed",
+      },
+      {
+        from: "ethereum_classic",
+        to: "ethereum",
+        tradeMethod: "fixed",
+      },
+    ],
+  },
+  {
+    provider: "ftx",
+    pairs: [
+      {
+        from: "bitcoin",
+        to: "ethereum",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+      {
+        from: "bitcoin",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "zcash",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "zcash",
+        to: "ethereum",
+        tradeMethod: "float",
+      },
+      {
+        from: "zcash",
+        to: "ethereum_classic",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum_classic",
+        to: "bitcoin",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum_classic",
+        to: "ethereum",
+        tradeMethod: "float",
+      },
+      {
+        from: "ethereum_classic",
+        to: "zcash",
+        tradeMethod: "float",
+      },
+    ],
+  },
+];
+
+jest.mock("axios");
+const mockedAxios = jest.mocked(axios);
+
+describe("swap/getProviders", () => {
+  const DEFAULT_SWAP_API_BASE = getEnv("SWAP_API_BASE");
+
+  afterAll(() => {
+    // Restore DEFAULT_SWAP_API_BASE
+    setEnv("SWAP_API_BASE", DEFAULT_SWAP_API_BASE);
+  });
+
+  describe("version 2", () => {
+    const data = [
+      {
+        provider: "changelly",
+        pairs: [
+          {
+            from: "bitcoin",
+            to: "ethereum",
+            tradeMethod: ["float", "fixed"],
+          },
+          {
+            from: "bitcoin",
+            to: "ethereum_classic",
+            tradeMethod: ["float", "fixed"],
+          },
+        ],
+      },
+    ];
+    const resp = {
+      data,
+      status: 200,
+      statusText: "",
+      headers: {},
+      config: {},
+    };
+
+    beforeAll(() => {
+      // set SWAP_API_BASE
+      setEnv("SWAP_API_BASE", "https://swap.ledger.com/v2");
+    });
+
+    beforeEach(() => {
+      mockedAxios.mockResolvedValue(Promise.resolve(resp));
+    });
+
+    afterEach(() => {
+      mockedAxios.mockClear();
+    });
+
+    test("should not be called with whitelist", async () => {
+      await getProviders();
+
+      expect(mockedAxios).toBeCalledWith(
+        expect.objectContaining({
+          params: undefined,
+        })
+      );
+    });
+  });
+
+  describe("version 3", () => {
+    const data = [
+      {
+        provider: "changelly",
+        pairs: [
+          {
+            from: "bitcoin",
+            to: "ethereum",
+            tradeMethod: ["float", "fixed"],
+          },
+          {
+            from: "bitcoin",
+            to: "ethereum_classic",
+            tradeMethod: ["float", "fixed"],
+          },
+        ],
+      },
+    ];
+    const resp = {
+      data,
+      status: 200,
+      statusText: "",
+      headers: {},
+      config: {},
+    };
+
+    beforeAll(() => {
+      // set SWAP_API_BASE
+      setEnv("SWAP_API_BASE", "https://swap.ledger.com/v3");
+    });
+
+    beforeEach(() => {
+      mockedAxios.mockResolvedValue(Promise.resolve(resp));
+    });
+
+    afterEach(() => {
+      mockedAxios.mockClear();
+    });
+
+    test("should be called with whitelist", async () => {
+      await getProviders();
+
+      expect(mockedAxios).toBeCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            whitelist: expect.any(Array),
+          }),
+        })
+      );
+    });
+
+    test("should throw error if no data", async () => {
+      const emptyResp = { ...resp, data: [] };
+
+      mockedAxios.mockResolvedValue(Promise.resolve(emptyResp));
+
+      await expect(getProviders).rejects.toThrow("SwapNoAvailableProviders");
+    });
+
+    test("should return list of providers with pairs", async () => {
+      const res = await getProviders();
+
+      expect(res).toEqual(data);
+    });
+  });
+
+  describe("version 4", () => {
+    const data = {
+      currencies: {
+        "1": "bitcoin",
+        "2": "ethereum",
+        "3": "zcash",
+        "4": "ethereum_classic",
+      },
+      providers: {
+        changelly: [
+          {
+            methods: ["float"],
+            pairs: {
+              "1": [2, 3, 4],
+              "2": [1, 3, 4],
+            },
+          },
+          {
+            methods: ["float", "fixed"],
+            pairs: {
+              "1": [2, 3, 4],
+              "2": [1, 3, 4],
+              "3": [1, 4],
+              "4": [1, 2],
+            },
+          },
+          {
+            methods: ["fixed"],
+            pairs: {
+              "3": [1, 4],
+              "4": [1, 2],
+            },
+          },
+        ],
+        ftx: [
+          {
+            methods: ["float"],
+            pairs: {
+              "1": [2, 3, 4],
+              "2": [1, 3, 4],
+              "3": [1, 2, 4],
+              "4": [1, 2, 3],
+            },
+          },
+        ],
+      },
+    };
+
+    const resp = {
+      data,
+      status: 200,
+      statusText: "",
+      headers: {},
+      config: {},
+    };
+
+    beforeAll(() => {
+      // set SWAP_API_BASE
+      setEnv("SWAP_API_BASE", "https://swap.ledger.com/v4");
+    });
+
+    beforeEach(() => {
+      mockedAxios.mockResolvedValue(Promise.resolve(resp));
+    });
+
+    afterEach(() => {
+      mockedAxios.mockClear();
+    });
+
+    test("should be called with whitelist", async () => {
+      await getProviders();
+
+      expect(mockedAxios).toBeCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            whitelist: expect.any(Array),
+          }),
+        })
+      );
+    });
+
+    test("should throw error if no providers", async () => {
+      const emptyResp = { ...resp, data: { ...data, providers: {} } };
+
+      mockedAxios.mockResolvedValue(Promise.resolve(emptyResp));
+
+      await expect(getProviders).rejects.toThrow("SwapNoAvailableProviders");
+    });
+
+    test("should return list of providers with pairs", async () => {
+      const res = await getProviders();
+
+      expect(res).toEqual(EXPECTED_RESULT_V4);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/exchange/swap/getProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getProviders.ts
@@ -2,29 +2,52 @@ import qs from "qs";
 import { getEnv } from "../../env";
 import { SwapNoAvailableProviders } from "../../errors";
 import network from "../../network";
-import { getAvailableProviders, getSwapAPIBaseURL } from "./";
+import {
+  getAvailableProviders,
+  getSwapAPIBaseURL,
+  getSwapAPIVersion,
+} from "./";
 import { mockGetProviders } from "./mock";
-import type { GetProviders } from "./types";
+import type { GetProviders, ProvidersResponseV4 } from "./types";
 
 const getProviders: GetProviders = async () => {
   if (getEnv("MOCK")) return mockGetProviders();
 
-  // Rely on the api base to determine the version logic
-  const usesV3 = getSwapAPIBaseURL().endsWith("v3");
+  const version = getSwapAPIVersion();
 
   const res = await network({
     method: "GET",
     url: `${getSwapAPIBaseURL()}/providers`,
-    params: usesV3 ? { whitelist: getAvailableProviders() } : undefined,
+    params: version >= 3 ? { whitelist: getAvailableProviders() } : undefined,
     paramsSerializer: (params) =>
       qs.stringify(params, { arrayFormat: "comma" }),
   });
 
-  if (!res.data.length) {
-    throw new SwapNoAvailableProviders();
+  if (version < 4) {
+    if (!res.data.length) {
+      throw new SwapNoAvailableProviders();
+    }
+    return res.data;
   }
 
-  return res.data;
+  const responseV4 = res.data as ProvidersResponseV4;
+  if (responseV4.providers.size == 0) {
+    throw new SwapNoAvailableProviders();
+  }
+  return Object.entries(responseV4.providers).flatMap(([provider, groups]) => ({
+    provider: provider,
+    pairs: groups.flatMap((group) =>
+      group.methods.flatMap((tradeMethod) =>
+        Object.entries(group.pairs).flatMap(([from, toArray]) =>
+          (toArray as number[]).map((to) => ({
+            from: responseV4.currencies[from],
+            to: responseV4.currencies[to.toString()],
+            tradeMethod,
+          }))
+        )
+      )
+    ),
+  }));
 };
 
 export default getProviders;

--- a/libs/ledger-live-common/src/exchange/swap/getProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getProviders.ts
@@ -31,7 +31,7 @@ const getProviders: GetProviders = async () => {
   }
 
   const responseV4 = res.data as ProvidersResponseV4;
-  if (responseV4.providers.size == 0) {
+  if (!responseV4.providers || !Object.keys(responseV4.providers).length) {
     throw new SwapNoAvailableProviders();
   }
   return Object.entries(responseV4.providers).flatMap(([provider, groups]) => ({

--- a/libs/ledger-live-common/src/exchange/swap/index.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.test.ts
@@ -1,4 +1,6 @@
-import { isSwapOperationPending } from ".";
+import { isSwapOperationPending, getSwapAPIVersion } from ".";
+
+import { getEnv, setEnv } from "../../env";
 
 describe("swap/index", () => {
   describe("isSwapOperationPending", () => {
@@ -31,6 +33,39 @@ describe("swap/index", () => {
       const result = isSwapOperationPending();
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe("getSwapAPIVersion", () => {
+    const DEFAULT_SWAP_API_BASE = getEnv("SWAP_API_BASE");
+
+    afterEach(() => {
+      // Restore DEFAULT_SWAP_API_BASE
+      setEnv("SWAP_API_BASE", DEFAULT_SWAP_API_BASE);
+    });
+
+    test("should return version when SWAP_API_BASE contains one", () => {
+      const result = getSwapAPIVersion();
+
+      expect(result).toBe(4);
+    });
+
+    test("should throw an error if no version in SWAP_API_BASE", () => {
+      setEnv("SWAP_API_BASE", "https://swap.ledger.com");
+
+      expect(getSwapAPIVersion).toThrow(Error);
+      expect(getSwapAPIVersion).toThrow(
+        "Configured swap API base URL is invalid, should end with /v<number>"
+      );
+    });
+
+    test("should throw an error if version is NaN", () => {
+      setEnv("SWAP_API_BASE", "https://swap.ledger.com/vtest");
+
+      expect(getSwapAPIVersion).toThrow(Error);
+      expect(getSwapAPIVersion).toThrow(
+        "Configured swap API base URL is invalid, should end with /v<number>"
+      );
     });
   });
 });

--- a/libs/ledger-live-common/src/exchange/swap/index.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.ts
@@ -11,6 +11,7 @@ import {
   JSONRPCResponseError,
   NoIPHeaderError,
   NotImplementedError,
+  SwapGenericAPIError,
   TradeMethodNotSupportedError,
   UnexpectedError,
   ValidationError,
@@ -35,6 +36,19 @@ export const isSwapOperationPending: (status: string) => boolean = (status) =>
   !operationStatusList.finishedKO.includes(status);
 
 const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");
+
+const SWAP_API_BASE_PATTERN = /.*\/v(?<version>\d+)\/*$/;
+const getSwapAPIVersion: () => number = () => {
+  const version = Number(
+    getSwapAPIBaseURL().match(SWAP_API_BASE_PATTERN)?.groups?.version
+  );
+  if (version == null || isNaN(version)) {
+    throw new SwapGenericAPIError(
+      "Configured swap API base URL is invalid, should end with /v<number>"
+    );
+  }
+  return version;
+};
 
 const ftx = {
   nameAndPubkey: Buffer.concat([
@@ -179,6 +193,7 @@ export const getSwapAPIError = (errorCode: number, errorMessage?: string) => {
 
 export {
   getSwapAPIBaseURL,
+  getSwapAPIVersion,
   getProviderConfig,
   getProviders,
   getExchangeRates,

--- a/libs/ledger-live-common/src/exchange/swap/mock.ts
+++ b/libs/ledger-live-common/src/exchange/swap/mock.ts
@@ -7,7 +7,7 @@ import {
   SwapExchangeRateAmountTooHigh,
   SwapExchangeRateAmountTooLow,
 } from "../../errors";
-import { getSwapAPIBaseURL } from "./";
+import { getSwapAPIVersion } from "./";
 import type {
   CheckQuote,
   Exchange,
@@ -129,7 +129,7 @@ export const mockInitSwap = (
 export const mockGetProviders: GetProviders = async () => {
   //Fake delay to show loading UI
   await new Promise((r) => setTimeout(r, 800));
-  const usesV3 = getSwapAPIBaseURL().endsWith("v3");
+  const usesV3 = getSwapAPIVersion() >= 3;
 
   return usesV3
     ? [

--- a/libs/ledger-live-common/src/exchange/swap/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/types.ts
@@ -82,6 +82,14 @@ export type AvailableProviderV3 = {
   provider: string;
   pairs: Array<{ from: string; to: string; tradeMethod: string }>;
 };
+export type TradeMethodGroup = {
+  methods: TradeMethod[];
+  pairs: Map<string, number[]>;
+};
+export type ProvidersResponseV4 = {
+  currencies: Map<string, string>;
+  providers: Map<string, TradeMethodGroup[]>;
+};
 
 type CheckQuoteOkStatus = {
   codeName: "RATE_VALID";

--- a/libs/ledger-live-common/src/exchange/swap/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/types.ts
@@ -82,13 +82,16 @@ export type AvailableProviderV3 = {
   provider: string;
   pairs: Array<{ from: string; to: string; tradeMethod: string }>;
 };
-export type TradeMethodGroup = {
+
+type TradeMethodGroup = {
   methods: TradeMethod[];
-  pairs: Map<string, number[]>;
+  pairs: {
+    [currencyIndex: number]: number[];
+  };
 };
 export type ProvidersResponseV4 = {
-  currencies: Map<string, string>;
-  providers: Map<string, TradeMethodGroup[]>;
+  currencies: { [currencyIndex: number]: string };
+  providers: { [providerName: string]: TradeMethodGroup[] };
 };
 
 type CheckQuoteOkStatus = {


### PR DESCRIPTION
### 📝 Description

This switches to swap backend API v4, which drastically reduces size of `/providers` endpoint response.

Note: this PR only converts response back to v3 flattened format of pairs, deeper changes are required to get full benefit of it:

- for swap pane, the response can be intersected with list of accounts instead of full decoding
- for swap button in market/portfolio pages, only a few lookups are sufficient instead of full decoding

### ❓ Context

- **Impacted projects**: swap, market page, portfolio, account pages
- **Linked resource(s)**:
   - https://ledgerhq.atlassian.net/browse/LIVE-3570
   - https://ledgerhq.atlassian.net/browse/BACK-3654
   - https://ledgerhq.atlassian.net/wiki/spaces/BE/pages/3753050176

### ✅ Checklist

- [x] **Test coverage**
- [x] **Atomic delivery** 
- [x] **No breaking changes** 

### 📸 Demo
[live-api-v4.webm](https://user-images.githubusercontent.com/102984500/187739589-0fcd4f9a-2468-4e45-bd48-18ee03770147.webm)
