### PR TITLE
bugfix/LIVE-3147 Better error handling for outdated device + outdated app flows

### DIFF
--- a/.changeset/perfect-singers-smell.md
+++ b/.changeset/perfect-singers-smell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Prevent update app loop for users on old fw and old apps

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -45,6 +45,20 @@ export const deviceInfo210lo5: DeviceInfo = {
   version: "2.1.0-lo5",
 };
 
+export const deviceInfo202 = {
+  version: "2.0.2",
+  isBootloader: false,
+  isOSU: false,
+  managerAllowed: true,
+  mcuVersion: "2.30",
+  pinValidated: true,
+  providerName: null,
+  majMin: "2.0",
+  targetId: 855638020,
+  seVersion: "2.0.2",
+  seTargetId: 855638020,
+};
+
 const firmware155: FinalFirmware = {
   id: 24,
   name: "1.5.5",

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -576,6 +576,7 @@ export const createAction = (
   ): AppState => {
     const dependenciesResolvedRef = useRef(false);
     const latestFirmwareResolvedRef = useRef(false);
+    const outdatedAppRef = useRef<AppAndVersion>();
 
     const connectApp = useCallback(
       (device, params) =>
@@ -591,12 +592,15 @@ export const createAction = (
               requireLatestFirmware: latestFirmwareResolvedRef.current
                 ? undefined
                 : params.requireLatestFirmware,
+              outdatedApp: outdatedAppRef.current,
             }).pipe(
               tap((e) => {
                 if (e.type === "dependencies-resolved") {
                   dependenciesResolvedRef.current = true;
                 } else if (e.type === "latest-firmware-resolved") {
                   latestFirmwareResolvedRef.current = true;
+                } else if (e.type === "has-outdated-app") {
+                  outdatedAppRef.current = e.outdatedApp as AppAndVersion;
                 }
               }),
               catchError((error: Error) =>

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.test.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.test.ts
@@ -1,0 +1,46 @@
+import isUpdateAvailable from "./isUpdateAvailable";
+import { deviceInfo155, deviceInfo202 } from "@ledgerhq/live-common/apps/mock";
+
+describe("isUpdateAvailable tests", () => {
+  const scenarios = [
+    {
+      name: "Old device, outdated app expects no update, needs fw update",
+      deviceInfo: deviceInfo155,
+      expectedResult: false,
+      outdatedApp: {
+        name: "Ethereum",
+        version: "1.0.0",
+      },
+    },
+    {
+      name: "Old device, up-to-date app expect no update",
+      deviceInfo: deviceInfo155,
+      expectedResult: false,
+      outdatedApp: {
+        name: "Ethereum",
+        version: "1.0.0",
+      },
+    },
+    {
+      name: "New device, outdated app expects an update",
+      deviceInfo: deviceInfo202,
+      expectedResult: true,
+      outdatedApp: {
+        name: "Ethereum",
+        version: "1.9.0",
+      },
+    },
+  ];
+
+  // We part from the fact that we are only calling this when we know the currently
+  // installed application does not meet the minimum so we don't really need more cases
+  // to cover.
+  scenarios.forEach(({ name, deviceInfo, outdatedApp, expectedResult }) => {
+    it(name, async () => {
+      jest.mock("../api/Manager");
+      // I don't know how to avoid the internal API calls to the Manager API.
+      const result = await isUpdateAvailable(deviceInfo, outdatedApp);
+      expect(result).toBe(expectedResult);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.test.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.test.ts
@@ -1,5 +1,6 @@
 import isUpdateAvailable from "./isUpdateAvailable";
-import { deviceInfo155, deviceInfo202 } from "@ledgerhq/live-common/apps/mock";
+import { deviceInfo155, deviceInfo202 } from "../apps/mock";
+import { AppAndVersion } from "../hw/connectApp";
 
 describe("isUpdateAvailable tests", () => {
   const scenarios = [
@@ -10,6 +11,7 @@ describe("isUpdateAvailable tests", () => {
       outdatedApp: {
         name: "Ethereum",
         version: "1.0.0",
+        flags: 0,
       },
     },
     {
@@ -19,6 +21,7 @@ describe("isUpdateAvailable tests", () => {
       outdatedApp: {
         name: "Ethereum",
         version: "1.0.0",
+        flags: 0,
       },
     },
     {
@@ -39,7 +42,10 @@ describe("isUpdateAvailable tests", () => {
     it(name, async () => {
       jest.mock("../api/Manager");
       // I don't know how to avoid the internal API calls to the Manager API.
-      const result = await isUpdateAvailable(deviceInfo, outdatedApp);
+      const result = await isUpdateAvailable(
+        deviceInfo,
+        outdatedApp as AppAndVersion
+      );
       expect(result).toBe(expectedResult);
     });
   });

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
@@ -1,0 +1,69 @@
+/**
+ * This covers the case where the user has the required application but we have
+ * a minimum version requirement in place. For instance I may have BTC installed on version
+ * 1.0.0 but we've defined that the minimum is 2.0.0.
+ *
+ * Up until now, all we were doing was throwing an "UpdateYourApp" error, the problem is
+ * that sometimes there is no app available for that device firmware version. If there's no
+ * app that fulfils the minimum version defined we are instead now throwing a fw update error.
+ */
+import { DeviceInfo } from "@ledgerhq/types-live";
+import { identifyTargetId, DeviceModelId } from "@ledgerhq/devices";
+import semver from "semver";
+import { getProviderId } from "../manager/provider";
+import ManagerAPI from "../api/Manager";
+import { AppAndVersion } from "./connectApp";
+import { mustUpgrade } from "../apps";
+
+const isUpdateAvailable = async (
+  deviceInfo: DeviceInfo,
+  appAndVersion: AppAndVersion,
+  checkMustUpdate = true
+): Promise<boolean> => {
+  const deviceModel = identifyTargetId(deviceInfo.targetId as number);
+
+  const deviceVersionP = ManagerAPI.getDeviceVersion(
+    deviceInfo.targetId,
+    getProviderId(deviceInfo)
+  );
+
+  const firmwareDataP = deviceVersionP.then((deviceVersion) =>
+    ManagerAPI.getCurrentFirmware({
+      deviceId: deviceVersion.id,
+      version: deviceInfo.version,
+      provider: getProviderId(deviceInfo),
+    })
+  );
+
+  const applicationsByDevice = await Promise.all([
+    deviceVersionP,
+    firmwareDataP,
+  ]).then(([deviceVersion, firmwareData]) =>
+    ManagerAPI.applicationsByDevice({
+      provider: getProviderId(deviceInfo),
+      current_se_firmware_final_version: firmwareData.id,
+      device_version: deviceVersion.id,
+    })
+  );
+
+  const appAvailableInProvider = applicationsByDevice.find(
+    ({ name }) => appAndVersion.name === name
+  );
+
+  if (!appAvailableInProvider) return false;
+
+  if (!checkMustUpdate) {
+    return semver.gt(appAvailableInProvider.version, appAndVersion.version);
+  }
+
+  return (
+    !!appAvailableInProvider &&
+    !mustUpgrade(
+      deviceModel?.id as DeviceModelId,
+      appAvailableInProvider.name,
+      appAvailableInProvider.version
+    )
+  );
+};
+
+export default isUpdateAvailable;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In our codebase we have hardcoded minimum app version for some specific applications. This was done when we introduced some breaking change in our functionality that was no longer compatible with older versions of the firmware app. What usually happens is that, when a user who has the firmware app in question installed, but with a version lower than the minimum, we prompt them to go to the manager to update the application.

The problem we are solving here is that, if the user is also not on the latest firmware, they can reach the manager and see that installing the application doesn't solve the issue. The solution proposed here checks whether the current provider has a valid application version available for the current device that would pass the minimum version requirement. If there is one, we prompt them to update the app in the manager just like we do today.

If there is no firmware app update available in the provider, then we throw the "Update your firmware" error instead. Assuming there must be a firmware update available that will allow them to install the application.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-3147` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
There is no demo here.

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
It's hard to test for QA, we need to ask someone in charge of the appstore to deploy a version of one of these apps that is lower than the value, for a given device firmware. That way, if we install that application and then we try to complete a flow we should get the firmware update error. Then switching to provider 1 for instance, since we would have a version that passes the minimum version, accessing the same flow should throw the "Update your app" error.

```
  Cosmos: ">= 2.34.4",
  Algorand: ">= 1.2.9",
  Polkadot: ">= 13.9250.0",
  Elrond: ">= 1.0.11",
  Ethereum: ">= 1.9.17",
  Solana: ">= 1.2.0",
  "Cardano ADA": ">= 4.1.0",
```

If, for example, they deploy a version 1.9.0 of Ethereum for Nano X 2.0.2 on provider 11, if we install that version we can then test the feature like so. Also make sure that not having the application installed, we still get the inline installation, since we shouldn't be breaking that part either.

## Test 1
- Still in provider 11
- Go to a receive flow for ETH
- It should prompt to open the ETH app because we don't know the version installed
- 1.9.0 does not meet the `>= 1.9.17` requirement.
- This provider does not have a version of ETH that can pass the test
- We see the update your firmware error

## Test 2
- Switch to provider 1
- Go to a receive flow for ETH
- It should prompt to open the ETH app because we don't know the version installed
- 1.9.0 does not meet the `>= 1.9.17` requirement.
- This provider does have a version of ETH that can pass the test!
- We see the update your app error

## Test 3
- Go to manager and update the app
- Go to a receive flow for ETH, latest version does pass the `>= 1.9.17` requirement.
- We see no error and complete the flow