### PR TITLE
Fix bad ticker used on speculos bot

### DIFF
--- a/libs/ledger-live-common/src/families/ethereum/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/ethereum/speculos-deviceActions.ts
@@ -86,7 +86,9 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
           return formatCurrencyUnit(
             {
               ...unit,
-              code: account.currency.deviceTicker || account.unit.code,
+              code:
+                (a || account).currency.deviceTicker ||
+                (a || account).unit.code,
               prefixCode: true,
             },
             amount,

--- a/libs/ledger-live-common/src/families/evm/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/evm/speculos-deviceActions.ts
@@ -54,7 +54,9 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
           return formatCurrencyUnit(
             {
               ...unit,
-              code: account.currency.deviceTicker || account.unit.code,
+              code:
+                (a || account).currency.deviceTicker ||
+                (a || account).unit.code,
               prefixCode: true,
             },
             amount,


### PR DESCRIPTION


### 📝 Description

unclear what happened but we started noticing bad ticker used by the bot when it tries to send tokens.
this hopefully fixes it. (it will trigger a bot run so we can confirm)

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
