### PR TITLE
LIVE-3652 - LLM - fix undefined lottie animations

### DIFF
--- a/.changeset/purple-roses-greet.md
+++ b/.changeset/purple-roses-greet.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - fix issue on lottie animations for nanoS nanoSP and blue

--- a/apps/ledger-live-mobile/src/components/Animation.tsx
+++ b/apps/ledger-live-mobile/src/components/Animation.tsx
@@ -11,14 +11,14 @@ export default function Animation({
 }: LottieProps & {
   style: ViewStyleProp;
 }) {
-  return (
+  return lottieProps.source ? (
     <Lottie
       {...lottieProps}
       style={[styles.default, style]}
       loop={lottieProps.loop ?? true}
       autoPlay={Config.MOCK ? false : lottieProps.autoplay ?? true}
     />
-  );
+  ) : null;
 }
 const styles = StyleSheet.create({
   default: {

--- a/apps/ledger-live-mobile/src/helpers/getDeviceAnimation.ts
+++ b/apps/ledger-live-mobile/src/helpers/getDeviceAnimation.ts
@@ -230,10 +230,10 @@ export function getDeviceAnimation({
     )
   ) {
     animation = animations[modelId][key][theme];
+  } else {
+    animation =
+      animations[modelId]?.[wired ? "wired" : "bluetooth"]?.[key][theme];
   }
-
-  animation =
-    animations[modelId]?.[wired ? "wired" : "bluetooth"]?.[key][theme];
 
   if (!animation) {
     console.error(`No animation for ${modelId} ${key}`);


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Fixes undefined lottie animations for nanoS nanoSP and blue_

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3652] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3652]: https://ledgerhq.atlassian.net/browse/LIVE-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ