### PR TITLE
LIVE-3662 Handle more cases of Stellar network errors

### DIFF
--- a/.changeset/eleven-dryers-bow.md
+++ b/.changeset/eleven-dryers-bow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Same wording on LLM for network errors as on LLD

--- a/.changeset/two-bats-hammer.md
+++ b/.changeset/two-bats-hammer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Handle more cases of Stellar API errors

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -286,6 +286,14 @@
       "title": "{{message}}",
       "description": "Something went wrong. Please retry. If the problem persists, please save your logs using the button below and provide them to Ledger Support."
     },
+    "LedgerAPI4xx": {
+      "title": "{{message}}",
+      "description": "Please check your connection and try again or contact Ledger Support."
+    },
+    "LedgerAPI5xx": {
+      "title": "Sorry, try again.",
+      "description": "The server could not handle your request. Please try again later or contact Ledger Support. {{message}}"
+    },
     "FeeEstimationFailed": {
       "title": "Sorry, fee estimation failed",
       "description": "Try setting the fee manually (status: {{status}})."


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Regression introduced with https://ledgerhq.atlassian.net/browse/LIVE-2722
Error handling of Stellar SDK is a mess, it was currently managed in other cases with a bunch of hacks, the task above didn't use these hacks and therefore felt on false network errors.

Also take the opportunity to add same wording on LLM as on LLD for Ledger API errors.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3662 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
  - Unfortunately no easy test coverage at the moment as the issue only happens on React Native environment. This would have been seen by a bot on mobile...
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

<!-- If any of the expectations are not met please explain the reason in detail. -->
