### PR TITLE
LIVE-3662 Revert #981 causing regression on Stellar network error

### DIFF
--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4597,10 +4597,6 @@
       "title": "Sorry, internet seems to be down",
       "description": "Please check your internet connection."
     },
-    "NetworkError": {
-      "title": "An error occurred during synchronization",
-      "description": "Please check your internet connection."
-    },
     "NoAddressesFound": {
       "title": "Sorry, no accounts were found",
       "description": "Something went wrong with the address calculation, try again or contact Ledger Support"

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -113,7 +113,6 @@ export const ManagerUninstallBTCDep = createCustomErrorClass(
   "ManagerUninstallBTCDep"
 );
 export const NetworkDown = createCustomErrorClass("NetworkDown");
-export const NetworkError = createCustomErrorClass("NetworkError");
 export const NoAddressesFound = createCustomErrorClass("NoAddressesFound");
 export const NotEnoughBalance = createCustomErrorClass("NotEnoughBalance");
 export const NotEnoughBalanceToDelegate = createCustomErrorClass(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This reverts commit cd4e07fd2dabd6d4639f5dac9d3d2b9137ad1d50.

Regression introduced with https://ledgerhq.atlassian.net/browse/LIVE-2722
Error handling of Stellar SDK is a mess, the task above attempted at better handling some cases of network erros, but this is very sensitive with Stellar and it doesn't work properly on mobile.

Reverting to unlock the release, as the initial ticket was not a critical fix.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3662 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
