### PR TITLE
provide a formatDeviceAmount helper for the bot

### DIFF
--- a/.changeset/smooth-seas-poke.md
+++ b/.changeset/smooth-seas-poke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+bot: add formatDeviceAmount utility to simplify writing speculos-deviceActions

--- a/libs/ledger-live-common/src/bot/specs.ts
+++ b/libs/ledger-live-common/src/bot/specs.ts
@@ -8,6 +8,8 @@ import type { DeviceAction, DeviceActionArg } from "./types";
 import { Account } from "@ledgerhq/types-live";
 import type { Transaction } from "../generated/types";
 import { botTest } from "./bot-test-context";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import BigNumber from "bignumber.js";
 
 export { botTest };
 
@@ -172,4 +174,41 @@ export function deviceActionFlow<T extends Transaction>(
       currentStep,
     };
   };
+}
+
+type DeviceAmountFormatOptions = {
+  // the ticker of the coin is AFTER the amount on the device (e.g. "600.1 USDT")
+  postfixCode: boolean;
+  // the device shows "42" as "42.0"
+  forceFloating: boolean;
+  // device don't even display the code (unit ticker)
+  hideCode: boolean;
+};
+const defaultFormatOptions: DeviceAmountFormatOptions = {
+  postfixCode: false,
+  forceFloating: false,
+  hideCode: false,
+};
+
+const sep = " ";
+export function formatDeviceAmount(
+  currency: CryptoCurrency | TokenCurrency,
+  value: BigNumber,
+  options: Partial<DeviceAmountFormatOptions> = defaultFormatOptions
+): string {
+  const [unit] = currency.units;
+  let code = unit.code;
+  if (currency.type === "CryptoCurrency") {
+    const { deviceTicker } = currency;
+    if (deviceTicker) code = deviceTicker;
+  }
+  let v = value.div(new BigNumber(10).pow(unit.magnitude)).toString(10);
+  if (options.forceFloating) {
+    if (!v.includes(".")) {
+      // if the value is pure integer, in the app it will automatically add an .0
+      v += ".0";
+    }
+  }
+  if (options.hideCode) return v;
+  return options.postfixCode ? v + sep + code : code + sep + v;
 }

--- a/libs/ledger-live-common/src/families/algorand/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/algorand/speculos-deviceActions.ts
@@ -1,25 +1,9 @@
 import type { DeviceAction } from "../../bot/types";
 import type { AlgorandTransaction } from "./types";
-import { formatCurrencyUnit, findTokenById } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { findTokenById } from "../../currencies";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 import { extractTokenId, addPrefixToken } from "./tokens";
 import { displayTokenValue } from "./deviceTransactionConfig";
-
-// Will be useful when unit is gonna be algo
-const expectedAmount = ({ account, status }) =>
-  formatCurrencyUnit(
-    {
-      ...account.unit,
-      code: account.currency.deviceTicker || account.unit.code,
-      prefixCode: true,
-    },
-    status.amount,
-    {
-      showCode: true,
-      disableRounding: true,
-      joinFragmentsSeparator: " ",
-    }
-  );
 
 export const acceptTransaction: DeviceAction<AlgorandTransaction, any> =
   deviceActionFlow({
@@ -42,19 +26,7 @@ export const acceptTransaction: DeviceAction<AlgorandTransaction, any> =
         title: "Fee",
         button: "Rr",
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(
-            {
-              ...account.unit,
-              code: account.currency.deviceTicker || account.unit.code,
-              prefixCode: true,
-            },
-            status.estimatedFees,
-            {
-              showCode: true,
-              disableRounding: true,
-              joinFragmentsSeparator: " ",
-            }
-          ),
+          formatDeviceAmount(account.currency, status.estimatedFees),
       },
       {
         title: "Asset ID",
@@ -95,10 +67,7 @@ export const acceptTransaction: DeviceAction<AlgorandTransaction, any> =
         expectedValue: ({ account, status, transaction }) =>
           transaction.mode === "claimReward"
             ? "0"
-            : expectedAmount({
-                account,
-                status,
-              }),
+            : formatDeviceAmount(account.currency, status.amount),
       },
       {
         title: "APPROVE",

--- a/libs/ledger-live-common/src/families/bitcoin/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 import { perCoinLogic } from "./logic";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
@@ -11,37 +10,15 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         title: "Amount",
         button: "Rr",
         ignoreAssertionFailure: true,
-        // https://ledgerhq.atlassian.net/browse/LLC-676
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(
-            {
-              ...account.unit,
-              code: account.currency.deviceTicker || account.unit.code,
-            },
-            status.amount,
-            {
-              showCode: true,
-              disableRounding: true,
-            }
-          ).replace(/\s/g, " "),
+          formatDeviceAmount(account.currency, status.amount),
       },
       {
         title: "Fees",
         button: "Rr",
         ignoreAssertionFailure: true,
-        // https://ledgerhq.atlassian.net/browse/LLC-676
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(
-            {
-              ...account.unit,
-              code: account.currency.deviceTicker || account.unit.code,
-            },
-            status.estimatedFees,
-            {
-              showCode: true,
-              disableRounding: true,
-            }
-          ).replace(/\s/g, " "),
+          formatDeviceAmount(account.currency, status.estimatedFees),
       },
       {
         title: "Address",

--- a/libs/ledger-live-common/src/families/cardano/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/cardano/speculos-deviceActions.ts
@@ -1,17 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
-import type { Unit } from "@ledgerhq/types-cryptoassets";
-import BigNumber from "bignumber.js";
-
-function expectedValue(unit: Unit, value: BigNumber) {
-  return formatCurrencyUnit(unit, value, {
-    showCode: true,
-    disableRounding: true,
-    showAllDigits: true,
-  });
-}
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -38,7 +27,7 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         button: "LRlr",
         ignoreAssertionFailure: true,
         expectedValue: ({ account, status }) =>
-          expectedValue(account.unit, status.amount),
+          formatDeviceAmount(account.currency, status.amount),
       },
       {
         title: "Asset fingerprint",
@@ -60,7 +49,7 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         button: "LRlr",
         ignoreAssertionFailure: true,
         expectedValue: ({ account, status }) =>
-          expectedValue(account.unit, status.estimatedFees),
+          formatDeviceAmount(account.currency, status.estimatedFees),
       },
       {
         title: "Transaction TTL",

--- a/libs/ledger-live-common/src/families/celo/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/celo/speculos-deviceActions.ts
@@ -1,7 +1,7 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { deviceActionFlow } from "../../bot/specs";
-import { formatCurrencyUnit } from "../../currencies";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
+
 const typeWording = {
   send: "Send",
   lock: "Lock",
@@ -23,18 +23,10 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
       {
         title: "Amount",
         button: "Rr",
-        expectedValue: ({ account, status }) => {
-          const formattedValue =
-            "CELO " +
-            formatCurrencyUnit(account.unit, status.amount, {
-              disableRounding: true,
-            });
-          if (!formattedValue.includes(".")) {
-            // if the value is pure integer, in the app it will automatically add an .0
-            return formattedValue + ".0";
-          }
-          return formattedValue;
-        },
+        expectedValue: ({ account, status }) =>
+          formatDeviceAmount(account.currency, status.amount, {
+            forceFloating: true,
+          }),
       },
       {
         title: "Address",

--- a/libs/ledger-live-common/src/families/elrond/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/elrond/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { deviceActionFlow } from "../../bot/specs";
-import { formatCurrencyUnit } from "../../currencies";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -15,13 +14,9 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         title: "Amount",
         button: "Rr",
         expectedValue: ({ account, transaction }) =>
-          formatCurrencyUnit(account.unit, transaction.amount, {
-            showCode: true,
-            disableRounding: true,
-            joinFragmentsSeparator: " ",
-          })
-            .replace(/\s+/g, " ")
-            .replace("egld", "EGLD"), // FIXME
+          formatDeviceAmount(account.currency, transaction.amount, {
+            postfixCode: true,
+          }),
       },
       {
         title: "Fee",

--- a/libs/ledger-live-common/src/families/evm/specs.ts
+++ b/libs/ledger-live-common/src/families/evm/specs.ts
@@ -45,7 +45,7 @@ const evmBasicMutations = ({ maxAccount }) => [
         "operation time to be older than 60s"
       );
       const estimatedGas = transaction.gasLimit.times(
-        transaction.gasPrice || 0
+        transaction.gasPrice || transaction.maxFeePerGas || 0
       );
       botTest("operation fee is not exceeding estimated gas", () =>
         expect(operation.fee.toNumber()).toBeLessThanOrEqual(

--- a/libs/ledger-live-common/src/families/evm/specs.ts
+++ b/libs/ledger-live-common/src/families/evm/specs.ts
@@ -3,7 +3,7 @@ import invariant from "invariant";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { getCryptoCurrencyById, parseCurrencyUnit } from "../../currencies";
 import { acceptTransaction } from "./speculos-deviceActions";
-import { pickSiblings } from "../../bot/specs";
+import { botTest, pickSiblings } from "../../bot/specs";
 import type { AppSpec } from "../../bot/types";
 import type { Transaction } from "./types";
 
@@ -47,11 +47,15 @@ const evmBasicMutations = ({ maxAccount }) => [
       const estimatedGas = transaction.gasLimit.times(
         transaction.gasPrice || 0
       );
-      expect(operation.fee.toNumber()).toBeLessThanOrEqual(
-        estimatedGas.toNumber()
+      botTest("operation fee is not exceeding estimated gas", () =>
+        expect(operation.fee.toNumber()).toBeLessThanOrEqual(
+          estimatedGas.toNumber()
+        )
       );
-      expect(account.balance.toString()).toBe(
-        accountBeforeTransaction.balance.minus(operation.value).toString()
+      botTest("account balance moved with operation value", () =>
+        expect(account.balance.toString()).toBe(
+          accountBeforeTransaction.balance.minus(operation.value).toString()
+        )
       );
     },
   },

--- a/libs/ledger-live-common/src/families/evm/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/evm/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 function subAccount(subAccountId, account) {
   const sub = (account.subAccounts || []).find((a) => a.id === subAccountId);
@@ -11,19 +10,7 @@ function subAccount(subAccountId, account) {
 }
 
 const maxFeesExpectedValue = ({ account, status }) =>
-  formatCurrencyUnit(
-    {
-      ...account.unit,
-      code: account.currency.deviceTicker || account.unit.code,
-      prefixCode: true,
-    },
-    status.estimatedFees,
-    {
-      showCode: true,
-      disableRounding: true,
-      joinFragmentsSeparator: " ",
-    }
-  ).replace(/\s/g, " ");
+  formatDeviceAmount(account.currency, status.estimatedFees);
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -44,26 +31,11 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
             ? subAccount(transaction.subAccountId, account)
             : null;
 
-          const unit = !a
-            ? {
-                ...account.unit,
-                code: account.currency.deviceTicker || account.unit.code,
-              }
-            : a.token.units[0];
-          const amount = status.amount;
-          return formatCurrencyUnit(
-            {
-              ...unit,
-              code: account.currency.deviceTicker || account.unit.code,
-              prefixCode: true,
-            },
-            amount,
-            {
-              showCode: true,
-              disableRounding: true,
-              joinFragmentsSeparator: " ",
-            }
-          ).replace(/\s/g, " ");
+          if (a) {
+            return formatDeviceAmount(a.token, status.amount);
+          }
+
+          return formatDeviceAmount(account.currency, status.amount);
         },
       },
       {

--- a/libs/ledger-live-common/src/families/filecoin/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/filecoin/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { deviceActionFlow } from "../../bot/specs";
-import { formatCurrencyUnit } from "../../currencies";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -25,9 +24,8 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         title: "Value",
         button: "Rr",
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(account.unit, status.amount, {
-            disableRounding: true,
-            showAllDigits: true,
+          formatDeviceAmount(account.currency, status.amount, {
+            hideCode: true,
           }),
       },
       {
@@ -39,18 +37,16 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         title: "Gas Premium",
         button: "Rr",
         expectedValue: ({ account, transaction }) =>
-          formatCurrencyUnit(account.unit, transaction.gasPremium, {
-            disableRounding: true,
-            showAllDigits: true,
+          formatDeviceAmount(account.currency, transaction.gasPremium, {
+            hideCode: true,
           }),
       },
       {
         title: "Gas Fee Cap",
         button: "Rr",
         expectedValue: ({ account, transaction }) =>
-          formatCurrencyUnit(account.unit, transaction.gasFeeCap, {
-            disableRounding: true,
-            showAllDigits: true,
+          formatDeviceAmount(account.currency, transaction.gasFeeCap, {
+            hideCode: true,
           }),
       },
       {

--- a/libs/ledger-live-common/src/families/polkadot/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/polkadot/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { PolkadotAccount, Transaction } from "./types";
-import { deviceActionFlow } from "../../bot/specs";
-import { formatCurrencyUnit } from "../../currencies";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -22,20 +21,10 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
       {
         title: "Amount",
         button: "Rr",
-        expectedValue: ({ account, transaction }) => {
-          const formattedValue =
-            "DOT " +
-            formatCurrencyUnit(account.unit, transaction.amount, {
-              disableRounding: true,
-            });
-
-          if (!formattedValue.includes(".")) {
-            // if the value is pure integer, in the app it will automatically add an .0
-            return formattedValue + ".0";
-          }
-
-          return formattedValue;
-        },
+        expectedValue: ({ account, transaction }) =>
+          formatDeviceAmount(account.currency, transaction.amount, {
+            forceFloating: true,
+          }),
       },
       {
         title: "Chain",

--- a/libs/ledger-live-common/src/families/ripple/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/ripple/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -15,37 +14,13 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         title: "Amount",
         button: "Rr",
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(
-            {
-              ...account.unit,
-              code: account.currency.deviceTicker || account.unit.code,
-              prefixCode: true,
-            },
-            status.amount,
-            {
-              showCode: true,
-              disableRounding: true,
-              joinFragmentsSeparator: " ",
-            }
-          ).replace(/\s/g, " "),
+          formatDeviceAmount(account.currency, status.amount),
       },
       {
         title: "Fee",
         button: "Rr",
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(
-            {
-              ...account.unit,
-              code: account.currency.deviceTicker || account.unit.code,
-              prefixCode: true,
-            },
-            status.estimatedFees,
-            {
-              showCode: true,
-              disableRounding: true,
-              joinFragmentsSeparator: " ",
-            }
-          ).replace(/\s/g, " "),
+          formatDeviceAmount(account.currency, status.estimatedFees),
       },
       {
         title: "Destination Tag",

--- a/libs/ledger-live-common/src/families/solana/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/solana/speculos-deviceActions.ts
@@ -1,7 +1,6 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import BigNumber from "bignumber.js";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
@@ -17,12 +16,11 @@ function ellipsis(str: string) {
   return `${str.slice(0, 7)}..${str.slice(-7)}`;
 }
 
-function formatAmount(currency: CryptoCurrency, amount: number) {
-  const unit = getMainCurrency(currency).units[0];
-  return formatCurrencyUnit(unit, new BigNumber(amount), {
-    disableRounding: true,
-    showCode: true,
-  }).replace(/\s/g, " ");
+function formatAmount(c: CryptoCurrency, amount: number) {
+  const currency = getMainCurrency(c);
+  return formatDeviceAmount(currency, new BigNumber(amount), {
+    postfixCode: true,
+  });
 }
 
 export const acceptTransferTransaction: DeviceAction<Transaction, any> =

--- a/libs/ledger-live-common/src/families/stellar/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/stellar/speculos-deviceActions.ts
@@ -1,14 +1,11 @@
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
 import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 const expectedAmount = ({ account, status, transaction }) => {
   if (transaction.assetCode && transaction.assetIssuer) {
-    const amount = formatCurrencyUnit(account.unit, status.amount, {
-      disableRounding: true,
-      useGrouping: false,
-    });
+    const amount = formatDeviceAmount(account.currency, status.amount);
 
     return `${amount} ${transaction.assetCode}@${truncateAddress(
       transaction.assetIssuer,
@@ -17,12 +14,9 @@ const expectedAmount = ({ account, status, transaction }) => {
     )}`;
   }
 
-  return (
-    formatCurrencyUnit(account.unit, status.amount, {
-      disableRounding: true,
-      useGrouping: false,
-    }) + " XLM"
-  );
+  return formatDeviceAmount(account.currency, status.amount, {
+    postfixCode: true,
+  });
 };
 
 const truncateAddress = (stellarAddress: string, start = 6, end = 6) =>

--- a/libs/ledger-live-common/src/families/tezos/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/tezos/speculos-deviceActions.ts
@@ -1,8 +1,7 @@
 // @flow
 import type { DeviceAction } from "../../bot/types";
 import type { Transaction } from "./types";
-import { formatCurrencyUnit } from "../../currencies";
-import { deviceActionFlow } from "../../bot/specs";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 
 export const acceptTransaction: DeviceAction<Transaction, any> =
   deviceActionFlow({
@@ -38,24 +37,18 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
       {
         title: "Amount",
         button: "Rr",
-        expectedValue: ({ account, transaction }) => {
-          const amount = transaction.amount;
-          return formatCurrencyUnit(account.unit, amount, {
-            disableRounding: true,
-            joinFragmentsSeparator: " ",
-          }).replace(/\s/g, " ");
-        },
+        expectedValue: ({ account, transaction }) =>
+          formatDeviceAmount(account.currency, transaction.amount, {
+            hideCode: true,
+          }),
       },
       {
         title: "Fee",
         button: "Rr",
-        expectedValue: ({ account, status }) => {
-          const amount = status.estimatedFees;
-          return formatCurrencyUnit(account.currency.units[0], amount, {
-            disableRounding: true,
-            joinFragmentsSeparator: " ",
-          }).replace(/\s/g, " ");
-        },
+        expectedValue: ({ account, status }) =>
+          formatDeviceAmount(account.currency, status.estimatedFees, {
+            hideCode: true,
+          }),
       },
       {
         title: "Source",

--- a/libs/ledger-live-common/src/families/tron/speculos-deviceActions.ts
+++ b/libs/ledger-live-common/src/families/tron/speculos-deviceActions.ts
@@ -1,6 +1,5 @@
 import type { DeviceAction } from "../../bot/types";
-import { deviceActionFlow } from "../../bot/specs";
-import { formatCurrencyUnit } from "../../currencies";
+import { deviceActionFlow, formatDeviceAmount } from "../../bot/specs";
 import type { Transaction, Vote } from "./types";
 
 function subAccount(subAccountId, account) {
@@ -40,16 +39,9 @@ export const acceptTransaction: DeviceAction<Transaction, any> =
         title: "Amount",
         button: "Rr",
         expectedValue: ({ account, status }) =>
-          formatCurrencyUnit(
-            {
-              ...account.unit,
-              code: account.currency.deviceTicker || account.unit.code,
-            },
-            status.amount,
-            {
-              disableRounding: true,
-            }
-          ),
+          formatDeviceAmount(account.currency, status.amount, {
+            hideCode: true,
+          }),
       },
       {
         title: "Token",

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -718,6 +718,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     coinType: 60,
     name: "Cronos",
     managerAppName: "Ethereum",
+    deviceTicker: "ETH", // FIXME this is a limiation of the app?
     ticker: "CRO",
     scheme: "cro",
     color: "#002D74",
@@ -971,6 +972,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     color: "#1b46c2",
     family: "elrond",
     blockAvgTime: 6,
+    deviceTicker: "EGLD",
     units: [
       {
         name: "EGLD",
@@ -1226,6 +1228,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     coinType: 60,
     name: "Flare",
     managerAppName: "Ethereum",
+    deviceTicker: "ETH", // FIXME this is a limiation of the app?
     ticker: "FLR",
     scheme: "flare",
     color: "#D95F6C",
@@ -1765,6 +1768,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     coinType: 60,
     name: "Moonbeam",
     managerAppName: "Ethereum",
+    deviceTicker: "ETH", // FIXME this is a limiation of the app?
     ticker: "GLMR",
     scheme: "moonbeam",
     color: "#5FC0C1",
@@ -2323,6 +2327,7 @@ export const cryptocurrenciesById: Record<string, CryptoCurrency> = {
     coinType: 60,
     name: "Songbird",
     managerAppName: "Ethereum",
+    deviceTicker: "ETH", // FIXME this is a limiation of the app?
     ticker: "SGB",
     scheme: "songbird",
     color: "#61ACD4",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

we have way too much boilerplate to implement the speculos-deviceActions using formatCurrencyUnit.
You can see the benefit of this simplification:
<img width="136" alt="Screenshot 2022-09-12 at 16 51 22" src="https://user-images.githubusercontent.com/211411/189685889-99be52c2-3810-4e84-bd72-c7aa0bc4ef18.png">

This also fixes the bot "evm" on Ethereum family by using what are the current "deviceTicker" to use for the latest ETH nano app.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
  - [x] see report of https://github.com/LedgerHQ/ledger-live/commit/e0a64b67f021a6f1aa68dd760a1f23a084476a87#commitcomment-83746299 
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
