### PR TITLE
LIVE-3684 (LLD) Remove duplicate Osmosis in the list during add accounts flow

### DIFF
--- a/.changeset/cold-books-laugh.md
+++ b/.changeset/cold-books-laugh.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Remove duplicates from all lists passed to setSupportedCurrencies

--- a/.changeset/sweet-points-tease.md
+++ b/.changeset/sweet-points-tease.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix duplicate Osmosis in the list during add accounts flow"

--- a/apps/ledger-live-desktop/src/live-common-set-supported-currencies.js
+++ b/apps/ledger-live-desktop/src/live-common-set-supported-currencies.js
@@ -28,7 +28,6 @@ setSupportedCurrencies([
   "decred",
   "digibyte",
   "algorand",
-  "osmosis",
   "qtum",
   "bitcoin_gold",
   "komodo",

--- a/apps/ledger-live-desktop/src/live-common-set-supported-currencies.test.js
+++ b/apps/ledger-live-desktop/src/live-common-set-supported-currencies.test.js
@@ -1,8 +1,0 @@
-import "./live-common-set-supported-currencies";
-import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
-
-test("No duplicate in the list of supported currencies on LLD", () => {
-  const supportedCurrenciesIds = listSupportedCurrencies().map(c => c.id);
-  const hasDuplicates = new Set(supportedCurrenciesIds).size !== supportedCurrenciesIds.length;
-  expect(hasDuplicates).toBeFalsy();
-});

--- a/apps/ledger-live-desktop/src/live-common-set-supported-currencies.test.js
+++ b/apps/ledger-live-desktop/src/live-common-set-supported-currencies.test.js
@@ -1,0 +1,8 @@
+import "./live-common-set-supported-currencies";
+import { listSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
+
+test("No duplicate in the list of supported currencies on LLD", () => {
+  const supportedCurrenciesIds = listSupportedCurrencies().map(c => c.id);
+  const hasDuplicates = new Set(supportedCurrenciesIds).size !== supportedCurrenciesIds.length;
+  expect(hasDuplicates).toBeFalsy();
+});

--- a/libs/ledger-live-common/src/currencies/support.ts
+++ b/libs/ledger-live-common/src/currencies/support.ts
@@ -75,7 +75,8 @@ export function listSupportedFiats(): FiatCurrency[] {
   return userSupportedFiats;
 }
 export function setSupportedCurrencies(ids: CryptoCurrencyIds[]) {
-  userSupportedCurrencies = ids.map((id) => getCryptoCurrencyById(id));
+  userSupportedCurrencies = Array.from(new Set(ids)) // Make sure to remove duplicates
+    .map((id) => getCryptoCurrencyById(id));
 }
 
 function getExperimentalSupports() {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Regression introduced on LLD 2.47 : Osmosis appears twice in the list when trying to add accounts.
Cause: was declared twice in the list of supported currencies. Probably introduced by a bad merge.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3684 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

![image](https://user-images.githubusercontent.com/59644786/189645958-0f7fdcd1-5d2c-4f03-99a4-33653844e4f3.png)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

<!-- If any of the expectations are not met please explain the reason in detail. -->
