### PR TITLE
support(Deeplink): Add Deeplink for Add Account and Accounts page

### DIFF
--- a/.changeset/happy-garlics-kick.md
+++ b/.changeset/happy-garlics-kick.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add Deeplink for Add Account and Accounts page

--- a/apps/ledger-live-mobile/docs/linking.md
+++ b/apps/ledger-live-mobile/docs/linking.md
@@ -11,9 +11,10 @@ They all are prefixed by **_ledgerlive://_**
 
   `ledgerlive://account` will redirect to accounts page
 
-  `ledgerlive://account?currency=btc` will open first bitcoin account found
+  `ledgerlive://account?currency=ethereum&address={{eth_account_address}}` will open a given ethereum account if found, will falback to the currency page found and if not to the list of accounts
 
   `?currency` param can be name or ticker of the currency targeted
+  `?address` param requires currency to work, address of the account to select
 
 - **_send?currency_** 🠒 Send Flow
 
@@ -48,6 +49,20 @@ They all are prefixed by **_ledgerlive://_**
 - **_swap_** 🠒 Swap Crypto Flow
 
   `ledgerlive://swap` will redirect to swap page
+
+- **_add_account_** 🠒 Add Account Crypto Flow
+
+  `ledgerlive://add-account` will redirect to add account page
+  `ledgerlive://add-account?currency=ethereum` will redirect to add account page with ethereum accounts search prefilled
+
+- **_accounts_** 🠒 Accounts page
+
+  `ledgerlive://accounts` will redirect to accounts page
+
+  `ledgerlive://accounts?currency=ethereum&address={{eth_account_address}}` will open a given ethereum account if found, will falback to the currency page found and if not to the list of accounts
+
+  `?currency` param can be name or ticker of the currency targeted
+  `?address` param requires currency to work, address of the account to select
 
 - **_discover_** 🠒 Live discover catalog
 

--- a/apps/ledger-live-mobile/docs/linking.md
+++ b/apps/ledger-live-mobile/docs/linking.md
@@ -7,6 +7,17 @@ They all are prefixed by **_ledgerlive://_**
 
   `ledgerlive://` _or_ `ledgerlive://portfolio`
 
+  Account page accessible via several deeplinks
+
+- **_accounts?id_** 🠒 Accounts page
+
+  `ledgerlive://accounts` will redirect to accounts page
+
+  `ledgerlive://accounts?currency=ethereum&address={{eth_account_address}}` will open a given ethereum account if found, will falback to the currency page found and if not to the list of accounts
+
+  `?currency` param can be name or ticker of the currency targeted
+  `?address` param requires currency to work, address of the account to select
+
 - **_account?currency_** 🠒 Account Page
 
   `ledgerlive://account` will redirect to accounts page
@@ -50,19 +61,10 @@ They all are prefixed by **_ledgerlive://_**
 
   `ledgerlive://swap` will redirect to swap page
 
-- **_add_account_** 🠒 Add Account Crypto Flow
+- **_add_account?currency_** 🠒 Add Account Crypto Flow
 
   `ledgerlive://add-account` will redirect to add account page
   `ledgerlive://add-account?currency=ethereum` will redirect to add account page with ethereum accounts search prefilled
-
-- **_accounts_** 🠒 Accounts page
-
-  `ledgerlive://accounts` will redirect to accounts page
-
-  `ledgerlive://accounts?currency=ethereum&address={{eth_account_address}}` will open a given ethereum account if found, will falback to the currency page found and if not to the list of accounts
-
-  `?currency` param can be name or ticker of the currency targeted
-  `?address` param requires currency to work, address of the account to select
 
 - **_discover_** 🠒 Live discover catalog
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/AddAccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/AddAccountsNavigator.tsx
@@ -29,14 +29,14 @@ const totalSteps = "3";
 export default function AddAccountsNavigator({ route }: { route: Route }) {
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const currency = route.params?.currency;
-  const token = route.params?.token;
-  const returnToSwap = route.params?.returnToSwap;
   const stackNavConfig = useMemo(
     () => getStackNavigatorConfig(colors),
     [colors],
   );
-  const analyticsPropertyFlow = route.params?.analyticsPropertyFlow;
+
+  const { currency, token, returnToSwap, analyticsPropertyFlow } =
+    route.params || {};
+
   return (
     <Stack.Navigator
       initialRouteName={

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -367,7 +367,7 @@ const linkingOptions: LinkingOptions<ReactNavigation.RootParamList> = {
                * @params ?currency: string
                * ie: "ledgerlive://receive?currency=bitcoin" will open the prefilled search account in the receive flow
                */
-              [ScreenName.ReceiveSelectAccount]: "receive",
+              [ScreenName.ReceiveSelectCrypto]: "receive",
             },
           },
           [NavigatorName.Swap]: {
@@ -386,6 +386,29 @@ const linkingOptions: LinkingOptions<ReactNavigation.RootParamList> = {
                * ie: "ledgerlive://send?currency=bitcoin" will open the prefilled search account in the send flow
                */
               [ScreenName.SendCoin]: "send",
+            },
+          },
+
+          [NavigatorName.Accounts]: {
+            screens: {
+              /**
+               * @params ?id: string
+               * ie: "ledgerlive://accounts?currency=ethereum&address={{eth_account_address}}"
+               */
+              [ScreenName.Accounts]: "accounts",
+            },
+          },
+
+          [NavigatorName.AddAccounts]: {
+            screens: {
+              /**
+               * ie: "ledgerlive://add-account" will open the add account flow
+               *
+               * @params ?currency: string
+               * ie: "ledgerlive://add-account?currency=bitcoin" will open the add account flow with "bitcoin" prefilled in the search input
+               *
+               */
+              [ScreenName.AddAccountsSelectCrypto]: "add-account",
             },
           },
 

--- a/apps/ledger-live-mobile/src/navigation/useDeepLinking.ts
+++ b/apps/ledger-live-mobile/src/navigation/useDeepLinking.ts
@@ -129,11 +129,11 @@ export function useDeepLinkHandler() {
             screen: ScreenName.PlatformCatalog,
             params: dapp
               ? {
-                platform: dapp.id,
-                name: dapp.name,
-                // $FlowFixMe Nope I want query to be spread last. Sry Flow.
-                ...query,
-              }
+                  platform: dapp.id,
+                  name: dapp.name,
+                  // $FlowFixMe Nope I want query to be spread last. Sry Flow.
+                  ...query,
+                }
               : query,
           });
           break;

--- a/apps/ledger-live-mobile/src/navigation/useDeepLinking.ts
+++ b/apps/ledger-live-mobile/src/navigation/useDeepLinking.ts
@@ -5,7 +5,7 @@ import { filterPlatformApps } from "@ledgerhq/live-common/platform/filters";
 import { getPlatformVersion } from "@ledgerhq/live-common/lib/platform/version";
 import { NavigatorName, ScreenName } from "../const";
 
-function getSettingsScreen(pathname) {
+function getSettingsScreen(pathname: string) {
   const secondPath = pathname.replace(/(^\/+|\/+$)/g, "");
   let screen;
 
@@ -64,7 +64,12 @@ export function useDeepLinkHandler() {
 
       switch (hostname) {
         case "accounts":
-          navigate(NavigatorName.Accounts);
+          if (currency) {
+            navigate(NavigatorName.Accounts, {
+              screen: ScreenName.Asset,
+              params: { currency },
+            });
+          } else navigate(NavigatorName.Accounts);
           break;
 
         case "buy": {
@@ -95,7 +100,7 @@ export function useDeepLinkHandler() {
 
         case "receive":
           navigate(NavigatorName.ReceiveFunds, {
-            screen: ScreenName.ReceiveSelectAccount,
+            screen: ScreenName.ReceiveSelectCrypto,
             params: {
               currency,
             },
@@ -124,11 +129,11 @@ export function useDeepLinkHandler() {
             screen: ScreenName.PlatformCatalog,
             params: dapp
               ? {
-                  platform: dapp.id,
-                  name: dapp.name,
-                  // $FlowFixMe Nope I want query to be spread last. Sry Flow.
-                  ...query,
-                }
+                platform: dapp.id,
+                name: dapp.name,
+                // $FlowFixMe Nope I want query to be spread last. Sry Flow.
+                ...query,
+              }
               : query,
           });
           break;
@@ -138,6 +143,16 @@ export function useDeepLinkHandler() {
           navigate(NavigatorName.Manager, {
             screen: ScreenName.Manager,
             params: query,
+          });
+          break;
+        }
+
+        case "add-account": {
+          navigate(NavigatorName.AddAccounts, {
+            screen: ScreenName.AddAccountsSelectCrypto,
+            params: {
+              currency,
+            },
           });
           break;
         }

--- a/apps/ledger-live-mobile/src/screens/Accounts/AccountRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/AccountRow.tsx
@@ -64,13 +64,8 @@ const AccountRow = ({
     if (navigationParams) {
       navigation.navigate(...navigationParams);
     } else if (account.type === "Account") {
-      navigation.navigate(NavigatorName.Accounts, {
-        screen: ScreenName.Account,
-        params: {
-          currencyId: currency.id,
-          accountId,
-          isForwardedFromAccounts: true,
-        },
+      navigation.navigate(ScreenName.Account, {
+        accountId,
       });
     } else if (account.type === "TokenAccount") {
       navigation.navigate(NavigatorName.Accounts, {

--- a/apps/ledger-live-mobile/src/screens/Accounts/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/index.tsx
@@ -32,21 +32,21 @@ const List = globalSyncRefreshControl(FlatList);
 
 type Props = {
   navigation: any;
-  route: {
-    params?: {
-      currency?: string;
-      search?: string;
-      currencyTicker?: string;
-      currencyId?: string;
-    };
-  };
+  route: { params?: Params };
+};
+
+type Params = {
+  currency?: string;
+  search?: string;
+  address?: string;
+  currencyTicker?: string;
+  currencyId?: string;
 };
 
 function Accounts({ navigation, route }: Props) {
   const accounts = useSelector(accountsSelector);
   const isUpToDate = useSelector(isUpToDateSelector);
   const globalSyncState = useGlobalSyncState();
-
   const { t } = useTranslation();
 
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
@@ -63,7 +63,7 @@ function Accounts({ navigation, route }: Props) {
         ? flattenAccounts(accounts, {
             enforceHideEmptySubAccounts: true,
           }).filter(
-            account =>
+            (account: Account | TokenAccount) =>
               getAccountCurrency(account).id === route?.params?.currencyId,
           )
         : flattenAccounts(accounts, {
@@ -80,20 +80,28 @@ function Accounts({ navigation, route }: Props) {
           params.currency.toUpperCase(),
         );
         if (currency) {
-          const account = accounts.find(acc => acc.currency.id === currency.id);
+          const account = params.address
+            ? accounts.find(
+                acc =>
+                  acc.currency.id === currency.id &&
+                  acc.freshAddress === params.address,
+              )
+            : null;
 
           if (account) {
-            // reset params so when we come back the redirection doesn't loop
-            navigation.setParams({ ...params, currency: undefined });
-            navigation.navigate(ScreenName.Account, {
+            navigation.replace(ScreenName.Account, {
               accountId: account.id,
+            });
+          } else {
+            navigation.replace(ScreenName.Asset, {
+              currency,
               isForwardedFromAccounts: true,
             });
           }
         }
       }
     }
-  }, [params, accounts, navigation]);
+  }, [params, accounts, navigation, account]);
 
   const renderItem = useCallback(
     ({ item, index }: { item: Account | TokenAccount; index: number }) => (

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/01-SelectCrypto.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/01-SelectCrypto.tsx
@@ -26,6 +26,7 @@ type Props = {
   route: {
     params: {
       filterCurrencyIds?: string[];
+      currency?: string;
     };
   };
 };
@@ -45,8 +46,7 @@ const listSupportedTokens = () =>
 
 export default function AddAccountsSelectCrypto({ navigation, route }: Props) {
   const { colors } = useTheme();
-  const { filterCurrencyIds = [] } = route.params || {};
-
+  const { filterCurrencyIds = [], currency } = route.params || {};
   const osmo = useFeature("currencyOsmosisMobile");
   const fantom = useFeature("currencyFantomMobile");
   const moonbeam = useFeature("currencyMoonbeamMobile");
@@ -134,6 +134,7 @@ export default function AddAccountsSelectCrypto({ navigation, route }: Props) {
           list={sortedCryptoCurrencies}
           renderList={renderList}
           renderEmptySearch={renderEmptyList}
+          initialQuery={currency}
         />
       </View>
     </SafeAreaView>

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/01-SelectCrypto.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/01-SelectCrypto.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { StyleSheet, FlatList } from "react-native";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
@@ -11,6 +11,7 @@ import {
   listTokens,
   useCurrenciesByMarketcap,
   listSupportedCurrencies,
+  findCryptoCurrencyByKeyword,
 } from "@ledgerhq/live-common/currencies/index";
 
 import { Flex } from "@ledgerhq/native-ui";
@@ -27,7 +28,7 @@ const SEARCH_KEYS = ["name", "ticker"];
 type Props = {
   devMode: boolean;
   navigation: any;
-  route: { params: { filterCurrencyIds?: string[] } };
+  route: { params: { filterCurrencyIds?: string[]; currency?: string } };
 };
 
 const keyExtractor = (currency: CryptoCurrency | TokenCurrency) => currency.id;
@@ -54,6 +55,8 @@ const findAccountByCurrency = (
   );
 
 export default function AddAccountsSelectCrypto({ navigation, route }: Props) {
+  const paramsCurrency = route?.params?.currency;
+
   const { t } = useTranslation();
   const filterCurrencyIds = useMemo(
     () => route.params?.filterCurrencyIds || [],
@@ -71,6 +74,18 @@ export default function AddAccountsSelectCrypto({ navigation, route }: Props) {
   );
 
   const accounts = useSelector(flattenAccountsSelector);
+
+  useEffect(() => {
+    if (paramsCurrency) {
+      const selectedCurrency = findCryptoCurrencyByKeyword(
+        paramsCurrency.toUpperCase(),
+      );
+
+      if (selectedCurrency) {
+        onPressItem(selectedCurrency);
+      }
+    }
+  }, [onPressItem, paramsCurrency]);
 
   const sortedCryptoCurrencies = useCurrenciesByMarketcap(cryptoCurrencies);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add Deeplink for Add Account and Accounts page

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3237] [LIVE-3238] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Start LLM and use `adb shell am start -W -a android.intent.action.VIEW -d "ledgerlive://add-account?currency=ethereum" com.ledger.live.debug` to trigger Deeplink for add-account. Ethereum should be filled by default

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3237]: https://ledgerhq.atlassian.net/browse/LIVE-3237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-3238]: https://ledgerhq.atlassian.net/browse/LIVE-3238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ