### PR TITLE
bugfix(TabBar): Wrap text when is too long in TabBar Transfer

### DIFF
--- a/.changeset/plenty-oranges-flash.md
+++ b/.changeset/plenty-oranges-flash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Wrap text when is too long in TabBar Tansfer

--- a/apps/ledger-live-mobile/src/components/TabBar/TransferButton.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TransferButton.tsx
@@ -87,6 +87,8 @@ export default function TransferButton({
           alignItems="flex-start"
           ml="16px"
           py="1px"
+          flexShrink={1}
+          flexWrap="wrap"
         >
           <Flex flexDirection="row">
             <Text variant="large" fontWeight="semiBold">


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Wrap text when is too long in TabBar Transfer

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3585] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
_Before_
<img width="333" alt="Screenshot 2022-09-13 at 14 12 13" src="https://user-images.githubusercontent.com/112866305/189899109-fc097412-b16d-46de-bc34-8165c8fdc3ad.png">
_After_
<img width="345" alt="Screenshot 2022-09-13 at 14 12 34" src="https://user-images.githubusercontent.com/112866305/189899123-b8d550d9-68d6-4aac-b3a4-e79717bf7fd1.png">


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
 Main app button

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-385]: https://ledgerhq.atlassian.net/browse/LIVE-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-3585]: https://ledgerhq.atlassian.net/browse/LIVE-3585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ