### PR TITLE
LLM custom image fixes

### DIFF
--- a/.changeset/selfish-schools-end.md
+++ b/.changeset/selfish-schools-end.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+UX and functional fixes in custom image flow

--- a/apps/ledger-live-mobile/src/components/CustomImage/ContrastChoice.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/ContrastChoice.tsx
@@ -1,10 +1,11 @@
-import { Box, Icons } from "@ledgerhq/native-ui";
+import { Box, Icons, InfiniteLoader } from "@ledgerhq/native-ui";
 import React from "react";
 import styled from "styled-components/native";
 
 type Props = {
   color: string;
   selected: boolean;
+  loading?: boolean;
 };
 
 const Container = styled(Box).attrs((p: { selected: boolean }) => ({
@@ -48,10 +49,14 @@ const CheckPill: React.FC<Record<string, never>> = () => (
   </CheckContainer>
 );
 
-const ContrastChoice: React.FC<Props> = ({ selected, color }) => (
+const ContrastChoice: React.FC<Props> = ({ loading, selected, color }) => (
   <Container selected={selected}>
-    <Round backgroundColor={color} />
-    {selected && <CheckPill />}
+    {selected && loading ? (
+      <InfiniteLoader size={28} />
+    ) : (
+      <Round backgroundColor={color} />
+    )}
+    {selected ? <CheckPill /> : null}
   </Container>
 );
 

--- a/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
@@ -24,7 +24,7 @@ const CustomImageBottomModal: React.FC<Props> = props => {
       if (importResult !== null) {
         navigation.navigate(NavigatorName.CustomImage, {
           screen: ScreenName.CustomImageStep1Crop,
-          params: importResult,
+          params: { ...importResult, isPictureFromGallery: true },
         });
       }
     } catch (error) {

--- a/apps/ledger-live-mobile/src/components/CustomImage/imageUtils.ts
+++ b/apps/ledger-live-mobile/src/components/CustomImage/imageUtils.ts
@@ -12,8 +12,8 @@ import {
 /**
  * Call this to prompt the user to pick an image from its phone.
  *
- * @returns (a promise) null if the user cancelled, otherwise an containing
- * the chosen image file URI as well as the image dimensions
+ * @returns (a promise) null if the user cancelled, otherwise an object
+ * containing the chosen image file URI as well as the image dimensions
  */
 export async function importImageFromPhoneGallery(): Promise<ImageFileUri | null> {
   try {

--- a/apps/ledger-live-mobile/src/components/CustomImage/injectedCode/resultDataTesting.ts
+++ b/apps/ledger-live-mobile/src/components/CustomImage/injectedCode/resultDataTesting.ts
@@ -31,7 +31,8 @@ function codeToInject() {
     postDataToWebView({ type: "ERROR", payload: error.toString() });
   };
 
-  const log = (...args) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const log = (...args: any[]) => {
     postDataToWebView({ type: "LOG", payload: JSON.stringify(args) });
   };
 

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
@@ -2,7 +2,10 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Flex, Icons, InfiniteLoader } from "@ledgerhq/native-ui";
 import { CropView } from "react-native-image-crop-tools";
 import { useTranslation } from "react-i18next";
-import { StackScreenProps } from "@react-navigation/stack";
+import {
+  StackNavigationEventMap,
+  StackScreenProps,
+} from "@react-navigation/stack";
 import { SafeAreaView } from "react-native-safe-area-context";
 import ImageCropper, {
   Props as ImageCropperProps,
@@ -12,13 +15,21 @@ import {
   ImageDimensions,
   ImageFileUri,
 } from "../../components/CustomImage/types";
-import { downloadImageToFile } from "../../components/CustomImage/imageUtils";
+import {
+  downloadImageToFile,
+  importImageFromPhoneGallery,
+} from "../../components/CustomImage/imageUtils";
 import { targetDimensions } from "./shared";
 import Button from "../../components/Button";
 import { ScreenName } from "../../const";
 import BottomContainer from "../../components/CustomImage/BottomButtonsContainer";
 import Touchable from "../../components/Touchable";
 import { ParamList } from "./types";
+import {
+  EventListenerCallback,
+  EventMapCore,
+  StackNavigationState,
+} from "@react-navigation/native";
 
 /**
  * UI component that loads the input image (from the route params) &
@@ -37,6 +48,8 @@ const Step1Cropping: React.FC<
 
   const { params } = route;
 
+  const { isPictureFromGallery } = params;
+
   const handleError = useCallback(
     (error: Error) => {
       console.error(error);
@@ -47,6 +60,39 @@ const Step1Cropping: React.FC<
     },
     [navigation],
   );
+
+  useEffect(() => {
+    let dead = false;
+    const listener: EventListenerCallback<
+      StackNavigationEventMap & EventMapCore<StackNavigationState<ParamList>>,
+      "beforeRemove"
+    > = e => {
+      if (!isPictureFromGallery) {
+        navigation.dispatch(e.data.action);
+        return;
+      }
+      e.preventDefault();
+      setImageToCrop(null);
+      importImageFromPhoneGallery()
+        .then(importResult => {
+          if (dead) return;
+          if (importResult !== null) {
+            setImageToCrop(importResult);
+          } else {
+            navigation.dispatch(e.data.action);
+          }
+        })
+        .catch(e => {
+          if (dead) return;
+          handleError(e);
+        });
+    };
+    navigation.addListener("beforeRemove", listener);
+    return () => {
+      dead = true;
+      navigation.removeListener("beforeRemove", listener);
+    };
+  }, [navigation, handleError, isPictureFromGallery]);
 
   /** LOAD SOURCE IMAGE FROM PARAMS */
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
@@ -6,6 +6,11 @@ import {
   StackNavigationEventMap,
   StackScreenProps,
 } from "@react-navigation/stack";
+import {
+  EventListenerCallback,
+  EventMapCore,
+  StackNavigationState,
+} from "@react-navigation/native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import ImageCropper, {
   Props as ImageCropperProps,
@@ -25,11 +30,6 @@ import { ScreenName } from "../../const";
 import BottomContainer from "../../components/CustomImage/BottomButtonsContainer";
 import Touchable from "../../components/Touchable";
 import { ParamList } from "./types";
-import {
-  EventListenerCallback,
-  EventMapCore,
-  StackNavigationState,
-} from "@react-navigation/native";
 
 /**
  * UI component that loads the input image (from the route params) &

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step2Preview.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step2Preview.tsx
@@ -58,6 +58,7 @@ const Step2Preview: React.FC<
   StackScreenProps<ParamList, "CustomImageStep2Preview">
 > = ({ navigation, route }) => {
   const imageProcessorRef = useRef<ImageProcessor>(null);
+  const [loading, setLoading] = useState(true);
   const [resizedImage, setResizedImage] = useState<ResizeResult | null>(null);
   const [contrast, setContrast] = useState(1);
   const [processorPreviewImage, setProcessorPreviewImage] =
@@ -103,6 +104,7 @@ const Step2Preview: React.FC<
     useCallback(
       data => {
         setProcessorPreviewImage(data);
+        setLoading(false);
       },
       [setProcessorPreviewImage],
     );
@@ -192,8 +194,21 @@ const Step2Preview: React.FC<
         {resizedImage?.imageBase64DataUri && (
           <Flex flexDirection="row" my={6} justifyContent="space-between">
             {contrasts.map(({ val, color }) => (
-              <Pressable key={val} onPress={() => setContrast(val)}>
-                <ContrastChoice selected={contrast === val} color={color} />
+              <Pressable
+                disabled={loading}
+                key={val}
+                onPress={() => {
+                  if (contrast !== val) {
+                    setLoading(true);
+                    setContrast(val);
+                  }
+                }}
+              >
+                <ContrastChoice
+                  selected={contrast === val}
+                  loading={loading}
+                  color={color}
+                />
               </Pressable>
             ))}
           </Flex>

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step2Preview.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step2Preview.tsx
@@ -31,7 +31,6 @@ export const PreviewImage = styled.Image.attrs({
   resizeMode: "contain",
 })`
   align-self: center;
-  margin: 16px;
   width: 200px;
   height: 200px;
 `;

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -105,21 +105,14 @@ const Step3Transfer: React.FC<
         {rawData?.hexData && (
           <>
             <Text variant="h3" py={4}>
-              Raw data (500 first characters):
+              Raw data (200 first characters):
             </Text>
             <Flex backgroundColor="neutral.c30">
               <Text>width: {rawData?.width}</Text>
               <Text>height: {rawData?.height}</Text>
-              <Text>{rawData?.hexData.slice(0, 500)}</Text>
+              <Text>{rawData?.hexData.slice(0, 200)}</Text>
             </Flex>
           </>
-        )}
-        {rawData && (
-          <ResultDataTester
-            {...rawData}
-            onPreviewResult={handlePreviewResult}
-            onError={handleError}
-          />
         )}
         <Flex
           flex={1}
@@ -131,20 +124,22 @@ const Step3Transfer: React.FC<
           <Text variant="h3" py={4} alignSelf="flex-start">
             Image reconstructed from raw data:
           </Text>
-          <Alert type="primary" title={infoMessage} />
+          {rawData && (
+            <ResultDataTester
+              {...rawData}
+              onPreviewResult={handlePreviewResult}
+              onError={handleError}
+            />
+          )}
           {reconstructedPreviewResult?.imageBase64DataUri ? (
-            <Flex mt={5} alignItems="center">
+            <Flex mb={5} alignItems="center">
               {isDataMatching ? (
                 <Alert type="success" title={successMessage} />
               ) : (
                 <Alert type="error" title={errorMessage} />
               )}
-              <Text>
-                {isDataMatching
-                  ? ""
-                  : "Press the image below to see the difference"}
-              </Text>
-              <Text>
+              <Text textAlign="center">
+                {"Press the image below to see the difference.\n"}
                 {showReconstructed
                   ? "Reconstructed image:"
                   : "Previewed image:"}
@@ -177,6 +172,7 @@ const Step3Transfer: React.FC<
           ) : (
             <InfiniteLoader />
           )}
+          <Alert type="primary" title={infoMessage} />
         </Flex>
       </Flex>
     </ScrollView>

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Dimensions, ScrollView } from "react-native";
+import { Dimensions, Pressable, ScrollView } from "react-native";
 import { Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import { StackScreenProps } from "@react-navigation/stack";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -85,6 +85,20 @@ const Step3Transfer: React.FC<
 
   const insets = useSafeAreaInsets();
 
+  const [showReconstructed, setShowReconstructed] = useState(true);
+  const handlePressIn = useCallback(
+    () => setShowReconstructed(false),
+    [setShowReconstructed],
+  );
+  const handlePressOut = useCallback(
+    () => setShowReconstructed(true),
+    [setShowReconstructed],
+  );
+
+  const isDataMatching =
+    reconstructedPreviewResult?.imageBase64DataUri ===
+    previewData?.imageBase64DataUri;
+
   return (
     <ScrollView contentContainerStyle={{ paddingBottom: insets.bottom }}>
       <Flex p={6}>
@@ -119,22 +133,46 @@ const Step3Transfer: React.FC<
           </Text>
           <Alert type="primary" title={infoMessage} />
           {reconstructedPreviewResult?.imageBase64DataUri ? (
-            <Flex mt={5}>
-              {reconstructedPreviewResult?.imageBase64DataUri ===
-              previewData?.imageBase64DataUri ? (
+            <Flex mt={5} alignItems="center">
+              {isDataMatching ? (
                 <Alert type="success" title={successMessage} />
               ) : (
                 <Alert type="error" title={errorMessage} />
               )}
-              <PreviewImage
-                source={{
-                  uri: reconstructedPreviewResult.imageBase64DataUri,
-                }}
+              <Text>
+                {isDataMatching
+                  ? ""
+                  : "Press the image below to see the difference"}
+              </Text>
+              <Text>
+                {showReconstructed
+                  ? "Reconstructed image:"
+                  : "Previewed image:"}
+              </Text>
+              <Pressable
+                onPressIn={handlePressIn}
+                onPressOut={handlePressOut}
                 style={{
-                  height: previewDimensions?.height,
-                  width: previewDimensions?.width,
+                  ...previewDimensions,
                 }}
-              />
+              >
+                <Flex position="absolute">
+                  <PreviewImage
+                    source={{
+                      uri: previewData.imageBase64DataUri,
+                    }}
+                    style={previewDimensions}
+                  />
+                </Flex>
+                <Flex position="absolute" opacity={showReconstructed ? 1 : 0}>
+                  <PreviewImage
+                    source={{
+                      uri: reconstructedPreviewResult.imageBase64DataUri,
+                    }}
+                    style={previewDimensions}
+                  />
+                </Flex>
+              </Pressable>
             </Flex>
           ) : (
             <InfiniteLoader />

--- a/apps/ledger-live-mobile/src/screens/CustomImage/types.ts
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/types.ts
@@ -5,7 +5,9 @@ import {
 } from "../../components/CustomImage/ImageProcessor";
 import { ImageFileUri, ImageUrl } from "../../components/CustomImage/types";
 
-type Step1CroppingParams = ImageUrl | ImageFileUri;
+type Step1CroppingParams = (ImageUrl | ImageFileUri) & {
+  isPictureFromGallery?: boolean;
+};
 
 type Step2PreviewParams = CropResult;
 


### PR DESCRIPTION
### 📝 Description

Fixes for the custom image tool: 

- Back button behaviour in the first step: If the image is coming from the phone gallery, pressing the back button should reopen the gallery
- Prevent choosing another contrast if current contrast is loading
- Implement dithering → quality improvement of image, avoiding color banding
- Implement new ordering of pixels 
  - in raw data result
  - in raw data result verifier (the last screen that reconstructs the image from the raw data)

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-395] [FAT-406] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-395]: https://ledgerhq.atlassian.net/browse/FAT-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAT-406]: https://ledgerhq.atlassian.net/browse/FAT-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ