### PR TITLE
BACK-3946: Fix outdated assertion on exchange signature size

### DIFF
--- a/libs/ledger-live-common/src/exchange/hw-app-exchange/Exchange.ts
+++ b/libs/ledger-live-common/src/exchange/hw-app-exchange/Exchange.ts
@@ -138,9 +138,9 @@ export default class Exchange {
     invariant(payoutCurrencyConfig.length <= 255, "Currency config is too big");
     invariant(addressParameters.length <= 255, "Address parameter is too big.");
     invariant(
-      currencyConfigSignature.length >= 70 &&
-        currencyConfigSignature.length <= 73,
-      "Signature should be DER serialized and have length in [70, 73] bytes."
+      currencyConfigSignature.length >= 67 &&
+        currencyConfigSignature.length <= 72,
+      "Signature should be DER serialized and have length in [67, 72] bytes."
     );
     const bufferToSend: Buffer = Buffer.concat([
       Buffer.from([payoutCurrencyConfig.length]),
@@ -170,9 +170,9 @@ export default class Exchange {
     invariant(refundCurrencyConfig.length <= 255, "Currency config is too big");
     invariant(addressParameters.length <= 255, "Address parameter is too big.");
     invariant(
-      currencyConfigSignature.length >= 70 &&
-        currencyConfigSignature.length <= 73,
-      "Signature should be DER serialized and have length in [70, 73] bytes."
+      currencyConfigSignature.length >= 67 &&
+        currencyConfigSignature.length <= 72,
+      "Signature should be DER serialized and have length in [67, 72] bytes."
     );
     const bufferToSend: Buffer = Buffer.concat([
       Buffer.from([refundCurrencyConfig.length]),


### PR DESCRIPTION
Boundaries are defined here: https://github.com/LedgerHQ/app-exchange/blob/develop/src/globals.h#L15

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed._

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
