### PR TITLE
bugfix(Layout): Layout issue with the error message if Bluetooth is disabled when user pairs device

### DIFF
--- a/.changeset/quick-moles-fix.md
+++ b/.changeset/quick-moles-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Layout issue with the error message if Bluetooth is disabled when user pairs device

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/BluetoothDisabled.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/BluetoothDisabled.tsx
@@ -11,8 +11,8 @@ const SafeAreaContainer = styled.SafeAreaView`
   align-items: center;
   justify-content: center;
   background-color: ${p => p.theme.colors.background.main};
-  margin-left: 24px;
-  margin-right: 24px;
+  margin-left: ${p => `${p.theme.space[4]}px`};
+  margin-right: ${p => `${p.theme.space[4]}px`};
 `;
 
 function BluetoothDisabled() {

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/BluetoothDisabled.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/BluetoothDisabled.tsx
@@ -11,6 +11,8 @@ const SafeAreaContainer = styled.SafeAreaView`
   align-items: center;
   justify-content: center;
   background-color: ${p => p.theme.colors.background.main};
+  margin-left: 24px;
+  margin-right: 24px;
 `;
 
 function BluetoothDisabled() {
@@ -24,13 +26,13 @@ function BluetoothDisabled() {
   return (
     <SafeAreaContainer>
       <IconBox Icon={BluetoothMedium} iconSize={24} boxSize={64} />
-      <Text variant={"h2"} mb={5} mt={7}>
+      <Text variant={"h2"} mb={5} mt={7} textAlign="center">
         <Trans i18nKey="bluetooth.required" />
       </Text>
       <Text
         variant={"body"}
         fontWeight={"medium"}
-        textAlign={"justify"}
+        textAlign="center"
         color={"neutral.c80"}
       >
         <Trans i18nKey="bluetooth.checkEnabled" values={deviceNames.nanoX} />


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Layout issue with the error message if Bluetooth is disabled when user pairs device

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2697] [LIVE-3562] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
_Before_
![simulator_screenshot_34AF9590-AB27-48E9-9AE0-F7CF2CAA4BB6](https://user-images.githubusercontent.com/112866305/190994497-2a4b333d-3112-4c50-b87d-08fb98e0833e.png)

_After_
![simulator_screenshot_32D69B8F-3A0A-475D-B7FC-760A7A32B902](https://user-images.githubusercontent.com/112866305/190994395-d2629a9b-d348-446f-b549-9e560668bee4.png)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Disable bluetooth > Go to Pair device flow 

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2697]: https://ledgerhq.atlassian.net/browse/LIVE-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-3562]: https://ledgerhq.atlassian.net/browse/LIVE-3562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ