### PR TITLE
bugfix(Storage): Wrong message when LNX storage is full

### DIFF
--- a/.changeset/rich-snakes-turn.md
+++ b/.changeset/rich-snakes-turn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Wrong message when LNX storage is full

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1071,7 +1071,7 @@
     },
     "stepLanguage": {
       "title": "Select your language",
-      "cta": "Continue", 
+      "cta": "Continue",
       "changeDeviceLanguage": "{{language}} is also available for your {{deviceName}}",
       "changeDeviceLanguageDescription": "Would you like to change its language to {{language}}?",
       "warning": {
@@ -3352,6 +3352,7 @@
       "appsInstalled": "<0>{{number}}</0> app",
       "appsInstalled_plural": "<0>{{number}}</0> apps",
       "storageAvailable": "available",
+      "noFreeSpace": "No storage left",
       "appsToUpdate": "<0>{{number}}</0> update",
       "appsToUpdate_plural": "<0>{{number}}</0> updates"
     },

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
@@ -49,6 +49,8 @@ const DeviceAppStorage = ({
     [apps, appsSpaceBytes],
   );
 
+  const isDeviceFull = !freeSpaceBytes;
+
   return (
     /* Fixme: Storage info line might be too tight with some translation, consider putting it on multiple lines */
     <Box mx={6}>
@@ -106,24 +108,35 @@ const DeviceAppStorage = ({
             </Trans>
           </Text>
         </Flex>
+
         <Flex flexDirection={"row"} alignItems={"center"}>
           {shouldWarnMemory && (
             <Box mr={2}>
               <WarningMedium color={"palette.warning.c60"} size={14} />
             </Box>
           )}
-          <Text
-            variant={"small"}
-            fontWeight={"medium"}
-            color={"palette.neutral.c80"}
-          >
-            <ByteSize
-              value={freeSpaceBytes}
-              deviceModel={deviceModel}
-              firmwareVersion={deviceInfo.version}
-            />{" "}
-            <Trans i18nKey="manager.storage.storageAvailable" />
-          </Text>
+          {isDeviceFull ? (
+            <Text
+              variant={"small"}
+              fontWeight={"medium"}
+              color={"palette.warning.c60"}
+            >
+              <Trans i18nKey="manager.storage.noFreeSpace" />
+            </Text>
+          ) : (
+            <Text
+              variant={"small"}
+              fontWeight={"medium"}
+              color={"palette.neutral.c80"}
+            >
+              <ByteSize
+                value={freeSpaceBytes}
+                deviceModel={deviceModel}
+                firmwareVersion={deviceInfo.version}
+              />{" "}
+              <Trans i18nKey="manager.storage.storageAvailable" />
+            </Text>
+          )}
         </Flex>
       </Flex>
       <StorageRepartition


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Wrong message when LNX storage is full
### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-1383] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/112866305/191206033-1261eae2-ceda-43fb-ba5b-7eb8c7fd7f95.mp4


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Go to My Ledger and add Apps to reach limit

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
