### PR TITLE
fix: show only available providers

### DIFF
--- a/.changeset/pretty-lobsters-smile.md
+++ b/.changeset/pretty-lobsters-smile.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Filter provider swap list by status

--- a/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
@@ -126,15 +126,22 @@ const inferError = (
     maxAmountFrom: string;
     errorCode?: number;
     errorMessage?: string;
+    status: string;
   }
 ): Error | CustomMinOrMaxError | undefined => {
   const tenPowMagnitude = new BigNumber(10).pow(unitFrom.magnitude);
-  const { amountTo, minAmountFrom, maxAmountFrom, errorCode, errorMessage } =
-    responseData;
+  const {
+    amountTo,
+    minAmountFrom,
+    maxAmountFrom,
+    errorCode = 0,
+    errorMessage,
+    status,
+  } = responseData;
 
   if (!amountTo) {
     // We are in an error case regardless of api version.
-    if (errorCode) {
+    if (status === "error") {
       return getSwapAPIError(errorCode, errorMessage);
     }
 


### PR DESCRIPTION
### 📝 Description

LLC Add error to swap depend of 'status'  instead 'errorCode'.

### ❓ Context

- **Impacted projects**: `` 
- LLC
- **Linked resource(s)**: `` 
- [swap] As a user on desktop, I want to be able to see only provider available https://ledgerhq.atlassian.net/browse/LIVE-3679
- LLD - FTX and FTXUS displayed as empty quotes even if 'Amount' is too high https://ledgerhq.atlassian.net/browse/LIVE-3766

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="1194" alt="Screenshot 2022-09-20 at 11 16 29" src="https://user-images.githubusercontent.com/38540290/191232774-952b5374-9a1c-4ba8-9d97-ef6a24bbcbea.png">

