### PR TITLE
Bugfix/live 3251 ratings and notifs modals conflicts fixed

### DIFF
--- a/.changeset/tough-nails-train.md
+++ b/.changeset/tough-nails-train.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixed a bug causing a freeze on ios when the ratings modal opened at the same time as the notifications one

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -61,6 +61,10 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import Account from "../../screens/Account";
 // eslint-disable-next-line import/no-cycle
 import ReadOnlyAccount from "../../screens/Account/ReadOnly/ReadOnlyAccount";
+import ReadOnlyAccountHeaderTitle from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderTitle";
+import ReadOnlyAccountHeaderRight from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderRight";
+import AccountHeaderTitle from "../../screens/Account/AccountHeaderTitle";
+import AccountHeaderRight from "../../screens/Account/AccountHeaderRight";
 import TransparentHeaderNavigationOptions from "../../navigation/TransparentHeaderNavigationOptions";
 import styles from "../../navigation/styles";
 import HeaderRightClose from "../HeaderRightClose";
@@ -102,8 +106,6 @@ import {
 } from "../../screens/BleDevicePairingFlow/index";
 import { readOnlyModeEnabledSelector } from "../../reducers/settings";
 import { accountsSelector } from "../../reducers/accounts";
-import ReadOnlyAccountHeaderTitle from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderTitle";
-import ReadOnlyAccountHeaderRight from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderRight";
 
 // TODO: types for each screens and navigators need to be set
 export type BaseNavigatorStackParamList = {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { Flex, Icons } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
+import { useSelector } from "react-redux";
 import { ScreenName, NavigatorName } from "../../const";
 import * as families from "../../families";
 import OperationDetails, {
@@ -58,6 +59,7 @@ import AnalyticsOperations from "../../screens/Analytics/Operations";
 import NftNavigator from "./NftNavigator";
 import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import Account from "../../screens/Account";
+import ReadOnlyAccount from "../../screens/Account/ReadOnly/ReadOnlyAccount";
 import TransparentHeaderNavigationOptions from "../../navigation/TransparentHeaderNavigationOptions";
 import styles from "../../navigation/styles";
 import HeaderRightClose from "../HeaderRightClose";
@@ -97,6 +99,10 @@ import {
   BleDevicePairingFlow,
   BleDevicePairingFlowParams,
 } from "../../screens/BleDevicePairingFlow/index";
+import { readOnlyModeEnabledSelector } from "../../reducers/settings";
+import { accountsSelector } from "../../reducers/accounts";
+import ReadOnlyAccountHeaderTitle from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderTitle";
+import ReadOnlyAccountHeaderRight from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderRight";
 
 // TODO: types for each screens and navigators need to be set
 export type BaseNavigatorStackParamList = {
@@ -123,6 +129,9 @@ export default function BaseNavigator() {
   const ptxSmartRoutingMobile = useFeature("ptxSmartRoutingMobile");
   const walletConnectLiveApp = useFeature("walletConnectLiveApp");
   const noNanoBuyNanoWallScreenOptions = useNoNanoBuyNanoWallScreenOptions();
+  const accounts = useSelector(accountsSelector);
+  const readOnlyModeEnabled =
+    useSelector(readOnlyModeEnabledSelector) && accounts.length <= 0;
 
   return (
     <Stack.Navigator
@@ -565,8 +574,24 @@ export default function BaseNavigator() {
       />
       <Stack.Screen
         name={ScreenName.Account}
-        component={Account}
-        options={{ headerShown: false }}
+        component={readOnlyModeEnabled ? ReadOnlyAccount : Account}
+        options={({ route, navigation }) => ({
+          headerLeft: () => (
+            <BackButton navigation={navigation} route={route} />
+          ),
+          headerTitle: () =>
+            readOnlyModeEnabled ? (
+              <ReadOnlyAccountHeaderTitle />
+            ) : (
+              <AccountHeaderTitle />
+            ),
+          headerRight: () =>
+            readOnlyModeEnabled ? (
+              <ReadOnlyAccountHeaderRight />
+            ) : (
+              <AccountHeaderRight />
+            ),
+        })}
       />
       <Stack.Screen
         name={ScreenName.ScanRecipient}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -59,6 +59,7 @@ import AnalyticsOperations from "../../screens/Analytics/Operations";
 import NftNavigator from "./NftNavigator";
 import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import Account from "../../screens/Account";
+// eslint-disable-next-line import/no-cycle
 import ReadOnlyAccount from "../../screens/Account/ReadOnly/ReadOnlyAccount";
 import TransparentHeaderNavigationOptions from "../../navigation/TransparentHeaderNavigationOptions";
 import styles from "../../navigation/styles";

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -61,10 +61,6 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import Account from "../../screens/Account";
 // eslint-disable-next-line import/no-cycle
 import ReadOnlyAccount from "../../screens/Account/ReadOnly/ReadOnlyAccount";
-import ReadOnlyAccountHeaderTitle from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderTitle";
-import ReadOnlyAccountHeaderRight from "../../screens/Account/ReadOnly/ReadOnlyAccountHeaderRight";
-import AccountHeaderTitle from "../../screens/Account/AccountHeaderTitle";
-import AccountHeaderRight from "../../screens/Account/AccountHeaderRight";
 import TransparentHeaderNavigationOptions from "../../navigation/TransparentHeaderNavigationOptions";
 import styles from "../../navigation/styles";
 import HeaderRightClose from "../HeaderRightClose";

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -578,23 +578,7 @@ export default function BaseNavigator() {
       <Stack.Screen
         name={ScreenName.Account}
         component={readOnlyModeEnabled ? ReadOnlyAccount : Account}
-        options={({ route, navigation }) => ({
-          headerLeft: () => (
-            <BackButton navigation={navigation} route={route} />
-          ),
-          headerTitle: () =>
-            readOnlyModeEnabled ? (
-              <ReadOnlyAccountHeaderTitle />
-            ) : (
-              <AccountHeaderTitle />
-            ),
-          headerRight: () =>
-            readOnlyModeEnabled ? (
-              <ReadOnlyAccountHeaderRight />
-            ) : (
-              <AccountHeaderRight />
-            ),
-        })}
+        options={{ headerShown: false }}
       />
       <Stack.Screen
         name={ScreenName.ScanRecipient}

--- a/apps/ledger-live-mobile/src/logic/notifications.tsx
+++ b/apps/ledger-live-mobile/src/logic/notifications.tsx
@@ -56,20 +56,6 @@ export type DataOfUser = {
 const pushNotificationsDataOfUserAsyncStorageKey =
   "pushNotificationsDataOfUser";
 
-const getCurrentRouteName = (
-  state: NavigationState | Required<NavigationState["routes"][0]>["state"],
-): Routes | undefined => {
-  if (state.index === undefined || state.index < 0) {
-    return undefined;
-  }
-
-  const nestedState = state.routes[state.index].state;
-  if (nestedState !== undefined) {
-    return getCurrentRouteName(nestedState);
-  }
-  return state.routes[state.index].name;
-};
-
 async function getPushNotificationsDataOfUserFromStorage() {
   const dataOfUser = await AsyncStorage.getItem(
     pushNotificationsDataOfUserAsyncStorageKey,
@@ -266,7 +252,7 @@ const useNotifications = () => {
     [pushNotificationsOldRoute],
   );
 
-  const onRouteChange = useCallback(
+  const onPushNotificationsRouteChange = useCallback(
     newRoute => {
       if (pushNotificationsEventTriggered?.timeout) {
         clearTimeout(pushNotificationsEventTriggered?.timeout);
@@ -311,18 +297,6 @@ const useNotifications = () => {
     [dispatch],
   );
 
-  const initPushNotifications = useCallback(() => {
-    if (!pushNotificationsFeature?.enabled) return;
-
-    navigation.addListener("state", e => {
-      const navState = e?.data?.state;
-      if (navState && navState.routeNames) {
-        const currentRouteName = getCurrentRouteName(navState);
-        onRouteChange(currentRouteName);
-      }
-    });
-  }, [navigation, pushNotificationsFeature?.enabled, onRouteChange]);
-
   const initPushNotificationsData = useCallback(() => {
     getPushNotificationsDataOfUserFromStorage().then(dataOfUser => {
       updatePushNotificationsDataOfUserInStateAndStore({
@@ -332,10 +306,6 @@ const useNotifications = () => {
       });
     });
   }, []);
-
-  const cleanPushNotifications = useCallback(() => {
-    navigation.removeListener("state");
-  }, [navigation]);
 
   const triggerMarketPushNotificationModal = useCallback(() => {
     if (
@@ -473,9 +443,8 @@ const useNotifications = () => {
   ]);
 
   return {
-    initPushNotifications,
     initPushNotificationsData,
-    cleanPushNotifications,
+    onPushNotificationsRouteChange,
     pushNotificationsOldRoute,
     pushNotificationsModalType,
     isPushNotificationsModalOpen,

--- a/apps/ledger-live-mobile/src/logic/notifications.tsx
+++ b/apps/ledger-live-mobile/src/logic/notifications.tsx
@@ -253,13 +253,13 @@ const useNotifications = () => {
   );
 
   const onPushNotificationsRouteChange = useCallback(
-    newRoute => {
+    (newRoute, isOtherModalOpened = false) => {
       if (pushNotificationsEventTriggered?.timeout) {
         clearTimeout(pushNotificationsEventTriggered?.timeout);
         dispatch(setRatingsModalLocked(false));
       }
 
-      if (isPushNotificationsModalLocked || !areConditionsMet()) return;
+      if (isOtherModalOpened || !areConditionsMet()) return false;
 
       for (const eventTrigger of pushNotificationsFeature?.params
         ?.trigger_events) {
@@ -274,9 +274,12 @@ const useNotifications = () => {
               timeout,
             }),
           );
+          dispatch(setNotificationsCurrentRouteName(newRoute));
+          return true;
         }
       }
       dispatch(setNotificationsCurrentRouteName(newRoute));
+      return false;
     },
     [
       areConditionsMet,
@@ -285,7 +288,6 @@ const useNotifications = () => {
       pushNotificationsFeature?.params?.trigger_events,
       isEventTriggered,
       setPushNotificationsModalOpenCallback,
-      isPushNotificationsModalLocked,
     ],
   );
 

--- a/apps/ledger-live-mobile/src/logic/ratings.tsx
+++ b/apps/ledger-live-mobile/src/logic/ratings.tsx
@@ -89,12 +89,12 @@ const useRatings = () => {
       if (!isRatingsModalOpen) {
         dispatch(setRatingsModalOpen(isRatingsModalOpen));
         dispatch(setNotificationsModalLocked(false));
-      } else if (!isRatingsModalLocked) {
+      } else {
         dispatch(setRatingsModalOpen(isRatingsModalOpen));
         dispatch(setNotificationsModalLocked(true));
       }
     },
-    [dispatch, isRatingsModalLocked],
+    [dispatch],
   );
 
   const areRatingsConditionsMet = useCallback(() => {
@@ -179,13 +179,13 @@ const useRatings = () => {
   );
 
   const onRatingsRouteChange = useCallback(
-    ratingsNewRoute => {
+    (ratingsNewRoute, isOtherModalOpened = false) => {
       if (ratingsHappyMoment?.timeout) {
         dispatch(setNotificationsModalLocked(false));
         clearTimeout(ratingsHappyMoment?.timeout);
       }
 
-      if (isRatingsModalLocked || !areRatingsConditionsMet()) return;
+      if (isOtherModalOpened || !areRatingsConditionsMet()) return false;
 
       for (const happyMoment of ratingsFeature?.params?.happy_moments) {
         if (isHappyMomentTriggered(happyMoment, ratingsNewRoute)) {
@@ -199,12 +199,14 @@ const useRatings = () => {
               timeout,
             }),
           );
+          dispatch(setRatingsCurrentRouteName(ratingsNewRoute));
+          return true;
         }
       }
       dispatch(setRatingsCurrentRouteName(ratingsNewRoute));
+      return false;
     },
     [
-      isRatingsModalLocked,
       areRatingsConditionsMet,
       ratingsHappyMoment?.timeout,
       dispatch,

--- a/apps/ledger-live-mobile/src/logic/ratings.tsx
+++ b/apps/ledger-live-mobile/src/logic/ratings.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { useNavigation } from "@react-navigation/native";
 import { add, isBefore, parseISO } from "date-fns";
 import type { Account } from "@ledgerhq/types-live";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -53,19 +52,6 @@ export type RatingsDataOfUser = {
 
 const ratingsDataOfUserAsyncStorageKey = "ratingsDataOfUser";
 
-const getCurrentRouteName = (
-  state: NavigationState | Required<NavigationState["routes"][0]>["state"],
-): Routes | undefined => {
-  if (state.index === undefined || state.index < 0) {
-    return undefined;
-  }
-  const nestedState = state.routes[state.index].state;
-  if (nestedState !== undefined) {
-    return getCurrentRouteName(nestedState);
-  }
-  return state.routes[state.index].name;
-};
-
 async function getRatingsDataOfUserFromStorage() {
   const ratingsDataOfUser = await AsyncStorage.getItem(
     ratingsDataOfUserAsyncStorageKey,
@@ -97,7 +83,6 @@ const useRatings = () => {
   );
 
   const dispatch = useDispatch();
-  const navigation = useNavigation();
 
   const setRatingsModalOpenCallback = useCallback(
     isRatingsModalOpen => {
@@ -193,7 +178,7 @@ const useRatings = () => {
     [ratingsOldRoute],
   );
 
-  const onRouteChange = useCallback(
+  const onRatingsRouteChange = useCallback(
     ratingsNewRoute => {
       if (ratingsHappyMoment?.timeout) {
         dispatch(setNotificationsModalLocked(false));
@@ -237,18 +222,6 @@ const useRatings = () => {
     [dispatch],
   );
 
-  const initRatings = useCallback(() => {
-    if (!ratingsFeature?.enabled) return;
-
-    navigation.addListener("state", e => {
-      const navState = e?.data?.state;
-      if (navState && navState.routeNames) {
-        const currentRouteName = getCurrentRouteName(navState);
-        onRouteChange(currentRouteName);
-      }
-    });
-  }, [navigation, ratingsFeature?.enabled, onRouteChange]);
-
   const initRatingsData = useCallback(() => {
     getRatingsDataOfUserFromStorage().then(ratingsDataOfUser => {
       updateRatingsDataOfUserInStateAndStore({
@@ -260,10 +233,6 @@ const useRatings = () => {
       });
     });
   }, []);
-
-  const cleanRatings = useCallback(() => {
-    navigation.removeListener("state");
-  }, [navigation]);
 
   const ratingsInitialStep = useMemo(
     () => (ratingsDataOfUser?.alreadyClosedFromEnjoyStep ? "enjoy" : "init"),
@@ -344,9 +313,8 @@ const useRatings = () => {
   }, [ratingsDataOfUser, updateRatingsDataOfUserInStateAndStore]);
 
   return {
-    initRatings,
     initRatingsData,
-    cleanRatings,
+    onRatingsRouteChange,
     handleSettingsRateApp,
     handleRatingsSetDateOfNextAllowedRequest,
     handleEnjoyNotNow,

--- a/apps/ledger-live-mobile/src/screens/Accounts/ReadOnly/ReadOnlyAccountRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/ReadOnly/ReadOnlyAccountRow.tsx
@@ -16,12 +16,9 @@ const ReadOnlyAccountRow = ({ navigation, currency, screen }: Props) => {
 
   const onAccountPress = useCallback(() => {
     track("account_clicked", { currency: name, screen });
-    navigation.navigate(NavigatorName.Accounts, {
-      screen: ScreenName.Account,
-      params: {
-        currencyId: id,
-        currencyType: type,
-      },
+    navigation.navigate(ScreenName.Account, {
+      currencyId: id,
+      currencyType: type,
     });
   }, [name, screen, navigation, id, type]);
 

--- a/apps/ledger-live-mobile/src/screens/Accounts/ReadOnly/ReadOnlyAccountRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/ReadOnly/ReadOnlyAccountRow.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { BigNumber } from "bignumber.js";
-import { NavigatorName, ScreenName } from "../../../const";
+import { ScreenName } from "../../../const";
 import AccountRowLayout from "../../../components/AccountRowLayout";
 import { track } from "../../../analytics";
 

--- a/apps/ledger-live-mobile/src/screens/Modals/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Modals/index.tsx
@@ -57,7 +57,8 @@ const Modals = () => {
   );
 
   useEffect(() => {
-    if (!pushNotificationsFeature?.enabled && !ratingsFeature?.enabled) return;
+    if (!pushNotificationsFeature?.enabled && !ratingsFeature?.enabled)
+      return undefined;
 
     navigation.removeListener("state", onRouteChange);
     navigation.addListener("state", onRouteChange);

--- a/apps/ledger-live-mobile/src/screens/Modals/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Modals/index.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from "react";
+import { NavigationState, useNavigation } from "@react-navigation/native";
+import {
+  FeatureToggle,
+  useFeature,
+} from "@ledgerhq/live-common/featureFlags/index";
+import PushNotificationsModal from "../PushNotificationsModal";
+import RatingsModal from "../RatingsModal";
+import useRatings from "../../logic/ratings";
+import useNotifications from "../../logic/notifications";
+
+const getCurrentRouteName = (
+  state: NavigationState | Required<NavigationState["routes"][0]>["state"],
+): Routes | undefined => {
+  if (state.index === undefined || state.index < 0) {
+    return undefined;
+  }
+  const nestedState = state.routes[state.index].state;
+  if (nestedState !== undefined) {
+    return getCurrentRouteName(nestedState);
+  }
+  return state.routes[state.index].name;
+};
+
+const Modals = () => {
+  const navigation = useNavigation();
+
+  const pushNotificationsFeature = useFeature("pushNotifications");
+  const { onPushNotificationsRouteChange } = useNotifications();
+
+  const ratingsFeature = useFeature("ratings");
+  const { onRatingsRouteChange } = useRatings();
+
+  useEffect(() => {
+    if (!pushNotificationsFeature?.enabled && !ratingsFeature?.enabled) return;
+
+    navigation.removeListener("state");
+    navigation.addListener("state", e => {
+      const navState = e?.data?.state;
+      if (navState && navState.routeNames) {
+        const currentRouteName = getCurrentRouteName(navState);
+        if (pushNotificationsFeature?.enabled) {
+          onPushNotificationsRouteChange(currentRouteName);
+        }
+        if (ratingsFeature?.enabled) {
+          onRatingsRouteChange(currentRouteName);
+        }
+      }
+    });
+
+    return () => navigation.removeListener("state");
+  }, [
+    navigation,
+    onPushNotificationsRouteChange,
+    onRatingsRouteChange,
+    pushNotificationsFeature?.enabled,
+    ratingsFeature?.enabled,
+  ]);
+
+  return (
+    <>
+      <FeatureToggle feature="pushNotifications">
+        <PushNotificationsModal />
+      </FeatureToggle>
+      <FeatureToggle feature="ratings">
+        <RatingsModal />
+      </FeatureToggle>
+    </>
+  );
+};
+
+export default Modals;

--- a/apps/ledger-live-mobile/src/screens/PushNotificationsModal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PushNotificationsModal/index.tsx
@@ -20,9 +20,7 @@ import { TrackScreen } from "../../analytics";
 const PushNotificationsModal = () => {
   const { t } = useTranslation();
   const {
-    initPushNotifications,
     initPushNotificationsData,
-    cleanPushNotifications,
     pushNotificationsModalType,
     isPushNotificationsModalOpen,
     modalAllowNotifications,
@@ -33,14 +31,6 @@ const PushNotificationsModal = () => {
     pushNotificationsOldRoute,
   } = useNotifications();
   const notificationsSettings = useSelector(notificationsSelector);
-
-  useEffect(() => {
-    initPushNotifications();
-
-    return () => {
-      cleanPushNotifications();
-    };
-  }, [initPushNotifications, cleanPushNotifications]);
 
   useEffect(() => {
     initPushNotificationsData();

--- a/apps/ledger-live-mobile/src/screens/RatingsModal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/RatingsModal/index.tsx
@@ -14,21 +14,11 @@ import DisappointedDone from "./DisappointedDone";
 
 const RatingsModal = () => {
   const {
-    initRatings,
     initRatingsData,
-    cleanRatings,
     ratingsInitialStep,
     isRatingsModalOpen,
     setRatingsModalOpen,
   } = useRatings();
-
-  useEffect(() => {
-    initRatings();
-
-    return () => {
-      cleanRatings();
-    };
-  }, [initRatings, cleanRatings]);
 
   useEffect(() => {
     initRatingsData();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixed a bug causing a freeze on ios when the ratings modal opened at the same time as the notifications one
Factorised some code regarding the navigation listener for the ratings and the push notifications
Fixed a navigation issue preventing the notifications modal to appear on the reborn account screens

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3251] [LIVE-3072] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3251]: https://ledgerhq.atlassian.net/browse/LIVE-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-3072]: https://ledgerhq.atlassian.net/browse/LIVE-3072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ