### PR TITLE
bugfix(BackButton): Close individual NFT drawer should back to Gallery/Collection screen

### DIFF
--- a/.changeset/twenty-ants-serve.md
+++ b/.changeset/twenty-ants-serve.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Close individual NFT drawer should back to Gallery/Collection screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/NftNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/NftNavigator.tsx
@@ -5,7 +5,7 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import NftViewer from "../Nft/NftViewer";
 import NftImageViewer from "../Nft/NftImageViewer";
 import { ScreenName } from "../../const";
-import { CloseButton, BackButton } from "../../screens/OperationDetails";
+import { BackButton } from "../../screens/OperationDetails";
 
 const NftNavigator = () => {
   const { colors } = useTheme();
@@ -22,7 +22,7 @@ const NftNavigator = () => {
         options={({ navigation }) => ({
           title: null,
           headerRight: null,
-          headerLeft: () => <CloseButton navigation={navigation} />,
+          headerLeft: () => <BackButton navigation={navigation} />,
         })}
       />
       <Stack.Screen


### PR DESCRIPTION
…

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

 Close individual NFT drawer should back to Gallery/Collection screen
### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3375] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/112866305/191505643-2351bc43-8bac-4030-a97b-305f45f27d8a.mp4


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

- Added ETH account with NFT
- Navigate to account page
- Access to NFT gallery or collection page
- Click one NFT to access an individual NFT page 
- 
_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3375]: https://ledgerhq.atlassian.net/browse/LIVE-3375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ