### PR TITLE
Bot: Solana: remove test for "destination" that don't work for MAX

### DIFF
--- a/libs/ledger-live-common/src/families/solana/specs.ts
+++ b/libs/ledger-live-common/src/families/solana/specs.ts
@@ -62,7 +62,6 @@ const solana: AppSpec<Transaction> = {
     {
       name: "Transfer Max",
       maxRun: 1,
-      testDestination: genericTestDestination,
       deviceAction: acceptTransferTransaction,
       transaction: ({ account, siblings, bridge, maxSpendable }) => {
         invariant(maxSpendable.gt(0), "balance is 0");


### PR DESCRIPTION

### 📝 Description

solana devs will have to add the relevant test but i was too optimistic here thinking it would work like other coins. this should restore solana to pass the bot. a "hint" will appear that you need to define a destinationTest but it's better to have a ✅  test as before until this is added properly. https://github.com/LedgerHQ/ledger-live/commit/b75896f14c694a81c2c1d17c5ce8ef9ce245ce4a#commitcomment-85144438

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** tested by the bot <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
