### PR TITLE
BACK-3946: Fix outdated assertion on exchange signature size

### DIFF
--- a/.changeset/shiny-forks-mix.md
+++ b/.changeset/shiny-forks-mix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix outdated assertion on exchange signature size

--- a/libs/ledger-live-common/src/exchange/hw-app-exchange/Exchange.ts
+++ b/libs/ledger-live-common/src/exchange/hw-app-exchange/Exchange.ts
@@ -139,8 +139,8 @@ export default class Exchange {
     invariant(addressParameters.length <= 255, "Address parameter is too big.");
     invariant(
       currencyConfigSignature.length >= 67 &&
-        currencyConfigSignature.length <= 72,
-      "Signature should be DER serialized and have length in [67, 72] bytes."
+        currencyConfigSignature.length <= 73,
+      "Signature should be DER serialized and have length in [67, 73] bytes."
     );
     const bufferToSend: Buffer = Buffer.concat([
       Buffer.from([payoutCurrencyConfig.length]),
@@ -171,8 +171,8 @@ export default class Exchange {
     invariant(addressParameters.length <= 255, "Address parameter is too big.");
     invariant(
       currencyConfigSignature.length >= 67 &&
-        currencyConfigSignature.length <= 72,
-      "Signature should be DER serialized and have length in [67, 72] bytes."
+        currencyConfigSignature.length <= 73,
+      "Signature should be DER serialized and have length in [67, 73] bytes."
     );
     const bufferToSend: Buffer = Buffer.concat([
       Buffer.from([refundCurrencyConfig.length]),

--- a/libs/ledger-live-common/src/exchange/hw-app-exchange/Exchange.ts
+++ b/libs/ledger-live-common/src/exchange/hw-app-exchange/Exchange.ts
@@ -138,9 +138,9 @@ export default class Exchange {
     invariant(payoutCurrencyConfig.length <= 255, "Currency config is too big");
     invariant(addressParameters.length <= 255, "Address parameter is too big.");
     invariant(
-      currencyConfigSignature.length >= 70 &&
-        currencyConfigSignature.length <= 73,
-      "Signature should be DER serialized and have length in [70, 73] bytes."
+      currencyConfigSignature.length >= 67 &&
+        currencyConfigSignature.length <= 72,
+      "Signature should be DER serialized and have length in [67, 72] bytes."
     );
     const bufferToSend: Buffer = Buffer.concat([
       Buffer.from([payoutCurrencyConfig.length]),
@@ -170,9 +170,9 @@ export default class Exchange {
     invariant(refundCurrencyConfig.length <= 255, "Currency config is too big");
     invariant(addressParameters.length <= 255, "Address parameter is too big.");
     invariant(
-      currencyConfigSignature.length >= 70 &&
-        currencyConfigSignature.length <= 73,
-      "Signature should be DER serialized and have length in [70, 73] bytes."
+      currencyConfigSignature.length >= 67 &&
+        currencyConfigSignature.length <= 72,
+      "Signature should be DER serialized and have length in [67, 72] bytes."
     );
     const bufferToSend: Buffer = Buffer.concat([
       Buffer.from([refundCurrencyConfig.length]),


### PR DESCRIPTION
Duplication of https://github.com/LedgerHQ/ledger-live/pull/1306 to make CI pass

### 📝 Description

Exchange app client code contains assertions to check signature is within bounds, but these are outdated, see here for up to date values: https://github.com/LedgerHQ/app-exchange/blob/develop/src/globals.h#L15

`GALA` has a signature size of 69 bytes: https://github.com/LedgerHQ/crypto-assets/blob/main/signatures/prod/tokens/ethereum/erc20/gala/exchange_signature.json

So current assertion makes GALA swap fail with `Something went wrong` error message.

### ❓ Context

- **Impacted projects**: swap
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/BACK-3946

### ✅ Checklist

- [ ] **Test coverage** No test covers this, this was detected by @stual-ledger's manual testing
- [x] **Atomic delivery** yes
- [x] **No breaking changes**
