### PR TITLE
Bugfix/live 2551 device model info apps undefined value fixed

### DIFF
--- a/.changeset/flat-tables-invent.md
+++ b/.changeset/flat-tables-invent.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixed the lastSeenDevice apps property that wasn't set properly in some cases

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -182,7 +182,7 @@ function PairDevicesInner({ navigation, route }: Props) {
             setLastSeenDeviceInfo({
               modelId: device.modelId,
               deviceInfo,
-              appsInstalled,
+              apps: appsInstalled,
             }),
           );
           dispatchRedux(setReadOnlyMode(false));


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixed the lastSeenDevice apps property that wasn't set properly in some cases

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-2551] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-2551]: https://ledgerhq.atlassian.net/browse/LIVE-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ