### PR TITLE
introduce getOperatingSystemSupportStatus() to ignore sentry reporting on old unsupported OSs

### DIFF
--- a/.changeset/six-moons-change.md
+++ b/.changeset/six-moons-change.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+introduce getOperatingSystemSupportStatus() to ignore sentry reporting on old unsupported OSs

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -66,6 +66,7 @@
     "@sentry/tracing": "7.8.1",
     "@tippyjs/react": "^4.2.6",
     "@trust/keyto": "^1.0.1",
+    "@types/semver": "^7.3.9",
     "@xstate/inspect": "^0.4.1",
     "@xstate/react": "^1.6.3",
     "animated": "^0.2.2",

--- a/apps/ledger-live-desktop/src/sentry/install.js
+++ b/apps/ledger-live-desktop/src/sentry/install.js
@@ -3,6 +3,7 @@ import os from "os";
 import pname from "~/logger/pname";
 import anonymizer from "~/logger/anonymizer";
 import "../env";
+import { getOperatingSystemSupportStatus } from "~/support/os";
 
 /* eslint-disable no-continue */
 
@@ -100,6 +101,7 @@ const ignoreErrors = [
 ];
 
 export function init(Sentry: any, opts: any) {
+  if (!getOperatingSystemSupportStatus().supported) return false;
   if (!__SENTRY_URL__) return false;
   Sentry.init({
     dsn: __SENTRY_URL__,

--- a/apps/ledger-live-desktop/src/support/os.test.ts
+++ b/apps/ledger-live-desktop/src/support/os.test.ts
@@ -1,0 +1,22 @@
+import { supportStatusForOS } from "./os";
+
+test("a regular Mac version passes", () => {
+  expect(supportStatusForOS("Darwin", "18.7.0")).toMatchObject({ supported: true }); // macos 10.14.7
+  expect(supportStatusForOS("Darwin", "21.2.0")).toMatchObject({ supported: true });
+});
+
+test("a regular Linux version passes", () => {
+  expect(supportStatusForOS("Linux", "5.19.1-3-MANJARO")).toMatchObject({ supported: true });
+});
+
+test("a regular Windows version passes", () => {
+  expect(supportStatusForOS("Windows_NT", "10.0.22000")).toMatchObject({ supported: true });
+});
+
+test("an old Mac version passes", () => {
+  expect(supportStatusForOS("Darwin", "17.7.0")).toMatchObject({ supported: false }); // macos 10.13.6
+});
+
+test("an old Windows version passes", () => {
+  expect(supportStatusForOS("Windows_NT", "6.1.7601")).toMatchObject({ supported: false });
+});

--- a/apps/ledger-live-desktop/src/support/os.ts
+++ b/apps/ledger-live-desktop/src/support/os.ts
@@ -1,0 +1,34 @@
+import os from "os";
+import semverSatisfies from "semver/functions/satisfies";
+
+export type SupportStatus =
+  | {
+      supported: false;
+      criteria: string;
+      type: string;
+      release: string;
+    }
+  | {
+      supported: true;
+      type: string;
+      release: string;
+    };
+
+const minVersions: { [_: string]: string } = {
+  Windows_NT: ">= 8.1",
+  Darwin: ">= 18", // this is a darwin version corresponding roughly to mac os 10.14
+};
+
+export function supportStatusForOS(type: string, release: string): SupportStatus {
+  const criteria = minVersions[type];
+  if (criteria && !semverSatisfies(release, criteria)) {
+    return { supported: false, criteria, type, release };
+  }
+  return { supported: true, type, release };
+}
+
+export function getOperatingSystemSupportStatus(): SupportStatus {
+  const type = os.type();
+  const release = os.release();
+  return supportStatusForOS(type, release);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,7 @@ importers:
       '@types/react-router-dom': ^5.3.2
       '@types/react-select': ^4
       '@types/redux-actions': ^2.6.2
+      '@types/semver': ^7.3.9
       '@types/serve-handler': ^6.1.1
       '@types/styled-components': ^5.1.14
       '@typescript-eslint/eslint-plugin': ^5.28.0
@@ -323,12 +324,13 @@ importers:
       '@ledgerhq/react-ui': link:../../libs/ui/packages/react
       '@ledgerhq/types-cryptoassets': link:../../libs/ledgerjs/packages/types-cryptoassets
       '@ledgerhq/types-live': link:../../libs/ledgerjs/packages/types-live
-      '@polkadot/react-identicon': 0.89.2_fane7jikarojcev26y27hpbhu4
+      '@polkadot/react-identicon': 0.89.2_grbnt2wkerwtzf6thy4efz3p5i
       '@sentry/electron': 4.0.0
       '@sentry/node': 7.8.1
       '@sentry/tracing': 7.8.1
       '@tippyjs/react': 4.2.6_sfoxds7t5ydpegc3knd667wn6m
       '@trust/keyto': 1.0.1
+      '@types/semver': 7.3.9
       '@xstate/inspect': 0.4.1_ws@7.5.7
       '@xstate/react': 1.6.3_trxcr4ukgza3iqpu7qkdqadng4
       animated: 0.2.2_sfoxds7t5ydpegc3knd667wn6m
@@ -7028,14 +7030,14 @@ packages:
     resolution: {integrity: sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.18.12
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.18.9
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.18.11
-      '@babel/types': 7.18.10
+      '@babel/code-frame': 7.16.7
+      '@babel/generator': 7.17.10
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.17.9
+      '@babel/helper-hoist-variables': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/parser': 7.17.10
+      '@babel/types': 7.17.10
       debug: 4.3.4_supports-color@5.5.0
       globals: 11.12.0
     transitivePeerDependencies:
@@ -12414,12 +12416,13 @@ packages:
       '@substrate/ss58-registry': 1.18.0
     dev: false
 
-  /@polkadot/react-identicon/0.89.2_fane7jikarojcev26y27hpbhu4:
+  /@polkadot/react-identicon/0.89.2_grbnt2wkerwtzf6thy4efz3p5i:
     resolution: {integrity: sha512-zxfhWfeN1N15NxEoPU0PsVme0SbV4eWmZ9jnlfJGa4D8PMJFzsJ/eA04hXn10DEttvQvrlQ+jhCwBpvmBQ29dw==}
     peerDependencies:
       react: '*'
       react-dom: '*'
       react-is: '*'
+      styled-components: '*'
     dependencies:
       '@babel/runtime': 7.17.9
       '@polkadot/keyring': 8.7.1
@@ -21237,10 +21240,10 @@ packages:
       lodash:
         optional: true
     dependencies:
+      7zip-bin: 5.1.1
       '@develar/schema-utils': 2.6.5
       '@electron/universal': 1.2.0
       '@malept/flatpak-bundler': 0.4.0
-      7zip-bin: 5.1.1
       async-exit-hook: 2.0.1
       bluebird-lst: 1.0.9
       builder-util: 23.0.2
@@ -23651,9 +23654,9 @@ packages:
   /builder-util/23.0.2:
     resolution: {integrity: sha512-HaNHL3axNW/Ms8O1mDx3I07G+ZnZ/TKSWWvorOAPau128cdt9S+lNx5ocbx8deSaHHX4WFXSZVHh3mxlaKJNgg==}
     dependencies:
+      7zip-bin: 5.1.1
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
-      7zip-bin: 5.1.1
       app-builder-bin: 4.0.0
       bluebird-lst: 1.0.9
       builder-util-runtime: 9.0.0
@@ -23823,7 +23826,7 @@ packages:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
       tar: 6.1.11
@@ -25059,8 +25062,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -34968,13 +34971,13 @@ packages:
       '@types/lodash': 4.14.182
       '@types/node': 12.20.52
       '@types/ws': 7.4.7
+      JSONStream: 1.3.5
       commander: 2.20.3
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
       isomorphic-ws: 4.0.1_ws@7.5.7
       json-stringify-safe: 5.0.1
-      JSONStream: 1.3.5
       lodash: 4.17.21
       uuid: 8.3.2
       ws: 7.5.7
@@ -40719,6 +40722,7 @@ packages:
     engines: {node: '>= 0.6'}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       browser-resolve: 1.11.3
       cached-path-relative: 1.1.0
       concat-stream: 1.5.2
@@ -40726,7 +40730,6 @@ packages:
       detective: 5.2.0
       duplexer2: 0.1.4
       inherits: 2.0.4
-      JSONStream: 1.3.5
       konan: 2.1.1
       readable-stream: 2.3.7
       resolve: 1.22.0
@@ -44715,6 +44718,15 @@ packages:
   /progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  /promise-inflight/1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dev: true
 
   /promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
@@ -49547,10 +49559,10 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       ansi-escape-sequences: 5.1.2
       byte-size: 6.2.0
       common-log-format: 1.0.0
-      JSONStream: 1.3.5
       lodash.throttle: 4.1.1
       stream-via: 1.0.4
       table-layout: 1.0.2


### PR DESCRIPTION

### 📝 Description

introduce getOperatingSystemSupportStatus() to ignore sentry reporting on old unsupported OSs

as we can get polluted by unsupported os version, we want clients to NOT send error report if their os isn't supported anymore. Typically we don’t want to see Win 7 related bugs in Sentry. That way we save bandwidth and prevent situation of incident that aren't incident (LIVE-3957 is possibly one of these case)

NB: this PR **do not** impact the UI. but a future goal is to also introduce this function for the UI to possibly tell the user they use too old OS version. For now, we really just need to stop reporting to sentry.

### ❓ Context

- **Impacted projects**: LLD <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-3958 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
