### PR TITLE
ci: auto close smartling prs

### DIFF
--- a/tools/github-bot/src/index.ts
+++ b/tools/github-bot/src/index.ts
@@ -56,7 +56,14 @@ export default (app: Probot) => {
     const branch = payload.pull_request.head.ref;
     const login = payload.pull_request.user.login;
 
-    if (!isValidUser(login)) return;
+    if (
+      !isValidUser(login) &&
+      // Close automatic PRs from smartling - except the ones triggered manually
+      !/^(smartling-content-updated|smartling-content-completed)-.+/.test(
+        branch
+      )
+    )
+      return;
 
     const isBranchValid = isValidBranchName(branch);
     const isBodyValid = isValidBody(payload.pull_request.body);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Request was made to keep the same Smartling configuration (watch PRs from develop and create jobs asap), but close the automatic PRs.

Smartling PRs triggered when manually exporting translations should still work.

### ❓ Context

- **Impacted projects**: `N/A` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `N/A` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** (N/A)<!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
