### PR TITLE
Support: refactor listen-to-hid-devices to TS and hook

### DIFF
--- a/.changeset/cyan-dingos-cheat.md
+++ b/.changeset/cyan-dingos-cheat.md
@@ -1,0 +1,10 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/hw-transport-node-hid-singleton": patch
+---
+
+Refactor on listen HID devices on LLD:
+
+- make the listenDevices definition command into TS, and rename into listenToHidDevices
+- transform the ListenDevices component (that was mainly a useEffect returning null) into a hook useListenToHidDevices
+- add the types-devices lib into LLD

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -60,6 +60,7 @@
     "@ledgerhq/react-ui": "workspace:^",
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
+    "@ledgerhq/types-devices": "workspace:^",
     "@polkadot/react-identicon": "0.89.2",
     "@sentry/electron": "^4.0.0",
     "@sentry/node": "7.8.1",

--- a/apps/ledger-live-desktop/src/internal/commands/index.js
+++ b/apps/ledger-live-desktop/src/internal/commands/index.js
@@ -7,7 +7,7 @@ import flushDevice from "./flushDevice";
 import firmwareUpdating from "./firmwareUpdating";
 import getLatestFirmwareForDevice from "./getLatestFirmwareForDevice";
 import getSatStackStatus from "./getSatStackStatus";
-import listenDevices from "./listenDevices";
+import listenToHidDevices from "./listenToHidDevices";
 import listApps from "./listApps";
 import signMessage from "./signMessage";
 import ping from "./ping";
@@ -38,7 +38,7 @@ export const commandsById = {
   firmwareUpdating,
   getLatestFirmwareForDevice,
   getSatStackStatus,
-  listenDevices,
+  listenToHidDevices,
   connectApp,
   connectManager,
   listApps,

--- a/apps/ledger-live-desktop/src/internal/commands/listenDevices.js
+++ b/apps/ledger-live-desktop/src/internal/commands/listenDevices.js
@@ -1,9 +1,0 @@
-// @flow
-import type { DescriptorEvent } from "@ledgerhq/hw-transport";
-import { Observable } from "rxjs";
-import TransportNodeHidSingleton from "@ledgerhq/hw-transport-node-hid-singleton";
-
-const cmd = (): Observable<DescriptorEvent<*>> =>
-  Observable.create(TransportNodeHidSingleton.listen);
-
-export default cmd;

--- a/apps/ledger-live-desktop/src/internal/commands/listenToHidDevices.ts
+++ b/apps/ledger-live-desktop/src/internal/commands/listenToHidDevices.ts
@@ -1,0 +1,10 @@
+import { Observable } from "rxjs";
+import TransportNodeHidSingleton, {
+  ListenDescriptorEvent,
+} from "@ledgerhq/hw-transport-node-hid-singleton";
+
+// Listen to HID/USB-connected devices
+const cmd = (): Observable<ListenDescriptorEvent> =>
+  new Observable(TransportNodeHidSingleton.listen);
+
+export default cmd;

--- a/apps/ledger-live-desktop/src/renderer/Default.jsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.jsx
@@ -25,7 +25,7 @@ import PlatformApp from "~/renderer/screens/platform/App";
 import NFTGallery from "~/renderer/screens/nft/Gallery";
 import NFTCollection from "~/renderer/screens/nft/Gallery/Collection";
 import Box from "~/renderer/components/Box/Box";
-import ListenDevices from "~/renderer/components/ListenDevices";
+import { useListenToHidDevices } from "./hooks/useListenToHidDevices";
 import ExportLogsButton from "~/renderer/components/ExportLogsButton";
 import Idler from "~/renderer/components/Idler";
 import IsUnlocked from "~/renderer/components/IsUnlocked";
@@ -146,6 +146,7 @@ export default function Default() {
   const history = useHistory();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
 
+  useListenToHidDevices();
   useDeeplink();
   useUSBTroubleshooting();
 
@@ -167,7 +168,6 @@ export default function Default() {
   return (
     <>
       <TriggerAppReady />
-      <ListenDevices />
       <ExportLogsButton hookToShortcut />
       <TrackAppStart />
       <Idler />

--- a/apps/ledger-live-desktop/src/renderer/hooks/useListenToHidDevices.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useListenToHidDevices.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { Subscription } from "rxjs";
-import { ListenDescriptorEvent } from "@ledgerhq/ledgerjs/hw-transport-node-hid-singleton/TransportNodeHid";
+import { ListenDescriptorEvent } from "@ledgerhq/hw-transport-node-hid-singleton";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { addDevice, removeDevice, resetDevices } from "~/renderer/actions/devices";
 import { command } from "~/renderer/commands";

--- a/apps/ledger-live-desktop/src/renderer/hooks/useListenToHidDevices.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useListenToHidDevices.ts
@@ -1,22 +1,25 @@
-// @flow
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
+import { Subscription } from "rxjs";
+import { ListenDescriptorEvent } from "@ledgerhq/ledgerjs/hw-transport-node-hid-singleton/TransportNodeHid";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import { addDevice, removeDevice, resetDevices } from "~/renderer/actions/devices";
 import { command } from "~/renderer/commands";
 
-const ListenDevices = () => {
+export const useListenToHidDevices = () => {
   const dispatch = useDispatch();
   useEffect(() => {
-    let sub;
+    let sub: Subscription;
     function syncDevices() {
-      const devices = {};
-      sub = command("listenDevices")().subscribe(
-        ({ device, deviceModel, type, descriptor }) => {
+      const devices: { [key: string]: boolean } = {};
+
+      sub = command("listenToHidDevices")().subscribe(
+        ({ device, deviceModel, type, descriptor }: ListenDescriptorEvent) => {
           if (device) {
             const deviceId = descriptor || "";
             const stateDevice = {
               deviceId,
-              modelId: deviceModel ? deviceModel.id : "nanoS",
+              modelId: deviceModel ? deviceModel.id : DeviceModelId.nanoS,
               wired: true,
             };
 
@@ -50,5 +53,3 @@ const ListenDevices = () => {
 
   return null;
 };
-
-export default ListenDevices;

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/README.md
@@ -73,7 +73,7 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 ##### Parameters
 
-*   `observer` **Observer\<DescriptorEvent\<any>>** 
+*   `observer` **Observer\<ListenDescriptorEvent>** 
 
 Returns **Subscription** 
 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts
@@ -30,6 +30,8 @@ const setDisconnectTimeout = () => {
   );
 };
 
+export type ListenDescriptorEvent = DescriptorEvent<any>;
+
 /**
  * node-hid Transport implementation
  * @example
@@ -52,7 +54,7 @@ export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents 
 
   /**
    */
-  static listen = (observer: Observer<DescriptorEvent<any>>): Subscription => {
+  static listen = (observer: Observer<ListenDescriptorEvent>): Subscription => {
     let unsubscribed;
     Promise.resolve(getDevices()).then((devices) => {
       // this needs to run asynchronously so the subscription is defined during this phase
@@ -151,7 +153,7 @@ export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents 
         new HID.HID(device.path as string)
       );
       const unlisten = listenDevices(
-        () => {},
+        () => { },
         () => {
           // assume any ledger disconnection concerns current transport
           if (transportInstance) {

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts
@@ -153,7 +153,7 @@ export default class TransportNodeHidSingleton extends TransportNodeHidNoEvents 
         new HID.HID(device.path as string)
       );
       const unlisten = listenDevices(
-        () => { },
+        () => {},
         () => {
           // assume any ledger disconnection concerns current transport
           if (transportInstance) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,7 @@ importers:
       '@ledgerhq/logs': workspace:^
       '@ledgerhq/react-ui': workspace:^
       '@ledgerhq/types-cryptoassets': workspace:^
+      '@ledgerhq/types-devices': workspace:^
       '@ledgerhq/types-live': workspace:^
       '@mapbox/node-pre-gyp': ^1.0.8
       '@octokit/rest': ^18.12.0
@@ -323,6 +324,7 @@ importers:
       '@ledgerhq/logs': link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/react-ui': link:../../libs/ui/packages/react
       '@ledgerhq/types-cryptoassets': link:../../libs/ledgerjs/packages/types-cryptoassets
+      '@ledgerhq/types-devices': link:../../libs/ledgerjs/packages/types-devices
       '@ledgerhq/types-live': link:../../libs/ledgerjs/packages/types-live
       '@polkadot/react-identicon': 0.89.2_grbnt2wkerwtzf6thy4efz3p5i
       '@sentry/electron': 4.0.0
@@ -39901,6 +39903,24 @@ packages:
       - supports-color
       - utf-8-validate
 
+  /metro-config/0.67.0_5rj3ktdhebdtkdjqejo5rbxriu:
+    resolution: {integrity: sha512-ThAwUmzZwTbKyyrIn2bKIcJDPDBS0LKAbqJZQioflvBGfcgA21h3fdL3IxRmvCEl6OnkEWI0Tn1Z9w2GLAjf2g==}
+    peerDependencies:
+      metro-transform-worker: '*'
+    peerDependenciesMeta:
+      metro-transform-worker:
+        optional: true
+    dependencies:
+      cosmiconfig: 5.2.1
+      jest-validate: 26.6.2
+      metro: 0.67.0
+      metro-cache: 0.67.0_metro@0.67.0
+      metro-core: 0.67.0_metro@0.67.0
+      metro-runtime: 0.67.0
+      metro-transform-worker: 0.67.0_metro-minify-uglify@0.67.0
+    transitivePeerDependencies:
+      - metro
+
   /metro-config/0.67.0_h77kaxayu5kga6qsud7rauzt6a:
     resolution: {integrity: sha512-ThAwUmzZwTbKyyrIn2bKIcJDPDBS0LKAbqJZQioflvBGfcgA21h3fdL3IxRmvCEl6OnkEWI0Tn1Z9w2GLAjf2g==}
     peerDependencies:
@@ -40235,7 +40255,7 @@ packages:
       '@babel/parser': 7.18.11
       '@babel/types': 7.18.10
       babel-preset-fbjs: 3.4.0_@babel+core@7.18.10
-      metro: 0.67.0
+      metro: 0.67.0_h77kaxayu5kga6qsud7rauzt6a
       metro-babel-transformer: 0.67.0
       metro-cache: 0.67.0_metro@0.67.0
       metro-cache-key: 0.67.0
@@ -40308,6 +40328,68 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - encoding
+      - supports-color
+      - utf-8-validate
+
+  /metro/0.67.0_h77kaxayu5kga6qsud7rauzt6a:
+    resolution: {integrity: sha512-DwuBGAFcAivoac/swz8Lp7Y5Bcge1tzT7T6K0nf1ubqJP8YzBUtyR4pkjEYVUzVu/NZf7O54kHSPVu1ibYzOBQ==}
+    hasBin: true
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@babel/core': 7.17.10
+      '@babel/generator': 7.17.10
+      '@babel/parser': 7.17.10
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.10
+      '@babel/types': 7.17.10
+      absolute-path: 0.0.0
+      accepts: 1.3.8
+      async: 2.6.4
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 2.6.9
+      denodeify: 1.2.1
+      error-stack-parser: 2.0.7
+      fs-extra: 1.0.0
+      graceful-fs: 4.2.10
+      hermes-parser: 0.5.0
+      image-size: 0.6.3
+      invariant: 2.2.4
+      jest-haste-map: 27.5.1_metro@0.67.0
+      jest-worker: 26.6.2_metro@0.67.0
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.67.0
+      metro-cache: 0.67.0_metro@0.67.0
+      metro-cache-key: 0.67.0
+      metro-config: 0.67.0_5rj3ktdhebdtkdjqejo5rbxriu
+      metro-core: 0.67.0_metro@0.67.0
+      metro-hermes-compiler: 0.67.0
+      metro-inspector-proxy: 0.67.0
+      metro-minify-uglify: 0.67.0
+      metro-react-native-babel-preset: 0.67.0_@babel+core@7.17.10
+      metro-resolver: 0.67.0
+      metro-runtime: 0.67.0
+      metro-source-map: 0.67.0
+      metro-symbolicate: 0.67.0
+      metro-transform-plugins: 0.67.0
+      metro-transform-worker: 0.67.0_metro-minify-uglify@0.67.0
+      mime-types: 2.1.35
+      mkdirp: 0.5.6
+      node-fetch: 2.6.7
+      nullthrows: 1.1.1
+      rimraf: 2.7.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      strip-ansi: 6.0.1
+      temp: 0.8.3
+      throat: 5.0.0
+      ws: 7.5.7
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Refactor that:
- make the `listenDevices` definition command into TS, and rename into `listenToHidDevices`
- transform the `ListenDevices` component (that was mainly a `useEffect` returning null) into a hook `useListenToHidDevices`
- add the `types-devices` lib into LLD

### ❓ Context

- **Impacted projects**:  `ledger-live-desktop` and `@ledgerhq/hw-transport-node-hid-singleton`
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage**: not yet QAed, not sure it needs to
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Demo showing that a device is still usb-detected:

https://user-images.githubusercontent.com/15096913/193070245-0addd198-c601-4b28-9a63-1d9e041437c9.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
