### PR TITLE
Bot: remove expectation of validating "destination" tests for celo & fil

### DIFF
--- a/libs/ledger-live-common/src/families/celo/specs/createSendMutation.ts
+++ b/libs/ledger-live-common/src/families/celo/specs/createSendMutation.ts
@@ -1,6 +1,6 @@
 import invariant from "invariant";
 import { getCryptoCurrencyById, parseCurrencyUnit } from "../../../currencies";
-import { genericTestDestination, pickSiblings } from "../../../bot/specs";
+import { pickSiblings } from "../../../bot/specs";
 import { MutationSpec } from "../../../bot/types";
 import type { Transaction } from "../types";
 
@@ -11,7 +11,6 @@ export const minimalAmount = parseCurrencyUnit(currency.units[0], "0.001");
 export const createSend50PercentMutation = (): MutationSpec<Transaction> => ({
   name: "Celo: Move 50% to another account",
   maxRun: 1,
-  testDestination: genericTestDestination,
   transaction: ({ account, siblings, bridge, maxSpendable }) => {
     invariant(
       maxSpendable.gt(minimalAmount),
@@ -30,7 +29,6 @@ export const createSend50PercentMutation = (): MutationSpec<Transaction> => ({
 export const createSendMaxMutation = (): MutationSpec<Transaction> => ({
   name: "Celo: Send max to another account",
   maxRun: 1,
-  testDestination: genericTestDestination,
   transaction: ({ account, siblings, bridge, maxSpendable }) => {
     invariant(
       maxSpendable.gt(minimalAmount),

--- a/libs/ledger-live-common/src/families/filecoin/specs.ts
+++ b/libs/ledger-live-common/src/families/filecoin/specs.ts
@@ -59,7 +59,6 @@ const filecoinSpecs: AppSpec<Transaction> = {
     {
       name: "Transfer Max",
       maxRun: 1,
-      testDestination: genericTestDestination,
       transaction: ({ account, siblings, bridge }) => {
         return {
           transaction: bridge.createTransaction(account),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

this reverts my recent addition of "destinationTest" on the bot for Celo and Filecoin which don't seem to properly validate these.

we want the bot tests to pass instead of having too much unstable tests until we can add them back (they will create more "warnings" on hints for developers to add tests there)

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
