### PR TITLE
support(Swap): On-click Swap button, some assets don't have {coin/token}'s accounts pre-selected in swap

### DIFF
--- a/.changeset/gentle-scissors-clean.md
+++ b/.changeset/gentle-scissors-clean.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Asset Quick Action Swap Improvements: On-click Swap button, some assets don't have {coin/token}'s accounts pre-selected in swap

--- a/.changeset/seven-peas-admire.md
+++ b/.changeset/seven-peas-admire.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Swap buttons not available on Currency and account screens

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
@@ -126,7 +126,10 @@ export default function useAssetActions({
                       NavigatorName.Swap,
                       {
                         screen: ScreenName.Swap,
-                        params: { currencyId: currency?.id, defaultAccount },
+                        params: {
+                          defaultAccount,
+                          currency,
+                        },
                       },
                     ],
                     disabled: areAccountsBalanceEmpty,

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -24,13 +24,16 @@ import {
   flattenAccounts,
   accountWithMandatoryTokens,
 } from "@ledgerhq/live-common/account/index";
+import { getSwapSelectableCurrencies } from "@ledgerhq/live-common/lib/exchange/swap/logic";
 import { shallowAccountsSelector } from "../../../reducers/accounts";
 import {
   swapAcceptedProvidersSelector,
   swapKYCSelector,
 } from "../../../reducers/settings";
-import { setSwapKYCStatus, setSwapSelectableCurrencies } from "../../../actions/settings";
-import { getSwapSelectableCurrencies } from "@ledgerhq/live-common/lib/exchange/swap/logic";
+import {
+  setSwapKYCStatus,
+  setSwapSelectableCurrencies,
+} from "../../../actions/settings";
 import {
   providersSelector,
   rateSelector,
@@ -60,9 +63,11 @@ export const useProviders = () => {
 
   useEffect(() => {
     if (providers) {
-      dispatch(updateProvidersAction(providers))
-      dispatch(setSwapSelectableCurrencies(getSwapSelectableCurrencies(providers)))
-    };
+      dispatch(updateProvidersAction(providers));
+      dispatch(
+        setSwapSelectableCurrencies(getSwapSelectableCurrencies(providers)),
+      );
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [providers]);
 

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -29,7 +29,8 @@ import {
   swapAcceptedProvidersSelector,
   swapKYCSelector,
 } from "../../../reducers/settings";
-import { setSwapKYCStatus } from "../../../actions/settings";
+import { setSwapKYCStatus, setSwapSelectableCurrencies } from "../../../actions/settings";
+import { getSwapSelectableCurrencies } from "@ledgerhq/live-common/lib/exchange/swap/logic";
 import {
   providersSelector,
   rateSelector,
@@ -58,7 +59,10 @@ export const useProviders = () => {
   const { providers, error: providersError } = useSwapProviders();
 
   useEffect(() => {
-    if (providers) dispatch(updateProvidersAction(providers));
+    if (providers) {
+      dispatch(updateProvidersAction(providers))
+      dispatch(setSwapSelectableCurrencies(getSwapSelectableCurrencies(providers)))
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [providers]);
 


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
Improvment on Quick Action : **Swap**
On-click Swap button, some assets don't have {coin/token}'s accounts pre-selected in swap
### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-3906] [LIVE-3781] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/112866305/193307142-201e167e-bcc3-4788-a07e-bef64c83fa3f.mp4


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-3906]: https://ledgerhq.atlassian.net/browse/LIVE-3906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-3781]: https://ledgerhq.atlassian.net/browse/LIVE-3781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ