### PR TITLE
introduce cli confirmOp + Increase timeouts for bot

### DIFF
--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -9,6 +9,7 @@ import botPortfolio from "./commands/botPortfolio";
 import botTransfer from "./commands/botTransfer";
 import broadcast from "./commands/broadcast";
 import cleanSpeculos from "./commands/cleanSpeculos";
+import confirmOp from "./commands/confirmOp";
 import countervalues from "./commands/countervalues";
 import derivation from "./commands/derivation";
 import devDeviceAppsScenario from "./commands/devDeviceAppsScenario";
@@ -61,6 +62,7 @@ export default {
   botTransfer,
   broadcast,
   cleanSpeculos,
+  confirmOp,
   countervalues,
   derivation,
   devDeviceAppsScenario,

--- a/apps/cli/src/commands/confirmOp.ts
+++ b/apps/cli/src/commands/confirmOp.ts
@@ -1,0 +1,45 @@
+import { switchMap } from "rxjs/operators";
+import {
+  formatOperation,
+  toOperationRaw,
+} from "@ledgerhq/live-common/account/index";
+import {
+  decodeOperationId,
+  findOperationInAccount,
+} from "@ledgerhq/live-common/operation";
+import { scan } from "../scan";
+
+export default {
+  description:
+    "Quickly verify if an operation id exists with our explorers (by synchronising the parent account)",
+  args: [
+    {
+      name: "id",
+      type: String,
+      desc: "operation id to search",
+    },
+    {
+      name: "format",
+      alias: "f",
+      type: String,
+      typeDesc: "json | text",
+      desc: "how to display the data",
+    },
+  ],
+  job: ({ id, format }: { id?: string; format?: "json" | "text" }) => {
+    if (!id) throw new Error("--id is required");
+    const { accountId } = decodeOperationId(id);
+    return scan({
+      id: [accountId],
+    }).pipe(
+      switchMap(async (account) => {
+        const op = findOperationInAccount(account, id);
+        if (!op)
+          throw new Error("operation was not found in account " + account.id);
+        return format === "text"
+          ? formatOperation(account)(op)
+          : toOperationRaw(op);
+      })
+    );
+  },
+};

--- a/libs/ledger-live-common/src/families/cardano/specs.ts
+++ b/libs/ledger-live-common/src/families/cardano/specs.ts
@@ -31,7 +31,7 @@ const cardano: AppSpec<Transaction> = {
   },
   minViableAmount: minBalanceRequired,
   genericDeviceAction: acceptTransaction,
-  testTimeout: 2 * 60 * 1000,
+  testTimeout: 5 * 60 * 1000,
   mutations: [
     {
       testDestination: genericTestDestination,

--- a/libs/ledger-live-common/src/families/celo/specs.ts
+++ b/libs/ledger-live-common/src/families/celo/specs.ts
@@ -34,7 +34,7 @@ const celo: AppSpec<Transaction> = {
     model: DeviceModelId.nanoS,
     appName: "Celo",
   },
-  testTimeout: 2 * 60 * 1000,
+  testTimeout: 4 * 60 * 1000,
   genericDeviceAction: acceptTransaction,
   minViableAmount: minimalAmount,
   mutations: [

--- a/libs/ledger-live-common/src/families/ethereum/specs.ts
+++ b/libs/ledger-live-common/src/families/ethereum/specs.ts
@@ -21,7 +21,7 @@ import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { CompoundAccountSummary } from "../../compound/types";
 import { acceptTransaction } from "./speculos-deviceActions";
 
-const testTimeout = 5 * 60 * 1000;
+const testTimeout = 8 * 60 * 1000;
 
 const ethereumBasicMutations = ({ maxAccount }) => [
   {

--- a/libs/ledger-live-common/src/families/filecoin/specs.ts
+++ b/libs/ledger-live-common/src/families/filecoin/specs.ts
@@ -19,7 +19,7 @@ const filecoinSpecs: AppSpec<Transaction> = {
     appName: "Filecoin",
   },
   genericDeviceAction: acceptTransaction,
-  testTimeout: 5 * 60 * 1000,
+  testTimeout: 6 * 60 * 1000,
   minViableAmount: MIN_SAFE,
   transactionCheck: ({ maxSpendable }) => {
     invariant(maxSpendable.gt(MIN_SAFE), "balance is too low");

--- a/libs/ledger-live-common/src/families/osmosis/specs.ts
+++ b/libs/ledger-live-common/src/families/osmosis/specs.ts
@@ -50,7 +50,7 @@ const osmosis: AppSpec<Transaction> = {
     appName: "Cosmos",
   },
   genericDeviceAction: acceptTransaction,
-  testTimeout: 2 * 60 * 1000,
+  testTimeout: 5 * 60 * 1000,
   minViableAmount: minimalAmount,
   transactionCheck: ({ maxSpendable }) => {
     invariant(maxSpendable.gt(minimalAmount), "balance is too low");


### PR DESCRIPTION
### 📝 Description

introduce a confirmOp on the cli, so we can easily do this:

```
pnpm run:cli confirmOp --id js:2:cardano:da85e83cab046f8a50aa6fcd67bd7dffee0e1fd15ad3345a78838239d4d3fc2291f70ea636c86770da1ab8bf2136d60d3f9e49292a5f32d1f460bd4c7e251372:cardano-75ffed02f79a815baf6164cb0175971978ce1f333c586c6df9e2ba762c1174da-OUT
```

when we see the bot message

```
⚠️ TEST waiting operation id to appear after broadcast
Error: could not find optimisticOperation js:2:cardano:da85e83cab046f8a50aa6fcd67bd7dffee0e1fd15ad3345a78838239d4d3fc2291f70ea636c86770da1ab8bf2136d60d3f9e49292a5f32d1f460bd4c7e251372:cardano-75ffed02f79a815baf6164cb0175971978ce1f333c586c6df9e2ba762c1174da-OUT
```

to confirm that it's just eventually landing but it was too slow for the bot to reach it.

in that case, we increase the timeout, which is what this PR also do.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
