### PR TITLE
bot: introduces a retries on scanAccounts to prevent tmp fails

### DIFF
--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -96,6 +96,8 @@ export type AppSpec<T extends Transaction> = {
   currency: CryptoCurrency;
   // how much time in ms does the test need to wait the operation to appear
   testTimeout?: number;
+  // how much should we retry scan accounts if an error occurs
+  scanAccountsRetries?: number;
   // if define, will run the mutations {multipleRuns} times in order to cover 2 txs in the same run and detect possible issues at the "second tx time"
   multipleRuns?: number;
   // define the frequency of exporting/importing back the account to simulate mobile export

--- a/libs/ledger-live-common/src/families/solana/specs.ts
+++ b/libs/ledger-live-common/src/families/solana/specs.ts
@@ -26,6 +26,7 @@ const maxAccount = 9;
 
 const solana: AppSpec<Transaction> = {
   name: "Solana",
+  scanAccountsRetries: 3,
   appQuery: {
     model: DeviceModelId.nanoS,
     firmware: "2",

--- a/libs/ledger-live-common/src/rxjs/operators/retryWithDelay.ts
+++ b/libs/ledger-live-common/src/rxjs/operators/retryWithDelay.ts
@@ -1,0 +1,36 @@
+import { MonoTypeOperatorFunction } from "rxjs";
+import { delay as delayOperator, retryWhen, scan } from "rxjs/operators";
+import { throwIf } from "./throwIf";
+
+// from https://github.com/NiklasPor/rxjs-boost (MIT)
+
+/**
+ * Retries an Observable with a [delay].
+ * Will retry [count] times. Defaults to `1`.
+ *
+ * @param delay The delay (milliseconds) the operator will wait before each retry.
+ *              This also includes the first try.
+ * @param count The number of times the operator will retry the execution.
+ *              Defaults to `1`.
+ */
+export function retryWithDelay<T>(
+  delay: number,
+  count = 1
+): MonoTypeOperatorFunction<T> {
+  return (input) =>
+    input.pipe(
+      retryWhen((errors) =>
+        errors.pipe(
+          scan((acc, error) => ({ count: acc.count + 1, error }), {
+            count: 0,
+            error: undefined as any,
+          }),
+          throwIf(
+            (current) => current.count > count,
+            (current) => current.error
+          ),
+          delayOperator(delay)
+        )
+      )
+    );
+}

--- a/libs/ledger-live-common/src/rxjs/operators/throwIf.ts
+++ b/libs/ledger-live-common/src/rxjs/operators/throwIf.ts
@@ -1,0 +1,40 @@
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+
+// from https://github.com/NiklasPor/rxjs-boost (MIT)
+
+/**
+ * Throws the error built by `errorFn` if `conditionFn` evaluates to be truthy.
+ *
+ * @param conditionFn Determines if an error should be thrown.
+ * @param errorFn Evaluates to the error which can be thrown.
+ *
+ * @example
+ * ```
+ * const input = cold('   ft', { f: false, t: true });
+ * const expected = cold('f#', { f: false }, 'error');
+ *
+ * const result = input.pipe(
+ *   // will throw 'error' for values === true
+ *   throwIf(
+ *     (val) => val
+ *     () => error
+ *   )
+ * );
+ * ```
+ */
+export function throwIf<T>(
+  conditionFn: (value: T, index: number) => boolean,
+  errorFn: (value: T, index: number) => any
+) {
+  return (input: Observable<T>) =>
+    input.pipe(
+      map((value, index) => {
+        if (conditionFn(value, index)) {
+          throw errorFn(value, index);
+        }
+
+        return value;
+      })
+    );
+}


### PR DESCRIPTION

### 📝 Description

introduces a retries on scanAccounts to prevent tmp fails. Sometimes we have dumb temporary `Can't parse '<'`, this should limit this problem. 

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: fixes https://github.com/LedgerHQ/ledger-live-issues/issues/36 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
