### PR TITLE
Support: FAT-462 handle 5515 locked-device response

### DIFF
--- a/apps/ledger-live-desktop/.eslintrc.js
+++ b/apps/ledger-live-desktop/.eslintrc.js
@@ -72,6 +72,16 @@ module.exports = {
         "flowtype/no-types-missing-file-annotation": 0,
         "react/jsx-filename-extension": 0,
 
+        // Enables no-unused-vars, with exception on _var, only for TypeScript
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            argsIgnorePattern: "^_",
+            vars: "all",
+            args: "after-used",
+            ignoreRestSiblings: true,
+          },
+        ],
         // Ignore live-common for the moment because this rule does not work with subpath exports
         // See: https://github.com/import-js/eslint-plugin-import/issues/1810
         // "import/no-unresolved": [

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -1,11 +1,16 @@
-// @flow
 import "./env";
 import axios from "axios";
-
+import { setDeviceMode } from "@ledgerhq/live-common/hw/actions/app";
 import { listen as listenLogs } from "@ledgerhq/logs";
 import logger from "./logger";
 
-listenLogs(({ id, date, ...log }) => {
+// To let TS knows it can expect to find this global variable
+declare const __APP_VERSION__: string;
+
+// Sets the device actions implementation to "polling", and not "event"
+setDeviceMode("polling");
+
+listenLogs(({ id: _id, date: _date, ...log }) => {
   if (log.type === "hid-frame") return;
   logger.debug(log);
 });

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.jsx
@@ -88,6 +88,7 @@ const DeviceAction = <R, H, P>({
     appAndVersion,
     device,
     unresponsive,
+    isLocked,
     error,
     isLoading,
     allowManagerRequestedWording,
@@ -287,11 +288,12 @@ const DeviceAction = <R, H, P>({
     });
   }
 
-  if ((!isLoading && !device) || unresponsive) {
+  if ((!isLoading && !device) || unresponsive || isLocked) {
     return renderConnectYourDevice({
       modelId,
       type,
       unresponsive,
+      isLocked,
       device,
       onRepairModal,
       onRetry,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.jsx
@@ -532,6 +532,7 @@ export const renderConnectYourDevice = ({
   onRepairModal,
   device,
   unresponsive,
+  isLocked = false,
 }: {
   modelId: DeviceModelId,
   type: "light" | "dark",
@@ -539,6 +540,7 @@ export const renderConnectYourDevice = ({
   onRepairModal: () => void,
   device: ?Device,
   unresponsive?: boolean,
+  isLocked?: boolean,
 }) => (
   <Wrapper>
     <Header />
@@ -547,7 +549,7 @@ export const renderConnectYourDevice = ({
         animation={getDeviceAnimation(
           modelId,
           type,
-          unresponsive ? "enterPinCode" : "plugAndPinCode",
+          unresponsive || isLocked ? "enterPinCode" : "plugAndPinCode",
         )}
       />
     </AnimationWrapper>
@@ -555,7 +557,9 @@ export const renderConnectYourDevice = ({
       <Title>
         <Trans
           i18nKey={
-            unresponsive ? "DeviceAction.unlockDevice" : "DeviceAction.connectAndUnlockDevice"
+            unresponsive || isLocked
+              ? "DeviceAction.unlockDevice"
+              : "DeviceAction.connectAndUnlockDevice"
           }
         />
       </Title>

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -62,6 +62,7 @@ export default function DeviceAction<R, H, P>({
     appAndVersion,
     device,
     unresponsive,
+    isLocked,
     error,
     isLoading,
     allowManagerRequestedWording,
@@ -96,12 +97,14 @@ export default function DeviceAction<R, H, P>({
     progress,
     listingApps,
   } = status;
+
   useEffect(() => {
     if (deviceInfo) {
       dispatch(
         setLastSeenDeviceInfo({
           modelId: device.modelId,
           deviceInfo,
+          apps: [],
         }),
       );
     }
@@ -306,11 +309,12 @@ export default function DeviceAction<R, H, P>({
     });
   }
 
-  if ((!isLoading && !device) || unresponsive) {
+  if ((!isLoading && !device) || unresponsive || isLocked) {
     return renderConnectYourDevice({
       t,
       device: selectedDevice,
       unresponsive,
+      isLocked,
       colors,
       theme,
       onSelectDeviceLink,

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -443,11 +443,13 @@ export function renderError({
 export function renderConnectYourDevice({
   t,
   unresponsive,
+  isLocked = false,
   device,
   theme,
   onSelectDeviceLink,
 }: RawProps & {
   unresponsive: boolean;
+  isLocked?: boolean;
   device: Device;
   onSelectDeviceLink?: () => void;
 }) {
@@ -457,7 +459,7 @@ export function renderConnectYourDevice({
         <Animation
           source={getDeviceAnimation({
             device,
-            key: unresponsive ? "enterPinCode" : "plugAndPinCode",
+            key: isLocked || unresponsive ? "enterPinCode" : "plugAndPinCode",
             theme,
           })}
         />
@@ -467,7 +469,7 @@ export function renderConnectYourDevice({
       )}
       <TitleText>
         {t(
-          unresponsive
+          isLocked || unresponsive
             ? "DeviceAction.unlockDevice"
             : device.wired
             ? "DeviceAction.connectAndUnlockDevice"

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -81,6 +81,7 @@ type State = {
   installingApp?: boolean;
   progress?: number;
   listingApps?: boolean;
+  isLocked: boolean;
 };
 
 export type AppState = State & {
@@ -150,6 +151,7 @@ const getInitialState = (device?: Device | null | undefined): State => ({
   requestQuitApp: false,
   requestOpenApp: null,
   unresponsive: false,
+  isLocked: false,
   requiresAppInstallation: null,
   allowOpeningRequestedWording: null,
   allowOpeningGranted: false,
@@ -172,6 +174,11 @@ const reducer = (state: State, e: Event): State => {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true };
 
+    case "lockedDevice":
+      return { ...state, isLocked: true };
+
+    // This event does not set isLocked and unresponsive properties, as
+    // by itself it does not request anything from the device
     case "device-update-last-seen":
       return {
         ...state,
@@ -201,6 +208,7 @@ const reducer = (state: State, e: Event): State => {
         derivation: null,
         displayUpgradeWarning: false,
         unresponsive: false,
+        isLocked: false,
         installingApp: true,
         progress: e.progress || 0,
         requestOpenApp: null,
@@ -208,7 +216,12 @@ const reducer = (state: State, e: Event): State => {
       };
 
     case "listing-apps":
-      return { ...state, listingApps: true };
+      return {
+        ...state,
+        listingApps: true,
+        unresponsive: false,
+        isLocked: false,
+      };
 
     case "error":
       return {
@@ -235,6 +248,7 @@ const reducer = (state: State, e: Event): State => {
         derivation: null,
         displayUpgradeWarning: false,
         unresponsive: false,
+        isLocked: false,
         requestOpenApp: e.appName,
       };
 
@@ -254,6 +268,7 @@ const reducer = (state: State, e: Event): State => {
         derivation: null,
         displayUpgradeWarning: false,
         unresponsive: false,
+        isLocked: false,
         requestQuitApp: true,
       };
 
@@ -270,6 +285,7 @@ const reducer = (state: State, e: Event): State => {
         derivation: null,
         displayUpgradeWarning: false,
         unresponsive: false,
+        isLocked: false,
         allowOpeningGranted: false,
         allowOpeningRequestedWording: null,
         allowManagerGranted: false,
@@ -289,6 +305,7 @@ const reducer = (state: State, e: Event): State => {
         derivation: null,
         displayUpgradeWarning: false,
         unresponsive: false,
+        isLocked: false,
         allowOpeningGranted: true,
         allowOpeningRequestedWording: null,
         allowManagerGranted: true,
@@ -307,6 +324,7 @@ const reducer = (state: State, e: Event): State => {
         displayUpgradeWarning: false,
         isLoading: false,
         unresponsive: false,
+        isLocked: false,
         allowOpeningGranted: false,
         allowOpeningRequestedWording: null,
         allowManagerGranted: false,
@@ -330,6 +348,7 @@ const reducer = (state: State, e: Event): State => {
         error: null,
         isLoading: false,
         unresponsive: false,
+        isLocked: false,
         opened: true,
         appAndVersion: e.app,
         derivation: e.derivation,
@@ -532,7 +551,7 @@ const implementations = {
 
 export let currentMode: keyof typeof implementations = "event";
 
-export function setDeviceMode(mode: keyof typeof implementations) {
+export function setDeviceMode(mode: keyof typeof implementations): void {
   currentMode = mode;
 }
 

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -47,6 +47,7 @@ type State = {
   deviceInfo: DeviceInfo | null | undefined;
   result: ListAppsResult | null | undefined;
   error: Error | null | undefined;
+  isLocked: boolean;
 };
 
 type ManagerState = State & {
@@ -101,6 +102,7 @@ const getInitialState = (device?: Device | null | undefined): State => ({
   isLoading: !!device,
   requestQuitApp: false,
   unresponsive: false,
+  isLocked: false,
   allowManagerRequestedWording: null,
   allowManagerGranted: false,
   device,
@@ -114,6 +116,9 @@ const reducer = (state: State, e: Event): State => {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true };
 
+    case "lockedDevice":
+      return { ...state, isLocked: true };
+
     case "deviceChange":
       return getInitialState(e.device);
 
@@ -122,10 +127,16 @@ const reducer = (state: State, e: Event): State => {
         ...getInitialState(state.device),
         error: e.error,
         isLoading: false,
+        isLocked: false,
       };
 
     case "appDetected":
-      return { ...state, unresponsive: false, requestQuitApp: true };
+      return {
+        ...state,
+        unresponsive: false,
+        isLocked: false,
+        requestQuitApp: true,
+      };
 
     case "osu":
     case "bootloader":
@@ -133,6 +144,7 @@ const reducer = (state: State, e: Event): State => {
         ...state,
         isLoading: false,
         unresponsive: false,
+        isLocked: false,
         requestQuitApp: false,
         deviceInfo: e.deviceInfo,
       };
@@ -142,6 +154,7 @@ const reducer = (state: State, e: Event): State => {
         ...state,
         requestQuitApp: false,
         unresponsive: false,
+        isLocked: false,
         deviceInfo: e.deviceInfo,
       };
 
@@ -149,6 +162,7 @@ const reducer = (state: State, e: Event): State => {
       return {
         ...state,
         unresponsive: false,
+        isLocked: false,
         allowManagerRequestedWording: e.wording,
       };
 
@@ -156,6 +170,7 @@ const reducer = (state: State, e: Event): State => {
       return {
         ...state,
         unresponsive: false,
+        isLocked: false,
         allowManagerRequestedWording: null,
         allowManagerGranted: true,
       };
@@ -165,6 +180,7 @@ const reducer = (state: State, e: Event): State => {
         ...state,
         isLoading: false,
         unresponsive: false,
+        isLocked: false,
         result: e.result,
       };
   }
@@ -312,6 +328,7 @@ const implementations = {
       };
     }).pipe(distinctUntilChanged(isEqual)),
 };
+
 export const createAction = (
   connectManagerExec: (
     arg0: ConnectManagerInput
@@ -349,6 +366,7 @@ export const createAction = (
     const [state, setState] = useState(() => getInitialState(device));
     const [resetIndex, setResetIndex] = useState(0);
     const deviceSubject = useReplaySubject(device);
+
     useEffect(() => {
       const impl = implementations[currentMode]({
         deviceSubject,
@@ -378,6 +396,7 @@ export const createAction = (
         sub.unsubscribe();
       };
     }, [deviceSubject, resetIndex, repairModalOpened, managerRequest]);
+
     const { deviceInfo } = state;
     useEffect(() => {
       if (!deviceInfo) return;

--- a/libs/ledger-live-common/src/hw/actions/types.ts
+++ b/libs/ledger-live-common/src/hw/actions/types.ts
@@ -1,11 +1,17 @@
 import type { DeviceModelId } from "@ledgerhq/devices";
+
 export type Device = {
   deviceId: string;
   deviceName?: string;
   modelId: DeviceModelId;
   wired: boolean;
 };
+
 export type Action<Request, HookState, Result> = {
   useHook: (arg0: Device | null | undefined, arg1: Request) => HookState;
   mapResult: (arg0: HookState) => Result | null | undefined;
+};
+
+export type LockedDeviceEvent = {
+  type: "lockedDevice";
 };

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -281,6 +281,7 @@ export const StatusCodes = {
   GP_AUTH_FAILED: 0x6300,
   LICENSING: 0x6f42,
   HALTED: 0x6faa,
+  LOCKED_DEVICE: 0x5515,
 };
 
 export function getAltStatusMessage(code: number): string | undefined | null {
@@ -298,6 +299,8 @@ export function getAltStatusMessage(code: number): string | undefined | null {
       return "Invalid data received";
     case 0x6b00:
       return "Invalid parameter received";
+    case 0x5515:
+      return "Locked device";
   }
   if (0x6f00 <= code && code <= 0x6fff) {
     return "Internal error, please report";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Part of Use universal OS lock response.

On new firmware versions, when a device is locked, it is now responding with a `0x5515` response.

This PR defines this response, and handle the case on connect-manager device action on LLM and LLD.
Once we agree on the way to handle this new response on the connect-manager device action, we will copy this behavior on other device actions.

### ❓ Context

- **Impacted projects**: live-common, LLM and LLD
- **Linked resource(s)**: [jira](https://ledgerhq.atlassian.net/browse/FAT-462?atlOrigin=eyJpIjoiYzFhMGU0M2M3MGIwNDdlYWJlNDliZDUzNWIyNzRlZjUiLCJwIjoiaiJ9)

### ✅ Checklist

- [ ] **Test coverage** : will be tested by QA
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

On Slack.

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
