### PR TITLE
bugfix/LIVE-2178 Prevent lock cases in USBTroubleShooting

### DIFF
--- a/.changeset/spicy-seahorses-laugh.md
+++ b/.changeset/spicy-seahorses-laugh.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Improve UX of USB Troubleshooting flow

--- a/apps/ledger-live-desktop/src/renderer/components/RepairDeviceButton.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RepairDeviceButton.jsx
@@ -14,13 +14,14 @@ import { openModal, closeModal } from "~/renderer/actions/modals";
 
 type Props = {
   buttonProps?: *,
+  disableDescription?: boolean,
   onRepair?: boolean => void,
   onClose?: ({ needHelp?: boolean }) => void,
   Component?: any,
 };
 
 const RepairDeviceButton: React$ComponentType<Props> = React.forwardRef(function RepairDevice(
-  { onRepair, onClose, buttonProps, Component }: Props,
+  { onRepair, onClose, buttonProps, Component, disableDescription }: Props,
   ref: React$ElementRef<*>,
 ) {
   const { t } = useTranslation();
@@ -127,7 +128,7 @@ const RepairDeviceButton: React$ComponentType<Props> = React.forwardRef(function
         repair={repair}
         isLoading={isLoading}
         title={t("settings.repairDevice.title")}
-        desc={t("settings.repairDevice.desc")}
+        desc={!disableDescription ? t("settings.repairDevice.desc") : undefined}
         progress={progress}
         error={error}
         enableSomethingElseChoice

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshooting.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshooting.jsx
@@ -22,18 +22,10 @@ const StepWrapper = styled(Box).attrs({
   mt: 32,
 })`
   position: absolute;
-  ${p =>
-    p.onboarding
-      ? `
   left: 0;
   margin: 0 20px;
   bottom: 20px;
   width: calc(100% - 40px);
-  `
-      : `
-  bottom: 12px;
-  width: 100%;
-  `}
 `;
 
 const USBTroubleshooting = ({ onboarding = false }: { onboarding?: boolean }) => {
@@ -82,7 +74,11 @@ const USBTroubleshooting = ({ onboarding = false }: { onboarding?: boolean }) =>
   ) : (
     <Box p={onboarding ? 48 : 0}>
       <SolutionComponent number={currentIndex + 1} sendEvent={sendEvent} done={done} />
-      {!isLastStep && <ConnectionTester onExit={onExit} onDone={onDone} />}
+      {!isLastStep && (
+        <Box p={20}>
+          <ConnectionTester onExit={onExit} onDone={onDone} />
+        </Box>
+      )}
       {!done && (
         <StepWrapper onboarding={onboarding}>
           {showExitOnboardingButton ? (
@@ -90,14 +86,15 @@ const USBTroubleshooting = ({ onboarding = false }: { onboarding?: boolean }) =>
               <ArrowRightIcon flipped size={16} />
               <Text ml={1}>{t("connectTroubleshooting.steps.entry.back")}</Text>
             </Button>
-          ) : (
-            <Button
-              disabled={!currentIndex}
-              onClick={() => sendEvent("PREVIOUS")}
-              id="USBTroubleshooting-previous"
-            >
+          ) : currentIndex ? (
+            <Button onClick={() => sendEvent("PREVIOUS")} id="USBTroubleshooting-previous">
               <ArrowRightIcon flipped size={16} />
               <Text ml={1}>{t("connectTroubleshooting.previousSolution")}</Text>
+            </Button>
+          ) : (
+            <Button onClick={onExit} id="USBTroubleshooting-exit">
+              <ArrowRightIcon flipped size={16} />
+              <Text ml={1}>{t("connectTroubleshooting.steps.entry.back")}</Text>
             </Button>
           )}
           {!isLastStep && (

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshootingMachine.js
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshootingMachine.js
@@ -95,6 +95,7 @@ export default createMachine(
         const currentIndex = solutions[platform].length <= 0 ? 0 : i - 1;
         return {
           currentIndex,
+          done: false,
         };
       }),
       // Tracking actions

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/RepairFunnel.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/RepairFunnel.jsx
@@ -3,7 +3,7 @@ import React, { useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
-import { Wrapper, Content, Title, Subtitle, Illustration } from "./shared";
+import { DeviceSelectorWrapper, Wrapper, Content, Title, Subtitle, Illustration } from "./shared";
 import illustration from "~/renderer/images/USBTroubleshooting/fail.png";
 import { DeviceSelector } from "~/renderer/components/Onboarding/Screens/SelectDevice/DeviceSelector";
 import { openURL } from "~/renderer/linking";
@@ -23,6 +23,10 @@ const RepairFunnelSolution = ({
   const onContactSupport = useCallback(() => {
     openURL(urls.contactSupport);
   }, []);
+
+  const onBack = useCallback(() => {
+    sendEvent("PREVIOUS");
+  }, [sendEvent]);
 
   const onSelectDevice = useCallback(
     deviceModel => {
@@ -48,13 +52,12 @@ const RepairFunnelSolution = ({
   return !done ? (
     <Wrapper>
       <Title>{t("connectTroubleshooting.steps.4.deviceSelection.title")}</Title>
-      <Subtitle style={{ padding: "0 50px" }} mb={36} mt={12}>
-        {t("connectTroubleshooting.steps.4.deviceSelection.desc")}
-      </Subtitle>
       <div style={{ display: "none" }}>
-        <RepairDeviceButton ref={repairRef} onClose={onRepairDeviceClose} />
+        <RepairDeviceButton disableDescription ref={repairRef} onClose={onRepairDeviceClose} />
       </div>
-      <DeviceSelector onClick={onSelectDevice} />
+      <DeviceSelectorWrapper>
+        <DeviceSelector onClick={onSelectDevice} />
+      </DeviceSelectorWrapper>
     </Wrapper>
   ) : (
     <Wrapper>
@@ -66,6 +69,9 @@ const RepairFunnelSolution = ({
         {t("connectTroubleshooting.steps.4.notFixed.desc")}
       </Subtitle>
       <Box horizontal>
+        <Button secondary onClick={onBack} mr={2}>
+          {t("connectTroubleshooting.steps.4.notFixed.cta2")}
+        </Button>
         <Button primary onClick={onContactSupport}>
           {t("connectTroubleshooting.steps.4.notFixed.cta")}
         </Button>

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/shared.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/shared.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
+import { Flex } from "@ledgerhq/react-ui";
 import Text from "~/renderer/components/Text";
 import ExternalLinkIcon from "~/renderer/icons/ExternalLink";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -12,6 +13,13 @@ export const Wrapper: ThemedComponent<{}> = styled(Box).attrs({
   padding: 20px;
   grid-gap: 12px;
 `;
+export const DeviceSelectorWrapper: ThemedComponent<{}> = styled(Flex).attrs({
+  height: "100%",
+  width: "100%",
+  justifyContent: "center",
+  alignItems: "center",
+  flexDirection: "column",
+})``;
 
 export const Number: ThemedComponent<{}> = styled(Text).attrs({
   color: "palette.primary.main",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4264,13 +4264,14 @@
       "4": {
         "deviceSelection": {
           "title": "What’s your device?",
-          "desc": "If you have a Nano S, you can try repairing your devices Firmware. For Nano X and Blue users, kindly contact Ledger support"
+          "desc": "If you’re trying to connect a Nano S, select the state displayed on your Nano. If you’re trying to connect a Nano S Plus or Nano X, <0>visit the Help Center</0>"
         },
         "notFixed": {
           "title": " USB connection problem still not fixed?",
           "desc": "If you've tried every possible solution, please reach out to Ledger Support. Otherwise, please follow the instructions of any solution you haven’t tried yet.",
           "back": "Back to portfolio",
-          "cta": "Contact Support"
+          "cta": "Contact Support",
+          "cta2": "Go Back"
         },
         "repair": {
           "title": "Repair your Nano S",


### PR DESCRIPTION

### 📝 Description

Improves the UX for the USB troubleshooting flow to prevent getting locked in it when we can't connect a device. It will now always include a way of escaping the flow and either returning to the onboarding flow or exiting if it was launched from the settings.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-2178` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

There are videos and screenshots on the linked Jira task.
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
I'd say this is a best effort bugfix, we are removing blocking cases so it is genuinely a better UX.
Up to product and QA whether this is good enough to merge or not.
