### PR TITLE
Implement handling of unsupported error to display an error at boot

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/RenderError.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RenderError.jsx
@@ -13,6 +13,7 @@ import TriggerAppReady from "./TriggerAppReady";
 import ExportLogsButton from "./ExportLogsButton";
 import Box from "~/renderer/components/Box";
 import Space from "~/renderer/components/Space";
+import TranslatedError from "~/renderer/components/TranslatedError";
 import Button from "~/renderer/components/Button";
 import ConfirmModal from "~/renderer/modals/ConfirmModal";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -61,13 +62,13 @@ export default function RenderError({ error, withoutAppData, children }: Props) 
   }, [hardReset]);
 
   return (
-    <Box alignItems="center" grow bg="palette.background.default">
+    <Box alignItems="center" grow bg="palette.background.default" data-test-id="render-error">
       <TriggerAppReady />
       <Space of={100} />
       <Image alt="" resource={CrashScreen} width="200" />
       <Space of={40} />
       <Box ff="Inter|SemiBold" fontSize={6} color="palette.text.shade100">
-        {t("crash.title")}
+        <TranslatedError error={error} field="title" />
       </Box>
       <Space of={15} />
       <Box
@@ -78,6 +79,8 @@ export default function RenderError({ error, withoutAppData, children }: Props) 
         color="palette.text.shade80"
         fontSize={4}
       >
+        <TranslatedError error={error} field="description" />
+        <br />
         {t("crash.description")}
       </Box>
       <Box py={6}>

--- a/apps/ledger-live-desktop/src/renderer/init.jsx
+++ b/apps/ledger-live-desktop/src/renderer/init.jsx
@@ -41,6 +41,7 @@ import {
 
 import ReactRoot from "~/renderer/ReactRoot";
 import AppError from "~/renderer/AppError";
+import { expectOperatingSystemSupportStatus } from "~/support/os";
 
 logger.add(new LoggerTransport());
 
@@ -59,6 +60,8 @@ async function init() {
     log,
     Transport,
   });
+
+  expectOperatingSystemSupportStatus();
 
   if (process.env.PLAYWRIGHT_RUN) {
     const spectronData = await getKey("app", "PLAYWRIGHT_RUN", {});

--- a/apps/ledger-live-desktop/src/support/os.test.ts
+++ b/apps/ledger-live-desktop/src/support/os.test.ts
@@ -1,22 +1,39 @@
-import { supportStatusForOS } from "./os";
+import { setEnv } from "@ledgerhq/live-common/lib/env";
+import { getOperatingSystemSupportStatus, supportStatusForOS } from "./os";
 
-test("a regular Mac version passes", () => {
-  expect(supportStatusForOS("Darwin", "18.7.0")).toMatchObject({ supported: true }); // macos 10.14.7
-  expect(supportStatusForOS("Darwin", "21.2.0")).toMatchObject({ supported: true });
+describe("supportStatusForOS", () => {
+  test("a regular Mac version passes", () => {
+    expect(supportStatusForOS("Darwin", "18.7.0")).toMatchObject({ supported: true }); // macos 10.14.7
+    expect(supportStatusForOS("Darwin", "21.2.0")).toMatchObject({ supported: true });
+  });
+
+  test("a regular Linux version passes", () => {
+    expect(supportStatusForOS("Linux", "5.19.1-3-MANJARO")).toMatchObject({ supported: true });
+  });
+
+  test("a regular Windows version passes", () => {
+    expect(supportStatusForOS("Windows_NT", "10.0.22000")).toMatchObject({ supported: true });
+  });
+
+  test("an old Mac version passes", () => {
+    expect(supportStatusForOS("Darwin", "17.7.0")).toMatchObject({ supported: false }); // macos 10.13.6
+  });
+
+  test("an old Windows version passes", () => {
+    expect(supportStatusForOS("Windows_NT", "6.1.7601")).toMatchObject({ supported: false });
+  });
 });
 
-test("a regular Linux version passes", () => {
-  expect(supportStatusForOS("Linux", "5.19.1-3-MANJARO")).toMatchObject({ supported: true });
-});
-
-test("a regular Windows version passes", () => {
-  expect(supportStatusForOS("Windows_NT", "10.0.22000")).toMatchObject({ supported: true });
-});
-
-test("an old Mac version passes", () => {
-  expect(supportStatusForOS("Darwin", "17.7.0")).toMatchObject({ supported: false }); // macos 10.13.6
-});
-
-test("an old Windows version passes", () => {
-  expect(supportStatusForOS("Windows_NT", "6.1.7601")).toMatchObject({ supported: false });
+describe("getOperatingSystemSupportStatus", () => {
+  test("default behavior of running on CI is passing", () => {
+    expect(getOperatingSystemSupportStatus()).toMatchObject({ supported: true });
+  });
+  test("the env is mockable", () => {
+    setEnv("MOCK_OS_VERSION", "Windows_NT@6.1.7601");
+    try {
+      expect(getOperatingSystemSupportStatus()).toMatchObject({ supported: false });
+    } finally {
+      setEnv("MOCK_OS_VERSION", "");
+    }
+  });
 });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4672,6 +4672,10 @@
     "NotEnoughGas": {
       "title": "The parent account balance is insufficient for network fees"
     },
+    "OperatingSystemOutdated": {
+      "title": "Your Operating System version is not supported",
+      "description": "Please upgrade your {{type}} OS to {{criteria}}. (You use {{release}})"
+    },
     "PasswordsDontMatch": {
       "title": "The Passwords don't match",
       "description": "Please try again"

--- a/apps/ledger-live-desktop/tests/models/Layout.ts
+++ b/apps/ledger-live-desktop/tests/models/Layout.ts
@@ -2,6 +2,7 @@ import { Page, Locator } from "@playwright/test";
 
 export class Layout {
   readonly page: Page;
+  readonly renderError: Locator;
   readonly totalBalance: Locator;
   readonly pageScroller: Locator;
   readonly loadingLogo: Locator;
@@ -32,6 +33,8 @@ export class Layout {
 
   constructor(page: Page) {
     this.page = page;
+
+    this.renderError = page.locator("data-test-id=render-error");
 
     // portfolio && accounts
     this.totalBalance = page.locator("data-test-id=total-balance");

--- a/apps/ledger-live-desktop/tests/specs/support/unsupported-os.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/support/unsupported-os.spec.ts
@@ -1,0 +1,19 @@
+import test from "../../fixtures/common";
+import { expect } from "@playwright/test";
+import { Layout } from "../../models/Layout";
+
+test.use({ userdata: "skip-onboarding" });
+
+test.use({
+  env: {
+    MOCK_OS_VERSION: "Windows_NT@6.1.7601",
+  },
+});
+
+test("Unsupported OS", async ({ page }) => {
+  const layout = new Layout(page);
+  await test.step("displays the error page", async () => {
+    await layout.renderError.waitFor({ state: "visible" });
+    expect(await layout.renderError.isVisible()).toBe(true);
+  });
+});

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -444,6 +444,11 @@ const envDefinitions = {
     parser: stringParser,
     desc: "mock remote live app manifest",
   },
+  MOCK_OS_VERSION: {
+    def: "",
+    parser: stringParser,
+    desc: "if defined, overrides the os and version. format: os@version. Example: Windows_NT@6.1.7601",
+  },
   NFT_CURRENCIES: {
     def: "ethereum,polygon",
     parser: stringParser,


### PR DESCRIPTION
someone from @LedgerHQ/live-hub team to takeover 🙏 

### 📝 Description

renders this screen if you come with an outdated OS version (windows, mac,...) as defined by `os.ts`

<img width="1279" alt="Screenshot 2022-10-06 at 12 59 48" src="https://user-images.githubusercontent.com/211411/194297869-630b26e2-ac33-40c3-b656-43e444f8103c.png">

at the moment the coded rules are:

```
const minVersions: { [_: string]: string } = {
  Windows_NT: ">= 8.1",
  Darwin: ">= 18", // this is a darwin version corresponding roughly to mac os 10.14
};
```

which can be updated any time.

This PR introduces a way to test this with an env variable, for instance you can use

```
MOCK_OS_VERSION=Windows_NT@6.1.7601
```

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: there are ongoing product discussion but not even a ticket about it 😑 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
