### PR TITLE
Add the possibility to change the dAppUrl send to eth-dapp-browser

### DIFF
--- a/.changeset/tiny-weeks-jam.md
+++ b/.changeset/tiny-weeks-jam.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add usePlatformUrl the capacity to change the dAppUrl of the provided manifest

--- a/libs/ledger-live-common/src/platform/react.test.ts
+++ b/libs/ledger-live-common/src/platform/react.test.ts
@@ -1,0 +1,120 @@
+import { platformUrl } from "./react";
+import { AppManifest } from "./types";
+
+describe("platformUrl", () => {
+  const appManifestUrl = "https://dapp-browser.apps.ledger.com/";
+  const appManifest: AppManifest = {
+    id: "1inch-lld",
+    name: "1inch",
+    private: true,
+    url: appManifestUrl,
+    homepageUrl: "https://1inch.io/",
+    icon: "https://cdn.live.ledger.com/icons/platform/1inch.png",
+    platform: "desktop",
+    apiVersion: "^1.0.0 || ~0.0.1",
+    manifestVersion: "1",
+    branch: "stable",
+    categories: ["swap", "defi"],
+    currencies: ["ethereum"],
+    content: {
+      shortDescription: {
+        en: "Exchange crypto via a Defi/DEX aggregator on Ethereum mainnet, BSC or Polygon",
+      },
+      description: {
+        en: "Exchange crypto via a Defi/DEX aggregator on Ethereum mainnet, BSC or Polygon",
+      },
+    },
+    permissions: [],
+    domains: ["https://*"],
+  };
+
+  it("returns url to call", () => {
+    // Given
+    const dAppParams =
+      '{ \
+      "dappUrl": "https://app.1inch.io/?ledgerLive=true", \
+      "nanoApp": "1inch", \
+      "dappName": "1inch", \
+      "networks": [ \
+        { \
+          "currency": "ethereum", \
+          "chainID": 1, \
+          "nodeURL": \
+            "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2", \
+        }, \
+        { \
+          "currency"": "bsc", \
+          "chainID": 56, \
+          "nodeURL": "https://bsc-dataseed.binance.org/", \
+        }, \
+        { \
+          "currency": "polygon", \
+          "chainID": 137, \
+          "nodeURL": \
+            "https://polygon-mainnet.g.alchemy.com/v2/oPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE", \
+        }, \
+      ], \
+    }';
+    appManifest.params = [dAppParams];
+    const params = { background: "background", text: "text" };
+    const inputs = { firstInput: "12", secondInput: "second" };
+
+    // When
+    const url: URL = platformUrl(appManifest, params, inputs);
+
+    // Then
+    const expectedUrl = new URL(
+      appManifestUrl +
+        "?firstInput=12&secondInput=second&backgroundColor=background&textColor=text"
+    );
+    expectedUrl.searchParams.set("params", JSON.stringify([dAppParams]));
+    expect(url).toEqual(expectedUrl);
+  });
+
+  it("returns url to call with a dAppUrl given in parameter", () => {
+    // Given
+    const dAppUrlToCall = "https://embedded.paraswap.io/?ledgerLive=true";
+    const dAppParams = {
+      dappUrl: "https://app.1inch.io/?ledgerLive=true",
+      nanoApp: "1inch",
+      dappName: "1inch",
+      networks: [
+        {
+          currency: "ethereum",
+          chainID: 1,
+          nodeURL:
+            "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2",
+        },
+        {
+          currency: "bsc",
+          chainID: 56,
+          nodeURL: "https://bsc-dataseed.binance.org/",
+        },
+        {
+          currency: "polygon",
+          chainID: 137,
+          nodeURL:
+            "https://polygon-mainnet.g.alchemy.com/v2/oPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE",
+        },
+      ],
+    };
+    appManifest.params = dAppParams;
+    const params = { background: "background", text: "text" };
+    const inputs = { firstInput: "12", secondInput: "second" };
+
+    // When
+    const url: URL = platformUrl(appManifest, params, inputs, dAppUrlToCall);
+
+    // Then
+    const expectedUrl = new URL(
+      appManifestUrl +
+        "?firstInput=12&secondInput=second&backgroundColor=background&textColor=text"
+    );
+    const expectedDAppParams = {
+      ...dAppParams,
+      dappUrl: dAppUrlToCall,
+    };
+    expectedUrl.searchParams.set("params", JSON.stringify(expectedDAppParams));
+    expect(url).toEqual(expectedUrl);
+  });
+});

--- a/libs/ledger-live-common/src/platform/react.ts
+++ b/libs/ledger-live-common/src/platform/react.ts
@@ -16,6 +16,7 @@ import {
   ListPlatformCurrency,
   PlatformCurrency,
   AppManifest,
+  isDAppParams,
 } from "./types";
 import { getParentAccount } from "../account";
 import { listCurrencies } from "../currencies";
@@ -29,35 +30,48 @@ import { listCurrencies } from "../currencies";
 export function usePlatformUrl(
   manifest: AppManifest,
   params: { background: string; text: string; loadDate?: Date },
-  inputs: Record<string, string>
+  inputs: Record<string, string>,
+  dAppURL?: string
 ): URL {
   return useMemo(() => {
-    const url = new URL(manifest.url.toString());
+    return platformUrl(manifest, params, inputs, dAppURL);
+  }, [manifest, params, inputs, dAppURL]);
+}
 
-    if (inputs) {
-      for (const key in inputs) {
-        if (
-          Object.prototype.hasOwnProperty.call(inputs, key) &&
-          inputs[key] !== undefined
-        ) {
-          url.searchParams.set(key, inputs[key]);
-        }
+export function platformUrl(
+  manifest: AppManifest,
+  params: { background: string; text: string; loadDate?: Date },
+  inputs: Record<string, string>,
+  dAppURL?: string
+): URL {
+  const url = new URL(manifest.url.toString());
+
+  if (inputs) {
+    for (const key in inputs) {
+      if (
+        Object.prototype.hasOwnProperty.call(inputs, key) &&
+        inputs[key] !== undefined
+      ) {
+        url.searchParams.set(key, inputs[key]);
       }
     }
+  }
 
-    if (params.background)
-      url.searchParams.set("backgroundColor", params.background);
-    if (params.text) url.searchParams.set("textColor", params.text);
-    if (params.loadDate) {
-      url.searchParams.set("loadDate", params.loadDate.valueOf().toString());
+  if (params.background)
+    url.searchParams.set("backgroundColor", params.background);
+  if (params.text) url.searchParams.set("textColor", params.text);
+  if (params.loadDate) {
+    url.searchParams.set("loadDate", params.loadDate.valueOf().toString());
+  }
+
+  if (manifest.params) {
+    if (isDAppParams(manifest.params) && dAppURL !== undefined) {
+      manifest.params.dappUrl = dAppURL;
     }
+    url.searchParams.set("params", JSON.stringify(manifest.params));
+  }
 
-    if (manifest.params) {
-      url.searchParams.set("params", JSON.stringify(manifest.params));
-    }
-
-    return url;
-  }, [manifest.url, manifest.params, params, inputs]);
+  return url;
 }
 
 export function useListPlatformAccounts(

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -8,7 +8,6 @@ import {
   Account as PlatformAccount,
   Currency as PlatformCurrency,
 } from "@ledgerhq/live-app-sdk";
-import { string } from "superstruct";
 
 export type {
   Account as PlatformAccount,

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -8,6 +8,7 @@ import {
   Account as PlatformAccount,
   Currency as PlatformCurrency,
 } from "@ledgerhq/live-app-sdk";
+import { string } from "superstruct";
 
 export type {
   Account as PlatformAccount,
@@ -40,6 +41,28 @@ export type AppPermission = {
   params?: any;
 };
 
+type dAppParamsNetwork = {
+  currency: string;
+  chainId: number;
+  nodeURL: string;
+};
+type dAppParams = {
+  dappUrl: string;
+  nanoApp: string;
+  dappName: string;
+  networks: Array<dAppParamsNetwork>;
+};
+export function isDAppParams(params: any): params is dAppParams {
+  return (params as dAppParams).dappUrl !== undefined;
+}
+type webAppParams = {
+  webUrl: string;
+  webAppName: string;
+  currencies: Array<string>;
+};
+export function isWebAppParams(params: any): params is webAppParams {
+  return (params as webAppParams).webUrl !== undefined;
+}
 export type AppManifest = {
   id: string;
   private?: boolean;
@@ -52,7 +75,7 @@ export type AppManifest = {
   apiVersion: string;
   manifestVersion: string;
   branch: AppBranch;
-  params?: string[];
+  params?: dAppParams | webAppParams | any;
   categories: string[];
   currencies: string[] | "*";
   content: {


### PR DESCRIPTION
Signed-off-by: Stéphane Prohaszka <stephane.prohaszka@ledger.fr>

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add the possibility to create a url to call a live-app of type eth-dapp-browser with a different dAppUrl than the one provided in the manifest.
The goal is allow the call of dApp with url containing queryParams or more complex path to set the dApp in a different state than the default one.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
