### PR TITLE
Bot: add 'environment' in report.json to filter by 'production'

### DIFF
--- a/.github/workflow-templates/bot-coin-family.yml
+++ b/.github/workflow-templates/bot-coin-family.yml
@@ -1,4 +1,4 @@
-name: "[Bot] '$COIN on Silicium'"
+name: "[Bot] Testing $COIN with 'Silicium'"
 on:
   push:
     branches:
@@ -61,3 +61,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed3:"
           SLACK_CHANNEL: ci-$COIN-ll
           BOT_FILTER_FAMILY: $COIN
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-bitcoin-mooncake.yml
+++ b/.github/workflows/bot-bitcoin-mooncake.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Bitcoin on Mooncake'"
+name: "[Bot] Testing Bitcoin with 'Mooncake'"
 on:
   push:
     branches:
@@ -65,3 +65,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed4:"
           SLACK_CHANNEL: ci-bitcoin-ll
           BOT_FILTER_FAMILY: bitcoin
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-cardano-silicium.yml
+++ b/.github/workflows/bot-cardano-silicium.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Cardano on Silicium'"
+name: "[Bot] Testing Cardano with 'Silicium'"
 on:
   push:
     branches:
@@ -60,3 +60,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed3:"
           SLACK_CHANNEL: ci-ada-ll
           BOT_FILTER_FAMILY: cardano
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-celo-silicium.yml
+++ b/.github/workflows/bot-celo-silicium.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Celo on Silicium'"
+name: "[Bot] Testing Celo with 'Silicium'"
 on:
   push:
     branches:
@@ -60,3 +60,4 @@ jobs:
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN}}
           SLACK_CHANNEL: ci-celo-ll
           BOT_FILTER_FAMILY: celo
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-coin-osmosis.yml
+++ b/.github/workflows/bot-coin-osmosis.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Osmosis on Silicium'"
+name: "[Bot] Testing Osmosis with 'Silicium'"
 on:
   push:
     branches:
@@ -61,3 +61,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed3:"
           SLACK_CHANNEL: ci-osmosis-ll
           BOT_FILTER_FAMILY: osmosis
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-cosmos-phosphore.yml
+++ b/.github/workflows/bot-cosmos-phosphore.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Cosmos on Phosphore'"
+name: "[Bot] Testing Cosmos with 'Phosphore'"
 on:
   push:
     branches:
@@ -61,3 +61,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed6:"
           SLACK_CHANNEL: ci-atom-ll
           BOT_FILTER_FAMILY: cosmos
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-filecoin-mooncake.yml
+++ b/.github/workflows/bot-filecoin-mooncake.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Filecoin on Mooncake'"
+name: "[Bot] Testing Filecoin with 'Mooncake'"
 on:
   push:
     branches:
@@ -62,3 +62,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed4:"
           SLACK_CHANNEL: ci-fil-ll
           BOT_FILTER_FAMILY: filecoin
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-hedera-mooncake.yml
+++ b/.github/workflows/bot-hedera-mooncake.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Hedera on Mooncake'"
+name: "[Bot] Testing Hedera with 'Mooncake'"
 on:
   push:
     branches:
@@ -61,3 +61,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed4:"
           SLACK_CHANNEL: ci-hbar-ll
           BOT_FILTER_FAMILY: hedera
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-mere-denis-nonreg.yml
+++ b/.github/workflows/bot-mere-denis-nonreg.yml
@@ -1,9 +1,7 @@
-name: "[Bot] 'Mère Denis'"
+name: "[Bot] non-reg on develop with 'Mère Denis'"
 on:
-  push:
-    branches:
-      - support/bot-mere-denis
-      - support/bot-actions-perf
+  schedule:
+    - cron: "0 7 * * 1"
 
 concurrency:
   group: bot-seed1
@@ -60,3 +58,4 @@ jobs:
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN}}
           SLACK_ICON_EMOJI: ":bot-seed1:"
           SEED: ${{ secrets.SEED1 }}
+          BOT_ENVIRONMENT: production

--- a/.github/workflows/bot-phosphore-nonreg.yml
+++ b/.github/workflows/bot-phosphore-nonreg.yml
@@ -1,8 +1,10 @@
-name: "[Bot] Testing EVM with 'Phosphore'"
+name: "[Bot] non-reg on develop with 'Phosphore'"
 on:
+  schedule:
+    - cron: "30 */6 * * *"
   push:
     branches:
-      - feat/evm-light-integration
+      - develop
 
 concurrency:
   group: bot-seed6
@@ -58,5 +60,6 @@ jobs:
         with:
           SHOW_LEGACY_NEW_ACCOUNT: "1"
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN}}
+          SLACK_ICON_EMOJI: ":bot-seed6:"
           SEED: ${{ secrets.SEED6 }}
-          BOT_ENVIRONMENT: testing
+          BOT_ENVIRONMENT: production

--- a/.github/workflows/bot-phosphore.yml
+++ b/.github/workflows/bot-phosphore.yml
@@ -1,7 +1,5 @@
-name: "[Bot] 'Phosphore'"
+name: "[Bot] Testing with 'Phosphore'"
 on:
-  schedule:
-    - cron: "0 8-16/2 * * 1-5"
   push:
     branches:
       - support/bot-phosphore
@@ -63,3 +61,4 @@ jobs:
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN}}
           SLACK_ICON_EMOJI: ":bot-seed6:"
           SEED: ${{ secrets.SEED6 }}
+          BOT_ENVIRONMENT: testing

--- a/.github/workflows/bot-staging-explorer-btc.yml
+++ b/.github/workflows/bot-staging-explorer-btc.yml
@@ -69,3 +69,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed2:"
           SLACK_CHANNEL: explorer-bot-stg
           BOT_FILTER_FAMILY: bitcoin
+          BOT_ENVIRONMENT: staging

--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -69,3 +69,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed2:"
           SLACK_CHANNEL: explorer-bot-stg
           BOT_FILTER_FAMILY: ethereum
+          BOT_ENVIRONMENT: staging

--- a/.github/workflows/bot-stellar-silicium.yml
+++ b/.github/workflows/bot-stellar-silicium.yml
@@ -1,4 +1,4 @@
-name: "[Bot] 'Stellar on Silicium'"
+name: "[Bot] Testing Stellar with 'Silicium'"
 on:
   push:
     branches:
@@ -61,3 +61,4 @@ jobs:
           SLACK_ICON_EMOJI: ":bot-seed3:"
           SLACK_CHANNEL: ci-xlm-ll
           BOT_FILTER_FAMILY: stellar
+          BOT_ENVIRONMENT: testing

--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -393,10 +393,6 @@ export async function bot({
     slackBody += warn;
   }
 
-  appendBody(
-    "\n> What is the bot and how does it work? [Everything is documented here!](https://github.com/LedgerHQ/ledger-live/wiki/LLC:bot)\n\n"
-  );
-
   appendBody("\n\n");
 
   if (specFatals.length) {
@@ -723,7 +719,11 @@ export async function bot({
 
   appendBody("\n</details>\n\n");
 
-  const { BOT_REPORT_FOLDER } = process.env;
+  appendBody(
+    "\n> What is the bot and how does it work? [Everything is documented here!](https://github.com/LedgerHQ/ledger-live/wiki/LLC:bot)\n\n"
+  );
+
+  const { BOT_REPORT_FOLDER, BOT_ENVIRONMENT } = process.env;
 
   const slackCommentTemplate = `${String(
     GITHUB_WORKFLOW
@@ -732,6 +732,7 @@ export async function bot({
   if (BOT_REPORT_FOLDER) {
     const serializedReport: MinimalSerializedReport = {
       results: results.map(convertSpecReport),
+      environment: BOT_ENVIRONMENT,
     };
 
     await Promise.all([

--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -193,4 +193,5 @@ export type MinimalSerializedSpecReport = {
 
 export type MinimalSerializedReport = {
   results: Array<MinimalSerializedSpecReport>;
+  environment: string | undefined;
 };

--- a/tools/actions/composites/bot/action.yml
+++ b/tools/actions/composites/bot/action.yml
@@ -22,6 +22,9 @@ inputs:
   EXPLORER:
     description: "EXPLORER value"
     required: false
+  BOT_ENVIRONMENT:
+    description: "defines an environment to be included in the report.json"
+    required: false
 
 runs:
   using: "composite"
@@ -51,6 +54,7 @@ runs:
         GITHUB_WORKFLOW: ${{ github.workflow }}
         BOT_FILTER_FAMILY: ${{ inputs.BOT_FILTER_FAMILY }}
         SHOW_LEGACY_NEW_ACCOUNT: ${{ inputs.SHOW_LEGACY_NEW_ACCOUNT }}
+        BOT_ENVIRONMENT: ${{ inputs.BOT_ENVIRONMENT }}
         explorerinput: ${{ inputs.EXPLORER }}
       run: |
         export COINAPPS=$PWD/coin-apps


### PR DESCRIPTION
### 📝 Description

one missing feature that #1494 will need to filter only production bot runs.
i also explicitly splitted "bot-phosphore" into two diff actions, we need one to be production, running on develop (now running on each commit with cancel mecanism + every 6 hours) VS the one on bot-phosphore branches push.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** the bot will run on this PR and i'll manually check the .json have the data i need <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
