### PR TITLE
LIVE-3386: Cosmos redelegate can fail when empty validators

### DIFF
--- a/libs/ledger-live-common/src/families/cosmos/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-getTransactionStatus.ts
@@ -307,7 +307,10 @@ export class CosmosTransactionStatusManager {
         })
       )
         return new CosmosRedelegationInProgress();
-      if (t.sourceValidator === t.validators[0].address)
+      if (
+        t.validators.length > 0 &&
+        t.sourceValidator === t.validators[0].address
+      )
         return new InvalidAddressBecauseDestinationIsAlsoSource();
     }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

 Cosmos redelegate can fail when empty validators.

There's already an error that we used to redelegate, i'm not sure if that's enough tho

```javascript
   if (
      t.validators.some(
        (v) =>
          !v.address ||
          !v.address.includes(this._validatorOperatorAddressPrefix)
      ) ||
      t.validators.length === 0
    )
      errors.recipient = new InvalidAddress(undefined, {
        currencyName: a.currency.name,
      });
```


### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3386 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
