### PR TITLE
Bot: add skipMutationsTimeout to make app ends in finite time

### DIFF
--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -159,14 +159,17 @@ export async function bot({
         log("bot", message);
         if (process.env.CI) console.log(message);
         logs.push(message);
-      }).catch((fatalError) => ({
-        spec,
-        fatalError,
-        mutations: [],
-        accountsBefore: [],
-        accountsAfter: [],
-        hintWarnings: [],
-      }));
+      }).catch(
+        (fatalError): SpecReport<any> => ({
+          spec,
+          fatalError,
+          mutations: [],
+          accountsBefore: [],
+          accountsAfter: [],
+          hintWarnings: [],
+          skipMutationsTimeoutReached: false,
+        })
+      );
     }
   );
   const totalDuration = Date.now() - timeBefore;

--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -130,6 +130,8 @@ export type AppSpec<T extends Transaction> = {
   // indicates to the engine what's the generally minimal amount we use to opt out from doing a transaction
   // NB: at the moment it's purely informative and help inferring good "hints", but we could eventually automate it
   minViableAmount?: BigNumber;
+  // global timeout to consider the run due date for the spec. (since a seed could have theorically an infinite amount of accounts and mutation could take a lot of time to validate transactions, we need a way to limit the run time)
+  skipMutationsTimeout?: number;
 };
 export type SpecReport<T extends Transaction> = {
   spec: AppSpec<T>;
@@ -142,6 +144,7 @@ export type SpecReport<T extends Transaction> = {
   fatalError?: Error;
   // express hints for the spec developers on things that could be improved
   hintWarnings: string[];
+  skipMutationsTimeoutReached: boolean;
 };
 export type MutationReport<T extends Transaction> = {
   resyncAccountsDuration: number;

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -171,9 +171,14 @@ const envDefinitions = {
     desc: "Ledger script runner API",
   },
   BOT_TIMEOUT_SCAN_ACCOUNTS: {
-    def: 30 * 60 * 1000,
+    def: 10 * 60 * 1000,
     parser: intParser,
     desc: "bot's default timeout for scanAccounts",
+  },
+  BOT_SPEC_DEFAULT_TIMEOUT: {
+    def: 30 * 60 * 1000,
+    parser: intParser,
+    desc: "define the default value of spec.skipMutationsTimeout (if not overriden by spec)",
   },
   CARDANO_API_ENDPOINT: {
     def: "https://cardano.coin.ledger.com/api",


### PR DESCRIPTION
ctx https://github.com/LedgerHQ/ledger-live-issues/issues/48

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add on bot specs a global timeout to consider the run due after some times so it stops trying more mutations. This is needed because a seed could have theorically an infinite amount of accounts and mutation could take a lot of time to validate transactions (especially when they fail), we need a way to limit the run time.

a typical example we have today is Cosmos spec having 32 accounts and a mutation timeout of 6 minutes. which makes the worse case of more than 3 hours of run: we would have a global failure because our global timeout is only of 2 hours.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: part of https://github.com/LedgerHQ/ledger-live-issues/issues/48 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
