### PR TITLE
Bot Super Report: add resilience on github HTTP 500 issues

### DIFF
--- a/.github/workflows/bot-super-report-custom.yml
+++ b/.github/workflows/bot-super-report-custom.yml
@@ -28,7 +28,7 @@ jobs:
         run: pnpm i --filter='!./apps/**' --frozen-lockfile
 
       - name: generate super report
-        uses: ledgerhq/ledger-live/tools/actions/generate-bot-super-report@develop
+        uses: ./tools/actions/generate-bot-super-report
         with:
           branch: ${{github.event.inputs.branch}}
           environment: ${{github.event.inputs.environment}}

--- a/.github/workflows/bot-super-report.yml
+++ b/.github/workflows/bot-super-report.yml
@@ -20,7 +20,7 @@ jobs:
         run: pnpm i --filter='!./apps/**' --frozen-lockfile
 
       - name: generate super report
-        uses: ledgerhq/ledger-live/tools/actions/generate-bot-super-report@develop
+        uses: ./tools/actions/generate-bot-super-report
         with:
           branch: develop
           environment: production

--- a/tools/actions/generate-bot-super-report/promise.ts
+++ b/tools/actions/generate-bot-super-report/promise.ts
@@ -1,0 +1,77 @@
+export const delay = (ms: number): Promise<void> =>
+  new Promise((f) => setTimeout(f, ms));
+
+const defaults = {
+  maxRetry: 4,
+  interval: 300,
+  intervalMultiplicator: 1.5,
+  context: "",
+};
+
+export function retry<A>(
+  f: () => Promise<A>,
+  options?: Partial<typeof defaults>
+): Promise<A> {
+  const { maxRetry, interval, intervalMultiplicator, context } = {
+    ...defaults,
+    ...options,
+  };
+
+  function rec(remainingTry, i) {
+    const result = f();
+
+    if (remainingTry <= 0) {
+      return result;
+    }
+
+    // In case of failure, wait the interval, retry the action
+    return result.catch((e) => {
+      console.log(
+        "promise-retry",
+        context + " failed. " + remainingTry + " retry remain. " + String(e)
+      );
+      return delay(i).then(() =>
+        rec(remainingTry - 1, i * intervalMultiplicator)
+      );
+    });
+  }
+
+  return rec(maxRetry, interval);
+}
+
+/**
+ * promiseAllBatched(n, items, i => f(i))
+ * is essentially like
+ * Promise.all(items.map(i => f(i)))
+ * but with a guarantee that it will not create more than n concurrent call to f
+ * where f is a function that returns a promise
+ */
+export async function promiseAllBatched<A, B>(
+  batch: number,
+  items: Array<A>,
+  fn: (arg0: A, arg1: number) => Promise<B>
+): Promise<B[]> {
+  const data = Array(items.length);
+  const queue = items.map((item, index) => ({
+    item,
+    index,
+  }));
+
+  async function step() {
+    if (queue.length === 0) return;
+    const first = queue.shift();
+    if (first) {
+      const { item, index } = first;
+      data[index] = await fn(item, index);
+    }
+    await step(); // each time an item redeem, we schedule another one
+  }
+
+  // initially, we schedule <batch> items in parallel
+  await Promise.all(
+    Array(Math.min(batch, items.length))
+      .fill(() => undefined)
+      .map(step)
+  );
+  return data;
+}


### PR DESCRIPTION

### 📝 Description

github `/artifacts` api appears to be capricious and randomly returns HTTP 500. This PR implements a retry mechanism to secure our weekly report. Also added some extra delay and a "promise all batched" approach to not spam too much http queries at same time.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** [https://github.com/LedgerHQ/ledger-live/actions/runs/3249192193 <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->](https://github.com/LedgerHQ/ledger-live/actions/runs/3249207570)
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
