### PR TITLE
Bot: make mutation.maxRun mandatory field to limit nb of txs

### DIFF
--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -66,7 +66,7 @@ export type MutationSpec<T extends Transaction> = {
   // Name what this mutation is doing
   name: string;
   // The maximum number of times to execute this mutation for a given test run
-  maxRun?: number;
+  maxRun: number;
   // Express the transaction to be done
   // it returns either a transaction T, or an array with T and a list of patch to apply to it
   transaction: (arg: TransactionArg<T>) => TransactionRes<T>;

--- a/libs/ledger-live-common/src/families/cosmos/specs.ts
+++ b/libs/ledger-live-common/src/families/cosmos/specs.ts
@@ -98,6 +98,7 @@ const cosmos: AppSpec<Transaction> = {
   mutations: [
     {
       name: "send some",
+      maxRun: 2,
       testDestination: genericTestDestination,
       test: ({ account, accountBeforeTransaction, operation }) => {
         expect(account.balance.toString()).toBe(


### PR DESCRIPTION

### 📝 Description

cosmos was not defining a maxRun for its 'send some' mutation which yielded a lot of txs that can cost fees and time of the bot runs. We only need to test 2 to confirm it works correctly.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** if it pass the CI it's enough to confirm it works as i only changed the types here (ts build will validate) <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
