### PR TITLE
Bot: Estimate the remaining number of runs

### DIFF
--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -66,7 +66,7 @@ export type MutationSpec<T extends Transaction> = {
   // Name what this mutation is doing
   name: string;
   // The maximum number of times to execute this mutation for a given test run
-  maxRun?: number;
+  maxRun: number;
   // Express the transaction to be done
   // it returns either a transaction T, or an array with T and a list of patch to apply to it
   transaction: (arg: TransactionArg<T>) => TransactionRes<T>;

--- a/libs/ledger-live-common/src/families/cosmos/specs.ts
+++ b/libs/ledger-live-common/src/families/cosmos/specs.ts
@@ -98,6 +98,7 @@ const cosmos: AppSpec<Transaction> = {
   mutations: [
     {
       name: "send some",
+      maxRun: 2,
       testDestination: genericTestDestination,
       test: ({ account, accountBeforeTransaction, operation }) => {
         expect(account.balance.toString()).toBe(


### PR DESCRIPTION
### 📝 Description

To have more visibility this gives an estimation of the number of runs possible in specs. (optimistic estimation)

This improve the bot run reporting:

![Screenshot 2022-10-17 at 16 51 31](https://user-images.githubusercontent.com/211411/196209857-13064961-70fa-429e-a057-e0dd4d3ddd8d.png)


### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** this PR triggers a run, we will want the report <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
