### PR TITLE
Bugfix: Update getFeesEstimation for EVM to prevent usage of `getFeeData`

### DIFF
--- a/libs/ledger-live-common/src/families/evm/api/rpc.common.ts
+++ b/libs/ledger-live-common/src/families/evm/api/rpc.common.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { transactionToEthersTransaction } from "../adapters";
-import { Transaction as EvmTransaction } from "../types";
+import { FeeHistory, Transaction as EvmTransaction } from "../types";
 import { Account } from "@ledgerhq/types-live";
 
 export const DEFAULT_RETRIES_RPC_METHODS = 2;
@@ -118,7 +118,42 @@ export const getFeesEstimation = (
   gasPrice: null | BigNumber;
 }> =>
   withApi(currency, async (api) => {
-    const feeData = await api.getFeeData();
+    const block = await api.getBlock("latest");
+    const supports1559 = Boolean(block.baseFeePerGas);
+    const feeData = await (async () => {
+      if (supports1559) {
+        const feeHistory: FeeHistory = await api.send("eth_feeHistory", [
+          "0x5", // Fetching the history for 5 blocks
+          "latest", // from the latest block
+          [50], // 50% percentile sample
+        ]);
+        // Taking the average priority fee used on the last 5 blocks
+        const maxPriorityFeePerGas = feeHistory.reward.reduce(
+          (acc, [curr], i, arr) => {
+            acc.plus(new BigNumber(curr));
+
+            const isLastElement = i === arr.length - 1;
+            return !isLastElement ? acc : acc.dividedBy(arr.length);
+          },
+          new BigNumber(0)
+        );
+        const nextBaseFee = new BigNumber(
+          feeHistory.baseFeePerGas[feeHistory.baseFeePerGas.length - 1]
+        );
+
+        return {
+          maxPriorityFeePerGas,
+          maxFeePerGas: nextBaseFee.multipliedBy(2).plus(maxPriorityFeePerGas),
+        };
+      } else {
+        const gasPrice = await api.getGasPrice();
+
+        return {
+          gasPrice,
+        };
+      }
+    })();
+
     return {
       maxFeePerGas: feeData.maxFeePerGas
         ? new BigNumber(feeData.maxFeePerGas.toString())

--- a/libs/ledger-live-common/src/families/evm/types.ts
+++ b/libs/ledger-live-common/src/families/evm/types.ts
@@ -82,3 +82,10 @@ export type EtherscanOperation = {
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type FeeHistory = {
+  baseFeePerGas: string[];
+  gasUsedRatio: number[];
+  oldestBlock: string;
+  reward: string[][];
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We discovered recently that `ethers` is hardcoding the value of `maxPriorityFeePerGas` on its [`getFeeData` method](https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/abstract-provider/src.ts/index.ts#L252) which is very dangerous. 

This updated method will catch the last 5 blocks on the chain, sample the transactions to get the average priority fee used to be included in a block (50% percentile) and provide it as `maxPriorityFeePerGas` + use it to infer the `maxFeePerGas` with `maxFeePerGas = 2 * nextBaseFee + maxPriorityFeePerGas`.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
