### PR TITLE
Feature - Update NFT endpoint default load config in hw-app-eth

### DIFF
--- a/.changeset/flat-schools-yawn.md
+++ b/.changeset/flat-schools-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-eth": minor
+---
+
+Add the NFT endpoint to the default loadConfig

--- a/libs/ledgerjs/packages/hw-app-eth/src/services/ledger/loadConfig.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/services/ledger/loadConfig.ts
@@ -1,7 +1,7 @@
 import type { LoadConfig } from "../types";
 
 const defaultLoadConfig = {
-  nftExplorerBaseURL: null, // set a value when an official production endpoint is released
+  nftExplorerBaseURL: "https://nft.api.live.ledger.com/v1/ethereum",
   pluginBaseURL: "https://cdn.live.ledger.com",
   extraPlugins: null,
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adding a the NFT endpoint as the default value for the `loadConfig` in `hw-app-eth` in order for other wallets to easily add NFT clear signing through resolution only.

### ❓ Context

- **Impacted projects**: `ledgerjs/hw-app-eth` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
