### PR TITLE
[LIVE-4283] Hotfix - Update getFeesEstimation for EVM to prevent usage of getFeeData

### DIFF
--- a/.changeset/rotten-jobs-fix.md
+++ b/.changeset/rotten-jobs-fix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Update getEstimationFee for evm family to prevent usage of hardcoded values by `ether.js`

--- a/libs/ledger-live-common/src/families/evm/api/etherscan.ts
+++ b/libs/ledger-live-common/src/families/evm/api/etherscan.ts
@@ -1,9 +1,44 @@
 import { Operation } from "@ledgerhq/types-live";
+import axios, { AxiosRequestConfig } from "axios";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { etherscanOperationToOperation } from "../adapters";
 import { EtherscanOperation } from "../types";
 import { makeLRUCache } from "../../../cache";
-import network from "../../../network";
+import { EtherscanAPIError } from "../errors";
+import { delay } from "../../../promise";
+
+export const DEFAULT_RETRIES_API = 5;
+export const ETHERSCAN_TIMEOUT = 5000; // 5 seconds between 2 calls
+
+async function fetchWithRetries<T>(
+  params: AxiosRequestConfig,
+  retries = DEFAULT_RETRIES_API
+): Promise<T> {
+  try {
+    const { data } = await axios.request<{
+      status: string;
+      message: string;
+      result: T;
+    }>(params);
+
+    if (!Number(data.status) && data.message === "NOTOK") {
+      throw new EtherscanAPIError(
+        "Error while fetching data from Etherscan like API",
+        { params, data }
+      );
+    }
+
+    return data.result;
+  } catch (e) {
+    if (retries) {
+      // wait the API timeout before trying again
+      await delay(ETHERSCAN_TIMEOUT);
+      // decrement with prefix here or it won't work
+      return fetchWithRetries<T>(params, --retries);
+    }
+    throw e;
+  }
+}
 
 /**
  * Get all the latest "normal" transactions (no tokens / NFTs)
@@ -23,24 +58,19 @@ export const getLatestTransactions = makeLRUCache<
       return [];
     }
 
-    let url = `${apiDomain}/api?module=account&action=txlist&address=${address}&tag=latest&page=1`;
+    let url = `${apiDomain}/api?module=account&action=txlist&address=${address}&tag=latest&page=1&sort=desc`;
     if (fromBlock) {
       url += `&startBlock=${fromBlock}`;
     }
 
-    try {
-      const { data }: { data: { result: EtherscanOperation[] } } =
-        await network({
-          method: "GET",
-          url,
-        });
+    const ops = await fetchWithRetries<EtherscanOperation[]>({
+      method: "GET",
+      url,
+    });
 
-      return data.result
-        .map((tx) => etherscanOperationToOperation(accountId, address, tx))
-        .filter(Boolean) as Operation[];
-    } catch (e) {
-      return [];
-    }
+    return ops
+      .map((tx) => etherscanOperationToOperation(accountId, address, tx))
+      .filter(Boolean) as Operation[];
   },
   (currency, address, accountId) => accountId,
   { maxAge: 6 * 1000 }

--- a/libs/ledger-live-common/src/families/evm/errors.ts
+++ b/libs/ledger-live-common/src/families/evm/errors.ts
@@ -1,0 +1,3 @@
+import { createCustomErrorClass } from "@ledgerhq/errors";
+
+export const EtherscanAPIError = createCustomErrorClass("EtherscanAPIError");

--- a/libs/ledger-live-common/src/families/evm/types.ts
+++ b/libs/ledger-live-common/src/families/evm/types.ts
@@ -82,3 +82,10 @@ export type EtherscanOperation = {
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
+
+export type FeeHistory = {
+  baseFeePerGas: string[];
+  gasUsedRatio: number[];
+  oldestBlock: string;
+  reward: string[][];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55871,7 +55871,7 @@ packages:
     dev: false
 
   github.com/bitcoinjs/bip39/d8ea080a18b40f301d4e2219a2991cd2417e83c2:
-    resolution: {commit: d8ea080a18b40f301d4e2219a2991cd2417e83c2, repo: git+ssh://git@github.com/bitcoinjs/bip39.git, type: git}
+    resolution: {tarball: https://codeload.github.com/bitcoinjs/bip39/tar.gz/d8ea080a18b40f301d4e2219a2991cd2417e83c2}
     name: bip39
     version: 3.0.3
     dependencies:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We discovered recently that ethers is hardcoding the value of maxPriorityFeePerGas on its [getFeeData method](https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/abstract-provider/src.ts/index.ts#L252) which is very dangerous.

This updated method will catch the last 5 blocks on the chain, sample the transactions to get the average priority fee used to be included in a block (50% percentile) and provide it as maxPriorityFeePerGas + use it to infer the maxFeePerGas with maxFeePerGas = 2 * nextBaseFee + maxPriorityFeePerGas. (Ensuring 6 blocks of valid baseFee)

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-4283

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
