### PR TITLE
OSMOSIS: replace integ with unit test

### DIFF
--- a/libs/ledger-live-common/src/families/osmosis/bridge.integration.test.ts
+++ b/libs/ledger-live-common/src/families/osmosis/bridge.integration.test.ts
@@ -12,7 +12,6 @@ import {
   NotEnoughBalance,
   AmountRequired,
 } from "@ledgerhq/errors";
-import { ClaimRewardsFeesWarning } from "../../errors";
 import invariant from "invariant";
 import type { Transaction } from "./types";
 import transactionTransformer from "./transaction";

--- a/libs/ledger-live-common/src/families/osmosis/bridge.integration.test.ts
+++ b/libs/ledger-live-common/src/families/osmosis/bridge.integration.test.ts
@@ -339,26 +339,6 @@ const osmosis: CurrenciesData<Transaction> = {
           },
         },
         {
-          name: "ClaimReward - Warning",
-          transaction: (t) => ({
-            ...t,
-            validators: [
-              {
-                address: "osmovaloper1hjct6q7npsspsg3dgvzk3sdf89spmlpf6t4agt",
-                amount: new BigNumber(0),
-              },
-            ],
-            fees: new BigNumber(9999999999999999),
-            mode: "claimReward",
-          }),
-          expectedStatus: {
-            errors: {},
-            warnings: {
-              claimReward: new ClaimRewardsFeesWarning(),
-            },
-          },
-        },
-        {
           name: "ClaimReward - not a osmovaloper",
           transaction: (t) => ({
             ...t,
@@ -395,26 +375,6 @@ const osmosis: CurrenciesData<Transaction> = {
               errors: {},
               warnings: {},
             };
-          },
-        },
-        {
-          name: "ClaimRewardCompound - Warning",
-          transaction: (t) => ({
-            ...t,
-            validators: [
-              {
-                address: "osmovaloper1hjct6q7npsspsg3dgvzk3sdf89spmlpf6t4agt",
-                amount: new BigNumber(100),
-              },
-            ],
-            fees: new BigNumber(99999999999999999999),
-            mode: "claimRewardCompound",
-          }),
-          expectedStatus: {
-            errors: {},
-            warnings: {
-              claimReward: new ClaimRewardsFeesWarning(),
-            },
           },
         },
       ],

--- a/libs/ledger-live-common/src/families/osmosis/js-getTransactionStatus.unit.test.ts
+++ b/libs/ledger-live-common/src/families/osmosis/js-getTransactionStatus.unit.test.ts
@@ -1,0 +1,56 @@
+import BigNumber from "bignumber.js";
+import { ClaimRewardsFeesWarning } from "../../errors";
+import { fromTransactionRaw } from "../cosmos/transaction";
+import {
+  CosmosAccount,
+  CosmosLikeTransaction,
+  CosmosResources,
+  TransactionRaw,
+} from "../cosmos/types";
+import transactionStatus from "./js-getTransactionStatus";
+
+const transaction: CosmosLikeTransaction = fromTransactionRaw({
+  family: "osmosis",
+  amount: "0",
+  recipient: "",
+  fees: "999999999999",
+  validators: [
+    {
+      address: "osmovaloper1hjct6q7npsspsg3dgvzk3sdf89spmlpf6t4agt",
+      amount: "0",
+    },
+  ],
+} as TransactionRaw);
+
+const account = {
+  cosmosResources: {
+    delegations: [
+      {
+        validatorAddress: "osmovaloper1hjct6q7npsspsg3dgvzk3sdf89spmlpf6t4agt",
+        amount: new BigNumber("2000000"),
+        pendingRewards: new BigNumber("100"),
+        status: "bonded",
+      },
+    ],
+  } as CosmosResources,
+} as CosmosAccount;
+
+describe("Cosmos GetTransactionStatus", () => {
+  it("should claim Reward with warning", async () => {
+    const { warnings } = await transactionStatus(account, {
+      ...transaction,
+      mode: "claimReward",
+    });
+
+    expect(warnings.claimReward).toStrictEqual(new ClaimRewardsFeesWarning());
+  });
+
+  it("should claim Reward Compound with warning", async () => {
+    const { warnings } = await transactionStatus(account, {
+      ...transaction,
+      mode: "claimRewardCompound",
+    });
+
+    expect(warnings.claimReward).toStrictEqual(new ClaimRewardsFeesWarning());
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Integration test didn't work anymore because the dataset account of osmosis account rewards' were higher than fees, so the warning wouldn't be display again.
So I replace the integ test with a more reliable unit test.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
