### PR TITLE
Support: FAT-550 fix bootloader repairing steps

### DIFF
--- a/.changeset/red-glasses-rule.md
+++ b/.changeset/red-glasses-rule.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/errors": patch
+---
+
+Fix bootloader repairing steps

--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -28,6 +28,7 @@ import generateTestScanAccounts from "./commands/generateTestScanAccounts";
 import generateTestTransaction from "./commands/generateTestTransaction";
 import genuineCheck from "./commands/genuineCheck";
 import getAddress from "./commands/getAddress";
+import getDeviceRunningMode from "./commands/getDeviceRunningMode";
 import getTransactionStatus from "./commands/getTransactionStatus";
 import i18n from "./commands/i18n";
 import liveData from "./commands/liveData";
@@ -83,6 +84,7 @@ export default {
   generateTestTransaction,
   genuineCheck,
   getAddress,
+  getDeviceRunningMode,
   getTransactionStatus,
   i18n,
   liveData,

--- a/apps/cli/src/commands/getDeviceRunningMode.ts
+++ b/apps/cli/src/commands/getDeviceRunningMode.ts
@@ -1,0 +1,36 @@
+import { Observable } from "rxjs";
+import { getDeviceRunningMode, GetDeviceRunningModeResult } from "@ledgerhq/live-common/hw/getDeviceRunningMode";
+import { deviceOpt } from "../scan";
+
+export default {
+  description: "Get the mode (bootloader, main, locked-device, disconnected-or-locked-device) in which the device is",
+  args: [
+    {
+      name: "nbUnresponsiveRetry",
+      alias: "r",
+      desc: "Number of received CantOpenDevice errors while retrying before considering the device as maybe disconnected or cold-started-locked",
+      type: Number,
+    },
+    {
+      name: "unresponsiveTimeoutMs",
+      alias: "t",
+      desc: "Time in ms of the timeout before considering the device unresponsive",
+      type: Number,
+    },
+    deviceOpt,
+  ],
+  job: ({
+    device,
+    unresponsiveTimeoutMs,
+    cantOpenDeviceRetryLimit,
+  }: Partial<{
+    device: string;
+    unresponsiveTimeoutMs: number;
+    cantOpenDeviceRetryLimit: number;
+  }>): Observable<GetDeviceRunningModeResult | null> =>
+    getDeviceRunningMode({ 
+      deviceId: device ?? "",
+      unresponsiveTimeoutMs,
+      cantOpenDeviceRetryLimit,
+  })
+};

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -395,18 +395,32 @@ export const createAction = (
           : null
       );
     }, []);
+
     const closeRepairModal = useCallback(() => {
+      // Sets isBootloader to true to avoid having the renderBootloaderStep rendered,
+      // on which the user could re-trigger a bootloader repairing scenario that is not needed
+      setState((prevState) => {
+        return {
+          ...prevState,
+          deviceInfo: prevState.deviceInfo
+            ? { ...prevState.deviceInfo, isBootloader: false }
+            : null,
+        };
+      });
       setRepairModalOpened(null);
     }, []);
+
     const onRetry = useCallback(() => {
       setResetIndex((currIndex) => currIndex + 1);
       setState((s) => getInitialState(s.device));
     }, []);
+
     const onAutoRepair = useCallback(() => {
       setRepairModalOpened({
         auto: true,
       });
     }, []);
+
     return {
       ...state,
       repairModalOpened,

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
@@ -21,9 +21,12 @@ import {
   followDeviceRepair,
   followDeviceUpdate,
 } from "../deviceWordings";
+import { getDeviceRunningMode } from "./getDeviceRunningMode";
+
 const wait2s = of({
   type: "wait",
 }).pipe(delay(2000));
+
 export const repairChoices = [
   {
     id: "mcuOutdated",
@@ -71,156 +74,175 @@ const repair = (
   );
 
   const loop = (forceMCU?: string | null | undefined) =>
-    withDeviceInfo.pipe(
-      concatMap((deviceInfo) => {
-        const installMcu = (version: string) =>
-          withDevice(deviceId)((transport) =>
-            ManagerAPI.installMcu(transport, "mcu", {
-              targetId: deviceInfo.targetId,
-              version,
-            })
-          );
-
-        if (!deviceInfo.isBootloader) {
-          // finish earlier
-          return EMPTY;
-        }
-
-        // This is a special case where user is in firmware 1.3.1
-        // and the device shows MCU Not Genuine.
-        // User needs to press both keys three times to go back to dashboard
-        // and continue the update process
-        if (
-          forceMCU &&
-          forceMCU === "0.7" &&
-          (deviceInfo.majMin === "0.6" || deviceInfo.majMin === "0.7")
-        ) {
-          // finish earlier
-          return throwError(new MCUNotGenuineToDashboard());
-        }
-
-        if (forceMCU) {
-          return concat(installMcu(forceMCU), wait2s, loop());
-        }
-
-        switch (deviceInfo.majMin) {
-          case "0.0":
-            return concat(installMcu("0.6"), wait2s, loop());
-
-          case "0.6":
-            return installMcu("1.5");
-
-          case "0.7":
-            return installMcu("1.6");
-
-          case "0.9":
-            return installMcu("1.7");
-
-          default:
-            return from(mcusPromise).pipe(
-              concatMap((mcus) => {
-                let next;
-                const { seVersion, seTargetId, mcuBlVersion } = deviceInfo;
-
-                // This is a special case where a user with LNX version >= 2.0.0
-                // comes back with a broken updated device. We need to be able
-                // to patch MCU or Bootloader if needed
-                if (seVersion && seTargetId) {
-                  log(
-                    "hw",
-                    "firmwareUpdate-repair seVersion and seTargetId found",
-                    { seVersion, seTargetId }
-                  );
-                  const validMcusForDeviceInfo = mcus
-                    .filter(filterMCUForDeviceInfo(deviceInfo))
-                    .filter((mcu) => mcu.from_bootloader_version !== "none");
-
-                  log("hw", "firmwareUpdate-repair valid mcus for device", {
-                    validMcusForDeviceInfo,
-                  });
-
-                  return from(
-                    ManagerAPI.getDeviceVersion(
-                      seTargetId,
-                      getProviderId(deviceInfo)
-                    )
-                  ).pipe(
-                    mergeMap((deviceVersion: DeviceVersion) =>
-                      from(
-                        ManagerAPI.getCurrentFirmware({
-                          deviceId: deviceVersion.id,
-                          version: seVersion,
-                          provider: getProviderId(deviceInfo),
-                        })
-                      )
-                    ),
-                    mergeMap((finalFirmware: FinalFirmware) => {
-                      log("hw", "firmwareUpdate-repair got final firmware", {
-                        finalFirmware,
-                      });
-
-                      const mcu = ManagerAPI.findBestMCU(
-                        finalFirmware.mcu_versions
-                          .map((id) =>
-                            validMcusForDeviceInfo.find((mcu) => mcu.id === id)
-                          )
-                          .filter(Boolean)
-                      );
-
-                      log("hw", "firmwareUpdate-repair got mcu", { mcu });
-
-                      if (!mcu) return EMPTY;
-                      const expectedBootloaderVersion = semver.coerce(
-                        mcu.from_bootloader_version
-                      )?.version;
-                      const currentBootloaderVersion =
-                        semver.coerce(mcuBlVersion)?.version;
-
-                      log("hw", "firmwareUpdate-repair bootloader versions", {
-                        currentBootloaderVersion,
-                        expectedBootloaderVersion,
-                      });
-
-                      if (
-                        expectedBootloaderVersion === currentBootloaderVersion
-                      ) {
-                        next = mcu;
-                        log(
-                          "hw",
-                          "firmwareUpdate-repair bootloader versions are the same",
-                          { next }
-                        );
-                      } else {
-                        next = {
-                          name: mcu.from_bootloader_version,
-                        };
-                        log(
-                          "hw",
-                          "firmwareUpdate-repair bootloader versions are different",
-                          { next }
-                        );
-                      }
-
-                      return installMcu(next.name);
-                    })
-                  );
-                } else {
-                  next = ManagerAPI.findBestMCU(
-                    ManagerAPI.compatibleMCUForDeviceInfo(
-                      mcus,
-                      deviceInfo,
-                      getProviderId(deviceInfo)
-                    )
-                  );
-
-                  if (next) return installMcu(next.name);
-                }
-
-                return EMPTY;
+    concat(
+      withDeviceInfo.pipe(
+        concatMap((deviceInfo) => {
+          const installMcu = (version: string) =>
+            withDevice(deviceId)((transport) =>
+              ManagerAPI.installMcu(transport, "mcu", {
+                targetId: deviceInfo.targetId,
+                version,
               })
             );
-        }
-      })
+
+          if (!deviceInfo.isBootloader) {
+            // finish earlier
+            return EMPTY;
+          }
+
+          // This is a special case where user is in firmware 1.3.1
+          // and the device shows MCU Not Genuine.
+          // User needs to press both keys three times to go back to dashboard
+          // and continue the update process
+          if (
+            forceMCU &&
+            forceMCU === "0.7" &&
+            (deviceInfo.majMin === "0.6" || deviceInfo.majMin === "0.7")
+          ) {
+            // finish earlier
+            return throwError(new MCUNotGenuineToDashboard());
+          }
+
+          if (forceMCU) {
+            return concat(installMcu(forceMCU), wait2s, loop());
+          }
+
+          switch (deviceInfo.majMin) {
+            case "0.0":
+              return concat(installMcu("0.6"), wait2s, loop());
+
+            case "0.6":
+              return installMcu("1.5");
+
+            case "0.7":
+              return installMcu("1.6");
+
+            case "0.9":
+              return installMcu("1.7");
+
+            default:
+              return from(mcusPromise).pipe(
+                concatMap((mcus) => {
+                  let next;
+                  const { seVersion, seTargetId, mcuBlVersion } = deviceInfo;
+
+                  // This is a special case where a user with LNX version >= 2.0.0
+                  // comes back with a broken updated device. We need to be able
+                  // to patch MCU or Bootloader if needed
+                  if (seVersion && seTargetId) {
+                    log(
+                      "hw",
+                      "firmwareUpdate-repair seVersion and seTargetId found",
+                      { seVersion, seTargetId }
+                    );
+                    const validMcusForDeviceInfo = mcus
+                      .filter(filterMCUForDeviceInfo(deviceInfo))
+                      .filter((mcu) => mcu.from_bootloader_version !== "none");
+
+                    log("hw", "firmwareUpdate-repair valid mcus for device", {
+                      validMcusForDeviceInfo,
+                    });
+
+                    return from(
+                      ManagerAPI.getDeviceVersion(
+                        seTargetId,
+                        getProviderId(deviceInfo)
+                      )
+                    ).pipe(
+                      mergeMap((deviceVersion: DeviceVersion) =>
+                        from(
+                          ManagerAPI.getCurrentFirmware({
+                            deviceId: deviceVersion.id,
+                            version: seVersion,
+                            provider: getProviderId(deviceInfo),
+                          })
+                        )
+                      ),
+                      mergeMap((finalFirmware: FinalFirmware) => {
+                        log("hw", "firmwareUpdate-repair got final firmware", {
+                          finalFirmware,
+                        });
+
+                        const mcu = ManagerAPI.findBestMCU(
+                          finalFirmware.mcu_versions
+                            .map((id) =>
+                              validMcusForDeviceInfo.find(
+                                (mcu) => mcu.id === id
+                              )
+                            )
+                            .filter(Boolean)
+                        );
+
+                        log("hw", "firmwareUpdate-repair got mcu", { mcu });
+
+                        if (!mcu) return EMPTY;
+                        const expectedBootloaderVersion = semver.coerce(
+                          mcu.from_bootloader_version
+                        )?.version;
+                        const currentBootloaderVersion =
+                          semver.coerce(mcuBlVersion)?.version;
+
+                        log("hw", "firmwareUpdate-repair bootloader versions", {
+                          currentBootloaderVersion,
+                          expectedBootloaderVersion,
+                        });
+
+                        if (
+                          expectedBootloaderVersion === currentBootloaderVersion
+                        ) {
+                          next = mcu;
+                          log(
+                            "hw",
+                            "firmwareUpdate-repair bootloader versions are the same",
+                            { next }
+                          );
+                        } else {
+                          next = {
+                            name: mcu.from_bootloader_version,
+                          };
+                          log(
+                            "hw",
+                            "firmwareUpdate-repair bootloader versions are different",
+                            { next }
+                          );
+                        }
+
+                        return installMcu(next.name);
+                      })
+                    );
+                  } else {
+                    next = ManagerAPI.findBestMCU(
+                      ManagerAPI.compatibleMCUForDeviceInfo(
+                        mcus,
+                        deviceInfo,
+                        getProviderId(deviceInfo)
+                      )
+                    );
+
+                    if (next) return installMcu(next.name);
+                  }
+
+                  return EMPTY;
+                })
+              );
+          }
+        })
+      ),
+      from(
+        getDeviceRunningMode({
+          deviceId,
+          unresponsiveTimeoutMs: 4000,
+          cantOpenDeviceRetryLimit: 2,
+        })
+      ).pipe(
+        mergeMap((result) => {
+          if (result.type === "bootloaderMode") {
+            return loop(forceMCU);
+          } else {
+            return EMPTY;
+          }
+        })
+      )
     );
 
   // TODO ideally we should race waitForBootloader with an event "display-bootloader-reboot", it should be a delayed event that is not emitted if waitForBootloader is fast enough..

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
@@ -1,0 +1,240 @@
+import { from, Observable, of, timer } from "rxjs";
+import { delay } from "rxjs/operators";
+import Transport, {
+  StatusCodes,
+  TransportStatusError,
+} from "@ledgerhq/hw-transport";
+import { CantOpenDevice, DisconnectedDevice } from "@ledgerhq/errors";
+import { DeviceInfo } from "@ledgerhq/types-live";
+import getDeviceInfo from "./getDeviceInfo";
+import { getDeviceRunningMode } from "./getDeviceRunningMode";
+import { aDeviceInfoBuilder } from "../mock/fixtures/aDeviceInfo";
+
+jest.useFakeTimers();
+
+// Only mocks withDevice
+jest.mock("./deviceAccess", () => {
+  const originalModule = jest.requireActual("./deviceAccess");
+
+  return {
+    ...originalModule, // import and retain the original functionalities
+    withDevice: jest.fn().mockReturnValue((job) => {
+      return from(job(new Transport()));
+    }),
+  };
+});
+
+// Needs to mock the timer from rxjs used in retryWhileErrors
+jest.mock("rxjs", () => {
+  const originalModule = jest.requireActual("rxjs");
+
+  return {
+    ...originalModule,
+    timer: jest.fn(),
+  };
+});
+const mockedTimer = jest.mocked(timer);
+
+jest.mock("./getDeviceInfo");
+const mockedGetDeviceInfo = jest.mocked(getDeviceInfo);
+
+const A_DEVICE_ID = "";
+
+describe("getDeviceRunningMode", () => {
+  beforeEach(() => {
+    mockedTimer.mockReturnValue(of(1));
+  });
+
+  afterEach(() => {
+    mockedTimer.mockClear();
+    mockedGetDeviceInfo.mockClear();
+  });
+
+  describe("When the device is in bootloader mode", () => {
+    it("pushes an event bootloaderMode", (done) => {
+      const aDeviceInfo = aDeviceInfoBuilder({ isBootloader: true });
+      mockedGetDeviceInfo.mockResolvedValue(aDeviceInfo);
+
+      getDeviceRunningMode({ deviceId: A_DEVICE_ID }).subscribe({
+        next: (event) => {
+          try {
+            expect(event.type).toBe("bootloaderMode");
+            done();
+          } catch (expectError) {
+            done(expectError);
+          }
+        },
+        error: (error) => {
+          // It should not reach here
+          done(error);
+        },
+      });
+
+      jest.advanceTimersByTime(1);
+    });
+
+    describe("but for now it is restarting and/or in a unknown state", () => {
+      it("it should wait and retry until the device is in bootloader", (done) => {
+        const aDeviceInfo = aDeviceInfoBuilder({ isBootloader: true });
+
+        const nbAcceptedErrors = 3;
+        let count = 0;
+        // Could not simply mockedRejectValueOnce several times followed by
+        // a mockedResolveValueOnce. Needed to transform getDeviceInfo
+        // into an Observable.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        mockedGetDeviceInfo.mockImplementation(() => {
+          return new Observable<DeviceInfo>((o) => {
+            if (count < nbAcceptedErrors) {
+              count++;
+              o.error(new DisconnectedDevice());
+            } else {
+              o.next(aDeviceInfo);
+            }
+          });
+        });
+
+        getDeviceRunningMode({
+          deviceId: A_DEVICE_ID,
+        }).subscribe({
+          next: (event) => {
+            try {
+              expect(mockedTimer).toBeCalledTimes(nbAcceptedErrors);
+              expect(event.type).toBe("bootloaderMode");
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
+          },
+          error: (error) => {
+            // It should not reach here
+            done(error);
+          },
+        });
+
+        // No need to handle the timer with a specific value as rxjs timer has been mocked
+        // because we could not advance the timer every time the retryWhileErrors is called
+        jest.advanceTimersByTime(1);
+      });
+    });
+  });
+
+  describe("When the device is NOT in bootloader mode and unlocked", () => {
+    it("pushes an event mainMode", (done) => {
+      const aDeviceInfo = aDeviceInfoBuilder({ isBootloader: false });
+      mockedGetDeviceInfo.mockResolvedValue(aDeviceInfo);
+
+      getDeviceRunningMode({ deviceId: A_DEVICE_ID }).subscribe({
+        next: (event) => {
+          try {
+            expect(event.type).toBe("mainMode");
+            done();
+          } catch (expectError) {
+            done(expectError);
+          }
+        },
+        error: (error) => {
+          // It should not reach here
+          done(error);
+        },
+      });
+
+      jest.advanceTimersByTime(1);
+    });
+  });
+
+  describe("When the device is locked (not in bootloader)", () => {
+    describe("And is not responsive", () => {
+      it("waits for a given time and pushes an event lockedDevice", (done) => {
+        const unresponsiveTimeoutMs = 5000;
+
+        // The deviceInfo will not be returned before the timeout
+        // leading to an "unresponsive device"
+        const aDeviceInfo = aDeviceInfoBuilder({ isBootloader: false });
+        mockedGetDeviceInfo.mockResolvedValue(
+          of(aDeviceInfo)
+            .pipe(delay(unresponsiveTimeoutMs + 1000))
+            .toPromise()
+        );
+
+        getDeviceRunningMode({
+          deviceId: A_DEVICE_ID,
+          unresponsiveTimeoutMs,
+        }).subscribe({
+          next: (event) => {
+            try {
+              expect(event.type).toBe("lockedDevice");
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
+          },
+          error: (error) => {
+            // It should not reach here
+            done(error);
+          },
+        });
+
+        jest.advanceTimersByTime(unresponsiveTimeoutMs + 1);
+      });
+    });
+
+    describe("And the device responds with a LOCKED_DEVICE error", () => {
+      it("pushes an event lockedDevice", (done) => {
+        mockedGetDeviceInfo.mockRejectedValue(
+          new TransportStatusError(StatusCodes.LOCKED_DEVICE)
+        );
+
+        getDeviceRunningMode({
+          deviceId: A_DEVICE_ID,
+        }).subscribe({
+          next: (event) => {
+            try {
+              expect(event.type).toBe("lockedDevice");
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
+          },
+          error: (error) => {
+            // It should not reach here
+            done(error);
+          },
+        });
+
+        jest.advanceTimersByTime(1);
+      });
+    });
+
+    describe("And the transport lib throws CantOpenDevice errors", () => {
+      it("pushes an event disconnectedOrlockedDevice after a given number of retry", (done) => {
+        const cantOpenDeviceRetryLimit = 3;
+        mockedGetDeviceInfo.mockRejectedValue(new CantOpenDevice());
+
+        getDeviceRunningMode({
+          deviceId: A_DEVICE_ID,
+          cantOpenDeviceRetryLimit,
+        }).subscribe({
+          next: (event) => {
+            try {
+              expect(mockedTimer).toBeCalledTimes(cantOpenDeviceRetryLimit);
+              expect(event.type).toBe("disconnectedOrlockedDevice");
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
+          },
+          error: (error) => {
+            // It should not reach here
+            done(error);
+          },
+        });
+
+        // No need to handle the timer with a specific value as rxjs timer has been mocked
+        // because we could not advance the timer every time the retryWhileErrors is called
+        jest.advanceTimersByTime(1);
+      });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
@@ -51,10 +51,10 @@ export const getDeviceRunningMode = ({
   deviceId,
   unresponsiveTimeoutMs = 5000,
   cantOpenDeviceRetryLimit = 3,
-}: CheckDeviceModeArgs): Observable<GetDeviceRunningModeResult> => {
-  let cantOpenDeviceRetryCount = 0;
+}: CheckDeviceModeArgs): Observable<GetDeviceRunningModeResult> =>
+  new Observable<GetDeviceRunningModeResult>((o) => {
+    let cantOpenDeviceRetryCount = 0;
 
-  return new Observable<GetDeviceRunningModeResult>((o) => {
     withDevice(deviceId)((transport) => from(getDeviceInfo(transport)))
       .pipe(
         timeout(unresponsiveTimeoutMs),
@@ -102,7 +102,6 @@ export const getDeviceRunningMode = ({
         complete: () => o.complete(),
       });
   });
-};
 
 const isLockedDeviceError = (e: Error) => {
   return (

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
@@ -1,0 +1,115 @@
+import {
+  TransportStatusError,
+  StatusCodes,
+  CantOpenDevice,
+} from "@ledgerhq/errors";
+import { DeviceInfo } from "@ledgerhq/types-live";
+import { from, Observable, TimeoutError } from "rxjs";
+import { retryWhen, timeout } from "rxjs/operators";
+import { retryWhileErrors, withDevice } from "./deviceAccess";
+import getDeviceInfo from "./getDeviceInfo";
+
+export type CheckDeviceModeArgs = {
+  deviceId: string;
+  unresponsiveTimeoutMs?: number;
+  cantOpenDeviceRetryLimit?: number;
+};
+
+export type GetDeviceRunningModeResult =
+  | {
+      type: "lockedDevice";
+    }
+  | {
+      type: "disconnectedOrlockedDevice";
+    }
+  | {
+      type: "mainMode";
+      deviceInfo: DeviceInfo;
+    }
+  | {
+      type: "bootloaderMode";
+      deviceInfo: DeviceInfo;
+    };
+
+/**
+ * Get the mode in which is device is: bootloader, main, locked device, maybe disconnected or locked device
+ * It will retry on all errors from getDeviceInfo, except the ones that implies that the device is
+ * disconnected (number of retry can be tweaked) or locked.
+ *
+ * Note: If no device is found, the current Transport implementations throw a CantOpenDevice error
+ * And if the device was cold started and not yet unlocked, the current Transport implementations
+ * don't see the device yet, and also throw a CantOpenDevice error.
+ *
+ * Does NOT handle recovery mode for now.
+ * @param deviceId A device id
+ * @param unresponsiveTimeoutMs Time in ms of the timeout before considering the device unresponsive
+ * @param cantOpenDeviceRetryLimit Number of received CantOpenDevice errors while retrying before considering
+ *   the device as maybe disconnected or cold-started-locked
+ * @returns An object GetDeviceRunningModeEvent
+ */
+export const getDeviceRunningMode = ({
+  deviceId,
+  unresponsiveTimeoutMs = 5000,
+  cantOpenDeviceRetryLimit = 3,
+}: CheckDeviceModeArgs): Observable<GetDeviceRunningModeResult> => {
+  let cantOpenDeviceRetryCount = 0;
+
+  return new Observable<GetDeviceRunningModeResult>((o) => {
+    withDevice(deviceId)((transport) => from(getDeviceInfo(transport)))
+      .pipe(
+        timeout(unresponsiveTimeoutMs),
+        retryWhen(
+          retryWhileErrors((e: Error) => {
+            // Does not retry on locked-device error
+            if (isLockedDeviceError(e)) {
+              return false;
+            }
+
+            if (e instanceof CantOpenDevice) {
+              if (cantOpenDeviceRetryCount < cantOpenDeviceRetryLimit) {
+                cantOpenDeviceRetryCount++;
+                return true;
+              }
+
+              return false;
+            }
+
+            // Retries on any other kind of errors
+            return true;
+          })
+        )
+      )
+      .subscribe({
+        next: (deviceInfo: DeviceInfo) => {
+          if (deviceInfo.isBootloader) {
+            o.next({ type: "bootloaderMode", deviceInfo });
+          } else {
+            o.next({ type: "mainMode", deviceInfo });
+          }
+          o.complete();
+        },
+        error: (e: Error) => {
+          if (isLockedDeviceError(e)) {
+            o.next({ type: "lockedDevice" });
+            o.complete();
+          } else if (e instanceof CantOpenDevice) {
+            o.next({ type: "disconnectedOrlockedDevice" });
+            o.complete();
+          } else {
+            o.error(e);
+          }
+        },
+        complete: () => o.complete(),
+      });
+  });
+};
+
+const isLockedDeviceError = (e: Error) => {
+  return (
+    (e &&
+      e instanceof TransportStatusError &&
+      // @ts-expect-error typescript not checking agains the instanceof
+      e.statusCode === StatusCodes.LOCKED_DEVICE) ||
+    e instanceof TimeoutError
+  );
+};

--- a/libs/ledger-live-common/src/mock/fixtures/aDeviceInfo.ts
+++ b/libs/ledger-live-common/src/mock/fixtures/aDeviceInfo.ts
@@ -1,0 +1,16 @@
+import type { DeviceInfo } from "@ledgerhq/types-live";
+
+export const aDeviceInfoBuilder = (props?: Partial<DeviceInfo>): DeviceInfo => {
+  return {
+    mcuVersion: "A_MCU_VERSION",
+    version: "A_VERSION",
+    majMin: "A_MAJ_MIN",
+    targetId: "0.0",
+    isBootloader: false,
+    isOSU: true,
+    providerName: undefined,
+    managerAllowed: false,
+    pinValidated: true,
+    ...props,
+  };
+};

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -281,6 +281,7 @@ export const StatusCodes = {
   GP_AUTH_FAILED: 0x6300,
   LICENSING: 0x6f42,
   HALTED: 0x6faa,
+  LOCKED_DEVICE: 0x5515,
 };
 
 export function getAltStatusMessage(code: number): string | undefined | null {
@@ -298,6 +299,8 @@ export function getAltStatusMessage(code: number): string | undefined | null {
       return "Invalid data received";
     case 0x6b00:
       return "Invalid parameter received";
+    case 0x5515:
+      return "Locked device";
   }
   if (0x6f00 <= code && code <= 0x6fff) {
     return "Internal error, please report";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix the following bug:
> When the user falls under the “bootloader repair” path (triggered when their nanos is on bootloader while on the manager, deviceInfo.isBootloader set to true), the [renderBootloaderStep](https://github.com/LedgerHQ/ledger-live/blob/b53d64842471eb2382066aecfc9f2b3b15ef7aed/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx#L795) is displayed, and the command firmwareRepair defined [here](https://github.com/LedgerHQ/ledger-live/blob/b53d64842471eb2382066aecfc9f2b3b15ef7aed/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts#L55) is called once the user clicks on the “continue” button (opening the [AutoRepair](https://github.com/LedgerHQ/ledger-live/blob/b53d64842471eb2382066aecfc9f2b3b15ef7aed/apps/ledger-live-desktop/src/renderer/components/AutoRepair.jsx#L14) modal).
When the device restarts during the repairing/bootloader/mcu update, the command reaches a “complete” state (nothing to do anymore), while actually the device is restarting to the bootloader. By going back to the bootloader, the DeviceAction receives a state with deviceInfo.isBootloader set to true , and re-displays the renderBootloaderStep again.

The fix also adds:
- a function `getDeviceRunningMode`
- unit tests for this function -> you can run them with `pnpm common jest libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts``
- a cli for this function -> you can run it with: `pnpm run:cli getDeviceRunningMode`


### ❓ Context

- **Impacted projects**: LLD and live-common
- **Linked resource(s)**: [jira](https://ledgerhq.atlassian.net/browse/FAT-550?atlOrigin=eyJpIjoiYTUxMjllM2EyNDZlNGY1Yzk5MGNjODhmZmM5NGVmNGYiLCJwIjoiaiJ9)

### ✅ Checklist

- [x] **Test coverage** unit tested for parts of it, it still need to be tested by QA
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

See slack

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
