### PR TITLE
Bugfix/live 4308 "Language" row bad layout in My Ledger

### DIFF
--- a/.changeset/short-adults-grow.md
+++ b/.changeset/short-adults-grow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix device localization button layout in My Ledger

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
@@ -4,6 +4,7 @@ import { Device } from "@ledgerhq/types-devices";
 import { useTranslation } from "react-i18next";
 
 import CustomImageBottomModal from "../../../components/CustomImage/CustomImageBottomModal";
+import DeviceOptionRow from "./DeviceOptionRow";
 
 const CustomLockScreen: React.FC<{ device: Device }> = ({ device }) => {
   const [isCustomImageOpen, setIsCustomImageOpen] = useState(false);
@@ -11,24 +12,20 @@ const CustomLockScreen: React.FC<{ device: Device }> = ({ device }) => {
   const { t } = useTranslation();
 
   return (
-    <Flex flex={1} flexDirection="row" alignItems="center">
-      <Icons.BracketsMedium size={20} color="neutral.c80" />
-      <Text ml={3} flex={1} variant="bodyLineHeight" color="neutral.c80">
-        {t("customImage.customImage")}
-      </Text>
-      <Link
+    <>
+      <DeviceOptionRow
+        Icon={Icons.BracketsMedium}
+        iconSize={20}
+        label={t("customImage.customImage")}
         onPress={() => setIsCustomImageOpen(true)}
-        type="color"
-        Icon={Icons.ChevronRightMedium}
-      >
-        {t("customImage.replace")}
-      </Link>
+        linkLabel={t("customImage.replace")}
+      />
       <CustomImageBottomModal
         device={device}
         isOpened={isCustomImageOpen}
         onClose={() => setIsCustomImageOpen(false)}
       />
-    </Flex>
+    </>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Flex, Icons, Link, Text } from "@ledgerhq/native-ui";
+import { Icons } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/types-devices";
 import { useTranslation } from "react-i18next";
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -8,6 +8,7 @@ import BottomModal from "../../../components/BottomModal";
 import DeviceLanguageSelection from "./DeviceLanguageSelection";
 import ChangeDeviceLanguageActionModal from "../../../components/ChangeDeviceLanguageActionModal";
 import { track } from "../../../analytics";
+import DeviceOptionRow from "./DeviceOptionRow";
 
 type Props = {
   pendingInstalls: boolean;
@@ -69,29 +70,23 @@ const DeviceLanguage: React.FC<Props> = ({
   const refreshDeviceLanguage = useCallback(() => {
     track("Page Manager LanguageInstalled", { selectedLanguage });
     onLanguageChange();
-  }, [selectedLanguage]);
+  }, [selectedLanguage, onLanguageChange]);
 
   return (
     <>
-      <Flex flex={1} flexDirection="row" alignItems="center">
-        <Icons.LanguageMedium size={24} color="neutral.c80" />
-        <Text ml={3} flex={1} variant="bodyLineHeight" color="neutral.c80">
-          {t("deviceLocalization.language")}
-        </Text>
-        {availableLanguages.length ? (
-          <Link
-            onPress={pendingInstalls ? undefined : openChangeLanguageModal}
-            type="color"
-            Icon={Icons.ChevronRightMedium}
-          >
-            {t(`deviceLocalization.languages.${currentDeviceLanguage}`)}
-          </Link>
-        ) : (
-          <Text>
-            {t(`deviceLocalization.languages.${currentDeviceLanguage}`)}
-          </Text>
-        )}
-      </Flex>
+      <DeviceOptionRow
+        Icon={Icons.LanguageMedium}
+        label={t("deviceLocalization.language")}
+        onPress={pendingInstalls ? undefined : openChangeLanguageModal}
+        linkLabel={t(`deviceLocalization.languages.${currentDeviceLanguage}`)}
+        right={
+          availableLanguages.length ? undefined : (
+            <Text>
+              {t(`deviceLocalization.languages.${currentDeviceLanguage}`)}
+            </Text>
+          )
+        }
+      />
       <BottomModal
         isOpened={isChangeLanguageOpen}
         onClose={closeChangeLanguageModal}

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -1,4 +1,4 @@
-import { Flex, Icons, Link, Text } from "@ledgerhq/native-ui";
+import { Icons, Text } from "@ledgerhq/native-ui";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Language, DeviceInfo } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceOptionRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceOptionRow.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Flex, Icons, Link, Text } from "@ledgerhq/native-ui";
+import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
+
+type Props = {
+  Icon: IconType;
+  iconSize?: number;
+  label: string;
+  linkLabel: string;
+  onPress?: () => void;
+  right?: React.ReactNode;
+};
+
+const DeviceOptionRow: React.FC<Props> = props => {
+  const { Icon, iconSize, label, right, linkLabel, onPress } = props;
+  return (
+    <Flex flexDirection="row" alignItems="center">
+      <Icon size={iconSize || 24} color="neutral.c80" />
+      <Text ml={3} variant="bodyLineHeight" color="neutral.c80">
+        {label}
+      </Text>
+      <Flex flex={1}></Flex>
+      {right || (
+        <Link
+          onPress={onPress}
+          disabled={!onPress}
+          type="color"
+          Icon={Icons.ChevronRightMedium}
+        >
+          {linkLabel}
+        </Link>
+      )}
+    </Flex>
+  );
+};
+
+export default DeviceOptionRow;

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceOptionRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceOptionRow.tsx
@@ -19,7 +19,7 @@ const DeviceOptionRow: React.FC<Props> = props => {
       <Text ml={3} variant="bodyLineHeight" color="neutral.c80">
         {label}
       </Text>
-      <Flex flex={1}></Flex>
+      <Flex flex={1} />
       {right || (
         <Link
           onPress={onPress}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There was a flex issue in the My Ledger screen where the "Language" option for a device was not properly displayed.
Fixed it & extracted the component "DeviceOptionRow" for other existing options.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-4308] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/91890529/196748527-a349ca91-a8d0-4257-b4eb-7ae573bf8a76.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-4308]: https://ledgerhq.atlassian.net/browse/LIVE-4308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ