### PR TITLE
Fix/LIVE-4302 - Fix update firmware notif breaking layout

### DIFF
--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -88,7 +88,7 @@ const FirmwareUpdateBanner = ({
     : "";
 
   return showBanner && hasCompletedOnboarding && hasConnectedDevice ? (
-    <Flex mt={4} mb={6} mx={6}>
+    <Flex mt={4} mb={6} mx={6} {...containerProps}>
       <Alert type="info" showIcon={false}>
         <Text flexShrink={1} flexGrow={1}>
           {t("FirmwareUpdate.newVersion", {

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -9,6 +9,7 @@ import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { StackNavigationProp } from "@react-navigation/stack";
+import { FlexBoxProps } from "@ledgerhq/native-ui/components/Layout/Flex";
 import { ScreenName, NavigatorName } from "../const";
 import {
   lastSeenDeviceSelector,
@@ -20,7 +21,11 @@ import Button from "./Button";
 import useLatestFirmware from "../hooks/useLatestFirmware";
 import { isFirmwareUpdateVersionSupported } from "../logic/firmwareUpdate";
 
-const FirmwareUpdateBanner = () => {
+const FirmwareUpdateBanner = ({
+  containerProps,
+}: {
+  containerProps?: FlexBoxProps;
+}) => {
   const lastSeenDevice: DeviceModelInfo | null = useSelector(
     lastSeenDeviceSelector,
   );

--- a/apps/ledger-live-mobile/src/components/TabBar/TabBarSafeAreaView.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TabBarSafeAreaView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 

--- a/apps/ledger-live-mobile/src/components/TabBar/TabBarSafeAreaView.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TabBarSafeAreaView.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  NativeSafeAreaViewProps,
-  SafeAreaView,
-} from "react-native-safe-area-context";
+import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
 
 export { TAB_BAR_SAFE_HEIGHT } from "./shared";
@@ -11,8 +8,4 @@ const StyledSafeAreaView = styled(SafeAreaView)`
   flex: 1;
 `;
 
-const TabBarSafeAreaView = (props: NativeSafeAreaViewProps) => (
-  <StyledSafeAreaView {...props} />
-);
-
-export default TabBarSafeAreaView;
+export default StyledSafeAreaView;

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -144,7 +144,6 @@ function PortfolioScreen({ navigation }: Props) {
 
   const data = useMemo(
     () => [
-      <FirmwareUpdateBanner />,
       postOnboardingVisible && (
         <Box m={6}>
           <PostOnboardingEntryPointCard />
@@ -246,7 +245,12 @@ function PortfolioScreen({ navigation }: Props) {
 
   return (
     <>
-      <TabBarSafeAreaView>
+      <TabBarSafeAreaView
+        style={{
+          flex: 1,
+          paddingTop: 48,
+        }}
+      >
         <CheckLanguageAvailability />
         <CheckTermOfUseUpdate />
         <TrackScreen
@@ -258,11 +262,11 @@ function PortfolioScreen({ navigation }: Props) {
           currentPositionY={currentPositionY}
           graphCardEndPosition={graphCardEndPosition}
         />
+        <FirmwareUpdateBanner containerProps={{ mt: 7, mb: 0 }} />
         <AnimatedFlatListWithRefreshControl
           data={data}
           style={{
             flex: 1,
-            paddingTop: 48,
           }}
           contentContainerStyle={{ paddingBottom: TAB_BAR_SAFE_HEIGHT }}
           renderItem={({ item }: { item: React.ReactNode }) => item}

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -262,7 +262,7 @@ function PortfolioScreen({ navigation }: Props) {
           currentPositionY={currentPositionY}
           graphCardEndPosition={graphCardEndPosition}
         />
-        <FirmwareUpdateBanner containerProps={{ mt: 7, mb: 0 }} />
+        <FirmwareUpdateBanner containerProps={{ mt: 9, mb: 0 }} />
         <AnimatedFlatListWithRefreshControl
           data={data}
           style={{


### PR DESCRIPTION
… It was mostly due to a react-native glitch with flex layout

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix update firmware notif breaking layout by putting it sticky again. It was mostly due to a react-native glitch with flex layout

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-4302

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/89014981/196754381-dbe5e4c0-f88a-4a08-9491-0e7cfa86dc30.mp4





https://user-images.githubusercontent.com/89014981/196752994-66100f41-e937-4be0-ba73-02819b5eae8a.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
