### PR TITLE
Export HttpTransport and WebSocketTransport

### DIFF
--- a/.changeset/mighty-scissors-compare.md
+++ b/.changeset/mighty-scissors-compare.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-transport-http": patch
+---
+
+Export `HttpTransport` and `WebSocketTransport`

--- a/libs/ledgerjs/packages/hw-transport-http/src/withStaticURLs.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/withStaticURLs.ts
@@ -19,6 +19,8 @@ const inferURLs = async (urls: In): Promise<string[]> => {
   return typeof r === "string" ? [r] : r;
 };
 
+export { HttpTransport, WebSocketTransport };
+
 export default (urls: In): new () => Transport => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

I need to import `HttpTransport` knowing beforehand which is going to be the type I get for that class. Importing from `lib` or `lib-es` directories is not enough as we don't know if final users will be using `commonjs` or ES modules.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
