### PR TITLE
Fixes LIVE-4305

### DIFF
--- a/.changeset/angry-vans-retire.md
+++ b/.changeset/angry-vans-retire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fixes connectApp not to throw LatestFirmwareVersionRequired if requireLatestFirmware wasn't requested

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -326,7 +326,7 @@ const cmd = ({
                             if (isLatest) {
                               o.next({ type: "latest-firmware-resolved" });
                               return innerSub({ appName, dependencies }); // NB without the fw version check
-                            } else {
+                            } else if (requireLatestFirmware) {
                               return throwError(
                                 new LatestFirmwareVersionRequired(
                                   "LatestFirmwareVersionRequired",


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This should fixes `connectApp` not to throw `LatestFirmwareVersionRequired` if `requireLatestFirmware` wasn't even requested.

What to learn from this & possible future improvements:
- this deserve unit tests
- this part deserve a rework to make the code simpler and less spaghetti.

### ❓ Context

- **Impacted projects**: llc, llm, lld <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-4305 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** this is NOT covered by test automation unfortunately. <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
