### PR TITLE
Bot: prevent hedera to "critical error" when it just miss funds

### DIFF
--- a/libs/ledger-live-common/src/bot/engine.ts
+++ b/libs/ledger-live-common/src/bot/engine.ts
@@ -200,10 +200,12 @@ export async function runWithAppSpec<T extends Transaction>(
       accounts[i] = await crossAccount(accounts[i]);
     }
     appReport.accountsBefore = accounts;
-    invariant(
-      accounts.length > 0,
-      "unexpected empty accounts for " + currency.name
-    );
+    if (!spec.allowEmptyAccounts) {
+      invariant(
+        accounts.length > 0,
+        "unexpected empty accounts for " + currency.name
+      );
+    }
     const preloadStats =
       preloadDuration > 10 ? ` (preload: ${formatTime(preloadDuration)})` : "";
     reportLog(

--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -132,6 +132,8 @@ export type AppSpec<T extends Transaction> = {
   minViableAmount?: BigNumber;
   // global timeout to consider the run due date for the spec. (since a seed could have theorically an infinite amount of accounts and mutation could take a lot of time to validate transactions, we need a way to limit the run time)
   skipMutationsTimeout?: number;
+  // do not expect an account to always be found (Hedera case)
+  allowEmptyAccounts?: boolean;
 };
 export type SpecReport<T extends Transaction> = {
   spec: AppSpec<T>;

--- a/libs/ledger-live-common/src/families/hedera/specs.ts
+++ b/libs/ledger-live-common/src/families/hedera/specs.ts
@@ -45,6 +45,7 @@ const hedera: AppSpec<Transaction> = {
   transactionCheck: ({ maxSpendable }) => {
     invariant(maxSpendable.gt(0), "Balance is too low");
   },
+  allowEmptyAccounts: true,
   mutations: [
     {
       name: "Send ~50%",


### PR DESCRIPTION
### 📝 Description

in the bot, we will consider "critical" when we fail to even reach the transactional mutations phase (see schema https://user-images.githubusercontent.com/211411/191263250-141d023c-c019-4139-b1db-5b2988eecca6.png )

in Hedera case, when no accounts were filled yet, it will crash badly. NB: it doesn't solve the fact we don't even see where to send funds, but it's a limitation of the choices of the current hedera implementation.

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** running "Oxygen" light bot with this will verify that we cover this properly <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
