### PR TITLE
Bot: dedup two successive identical speculos text events

### DIFF
--- a/libs/ledger-live-common/src/bot/types.ts
+++ b/libs/ledger-live-common/src/bot/types.ts
@@ -13,7 +13,7 @@ import {
 } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 export type { AppCandidate };
-type DeviceActionEvent = {
+export type DeviceActionEvent = {
   text: string;
   x: number;
   y: number;


### PR DESCRIPTION

### 📝 Description

in https://github.com/LedgerHQ/ledger-live/commit/e2da2d229c83a9a65fbdeafcf86ec183614d4eba#commitcomment-87406584, a rare case occured where it seems that the speculos text was duplicated and streamed twice in the events payload.

> - Crypto org > deviceAction confirm step 'To'

this appears to be a bug in the bot engine and the logic that concatenate the value from the device screen.

```
  Object {
-   "To": "cro1t62l7pcawxpskk29v3aqfzv77aey82x50gzjjk",
+   "To": "cro1t62l7pcawxpskk29v3aqfzv77aey82x50gzjjk0gzjjk",
  }
```

I suspect that the device screen shown

```
cro1t62l7pcawxpskk29v3aqfzv77aey82x5
0gzjjk
```

in two screens, but somehow we "received"

```
cro1t62l7pcawxpskk29v3aqfzv77aey82x50gzjjk
0gzjjk
0gzjjk
```

like we counted twice the second text.


### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** , if the run triggered on this PR works, then we are good. that said the bug was random and rare so it's not 100% sure we fix it here, but there is a high chance. <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
