### PR TITLE
Bugfix: LIVE-4305 new rendering in the case of a LatestFirmwareVersionRequired error

### DIFF
--- a/.changeset/soft-insects-look.md
+++ b/.changeset/soft-insects-look.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: new rendering in the case of a LatestFirmwareVersionRequired error

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import type { Action, Device } from "@ledgerhq/live-common/hw/actions/types";
-import { DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
+import {
+  DeviceNotOnboarded,
+  LatestFirmwareVersionRequired,
+} from "@ledgerhq/live-common/errors";
 import { TransportStatusError } from "@ledgerhq/errors";
 import { useTranslation } from "react-i18next";
 import { useNavigation, useTheme } from "@react-navigation/native";
@@ -30,6 +33,7 @@ import {
   renderImageLoadRequested,
   renderLoadingImage,
   renderImageCommitRequested,
+  RequiredFirmwareUpdate,
 } from "./rendering";
 import PreventNativeBack from "../PreventNativeBack";
 import SkipLock from "../behaviour/SkipLock";
@@ -327,6 +331,16 @@ export function DeviceActionDefaultRendering<R, H, P>({
         error.message.includes("0x6d06"))
     ) {
       return renderDeviceNotOnboarded({ t, device, navigation });
+    }
+
+    if (error instanceof LatestFirmwareVersionRequired) {
+      return (
+        <RequiredFirmwareUpdate
+          t={t}
+          navigation={navigation}
+          device={selectedDevice}
+        />
+      );
     }
 
     return renderError({

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -613,6 +613,7 @@ export function RequiredFirmwareUpdate({
   const onPress = () => {
     navigation.navigate(NavigatorName.Manager, {
       screen: ScreenName.Manager,
+      params: { firmwareUpdate: true },
     });
   };
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { ScrollView } from "react-native";
-import { useDispatch } from "react-redux";
+import { Platform, ScrollView } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components/native";
 import { WrongDeviceForAccount } from "@ledgerhq/errors";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -17,6 +17,7 @@ import {
   Tag,
   Icons,
   Log,
+  BoxedIcon,
 } from "@ledgerhq/native-ui";
 import BigNumber from "bignumber.js";
 import {
@@ -31,6 +32,11 @@ import {
 } from "@ledgerhq/live-common/account/index";
 import { TFunction } from "react-i18next";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import type { DeviceModelInfo } from "@ledgerhq/types-live";
+import { DownloadMedium } from "@ledgerhq/native-ui/assets/icons";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
+import { isFirmwareUpdateVersionSupported } from "../../logic/firmwareUpdate";
+import { lastSeenDeviceSelector } from "../../reducers/settings";
 import { setModalLock } from "../../actions/appstate";
 import { urls } from "../../config/urls";
 import Alert from "../Alert";
@@ -575,6 +581,91 @@ export function renderError({
           </ActionContainer>
         ) : null}
       </GenericErrorView>
+    </Wrapper>
+  );
+}
+
+export function RequiredFirmwareUpdate({
+  t,
+  device,
+  navigation,
+}: RawProps & {
+  // Sorry for the any DX team 🙇
+  navigation: any;
+  device: Device;
+}) {
+  const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(
+    lastSeenDeviceSelector,
+  );
+
+  const usbFwUpdateFeatureFlag = useFeature("llmUsbFirmwareUpdate");
+  const isUsbFwVersionUpdateSupported =
+    lastSeenDevice &&
+    isFirmwareUpdateVersionSupported(lastSeenDevice.deviceInfo, device.modelId);
+
+  const usbFwUpdateActivated =
+    usbFwUpdateFeatureFlag?.enabled &&
+    Platform.OS === "android" &&
+    isUsbFwVersionUpdateSupported;
+
+  const deviceName = getDeviceModel(device.modelId).productName;
+
+  const onPress = () => {
+    navigation.navigate(NavigatorName.Manager, {
+      screen: ScreenName.Manager,
+    });
+  };
+
+  return (
+    <Wrapper>
+      <Flex flexDirection="column" alignItems="center" alignSelf="stretch">
+        <Flex mb={5}>
+          <BoxedIcon
+            size={64}
+            Icon={DownloadMedium}
+            iconSize={24}
+            iconColor="neutral.c100"
+          />
+        </Flex>
+
+        <Text
+          variant="h4"
+          fontWeight="semiBold"
+          textAlign="center"
+          numberOfLines={3}
+          mb={6}
+        >
+          {usbFwUpdateActivated
+            ? t("firmwareUpdateRequired.updateAvailableFromLLM.title", {
+                deviceName,
+              })
+            : t("firmwareUpdateRequired.updateNotAvailableFromLLM.title", {
+                deviceName,
+              })}
+        </Text>
+        <Text variant="paragraph" textAlign="center" numberOfLines={3} mb={6}>
+          {usbFwUpdateActivated
+            ? t("firmwareUpdateRequired.updateAvailableFromLLM.description", {
+                deviceName,
+              })
+            : t(
+                "firmwareUpdateRequired.updateNotAvailableFromLLM.description",
+                {
+                  deviceName,
+                },
+              )}
+        </Text>
+        {usbFwUpdateActivated ? (
+          <ActionContainer marginBottom={0} marginTop={32}>
+            <StyledButton
+              type="main"
+              outline={false}
+              title={t("firmwareUpdateRequired.updateAvailableFromLLM.cta")}
+              onPress={onPress}
+            />
+          </ActionContainer>
+        ) : null}
+      </Flex>
     </Wrapper>
   );
 }

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -610,10 +610,14 @@ export function RequiredFirmwareUpdate({
 
   const deviceName = getDeviceModel(device.modelId).productName;
 
+  const isDeviceConnectedViaUSB = device.wired;
+
+  // Goes to the manager if a firmware update is available, but only automatically
+  // displays the firmware update drawer if the device is already connected via USB
   const onPress = () => {
     navigation.navigate(NavigatorName.Manager, {
       screen: ScreenName.Manager,
-      params: { firmwareUpdate: true },
+      params: { device, firmwareUpdate: isDeviceConnectedViaUSB },
     });
   };
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3851,6 +3851,17 @@
       "pleaseConnectUsbDescription": "To start the firmware update, plug your {{deviceName}} to your mobile phone using a USB cable."
     }
   },
+  "firmwareUpdateRequired": {
+      "updateAvailableFromLLM": {
+        "title": "Firmware update required",
+        "description": "To perform this action, you first need to update the firmware of your {{ deviceName }}.",
+        "cta": "Go to My Ledger"
+      },
+      "updateNotAvailableFromLLM": {
+        "title": "Firmware update required on computer",
+        "description": "Update your {{ deviceName }} on Ledger Live Desktop."
+      }
+  },
   "FirmwareUpdateReleaseNotes": {
     "introTitle": "Update {{deviceName}} to version {{version}}",
     "recoveryPhraseBackupInstructions": "Ensure your 24-word recovery phrase is written down on the Recovery sheet and it is available, as a precaution.",


### PR DESCRIPTION
### 📝 Description

New Device Action rendering in the case of a LatestFirmwareVersionRequired error

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: [jira](https://ledgerhq.atlassian.net/browse/LIVE-4305)

### ✅ Checklist

- [ ] **Test coverage** Need to be tested by QA
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Fwm update can be done on LLM:
![Screenshot_20221021-114908_LL  DEV](https://user-images.githubusercontent.com/15096913/197174948-014c06e7-8fca-4c36-8717-30d1818c118b.jpeg)

Fwm update cannot be done on LLM:
![Screenshot_20221021-114829_LL  DEV](https://user-images.githubusercontent.com/15096913/197174961-3357e0f2-1628-4759-926c-6f0bff7693db.jpeg)

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->