### PR TITLE
Bugfix/fat 567 localization

### DIFF
--- a/.changeset/fair-seas-shake.md
+++ b/.changeset/fair-seas-shake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix hardware version checking logic in getVersion command

--- a/libs/ledger-live-common/src/hw/getVersion.test.ts
+++ b/libs/ledger-live-common/src/hw/getVersion.test.ts
@@ -1,0 +1,94 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import {
+  isBootloaderVersionSupported,
+  isHardwareVersionSupported,
+} from "./getVersion";
+const { nanoS, nanoSP, nanoX, nanoFTS } = DeviceModelId;
+
+test("isBootloaderVersionSupported", () => {
+  /**
+   * Nano S
+   * */
+  expect(isBootloaderVersionSupported("1.9.0", nanoS)).toBe(false);
+  expect(isBootloaderVersionSupported("1.9.0-whatever0", nanoS)).toBe(false);
+
+  expect(isBootloaderVersionSupported("2.0.0", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("2.0.0-rc1", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("2.0.1", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("2.0.1-whatever0", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("2.1.0", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("2.1.0-whatever0", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("3.0.0", nanoS)).toBe(true);
+  expect(isBootloaderVersionSupported("3.0.0-whatever0", nanoS)).toBe(true);
+
+  /**
+   * Nano X
+   * */
+  expect(isBootloaderVersionSupported("1.9.0", nanoX)).toBe(false);
+  expect(isBootloaderVersionSupported("1.9.0-whatever0", nanoX)).toBe(false);
+
+  expect(isBootloaderVersionSupported("2.0.0", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("2.0.0-rc1", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("2.0.1", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("2.0.1-whatever0", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("2.1.0", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("2.1.0-whatever0", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("3.0.0", nanoX)).toBe(true);
+  expect(isBootloaderVersionSupported("3.0.0-whatever0", nanoX)).toBe(true);
+
+  /**
+   * Nano SP
+   * */
+  expect(isBootloaderVersionSupported("0.9.0", nanoSP)).toBe(false);
+  expect(isBootloaderVersionSupported("0.9.0-whatever0", nanoSP)).toBe(false);
+
+  expect(isBootloaderVersionSupported("1.0.0", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.0-rc1", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.1", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.1-whatever0", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.1.0", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.1.0-whatever0", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.0", nanoSP)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.0-whatever0", nanoSP)).toBe(true);
+
+  /**
+   * Nano FTS
+   * */
+  expect(isBootloaderVersionSupported("1.0.0", nanoFTS)).toBe(false);
+  expect(isBootloaderVersionSupported("1.0.0-whatever0", nanoFTS)).toBe(false);
+});
+
+test("isHardwareVersionSupported", () => {
+  /**
+   * Nano S
+   * */
+  expect(isHardwareVersionSupported("2.0.0", nanoS)).toBe(false);
+  expect(isHardwareVersionSupported("2.0.0-whatever0", nanoS)).toBe(false);
+
+  /**
+   * Nano X
+   * */
+  expect(isHardwareVersionSupported("1.9.0", nanoX)).toBe(false);
+  expect(isHardwareVersionSupported("1.9.0-whatever0", nanoX)).toBe(false);
+
+  expect(isHardwareVersionSupported("2.0.0", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("2.0.0-rc1", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("2.0.1", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("2.0.1-whatever0", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("2.1.0", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("2.1.0-whatever0", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("3.0.0", nanoX)).toBe(true);
+  expect(isHardwareVersionSupported("3.0.0-whatever0", nanoX)).toBe(true);
+
+  /**
+   * Nano SP
+   * */
+  expect(isHardwareVersionSupported("2.0.0", nanoSP)).toBe(false);
+  expect(isHardwareVersionSupported("2.0.0-whatever0", nanoSP)).toBe(false);
+
+  /**
+   * Nano FTS
+   * */
+  expect(isHardwareVersionSupported("2.0.0", nanoFTS)).toBe(false);
+  expect(isHardwareVersionSupported("2.0.0-whatever0", nanoFTS)).toBe(false);
+});

--- a/libs/ledger-live-common/src/hw/getVersion.ts
+++ b/libs/ledger-live-common/src/hw/getVersion.ts
@@ -15,9 +15,9 @@ export const isBootloaderVersionSupported = (
   seVersion: string,
   modelId?: DeviceModelId
 ): boolean =>
-  modelId &&
-  deviceVersionRangesForBootloaderVersion[modelId] &&
-  versionSatisfies(
+  !!modelId &&
+  !!deviceVersionRangesForBootloaderVersion[modelId] &&
+  !!versionSatisfies(
     semverCoerce(seVersion) || seVersion,
     deviceVersionRangesForBootloaderVersion[modelId] as string
   );
@@ -36,9 +36,9 @@ export const isHardwareVersionSupported = (
   seVersion: string,
   modelId?: DeviceModelId
 ): boolean =>
-  modelId &&
-  deviceVersionRangesForHardwareVersion[modelId] &&
-  versionSatisfies(
+  !!modelId &&
+  !!deviceVersionRangesForHardwareVersion[modelId] &&
+  !!versionSatisfies(
     semverCoerce(seVersion) || seVersion,
     deviceVersionRangesForHardwareVersion[modelId] as string
   );

--- a/libs/ledger-live-common/src/hw/getVersion.ts
+++ b/libs/ledger-live-common/src/hw/getVersion.ts
@@ -1,40 +1,40 @@
 import { DeviceModelId, identifyTargetId } from "@ledgerhq/devices";
 import Transport from "@ledgerhq/hw-transport";
 import type { FirmwareInfo } from "@ledgerhq/types-live";
-import { satisfies as versionSatisfies } from "semver";
+import { satisfies as versionSatisfies, coerce as semverCoerce } from "semver";
 import { isDeviceLocalizationSupported } from "../manager/localization";
 
 const deviceVersionRangesForBootloaderVersion: {
   [key in DeviceModelId]?: string;
 } = {
   nanoS: ">=2.0.0",
-  nanoX: ">=2.0.0 || =2.1.0-lo2 || =2.1.0-lo4 || =2.1.0-lo5", // TODO: remove pre-release version
+  nanoX: ">=2.0.0",
   nanoSP: ">=1.0.0",
 };
 export const isBootloaderVersionSupported = (
   seVersion: string,
   modelId?: DeviceModelId
-) =>
+): boolean =>
   modelId &&
   deviceVersionRangesForBootloaderVersion[modelId] &&
   versionSatisfies(
-    seVersion,
+    semverCoerce(seVersion) || seVersion,
     deviceVersionRangesForBootloaderVersion[modelId] as string
   );
 
 const deviceVersionRangesForHardwareVersion: {
   [key in DeviceModelId]?: string;
 } = {
-  nanoX: ">=2.0.0 || =2.1.0-lo2 || =2.1.0-lo4 || =2.1.0-lo5", // TODO: remove pre-release version
+  nanoX: ">=2.0.0",
 };
 export const isHardwareVersionSupported = (
   seVersion: string,
   modelId?: DeviceModelId
-) =>
+): boolean =>
   modelId &&
   deviceVersionRangesForHardwareVersion[modelId] &&
   versionSatisfies(
-    seVersion,
+    semverCoerce(seVersion) || seVersion,
     deviceVersionRangesForHardwareVersion[modelId] as string
   );
 

--- a/libs/ledger-live-common/src/hw/getVersion.ts
+++ b/libs/ledger-live-common/src/hw/getVersion.ts
@@ -27,6 +27,11 @@ const deviceVersionRangesForHardwareVersion: {
 } = {
   nanoX: ">=2.0.0",
 };
+
+/**
+ * @returns whether the Hardware Version bytes are included in the result of the
+ * getVersion APDU
+ * */
 export const isHardwareVersionSupported = (
   seVersion: string,
   modelId?: DeviceModelId

--- a/libs/ledger-live-common/src/manager/localization.test.ts
+++ b/libs/ledger-live-common/src/manager/localization.test.ts
@@ -1,0 +1,47 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { isDeviceLocalizationSupported } from "./localization";
+const { nanoS, nanoSP, nanoX, nanoFTS } = DeviceModelId;
+
+test("isDeviceLocalizationSupported", () => {
+  /**
+   * Nano X
+   * */
+  expect(isDeviceLocalizationSupported("2.0.0", nanoX)).toBe(false);
+  expect(isDeviceLocalizationSupported("2.0.0-whatever0", nanoX)).toBe(false);
+
+  expect(isDeviceLocalizationSupported("2.1.0", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.1.0-rc1", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.1.1", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.1.1-whatever0", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.2.0", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.2.0-whatever0", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("3.0.0", nanoX)).toBe(true);
+  expect(isDeviceLocalizationSupported("3.0.0-whatever0", nanoX)).toBe(true);
+
+  /**
+   * Nano SP
+   * */
+  expect(isDeviceLocalizationSupported("1.0.0", nanoSP)).toBe(false);
+  expect(isDeviceLocalizationSupported("1.0.0-whatever", nanoSP)).toBe(false);
+
+  expect(isDeviceLocalizationSupported("1.1.0", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("1.1.0-rc1", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("1.1.2", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("1.1.2-whatever0", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("1.2.0", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("1.2.0-whatever0", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.0.0", nanoSP)).toBe(true);
+  expect(isDeviceLocalizationSupported("2.0.0-whatever0", nanoSP)).toBe(true);
+
+  /**
+   * NanoFTS
+   * */
+  expect(isDeviceLocalizationSupported("9.0.0", nanoFTS)).toBe(false);
+  expect(isDeviceLocalizationSupported("9.0.0-whatever", nanoFTS)).toBe(false);
+
+  /**
+   * NanoS
+   * */
+  expect(isDeviceLocalizationSupported("9.0.0", nanoS)).toBe(false);
+  expect(isDeviceLocalizationSupported("9.0.0-whatever", nanoS)).toBe(false);
+});

--- a/libs/ledger-live-common/src/manager/localization.ts
+++ b/libs/ledger-live-common/src/manager/localization.ts
@@ -1,10 +1,10 @@
 import { DeviceModelId } from "@ledgerhq/devices";
-import { satisfies as versionSatisfies } from "semver";
+import { satisfies as versionSatisfies, coerce as semverCoerce } from "semver";
 
 const deviceVersionRangesForLocalization: { [key in DeviceModelId]?: string } =
   {
-    nanoX: ">=2.1.0 || =2.1.0-lo2 || =2.1.0-lo4 || =2.1.0-lo5 || =2.1.0-rc1",
-    nanoSP: ">=1.1.0 || =1.1.0-lo1 || =1.1.0-rc1",
+    nanoX: ">=2.1.0",
+    nanoSP: ">=1.1.0",
   };
 
 export const isDeviceLocalizationSupported = (
@@ -14,6 +14,6 @@ export const isDeviceLocalizationSupported = (
   modelId &&
   deviceVersionRangesForLocalization[modelId] &&
   versionSatisfies(
-    seVersion,
+    semverCoerce(seVersion) || seVersion,
     deviceVersionRangesForLocalization[modelId] as string
   );

--- a/libs/ledger-live-common/src/manager/localization.ts
+++ b/libs/ledger-live-common/src/manager/localization.ts
@@ -11,9 +11,9 @@ export const isDeviceLocalizationSupported = (
   seVersion: string,
   modelId?: DeviceModelId
 ): boolean =>
-  modelId &&
-  deviceVersionRangesForLocalization[modelId] &&
-  versionSatisfies(
+  !!modelId &&
+  !!deviceVersionRangesForLocalization[modelId] &&
+  !!versionSatisfies(
     semverCoerce(seVersion) || seVersion,
     deviceVersionRangesForLocalization[modelId] as string
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### Issue:
In LLM or LLD, open the manager on a Nano S Plus with 1.1.0-rc1 or Nano X with 2.1.0-rc1.
Activate the localization FF and go to the manager.

- Expected behavior:
The current language on the device is properly displayed.

- Actual behavior:
The current language on the device is displayed as "deviceLocalization.languages.undefined"

#### Analysis & solution


A check on the hw version (with semver) was used to determine whether or not to parse some information in the result of the `getVersion` command.
For instance, `"2.1.0-rc1"` was not a valid semver so it wasn't fulfilling the semver condition `">=2.0.0"`. Because of that, some bytes were not read and the read index (the byte offset) was misplaced for further steps of the parsing logic.

The solution is to use the `coerce` function of the `semver` library to transform all version strings into valid semver version (for instance `coerce("2.1.0-rc1")` returns `"2.1.0"`, a valid semver string).
This also allows to remove from the semver condition some hardcoded versions that had a prefix such as `"2.1.0-lo5"`, and have a simpler, less hardcoded logic.

![image (1)](https://user-images.githubusercontent.com/91890529/197223877-ea652fa9-b082-413d-8221-5c4bfcbec9e6.png)

### ❓ Context

- **Impacted projects**: `live-common` `ledger-live-mobile` `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-567] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="818" alt="Screenshot 2022-10-21 at 16 45 29" src="https://user-images.githubusercontent.com/91890529/197227337-ec547fa2-6231-4fc7-a4c4-62c7310e0c53.png">

<img width="820" alt="Screenshot 2022-10-21 at 16 45 57" src="https://user-images.githubusercontent.com/91890529/197227351-fa330689-cf8d-49aa-b766-7248322932aa.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-567]: https://ledgerhq.atlassian.net/browse/FAT-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ