### PR TITLE
Add install set of apps step in mobile sync onboarding

### DIFF
--- a/.changeset/tricky-mugs-battle.md
+++ b/.changeset/tricky-mugs-battle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add install set of apps step in sync onboarding

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useMemo } from "react";
 import { Trans } from "react-i18next";
 import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { getDeviceModel } from "@ledgerhq/devices";
@@ -11,7 +12,6 @@ import BottomModal from "../../BottomModal";
 
 import Item from "./Item";
 import Confirmation from "./Confirmation";
-import withRemountableWrapper from "../../withRemountableWrapper";
 
 type Props = {
   dependencies?: string[];

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -11,12 +11,13 @@ import BottomModal from "../../BottomModal";
 
 import Item from "./Item";
 import Confirmation from "./Confirmation";
+import withRemountableWrapper from "../../withRemountableWrapper";
 
 type Props = {
   dependencies?: string[];
   device: Device;
   onResult: (done: boolean) => void;
-  onError: (error: Error) => void;
+  onError?: (error: Error) => void;
 };
 
 const action = createAction(connectApp);
@@ -33,7 +34,8 @@ const InstallSetOfApps = ({
   device: selectedDevice,
   onResult,
   onError,
-}: Props) => {
+  remountMe,
+}: Props & { remountMe: () => void }) => {
   const [userConfirmed, setUserConfirmed] = useState(false);
   const productName = getDeviceModel(selectedDevice.modelId).productName;
 
@@ -63,10 +65,13 @@ const InstallSetOfApps = ({
   } = status;
 
   const onWrappedError = useCallback(() => {
-    if (onError && error) {
-      onError(error);
+    if (error) {
+      remountMe();
+      if (onError) {
+        onError(error);
+      }
     }
-  }, [error, onError]);
+  }, [remountMe, error, onError]);
 
   if (opened) {
     onResult(true);
@@ -134,4 +139,4 @@ const InstallSetOfApps = ({
   );
 };
 
-export default InstallSetOfApps;
+export default withRemountableWrapper(InstallSetOfApps);

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -66,10 +66,12 @@ const InstallSetOfApps = ({
 
   const onWrappedError = useCallback(() => {
     if (error) {
-      remountMe();
       if (onError) {
         onError(error);
       }
+      // We force the component to remount for action.useHook to re-run from
+      // scratch and reset the status value
+      remountMe();
     }
   }, [remountMe, error, onError]);
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1807,6 +1807,9 @@
         }
       }
     },
+    "appsStep": {
+      "title": "{{productName}} applications"
+    },
     "readyStep": {
       "title": "{{productName}} is ready"
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add an extra step in the sync onboarding flow to propose installing a default set of apps to the user after genuine check. The app list in flagged, and the fallback in case of network problem is BTC, ETH and Polygon.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-542] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] ~**Test coverage**~: no UI testing on mobile yet <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A, see slack channels

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-542]: https://ledgerhq.atlassian.net/browse/FAT-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ