### PR TITLE
💄 [FIX] : LLD - UI glitch in Operation details drawer when Collection name is too long

### DIFF
--- a/.changeset/long-sloths-share.md
+++ b/.changeset/long-sloths-share.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+UI glitch in Operation details drawer when Collection name is too long

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/NFTOperationDetails.jsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/NFTOperationDetails.jsx
@@ -55,7 +55,9 @@ const NFTOperationDetails = ({ operation }: { operation: Operation }) => {
             </Skeleton>
             <Box ml={2}>
               <Skeleton width={200} barHeight={10} minHeight={32} show={show}>
-                <TextEllipsis>{collectionMetadata?.tokenName || "-"}</TextEllipsis>
+                <TextEllipsis>
+                  {centerEllipsis(collectionMetadata?.tokenName, 33) || "-"}
+                </TextEllipsis>
               </Skeleton>
             </Box>
           </Box>


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

 UI glitch in Operation details drawer when Collection name is too long

### ❓ Context

- **Impacted projects**: `live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-4277] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-4277]: https://ledgerhq.atlassian.net/browse/LIVE-4277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ