### PR TITLE
Bugfix: onboarding navigator for support/fix-llm-ts

### DIFF
--- a/apps/ledger-live-mobile/src/components/NavigationModalContainer.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationModalContainer.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components/native";
 import type { FlexBoxProps } from "@ledgerhq/native-ui/components/Layout/Flex";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { OnboardingNavigatorParamList } from "./RootNavigator/types/OnboardingNavigator";
-import { ScreenName, NavigatorName } from "../const";
+import { NavigatorName } from "../const";
 import { StackNavigatorProps } from "./RootNavigator/types/helpers";
 
 export const MIN_MODAL_HEIGHT = 30;
@@ -34,7 +34,7 @@ const InnerContainer = styled(Flex).attrs({
 
 type Props = StackNavigatorProps<
   OnboardingNavigatorParamList,
-  NavigatorName.OnboardingCarefulWarning | ScreenName.OnboardingPreQuizModal
+  NavigatorName.OnboardingCarefulWarning | NavigatorName.OnboardingPreQuiz
 > &
   React.PropsWithChildren<{
     children: React.ReactNode;

--- a/apps/ledger-live-mobile/src/components/NavigationModalContainer.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationModalContainer.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components/native";
 import type { FlexBoxProps } from "@ledgerhq/native-ui/components/Layout/Flex";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { OnboardingNavigatorParamList } from "./RootNavigator/types/OnboardingNavigator";
-import { ScreenName } from "../const";
+import { ScreenName, NavigatorName } from "../const";
 import { StackNavigatorProps } from "./RootNavigator/types/helpers";
 
 export const MIN_MODAL_HEIGHT = 30;
@@ -34,7 +34,7 @@ const InnerContainer = styled(Flex).attrs({
 
 type Props = StackNavigatorProps<
   OnboardingNavigatorParamList,
-  ScreenName.OnboardingModalWarning | ScreenName.OnboardingPreQuizModal
+  NavigatorName.OnboardingCarefulWarning | ScreenName.OnboardingPreQuizModal
 > &
   React.PropsWithChildren<{
     children: React.ReactNode;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/OnboardingNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/OnboardingNavigator.tsx
@@ -55,7 +55,7 @@ const OnboardingPreQuizModalStack =
 function OnboardingCarefulWarning(
   props: StackNavigatorProps<
     OnboardingNavigatorParamList,
-    ScreenName.OnboardingModalWarning
+    NavigatorName.OnboardingCarefulWarning
   >,
 ) {
   const options: Partial<StackNavigationOptions> = {
@@ -203,7 +203,7 @@ export default function OnboardingNavigator() {
         component={OnboardingUseCase}
       />
       <Stack.Screen
-        name={ScreenName.OnboardingModalWarning}
+        name={NavigatorName.OnboardingCarefulWarning} // ScreenName.OnboardingModalWarning}
         component={OnboardingCarefulWarning}
         options={modalOptions}
       />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/OnboardingNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/OnboardingNavigator.tsx
@@ -109,7 +109,7 @@ function OnboardingCarefulWarning(
 function OnboardingPreQuizModalNavigator(
   props: StackNavigatorProps<
     OnboardingNavigatorParamList,
-    ScreenName.OnboardingPreQuizModal
+    NavigatorName.OnboardingPreQuiz
   >,
 ) {
   const options: Partial<StackNavigationOptions> = {
@@ -139,7 +139,7 @@ function OnboardingPreQuizModalNavigator(
           name={ScreenName.OnboardingPreQuizModal}
           component={OnboardingPreQuizModal}
           options={{ title: "", ...options }}
-          initialParams={props.route.params}
+          // initialParams={props.route.params}
         />
       </OnboardingPreQuizModalStack.Navigator>
     </NavigationModalContainer>
@@ -203,12 +203,12 @@ export default function OnboardingNavigator() {
         component={OnboardingUseCase}
       />
       <Stack.Screen
-        name={NavigatorName.OnboardingCarefulWarning} // ScreenName.OnboardingModalWarning}
+        name={NavigatorName.OnboardingCarefulWarning}
         component={OnboardingCarefulWarning}
         options={modalOptions}
       />
       <Stack.Screen
-        name={ScreenName.OnboardingPreQuizModal}
+        name={NavigatorName.OnboardingPreQuiz}
         component={OnboardingPreQuizModalNavigator}
         options={modalOptions}
       />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -96,9 +96,11 @@ export type PathToDeviceParam = PropertyPath;
 export type NavigationType = "navigate" | "replace" | "push";
 
 export type BaseNavigatorStackParamList = {
-  [NavigatorName.Main]: NavigatorScreenParams<MainNavigatorParamList> & {
-    hideTabNavigation?: boolean;
-  };
+  [NavigatorName.Main]:
+    | (NavigatorScreenParams<MainNavigatorParamList> & {
+        hideTabNavigation?: boolean;
+      })
+    | undefined;
   [NavigatorName.BuyDevice]:
     | NavigatorScreenParams<BuyDeviceNavigatorParamList>
     | undefined;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/OnboardingNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/OnboardingNavigator.ts
@@ -24,9 +24,7 @@ export type OnboardingNavigatorParamList = {
   [ScreenName.OnboardingDeviceSelection]: undefined;
   [ScreenName.OnboardingUseCase]: { deviceModelId: DeviceModelId };
   [NavigatorName.OnboardingCarefulWarning]: NavigatorScreenParams<OnboardingCarefulWarningParamList>;
-  [ScreenName.OnboardingPreQuizModal]: NavigatorScreenParams<OnboardingPreQuizModalNavigatorParamList> & {
-    onNext?: () => void;
-  };
+  [NavigatorName.OnboardingPreQuiz]: NavigatorScreenParams<OnboardingPreQuizModalNavigatorParamList>;
   [ScreenName.OnboardingDoYouHaveALedgerDevice]: undefined;
   [ScreenName.OnboardingModalDiscoverLive]: undefined;
   [ScreenName.OnboardingModalSetupNewDevice]: { deviceModelId: DeviceModelId };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/OnboardingNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/OnboardingNavigator.ts
@@ -23,7 +23,7 @@ export type OnboardingNavigatorParamList = {
   [ScreenName.OnboardingTermsOfUse]: undefined;
   [ScreenName.OnboardingDeviceSelection]: undefined;
   [ScreenName.OnboardingUseCase]: { deviceModelId: DeviceModelId };
-  [ScreenName.OnboardingModalWarning]: NavigatorScreenParams<OnboardingCarefulWarningParamList>;
+  [NavigatorName.OnboardingCarefulWarning]: NavigatorScreenParams<OnboardingCarefulWarningParamList>;
   [ScreenName.OnboardingPreQuizModal]: NavigatorScreenParams<OnboardingPreQuizModalNavigatorParamList> & {
     onNext?: () => void;
   };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -470,6 +470,7 @@ export enum NavigatorName {
   MigrateAccountsFlow = "MigrateAccountsFlow",
   NftNavigator = "NftNavigator",
   Onboarding = "Onboarding",
+  OnboardingCarefulWarning = "OnboardingCarefulWarning",
   PasswordAddFlow = "PasswordAddFlow",
   PasswordModifyFlow = "PasswordModifyFlow",
   Platform = "Platform",

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -471,6 +471,7 @@ export enum NavigatorName {
   NftNavigator = "NftNavigator",
   Onboarding = "Onboarding",
   OnboardingCarefulWarning = "OnboardingCarefulWarning",
+  OnboardingPreQuiz = "OnboardingPreQuiz",
   PasswordAddFlow = "PasswordAddFlow",
   PasswordModifyFlow = "PasswordModifyFlow",
   Platform = "Platform",

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/finish.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/finish.tsx
@@ -78,10 +78,8 @@ export default function OnboardingStepFinish({ navigation }: NavigationProps) {
       parentNav.popToTop();
     }
 
-    // @ts-expect-error TS requires params to be defined, but it crashes the app
     navigation.replace(NavigatorName.Base, {
       screen: NavigatorName.Main,
-      params: undefined,
     });
   }
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/importAccounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/importAccounts.tsx
@@ -76,10 +76,8 @@ function OnboardingStepPairNew() {
       parentNav.popToTop();
     }
 
-    // @ts-expect-error TS requires params to be defined, but it crashes the app
     navigation.replace(NavigatorName.Base, {
       screen: NavigatorName.Main,
-      params: undefined,
     });
   }, [dispatch, navigation, resetCurrentStep]);
 
@@ -95,7 +93,7 @@ function OnboardingStepPairNew() {
   );
 
   const nextPage = useCallback(() => {
-    navigation.navigate(ScreenName.OnboardingModalWarning, {
+    navigation.navigate(NavigatorName.OnboardingCarefulWarning, {
       screen: ScreenName.OnboardingModalSyncDesktopInformation,
       params: { onNext },
     });

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
@@ -112,10 +112,8 @@ function OnboardingStepPairNew() {
       parentNav.popToTop();
     }
 
-    // @ts-expect-error TS requires params to be defined, but it crashes the app
     navigation.replace(NavigatorName.Base, {
       screen: NavigatorName.Main,
-      params: undefined,
     });
 
     startPostOnboarding();

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal.tsx
@@ -1,18 +1,21 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { Flex, Button, Text, Icons, IconBox } from "@ledgerhq/native-ui";
-import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { ScrollView } from "react-native";
+import { StackNavigatorProps } from "../../../../../components/RootNavigator/types/helpers";
+import { OnboardingPreQuizModalNavigatorParamList } from "../../../../../components/RootNavigator/types/OnboardingNavigator";
+import { ScreenName } from "../../../../../const";
 
-type WarningRouteProps = RouteProp<
-  { params: { onNext?: () => void } },
-  "params"
+type NavigationProps = StackNavigatorProps<
+  OnboardingPreQuizModalNavigatorParamList,
+  ScreenName.OnboardingPreQuizModal
 >;
 
 const OnboardingPreQuizModal = () => {
   const { t } = useTranslation();
   const navigation = useNavigation();
-  const route = useRoute<WarningRouteProps>();
+  const route = useRoute<NavigationProps["route"]>();
 
   const handlePress = () => {
     navigation.goBack();

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/drawers/Warning.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/drawers/Warning.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Flex, Button, Text, Icons, IconBox } from "@ledgerhq/native-ui";
 import { useNavigation, useRoute } from "@react-navigation/native";
@@ -16,10 +16,10 @@ const OnboardingSetupDeviceInformation = () => {
   const navigation = useNavigation();
   const route = useRoute<NavigationProps["route"]>();
 
-  const handlePress = () => {
+  const handlePress = useCallback(() => {
     navigation.goBack();
     if (route.params?.onNext) route.params.onNext();
-  };
+  }, [navigation, route]);
 
   return (
     <Flex

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, memo } from "react";
 import { useNavigation, useRoute } from "@react-navigation/native";
 
 import { useTheme } from "styled-components/native";
-import { ScreenName } from "../../../../const";
+import { NavigatorName, ScreenName } from "../../../../const";
 import Illustration from "../../../../images/illustration/Illustration";
 import BaseStepperView, {
   Intro,
@@ -184,13 +184,14 @@ function OnboardingStepNewDevice() {
   );
 
   const nextPage = useCallback(() => {
-    // @ts-expect-error TS requires state to be defined, but it crashes the app
-    navigation.navigate(ScreenName.OnboardingPreQuizModal, {
-      screen: undefined,
-      onNext: () =>
-        navigation.navigate(ScreenName.OnboardingQuiz, {
-          deviceModelId: route.params.deviceModelId,
-        }),
+    navigation.navigate(NavigatorName.OnboardingPreQuiz, {
+      screen: ScreenName.OnboardingPreQuizModal,
+      params: {
+        onNext: () =>
+          navigation.navigate(ScreenName.OnboardingQuiz, {
+            deviceModelId: route.params.deviceModelId,
+          }),
+      },
     });
   }, [navigation, route.params]);
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/Intro.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/Intro.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Text, IconBoxList, Icons } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
-import { ScreenName } from "../../../../../const";
+import { NavigatorName, ScreenName } from "../../../../../const";
 import Button from "../../../../../components/PreventDoubleClickButton";
 import { StackNavigatorNavigation } from "../../../../../components/RootNavigator/types/helpers";
-import { OnboardingCarefulWarningParamList } from "../../../../../components/RootNavigator/types/OnboardingNavigator";
+import { OnboardingNavigatorParamList } from "../../../../../components/RootNavigator/types/OnboardingNavigator";
 
 const items = [
   {
@@ -42,15 +42,16 @@ IntroScene.id = "IntroScene";
 const Next = ({ onNext }: { onNext: () => void }) => {
   const { t } = useTranslation();
   const navigation =
-    useNavigation<
-      StackNavigatorNavigation<OnboardingCarefulWarningParamList>
-    >();
+    useNavigation<StackNavigatorNavigation<OnboardingNavigatorParamList>>();
 
-  const next = () => {
-    navigation.navigate(ScreenName.OnboardingModalWarning, {
-      onNext,
+  const next = useCallback(() => {
+    navigation.navigate(NavigatorName.OnboardingCarefulWarning, {
+      screen: ScreenName.OnboardingModalWarning,
+      params: {
+        onNext,
+      },
     });
-  };
+  }, [onNext, navigation]);
 
   return (
     <Button type="main" size="large" onPress={next}>

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RestoreRecoveryPhrase.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RestoreRecoveryPhrase.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Text } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
-import { ScreenName } from "../../../../../const";
+import { NavigatorName, ScreenName } from "../../../../../const";
 import Button from "../../../../../components/PreventDoubleClickButton";
 import { StackNavigatorNavigation } from "../../../../../components/RootNavigator/types/helpers";
 import { OnboardingNavigatorParamList } from "../../../../../components/RootNavigator/types/OnboardingNavigator";
@@ -32,7 +32,7 @@ const Next = ({ onNext }: { onNext: () => void }) => {
     useNavigation<StackNavigatorNavigation<OnboardingNavigatorParamList>>();
 
   const handlePress = useCallback(() => {
-    navigation.navigate(ScreenName.OnboardingModalWarning, {
+    navigation.navigate(NavigatorName.OnboardingCarefulWarning, {
       screen: ScreenName.OnboardingModalRecoveryPhraseWarning,
       params: { onNext },
     });

--- a/apps/ledger-live-mobile/src/screens/PostBuyDeviceScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostBuyDeviceScreen.tsx
@@ -33,8 +33,6 @@ export default function PostBuyDeviceScreen() {
   const navigation = useNavigation<NavigationProp>();
 
   const onClose = useCallback(() => {
-    // FIXME: navigating to a nested navigator without providing a key / screen name…
-    // @ts-expect-error typescript is rightfully screaming that this is wrong
     navigation.navigate(NavigatorName.Base, {
       screen: NavigatorName.Main,
     });

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -73,8 +73,6 @@ const PostOnboardingHub = ({ navigation }: NavigationProps) => {
 
   const navigateToMainScreen = useCallback(() => {
     allowClosingScreen.current = true;
-    // FIXME: Why are navigating to a nested navigator directly…
-    // @ts-expect-error Typescript rightfully complains here.
     navigation.replace(NavigatorName.Base, {
       screen: NavigatorName.Main,
     });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The navigation was broken on the current onboarding. From my understanding, it was coming from the definition of the navigator previously named `ScreenName.OnboardingModalWarning` and with a screen also named `ScreenName.OnboardingModalWarning`.

How was it working before ? Idk 🤷 

If ok, we'll also do the navigator currently named `ScreenName.OnboardingPreQuizModal` - but there is no bug right now, just the same warning about the fact that 2 screens (well 1 navigator and 1 screen) have the same name

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
