### PR TITLE
chore(release): generate github releases on manual trigger

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -1,6 +1,18 @@
 name: "[Release] Publish packages and apps"
 on:
   workflow_dispatch:
+    inputs:
+      app:
+        description: "which app to release (libraries are always published, chose NONE to release libs only)"
+        required: true
+        type: choice
+        default: NONE
+        options:
+          - NONE
+          - LLD
+          - LLM
+          - ALL
+
   workflow_run:
     workflows:
       - \[Release\] Prepare for releasing
@@ -45,13 +57,25 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       - name: check if desktop versions are different
+        if: ${{ github.event_name == 'workflow_run' }}
         id: desktop-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
+      - name: check if desktop versions are different
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), github.event.inputs.app) }}
+        id: desktop-changed
+        run: |
+          echo "status=1" >> $GITHUB_OUTPUT
       - name: check if mobile versions are different
+        if: ${{ github.event_name == 'workflow_run' }}
         id: mobile-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
+      - name: check if mobile versions are different
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), github.event.inputs.app) }}
+        id: mobile-changed
+        run: |
+          echo "status=1" >> $GITHUB_OUTPUT
       - uses: ledgerhq/ledger-live/tools/actions/get-package-infos@develop
         id: desktop-version
         with:


### PR DESCRIPTION
### 📝 Description

When automatic workflow fails for `release-final.yml` job, github releases are not always created due to inconsistent merging on main (one commit should equal to one version but unfortunately that is not the case). I added a skip on the condition to make sure we generate the release on manual trigger.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://github.com/LedgerHQ/ledger-live-issues/issues/56 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

closes https://github.com/LedgerHQ/ledger-live-issues/issues/56

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
