### PR TITLE
bugfix/LIVE 4375 reactivate brazilian portuguese

### DIFF
--- a/.changeset/tiny-points-decide.md
+++ b/.changeset/tiny-points-decide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix the remove of portugues

--- a/.changeset/tiny-points-decide.md
+++ b/.changeset/tiny-points-decide.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": minor
+"ledger-live-desktop": patch
 ---
 
 fix the remove of portugues

--- a/apps/ledger-live-desktop/src/config/languages.ts
+++ b/apps/ledger-live-desktop/src/config/languages.ts
@@ -55,7 +55,18 @@ export const allLanguages: Locale[] = [
   "zh",
 ];
 
-export const prodStableLanguages: Locale[] = ["en", "fr", "es", "ru", "zh", "de", "tr", "ja", "ko"];
+export const prodStableLanguages: Locale[] = [
+  "en",
+  "fr",
+  "es",
+  "ru",
+  "zh",
+  "de",
+  "tr",
+  "ja",
+  "ko",
+  "pt",
+];
 
 /**
  * List of languages that should be prompted to existing users once if they are
@@ -80,7 +91,7 @@ export const defaultLocaleForLanguage = {
   nl: "nl-NL",
   no: "no-NO",
   pl: "pl-PL",
-  pt: "pt-PT",
+  pt: "pt-BR",
   ru: "ru-RU",
   sr: "sr-SR",
   sv: "sv-SV",


### PR DESCRIPTION
- fix translation key missing and old format
- changeset

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Reactivate Brazilian portuguese in LLD
@grsoares21 "removed" this feature during the change of file from js to ts.
Not a big deal, only had to change the language key to PT-br and to add the language to suported list.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-4375` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

![image](https://user-images.githubusercontent.com/8106590/198218024-af3de0bf-ed1b-4609-815f-7ef5b0232c86.png)

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
