### PR TITLE
LIVE 4187 :  cosmos speculos bot specs fix

### DIFF
--- a/libs/ledger-live-common/src/families/cosmos/specs.ts
+++ b/libs/ledger-live-common/src/families/cosmos/specs.ts
@@ -168,7 +168,7 @@ const cosmos: AppSpec<Transaction> = {
           "already enough delegations"
         );
         const data = getCurrentCosmosPreloadData();
-        const count = 1 + Math.round(2 * Math.random() * Math.random());
+        const count = 1; // we always gonna be have only one validator because of the new delegation flow.
         let remaining = getMaxDelegationAvailable(
           account as CosmosAccount,
           count
@@ -183,6 +183,7 @@ const cosmos: AppSpec<Transaction> = {
               (d) => d.validatorAddress === v.validatorAddress
             )
         );
+        invariant(all.length > 0, "no validators found");
         const validators = sampleSize(all, count)
           .map((delegation) => {
             // take a bit of remaining each time (less is preferred with the random() square)
@@ -204,9 +205,10 @@ const cosmos: AppSpec<Transaction> = {
               memo: "LedgerLiveBot",
               mode: "delegate",
             },
-            ...validators.map((_, i) => ({
-              validators: validators.slice(0, i + 1),
-            })),
+            {
+              validators: validators,
+            },
+            { amount: validators[0].amount },
           ],
         };
       },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Cosmos couldn't do a delegate since we change how we build the delegation message, because of the UI, we will only have one validator and one amount that's set in transaction.amount instead of validators[].amount

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
