### PR TITLE
Bot: rework jsHelpers makeSync to improve TS and make it update a.used + fixes Bitcoin bot to send txs

### DIFF
--- a/libs/ledger-live-common/src/bot/specs.ts
+++ b/libs/ledger-live-common/src/bot/specs.ts
@@ -23,7 +23,7 @@ const stepValueTransformDefault = (s) => s.trim();
 export function pickSiblings(siblings: Account[], maxAccount = 5): Account {
   const withoutEmpties = siblings.filter((a) => a.used);
 
-  if (siblings.length > maxAccount) {
+  if (withoutEmpties.length >= maxAccount) {
     // we are no longer creating accounts
     const maybeAccount = sample(withoutEmpties);
     if (!maybeAccount) {

--- a/libs/ledger-live-common/src/families/bitcoin/account-used.integration.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/account-used.integration.test.ts
@@ -1,0 +1,29 @@
+import { reduce } from "rxjs/operators";
+import { Account } from "@ledgerhq/types-live";
+import { fromAccountRaw } from "../../account";
+import { getAccountBridge } from "../../bridge";
+import { accountDataToAccount, accountToAccountData } from "../../cross";
+import "../../__tests__/test-helpers/setup";
+import { bitcoin1 } from "./datasets/bitcoin";
+
+async function syncAccount(initialAccount: Account): Promise<Account> {
+  const acc = await getAccountBridge(initialAccount)
+    .sync(initialAccount, {
+      paginationConfig: {},
+    })
+    .pipe(reduce((a, f: (arg0: Account) => Account) => f(a), initialAccount))
+    .toPromise();
+  return acc;
+}
+
+async function crossAccount(account: Account): Promise<Account> {
+  const a = accountDataToAccount(accountToAccountData(account));
+  const synced = await syncAccount(a);
+  return synced;
+}
+
+test("account.used is true after crossAccount", async () => {
+  let account = fromAccountRaw(bitcoin1);
+  account = await crossAccount(account);
+  expect(account.used).toBe(true);
+});

--- a/libs/ledger-live-common/src/families/bitcoin/datasets/bitcoin.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/datasets/bitcoin.ts
@@ -29,6 +29,61 @@ const networkInfo: NetworkInfoRaw = {
   },
 };
 
+export const bitcoin1: BitcoinAccountRaw = {
+  id: "libcore:1:bitcoin:xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn:",
+  seedIdentifier:
+    "041caa3a42db5bdd125b2530c47cfbe829539b5a20a5562ec839d241c67d1862f2980d26ebffee25e4f924410c3316b397f34bd572543e72c59a7569ef9032f498",
+  name: "Bitcoin 1 (legacy)",
+  derivationMode: "",
+  index: 0,
+  freshAddress: "17gPmBH8b6UkvSmxMfVjuLNAqzgAroiPSe",
+  freshAddressPath: "44'/0'/0'/0/59",
+  freshAddresses: [
+    {
+      address: "17gPmBH8b6UkvSmxMfVjuLNAqzgAroiPSe",
+      derivationPath: "44'/0'/0'/0/59",
+    },
+  ],
+  pendingOperations: [],
+  operations: [],
+  currencyId: "bitcoin",
+  unitMagnitude: 8,
+  balance: "2757",
+  blockHeight: 0,
+  lastSyncDate: "",
+  xpub: "xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn",
+  bitcoinResources: {
+    utxos: [],
+  },
+};
+export const bitcoin2: BitcoinAccountRaw = {
+  id: "libcore:1:bitcoin:xpub6DEHKg8fgKcb9at2u9Xhjtx4tXGyWqUPQAx2zNCzr41gQRyCqpCn7onSoJU4VS96GXyCtAhhFxErnG2pGVvVexaqF7DEfqGGnGk7Havn7C2:native_segwit",
+  seedIdentifier:
+    "043188c7e9e184aa3f6c2967b9b2b19a5966efe88c526ac091687642540573ecfb4c988261e7b0b876c6aec0b393518676232b34289a5bfc0cc78cc2ef735fa512",
+  name: "Bitcoin 2 (native segwit)",
+  derivationMode: "native_segwit",
+  index: 1,
+  freshAddress: "bc1q8vp7v5wyv8nvhsh5p2dvkgalep4q325kd5xk4e",
+  freshAddressPath: "84'/0'/1'/0/53",
+  freshAddresses: [
+    {
+      address: "bc1q8vp7v5wyv8nvhsh5p2dvkgalep4q325kd5xk4e",
+      derivationPath: "84'/0'/1'/0/53",
+    },
+  ],
+  blockHeight: 0,
+  operations: [],
+  pendingOperations: [],
+  currencyId: "bitcoin",
+  unitMagnitude: 8,
+  lastSyncDate: "",
+  balance: "2717",
+  xpub: "xpub6DEHKg8fgKcb9at2u9Xhjtx4tXGyWqUPQAx2zNCzr41gQRyCqpCn7onSoJU4VS96GXyCtAhhFxErnG2pGVvVexaqF7DEfqGGnGk7Havn7C2",
+  bitcoinResources: {
+    utxos: [],
+  },
+};
+
 const dataset: CurrenciesData<Transaction> = {
   FIXME_ignoreAccountFields: [
     "bitcoinResources.walletAccount", // it is not "stable"
@@ -135,62 +190,10 @@ const dataset: CurrenciesData<Transaction> = {
           },
         },
       ],
-      raw: {
-        id: "libcore:1:bitcoin:xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn:",
-        seedIdentifier:
-          "041caa3a42db5bdd125b2530c47cfbe829539b5a20a5562ec839d241c67d1862f2980d26ebffee25e4f924410c3316b397f34bd572543e72c59a7569ef9032f498",
-        name: "Bitcoin 1 (legacy)",
-        derivationMode: "",
-        index: 0,
-        freshAddress: "17gPmBH8b6UkvSmxMfVjuLNAqzgAroiPSe",
-        freshAddressPath: "44'/0'/0'/0/59",
-        freshAddresses: [
-          {
-            address: "17gPmBH8b6UkvSmxMfVjuLNAqzgAroiPSe",
-            derivationPath: "44'/0'/0'/0/59",
-          },
-        ],
-        pendingOperations: [],
-        operations: [],
-        currencyId: "bitcoin",
-        unitMagnitude: 8,
-        balance: "2757",
-        blockHeight: 0,
-        lastSyncDate: "",
-        xpub: "xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn",
-        bitcoinResources: {
-          utxos: [],
-        },
-      } as BitcoinAccountRaw,
+      raw: bitcoin1,
     },
     {
-      raw: {
-        id: "libcore:1:bitcoin:xpub6DEHKg8fgKcb9at2u9Xhjtx4tXGyWqUPQAx2zNCzr41gQRyCqpCn7onSoJU4VS96GXyCtAhhFxErnG2pGVvVexaqF7DEfqGGnGk7Havn7C2:native_segwit",
-        seedIdentifier:
-          "043188c7e9e184aa3f6c2967b9b2b19a5966efe88c526ac091687642540573ecfb4c988261e7b0b876c6aec0b393518676232b34289a5bfc0cc78cc2ef735fa512",
-        name: "Bitcoin 2 (native segwit)",
-        derivationMode: "native_segwit",
-        index: 1,
-        freshAddress: "bc1q8vp7v5wyv8nvhsh5p2dvkgalep4q325kd5xk4e",
-        freshAddressPath: "84'/0'/1'/0/53",
-        freshAddresses: [
-          {
-            address: "bc1q8vp7v5wyv8nvhsh5p2dvkgalep4q325kd5xk4e",
-            derivationPath: "84'/0'/1'/0/53",
-          },
-        ],
-        blockHeight: 0,
-        operations: [],
-        pendingOperations: [],
-        currencyId: "bitcoin",
-        unitMagnitude: 8,
-        lastSyncDate: "",
-        balance: "2717",
-        xpub: "xpub6DEHKg8fgKcb9at2u9Xhjtx4tXGyWqUPQAx2zNCzr41gQRyCqpCn7onSoJU4VS96GXyCtAhhFxErnG2pGVvVexaqF7DEfqGGnGk7Havn7C2",
-        bitcoinResources: {
-          utxos: [],
-        },
-      } as BitcoinAccountRaw,
+      raw: bitcoin2,
     },
   ],
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Phosphore bot reveals a problem here. Here are its account:

```
Bitcoin 1 cross [native segwit]: 0.006553 BTC (6ops) (bc1qtmdltwjkf4s0tn45hnwe5astlha6ptrrhp2dsv on 84'/0'/0'/0/4) native_segwit#0 js:2:bitcoin:xpub6BqFXyqM4GtCXuxT6zna2zbVnX7Caig7errmzcb99x43DEZoRYeBKWEjAcxMRWkxZYDhXKrUDPASGsNz9KKArY5zcM12KagZfeg3r655wbc:native_segwit
Bitcoin 2 [native segwit]: 0 BTC (0ops) (bc1qv0dj006wuzhgten806mswcqqx8wmptwuanrd6s on 84'/0'/1'/0/0) native_segwit#1 js:2:bitcoin:xpub6BqFXyqM4GtCbSr2LZGTNEV4HctQrQoCUioCUKjS9sV2TZngK6h6yf4wvJpFRTKtp51cSKsrjS7NtXRUyic9WYSbm8B7XM5cPepYrKtcKY4:native_segwit
Bitcoin 1 [taproot]: 0 BTC (0ops) (bc1p9rqp0ytvfxzmepq7qcryhzvk8uhsvg545ckath6s4sx67ctjdxkq6uhrgm on 86'/0'/0'/0/0) taproot#0 js:2:bitcoin:xpub6C7PPFfQw1G6xBtbf7nKN96UiQx9YKiNUswPZ4mGRLsSn3wdHv9AXAqfRxEezaT9Dn8pzJspY3tiP6qTgPparwXysA2J28QxFqNEG6uBiMf:taproot
Bitcoin 1 [segwit]: 0 BTC (0ops) (3M9iGVWDcmWvxGLT3Cskz9MnWF4tvjq5aH on 49'/0'/0'/0/0) segwit#0 js:2:bitcoin:xpub6CRH2NQQ9pU9X9VoB3Gs1hJCookaLJ621xGHthtdAc1MYshx2AGFwfTJnARTpbRXLQ4mDruMTNwPi1twHNTEXeyYG1tVCCTGkKaVQFzJtbh:segwit
Bitcoin 1 [legacy]: 0 BTC (0ops) (1McUM386TvnYa9R9KhCwnBaWBe4d3d9M63 on 44'/0'/0'/0/0) #0 js:2:bitcoin:xpub6DSHqL3C1WaQzB5LaDTM3HUamgZDH7ddhEY6bk6Ppf8iEcct3sbEALLs6KUJfweU91HXumdTmQXfXtMLxfdrrKHthM5uYxav5FJRuPYnhUc:
```

it seems that the first account will get into `at least one non-empty sibling account exists. maxAccount=3 (1)` problem, which indicates that all other siblings account have `a.used` to be false. per the logic:

```ts
export function pickSiblings(siblings: Account[], maxAccount = 5): Account {
  const withoutEmpties = siblings.filter((a) => a.used);

  if (siblings.length > maxAccount) {
    // we are no longer creating accounts
    const maybeAccount = sample(withoutEmpties);
    if (!maybeAccount) {
      throw new Error(
        "at least one non-empty sibling account exists. maxAccount=" +
          maxAccount
      );
    }
    return maybeAccount;
  }
```

there are apparently one case in our codebase where `Account#used` can be set back to `false`: 
- via cross.ts, (which we are USING in the bot logic above, see the "cross" mention in the name of the account)

On the path of investigating this, i also noticed `.used` actually don't work properly and may causes issue at discovering accounts if we trust this field to reflect "was the account ever used"🤔  **The solution attempt here is going to recalculate it based on balance and operations presence.**

but that was not alone the way to fix the bot, instead i had to change a bit the logic of `pickSiblings` to consider the number of "used" accounts instead of the total amount of siblings (because we may have lot of "empty" siblings, more than one).

### ❓ Context

- **Impacted projects**: Bot, synchronisation of all accounts <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-4418](https://ledgerhq.atlassian.net/browse/LIVE-4418) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
