### PR TITLE
LIVE-3386: Cosmos redelegate can fail when empty validators (part 2)

### DIFF
--- a/libs/ledger-live-common/src/families/cosmos/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-getTransactionStatus.ts
@@ -297,6 +297,7 @@ export class CosmosTransactionStatusManager {
         redelegations.length < COSMOS_MAX_REDELEGATIONS,
         "redelegation should not have more than 6 entries"
       );
+
       if (
         redelegations.some((redelegation) => {
           const dstValidator = redelegation.validatorDstAddress;
@@ -305,16 +306,20 @@ export class CosmosTransactionStatusManager {
             redelegation.completionDate > new Date()
           );
         })
-      )
+      ) {
         return new CosmosRedelegationInProgress();
-      if (
-        t.validators.length > 0 &&
-        t.sourceValidator === t.validators[0].address
-      )
-        return new InvalidAddressBecauseDestinationIsAlsoSource();
+      }
+
+      if (t.validators.length > 0) {
+        if (t.sourceValidator === t.validators[0].address) {
+          return new InvalidAddressBecauseDestinationIsAlsoSource();
+        } else {
+          return this.isDelegable(a, t.sourceValidator, t.validators[0].amount);
+        }
+      }
     }
 
-    return this.isDelegable(a, t.sourceValidator, t.validators[0].amount);
+    return null;
   };
 
   private isDelegable = (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Follow-up of bugfix/LIVE-3386-cosmos-redelegate-validators-empty
Some sanity checks were still missing on `validators` in Cosmos transaction, causing potential crashes seen by Sentry, e.g:
https://sentry.io/organizations/ledger/issues/3687994202/?project=6723478&referrer=slack


### ❓ Context

- **Impacted projects**: `LLC` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3386 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
