### PR TITLE
Bot: Remove the .ref of GH actions

### DIFF
--- a/.github/workflows/bot-carbon.yml
+++ b/.github/workflows/bot-carbon.yml
@@ -2,9 +2,6 @@ name: "[Bot] Testing with 'Carbon'"
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: The branch to run on
-        required: true
       family:
         description: coin family to filter with (if any)
         required: false
@@ -54,11 +51,6 @@ jobs:
     needs: [start-runner]
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.event.inputs.ref != null }}
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/checkout@v3
-        if: ${{ !github.event.inputs.ref }}
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bot-mere-denis.yml
+++ b/.github/workflows/bot-mere-denis.yml
@@ -2,9 +2,6 @@ name: "[Bot] Testing with 'Mère Denis'"
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: The branch to run on
-        required: true
       family:
         description: coin family to filter with (if any)
         required: false
@@ -54,11 +51,6 @@ jobs:
     needs: [start-runner]
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.event.inputs.ref != null }}
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/checkout@v3
-        if: ${{ !github.event.inputs.ref }}
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bot-mooncake.yml
+++ b/.github/workflows/bot-mooncake.yml
@@ -2,9 +2,6 @@ name: "[Bot] Testing with 'Mooncake'"
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: The branch to run on
-        required: true
       family:
         description: coin family to filter with (if any)
         required: false
@@ -54,11 +51,6 @@ jobs:
     needs: [start-runner]
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.event.inputs.ref != null }}
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/checkout@v3
-        if: ${{ !github.event.inputs.ref }}
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bot-oxygen.yml
+++ b/.github/workflows/bot-oxygen.yml
@@ -2,9 +2,6 @@ name: "[Bot] Testing with 'Oxygen'"
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: The branch to run on
-        required: true
       family:
         description: coin family to filter with (if any)
         required: false
@@ -54,11 +51,6 @@ jobs:
     needs: [start-runner]
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.event.inputs.ref != null }}
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/checkout@v3
-        if: ${{ !github.event.inputs.ref }}
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bot-phosphore.yml
+++ b/.github/workflows/bot-phosphore.yml
@@ -2,9 +2,6 @@ name: "[Bot] Testing with 'Phosphore'"
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: The branch to run on
-        required: true
       family:
         description: coin family to filter with (if any)
         required: false
@@ -54,11 +51,6 @@ jobs:
     needs: [start-runner]
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.event.inputs.ref != null }}
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/checkout@v3
-        if: ${{ !github.event.inputs.ref }}
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/bot-silicium.yml
+++ b/.github/workflows/bot-silicium.yml
@@ -2,9 +2,6 @@ name: "[Bot] Testing with 'Silicium'"
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: The branch to run on
-        required: true
       family:
         description: coin family to filter with (if any)
         required: false
@@ -54,11 +51,6 @@ jobs:
     needs: [start-runner]
     steps:
       - uses: actions/checkout@v3
-        if: ${{ github.event.inputs.ref != null }}
-        with:
-          ref: ${{ github.event.inputs.ref }}
-      - uses: actions/checkout@v3
-        if: ${{ !github.event.inputs.ref }}
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION

### 📝 Description

Remove the redundancy of having to set both "Use workflow from" and "The branch to run on" if we want a manually triggered bot run to properly run against the branch AND report to the PR and the associated commits.

**BEFORE:**
![Screenshot 2022-11-03 at 15 54 36](https://user-images.githubusercontent.com/211411/199755279-35a688af-baba-4da9-962d-acedc04350d8.png)

many recent bot runs have shown this was not understood and done properly, indeed it's actually confusing.

I suspect we actually don't need the "ref" field at all as we can just works with the native support of it.

testing this with Tezos test against this branch on phosphore:

**AFTER:**
![Screenshot 2022-11-03 at 15 57 28](https://user-images.githubusercontent.com/211411/199755840-211c8783-1ea9-4d8d-a93f-471c184a776f.png)


### ❓ Context

- **Impacted projects**: `n/a` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** we will test directly to run a bot on this PR <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
