### PR TITLE
LIVE-4036 - LLM - Analytics added firstConnectHasDeviceUpdated prop

### DIFF
--- a/.changeset/silly-chairs-pretend.md
+++ b/.changeset/silly-chairs-pretend.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Analytics - added firstConnectHasDeviceUpdated property

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -369,6 +369,10 @@ export type SettingsSetFirstConnectionHasDevicePayload = Pick<
   SettingsState,
   "firstConnectionHasDevice"
 >;
+export type SettingsSetFirstConnectHasDeviceUpdatedPayload = Pick<
+  SettingsState,
+  "firstConnectHasDeviceUpdated"
+>;
 export type SettingsSetNotificationsPayload = {
   notifications: Partial<SettingsState["notifications"]>;
 };
@@ -414,7 +418,7 @@ export type SettingsPayload =
   | SettingsSetMarketCounterCurrencyPayload
   | SettingsSetMarketFilterByStarredAccountsPayload
   | SettingsSetSensitiveAnalyticsPayload
-  | SettingsSetFirstConnectionHasDevicePayload
+  | SettingsSetFirstConnectHasDeviceUpdatedPayload
   | SettingsSetNotificationsPayload
   | SettingsDangerouslyOverrideStatePayload;
 

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -30,6 +30,7 @@ import {
   lastSeenDeviceSelector,
   sensitiveAnalyticsSelector,
   firstConnectionHasDeviceSelector,
+  firstConnectHasDeviceUpdatedSelector,
   readOnlyModeEnabledSelector,
   hasOrderedNanoSelector,
 } from "../reducers/settings";
@@ -73,6 +74,8 @@ const extraProperties = (store: AppStore) => {
       }
     : {};
   const firstConnectionHasDevice = firstConnectionHasDeviceSelector(state);
+  const firstConnectHasDeviceUpdated =
+    firstConnectHasDeviceUpdatedSelector(state);
 
   return {
     appVersion,
@@ -87,6 +90,7 @@ const extraProperties = (store: AppStore) => {
     sessionId,
     devicesCount: devices.length,
     firstConnectionHasDevice,
+    firstConnectHasDeviceUpdated,
     ...(satisfaction
       ? {
           satisfaction,

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -38,7 +38,7 @@ import type {
   SettingsSetCountervaluePayload,
   SettingsSetDiscreetModePayload,
   SettingsSetExperimentalUsbSupportPayload,
-  SettingsSetFirstConnectionHasDevicePayload,
+  SettingsSetFirstConnectHasDeviceUpdatedPayload,
   SettingsSetHasOrderedNanoPayload,
   SettingsSetLanguagePayload,
   SettingsSetLastConnectedDevicePayload,
@@ -136,6 +136,7 @@ export const INITIAL_STATE: SettingsState = {
   marketFilterByStarredAccounts: false,
   sensitiveAnalytics: false,
   firstConnectionHasDevice: null,
+  firstConnectHasDeviceUpdated: null,
   notifications: {
     allowed: false,
     transactions: false,
@@ -507,9 +508,9 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
 
   [SettingsActionTypes.SET_FIRST_CONNECTION_HAS_DEVICE]: (state, action) => ({
     ...state,
-    firstConnectionHasDevice: (
-      action as Action<SettingsSetFirstConnectionHasDevicePayload>
-    ).payload.firstConnectionHasDevice,
+    firstConnectHasDeviceUpdated: (
+      action as Action<SettingsSetFirstConnectHasDeviceUpdatedPayload>
+    ).payload.firstConnectHasDeviceUpdated,
   }),
 
   [SettingsActionTypes.SET_NOTIFICATIONS]: (state, action) => ({
@@ -719,5 +720,7 @@ export const sensitiveAnalyticsSelector = (state: State) =>
   state.settings.sensitiveAnalytics;
 export const firstConnectionHasDeviceSelector = (state: State) =>
   state.settings.firstConnectionHasDevice;
+export const firstConnectHasDeviceUpdatedSelector = (state: State) =>
+  state.settings.firstConnectHasDeviceUpdated;
 export const notificationsSelector = (state: State) =>
   state.settings.notifications;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -189,6 +189,7 @@ export type SettingsState = {
   marketFilterByStarredAccounts: boolean;
   sensitiveAnalytics: boolean;
   firstConnectionHasDevice: boolean | null;
+  firstConnectHasDeviceUpdated: boolean | null;
   notifications: {
     allowed: boolean;
     transactions: boolean;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_LLM - Analytics added firstConnectHasDeviceUpdated prop_

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-4036] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-4036]: https://ledgerhq.atlassian.net/browse/LIVE-4036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ