### PR TITLE
makes playwright test fail on an internal process crash

### DIFF
--- a/apps/ledger-live-desktop/src/main/internal-lifecycle.js
+++ b/apps/ledger-live-desktop/src/main/internal-lifecycle.js
@@ -116,6 +116,9 @@ internal.onExit((code, signal, unexpected) => {
         },
       });
     });
+    if (process.env.CRASH_ON_INTERNAL_CRASH) {
+      process.exit(code || 1);
+    }
   }
 });
 

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -65,6 +65,7 @@ const test = base.extend<TestFixtures>({
         HIDE_DEBUG_MOCK: true,
         CI: process.env.CI || undefined,
         PLAYWRIGHT_RUN: true,
+        CRASH_ON_INTERNAL_CRASH: true,
         LEDGER_MIN_HEIGHT: 768,
         FEATURE_FLAGS: JSON.stringify(featureFlags),
       },


### PR DESCRIPTION
### 📝 Description

To make sure we detect internal process crash in future, this makes all the playwright tests running the app in a more strict way which don't allow an internal crash to happen (by default our app would behave in a resilient way, e.g. if a sync makes a bad crash case, a second sync would try to make it run again – that said, an internal crash isn't really acceptable and does not happen really often in real life – this could be made the default behavior, for now we try this strict mode in our tests)

---

how did i test this is working?

I have added `setTimeout(() => process.exit(1), 5000)` in internal/index.js, and bunch of tests were then failing (locally).

now, we can just confirm on this PR that the CI is ✅ 

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-4473 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
