### PR TITLE
Swap: fixes "{}" error to appear in all ExchangeRateRaw

### DIFF
--- a/libs/ledger-live-common/src/exchange/swap/serialization.ts
+++ b/libs/ledger-live-common/src/exchange/swap/serialization.ts
@@ -66,7 +66,7 @@ export const toExchangeRateRaw = (
     provider,
     providerURL,
     tradeMethod,
-    error: JSON.stringify(serializeError(error)) || "{}",
+    error: error ? JSON.stringify(serializeError(error)) : undefined,
   };
 };
 


### PR DESCRIPTION

### 📝 Description

It seems that in `toExchangeRateRaw` we always make objects having a `error: "{}"` where the field was designed (according to types) to be falsy if there are no error.

I keep this PR opened a Draft until somewhere can makes sense of the previous code / and with a full assessment of the impact, but this problem was creating the other issue of #1766 .

### ❓ Context

- **Impacted projects**: `LLD`: it's in live-common but only used by LLD <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-4504 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** -> unclear if this covered by tests? <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
