### PR TITLE
support: update android PendingIntent usage to support API level above 31

### DIFF
--- a/.changeset/many-eels-work.md
+++ b/.changeset/many-eels-work.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hid": minor
+---
+
+Bump target and compile sdk versions to mark PendingIntents with PendingIntent.FLAG_MUTABLE. Starting with Build.VERSION_CODES.S, it is required to explicitly specify the mutability of PendingIntents on creation with either FLAG_IMMUTABLE or FLAG_MUTABLE.

--- a/libs/ledgerjs/packages/react-native-hid/android/build.gradle
+++ b/libs/ledgerjs/packages/react-native-hid/android/build.gradle
@@ -21,11 +21,10 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 29
-
   defaultConfig {
     minSdkVersion 24
-    targetSdkVersion 29
+    compileSdkVersion 33
+    targetSdkVersion 33
     versionCode 1
     versionName "1.0"
   }

--- a/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDModule.java
+++ b/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDModule.java
@@ -10,6 +10,7 @@ import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -162,10 +163,18 @@ public class ReactHIDModule extends ReactContextBaseJavaModule {
         return result.toByteArray();
     }
 
+    public static PendingIntent createPendingIntentGetBroadcast(Context context, int id, Intent intent, int flag) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return PendingIntent.getBroadcast(context, id, intent, PendingIntent.FLAG_MUTABLE | flag);
+        } else {
+            return PendingIntent.getBroadcast(context, id, intent, flag);
+        }
+    }
+
     private void requestUsbPermission(UsbManager manager, UsbDevice device, Promise p) {
         try {
             ReactApplicationContext rAppContext = getReactApplicationContext();
-            PendingIntent permIntent = PendingIntent.getBroadcast(rAppContext, 0, new Intent(ACTION_USB_PERMISSION), 0);
+            PendingIntent permIntent = createPendingIntentGetBroadcast(rAppContext, 0, new Intent(ACTION_USB_PERMISSION), 0);
             registerBroadcastReceiver(p);
             manager.requestPermission(device, permIntent);
         } catch (Exception e) {


### PR DESCRIPTION
### 📝 Description

Bumping target and compile SDK versions to mark PendingIntents with PendingIntent.FLAG_MUTABLE. This will add support for API level above 31. 
Starting with Build.VERSION_CODES.S, it is required to explicitly specify the mutability of PendingIntents on creation with either FLAG_IMMUTABLE or FLAG_MUTABLE.

### ❓ Context

- **Impacted projects**: `none` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `none` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage**
- [x] **Atomic delivery** 
- [x] **No breaking changes**

### 📸 Demo

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._
