### PR TITLE
Fix webview usage with electron 21

### DIFF
--- a/apps/ledger-live-desktop/src/main/index.js
+++ b/apps/ledger-live-desktop/src/main/index.js
@@ -4,7 +4,7 @@ require("@electron/remote/main").initialize();
 
 /* eslint-disable import/first */
 import "./setup";
-import { app, Menu, ipcMain, session } from "electron";
+import { app, Menu, ipcMain, session, webContents, shell } from "electron";
 import menu from "./menu";
 import {
   createMainWindow,
@@ -157,6 +157,19 @@ app.on("ready", async () => {
   });
 
   ipcMain.on("log", (event, { log }) => logger.log(log));
+
+  // To handle openning new windows from webview
+  // cf. https://gist.github.com/codebytere/409738fcb7b774387b5287db2ead2ccb
+  ipcMain.on("webview-dom-ready", (_, id) => {
+    const wc = webContents.fromId(id);
+    wc.setWindowOpenHandler(({ url }) => {
+      const protocol = new URL(url).protocol;
+      if (["https:", "http:"].includes(protocol)) {
+        shell.openExternal(url);
+      }
+      return { action: "deny" };
+    });
+  });
 
   Menu.setApplicationMenu(menu);
 

--- a/apps/ledger-live-desktop/src/preloader/index.js
+++ b/apps/ledger-live-desktop/src/preloader/index.js
@@ -32,9 +32,13 @@ const appLoaded = () => {
 
 const reloadRenderer = () => ipcRenderer.invoke("reloadRenderer");
 
+// cf. https://gist.github.com/codebytere/409738fcb7b774387b5287db2ead2ccb
+const openWindow = id => ipcRenderer.send("webview-dom-ready", id);
+
 window.api = {
   appLoaded,
   reloadRenderer,
+  openWindow,
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

cf. https://ledgerhq.atlassian.net/browse/LIVE-4335?focusedCommentId=247299

In a breaking change in Electron 18 the nativeWindowOpen web preference (used [here](https://github.com/LedgerHQ/ledger-live/blob/ff2d747c1a3aa6bc779d1987c0f2a5e0369c2d72/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/index.tsx#L416)) have [been removed](https://www.electronjs.org/blog/electron-18-0#removed-nativewindowopen) (cf. [this PR](https://github.com/electron/electron/pull/29405))

Now, Ledger live does not seem to receive (and handle) new-window events when a live-apps wants to open a new window (regularly used throughout Live Apps to open external contextual info like redirect to Twitter account, open ToS page, etc…)

`webview` are deprecated and not formerly integrated / maintained in electron.
updating electron broke previous handleding of new window opened from a `webview`

use `setWindowOpenHandler` on the `webview` webContents to handle opening new window.
cf. https://github.com/electron/electron/issues/31117#issuecomment-958733861

also, there seem to be issues between `webview` and React
cf. https://github.com/electron/electron/issues/6046

PS: this solution works as is. It might not be the most beautiful. Feel free to use it as a base version and improve on it if need be.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
