### PR TITLE
Add one switch to enable multiple flags at once

### DIFF
--- a/.changeset/pink-monkeys-heal.md
+++ b/.changeset/pink-monkeys-heal.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add a way to activate multiple Feature Flags at once

--- a/.changeset/popular-eagles-camp.md
+++ b/.changeset/popular-eagles-camp.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix crash at the install apps step of the synchronous onboarding

--- a/.changeset/pretty-rivers-hear.md
+++ b/.changeset/pretty-rivers-hear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add a way to activate multiple Feature Flags at once

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -55,9 +55,7 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
     (["customImage", "deviceInitialApps", "syncOnboarding"] as FeatureId[]).forEach(featureId =>
       overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
     );
-    window.alert(
-      "You now have the one ring. Remember, with great power comes great responsibility.",
-    );
+    window.alert("With great power comes great responsibility.");
   }, [overrideFeature, getFeature]);
 
   const onDescriptionClick = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback, useRef } from "react";
 import ButtonV2 from "~/renderer/components/Button";
 import { useTranslation } from "react-i18next";
-import { defaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
+import { defaultFeatures, useFeatureFlags } from "@ledgerhq/live-common/featureFlags/index";
 import { SettingsSectionRow as Row } from "../../../SettingsSection";
 import { Input, Icons, Flex, SearchInput, Alert } from "@ledgerhq/react-ui";
 import { FeatureId } from "@ledgerhq/types-live";
@@ -46,6 +46,38 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
       .filter(name => !searchInput || includes(lowerCase(name), lowerCase(searchInput)));
   }, [featureFlags, searchInput]);
 
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pressCount = useRef(0);
+
+  const { getFeature, overrideFeature } = useFeatureFlags();
+
+  const ruleThemAll = useCallback(() => {
+    (["customImage", "deviceInitialApps", "syncOnboarding"] as FeatureId[]).forEach(featureId =>
+      overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
+    );
+    window.alert(
+      "You now have the one ring. Remember, with great power comes great responsibility.",
+    );
+  }, [overrideFeature, getFeature]);
+
+  const onDescriptionClick = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    pressCount.current += 1;
+    const timeout = setTimeout(() => {
+      pressCount.current = 0;
+    }, 300);
+    if (pressCount.current > 6) {
+      ruleThemAll();
+      pressCount.current = 0;
+    }
+    timeoutRef.current = timeout;
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [ruleThemAll]);
+
   const content = useMemo(
     () =>
       filteredFlags.map(flagName => (
@@ -61,7 +93,7 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
 
   return (
     <Flex flexDirection="column" pt={2} rowGap={2} alignSelf="stretch">
-      {t("settings.developer.featureFlagsDesc")}
+      <div onClick={onDescriptionClick}>{t("settings.developer.featureFlagsDesc")}</div>
       {!props.visible ? null : (
         <>
           <SearchInput

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -51,11 +51,12 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
 
   const { getFeature, overrideFeature } = useFeatureFlags();
 
+  const [cheatActivated, setCheatActivated] = useState(false);
   const ruleThemAll = useCallback(() => {
     (["customImage", "deviceInitialApps", "syncOnboarding"] as FeatureId[]).forEach(featureId =>
       overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
     );
-    window.alert("With great power comes great responsibility.");
+    setCheatActivated(true);
   }, [overrideFeature, getFeature]);
 
   const onDescriptionClick = useCallback(() => {
@@ -91,7 +92,10 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
 
   return (
     <Flex flexDirection="column" pt={2} rowGap={2} alignSelf="stretch">
-      <div onClick={onDescriptionClick}>{t("settings.developer.featureFlagsDesc")}</div>
+      <div onClick={onDescriptionClick}>
+        {t("settings.developer.featureFlagsDesc")}
+        {cheatActivated ? " With great power comes great responsibility." : null}
+      </div>
       {!props.visible ? null : (
         <>
           <SearchInput

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -96,19 +96,20 @@ const InstallSetOfApps = ({
               <Trans i18nKey="installSetOfApps.ongoing.loading" />
             )}
           </Text>
-          {itemProgress &&
-            dependencies?.map((appName, i) => (
-              <Item
-                key={appName}
-                i={i}
-                appName={appName}
-                isActive={currentAppOp?.name === appName}
-                installed={
-                  progress ? !installQueue?.includes(appName) : undefined
-                }
-                itemProgress={itemProgress}
-              />
-            ))}
+          {itemProgress !== undefined
+            ? dependencies?.map((appName, i) => (
+                <Item
+                  key={appName}
+                  i={i}
+                  appName={appName}
+                  isActive={currentAppOp?.name === appName}
+                  installed={
+                    progress ? !installQueue?.includes(appName) : undefined
+                  }
+                  itemProgress={itemProgress}
+                />
+              ))
+            : null}
         </Flex>
       </Flex>
       <Text textAlign="center" color="neutral.c70">

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { useNavigation } from "@react-navigation/native";
 import config from "react-native-config";
 import { Box, Text } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { Alert, TouchableWithoutFeedback, View } from "react-native";
+import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/provider";
+import { FeatureId } from "@ledgerhq/types-live";
 import { TrackScreen } from "../../../analytics";
 import SettingsRow from "../../../components/SettingsRow";
 import SelectDevice from "../../../components/SelectDevice";
@@ -39,6 +42,7 @@ import {
   StackNavigatorProps,
 } from "../../../components/RootNavigator/types/helpers";
 import { SettingsNavigatorStackParamList } from "../../../components/RootNavigator/types/SettingsNavigator";
+import PoweredByLedger from "../PoweredByLedger";
 import OpenStoryly from "./OpenDebugStoryly";
 
 export function DebugMocks() {
@@ -110,6 +114,45 @@ export default function DebugSettings({
   SettingsNavigatorStackParamList,
   ScreenName.DebugSettings
 >) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pressCount = useRef(0);
+
+  const { getFeature, overrideFeature } = useFeatureFlags();
+
+  const ruleThemAll = useCallback(() => {
+    (
+      [
+        "customImage",
+        "deviceInitialApps",
+        "syncOnboarding",
+        "llmNewDeviceSelection",
+      ] as FeatureId[]
+    ).forEach(featureId =>
+      overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
+    );
+    Alert.alert(
+      "You now have the one ring. I can only show you the door, you're the one that has to walk through it.",
+    );
+  }, [overrideFeature, getFeature]);
+
+  const onDebugHiddenPress = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    pressCount.current += 1;
+    const timeout = setTimeout(() => {
+      pressCount.current = 0;
+    }, 300);
+    if (pressCount.current > 6) {
+      ruleThemAll();
+      pressCount.current = 0;
+    }
+    timeoutRef.current = timeout;
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [ruleThemAll]);
+
   return (
     <SettingsNavigationScrollView>
       <TrackScreen category="Settings" name="Debug" />
@@ -134,6 +177,11 @@ export default function DebugSettings({
           {global.HermesInternal ? "Hermes" : "Jsc"}
         </Text>
       </SettingsRow>
+      <TouchableWithoutFeedback onPress={onDebugHiddenPress}>
+        <View>
+          <PoweredByLedger />
+        </View>
+      </TouchableWithoutFeedback>
     </SettingsNavigationScrollView>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -131,7 +131,7 @@ export default function DebugSettings({
       overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
     );
     Alert.alert(
-      "You now have the one ring. I can only show you the door, you're the one that has to walk through it.",
+      "I can only show you the door, you're the one that has to walk through it.",
     );
   }, [overrideFeature, getFeature]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

See more info in [FAT-649]

- Includes a fix for a crash that was happening in the "install set of apps" step of the sync onboarding: because of a bad conditional logic some text was getting rendered outside of a `Text` component.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-649] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-649]: https://ledgerhq.atlassian.net/browse/FAT-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FAT-649]: https://ledgerhq.atlassian.net/browse/FAT-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ