### PR TITLE
bugfix/LIVE-4591 Fix navigation lock bug on top left (back) navigation

### DIFF
--- a/.changeset/witty-fireants-hide.md
+++ b/.changeset/witty-fireants-hide.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix navigation lock bug after (un)installing apps, top arrow

--- a/apps/ledger-live-mobile/src/components/RootNavigator/CustomBlockRouterNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/CustomBlockRouterNavigator.tsx
@@ -65,7 +65,7 @@ export const useLockNavigation = (
   useEffect(() => {
     exposedManagerNavLockCallback.next(when ? callback : undefined);
     lockSubject.next(when);
-    const listener = navigation.addListener("beforeRemove", e => {
+    const listenerCleanup = navigation.addListener("beforeRemove", e => {
       if (!when) {
         // If we don't have unsaved changes, then we don't need to do anything
         return;
@@ -80,7 +80,7 @@ export const useLockNavigation = (
     return () => {
       lockSubject.next(false);
       exposedManagerNavLockCallback.next(undefined);
-      navigation.removeListener("beforeRemove", listener);
+      listenerCleanup();
     };
   }, [callback, navigation, when]);
 };

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -117,16 +117,11 @@ const PostOnboardingHub = ({ navigation }: NavigationProps) => {
     navigation.setOptions({ gestureEnabled: false, headerRight: () => null });
     navigation.getParent()?.setOptions({ gestureEnabled: false });
     allowClosingScreen.current = false;
-    const beforeRemoveCallback: EventListenerCallback<
-      StackNavigationEventMap &
-        EventMapCore<StackNavigationState<NavigationProps>>,
-      "beforeRemove"
-    > = e => {
+    const listenerCleanup = navigation.addListener("beforeRemove", e => {
       if (!allowClosingScreen.current) e.preventDefault();
-    };
-    navigation.addListener("beforeRemove", beforeRemoveCallback);
+    });
     return () => {
-      navigation.removeListener("beforeRemove", beforeRemoveCallback);
+      listenerCleanup();
       clearAnimationTimeout();
       cancelAnimation(animDoneValue);
     };

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -4,12 +4,7 @@ import { useTranslation } from "react-i18next";
 import { ScrollView, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
-import {
-  StackNavigationState,
-  EventListenerCallback,
-  EventMapCore,
-  useFocusEffect,
-} from "@react-navigation/native";
+import { useFocusEffect } from "@react-navigation/native";
 import Animated, {
   cancelAnimation,
   interpolate,
@@ -19,7 +14,6 @@ import Animated, {
   withDelay,
   withTiming,
 } from "react-native-reanimated";
-import { StackNavigationEventMap } from "@react-navigation/stack";
 import {
   useAllPostOnboardingActionsCompleted,
   usePostOnboardingHubState,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This fixes a regression that made the Quit Manager confirmation modal show every time even if we didn't have any pending actions as long as we performed one or more actions in that session. So, for example, if you enter manager and install BTC, wait for it to complete and then attempt to quit, it will still prompt you to confirm the action because of pending operations.


### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-4591` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->


### 🚀 Expectations to reach
- User should be able to quit the manager without having to confirm if there are no pending actions running at the time of clicking the back arrow.