### PR TITLE
Fix chainId encoding for Ethereum family transactions

### DIFF
--- a/libs/ledger-live-common/src/families/ethereum/signOperation.ts
+++ b/libs/ledger-live-common/src/families/ethereum/signOperation.ts
@@ -84,6 +84,7 @@ export const signOperation = ({
 
               const { ethTxObject, tx, common, fillTransactionDataResult } =
                 buildEthereumTx(account, transaction, nonce);
+
               const to = eip55.encode((tx.to || "").toString());
               const value = new BigNumber(
                 "0x" + (tx.value.toString("hex") || "0")
@@ -97,7 +98,11 @@ export const signOperation = ({
                 }
 
                 const rawData = tx.raw();
-                rawData[6] = Buffer.from([common.chainIdBN().toNumber()]);
+                rawData[6] = Buffer.from(
+                  common.chainIdBN().toString("hex"),
+                  "hex"
+                );
+
                 return Buffer.from(encode(rawData)).toString("hex");
               })();
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The current way of encoding chainIds caused an issue when encoding larger numbers to hexadecimals.
This PR guarantees that chainIds are correctly encoding as hexadicamals.

### ❓ Context

- **Impacted projects**: `N/A` 
- **Linked resource(s)**: `N/A`

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
