### PR TITLE
Fix: FAT-607: a first improvement on BLE and polling mechanism

### DIFF
--- a/apps/ledger-live-mobile/src/helpers/useResetOnNavigationFocusState.ts
+++ b/apps/ledger-live-mobile/src/helpers/useResetOnNavigationFocusState.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { NavigationProp } from "@react-navigation/native";
+
+// A state that resets to its default value when the screen gets the focus from the navigation mechanism
+export function useResetOnNavigationFocusState<
+  ValueType,
+  NavigationType extends NavigationProp<ReactNavigation.RootParamList>,
+>(
+  navigation: NavigationType,
+  defaultValue: ValueType,
+): [ValueType, React.Dispatch<React.SetStateAction<ValueType>>] {
+  const [value, setValue] = useState<ValueType>(defaultValue);
+
+  useEffect(() => {
+    return navigation.addListener("focus", () => {
+      setValue(defaultValue);
+    });
+  }, [navigation, defaultValue]);
+
+  return [value, setValue];
+}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -207,6 +207,15 @@ export const SyncOnboarding = ({
     stopPolling,
   });
 
+  // Unmount cleanup to make sure the polling is stopped.
+  // The cleanup function triggered by the useEffect of useOnboardingStatePolling
+  // has been observed to be called after, and some apdu could still be exchanged with the device
+  useEffect(() => {
+    return () => {
+      setStopPolling(true);
+    };
+  }, []);
+
   const handleClose = useCallback(() => {
     goBackToPairingFlow();
   }, [goBackToPairingFlow]);

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
@@ -83,9 +83,13 @@ describe("getOnboardingStatePolling", () => {
           pollingPeriodMs,
         }).subscribe({
           next: (value) => {
-            expect(value.onboardingState).toBeNull();
-            expect(value.allowedError).toBeInstanceOf(DisconnectedDevice);
-            done();
+            try {
+              expect(value.onboardingState).toBeNull();
+              expect(value.allowedError).toBeInstanceOf(DisconnectedDevice);
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
           },
         });
 
@@ -106,9 +110,13 @@ describe("getOnboardingStatePolling", () => {
           pollingPeriodMs,
         }).subscribe({
           next: (value) => {
-            expect(value.onboardingState).toBeNull();
-            expect(value.allowedError).toBeInstanceOf(TimeoutError);
-            done();
+            try {
+              expect(value.onboardingState).toBeNull();
+              expect(value.allowedError).toBeInstanceOf(TimeoutError);
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
           },
         });
 
@@ -129,9 +137,13 @@ describe("getOnboardingStatePolling", () => {
           fetchingTimeoutMs,
         }).subscribe({
           next: (value) => {
-            expect(value.onboardingState).toBeNull();
-            expect(value.allowedError).toBeInstanceOf(TimeoutError);
-            done();
+            try {
+              expect(value.onboardingState).toBeNull();
+              expect(value.allowedError).toBeInstanceOf(TimeoutError);
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
           },
         });
 
@@ -151,9 +163,13 @@ describe("getOnboardingStatePolling", () => {
           pollingPeriodMs,
         }).subscribe({
           error: (error) => {
-            expect(error).toBeInstanceOf(Error);
-            expect(error?.message).toBe("Unknown error");
-            done();
+            try {
+              expect(error).toBeInstanceOf(Error);
+              expect(error?.message).toBe("Unknown error");
+              done();
+            } catch (expectError) {
+              done(expectError);
+            }
           },
         });
 
@@ -178,11 +194,15 @@ describe("getOnboardingStatePolling", () => {
         pollingPeriodMs,
       }).subscribe({
         next: (value) => {
-          expect(value.onboardingState).toBeNull();
-          expect(value.allowedError).toBeInstanceOf(
-            DeviceExtractOnboardingStateError
-          );
-          done();
+          try {
+            expect(value.onboardingState).toBeNull();
+            expect(value.allowedError).toBeInstanceOf(
+              DeviceExtractOnboardingStateError
+            );
+            done();
+          } catch (expectError) {
+            done(expectError);
+          }
         },
       });
 
@@ -202,9 +222,13 @@ describe("getOnboardingStatePolling", () => {
         pollingPeriodMs,
       }).subscribe({
         next: (value) => {
-          expect(value.allowedError).toBeNull();
-          expect(value.onboardingState).toEqual(anOnboardingState);
-          done();
+          try {
+            expect(value.allowedError).toBeNull();
+            expect(value.onboardingState).toEqual(anOnboardingState);
+            done();
+          } catch (expectError) {
+            done(expectError);
+          }
         },
         error: (error) => {
           done(error);
@@ -236,8 +260,8 @@ describe("getOnboardingStatePolling", () => {
             expect(value.allowedError).toBeNull();
             expect(spiedRepeatWhen).toHaveBeenCalledTimes(1);
             done();
-          } catch (expectedError) {
-            done(expectedError);
+          } catch (expectError) {
+            done(expectError);
           }
         },
         error: (error) => {

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
@@ -222,25 +222,30 @@ describe("getOnboardingStatePolling", () => {
 
       // Did not manage to test that the polling is repeated by using jest's fake timer
       // and advanceTimersByTime method or equivalent.
-      // Hacky test: spy on the repeat operator to see if it has been called.
-      const spiedRepeat = jest.spyOn(rxjsOperators, "repeat");
+      // Hacky test: spy on the repeatWhen operator to see if it has been called.
+      const spiedRepeatWhen = jest.spyOn(rxjsOperators, "repeatWhen");
 
       onboardingStatePollingSubscription = getOnboardingStatePolling({
         deviceId: device.deviceId,
         pollingPeriodMs,
+        fetchingTimeoutMs: pollingPeriodMs * 10,
       }).subscribe({
         next: (value) => {
-          expect(value.onboardingState).toEqual(anOnboardingState);
-          expect(value.allowedError).toBeNull();
-          expect(spiedRepeat).toHaveBeenCalledTimes(1);
-          done();
+          try {
+            expect(value.onboardingState).toEqual(anOnboardingState);
+            expect(value.allowedError).toBeNull();
+            expect(spiedRepeatWhen).toHaveBeenCalledTimes(1);
+            done();
+          } catch (expectedError) {
+            done(expectedError);
+          }
         },
         error: (error) => {
           done(error);
         },
       });
 
-      jest.runOnlyPendingTimers();
+      jest.advanceTimersByTime(1);
     });
   });
 });

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -7,7 +7,14 @@ import {
   Observable,
   TimeoutError,
 } from "rxjs";
-import { map, catchError, repeat, first, timeout } from "rxjs/operators";
+import {
+  map,
+  catchError,
+  first,
+  timeout,
+  repeatWhen,
+  delay,
+} from "rxjs/operators";
 import getVersion from "./getVersion";
 import { withDevice } from "./deviceAccess";
 import {
@@ -50,97 +57,79 @@ export const getOnboardingStatePolling = ({
   pollingPeriodMs,
   fetchingTimeoutMs = pollingPeriodMs,
 }: GetOnboardingStatePollingArgs): GetOnboardingStatePollingResult => {
-  let firstRun = true;
+  const getOnboardingStateOnce =
+    (): Observable<OnboardingStatePollingResult> => {
+      const firmwareInfoOrAllowedErrorObservable = withDevice(deviceId)((t) =>
+        from(getVersion(t))
+      ).pipe(
+        timeout(fetchingTimeoutMs), // Throws a TimeoutError
+        first(),
+        catchError((error: any) => {
+          if (isAllowedOnboardingStatePollingError(error)) {
+            // Pushes the error to the next step to be processed (no retry from the beginning)
+            return of(error);
+          }
 
-  const delayedOnceOnboardingStateObservable: Observable<OnboardingStatePollingResult> =
-    new Observable((subscriber) => {
-      const delayMs = firstRun ? 0 : pollingPeriodMs;
-      firstRun = false;
+          return throwError(error);
+        })
+      );
 
-      const getOnboardingStateOnce = () => {
-        const firmwareInfoOrAllowedErrorObservable = withDevice(deviceId)((t) =>
-          from(getVersion(t))
-        ).pipe(
-          timeout(fetchingTimeoutMs), // Throws a TimeoutError
-          first(),
-          catchError((error: any) => {
-            if (isAllowedOnboardingStatePollingError(error)) {
-              // Pushes the error to the next step to be processed (no retry from the beginning)
-              return of(error);
+      // If an error is catched previously, and this error is "allowed",
+      // the value from the observable is not a FirmwareInfo but an Error
+      const [firmwareInfoObservable, allowedErrorObservable] = partition(
+        firmwareInfoOrAllowedErrorObservable,
+        // TS cannot infer correctly the value given to RxJS partition
+        (value) => Boolean(value?.flags)
+      );
+
+      const onboardingStateFromFirmwareInfoObservable =
+        firmwareInfoObservable.pipe(
+          map((firmwareInfo: FirmwareInfo) => {
+            let onboardingState: OnboardingState | null = null;
+
+            try {
+              onboardingState = extractOnboardingState(firmwareInfo.flags);
+            } catch (error: any) {
+              if (error instanceof DeviceExtractOnboardingStateError) {
+                return {
+                  onboardingState: null,
+                  allowedError: error,
+                };
+              } else {
+                return {
+                  onboardingState: null,
+                  allowedError: new DeviceOnboardingStatePollingError(
+                    `SyncOnboarding: Unknown error while extracting the onboarding state ${
+                      error?.name ?? error
+                    } ${error?.message}`
+                  ),
+                };
+              }
             }
-
-            return throwError(error);
+            return { onboardingState, allowedError: null };
           })
         );
 
-        // If an error is catched previously, and this error is "allowed",
-        // the value from the observable is not a FirmwareInfo but an Error
-        const [firmwareInfoObservable, allowedErrorObservable] = partition(
-          firmwareInfoOrAllowedErrorObservable,
-          // TS cannot infer correctly the value given to RxJS partition
-          (value: any) => Boolean(value?.flags)
+      // Handles the case of an (allowed) Error value
+      const onboardingStateFromAllowedErrorObservable =
+        allowedErrorObservable.pipe(
+          map((allowedError: Error) => {
+            return {
+              onboardingState: null,
+              allowedError: allowedError,
+            };
+          })
         );
 
-        const onboardingStateFromFirmwareInfoObservable =
-          firmwareInfoObservable.pipe(
-            map((firmwareInfo: FirmwareInfo) => {
-              let onboardingState: OnboardingState | null = null;
+      return merge(
+        onboardingStateFromFirmwareInfoObservable,
+        onboardingStateFromAllowedErrorObservable
+      );
+    };
 
-              try {
-                onboardingState = extractOnboardingState(firmwareInfo.flags);
-              } catch (error: any) {
-                if (error instanceof DeviceExtractOnboardingStateError) {
-                  return {
-                    onboardingState: null,
-                    allowedError: error,
-                  };
-                } else {
-                  return {
-                    onboardingState: null,
-                    allowedError: new DeviceOnboardingStatePollingError(
-                      `SyncOnboarding: Unknown error while extracting the onboarding state ${
-                        error?.name ?? error
-                      } ${error?.message}`
-                    ),
-                  };
-                }
-              }
-              return { onboardingState, allowedError: null };
-            })
-          );
-
-        // Handles the case of an (allowed) Error value
-        const onboardingStateFromAllowedErrorObservable =
-          allowedErrorObservable.pipe(
-            map((allowedError: Error) => {
-              return {
-                onboardingState: null,
-                allowedError: allowedError,
-              };
-            })
-          );
-
-        return merge(
-          onboardingStateFromFirmwareInfoObservable,
-          onboardingStateFromAllowedErrorObservable
-        );
-      };
-
-      // Delays the fetch of the onboarding state
-      setTimeout(() => {
-        getOnboardingStateOnce().subscribe({
-          next: (value: OnboardingStatePollingResult) => {
-            subscriber.next(value);
-          },
-          error: (error: any) => {
-            subscriber.error(error);
-          },
-          complete: () => subscriber.complete(),
-        });
-      }, delayMs);
-    });
-
-  return delayedOnceOnboardingStateObservable.pipe(repeat());
+  return getOnboardingStateOnce().pipe(
+    repeatWhen((completed) => completed.pipe(delay(pollingPeriodMs)))
+  );
 };
 
 export const isAllowedOnboardingStatePollingError = (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

During sync onboarding:
- Polling would continue a bit after navigating to another screen (for example when returning back to the BLE pairing screen) 
- This would exchange an apdu with the device, while the BLE scanning would start, making the current device not seen by our BLE library

BLE pairing screen:
- When returning to this screen using our navigation system, the state of the screen would not be reseted, taking the former paired device as the newly paired device

This does not fix every problem, it looks like it's still possible that some apdu are exchanged while the BLE scanning starts, making sometime the previously paired device unseen by the scanning. But this PR does improve our flows, and fix certain scenarios. 

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-607](https://ledgerhq.atlassian.net/browse/FAT-607)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

See on Slack

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
