### PR TITLE
bugfix/LIVE-4623 Fix crash on Android 12+ during FW Update

### DIFF
--- a/.changeset/twelve-plums-rescue.md
+++ b/.changeset/twelve-plums-rescue.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix crash on Android 12+ during Firmware Update

--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -361,3 +361,9 @@ def isNewArchitectureEnabled() {
     // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
+
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+}

--- a/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
     </service>
       <activity
         android:name=".MainActivity"
-        android:label="@string/app_name"
+        android:exported="true"
         android:launchMode="singleInstance"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:windowSoftInputMode="adjustResize"

--- a/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
     </service>
       <activity
         android:name=".MainActivity"
-        android:exported="true"
+        android:label="@string/app_name"
         android:launchMode="singleInstance"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:windowSoftInputMode="adjustResize"

--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/BackgroundRunner.kt
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/BackgroundRunner.kt
@@ -23,7 +23,13 @@ class BackgroundRunner(var context: ReactApplicationContext) : ReactContextBaseJ
         val intent = Intent(context, MainActivity::class.java)
         intent.addCategory(Intent.CATEGORY_LAUNCHER)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-        val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
+
+        val needsFlagMutable = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, intent, if (needsFlagMutable) {
+            PendingIntent.FLAG_IMMUTABLE
+        } else {
+            0
+        })
 
         var builder = NotificationCompat.Builder(context, if (requiresUserInput) {
             MainApplication.HI_NOTIFICATION_CHANNEL

--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -12,13 +12,10 @@ import android.view.WindowManager;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 
 import org.devio.rn.splashscreen.SplashScreen;
 
 import java.util.Locale;
-
-import expo.modules.ReactActivityDelegateWrapper;
 
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 
@@ -77,7 +74,7 @@ public class MainActivity extends ReactActivity {
             }
         }
         super.onCreate(null);
-        /**
+        /*
          * Addresses an inconvenient side-effect of using `password-visible`, that
          * allowed styled texts to be pasted (receiver's address for instance) retaining
          * the styles of the source text.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Starting on Android 12+ a hard requirement was introduced to set a flag on `PendingIntent` that caused a crash when attempting a firmware update. Following the error logs, this PR introduces said flag for affected versions.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-4623` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->


### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

- For both Android < 12 and Android 12+, make sure that the firmware update works correctly without the crash.