### PR TITLE
bugfix/FAT-588 Improve LLM background device communication

### DIFF
--- a/.changeset/cyan-feet-worry.md
+++ b/.changeset/cyan-feet-worry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Allow runner errors to bubble up and not be silenced

--- a/.changeset/giant-walls-march.md
+++ b/.changeset/giant-walls-march.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+Provide a forceful disconnection mechanism for close request on BleTransport

--- a/.changeset/sour-countries-learn.md
+++ b/.changeset/sour-countries-learn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Enabled BLE background capabilities again

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Braze</key>
+	<dict>
+		<key>Endpoint</key>
+		<string>sdk.fra-02.braze.eu</string>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -103,6 +108,7 @@
 	</array>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>bluetooth-central</string>
 		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
@@ -118,10 +124,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>Braze</key>
-	<dict>
-		<key>Endpoint</key>
-		<string>sdk.fra-02.braze.eu</string>
-	</dict>
 </dict>
 </plist>

--- a/libs/ledger-live-common/src/apps/runner.ts
+++ b/libs/ledger-live-common/src/apps/runner.ts
@@ -100,13 +100,15 @@ export const runAllWithProgress = (
   return concat(
     ...getActionPlan(state).map((appOp) => runAppOp(state, appOp, exec))
   ).pipe(
-    map(
-      (event) =>
-        <Action>{
-          type: "onRunnerEvent",
-          event,
-        }
-    ),
+    map((event) => {
+      if (event.type === "runError") {
+        throw event.error;
+      }
+      return <Action>{
+        type: "onRunnerEvent",
+        event,
+      };
+    }),
     scan(reducer, state),
     mergeMap((s) => {
       // Nb if you also want to expose the uninstall queue, feel free.

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -412,7 +412,7 @@ export default class BluetoothTransport extends Transport {
   static disconnect = async (id: any) => {
     log("ble-verbose", `user disconnect(${id})`);
     await bleManager.cancelDeviceConnection(id);
-    await delay(1000);
+    await delay(1000); // Nb Test to improve stability of re-connections.
   };
   id: string;
   device: Device;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR introduces a fix on the runners that allows the internal errors that can occur while installing an app to bubble up and reach the surface device action instead of being treated as false completion positives. 

It also introduces a forceful disconnection timeout when we try to close the connection with a device on the BleTransport, preventing endless awaits if the JavaScript thread is paused in the middle of an exchange. This unlocks cases where we were left in a soft brick state where we couldn't communicate with the device anymore until we rebooted or restarted LLM.

Lastly, it enables (like on BIM) background BLE communication capabilities, allowing us to communicate with the device over BLE for _some time_ making the UX a bit better than abruptly breaking.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile, react-native-hw-transport-ble, ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-588` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

We shouldn't get stuck in a flow regardless of a failure to communicate or complete the flow because of a background or disconnect. 