### PR TITLE
Make playwright runs generate log files exported on the CI

### DIFF
--- a/apps/ledger-live-desktop/src/logger/logger-transport-file.js
+++ b/apps/ledger-live-desktop/src/logger/logger-transport-file.js
@@ -6,9 +6,10 @@ import moment from "moment";
 
 import { add } from "./logger";
 
-export async function enableFileLogger() {
+export async function enableFileLogger(basedir) {
   await app.whenReady();
-  const desktopDir = app.getPath("desktop");
+
+  const desktopDir = basedir || app.getPath("desktop");
 
   const fileT = new winston.transports.File({
     filename: path.join(

--- a/apps/ledger-live-desktop/src/main/setup.js
+++ b/apps/ledger-live-desktop/src/main/setup.js
@@ -23,7 +23,11 @@ if (process.env.DEV_TOOLS || process.env.DEBUG_LOGS) {
 }
 
 if (process.env.DESKTOP_LOGS_FILE) {
-  enableFileLogger();
+  let possiblydir = process.env.DESKTOP_LOGS_FILE;
+  if (possiblydir === "true" || possiblydir === "1") {
+    possiblydir = null; // we will infer the base desktop app folder instead
+  }
+  enableFileLogger(possiblydir);
 }
 
 ipcMain.on("mainCrashTest", () => {

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -67,6 +67,7 @@ const test = base.extend<TestFixtures>({
         PLAYWRIGHT_RUN: true,
         LEDGER_MIN_HEIGHT: 768,
         FEATURE_FLAGS: JSON.stringify(featureFlags),
+        DESKTOP_LOGS_FILE: path.join(__dirname, "../artifacts/logs"),
       },
       env,
     );

--- a/tools/actions/composites/test-desktop/action.yml
+++ b/tools/actions/composites/test-desktop/action.yml
@@ -63,3 +63,4 @@ runs:
           apps/ledger-live-desktop/tests/artifacts/html-report
           apps/ledger-live-desktop/tests/artifacts/coverage
           apps/ledger-live-desktop/tests/artifacts/videos
+          apps/ledger-live-desktop/tests/artifacts/logs


### PR DESCRIPTION

### 📝 Description

<img width="847" alt="Screenshot 2022-11-21 at 11 33 30" src="https://user-images.githubusercontent.com/211411/203028543-5048b06a-eb33-4a50-ba72-2a684dfd88a6.png">


these should be the same logs you get when you do Ctrl+E and they can therefore be opened on https://live.ledger.tools/logsviewer

when we have a very technical problem on a playwright run, this could be useful to look into, for instance of internal process crash, etc..

### ❓ Context

- **Impacted projects**: `LLD tests` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
