### PR TITLE
Fix rendering crash in new device selection screen

### DIFF
--- a/.changeset/brown-pumpkins-crash.md
+++ b/.changeset/brown-pumpkins-crash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix rendering crash in new device selection screen

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { DeviceModelId } from "@ledgerhq/devices";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
 import { useTheme } from "styled-components/native";
 import { Flex } from "@ledgerhq/native-ui";
@@ -17,11 +18,11 @@ import BottomModal from "../BottomModal";
 import { removeKnownDevice } from "../../actions/ble";
 
 const illustrations = {
-  nanoS: NanoS,
-  nanoSP: NanoS,
-  nanoX: NanoX,
-  blue: NanoS,
-  nanoFTS: NanoFTS,
+  [DeviceModelId.nanoS]: NanoS,
+  [DeviceModelId.nanoSP]: NanoS,
+  [DeviceModelId.nanoX]: NanoX,
+  [DeviceModelId.blue]: NanoS,
+  [DeviceModelId.nanoFTS]: NanoFTS,
 };
 
 const RemoveDeviceMenu = ({
@@ -36,11 +37,12 @@ const RemoveDeviceMenu = ({
   const dispatch = useDispatch();
   const { colors } = useTheme();
 
-  const illustration = useMemo(
-    () =>
-      illustrations[device.modelId]({ color: colors.neutral.c100, size: 200 }),
-    [device.modelId, colors],
-  );
+  const illustration = useMemo(() => {
+    const illustration = illustrations[device.modelId];
+    return illustration
+      ? illustration({ color: colors.neutral.c100, size: 200 })
+      : null;
+  }, [device.modelId, colors]);
 
   const onRemoveDevice = useCallback(async () => {
     dispatch(removeKnownDevice(device.deviceId));

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
@@ -37,12 +37,14 @@ const RemoveDeviceMenu = ({
   const dispatch = useDispatch();
   const { colors } = useTheme();
 
-  const illustration = useMemo(() => {
-    const illustration = illustrations[device.modelId];
-    return illustration
-      ? illustration({ color: colors.neutral.c100, size: 200 })
-      : null;
-  }, [device.modelId, colors]);
+  const illustration = useMemo(
+    () =>
+      (illustrations[device.modelId] ?? NanoX)({
+        color: colors.neutral.c100,
+        size: 200,
+      }),
+    [device.modelId, colors],
+  );
 
   const onRemoveDevice = useCallback(async () => {
     dispatch(removeKnownDevice(device.deviceId));

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -69,7 +69,7 @@ export type DeviceLike = {
   name: string;
   deviceInfo?: DeviceInfo;
   appsInstalled?: number;
-  modelId?: DeviceModelId;
+  modelId: DeviceModelId;
 };
 
 export type BleState = {

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -6,7 +6,7 @@ import { timeout, tap } from "rxjs/operators";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
 import getDeviceName from "@ledgerhq/live-common/hw/getDeviceName";
 import { listApps } from "@ledgerhq/live-common/apps/hw";
-import type { DeviceModelId } from "@ledgerhq/devices";
+import { DeviceModelId } from "@ledgerhq/devices";
 import { delay } from "@ledgerhq/live-common/promise";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "@react-navigation/native";
@@ -125,7 +125,7 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
       const device = {
         deviceName: bleDevice.name,
         deviceId: bleDevice.id,
-        modelId: "nanoX",
+        modelId: deviceMeta?.modelId ?? DeviceModelId.nanoX,
         wired: false,
       };
       dispatch({
@@ -187,12 +187,12 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
               name,
               deviceInfo,
               appsInstalled,
-              modelId: device.modelId as DeviceModelId,
+              modelId: device.modelId,
             }),
           );
           dispatchRedux(
             setLastSeenDeviceInfo({
-              modelId: device.modelId as DeviceModelId,
+              modelId: device.modelId,
               deviceInfo,
               apps: appsInstalled || [],
             }),

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -227,6 +227,7 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
         addKnownDevice({
           id: device.deviceId,
           name: name ?? device.deviceName ?? "",
+          modelId: device.modelId,
         }),
       );
       dispatch({

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -187,7 +187,7 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
               name,
               deviceInfo,
               appsInstalled,
-              modelId: deviceMeta?.modelId,
+              modelId: device.modelId as DeviceModelId,
             }),
           );
           dispatchRedux(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The issue is logged [on Sentry](https://sentry.io/organizations/ledger/issues/3747163866/?project=6619346&referrer=project-issue-stream) but I could not find a way to reproduce it. It is probably due to us saving the device without saving the model id somewhere. So there is 1 place where this has been fixed.
If there is no device id, then no illustration is found for the device id and it would crash (`undefined is not a function`).

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-661] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-661]: https://ledgerhq.atlassian.net/browse/FAT-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ