### PR TITLE
FAT-659 Automatically select last seen device if compatible for CLS

### DIFF
--- a/.changeset/warm-fishes-talk.md
+++ b/.changeset/warm-fishes-talk.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Auto-select the last connected device for CLS if it is a Nano FTS

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { ScrollView } from "react-native";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Flex } from "@ledgerhq/native-ui";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -17,6 +17,7 @@ import {
   StackNavigatorProps,
 } from "../../components/RootNavigator/types/helpers";
 import { CustomImageNavigatorParamList } from "../../components/RootNavigator/types/CustomImageNavigator";
+import { lastConnectedDeviceSelector } from "../../reducers/settings";
 
 const deviceModelIds = [DeviceModelId.nanoFTS];
 
@@ -43,7 +44,15 @@ type NavigationProps = BaseComposite<
 const Step3Transfer = ({ route, navigation }: NavigationProps) => {
   const dispatch = useDispatch();
   const { rawData, device: deviceFromRoute, previewData } = route.params;
+
   const [device, setDevice] = useState<Device | null>(deviceFromRoute);
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+
+  useEffect(() => {
+    if (!device && lastConnectedDevice?.modelId === DeviceModelId.nanoFTS) {
+      setDevice(lastConnectedDevice);
+    }
+  }, [lastConnectedDevice, device]);
 
   const handleError = useCallback(
     (error: Error) => {


### PR DESCRIPTION
### 📝 Description
This PR changes slightly the CLS flow so it auto-selects a device for the image when the last connected device is an FTS. 

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**:  [FAT-659]

### ✅ Checklist

- [ ] **Test coverage** - N/A
- [x] **Atomic delivery** 
- [x] **No breaking changes**


### 📸 Demo
N/A


[FAT-659]: https://ledgerhq.atlassian.net/browse/FAT-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ