### PR TITLE
bot engine to include spec mutation with .error

### DIFF
--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -282,7 +282,7 @@ export async function bot({
       !s.fatalError &&
       s.mutations &&
       !specsWithoutFunds.includes(s) &&
-      s.mutations.some((r) => r.mutation && !r.operation)
+      s.mutations.some((r) => r.error || (r.mutation && !r.operation))
   );
 
   const specsWithoutOperations = results.filter(


### PR DESCRIPTION


### 📝 Description

it was assumed that having a .mutation & !.operation was synonym to having errors but it doesn't include the error that could happen before even reaching mutation

that technically means that the bot was only raising (on slack / in the description summary) a partial version of all spec having errors

for instance, in this screenshot you see no mention of "Viacoin" in the "5 specs have problems", yet there is a critical problem at stake (maybe during estimation of max spendable)

![Screenshot 2022-11-22 at 14 51 01](https://user-images.githubusercontent.com/211411/203330796-9a9722ce-2fc7-4484-80fd-a7467d229523.png)


### ❓ Context

- **Impacted projects**: `lld bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** tested by this PR as it will trigger the bot <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
