### PR TITLE
fix(ci): generate-screenshot to use is-fork now

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -46,18 +46,17 @@ jobs:
               body,
             })
 
-  is-org-member:
-    name: "Check Org Member"
-    uses: ./.github/workflows/is-org-member.yml
+  pr-is-fork:
+    name: "Check if the PR is a fork"
+    uses: ledgerhq/ledger-live/.github/workflows/pr-is-fork.yml@develop
     with:
-      username: ${{ github.event.inputs.login }}
-      organisation: ledgerhq
+      non-pr-result: false
     secrets:
       token: ${{ secrets.COMMON_READ_ORG }}
 
   generate-screenshots:
-    needs: [is-org-member]
-    if: ${{ fromJSON(needs.is-org-member.outputs.is-org-member) }}
+    needs: [pr-is-fork]
+    if: ${{ !fromJSON(needs.pr-is-fork.outputs.pr-is-fork) }}
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
@@ -104,8 +103,8 @@ jobs:
           turbo-server-port: ${{ steps.turborepo-cache-server.outputs.port }}
 
   generate-screenshots-mac-internal:
-    needs: [is-org-member]
-    if: ${{ fromJSON(needs.is-org-member.outputs.is-org-member) }}
+    needs: [pr-is-fork]
+    if: ${{ !fromJSON(needs.pr-is-fork.outputs.pr-is-fork) }}
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

`generate-screenshot` action is using the old `is-org-member` action (dead now). Updated it to use `is-fork` instead

### ❓ Context

- **Impacted projects**: `automation` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: Slack <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

If it runs correctly we are golden 
We are golden (_edited_)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
