### PR TITLE
[LIVE-4684] Bugfix - Wrong prepareTransaction gasPrice with EIP1559

### DIFF
--- a/.changeset/warm-dolphins-study.md
+++ b/.changeset/warm-dolphins-study.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix Ethereum send max transactions using the wrong fee per gas method with EIP1559

--- a/libs/ledger-live-common/src/families/ethereum/__tests__/transaction.unit.test.ts
+++ b/libs/ledger-live-common/src/families/ethereum/__tests__/transaction.unit.test.ts
@@ -4,12 +4,76 @@ import { ethereum1 } from "../datasets/ethereum1";
 import { Transaction } from "../types";
 import { modes } from "../modules";
 import { fail } from "assert";
+import BigNumber from "bignumber.js";
 
-const account = fromAccountRaw(ethereum1);
+const ethAccount = fromAccountRaw(ethereum1);
+const bscAccount = fromAccountRaw({
+  ...ethereum1,
+  currencyId: "bsc",
+});
+
+const ONE_ETH = new BigNumber("1000000000000000000"); // 1 ETH
 
 describe("Ethereum transaction tests", () => {
   describe("modules", () => {
     describe("fillTransactionData", () => {
+      describe("Send", () => {
+        const mode = modes["send"];
+        it("should get the right amount for a send max transaction with EIP1559", () => {
+          const ethAccountWithBalance = {
+            ...ethAccount,
+            spendableBalance: ONE_ETH,
+            balance: ONE_ETH,
+          };
+          const sendMaxTransaction = {
+            ...createTransaction(),
+            recipient: "0xc3f95102D5c8F2c83e49Ce3Acfb905eDfb7f37dE",
+            useAllAmount: true,
+            maxFeePerGas: new BigNumber(1000000000), // 1 Gwei
+            useGasLimit: new BigNumber(21000),
+          };
+          const txData = {};
+
+          mode.fillTransactionData(
+            ethAccountWithBalance,
+            sendMaxTransaction,
+            txData
+          );
+
+          expect(txData).toEqual({
+            value: "0xde0a39a35d9b000", // 999979000000000000 (1000000000000000000 - (21000 * 1000000000))
+            to: sendMaxTransaction.recipient,
+          });
+        });
+
+        it("should get the right amount for a send max transaction without EIP1559", () => {
+          const bscAccountWithBalance = {
+            ...bscAccount,
+            spendableBalance: ONE_ETH,
+            balance: ONE_ETH,
+          };
+          const sendMaxTransaction = {
+            ...createTransaction(),
+            recipient: "0xc3f95102D5c8F2c83e49Ce3Acfb905eDfb7f37dE",
+            useAllAmount: true,
+            gasPrice: new BigNumber(1000000000), // 1 Gwei
+            useGasLimit: new BigNumber(21000),
+          };
+          const txData = {};
+
+          mode.fillTransactionData(
+            bscAccountWithBalance,
+            sendMaxTransaction,
+            txData
+          );
+
+          expect(txData).toEqual({
+            value: "0xde0a39a35d9b000", // 999979000000000000 (1000000000000000000 - (21000 * 1000000000))
+            to: sendMaxTransaction.recipient,
+          });
+        });
+      });
+
       describe("ERC1155", () => {
         const mode = modes["erc1155.transfer"];
         it("should not break on transaction quantities filled with null values", () => {
@@ -23,7 +87,7 @@ describe("Ethereum transaction tests", () => {
           const txData = {};
 
           try {
-            mode.fillTransactionData(account, transaction, txData);
+            mode.fillTransactionData(ethAccount, transaction, txData);
             expect(txData).toEqual({
               data: "0x2eb2c2d60000000000000000000000000e3f0bb9516f01f2c34c25e0957518b8ac9414c5000000000000000000000000c3f95102d5c8f2c83e49ce3acfb905edfb7f37de00000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000043078303000000000000000000000000000000000000000000000000000000000",
               to: transaction.collection,
@@ -47,7 +111,7 @@ describe("Ethereum transaction tests", () => {
           const txData = {};
 
           try {
-            mode.fillTransactionData(account, transaction, txData);
+            mode.fillTransactionData(ethAccount, transaction, txData);
             expect(txData).toEqual({
               data: "0xb88d4fde0000000000000000000000000e3f0bb9516f01f2c34c25e0957518b8ac9414c5000000000000000000000000c3f95102d5c8f2c83e49ce3acfb905edfb7f37de0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000043078303000000000000000000000000000000000000000000000000000000000",
               to: transaction.collection,

--- a/libs/ledger-live-common/src/families/ethereum/modules/send.ts
+++ b/libs/ledger-live-common/src/families/ethereum/modules/send.ts
@@ -10,7 +10,11 @@ import {
   NotEnoughBalanceInParentAccount,
   AmountRequired,
 } from "@ledgerhq/errors";
-import { inferTokenAccount, getGasLimit } from "../transaction";
+import {
+  inferTokenAccount,
+  getGasLimit,
+  EIP1559ShouldBeUsed,
+} from "../transaction";
 export type Modes = "send";
 const send: ModeModule = {
   fillTransactionStatus(a, t, result) {
@@ -80,7 +84,10 @@ const send: ModeModule = {
 
       if (t.useAllAmount) {
         const gasLimit = getGasLimit(t);
-        amount = a.spendableBalance.minus(gasLimit.times(t.gasPrice || 0));
+        const feePerGas = EIP1559ShouldBeUsed(a.currency)
+          ? t.maxFeePerGas
+          : t.gasPrice;
+        amount = a.spendableBalance.minus(gasLimit.times(feePerGas || 0));
       } else {
         invariant(t.amount, "amount is missing");
         amount = t.amount;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes wrong amount estimation in send mode`prepareTransaction` when during a send max.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-4684 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/44363395/203337722-cf0116f6-9ab9-42dd-a97a-89964b978f2e.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
