### PR TITLE
LIVE-3475: Enable Solana in swap

### DIFF
--- a/libs/ledger-live-common/src/exchange/index.ts
+++ b/libs/ledger-live-common/src/exchange/index.ts
@@ -19,6 +19,7 @@ const exchangeSupportAppVersions = {
   litecoin: "1.5.0",
   qtum: "1.5.0",
   ripple: "2.1.0",
+  solana: "1.4.0",
   stellar: "3.3.0",
   stratis: "1.5.0",
   tezos: "2.2.13",

--- a/libs/ledger-live-common/src/families/solana/exchange.ts
+++ b/libs/ledger-live-common/src/families/solana/exchange.ts
@@ -1,0 +1,16 @@
+import { bip32asBuffer } from "@ledgerhq/hw-app-btc/bip32";
+
+const getSerializedAddressParameters = (
+  path: string
+): {
+  addressParameters: Buffer;
+} => {
+  const addressParameters = bip32asBuffer(path);
+  return {
+    addressParameters,
+  };
+};
+
+export default {
+  getSerializedAddressParameters,
+};

--- a/libs/ledger-live-common/src/generated/exchange.ts
+++ b/libs/ledger-live-common/src/generated/exchange.ts
@@ -1,15 +1,15 @@
 import bitcoin from "../families/bitcoin/exchange";
 import ethereum from "../families/ethereum/exchange";
 import ripple from "../families/ripple/exchange";
+import solana from "../families/solana/exchange";
 import stellar from "../families/stellar/exchange";
 import tezos from "../families/tezos/exchange";
-import solana from "../families/solana/exchange";
 
 export default {
   bitcoin,
   ethereum,
   ripple,
+  solana,
   stellar,
   tezos,
-  solana
 };

--- a/libs/ledger-live-common/src/generated/exchange.ts
+++ b/libs/ledger-live-common/src/generated/exchange.ts
@@ -3,6 +3,7 @@ import ethereum from "../families/ethereum/exchange";
 import ripple from "../families/ripple/exchange";
 import stellar from "../families/stellar/exchange";
 import tezos from "../families/tezos/exchange";
+import solana from "../families/solana/exchange";
 
 export default {
   bitcoin,
@@ -10,4 +11,5 @@ export default {
   ripple,
   stellar,
   tezos,
+  solana
 };


### PR DESCRIPTION
### 📝 Description

Enable Solana support in swap.

### ❓ Context

- **Impacted projects**: LLD, LLM
- **Linked resource(s)**:
    - https://ledgerhq.atlassian.net/browse/LIVE-3475
    - https://ledgerhq.atlassian.net/browse/BACK-3827

### ✅ Checklist

- [ ] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo

TODO

### 🚀 Expectations to reach

Solana from/to swaps works with Changelly and CIC.
