### PR TITLE
[LIVE-4698][LIVE-4702] Bugfix - Fix ethereum send max on dusty account and getTransactionStatus not being triggered

### DIFF
--- a/.changeset/shaggy-chairs-end.md
+++ b/.changeset/shaggy-chairs-end.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fixing ethereum prepareTransaction breaking before the getTransactionStatus and fixing send max on account with only dust

--- a/libs/ledger-live-common/src/families/ethereum/__tests__/transaction.unit.test.ts
+++ b/libs/ledger-live-common/src/families/ethereum/__tests__/transaction.unit.test.ts
@@ -72,6 +72,29 @@ describe("Ethereum transaction tests", () => {
             to: sendMaxTransaction.recipient,
           });
         });
+
+        it("should not return a negative amount for a send max", () => {
+          const ethEmptyAccount = {
+            ...ethAccount,
+            spendableBalance: new BigNumber(0), // empty account
+            balance: new BigNumber(0), // empty account
+          };
+          const sendMaxTransaction = {
+            ...createTransaction(),
+            recipient: "0xc3f95102D5c8F2c83e49Ce3Acfb905eDfb7f37dE",
+            useAllAmount: true,
+            maxFeePerGas: new BigNumber(1000000000), // 1 Gwei
+            useGasLimit: new BigNumber(21000),
+          };
+          const txData = {};
+
+          mode.fillTransactionData(ethEmptyAccount, sendMaxTransaction, txData);
+
+          expect(txData).toEqual({
+            value: "0x0", // theorically this should be negative as the account has 0 ETH but transaction still has fees
+            to: sendMaxTransaction.recipient,
+          });
+        });
       });
 
       describe("ERC1155", () => {

--- a/libs/ledger-live-common/src/families/ethereum/modules/send.ts
+++ b/libs/ledger-live-common/src/families/ethereum/modules/send.ts
@@ -87,7 +87,11 @@ const send: ModeModule = {
         const feePerGas = EIP1559ShouldBeUsed(a.currency)
           ? t.maxFeePerGas
           : t.gasPrice;
-        amount = a.spendableBalance.minus(gasLimit.times(feePerGas || 0));
+        // Prevents a send max with a negative amount
+        amount = BigNumber.maximum(
+          a.spendableBalance.minus(gasLimit.times(feePerGas || 0)),
+          0
+        );
       } else {
         invariant(t.amount, "amount is missing");
         amount = t.amount;

--- a/libs/ledger-live-common/src/families/ethereum/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/families/ethereum/prepareTransaction.ts
@@ -11,6 +11,7 @@ import { isEthereumAddress } from "./logic";
 import { NetworkInfo, Transaction } from "./types";
 import { buildEthereumTx, EIP1559ShouldBeUsed } from "./transaction";
 import { prepareTransaction as prepareTransactionModules } from "./modules";
+import { findSubAccountById } from "../../account";
 
 export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"] =
   async (account, tx) => {
@@ -49,22 +50,38 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
 
     let estimatedGasLimit;
     if (isEthereumAddress(tx.recipient)) {
-      const { tx: transaction } = buildEthereumTx(
-        account,
-        tx,
-        account.operationsCount
-      );
-      invariant(transaction.to, "ethereum transaction has no recipient");
+      // building a bear minimum transaction for gas estimation
+      const protoTransaction = (() => {
+        try {
+          return buildEthereumTx(account, tx, account.operationsCount).tx;
+        } catch (e) {
+          // fallback in case @ethereumjs/tx breaks on building a potentially partial transaction
+          const subAccount = tx.subAccountId
+            ? findSubAccountById(account, tx.subAccountId)
+            : null;
+          const recipient =
+            subAccount?.type === "TokenAccount"
+              ? subAccount.token.contractAddress
+              : tx.recipient;
+          return {
+            from: account.freshAddress,
+            to: recipient,
+            data: undefined,
+            value: tx.amount,
+          };
+        }
+      })();
+      invariant(protoTransaction.to, "ethereum transaction has no recipient");
 
       estimatedGasLimit = await estimateGasLimit(
         account,
-        transaction.to!.toString(),
+        protoTransaction.to!.toString(),
         // Those are the only elements from a transaction necessary to estimate the gas limit
         {
           from: account.freshAddress,
-          value: "0x" + (transaction.value.toString(16) || "00"),
-          data: transaction.data
-            ? `0x${transaction.data.toString("hex")}`
+          value: "0x" + (protoTransaction.value.toString(16) || "00"),
+          data: protoTransaction.data
+            ? `0x${protoTransaction.data.toString("hex")}`
             : "0x",
         }
       );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixing an error when Ethereum accounts with only dust in it where trying to do a send max.
Fixing the `getTransactionStatus` not being triggered because of `@ethereumjs/tx` throwing in `prepareTransaction` 

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: 
- https://ledgerhq.atlassian.net/browse/LIVE-4698
- https://ledgerhq.atlassian.net/browse/LIVE-4702 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Send max on dusty account


https://user-images.githubusercontent.com/44363395/203549156-23c9d899-0733-40f7-ae89-39479d0b9f51.mp4



getTransactionStatus


https://user-images.githubusercontent.com/44363395/203549084-250a1d17-c0c0-4df3-a640-e8781f319f29.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
