### PR TITLE
Allows ci-test-integration to pass without test

### DIFF
--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -79,7 +79,7 @@
     "ci-lint": "pnpm lint",
     "test": "pnpm ci-test-unit",
     "ci-test-unit": "env-cmd -f .ci.unit.env pnpm jest --ci --updateSnapshot && git diff --exit-code src",
-    "ci-test-integration": "env-cmd -f .ci.integration.env pnpm jest --ci --updateSnapshot"
+    "ci-test-integration": "env-cmd -f .ci.integration.env pnpm jest --ci --updateSnapshot --passWithNoTests"
   },
   "files": [
     "lib",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

a edge case of previously introduce feature (https://github.com/LedgerHQ/ledger-live/pull/1888)
is that if a live-common/src file is modified not inside a folder that have a nearby `.integration.test.ts`
it will fail, like experienced in https://github.com/LedgerHQ/ledger-live/pull/1871

### ❓ Context

- **Impacted projects**: `n/a` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** to test this, i'll send a integration test against this PR with a dummy filter <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
  - this should fail (develop version): https://github.com/LedgerHQ/ledger-live/actions/runs/3548919712 
  - this should succeed (this pr): https://github.com/LedgerHQ/ledger-live/actions/runs/3548933751
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
