### PR TITLE
Improve layout in ValidateOnDevice

### DIFF
--- a/.changeset/funny-ants-accept.md
+++ b/.changeset/funny-ants-accept.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Device actions: remove unnecessary padding & replace huge text by smaller text

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -109,24 +109,12 @@ const CenteredText = styled(Text).attrs({
   textAlign: "center",
 })``;
 
-const TitleContainer = styled(Flex).attrs({
-  py: 8,
-})``;
-
-const TitleText = ({
-  children,
-  disableUppercase,
-}: {
-  children: React.ReactNode;
-  disableUppercase?: boolean;
-}) => (
-  <TitleContainer>
-    <Log
-      extraTextProps={disableUppercase ? { textTransform: "none" } : undefined}
-    >
+export const TitleText = ({ children }: { children: React.ReactNode }) => (
+  <Flex>
+    <Text textAlign="center" variant="h4" fontWeight="semiBold">
       {children}
-    </Log>
-  </TitleContainer>
+    </Text>
+  </Flex>
 );
 
 const DescriptionText = styled(CenteredText).attrs({

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -19,10 +19,13 @@ import {
   Flex,
   Tag,
   Icons,
-  Log,
   BoxedIcon,
+  Log,
 } from "@ledgerhq/native-ui";
-import { LockAltMedium } from "@ledgerhq/native-ui/assets/icons";
+import {
+  LockAltMedium,
+  DownloadMedium,
+} from "@ledgerhq/native-ui/assets/icons";
 import BigNumber from "bignumber.js";
 import {
   ExchangeRate,
@@ -37,7 +40,6 @@ import {
 import { TFunction } from "react-i18next";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
-import { DownloadMedium } from "@ledgerhq/native-ui/assets/icons";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { ParamListBase } from "@react-navigation/native";
@@ -231,7 +233,11 @@ export function renderVerifyAddress({
             onPress={onPress}
           />
         )}
-        {address && <TitleText disableUppercase>{address}</TitleText>}
+        {address && (
+          <Flex py={8}>
+            <Log extraTextProps={{ textTransform: "none" }}>{address}</Log>
+          </Flex>
+        )}
       </ActionContainer>
     </Wrapper>
   );

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
@@ -186,12 +186,14 @@ export default function ValidateOnDevice({
   const isBigLottie = device.modelId === DeviceModelId.nanoFTS;
 
   return (
-    <RootContainer>
+    <Flex flex={1}>
       <ScrollView
-        // @ts-expect-error this property actually working and the only way to do what we want (contentContainerStyle doesn't work)
-        justifyContent="center"
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: "center",
+        }}
       >
-        <InnerContainer>
+        <Flex alignItems="center">
           <Flex marginBottom={isBigLottie ? 0 : 8}>
             <Animation
               source={getDeviceAnimation({ device, key: "validate", theme })}
@@ -241,7 +243,7 @@ export default function ValidateOnDevice({
               />
             ) : null}
           </DataRowsContainer>
-        </InnerContainer>
+        </Flex>
       </ScrollView>
       {Footer ? (
         <Footer transaction={transaction} recipientWording={recipientWording} />
@@ -250,21 +252,11 @@ export default function ValidateOnDevice({
           <Alert type="help">{recipientWording}</Alert>
         </Flex>
       )}
-    </RootContainer>
+    </Flex>
   );
 }
-
-const RootContainer = styled(Flex).attrs({
-  flex: 1,
-})``;
 
 const DataRowsContainer = styled(Flex).attrs({
   my: 7,
   alignSelf: "stretch",
-})``;
-
-const InnerContainer = styled(Flex).attrs({
-  flexDirection: "column",
-  alignItems: "center",
-  flex: 1,
 })``;

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
@@ -21,12 +21,14 @@ import { getDeviceModel } from "@ledgerhq/devices";
 
 import { useTheme } from "@react-navigation/native";
 import styled from "styled-components/native";
-import { Flex, Log } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import Alert from "./Alert";
 import perFamilyTransactionConfirmFields from "../generated/TransactionConfirmFields";
 import { DataRowUnitValue, TextValueField } from "./ValidateOnDeviceDataRow";
 import Animation from "./Animation";
 import { getDeviceAnimation } from "../helpers/getDeviceAnimation";
+import { TitleText } from "./DeviceAction/rendering";
 
 export type FieldComponentProps = {
   account: AccountLike;
@@ -181,15 +183,20 @@ export default function ValidateOnDevice({
       ? transTitleWording
       : t("ValidateOnDevice.title.send", getDeviceModel(device.modelId));
 
+  const isBigLottie = device.modelId === DeviceModelId.nanoFTS;
+
   return (
     <RootContainer>
-      <ScrollContainer>
+      <ScrollView
+        // @ts-expect-error this property actually working and the only way to do what we want (contentContainerStyle doesn't work)
+        justifyContent="center"
+      >
         <InnerContainer>
-          <AnimationContainer>
+          <Flex marginBottom={isBigLottie ? 0 : 8}>
             <Animation
               source={getDeviceAnimation({ device, key: "validate", theme })}
             />
-          </AnimationContainer>
+          </Flex>
           {Title ? (
             <Title
               account={account}
@@ -235,13 +242,13 @@ export default function ValidateOnDevice({
             ) : null}
           </DataRowsContainer>
         </InnerContainer>
-      </ScrollContainer>
+      </ScrollView>
       {Footer ? (
         <Footer transaction={transaction} recipientWording={recipientWording} />
       ) : (
-        <FooterContainer>
+        <Flex>
           <Alert type="help">{recipientWording}</Alert>
-        </FooterContainer>
+        </Flex>
       )}
     </RootContainer>
   );
@@ -252,36 +259,12 @@ const RootContainer = styled(Flex).attrs({
 })``;
 
 const DataRowsContainer = styled(Flex).attrs({
-  marginVertical: 24,
+  my: 7,
   alignSelf: "stretch",
 })``;
 
 const InnerContainer = styled(Flex).attrs({
   flexDirection: "column",
-  justifyContent: "center",
   alignItems: "center",
   flex: 1,
 })``;
-
-const FooterContainer = styled(Flex).attrs({
-  padding: 16,
-})``;
-
-const AnimationContainer = styled(Flex).attrs({
-  marginBottom: 40,
-})``;
-
-const ScrollContainer = styled(ScrollView)`
-  flex: 1;
-  padding: 16px;
-`;
-
-const TitleContainer = styled(Flex).attrs({
-  py: 8,
-})``;
-
-const TitleText = ({ children }: { children: React.ReactNode }) => (
-  <TitleContainer>
-    <Log>{children}</Log>
-  </TitleContainer>
-);

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import React, { useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { createAction } from "@ledgerhq/live-common/hw/actions/transaction";
@@ -272,7 +272,7 @@ export default function ConnectDevice({ route, navigation }: Props) {
   );
 }
 
-const edges = ["bottom"];
+const edges = ["bottom"] as Edge[];
 
 const styles = StyleSheet.create({
   root: {

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -238,6 +238,7 @@ export default function ConnectDevice({ route, navigation }: Props) {
     () =>
       transaction ? (
         <SafeAreaView
+          edges={edges}
           style={[
             styles.root,
             {
@@ -270,6 +271,9 @@ export default function ConnectDevice({ route, navigation }: Props) {
     [status, transaction, tokenCurrency, route.params.device],
   );
 }
+
+const edges = ["bottom"];
+
 const styles = StyleSheet.create({
   root: {
     flex: 1,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Device actions have so much padding all over the place that some critical info is out of view and on some screens you need to (not obviously) scroll to see it. This is even worse with some of the bigger lottie animations where the title is not even visible depending on the screen size.
This particular screen has been validated with Aamir from design by the way, I'm not just improvising.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-689] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

#### Before (this is on an Android device with the display settings set to "big" to emulate what it would be like on a smaller screen): the essential info is almost out of the visible part of the scroll view.

https://user-images.githubusercontent.com/91890529/204019280-29c6e685-247e-4a49-866e-4d086235acfc.mp4


#### After: much more space and room for more information without scrolling

<img width="478" alt="Screenshot 2022-11-25 at 16 31 30" src="https://user-images.githubusercontent.com/91890529/204019288-fd9d3fd1-4b63-4ef4-9889-d2f32fe792eb.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-689]: https://ledgerhq.atlassian.net/browse/FAT-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ