### PR TITLE
LIVE-2627 Revert change key on mobile for usemax

### DIFF
--- a/.changeset/real-bees-roll.md
+++ b/.changeset/real-bees-roll.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Revert mobile usemax key to original

--- a/apps/ledger-live-mobile/src/screens/Lending/shared/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Lending/shared/01-Amount.tsx
@@ -208,7 +208,7 @@ export default function AmountScreen({
                       </View>
                       <View style={styles.availableRight}>
                         <LText style={styles.maxLabel}>
-                          <Trans i18nKey="send.amount.sendMax" />
+                          <Trans i18nKey="send.amount.useMax" />
                         </LText>
                         <Switch
                           value={useAllAmount || false}

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -191,7 +191,7 @@ export default function SendAmountCoin({ navigation, route }: Props) {
                   {typeof useAllAmount === "boolean" ? (
                     <View style={styles.availableRight}>
                       <LText style={styles.maxLabel} color="grey">
-                        <Trans i18nKey="send.amount.sendMax" />
+                        <Trans i18nKey="send.amount.useMax" />
                       </LText>
                       <Switch
                         style={styles.switch}

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Max.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Max.tsx
@@ -10,7 +10,7 @@ export function Max({ swapTx }: { swapTx: SwapTransactionType }) {
     <Flex alignSelf="flex-end" flexDirection="row" alignItems="center">
       <Flex flexDirection="row" alignItems="center" paddingY={4}>
         <Text variant="small" paddingRight={2}>
-          {t("transfer.swap2.form.amount.sendMax")}
+          {t("transfer.swap2.form.amount.useMax")}
         </Text>
 
         <Switch


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Mobile key wasn't translate so we revert change to make it only appears on desktop and have no impact in mobile

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-2627 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
