### PR TITLE
docs: rename methods in out of date README

### DIFF
--- a/libs/ledgerjs/packages/hw-app-btc/README.md
+++ b/libs/ledgerjs/packages/hw-app-btc/README.md
@@ -182,7 +182,7 @@ You can sign a message according to the Bitcoin Signature format and retrieve v,
 ##### Examples
 
 ```javascript
-btc.signMessageNew_async("44'/60'/0'/0'/0", Buffer.from("test").toString("hex")).then(function(result) {
+btc.signMessageNew("44'/60'/0'/0'/0", Buffer.from("test").toString("hex")).then(function(result) {
 var v = result['v'] + 27 + 4;
 var signature = Buffer.from(v.toString(16) + result['r'] + result['s'], 'hex').toString('base64');
 console.log("Signature : " + signature);
@@ -232,7 +232,7 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### signP2SHTransaction
 
-To obtain the signature of multisignature (P2SH) inputs, call signP2SHTransaction_async with the folowing parameters
+To obtain the signature of multisignature (P2SH) inputs, call signP2SHTransaction with the folowing parameters
 
 ##### Parameters
 


### PR DESCRIPTION
### 📝 Description

This is a simple update of hw-app-btc README regarding the 'signMessageNew' and 'signP2SHTransaction' methods. They had an "_async" suffix appended to their name which did not match any actually existing method. This is probably their older name, which is why I did not make the change in the `BtcOld` part of the documentation. Although this might be necessary too.