### PR TITLE
feat/FAT-690 Support for custom image storage in logic + UI

### DIFF
--- a/.changeset/calm-bulldogs-crash.md
+++ b/.changeset/calm-bulldogs-crash.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+LLD React to custom image loading and reflect the space taken by it

--- a/.changeset/chatty-spies-wash.md
+++ b/.changeset/chatty-spies-wash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM React to custom image loading and reflect the space taken by it

--- a/.changeset/slimy-tigers-invite.md
+++ b/.changeset/slimy-tigers-invite.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add support for custom image storage usage in the list apps and distribution logic

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.js
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.js
@@ -119,6 +119,16 @@ export const hideNftCollection = (collectionId: string) => ({
   type: "HIDE_NFT_COLLECTION",
   payload: collectionId,
 });
+export const setLastSeenCustomImage = (lastSeenCustomImage: {
+  imageSize: number,
+  imageHash: string,
+}) => ({
+  type: "SET_LAST_SEEN_CUSTOM_IMAGE",
+  payload: {
+    imageSize: lastSeenCustomImage.imageSize,
+    imageHash: lastSeenCustomImage.imageHash,
+  },
+});
 
 export const swapAcceptProvider = (providerId: string) => ({
   type: "ACCEPT_SWAP_PROVIDER",

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.js
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.js
@@ -129,6 +129,13 @@ export const setLastSeenCustomImage = (lastSeenCustomImage: {
     imageHash: lastSeenCustomImage.imageHash,
   },
 });
+export const clearLastSeenCustomImage = () => ({
+  type: "SET_LAST_SEEN_CUSTOM_IMAGE",
+  payload: {
+    imageSize: 0,
+    imageHash: "",
+  },
+});
 
 export const swapAcceptProvider = (providerId: string) => ({
   type: "ACCEPT_SWAP_PROVIDER",

--- a/apps/ledger-live-desktop/src/renderer/components/ByteSize.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ByteSize.jsx
@@ -2,42 +2,21 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import type { DeviceModel } from "@ledgerhq/devices";
+import { formatSize } from "@ledgerhq/live-common/apps/formatting";
 
-const k = 1024; // 1kb unit
-const sizes = ["bytes", "kbUnit", "mbUnit"];
-
-/** formats a byte value into its correct size in kb or mb unit taking in account the device block size */
 const ByteSize = ({
   value,
   deviceModel,
-  decimals = 2,
   firmwareVersion,
-  formatFunction,
 }: {
   value: number,
   deviceModel: DeviceModel,
-  decimals?: number,
   firmwareVersion: string,
-  formatFunction?: (val: number) => number,
 }) => {
   if (!value) return "–";
-
   const blockSize = deviceModel.getBlockSize(firmwareVersion);
-
-  // FIXME it should be on live-common side
-  const bytes = Math.ceil(value / blockSize) * blockSize;
-  const i = Math.floor(Math.log(bytes) / Math.log(k)) || 1; // Nb no more bytes
-  const rawSize = parseFloat(bytes / Math.pow(k, i));
-  const dm = rawSize < 1 ? 1 : i > 1 ? Math.max(0, decimals) : 0;
-
-  const divider = Math.pow(10, dm);
-  const toFormat = rawSize * divider;
-  let formattedSize = formatFunction ? formatFunction(toFormat) : toFormat;
-  formattedSize /= divider;
-
-  const size = formattedSize.toFixed(dm);
-
-  return <Trans i18nKey={`byteSize.${sizes[i]}`} values={{ size }} />;
+  const [size, unit] = formatSize(value, blockSize);
+  return <Trans i18nKey={`byteSize.${unit}`} values={{ size }} />;
 };
 
 export default ByteSize;

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomImageDeviceAction.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { setLastSeenCustomImage } from "~/renderer/actions/settings";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { createAction } from "@ledgerhq/live-common/hw/actions/ftsLoadImage";
 import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
@@ -52,6 +54,7 @@ const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props =>
   const commandRequest = hexImage;
 
   const { t } = useTranslation();
+  const dispatch = useDispatch();
 
   const validDevice = device?.modelId === DeviceModelId.nanoFTS ? device : null;
 
@@ -65,11 +68,15 @@ const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props =>
     }
   }, [onStart, validDevice]);
 
-  const handleResult = useCallback(() => {
-    if (onResult && validDevice) {
-      onResult();
-    }
-  }, [onResult, validDevice]);
+  const handleResult = useCallback(
+    lastSeenCustomImage => {
+      if (onResult && validDevice) {
+        dispatch(setLastSeenCustomImage(lastSeenCustomImage));
+        onResult();
+      }
+    },
+    [dispatch, onResult, validDevice],
+  );
 
   const { error, imageLoadRequested, loadingImage, imageCommitRequested, progress } = status;
   const isError = !!error;

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.js
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.js
@@ -101,6 +101,10 @@ export type SettingsState = {
   blacklistedTokenIds: string[],
   hiddenNftCollections: string[],
   deepLinkUrl: ?string,
+  lastSeenCustomImage: {
+    size: number,
+    hash: string,
+  },
   firstTimeLend: boolean,
   showClearCacheBanner: boolean,
   fullNodeEnabled: boolean,
@@ -175,6 +179,10 @@ const INITIAL_STATE: SettingsState = {
   hasInstalledApps: true,
   carouselVisibility: 0,
   lastSeenDevice: null,
+  lastSeenCustomImage: {
+    size: 0,
+    hash: "",
+  },
   latestFirmware: null,
   blacklistedTokenIds: [],
   hiddenNftCollections: [],
@@ -371,6 +379,13 @@ const handlers: Object = {
       KYC: {},
     },
   }),
+  SET_LAST_SEEN_CUSTOM_IMAGE: (state: SettingsState, { payload }) => ({
+    ...state,
+    lastSeenCustomImage: {
+      size: payload.imageSize,
+      hash: payload.imageHash,
+    },
+  }),
 };
 
 // TODO refactor selectors to *Selector naming convention
@@ -382,6 +397,8 @@ export const settingsExportSelector = storeSelector;
 export const discreetModeSelector = (state: State): boolean => state.settings.discreetMode === true;
 
 export const getCounterValueCode = (state: State) => state.settings.counterValue;
+
+export const lastSeenCustomImageSelector = (state: State) => state.settings.lastSeenCustomImage;
 
 export const deepLinkUrlSelector = (state: State) => state.settings.deepLinkUrl;
 

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { memo, useState, useCallback, useMemo, useEffect } from "react";
+import React, { memo, useRef, useState, useCallback, useMemo, useEffect } from "react";
 import styled from "styled-components";
 import { withTranslation } from "react-i18next";
 import type { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
@@ -25,7 +25,10 @@ import AppDepsUnInstallModal from "./AppDepsUnInstallModal";
 import ErrorModal from "~/renderer/modals/ErrorModal/index";
 import { setHasInstalledApps, setLastSeenDeviceInfo } from "~/renderer/actions/settings";
 import { useDispatch, useSelector } from "react-redux";
-import { hasInstalledAppsSelector } from "~/renderer/reducers/settings";
+import {
+  hasInstalledAppsSelector,
+  lastSeenCustomImageSelector,
+} from "~/renderer/reducers/settings";
 
 const Container = styled.div`
   display: flex;
@@ -83,6 +86,16 @@ const AppsList = ({
   const isIncomplete = isIncompleteState(state);
   const hasInstalledApps = useSelector(hasInstalledAppsSelector);
   const reduxDispatch = useDispatch();
+
+  const lastSeenCustomImage = useSelector(lastSeenCustomImageSelector);
+  const isFirstCustomImageUpdate = useRef<boolean>(true);
+  useEffect(() => {
+    if (isFirstCustomImageUpdate.current) {
+      isFirstCustomImageUpdate.current = false;
+    } else {
+      dispatch({ type: "setCustomImage", lastSeenCustomImage });
+    }
+  }, [dispatch, lastSeenCustomImage]);
 
   const { installQueue, uninstallQueue, currentError } = state;
 

--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -168,7 +168,7 @@ export class DeviceAction {
 
   async confirmImageLoaded() {
     await this.page.evaluate(() => {
-      (window as any).mock.events.mockDeviceEvent({ type: "imageLoaded" });
+      (window as any).mock.events.mockDeviceEvent({ type: "imageLoaded", imageSize: 35305 });
     });
   }
 

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -32,6 +32,7 @@ import {
   SettingsSetAnalyticsPayload,
   SettingsSetAvailableUpdatePayload,
   SettingsSetCarouselVisibilityPayload,
+  SettingsSetLastSeenCustomImagePayload,
   SettingsSetCountervaluePayload,
   SettingsSetDiscreetModePayload,
   SettingsSetExperimentalUsbSupportPayload,
@@ -184,6 +185,16 @@ const completeCustomImageFlowAction = createAction(
   SettingsActionTypes.SETTINGS_COMPLETE_CUSTOM_IMAGE_FLOW,
 );
 export const completeCustomImageFlow = () => completeCustomImageFlowAction();
+
+const setLastSeenCustomImageAction =
+  createAction<SettingsSetLastSeenCustomImagePayload>(
+    SettingsActionTypes.SET_LAST_SEEN_CUSTOM_IMAGE,
+  );
+export const setLastSeenCustomImage = ({
+  imageSize,
+  imageHash,
+}: SettingsSetLastSeenCustomImagePayload) =>
+  setLastSeenCustomImageAction({ imageSize, imageHash });
 
 const completeOnboardingAction = createAction(
   SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING,

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -195,6 +195,8 @@ export const setLastSeenCustomImage = ({
   imageHash,
 }: SettingsSetLastSeenCustomImagePayload) =>
   setLastSeenCustomImageAction({ imageSize, imageHash });
+export const clearLastSeenCustomImage = () =>
+  setLastSeenCustomImageAction({ imageSize: 0, imageHash: "" });
 
 const completeOnboardingAction = createAction(
   SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -257,6 +257,7 @@ export enum SettingsActionTypes {
   ACCEPT_SWAP_PROVIDER = "ACCEPT_SWAP_PROVIDER",
   LAST_SEEN_DEVICE = "LAST_SEEN_DEVICE",
   LAST_SEEN_DEVICE_INFO = "LAST_SEEN_DEVICE_INFO",
+  SET_LAST_SEEN_CUSTOM_IMAGE = "SET_LAST_SEEN_CUSTOM_IMAGE",
   ADD_STARRED_MARKET_COINS = "ADD_STARRED_MARKET_COINS",
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
   SET_LAST_CONNECTED_DEVICE = "SET_LAST_CONNECTED_DEVICE",
@@ -362,6 +363,10 @@ export type SettingsSetSwapKycPayload = {
 export type SettingsAcceptSwapProviderPayload = {
   acceptedProvider: Unpacked<SettingsState["swap"]["acceptedProviders"]>;
 };
+export type SettingsSetLastSeenCustomImagePayload = {
+  imageSize: number;
+  imageHash: string;
+};
 export type SettingsLastSeenDevicePayload = {
   deviceInfo: NonNullable<SettingsState["lastSeenDevice"]>["deviceInfo"];
 };
@@ -449,6 +454,7 @@ export type SettingsPayload =
   | SettingsAcceptSwapProviderPayload
   | SettingsLastSeenDevicePayload
   | SettingsLastSeenDeviceInfoPayload
+  | SettingsSetLastSeenCustomImagePayload
   | SettingsAddStarredMarketcoinsPayload
   | SettingsRemoveStarredMarketcoinsPayload
   | SettingsSetLastConnectedDevicePayload

--- a/apps/ledger-live-mobile/src/components/ByteSize.tsx
+++ b/apps/ledger-live-mobile/src/components/ByteSize.tsx
@@ -1,41 +1,23 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import type { DeviceModel } from "@ledgerhq/types-devices";
+import { formatSize } from "@ledgerhq/live-common/apps/formatting";
 
-const k = 1024; // 1kb unit
-
-const sizes = ["bytes", "kbUnit", "mbUnit"];
-
-/** formats a byte value into its correct size in kb or mb unit taking in account the device block size */
 const ByteSize = ({
   value,
   deviceModel,
-  decimals = 2,
   firmwareVersion,
-  formatFunction,
 }: {
   value?: number | null;
   deviceModel: DeviceModel;
-  decimals?: number;
   firmwareVersion: string;
-  formatFunction?: (_: number) => number;
 }) => {
   if (!value) return <>{"-"}</>;
   const blockSize = deviceModel.getBlockSize(firmwareVersion);
-  // FIXME it should be on live-common side
-  const bytes = Math.ceil(value / blockSize) * blockSize;
-  const i = Math.floor(Math.log(bytes) / Math.log(k)) || 1; // Nb no more bytes
-
-  const rawSize = bytes / k ** i;
-  const dm = rawSize < 1 ? 1 : i > 1 ? Math.max(0, decimals) : 0;
-  const divider = 10 ** dm;
-  const toFormat = rawSize * divider;
-  let formattedSize = formatFunction ? formatFunction(toFormat) : toFormat;
-  formattedSize /= divider;
-  const size = formattedSize.toFixed(dm);
+  const [size, unit] = formatSize(value, blockSize);
   return (
     <Trans
-      i18nKey={`byteSize.${sizes[i]}`}
+      i18nKey={`byteSize.${unit}`}
       values={{
         size,
       }}

--- a/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
@@ -21,7 +21,13 @@ type Props = {
   hexImage: string;
   source?: ComponentProps<typeof Image>["source"];
   onStart?: () => void;
-  onResult?: () => void;
+  onResult?: ({
+    imageHash,
+    imageSize,
+  }: {
+    imageHash: string;
+    imageSize: number;
+  }) => void;
   onSkip?: () => void;
 };
 

--- a/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
@@ -1,4 +1,5 @@
 import React, { ComponentProps, useCallback, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { Image } from "react-native";
 import { Link, Flex, Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
@@ -10,6 +11,10 @@ import {
   ImageLoadRefusedOnDevice,
   ImageCommitRefusedOnDevice,
 } from "@ledgerhq/live-common/errors";
+import {
+  setLastSeenCustomImage,
+  clearLastSeenCustomImage,
+} from "../actions/settings";
 import { DeviceActionDefaultRendering } from "./DeviceAction";
 import { ImageSourceContext } from "./CustomImage/FramedImage";
 import { renderError } from "./DeviceAction/rendering";
@@ -31,11 +36,6 @@ type Props = {
   onSkip?: () => void;
 };
 
-const errorNamesRetryAnotherImage = [
-  ImageLoadRefusedOnDevice().name,
-  ImageCommitRefusedOnDevice().name,
-];
-
 const action = createAction(loadImage);
 
 const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
@@ -50,6 +50,7 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   const commandRequest = hexImage;
 
   const { t } = useTranslation();
+  const dispatch = useDispatch();
 
   const status = action?.useHook(device, commandRequest);
   const payload = action?.mapResult(status);
@@ -70,10 +71,26 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
     setIsModalOpened(true);
   }, [setIsModalOpened]);
 
+  const handleResult = useCallback(
+    lastSeenCustomImage => {
+      dispatch(setLastSeenCustomImage(lastSeenCustomImage));
+      onResult && onResult(lastSeenCustomImage);
+    },
+    [dispatch, onResult],
+  );
+
   const { error } = status;
   const isError = !!error;
   const isRefusedOnStaxError =
-    error?.name && errorNamesRetryAnotherImage.includes(error?.name);
+    (error as unknown) instanceof ImageLoadRefusedOnDevice ||
+    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+
+  useEffect(() => {
+    // Once transferred the old image is wiped, we need to clear it from the data.
+    if (error instanceof ImageCommitRefusedOnDevice) {
+      dispatch(clearLastSeenCustomImage());
+    }
+  }, [dispatch, error]);
 
   const handleRetry = useCallback(() => {
     if (isRefusedOnStaxError) openModal();
@@ -117,7 +134,7 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
             device={device}
             request={commandRequest}
             payload={payload}
-            onResult={onResult}
+            onResult={handleResult}
           />
         )}
       </Flex>

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -45,6 +45,7 @@ import type {
   SettingsSetLocalePayload,
   SettingsSetMarketCounterCurrencyPayload,
   SettingsSetCustomImageBackupPayload,
+  SettingsSetLastSeenCustomImagePayload,
   SettingsSetMarketFilterByStarredAccountsPayload,
   SettingsSetMarketRequestParamsPayload,
   SettingsSetNotificationsPayload,
@@ -115,7 +116,10 @@ export const INITIAL_STATE: SettingsState = {
   theme: "system",
   osTheme: undefined,
   customImageBackup: undefined,
-
+  lastSeenCustomImage: {
+    size: 0,
+    hash: "",
+  },
   carouselVisibility: Object.fromEntries(
     SLIDES.map(slide => [slide.name, true]),
   ),
@@ -264,6 +268,16 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
   [SettingsActionTypes.SETTINGS_COMPLETE_CUSTOM_IMAGE_FLOW]: state => ({
     ...state,
     hasCompletedCustomImageFlow: true,
+  }),
+
+  [SettingsActionTypes.SET_LAST_SEEN_CUSTOM_IMAGE]: (state, action) => ({
+    ...state,
+    lastSeenCustomImage: {
+      size: (action as Action<SettingsSetLastSeenCustomImagePayload>).payload
+        .imageSize,
+      hash: (action as Action<SettingsSetLastSeenCustomImagePayload>).payload
+        .imageHash,
+    },
   }),
 
   [SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING]: state => ({
@@ -631,6 +645,10 @@ export const analyticsEnabledSelector = createSelector(
 export const experimentalUSBEnabledSelector = createSelector(
   storeSelector,
   s => s.experimentalUSBEnabled,
+);
+export const lastSeenCustomImageSelector = createSelector(
+  storeSelector,
+  s => s.lastSeenCustomImage,
 );
 export const currencySettingsForAccountSelector = (
   s: State,

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -205,6 +205,10 @@ export type SettingsState = {
   firstConnectionHasDevice: boolean | null;
   firstConnectHasDeviceUpdated: boolean | null;
   customImageBackup?: { hex: string; hash: string };
+  lastSeenCustomImage: {
+    size: number;
+    hash: string;
+  };
   notifications: NotificationsSettings;
   walletTabNavigatorLastVisitedTab: keyof WalletTabNavigatorStackParamList;
 };

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -10,7 +10,6 @@ import {
   completeCustomImageFlow,
   setLastConnectedDevice,
   setReadOnlyMode,
-  setLastSeenCustomImage,
 } from "../../actions/settings";
 import { ScreenName } from "../../const";
 import CustomImageDeviceAction from "../../components/CustomImageDeviceAction";
@@ -40,7 +39,7 @@ type NavigationProps = BaseComposite<
  * route param.
  *
  * This is meant as a data validation. We want to validate that the raw data
- * (that is eventually what will be transfered) allows to reconstruct exactly
+ * (that is eventually what will be transferred) allows to reconstruct exactly
  * the image previewed on the previous screen.
  *
  * We take this raw data and use it to rebuild the image from scratch, then
@@ -90,15 +89,11 @@ const Step3Transfer = ({ route, navigation }: NavigationProps) => {
     navigation.getParent()?.goBack();
   }, [navigation]);
 
-  const handleResult = useCallback(
-    payload => {
-      completeAction(PostOnboardingActionId.customImage);
-      dispatch(completeCustomImageFlow());
-      dispatch(setLastSeenCustomImage(payload));
-      handleExit();
-    },
-    [completeAction, dispatch, handleExit],
-  );
+  const handleResult = useCallback(() => {
+    completeAction(PostOnboardingActionId.customImage);
+    dispatch(completeCustomImageFlow());
+    handleExit();
+  }, [completeAction, dispatch, handleExit]);
 
   const insets = useSafeAreaInsets();
   const DEBUG = false;

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -10,6 +10,7 @@ import {
   completeCustomImageFlow,
   setLastConnectedDevice,
   setReadOnlyMode,
+  setLastSeenCustomImage,
 } from "../../actions/settings";
 import { ScreenName } from "../../const";
 import CustomImageDeviceAction from "../../components/CustomImageDeviceAction";
@@ -89,11 +90,15 @@ const Step3Transfer = ({ route, navigation }: NavigationProps) => {
     navigation.getParent()?.goBack();
   }, [navigation]);
 
-  const handleResult = useCallback(() => {
-    completeAction(PostOnboardingActionId.customImage);
-    dispatch(completeCustomImageFlow());
-    handleExit();
-  }, [completeAction, dispatch, handleExit]);
+  const handleResult = useCallback(
+    payload => {
+      completeAction(PostOnboardingActionId.customImage);
+      dispatch(completeCustomImageFlow());
+      dispatch(setLastSeenCustomImage(payload));
+      handleExit();
+    },
+    [completeAction, dispatch, handleExit],
+  );
 
   const insets = useSafeAreaInsets();
   const DEBUG = false;

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
@@ -150,6 +150,7 @@ const DeviceAppStorage = ({
             height={"100%"}
           />
         ))}
+        <Box key={"fix"} flexBasis={"0%"} flexShrink={1} height={"100%"} />
       </StorageRepartition>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
@@ -1,4 +1,12 @@
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, {
+  useRef,
+  useEffect,
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
 
 import {
@@ -16,6 +24,7 @@ import { isDeviceLocalizationSupported } from "@ledgerhq/live-common/manager/loc
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import { lastSeenCustomImageSelector } from "../../../reducers/settings";
 import DeviceAppStorage from "./DeviceAppStorage";
 
 import NanoS from "../../../images/devices/NanoS";
@@ -74,12 +83,23 @@ const DeviceCard = ({
   onLanguageChange,
 }: Props) => {
   const { colors, theme } = useTheme();
+  const lastSeenCustomImage = useSelector(lastSeenCustomImageSelector);
+  const isFirstCustomImageUpdate = useRef<boolean>(true);
+
   const { deviceModel } = state;
   const [appsModalOpen, setAppsModalOpen] = useState(false);
 
   const [illustration] = useState(
     illustrations[deviceModel.id]({ color: colors.neutral.c100, theme }),
   );
+
+  useEffect(() => {
+    if (isFirstCustomImageUpdate.current) {
+      isFirstCustomImageUpdate.current = false;
+    } else {
+      dispatch({ type: "setCustomImage", lastSeenCustomImage });
+    }
+  }, [dispatch, lastSeenCustomImage]);
 
   const deviceLocalizationFeatureFlag = useFeature("deviceLocalization");
 

--- a/libs/ledger-live-common/src/api/Manager.ts
+++ b/libs/ledger-live-common/src/api/Manager.ts
@@ -474,6 +474,7 @@ export type ListInstalledAppsEvent =
       payload: Array<{
         hash: string;
         name: string;
+        hash_code_data?: string;
       }>;
     };
 
@@ -520,12 +521,13 @@ const listInstalledApps = (
               typeof a === "object" && a,
               "payload array item are objects"
             );
-            const { hash, name } = a;
+            const { hash, name, hash_code_data } = a;
             invariant(typeof hash === "string", "hash is defined");
             invariant(typeof name === "string", "name is defined");
             return {
               hash,
               name,
+              hash_code_data,
             };
           }),
         };

--- a/libs/ledger-live-common/src/apps/formatting.test.ts
+++ b/libs/ledger-live-common/src/apps/formatting.test.ts
@@ -1,14 +1,48 @@
 import { formatSize } from "./formatting";
-test("Scenario: Formatting - format bytes", () => {
-  const bytes: [number | undefined, number][] = [
-    [4096, 4096],
-    [1, 4096],
-    [1025, 1024],
-    [4097, 4096],
-    [undefined, 4096],
-    [0, 4096],
+describe("Formatting bytes depending on device block size", () => {
+  const scenarios = [
+    {
+      bytes: 1024,
+      blockSize: 4 * 1024,
+      expectation: ["4", "kbUnit"],
+      desc: "Bytes need to be rounded to block size.",
+    },
+    {
+      bytes: 1024,
+      blockSize: 4 * 1024,
+      expectation: ["4", "kbUnit"],
+      desc: "Bytes need to be rounded to block size.",
+    },
+    {
+      bytes: 1150000,
+      blockSize: 4 * 1024,
+      expectation: ["1.10", "mbUnit"],
+      desc: "Megabytes do have decimal points",
+    },
+    {
+      bytes: 1150000,
+      blockSize: 32,
+      expectation: ["1.10", "mbUnit"],
+      desc: "Megabytes do have decimal points",
+    },
+    {
+      bytes: 1150000,
+      blockSize: 4 * 1024,
+      expectation: ["1.09", "mbUnit"],
+      floor: true,
+      desc: "Rounding down works",
+    },
+    {
+      bytes: 1050,
+      blockSize: 32,
+      expectation: ["2", "kbUnit"],
+      desc: "Nano S Plus will round to nearest ceil kb",
+    },
   ];
-  const formattedBytes = bytes.map((args) => formatSize(args[0], args[1]));
-  const expectedSizes = ["4Kb", "4Kb", "2Kb", "8Kb", "", ""];
-  expect(formattedBytes).toEqual(expectedSizes);
+
+  scenarios.map(({ bytes, blockSize, desc, expectation, floor }) => {
+    it(desc, () => {
+      expect(formatSize(bytes, blockSize, floor)).toMatchObject(expectation);
+    });
+  });
 });

--- a/libs/ledger-live-common/src/apps/formatting.ts
+++ b/libs/ledger-live-common/src/apps/formatting.ts
@@ -1,9 +1,29 @@
 import type { AppOp, InstalledItem } from "./types";
 
-export const formatSize = (size = 0, blockSize: number): string => {
-  const formatedSize =
-    size && Math.ceil((Math.ceil(size / blockSize) * blockSize) / 1024);
-  return formatedSize ? `${formatedSize}Kb` : "";
+/**
+ * Formats a byte value into its correct size in kb or mb unit taking into
+ * the device block size. It accepts a formatting function to be able to
+ * customize the rounding if needed.
+ **/
+export const formatSize = (
+  value = 0,
+  blockSize: number,
+  floor = false
+): [string, string] => {
+  const units = ["bytes", "kbUnit", "mbUnit"];
+  const k = 1024; // 1kb unit
+
+  const bytes = Math.ceil(value / blockSize) * blockSize;
+  const i = Math.floor(Math.log(bytes) / Math.log(k)) || 1; // Nb Byte units were removed from UI
+  const rawSize = bytes / Math.pow(k, i);
+  const roundingPrecision = rawSize < 1 ? 1 : i > 1 ? 2 : 0;
+
+  const divider = Math.pow(10, roundingPrecision);
+  const toFormat = rawSize * divider;
+  let formattedSize = floor ? Math.floor(toFormat) : Math.ceil(toFormat);
+  formattedSize /= divider;
+
+  return [formattedSize.toFixed(roundingPrecision), units[i]];
 };
 
 export const prettyActionPlan = (ops: AppOp[]): string =>

--- a/libs/ledger-live-common/src/apps/hw.ts
+++ b/libs/ledger-live-common/src/apps/hw.ts
@@ -1,12 +1,17 @@
 import Transport from "@ledgerhq/hw-transport";
-import { getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
-import { UnexpectedBootloader } from "@ledgerhq/errors";
+import {
+  DeviceModelId,
+  getDeviceModel,
+  identifyTargetId,
+} from "@ledgerhq/devices";
+import { UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
 import { concat, of, EMPTY, from, Observable, throwError, defer } from "rxjs";
 import { mergeMap, map } from "rxjs/operators";
 import type { Exec, AppOp, ListAppsEvent, ListAppsResult } from "./types";
 import manager, { getProviderId } from "../manager";
 import installApp from "../hw/installApp";
 import uninstallApp from "../hw/uninstallApp";
+import ftsFetchImageSize from "../hw/ftsFetchImageSize";
 import { log } from "@ledgerhq/logs";
 import getDeviceInfo from "../hw/getDeviceInfo";
 import {
@@ -142,7 +147,8 @@ export const streamAppInstall = ({
       })
     )
   );
-
+const emptyHashData =
+  "0000000000000000000000000000000000000000000000000000000000000000";
 export const listApps = (
   transport: Transport,
   deviceInfo: DeviceInfo
@@ -161,30 +167,37 @@ export const listApps = (
 
     async function main() {
       const installedP: Promise<[{ name: string; hash: string }[], boolean]> =
-        new Promise<{ name: string; hash: string }[]>((resolve, reject) => {
-          sub = ManagerAPI.listInstalledApps(transport, {
-            targetId: deviceInfo.targetId,
-            perso: "perso_11",
-          }).subscribe({
-            next: (e) => {
-              if (e.type === "result") {
-                resolve(e.payload);
-              } else if (
-                e.type === "device-permission-granted" ||
-                e.type === "device-permission-requested"
-              ) {
-                o.next(e);
-              }
-            },
-            error: reject,
-          });
-        })
+        new Promise<{ name: string; hash: string; hash_code_data: string }[]>(
+          (resolve, reject) => {
+            sub = ManagerAPI.listInstalledApps(transport, {
+              targetId: deviceInfo.targetId,
+              perso: "perso_11",
+            }).subscribe({
+              next: (e) => {
+                if (e.type === "result") {
+                  resolve(e.payload);
+                } else if (
+                  e.type === "device-permission-granted" ||
+                  e.type === "device-permission-requested"
+                ) {
+                  o.next(e);
+                }
+              },
+              error: reject,
+            });
+          }
+        )
           .then((apps) =>
-            apps.map(({ name, hash }) => ({
-              name,
-              hash,
-              blocks: 0,
-            }))
+            apps
+              .filter(({ hash_code_data }) => {
+                console.log("wadus", { hash_code_data }); 
+                return hash_code_data !== emptyHashData;
+              })
+              .map(({ name, hash }) => ({
+                name,
+                hash,
+                blocks: 0,
+              }))
           )
           .catch((e) => {
             log("hw", "failed to HSM list apps " + String(e) + "\n" + e.stack);
@@ -380,6 +393,8 @@ export const listApps = (
         }
       );
       const deviceModel = getDeviceModel(deviceModelId);
+      const bytesPerBlock = deviceModel.getBlockSize(deviceInfo.version);
+
       const appByName = {};
       apps.forEach((app) => {
         if (app) appByName[app.name] = app;
@@ -400,7 +415,7 @@ export const listApps = (
               availableAppVersion || {
                 bytes: 0,
               }
-            ).bytes || 0) / deviceModel.getBlockSize(deviceInfo.version)
+            ).bytes || 0) / bytesPerBlock
           );
         const updated =
           appsThatKeepChangingHashes.includes(name) ||
@@ -429,6 +444,14 @@ export const listApps = (
         .map((a) => a?.name ?? "")
         .filter(Boolean);
 
+      let customImageBlocks = 0;
+      if (deviceModelId === DeviceModelId.nanoFTS) {
+        const customImageSize = await ftsFetchImageSize(transport);
+        if (customImageSize) {
+          customImageBlocks = Math.ceil(customImageSize / bytesPerBlock);
+        }
+      }
+
       const result: ListAppsResult = {
         appByName,
         appsListNames,
@@ -437,6 +460,7 @@ export const listApps = (
         deviceInfo,
         deviceModelId,
         firmware,
+        customImageBlocks,
       };
       o.next({
         type: "result",

--- a/libs/ledger-live-common/src/apps/hw.ts
+++ b/libs/ledger-live-common/src/apps/hw.ts
@@ -4,7 +4,7 @@ import {
   getDeviceModel,
   identifyTargetId,
 } from "@ledgerhq/devices";
-import { UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { concat, of, EMPTY, from, Observable, throwError, defer } from "rxjs";
 import { mergeMap, map } from "rxjs/operators";
 import type { Exec, AppOp, ListAppsEvent, ListAppsResult } from "./types";
@@ -189,10 +189,7 @@ export const listApps = (
         )
           .then((apps) =>
             apps
-              .filter(({ hash_code_data }) => {
-                console.log("wadus", { hash_code_data }); 
-                return hash_code_data !== emptyHashData;
-              })
+              .filter(({ hash_code_data }) => hash_code_data !== emptyHashData)
               .map(({ name, hash }) => ({
                 name,
                 hash,

--- a/libs/ledger-live-common/src/apps/logic.test.ts
+++ b/libs/ledger-live-common/src/apps/logic.test.ts
@@ -1,4 +1,3 @@
-// import { ManagerDeviceLockedError } from "@ledgerhq/errors";
 import {
   initState,
   reducer,

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -362,6 +362,14 @@ export const reducer = (state: State, action: Action): State => {
       );
       return { ...state, currentError: null, installQueue, uninstallQueue };
     }
+    case "setCustomImage": {
+      const { lastSeenCustomImage } = action;
+      const { size } = lastSeenCustomImage;
+      return {
+        ...state,
+        customImageBlocks: Math.ceil(size / getBlockSize(state)),
+      };
+    }
 
     case "uninstall": {
       const { name } = action;
@@ -405,13 +413,14 @@ export const distribute = (
   state: State,
   config?: $Shape<typeof defaultConfig>
 ): AppsDistribution => {
+  const { customImageBlocks } = state;
   const { warnMemoryRatio, sortApps } = { ...defaultConfig, ...config };
   const blockSize = getBlockSize(state);
   const totalBytes = state.deviceModel.memorySize;
   const totalBlocks = Math.floor(totalBytes / blockSize);
   const osBytes = (state.firmware && state.firmware.bytes) || 0;
   const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks;
+  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
   const appsSpaceBytes = appsSpaceBlocks * blockSize;
   let totalAppsBlocks = 0;
   const apps = state.installed.map((app) => {
@@ -447,6 +456,7 @@ export const distribute = (
     appsSpaceBlocks,
     appsSpaceBytes,
     totalAppsBlocks,
+    customImageBlocks,
     totalAppsBytes,
     freeSpaceBlocks,
     freeSpaceBytes,

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -188,6 +188,7 @@ export function mockListAppsResult(
     firmware: firmware155,
     installed,
     installedAvailable: true,
+    customImageBlocks: 0,
   };
 }
 

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -40,6 +40,7 @@ export type ListAppsResult = {
   deviceInfo: DeviceInfo;
   deviceModelId: DeviceModelId;
   firmware: FinalFirmware | null | undefined;
+  customImageBlocks: number;
 };
 export type State = {
   deviceInfo: DeviceInfo;
@@ -47,6 +48,7 @@ export type State = {
   firmware: FinalFirmware | null | undefined;
   appByName: Record<string, App>;
   apps: App[];
+  customImageBlocks: number;
   installedAvailable: boolean;
   installed: InstalledItem[];
   recentlyInstalledApps: string[];
@@ -93,6 +95,13 @@ export type Action =  // recover from an error
       type: "updateAll";
     } // action to run after an update was done on the device (uninstall/install)
   | {
+      type: "setCustomImage";
+      lastSeenCustomImage: {
+        hash: string;
+        size: number;
+      };
+    } // action to run after a successful custom image flow, to update the UI accordingly
+  | {
       type: "onRunnerEvent";
       event: RunnerEvent;
     };
@@ -138,4 +147,5 @@ export type AppsDistribution = {
   freeSpaceBlocks: number;
   freeSpaceBytes: number;
   shouldWarnMemory: boolean;
+  customImageBlocks: number;
 };

--- a/libs/ledger-live-common/src/hw/actions/ftsLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/ftsLoadImage.ts
@@ -40,16 +40,24 @@ type State = {
   loadingImage?: boolean;
   imageLoaded?: boolean;
   imageCommitRequested?: boolean;
-  imageHash?: string;
+  imageHash: string;
+  imageSize: number;
   device: Device | null | undefined;
   deviceInfo: DeviceInfo | null | undefined;
   error: Error | null | undefined;
   progress?: number;
 };
 
-type LoadImageAction = Action<string, State, { imageHash?: string }>;
+type LoadImageAction = Action<
+  string,
+  State,
+  { imageHash: string; imageSize: number }
+>;
 
-const mapResult = ({ imageHash }: State) => ({ imageHash });
+const mapResult = ({ imageHash, imageSize }: State) => ({
+  imageHash,
+  imageSize,
+});
 
 type Event =
   | LoadImageEvent
@@ -69,6 +77,8 @@ const getInitialState = (device?: Device | null | undefined): State => ({
   device,
   deviceInfo: null,
   error: null,
+  imageSize: 0,
+  imageHash: "",
 });
 
 const reducer = (state: State, e: Event): State => {
@@ -116,6 +126,8 @@ const reducer = (state: State, e: Event): State => {
         isLoading: false,
         loadingImage: false,
         imageLoaded: true,
+        imageSize: e.imageSize,
+        imageHash: e.imageHash,
       };
     case "progress":
       return {

--- a/libs/ledger-live-common/src/hw/ftsFetchImageSize.test.ts
+++ b/libs/ledger-live-common/src/hw/ftsFetchImageSize.test.ts
@@ -1,0 +1,30 @@
+import ftsFetchImageSize from "./ftsFetchImageSize";
+
+const mockTransportGenerator = (out) => ({ send: () => out });
+describe("ftsFetchImageSize", () => {
+  test("should return size if available", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("000089e99000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await ftsFetchImageSize(mockedTransport);
+    expect(response).toBe(35305);
+  });
+
+  test("should return 0 when no size is returned", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("000000009000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    await expect(ftsFetchImageSize(mockedTransport)).resolves.toBe(0);
+  });
+
+  test("unexpected bootloader or any other code, should throw", async () => {
+    const mockedTransport = mockTransportGenerator(Buffer.from("662d", "hex"));
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    await expect(ftsFetchImageSize(mockedTransport)).rejects.toThrow(Error);
+  });
+});

--- a/libs/ledger-live-common/src/hw/ftsFetchImageSize.ts
+++ b/libs/ledger-live-common/src/hw/ftsFetchImageSize.ts
@@ -1,0 +1,29 @@
+import {
+  TransportStatusError,
+  UnexpectedBootloader,
+  StatusCodes,
+} from "@ledgerhq/errors";
+import Transport from "@ledgerhq/hw-transport";
+
+/**
+ * Attempt to fetch the size of the custom image set on the device,
+ * or zero if there is no custom image set.
+ */
+export default async (transport: Transport): Promise<number> => {
+  const res = await transport.send(0xe0, 0x64, 0x00, 0x00, Buffer.from([]), [
+    StatusCodes.OK,
+    StatusCodes.CUSTOM_IMAGE_BOOTLOADER,
+  ]);
+
+  const status = res.readUInt16BE(res.length - 2);
+
+  switch (status) {
+    case StatusCodes.OK:
+      return res.readUInt32BE();
+    case StatusCodes.CUSTOM_IMAGE_EMPTY:
+      return 0;
+    case StatusCodes.CUSTOM_IMAGE_BOOTLOADER:
+      throw new UnexpectedBootloader();
+  }
+  throw new TransportStatusError(status);
+};

--- a/libs/ledger-live-common/src/hw/ftsLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/ftsLoadImage.ts
@@ -15,6 +15,8 @@ import {
 import getAppAndVersion from "./getAppAndVersion";
 import { isDashboardName } from "./isDashboardName";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
+import ftsFetchImageSize from "./ftsFetchImageSize";
+import ftsFetchImageHash from "./ftsFetchImageHash";
 import { gzip } from "pako";
 
 const MAX_APDU_SIZE = 255;
@@ -34,6 +36,8 @@ export type LoadImageEvent =
     }
   | {
       type: "imageLoaded";
+      imageSize: number;
+      imageHash: string;
     };
 
 export type LoadImageRequest = {
@@ -155,8 +159,16 @@ export default function loadImage({
                 );
               }
 
+              // Fetch image size
+              const imageBytes = await ftsFetchImageSize(transport);
+
+              // Fetch image hash
+              const imageHash = await ftsFetchImageHash(transport);
+
               subscriber.next({
                 type: "imageLoaded",
+                imageSize: imageBytes,
+                imageHash,
               });
 
               subscriber.complete();
@@ -167,7 +179,7 @@ export default function loadImage({
                 (e &&
                   e instanceof TransportStatusError &&
                   [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
-                    // @ts-expect-error typescript not checking agains the instanceof
+                    // @ts-expect-error typescript not checking against the instanceof
                     e.statusCode
                   ))
               ) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently the space taken by the custom image is not taken into account when we access My Ledger, leading to an incorrect available storage breakdown. This PR introduces support for it as part of the response of the `listApps` logic as well as support for updating the space while already in My Ledger if we set it following the CTA.

In addition to this support it fixes two bugs founds during the development:
- A custom image was detected as an app for LLD, breaking the storage distribution and showing a warning about the storage being incomplete. This should be solved too, it can be tested by making sure that a device with no apps but with a custom image shows zero apps in My Ledger and not 1.
- A rendering bug on LLM that only occurred when we have a single application installed. It would show the storage bar with a very very small bar of the color of the app installed. This should be solved here, and the area should be the percentage of the storage taken by the account.

### ❓ Context

- **Impacted projects**: `ledger-live-common, ledger-live-mobile, ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: 
    - https://ledgerhq.atlassian.net/browse/FAT-690
    - https://ledgerhq.atlassian.net/browse/FAT-691

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach
- We need to ensure that the space taken by the custom image is reflected when entering the manager, but also updated when we set a custom image while inside the manager. However!, it will not respond to deleting the image on the device side, since we have no way of knowing this until you access the manager again.