### PR TITLE
Fixes ReceiveFunds/01-SelectCrypto to not accept TokenCurrency

### DIFF
--- a/.changeset/thin-otters-cross.md
+++ b/.changeset/thin-otters-cross.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Solve crash when entering token receive flow

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
@@ -21,7 +21,7 @@ export type ReceiveFundsStackParamList = {
   [ScreenName.ReceiveAddAccountSelectDevice]: {
     accountId?: string;
     parentId?: string;
-    currency: CryptoCurrency | TokenCurrency;
+    currency: CryptoCurrency;
     inline?: boolean;
     analyticsPropertyFlow?: string;
     createTokenAccount?: boolean;

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/01-SelectCrypto.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/01-SelectCrypto.tsx
@@ -124,7 +124,7 @@ export default function AddAccountsSelectCrypto({ navigation, route }: Props) {
         } else {
           // if we didn't find any account of the parent currency we add and create one
           navigation.navigate(ScreenName.ReceiveAddAccountSelectDevice, {
-            currency,
+            currency: currency.parentCurrency,
             createTokenAccount: true,
           });
         }


### PR DESCRIPTION
### 📝 Description

ReceiveFunds/01-SelectCrypto must actively not accept TokenCurrency. There were a path in the code that allowed to open that screen with a token which make the app crash ⚠️ 

### ❓ Context

- **Impacted projects**: LLM <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://sentry.io/organizations/ledger/issues/3756208221 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** we will need to confirm the fix, but this problem was proven by types and we improved the typing to not make it happen again <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
