### PR TITLE
feat/FAT-549 getBatteryStatus apdu command implementation

### DIFF
--- a/.changeset/thirty-cows-brake.md
+++ b/.changeset/thirty-cows-brake.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/types-devices": patch
+---
+
+Added support for Battery status APDU + CLI command and tests

--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -30,6 +30,7 @@ import generateTestScanAccounts from "./commands/generateTestScanAccounts";
 import generateTestTransaction from "./commands/generateTestTransaction";
 import genuineCheck from "./commands/genuineCheck";
 import getAddress from "./commands/getAddress";
+import getBatteryStatus from "./commands/getBatteryStatus";
 import getDeviceRunningMode from "./commands/getDeviceRunningMode";
 import getTransactionStatus from "./commands/getTransactionStatus";
 import i18n from "./commands/i18n";
@@ -88,6 +89,7 @@ export default {
   generateTestTransaction,
   genuineCheck,
   getAddress,
+  getBatteryStatus,
   getDeviceRunningMode,
   getTransactionStatus,
   i18n,

--- a/apps/cli/src/commands/getBatteryStatus.ts
+++ b/apps/cli/src/commands/getBatteryStatus.ts
@@ -1,0 +1,24 @@
+import { from } from "rxjs";
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import getBatteryStatus, { BatteryStatusTypes } from "@ledgerhq/live-common/hw/getBatteryStatus";
+import { currencyOpt, deviceOpt, inferCurrency } from "../scan";
+export default {
+  description:
+    "Get the battery status of the current device",
+  args: [
+    currencyOpt,
+    deviceOpt,
+    {
+      name: "p1",
+      type: String,
+      desc: "What type of request to run (00-04)",
+    },
+  ],
+  job: (
+    arg: Partial<{
+      device: string;
+      p1: string;
+    }>
+  ): any =>
+    withDevice(arg.device || "")((t) => from(getBatteryStatus(t, parseInt(arg.p1 || "0") as BatteryStatusTypes)))
+};

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.test.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.test.ts
@@ -1,0 +1,127 @@
+import getBatteryStatus, { BatteryStatusTypes } from "./getBatteryStatus";
+
+const mockTransportGenerator = (out) => ({ send: () => out });
+describe("getBatteryStatus", () => {
+  test("battery percentage OK", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_PERCENTAGE;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("639000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(99);
+  });
+
+  test("battery percentage KO returns -1", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_PERCENTAGE;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("FF9000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(-1);
+  });
+
+  test("battery voltage resolves", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_VOLTAGE;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("0FFF9000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(4095);
+  });
+
+  test("battery temperature with positive values", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_TEMPERATURE;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("109000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(16);
+  });
+
+  test("battery temperature with negative values", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_TEMPERATURE;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("FD9000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(-3);
+  });
+
+  test("battery current with positive values", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_CURRENT;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("109000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(16);
+  });
+
+  test("battery current with negative values", async () => {
+    const p1 = BatteryStatusTypes.BATTERY_CURRENT;
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("FD9000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport, p1);
+    expect(response).toBe(-3);
+  });
+
+  test("battery flags if no parameter passed", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("000000009000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport);
+    expect(response).not.toBeNull();
+  });
+
+  test("battery flags for healthy USB connection", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("0000000F9000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport);
+    expect(response).toMatchObject({
+      isCharging: true,
+      isUsbOn: true,
+      isBleOn: true,
+      isUsbPowered: true,
+      hasChargingIssue: false,
+      hasTemperatureIssue: false,
+      hasBatteryIssue: false,
+    });
+  });
+
+  test("battery flags for healthy BLE connection", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from("000000069000", "hex")
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next-line
+    const response = await getBatteryStatus(mockedTransport);
+    expect(response).toMatchObject({
+      isCharging: false,
+      isUsbOn: true,
+      isBleOn: true,
+      isUsbPowered: false,
+      hasChargingIssue: false,
+      hasTemperatureIssue: false,
+      hasBatteryIssue: false,
+    });
+  });
+});

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.ts
@@ -1,0 +1,66 @@
+import Transport from "@ledgerhq/hw-transport";
+import { BatteryStatusFlags } from "@ledgerhq/types-devices";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+
+export enum BatteryStatusTypes {
+  BATTERY_PERCENTAGE = 0x00,
+  BATTERY_VOLTAGE = 0x01,
+  BATTERY_TEMPERATURE = 0x02,
+  BATTERY_CURRENT = 0x03,
+  BATTERY_FLAGS = 0x04,
+}
+
+enum FlagMasks {
+  IS_CHARGING = 0x00000001,
+  IS_USB_ON = 0x00000002,
+  IS_BLE_ON = 0x00000004,
+  IS_USB_POWERED = 0x00000008,
+  HAS_CHARGING_ISSUE = 0x00000010,
+  HAS_TEMPERATURE_ISSUE = 0x00000020,
+  HAS_BATTERY_ISSUE = 0x00000080,
+}
+
+const wadus = async (
+  transport: Transport,
+  p1: BatteryStatusTypes = BatteryStatusTypes.BATTERY_FLAGS
+): Promise<BatteryStatusFlags | number> => {
+  const res = await transport.send(0xe0, 0x10, 0x00, p1);
+  const status = res.readUInt16BE(res.length - 2);
+
+  if (status === StatusCodes.OK) {
+    switch (p1) {
+      case BatteryStatusTypes.BATTERY_PERCENTAGE: {
+        // Nb values greater that 100 would mean a bad case
+        // to be assessed if we want to break the flow.
+        const temp = res.readUInt8(0);
+        return temp > 100 ? -1 : temp;
+      }
+
+      case BatteryStatusTypes.BATTERY_VOLTAGE:
+        return res.readUInt16BE(0);
+
+      case BatteryStatusTypes.BATTERY_TEMPERATURE:
+      case BatteryStatusTypes.BATTERY_CURRENT:
+        // Nb turn the usigned byte into a signed int to cover
+        // negative values. Two's compliment.
+        return (res.readUInt8() << 24) >> 24;
+
+      case BatteryStatusTypes.BATTERY_FLAGS: {
+        const flags = res.readUInt16BE(2); // Nb Ignoring the first two bytes
+        return {
+          isCharging: !!(flags & FlagMasks.IS_CHARGING),
+          isUsbOn: !!(flags & FlagMasks.IS_USB_ON),
+          isBleOn: !!(flags & FlagMasks.IS_BLE_ON),
+          isUsbPowered: !!(flags & FlagMasks.IS_USB_POWERED),
+          hasChargingIssue: !!(flags & FlagMasks.HAS_CHARGING_ISSUE),
+          hasTemperatureIssue: !!(flags & FlagMasks.HAS_TEMPERATURE_ISSUE),
+          hasBatteryIssue: !!(flags & FlagMasks.HAS_BATTERY_ISSUE),
+        };
+      }
+    }
+  }
+
+  throw new TransportStatusError(status);
+};
+
+export default wadus;

--- a/libs/ledgerjs/packages/types-devices/README.md
+++ b/libs/ledgerjs/packages/types-devices/README.md
@@ -12,6 +12,7 @@ Ledger types for devices and transport.
 
 *   [DeviceModelId](#devicemodelid)
 *   [DeviceModel](#devicemodel)
+*   [BatteryStatusFlags](#batterystatusflags)
 *   [BluetoothInfos](#bluetoothinfos)
 *   [Subscription](#subscription)
     *   [Properties](#properties)
@@ -31,6 +32,10 @@ DeviceModelId is a unique identifier to identify the model of a Ledger hardware 
 ### DeviceModel
 
 a DeviceModel contains all the information of a specific Ledger hardware wallet model.
+
+### BatteryStatusFlags
+
+Series of flags to represent the health status of the Ledger hardware wallet battery.
 
 ### BluetoothInfos
 

--- a/libs/ledgerjs/packages/types-devices/src/index.ts
+++ b/libs/ledgerjs/packages/types-devices/src/index.ts
@@ -29,6 +29,19 @@ export interface DeviceModel {
 }
 
 /**
+ * Series of flags to represent the health status of the Ledger hardware wallet battery.
+ */
+export interface BatteryStatusFlags {
+  isCharging: boolean;
+  isUsbOn: boolean;
+  isBleOn: boolean;
+  isUsbPowered: boolean;
+  hasChargingIssue: boolean;
+  hasTemperatureIssue: boolean;
+  hasBatteryIssue: boolean;
+}
+
+/**
  *
  */
 export interface BluetoothInfos {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In upcoming firmware version we will have the ability to query the device for some information regarding it's battery. This will open the door for a better UX in some flows, preventing users from starting sensitive operations if the battery is too low (or warning them, I'm not product), identifying faults in charging, overheating issues, etc.

### ❓ Context

- **Impacted projects**: `ledger-live-common, cli` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-549` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach
The implementation is covered by tests but there's also the posibility of using it via CLI by calling the `getBatteryStatus` command. This will allow you to see a series of values and flags that are documented [at the APDU level](https://ledgerhq.atlassian.net/wiki/spaces/~5be5d09253edba78d2964720/pages/3753377984/An+attempt+at+APDU+specs#getBatteryState-e01000xx00) in our confluence page.