### PR TITLE
fix unhandled undefined or null for feePerByte

### DIFF
--- a/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
@@ -85,11 +85,15 @@ const getTransactionStatus = (account, t) => {
     errors.amount = new NotEnoughBalance();
   }
 
-  const txSize = Math.ceil(estimatedFees.toNumber() / t.feePerByte!.toNumber());
-  const crypto = cryptoFactory(account.currency.id as Currency);
+  if (t.feePerByte) {
+    const txSize = Math.ceil(
+      estimatedFees.toNumber() / t.feePerByte.toNumber()
+    );
+    const crypto = cryptoFactory(account.currency.id as Currency);
 
-  if (amount.gt(0) && amount.lt(computeDustAmount(crypto, txSize))) {
-    errors.dustLimit = new DustLimit();
+    if (amount.gt(0) && amount.lt(computeDustAmount(crypto, txSize))) {
+      errors.dustLimit = new DustLimit();
+    }
   }
 
   // Fill up recipient errors...

--- a/libs/ledger-live-common/src/families/bitcoin/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/js-getTransactionStatus.ts
@@ -117,12 +117,16 @@ const getTransactionStatus = async (
     warnings.feeTooHigh = new FeeTooHigh();
   }
 
-  const txSize = Math.ceil(estimatedFees.toNumber() / t.feePerByte!.toNumber());
-  const crypto = cryptoFactory(a.currency.id as Currency);
-  const dustAmount = computeDustAmount(crypto, txSize);
+  if (t.feePerByte) {
+    const txSize = Math.ceil(
+      estimatedFees.toNumber() / t.feePerByte.toNumber()
+    );
+    const crypto = cryptoFactory(a.currency.id as Currency);
+    const dustAmount = computeDustAmount(crypto, txSize);
 
-  if (amount.gt(0) && amount.lt(dustAmount)) {
-    errors.dustLimit = new DustLimit();
+    if (amount.gt(0) && amount.lt(dustAmount)) {
+      errors.dustLimit = new DustLimit();
+    }
   }
 
   return {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

`t.feePerByte` can be undefined, triggering a `Cannot read properties of null (reading 'toNumber')` error and potentially crashing the app.

This PR handles this case properly.


Introduced by this line -> https://github.com/LedgerHQ/ledger-live/pull/1705/files#diff-9481356d1850289b630777fce1fef96c6ace0798ba31894f9357b85cf043c7e3R120

cf. this [CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/3533577647/jobs/5929402610#step:8:6639) failing due to this issue for example

### ❓ Context

- **Impacted projects**: `LLC`
- **Linked resource(s)**: https://github.com/LedgerHQ/ledger-live/pull/1705

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
