### PR TITLE
bugfix/rollback-ble Undo BleTransport changes 

### DIFF
--- a/.changeset/chilly-donkeys-double.md
+++ b/.changeset/chilly-donkeys-double.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+Undo the auto disconnect mechanism, due to regressions

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -40,7 +40,6 @@ import { decoratePromiseErrors, remapError } from "./remapErrors";
 let connectOptions: Record<string, unknown> = {
   requestMTU: 156,
   connectionPriority: 1,
-  forceDisconnectTimeout: 4000,
 };
 const transportsCache = {};
 const bleManager = new BleManager();
@@ -59,10 +58,12 @@ type ReconnectionConfig = {
   delayAfterFirstPairing: number;
 };
 let reconnectionConfig: ReconnectionConfig | null | undefined = {
-  pairingThreshold: 2000,
+  pairingThreshold: 1000,
   delayAfterFirstPairing: 4000,
 };
-export function setReconnectionConfig(config: ReconnectionConfig | null): void {
+export function setReconnectionConfig(
+  config: ReconnectionConfig | null | undefined
+) {
   reconnectionConfig = config;
 }
 
@@ -74,11 +75,6 @@ async function open(deviceOrId: Device | string, needsReconnect: boolean) {
   if (typeof deviceOrId === "string") {
     if (transportsCache[deviceOrId]) {
       log("ble-verbose", "Transport in cache, using that.");
-      const maybeTimeout = transportsCache[deviceOrId].disconnectTimeout;
-      if (maybeTimeout) {
-        log("ble-verbose", "Clearing queued disconnect");
-        clearTimeout(transportsCache[deviceOrId].disconnectTimeout);
-      }
       return transportsCache[deviceOrId];
     }
 
@@ -412,7 +408,6 @@ export default class BluetoothTransport extends Transport {
   static disconnect = async (id: any) => {
     log("ble-verbose", `user disconnect(${id})`);
     await bleManager.cancelDeviceConnection(id);
-    await delay(1000); // Nb Test to improve stability of re-connections.
   };
   id: string;
   device: Device;
@@ -422,7 +417,6 @@ export default class BluetoothTransport extends Transport {
   notifyObservable: Observable<any>;
   deviceModel: DeviceModel;
   notYetDisconnected = true;
-  disconnectTimeout: null | ReturnType<typeof setTimeout> = null;
 
   constructor(
     device: Device,
@@ -543,31 +537,9 @@ export default class BluetoothTransport extends Transport {
     }
   };
 
-  async close(): Promise<void> {
-    // Clear any potential leftover timeouts
-    if (this.disconnectTimeout) {
-      clearTimeout(this.disconnectTimeout);
+  async close() {
+    if (this.exchangeBusyPromise) {
+      await this.exchangeBusyPromise;
     }
-
-    let resolve;
-    const disconnectPromise = new Promise<void>((res) => {
-      resolve = res;
-    });
-
-    // Queue a disconnect
-    this.disconnectTimeout = setTimeout(() => {
-      BluetoothTransport.disconnect(this.id);
-      resolve();
-    }, connectOptions.forceDisconnectTimeout as number);
-
-    // For cases where an exchange hasn't resolve and we triggered a `close` we
-    // introduce a timeout to forcefully disconnect in order to unblock subsequent
-    // usages of the `withDevice` logic.
-    await Promise.race([
-      this.exchangeBusyPromise || Promise.resolve(),
-      disconnectPromise,
-    ]);
-
-    return;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

It was found out during regression testing that the stability of the BLE connection was in fact worse than before the changes, so we need to roll them back for now until we understand the underlying cause of this behaviour.

### ❓ Context

- **Impacted projects**: `react-native-hw-transport-ble` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Nothing to demo

### 🚀 Expectations to reach
Those crashes shouldn't be happening anymore