### PR TITLE
Update deprecated action environments

### DIFF
--- a/tools/actions/get-release-by-tag/action.yml
+++ b/tools/actions/get-release-by-tag/action.yml
@@ -21,5 +21,5 @@ outputs:
     description: "Previous release's tagname"
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'build/index.js'

--- a/tools/actions/publish-release/action.yml
+++ b/tools/actions/publish-release/action.yml
@@ -19,5 +19,5 @@ inputs:
     default: ''
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'build/index.js'


### PR DESCRIPTION
### 📝 Description

🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following deprecation warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) rather then node12.

This is supported on all Actions Runners v2.285.0 or later.

Signed-off-by: Enes <ahmedenesturan@gmail.com>

### ❓ Context

- **Linked resource(s)**: Issue, #2026


### 📸 Demo

There is nothing to show in demo 

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

Fixing the deprecated action environments