### PR TITLE
bugfix/LIVE-4809 Fix bug that crashed LLM on add account step of receive flow

### DIFF
--- a/.changeset/olive-ligers-grow.md
+++ b/.changeset/olive-ligers-grow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix bug that crashed LLM on receive add account for tokens

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
@@ -5,7 +5,6 @@ import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { useTheme } from "@react-navigation/native";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import { prepareCurrency } from "../../bridge/cache";
 import { ScreenName } from "../../const";
@@ -94,10 +93,9 @@ export default function AddAccountsSelectDevice({
         onResult={onResult}
         onClose={onClose}
         request={{
-          currency:
-            currency.type === "TokenCurrency"
-              ? currency.parentCurrency
-              : currency,
+          currency: isTokenCurrency(currency)
+            ? currency.parentCurrency
+            : currency,
         }}
         onSelectDeviceLink={() => setDevice(null)}
         analyticsPropertyFlow={analyticsPropertyFlow || "add account"}

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
@@ -6,6 +6,7 @@ import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { useTheme } from "@react-navigation/native";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import { prepareCurrency } from "../../bridge/cache";
 import { ScreenName } from "../../const";
 import { TrackScreen } from "../../analytics";
@@ -58,7 +59,10 @@ export default function AddAccountsSelectDevice({
 
   useEffect(() => {
     // load ahead of time
-    prepareCurrency(route.params.currency as CryptoCurrency);
+    const currency = route.params.currency;
+    prepareCurrency(
+      isTokenCurrency(currency) ? currency.parentCurrency : currency,
+    );
   }, [route.params.currency]);
 
   const currency = route.params.currency;
@@ -90,11 +94,10 @@ export default function AddAccountsSelectDevice({
         onResult={onResult}
         onClose={onClose}
         request={{
-          currency: currency as CryptoCurrency,
-          // FIXME: IT SEEMS TokenCurrency WILL NEVER HAPPEN
-          // currency.type === "TokenCurrency"
-          //   ? currency.parentCurrency
-          //   : currency,
+          currency:
+            currency.type === "TokenCurrency"
+              ? currency.parentCurrency
+              : currency,
         }}
         onSelectDeviceLink={() => setDevice(null)}
         analyticsPropertyFlow={analyticsPropertyFlow || "add account"}


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

With the typescript migration we introduced a regression that we missed. When doing the add accounts that’s part of the receive flow for a TokenCurrency we need to pass the parent currency to the DeviceAction, device actions that receive a TokenCurrency can’t find the app they need to launch on the inferCommands part and they crash.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->


### 🚀 Expectations to reach
Without accounts, try to do a receive for USDT, it should no longer crash.