### PR TITLE
bugfix/LIVE-4812 Fix white screen on fallback camera for recipient scanner iOS

### DIFF
--- a/.changeset/pink-terms-breathe.md
+++ b/.changeset/pink-terms-breathe.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix blank screen when refused camera permissions on iOS scanning recipient for the send flow


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
The fallback camera screen for iOS was rendering a white screen instead of the fallback UI that leads the user to the permission settings. This PR should address that and make it work for both iOS and Android builds correctly.

_Replace this text by a clear and concise description of what this pull request is about and why it is needed._

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-4812` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/205108315-d7368c9f-59d3-42c8-babc-1e0ada950490.mov


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- Refused permissions on camera for iOS should not render a white screen but rather the help UI