### PR TITLE
LLD - bug - fixes loading indicator on swap page

### DIFF
--- a/.changeset/tiny-brooms-sit.md
+++ b/.changeset/tiny-brooms-sit.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fixes loading indicator padding on swap screen

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.jsx
@@ -68,12 +68,6 @@ type Props = {
 /* @dev: Yeah, Im sorry if you read this, design asked us to
  override the input component when it is called from the swap form. */
 const InputSection = styled(Box)`
-  & div {
-    padding-right: 0;
-    > input {
-      padding-right: 15px;
-    }
-  }
   & ${ErrorContainer} {
     font-weight: 500;
     font-size: 11px;
@@ -81,6 +75,7 @@ const InputSection = styled(Box)`
     margin-left: calc(calc(100% + 30px) * -1);
     margin-top: 6px;
     align-self: flex-end;
+    margin-right: -15px;
   }
 `;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In LLD, the loading indicator is currently misaligned in the From form on the Swap screen.

### ❓ Context

- **Impacted projects**:  LLD
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-4747

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="615" alt="image" src="https://user-images.githubusercontent.com/119950081/206170308-8753b86d-f6ab-4b25-b923-c674f28e1684.png">

<img width="602" alt="image" src="https://user-images.githubusercontent.com/119950081/206170021-eb9c0f61-cce4-4b9a-b902-812a2e877ee0.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
