### PR TITLE
Detox - Allure - Fix screenshots when test failed

### DIFF
--- a/apps/ledger-live-mobile/e2e/reporters/AllureReporterCircus.js
+++ b/apps/ledger-live-mobile/e2e/reporters/AllureReporterCircus.js
@@ -1,12 +1,12 @@
 const Allure = require('allure-js-commons'); // version "1.3.2",
 const fs = require('fs');
 const stripAnsi = require('strip-ansi');
+const { device } = require('detox');
 
 class AllureReporterCircus {
 
-  constructor({ detox }) {
+  constructor() {
     this.allure = new Allure();
-    this.detox = detox;
   }
 
   run_describe_start(event) {
@@ -29,7 +29,7 @@ class AllureReporterCircus {
   async test_done(event) {
     if (event.test.errors.length > 0) {
       const { test } = event;
-      const screenshotPath = await this.detox.device.takeScreenshot(`${test.startedAt}-failed`);
+      const screenshotPath = await device.takeScreenshot(`${test.startedAt}-failed`);
       const buffer = fs.readFileSync(`${screenshotPath}`);
       this.allure.addAttachment('Screenshot test failue', Buffer.from(buffer, 'base64'), 'image/png');
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Small PR to fix taking screenshot when test fails for allure reporting.
Like in this [run](https://github.com/LedgerHQ/ledger-live/actions/runs/3619804263/jobs/6101278055)
` error: TypeError: Cannot read properties of undefined (reading 'device')
      at AllureReporterCircus.test_done`

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
