### PR TITLE
bugfix: llm - fixes issue on swap screen whereby target account was the From account name

### DIFF
--- a/.changeset/hot-jars-obey.md
+++ b/.changeset/hot-jars-obey.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+bugfix: llm - fixes issue where From account was being displayed as target account on swap screen"

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -375,14 +375,6 @@ export function SwapForm({
           undefined,
         );
         swapTransaction.setFromAccount(account);
-      } else {
-        swapTransaction.setToAccount(
-          swapTransaction.swap.to.currency,
-          account,
-          isTokenAccount(account)
-            ? getParentAccount(account, accounts)
-            : undefined,
-        );
       }
     }
 

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -376,6 +376,16 @@ export function SwapForm({
         );
         swapTransaction.setFromAccount(account);
       }
+
+      if (params.target === "to") {
+        swapTransaction.setToAccount(
+          swapTransaction.swap.to.currency,
+          account,
+          isTokenAccount(account)
+            ? getParentAccount(account, accounts)
+            : undefined,
+        );
+      }
     }
 
     if (params?.rate) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In LLM on the Swap screen, if you changed the network fee then we were incorrectly displaying the target account with the From account name. This PR fixes that to not update the target account name when the network fee is changed.

I have also manually checked that you can still change the target account from one ethereum account to another, and it still works as expected.

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-4781

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/119950081/206242523-ab475ab7-1c60-46ac-8891-536ee30a78d4.mp4




<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
