### PR TITLE
bugfix - llm - aligns terms & conditions link on the swap confirmation modal

### DIFF
--- a/.changeset/nervous-socks-invite.md
+++ b/.changeset/nervous-socks-invite.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+bugfix - llm - centers t&c link on swap confirmation modal

--- a/apps/ledger-live-mobile/src/components/TermsFooter.tsx
+++ b/apps/ledger-live-mobile/src/components/TermsFooter.tsx
@@ -36,8 +36,10 @@ const TermsFooter: React.FC<{
         i18nKey="DeviceAction.confirmSwap.acceptTerms"
         values={{ provider }}
         components={[
-          <UnderlinedText onPress={onLinkClick}>
-            <Text textTransform="capitalize">{provider}</Text>
+          <UnderlinedText onPress={onLinkClick} textAlign="center">
+            <Text textTransform="capitalize" textAlign="center">
+              {provider}
+            </Text>
           </UnderlinedText>,
         ]}
       />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently, the terms & conditions link is aligned to the left whereas it should be centre. This PR fixes this issue.

### ❓ Context

- **Impacted projects**:  LLM
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-4780

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

ios on left, android on right

<img width="887" alt="Screenshot 2022-12-08 at 15 56 34" src="https://user-images.githubusercontent.com/119950081/206498957-b42d9145-b550-4aea-a9b7-054854d6e0d6.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
