### PR TITLE
bugfix/FAT-730 Fix UI for fallback camera

### DIFF
--- a/.changeset/dirty-cycles-itch.md
+++ b/.changeset/dirty-cycles-itch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix UI for Fallback Camera screen, import accounts/scan

--- a/apps/ledger-live-mobile/src/components/FallbackCameraBody.tsx
+++ b/apps/ledger-live-mobile/src/components/FallbackCameraBody.tsx
@@ -1,8 +1,8 @@
 import React, { memo } from "react";
 import { View, StyleSheet } from "react-native";
 import Icon from "react-native-vector-icons/Feather";
-import { useTheme } from "@react-navigation/native";
-import LText from "./LText";
+import { useTheme } from "styled-components/native";
+import { Text, Flex } from "@ledgerhq/native-ui";
 import Button from "./Button";
 import FallbackCamera from "../icons/FallbackCamera";
 
@@ -20,21 +20,20 @@ function FallbackCameraBody({
   onPress,
 }: Props) {
   const { colors } = useTheme();
-
   const IconSettings = () => (
-    <Icon name="settings" size={16} color={colors.white} />
+    <Icon name="settings" size={16} color={colors.palette.neutral.c100} />
   );
 
   return (
-    <View style={styles.root}>
+    <Flex flex={1} bg="background.main" px={6}>
       <View style={styles.body}>
-        <FallbackCamera />
-        <LText secondary bold style={styles.title}>
+        <FallbackCamera color={colors.constant.white} />
+        <Text variant="paragraph" mt={9} mb={3} fontSize={6}>
           {title}
-        </LText>
-        <LText style={styles.desc} color="smoke">
+        </Text>
+        <Text variant="paragraph" color="neutral.c70" mb={10}>
           {description}
-        </LText>
+        </Text>
         <Button
           event="CameraOpenSettings"
           type="primary"
@@ -44,19 +43,16 @@ function FallbackCameraBody({
           IconLeft={IconSettings}
         />
       </View>
-    </View>
+    </Flex>
   );
 }
 
 export default memo<Props>(FallbackCameraBody);
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
   body: {
     alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
   },
   title: {
     marginTop: 40,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ImportAccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ImportAccountsNavigator.tsx
@@ -28,7 +28,7 @@ export default function ImportAccountsNavigator() {
           ...TransparentHeaderNavigationOptions,
           headerShown: true,
           headerTitle: () => (
-            <Text variant="h3" color="constant.white" uppercase>
+            <Text variant="h3" uppercase>
               {t("account.import.scan.title")}
             </Text>
           ),

--- a/apps/ledger-live-mobile/src/components/Scanner.tsx
+++ b/apps/ledger-live-mobile/src/components/Scanner.tsx
@@ -69,11 +69,7 @@ const Scanner = ({ onResult, liveQrCode, progress, instruction }: Props) => {
     case null:
       return <View />;
     case false:
-      return (
-        <View style={styles.container}>
-          <FallbackCameraScreen route={route} navigation={navigation} />
-        </View>
-      );
+      return <FallbackCameraScreen route={route} navigation={navigation} />;
     default:
       return (
         <View style={styles.container}>

--- a/apps/ledger-live-mobile/src/icons/FallbackCamera.tsx
+++ b/apps/ledger-live-mobile/src/icons/FallbackCamera.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Svg, { G, Path, Rect } from "react-native-svg";
 
-export default function FallbackCamera() {
+export default function FallbackCamera({ color }: { color: string }) {
   return (
     <Svg width="116" height="116">
       <G stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
@@ -25,13 +25,13 @@ export default function FallbackCamera() {
               <G transform="translate(72.000000, 0.000000)">
                 <Path
                   d="M20,42 C7.8497355,42 -2,32.1502645 -2,20 C-2,7.8497355 7.8497355,-2 20,-2 C32.1502645,-2 42,7.8497355 42,20 C42,32.1502645 32.1502645,42 20,42 Z"
-                  stroke="#FFFFFF"
+                  stroke={color}
                   strokeWidth="4"
                   fill="#EA2E49"
                 />
                 <Path
                   d="M21.4171429,22.498321 L18.6285714,22.498321 L18.0457143,12 L22,12 L21.4171429,22.498321 Z M18,26.1732707 C18,25.5715215 18.1714269,25.1166346 18.5142857,24.8085964 C18.8571446,24.5005581 19.3561872,24.3465413 20.0114286,24.3465413 C20.6438127,24.3465413 21.1333316,24.5041399 21.48,24.8193418 C21.8266684,25.1345438 22,25.5858489 22,26.1732707 C22,26.7392014 21.8247637,27.1851338 21.4742857,27.5110813 C21.1238078,27.8370287 20.6361936,28 20.0114286,28 C19.3714254,28 18.8761922,27.8406105 18.5257143,27.5218267 C18.1752363,27.203043 18,26.7535288 18,26.1732707 Z"
-                  fill="#FFFFFF"
+                  fill={color}
                 />
               </G>
             </G>

--- a/apps/ledger-live-mobile/src/screens/ImportAccounts/Scan.tsx
+++ b/apps/ledger-live-mobile/src/screens/ImportAccounts/Scan.tsx
@@ -102,16 +102,8 @@ class Scan extends PureComponent<
 
   render() {
     const { progress, error } = this.state;
-    const { colors } = this.props;
     return (
-      <View
-        style={[
-          styles.root,
-          {
-            backgroundColor: colors.darkBlue,
-          },
-        ]}
-      >
+      <View style={styles.root}>
         <TrackScreen category="ImportAccounts" name="Scan" />
         <Scanner onResult={this.onBarCodeRead} progress={progress} liveQrCode />
         <GenericErrorBottomModal error={error} onClose={this.onCloseError} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The UI for the fallback screen was not adapting well to theme changes, this must've been like this since the v3 rework because it was still using old color palette references and some components were not adapted to themes at all (like the icon). This is just a small polish on what should be a rework of the screen as far as I'm concerned.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-730` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://user-images.githubusercontent.com/4631227/207642208-72e436b4-48e2-4a9c-bb25-3b1a9dc60dc5.mov

### 🚀 Expectations to reach
Ensure that the camera fallback works with the expected UI for both themes, on both Android and iOS, respecting the color changes. Easily testable using the `DEBUG_THEME=1` flag for switching themes like on the video above. Also ensure that when having the permission granted, the UI is not broken. I've looked at possible impact on the Send flow scanning and it seems good to me, but probably good to check there too.