### PR TITLE
fix: NEAR LLM bust staking positions cache

### DIFF
--- a/.changeset/green-tools-share.md
+++ b/.changeset/green-tools-share.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add cache busting strategy for NEAR LLM staking positions, and cover staking edge case where node returns a tiny bit less than what was actually staked.

--- a/libs/ledger-live-common/src/families/near/api/near-staking-positions-sdk.ts
+++ b/libs/ledger-live-common/src/families/near/api/near-staking-positions-sdk.ts
@@ -10,7 +10,9 @@ export const getStakingDeposits = async (
 ): Promise<NearStakingDeposit[]> => {
   const { data } = await network({
     method: "GET",
-    url: getIndexerUrl(`staking-deposits/${address}`),
+    url: getIndexerUrl(
+      `staking-deposits/${address}?date=${new Date().getTime()}`
+    ),
   });
 
   return Array.isArray(data) ? data : [];

--- a/libs/ledger-live-common/src/families/near/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/near/js-getTransactionStatus.ts
@@ -21,6 +21,7 @@ import {
   getMaxAmount,
   getTotalSpent,
   getYoctoThreshold,
+  YOCTO_THRESHOLD_VARIATION,
 } from "./logic";
 import { fetchAccountDetails } from "./api";
 import { getCurrentNearPreloadData } from "./preload";
@@ -78,7 +79,7 @@ const getTransactionStatus = async (
     const currency = getCryptoCurrencyById("near");
     const formattedStakingThreshold = formatCurrencyUnit(
       currency.units[0],
-      stakingThreshold.plus("1"),
+      stakingThreshold.plus(YOCTO_THRESHOLD_VARIATION),
       {
         showCode: true,
       }

--- a/libs/ledger-live-common/src/families/near/logic.ts
+++ b/libs/ledger-live-common/src/families/near/logic.ts
@@ -18,6 +18,7 @@ export const MIN_ACCOUNT_BALANCE_BUFFER = "50000000000000000000000";
 export const STAKING_GAS_BASE = "25000000000000";
 export const FIGMENT_NEAR_VALIDATOR_ADDRESS = "ledgerbyfigment.poolv1.near";
 export const FRACTIONAL_DIGITS = 5;
+export const YOCTO_THRESHOLD_VARIATION = "10";
 
 export const isValidAddress = (address: string): boolean => {
   const readableAddressRegex =
@@ -178,7 +179,7 @@ export const canWithdraw = (
 export const getYoctoThreshold = (): BigNumber => {
   return new BigNumber(10)
     .pow(new BigNumber(utils.format.NEAR_NOMINATION_EXP - FRACTIONAL_DIGITS))
-    .minus("1");
+    .minus(YOCTO_THRESHOLD_VARIATION);
 };
 
 /*


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Was noted that new staking positions will not appear on NEAR LLM immediately after staking, it takes awhile. Looks like this is due to a cache ONLY on the staking positions endpoint, only on LLM. We can get around this by adding a `date` param with the timestamp.

### ❓ Context

- **Impacted projects**: `LLM` `LLC`
- **Linked resource(s)**: [Discord message](https://discord.com/channels/885256081289379850/973221693638193152/1052216993757024306)

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

[This Discord message](https://discord.com/channels/885256081289379850/973221693638193152/1052598485280628828) has a demo attached.

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
