### PR TITLE
Feature flags UX improvements

### DIFF
--- a/.changeset/mean-panthers-live.md
+++ b/.changeset/mean-panthers-live.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Feature flags overriding persistency over app restarts + UX improvements (feature groups, banner, reset all)

--- a/.changeset/rare-dryers-punch.md
+++ b/.changeset/rare-dryers-punch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Feature flags overriding persistency over app restarts

--- a/.changeset/twenty-experts-cough.md
+++ b/.changeset/twenty-experts-cough.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Exported object groupedFeatures that contains features grouped by common theme.

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.js
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.js
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import type { PortfolioRange } from "@ledgerhq/live-common/portfolio/v2/types";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
-import type { DeviceModelInfo } from "@ledgerhq/types-live";
+import type { DeviceModelInfo, FeatureId, Feature } from "@ledgerhq/types-live";
 import { setEnvOnAllThreads } from "~/helpers/env";
 import type { SettingsState as Settings } from "~/renderer/reducers/settings";
 import {
@@ -242,4 +242,16 @@ export const removeStarredMarketCoins = (payload: string) => ({
 export const toggleStarredMarketCoins = (payload: string) => ({
   type: "TOGGLE_STARRED_MARKET_COINS",
   payload,
+});
+
+export const setOverriddenFeatureFlag = (key: FeatureId, value: Feature | undefined) => ({
+  type: "SET_OVERRIDDEN_FEATURE_FLAG",
+  payload: { key, value },
+});
+
+export const setOverriddenFeatureFlags = (overriddenFeatureFlags: {
+  [key: FeatureId]: Feature,
+}) => ({
+  type: "SET_OVERRIDDEN_FEATURE_FLAGS",
+  payload: { overriddenFeatureFlags },
 });

--- a/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
@@ -11,7 +11,7 @@ export const FirebaseRemoteConfigContext = React.createContext<RemoteConfig | nu
 
 export const useFirebaseRemoteConfig = () => useContext(FirebaseRemoteConfigContext);
 
-export const formatFeatureId = (id: string) => `feature_${snakeCase(id)}`;
+export const formatToFirebaseFeatureId = (id: string) => `feature_${snakeCase(id)}`;
 
 // Firebase SDK treat JSON values as strings
 const formatDefaultFeatures = (config: DefaultFeatures) =>
@@ -19,7 +19,7 @@ const formatDefaultFeatures = (config: DefaultFeatures) =>
     config,
     (acc, feature, featureId) => ({
       ...acc,
-      [formatFeatureId(featureId)]: JSON.stringify(feature),
+      [formatToFirebaseFeatureId(featureId)]: JSON.stringify(feature),
     }),
     {},
   );

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.js
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.js
@@ -10,9 +10,8 @@ import {
   getFiatCurrencyByTicker,
 } from "@ledgerhq/live-common/currencies/index";
 import type { DeviceModelId } from "@ledgerhq/devices";
-import type { FeatureId, Feature } from "@ledgerhq/types-live";
+import type { DeviceModelInfo, FeatureId, Feature } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
-import type { DeviceModelInfo } from "@ledgerhq/types-live";
 import type { PortfolioRange } from "@ledgerhq/live-common/portfolio/v2/types";
 import { getEnv } from "@ledgerhq/live-common/env";
 import { getLanguages, defaultLocaleForLanguage } from "~/config/languages";

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.js
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.js
@@ -10,6 +10,7 @@ import {
   getFiatCurrencyByTicker,
 } from "@ledgerhq/live-common/currencies/index";
 import type { DeviceModelId } from "@ledgerhq/devices";
+import type { FeatureId, Feature } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
 import type { PortfolioRange } from "@ledgerhq/live-common/portfolio/v2/types";
@@ -128,6 +129,7 @@ export type SettingsState = {
     },
   },
   starredMarketCoins: string[],
+  overriddenFeatureFlags: { [key: FeatureId]: Feature },
 };
 
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {
@@ -205,6 +207,7 @@ const INITIAL_STATE: SettingsState = {
     KYC: {},
   },
   starredMarketCoins: [],
+  overriddenFeatureFlags: {},
 };
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`;
@@ -385,6 +388,17 @@ const handlers: Object = {
       size: payload.imageSize,
       hash: payload.imageHash,
     },
+  }),
+  SET_OVERRIDDEN_FEATURE_FLAG: (state: SettingsState, { payload }) => ({
+    ...state,
+    overriddenFeatureFlags: {
+      ...state.overriddenFeatureFlags,
+      [payload.key]: payload.value,
+    },
+  }),
+  SET_OVERRIDDEN_FEATURE_FLAGS: (state: SettingsState, { payload }) => ({
+    ...state,
+    overriddenFeatureFlags: payload.overriddenFeatureFlags,
   }),
 };
 
@@ -601,5 +615,8 @@ export const exportSettingsSelector: OutputSelector<State, void, *> = createSele
 );
 
 export const starredMarketCoinsSelector = (state: State) => state.settings.starredMarketCoins;
+
+export const overriddenFeatureFlagsSelector = (state: State) =>
+  state.settings.overriddenFeatureFlags;
 
 export default handleActions(handlers, INITIAL_STATE);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -3,46 +3,36 @@ import ButtonV2 from "~/renderer/components/Button";
 import { useTranslation } from "react-i18next";
 import {
   defaultFeatures,
+  groupedFeatures,
   useFeature,
   useFeatureFlags,
 } from "@ledgerhq/live-common/featureFlags/index";
-import { Input, Icons, Flex, SearchInput, Alert, Tag } from "@ledgerhq/react-ui";
+import { Flex, SearchInput, Alert, Tag } from "@ledgerhq/react-ui";
 import { SettingsSectionRow as Row } from "../../../SettingsSection";
 import { FeatureId } from "@ledgerhq/types-live";
-import { InputRenderLeftContainer } from "@ledgerhq/react-ui/components/form/BaseInput/index";
 import { includes, lowerCase, trim } from "lodash";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import FeatureFlagDetails from "./FeatureFlagDetails";
 
 const addFlagHint = `\
 If a feature flag is defined in the targeted Firebase environment \
-but it is missing from the following list, you can type its name in \
-the input field below and it will appear in the list. Type the \
+but it is missing from the following list, you can type its **exact** name in \
+the search input and it will appear in the list. Type the \
 flag name in camelCase without the "feature" prefix.\
 `;
 
 export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolean }) => {
   const { t } = useTranslation();
   const [focusedName, setFocusedName] = useState<string | undefined>();
-  const [hiddenFlagName, setHiddenFlagName] = useState("");
   const [searchInput, setSearchInput] = useState("");
-
-  const trimmedHiddenFlagName = trim(hiddenFlagName);
+  const searchInputTrimmed = trim(searchInput);
 
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
-    if (trimmedHiddenFlagName && !featureKeys.includes(trimmedHiddenFlagName))
-      featureKeys.push(trimmedHiddenFlagName);
+    if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed))
+      featureKeys.push(searchInputTrimmed);
     return featureKeys;
-  }, [trimmedHiddenFlagName]);
-
-  const handleAddHiddenFlag = useCallback(
-    value => {
-      setHiddenFlagName(value);
-      setSearchInput(value);
-    },
-    [setSearchInput, setHiddenFlagName],
-  );
+  }, [searchInputTrimmed]);
 
   const filteredFlags = useMemo(() => {
     return featureFlags
@@ -57,12 +47,7 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
 
   const [cheatActivated, setCheatActivated] = useState(false);
   const ruleThemAll = useCallback(() => {
-    ([
-      "customImage",
-      "deviceInitialApps",
-      "syncOnboarding",
-      "staxWelcomeScreen",
-    ] as FeatureId[]).forEach(featureId =>
+    groupedFeatures.stax.featureIds.forEach(featureId =>
       overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
     );
     setCheatActivated(true);
@@ -100,7 +85,11 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
   );
 
   const config = useFeature("firebaseEnvironmentReadOnly");
-  const project = config?.params?.project;
+  const params = config?.params;
+  const project =
+    params !== null && typeof params === "object" && "project" in params
+      ? (params as { project: string }).project
+      : "";
 
   return (
     <Flex flexDirection="column" pt={2} rowGap={2} alignSelf="stretch">
@@ -123,17 +112,6 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
             clearable
           />
           <Alert type="info" title={addFlagHint} showIcon={false} />
-          <Input
-            renderLeft={() => (
-              <InputRenderLeftContainer>
-                <Icons.PlusMedium color="neutral.c80" />
-              </InputRenderLeftContainer>
-            )}
-            clearable
-            placeholder={"Add missing flag (instructions above)"}
-            value={hiddenFlagName}
-            onChange={handleAddHiddenFlag}
-          />
           <Flex height={15} />
           {content}
         </>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -23,17 +23,23 @@ flag name in camelCase without the "feature" prefix.\
 
 export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolean }) => {
   const { t } = useTranslation();
+  const { getFeature, overrideFeature, isFeature } = useFeatureFlags();
   const [focusedName, setFocusedName] = useState<string | undefined>();
   const [searchInput, setSearchInput] = useState("");
   const searchInputTrimmed = trim(searchInput);
 
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
-    if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed))
-      // The search input is added to the `featureKeys` in order to check for "hidden" feature flags
-      featureKeys.push(searchInputTrimmed);
+    if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed)) {
+      const isHiddenFeature = isFeature(searchInputTrimmed);
+
+      // Only adds the search input value to the featureKeys if it is an existing hidden feature
+      if (isHiddenFeature) {
+        featureKeys.push(searchInputTrimmed);
+      }
+    }
     return featureKeys;
-  }, [searchInputTrimmed]);
+  }, [isFeature, searchInputTrimmed]);
 
   const filteredFlags = useMemo(() => {
     return featureFlags
@@ -43,8 +49,6 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
 
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pressCount = useRef(0);
-
-  const { getFeature, overrideFeature } = useFeatureFlags();
 
   const [cheatActivated, setCheatActivated] = useState(false);
   const ruleThemAll = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -30,13 +30,14 @@ export const FeatureFlagContent = withV3StyleProvider((props: { visible?: boolea
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
     if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed))
+      // The search input is added to the `featureKeys` in order to check for "hidden" feature flags
       featureKeys.push(searchInputTrimmed);
     return featureKeys;
   }, [searchInputTrimmed]);
 
   const filteredFlags = useMemo(() => {
     return featureFlags
-      .sort((a, b) => a[0].localeCompare(b[0]))
+      .sort()
       .filter(name => !searchInput || includes(lowerCase(name), lowerCase(searchInput)));
   }, [featureFlags, searchInput]);
 

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -2,7 +2,12 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { createAction } from "redux-actions";
 import { useDispatch, useSelector } from "react-redux";
-import { DeviceModelInfo, DeviceInfo } from "@ledgerhq/types-live";
+import {
+  DeviceModelInfo,
+  DeviceInfo,
+  FeatureId,
+  Feature,
+} from "@ledgerhq/types-live";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { PortfolioRange } from "@ledgerhq/types-live";
 import { MarketListRequestParams } from "@ledgerhq/live-common/market/types";
@@ -63,6 +68,8 @@ import {
   SettingsActionTypes,
   SettingsSetWalletTabNavigatorLastVisitedTabPayload,
   SettingsSetDismissedDynamicCardsPayload,
+  SettingsSetOverriddenFeatureFlagPlayload,
+  SettingsSetOverriddenFeatureFlagsPlayload,
 } from "./types";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";
 
@@ -484,6 +491,27 @@ export const setWalletTabNavigatorLastVisitedTab = (
   setWalletTabNavigatorLastVisitedTabAction({
     walletTabNavigatorLastVisitedTab,
   });
+
+const setOverriddenFeatureFlagAction =
+  createAction<SettingsSetOverriddenFeatureFlagPlayload>(
+    SettingsActionTypes.SET_OVERRIDDEN_FEATURE_FLAG,
+  );
+export const setOverriddenFeatureFlag = (
+  id: FeatureId,
+  value: Feature | undefined,
+) =>
+  setOverriddenFeatureFlagAction({
+    id,
+    value,
+  });
+
+const setOverriddenFeatureFlagsAction =
+  createAction<SettingsSetOverriddenFeatureFlagsPlayload>(
+    SettingsActionTypes.SET_OVERRIDDEN_FEATURE_FLAGS,
+  );
+export const setOverriddenFeatureFlags = (overriddenFeatureFlags: {
+  [key in FeatureId]?: Feature;
+}) => setOverriddenFeatureFlagsAction({ overriddenFeatureFlags });
 
 const dangerouslyOverrideStateAction =
   createAction<SettingsDangerouslyOverrideStatePayload>(

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -70,7 +70,6 @@ import {
   SettingsSetDismissedDynamicCardsPayload,
   SettingsSetOverriddenFeatureFlagPlayload,
   SettingsSetOverriddenFeatureFlagsPlayload,
-  SettingsSetFeatureFlagsBannerVisible,
   SettingsSetFeatureFlagsBannerVisiblePayload,
 } from "./types";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -70,6 +70,8 @@ import {
   SettingsSetDismissedDynamicCardsPayload,
   SettingsSetOverriddenFeatureFlagPlayload,
   SettingsSetOverriddenFeatureFlagsPlayload,
+  SettingsSetFeatureFlagsBannerVisible,
+  SettingsSetFeatureFlagsBannerVisiblePayload,
 } from "./types";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";
 
@@ -512,6 +514,14 @@ const setOverriddenFeatureFlagsAction =
 export const setOverriddenFeatureFlags = (overriddenFeatureFlags: {
   [key in FeatureId]?: Feature;
 }) => setOverriddenFeatureFlagsAction({ overriddenFeatureFlags });
+
+const setFeatureFlagsBannerVisibleAction =
+  createAction<SettingsSetFeatureFlagsBannerVisiblePayload>(
+    SettingsActionTypes.SET_FEATURE_FLAGS_BANNER_VISIBLE,
+  );
+export const setFeatureFlagsBannerVisible = (
+  featureFlagsBannerVisible: boolean,
+) => setFeatureFlagsBannerVisibleAction({ featureFlagsBannerVisible });
 
 const dangerouslyOverrideStateAction =
   createAction<SettingsDangerouslyOverrideStatePayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -5,7 +5,12 @@ import type {
   ImportAccountsReduceInput,
 } from "@ledgerhq/live-common/account/index";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import type { Account, DeviceModelInfo } from "@ledgerhq/types-live";
+import type {
+  Account,
+  DeviceModelInfo,
+  Feature,
+  FeatureId,
+} from "@ledgerhq/types-live";
 import type { Payload as PostOnboardingPayload } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate } from "@ledgerhq/live-common/exchange/swap/types";
@@ -271,6 +276,8 @@ export enum SettingsActionTypes {
   SET_NOTIFICATIONS = "SET_NOTIFICATIONS",
   RESET_SWAP_LOGIN_AND_KYC_DATA = "RESET_SWAP_LOGIN_AND_KYC_DATA",
   WALLET_TAB_NAVIGATOR_LAST_VISITED_TAB = "WALLET_TAB_NAVIGATOR_LAST_VISITED_TAB",
+  SET_OVERRIDDEN_FEATURE_FLAG = "SET_OVERRIDDEN_FEATURE_FLAG",
+  SET_OVERRIDDEN_FEATURE_FLAGS = "SET_OVERRIDDEN_FEATURE_FLAGS",
 }
 
 export type SettingsImportPayload = Partial<SettingsState>;
@@ -417,6 +424,14 @@ export type SettingsSetWalletTabNavigatorLastVisitedTabPayload = Pick<
   "walletTabNavigatorLastVisitedTab"
 >;
 export type SettingsDangerouslyOverrideStatePayload = State;
+export type SettingsSetOverriddenFeatureFlagPlayload = {
+  id: FeatureId;
+  value: Feature | undefined;
+};
+export type SettingsSetOverriddenFeatureFlagsPlayload = Pick<
+  SettingsState,
+  "overriddenFeatureFlags"
+>;
 export type SettingsPayload =
   | SettingsImportPayload
   | SettingsImportDesktopPayload
@@ -460,7 +475,9 @@ export type SettingsPayload =
   | SettingsSetSensitiveAnalyticsPayload
   | SettingsSetFirstConnectHasDeviceUpdatedPayload
   | SettingsSetNotificationsPayload
-  | SettingsDangerouslyOverrideStatePayload;
+  | SettingsDangerouslyOverrideStatePayload
+  | SettingsSetOverriddenFeatureFlagPlayload
+  | SettingsSetOverriddenFeatureFlagsPlayload;
 
 // === WALLET CONNECT ACTIONS ===
 

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -278,6 +278,7 @@ export enum SettingsActionTypes {
   WALLET_TAB_NAVIGATOR_LAST_VISITED_TAB = "WALLET_TAB_NAVIGATOR_LAST_VISITED_TAB",
   SET_OVERRIDDEN_FEATURE_FLAG = "SET_OVERRIDDEN_FEATURE_FLAG",
   SET_OVERRIDDEN_FEATURE_FLAGS = "SET_OVERRIDDEN_FEATURE_FLAGS",
+  SET_FEATURE_FLAGS_BANNER_VISIBLE = "SET_FEATURE_FLAGS_BANNER_VISIBLE",
 }
 
 export type SettingsImportPayload = Partial<SettingsState>;
@@ -432,6 +433,10 @@ export type SettingsSetOverriddenFeatureFlagsPlayload = Pick<
   SettingsState,
   "overriddenFeatureFlags"
 >;
+export type SettingsSetFeatureFlagsBannerVisiblePayload = Pick<
+  SettingsState,
+  "featureFlagsBannerVisible"
+>;
 export type SettingsPayload =
   | SettingsImportPayload
   | SettingsImportDesktopPayload
@@ -477,7 +482,8 @@ export type SettingsPayload =
   | SettingsSetNotificationsPayload
   | SettingsDangerouslyOverrideStatePayload
   | SettingsSetOverriddenFeatureFlagPlayload
-  | SettingsSetOverriddenFeatureFlagsPlayload;
+  | SettingsSetOverriddenFeatureFlagsPlayload
+  | SettingsSetFeatureFlagsBannerVisiblePayload;
 
 // === WALLET CONNECT ACTIONS ===
 

--- a/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
@@ -16,7 +16,10 @@ import {
   languageSelector,
   overriddenFeatureFlagsSelector,
 } from "../reducers/settings";
-import { setOverriddenFeatureFlag } from "../actions/settings";
+import {
+  setOverriddenFeatureFlag,
+  setOverriddenFeatureFlags,
+} from "../actions/settings";
 
 const checkFeatureFlagVersion = (feature: Feature | undefined) => {
   if (
@@ -133,6 +136,10 @@ export const FirebaseFeatureFlagsProvider: React.FC<Props> = ({ children }) => {
     dispatch(setOverriddenFeatureFlag(key, undefined));
   };
 
+  const resetFeatures = (): void => {
+    dispatch(setOverriddenFeatureFlags({}));
+  };
+
   // Nb wrapped because the method is also called from outside.
   const wrappedGetFeature = useCallback(
     (key: FeatureId): Feature =>
@@ -145,6 +152,7 @@ export const FirebaseFeatureFlagsProvider: React.FC<Props> = ({ children }) => {
       getFeature={wrappedGetFeature}
       overrideFeature={overrideFeature}
       resetFeature={resetFeature}
+      resetFeatures={resetFeatures}
     >
       {children}
     </FeatureFlagsProvider>

--- a/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
@@ -11,7 +11,7 @@ import {
 import { FeatureId, Feature } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-common/env";
 
-import { formatFeatureId } from "./FirebaseRemoteConfig";
+import { formatToFirebaseFeatureId } from "./FirebaseRemoteConfig";
 import {
   languageSelector,
   overriddenFeatureFlagsSelector,
@@ -41,6 +41,21 @@ const checkFeatureFlagVersion = (feature: Feature | undefined) => {
 
 type Props = PropsWithChildren<unknown>;
 
+const isFeature = (key: string): boolean => {
+  try {
+    const value = remoteConfig().getValue(formatToFirebaseFeatureId(key));
+
+    if (!value || !value.asString()) {
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error(`Failed to check if feature "${key}" exists`);
+    return false;
+  }
+};
+
 const getFeature = (args: {
   key: FeatureId;
   appLanguage: string;
@@ -68,7 +83,7 @@ const getFeature = (args: {
         };
     }
 
-    const value = remoteConfig().getValue(formatFeatureId(key));
+    const value = remoteConfig().getValue(formatToFirebaseFeatureId(key));
     const feature = JSON.parse(value.asString());
 
     if (
@@ -149,6 +164,7 @@ export const FirebaseFeatureFlagsProvider: React.FC<Props> = ({ children }) => {
 
   return (
     <FeatureFlagsProvider
+      isFeature={isFeature}
       getFeature={wrappedGetFeature}
       overrideFeature={overrideFeature}
       resetFeature={resetFeature}

--- a/apps/ledger-live-mobile/src/components/FirebaseRemoteConfig.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseRemoteConfig.tsx
@@ -2,9 +2,10 @@ import React, { ReactNode, useEffect, useState } from "react";
 import remoteConfig from "@react-native-firebase/remote-config";
 import { defaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
 import { reduce, snakeCase } from "lodash";
-import { FeatureId, DefaultFeatures } from "@ledgerhq/types-live";
+import { DefaultFeatures } from "@ledgerhq/types-live";
 
-export const formatFeatureId = (id: FeatureId) => `feature_${snakeCase(id)}`;
+export const formatToFirebaseFeatureId = (id: string) =>
+  `feature_${snakeCase(id)}`;
 
 // Firebase SDK treat JSON values as strings
 const formatDefaultFeatures = (config: DefaultFeatures) =>
@@ -12,7 +13,7 @@ const formatDefaultFeatures = (config: DefaultFeatures) =>
     config,
     (acc, feature, featureId) => ({
       ...acc,
-      [formatFeatureId(featureId as FeatureId)]: JSON.stringify(feature),
+      [formatToFirebaseFeatureId(featureId)]: JSON.stringify(feature),
     }),
     {},
   );

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2640,7 +2640,9 @@
       "featureFlagsRestoreAll": "Restore all flag values",
       "featureFlagsTabAll": "All",
       "featureFlagsTabGroups": "Groups",
-      "firebaseProject": "Firebase project targeted by this build:"
+      "firebaseProject": "Firebase project targeted by this build:",
+      "showBannerDesc": "Show banner when flags are overridden",
+      "bannerTitle": "Flags overridden locally"
     }
   },
   "notifications": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2637,6 +2637,7 @@
       "featureFlagsDesc": "Overridden values will be reset if the app is relaunched. Only valid JSON strings will be accepted.",
       "featureFlagsEdit": "Edit",
       "featureFlagsRestore": "Restore",
+      "featureFlagsRestoreAll": "Restore all flag values",
       "firebaseProject": "Firebase project targeted by this build:"
     }
   },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2638,6 +2638,8 @@
       "featureFlagsEdit": "Edit",
       "featureFlagsRestore": "Restore",
       "featureFlagsRestoreAll": "Restore all flag values",
+      "featureFlagsTabAll": "All",
+      "featureFlagsTabGroups": "Groups",
       "firebaseProject": "Firebase project targeted by this build:"
     }
   },

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -159,7 +159,7 @@ export const INITIAL_STATE: SettingsState = {
   },
   walletTabNavigatorLastVisitedTab: ScreenName.Portfolio,
   overriddenFeatureFlags: {},
-  featureFlagsBannerVisible: true,
+  featureFlagsBannerVisible: false,
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -66,6 +66,7 @@ import type {
   SettingsSetDismissedDynamicCardsPayload,
   SettingsSetOverriddenFeatureFlagPlayload,
   SettingsSetOverriddenFeatureFlagsPlayload,
+  SettingsSetFeatureFlagsBannerVisiblePayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -158,6 +159,7 @@ export const INITIAL_STATE: SettingsState = {
   },
   walletTabNavigatorLastVisitedTab: ScreenName.Portfolio,
   overriddenFeatureFlags: {},
+  featureFlagsBannerVisible: true,
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -598,6 +600,15 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
       overriddenFeatureFlags,
     };
   },
+  [SettingsActionTypes.SET_FEATURE_FLAGS_BANNER_VISIBLE]: (state, action) => {
+    const {
+      payload: { featureFlagsBannerVisible },
+    } = action as Action<SettingsSetFeatureFlagsBannerVisiblePayload>;
+    return {
+      ...state,
+      featureFlagsBannerVisible,
+    };
+  },
 };
 
 export default handleActions<SettingsState, SettingsPayload>(
@@ -821,3 +832,5 @@ export const walletTabNavigatorLastVisitedTabSelector = (state: State) =>
   state.settings.walletTabNavigatorLastVisitedTab;
 export const overriddenFeatureFlagsSelector = (state: State) =>
   state.settings.overriddenFeatureFlags;
+export const featureFlagsBannerVisibleSelector = (state: State) =>
+  state.settings.featureFlagsBannerVisible;

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -64,6 +64,8 @@ import type {
   SettingsUpdateCurrencyPayload,
   SettingsSetSwapSelectableCurrenciesPayload,
   SettingsSetDismissedDynamicCardsPayload,
+  SettingsSetOverriddenFeatureFlagPlayload,
+  SettingsSetOverriddenFeatureFlagsPlayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -155,6 +157,7 @@ export const INITIAL_STATE: SettingsState = {
     recommendationsCategory: true,
   },
   walletTabNavigatorLastVisitedTab: ScreenName.Portfolio,
+  overriddenFeatureFlags: {},
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -573,6 +576,28 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
       action as Action<SettingsSetWalletTabNavigatorLastVisitedTabPayload>
     ).payload.walletTabNavigatorLastVisitedTab,
   }),
+
+  [SettingsActionTypes.SET_OVERRIDDEN_FEATURE_FLAG]: (state, action) => {
+    const {
+      payload: { id, value },
+    } = action as Action<SettingsSetOverriddenFeatureFlagPlayload>;
+    return {
+      ...state,
+      overriddenFeatureFlags: {
+        ...state.overriddenFeatureFlags,
+        [id]: value,
+      },
+    };
+  },
+  [SettingsActionTypes.SET_OVERRIDDEN_FEATURE_FLAGS]: (state, action) => {
+    const {
+      payload: { overriddenFeatureFlags },
+    } = action as Action<SettingsSetOverriddenFeatureFlagsPlayload>;
+    return {
+      ...state,
+      overriddenFeatureFlags,
+    };
+  },
 };
 
 export default handleActions<SettingsState, SettingsPayload>(
@@ -794,3 +819,5 @@ export const notificationsSelector = (state: State) =>
   state.settings.notifications;
 export const walletTabNavigatorLastVisitedTabSelector = (state: State) =>
   state.settings.walletTabNavigatorLastVisitedTab;
+export const overriddenFeatureFlagsSelector = (state: State) =>
+  state.settings.overriddenFeatureFlags;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -213,6 +213,7 @@ export type SettingsState = {
   notifications: NotificationsSettings;
   walletTabNavigatorLastVisitedTab: keyof WalletTabNavigatorStackParamList;
   overriddenFeatureFlags: { [key in FeatureId]?: Feature | undefined };
+  featureFlagsBannerVisible: boolean;
 };
 
 export type NotificationsSettings = {

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -2,6 +2,8 @@ import type {
   Account,
   DeviceInfo,
   DeviceModelInfo,
+  Feature,
+  FeatureId,
   PortfolioRange,
 } from "@ledgerhq/types-live";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -210,6 +212,7 @@ export type SettingsState = {
   };
   notifications: NotificationsSettings;
   walletTabNavigatorLastVisitedTab: keyof WalletTabNavigatorStackParamList;
+  overriddenFeatureFlags: { [key in FeatureId]?: Feature | undefined };
 };
 
 export type NotificationsSettings = {

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/FeatureFlagDetails.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/FeatureFlagDetails.tsx
@@ -3,16 +3,9 @@ import { Pressable, View } from "react-native";
 import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/index";
 import type { FeatureId } from "@ledgerhq/types-live";
 
-import { Flex, Box, Tag } from "@ledgerhq/native-ui";
+import { Flex, Divider, Tag } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
 import FeatureFlagEdit from "./FeatureFlagEdit";
-
-export const Divider = styled(Box).attrs({
-  width: "100%",
-  my: 4,
-  height: 1,
-  bg: "neutral.c50",
-})``;
 
 export const TagEnabled = styled(Tag).attrs({
   bg: "success.c100",

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/FeatureFlagEdit.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/FeatureFlagEdit.tsx
@@ -94,10 +94,11 @@ const FeatureFlagEdit: React.FC<{
         )}
       />
       <Flex flexDirection="row" mt={3}>
-        <Button type="main" outline onPress={handleRestoreFeature}>
+        <Button size="small" type="main" outline onPress={handleRestoreFeature}>
           {t("settings.debug.featureFlagsRestore")}
         </Button>
         <Button
+          size="small"
           disabled={!inputValue}
           type="main"
           onPress={handleOverrideFeature}

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
@@ -65,7 +65,7 @@ const GroupedFeatures: React.FC<Props> = ({
   }, [featureIds, resetFeature]);
 
   return (
-    <Flex>
+    <Flex mb={2}>
       <Pressable
         onPress={() => setFocusedGroupName(focused ? undefined : groupName)}
       >

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
@@ -1,6 +1,6 @@
 import { groupedFeatures } from "@ledgerhq/live-common/featureFlags/groupedFeatures";
 import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/provider";
-import { Flex, Link, Switch, Tag } from "@ledgerhq/native-ui";
+import { Divider, Flex, Link, Switch, Tag } from "@ledgerhq/native-ui";
 import { FeatureId } from "@ledgerhq/types-live";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -18,6 +18,7 @@ const GroupedFeatures: React.FC<Props> = ({
   groupName,
   focused,
   setFocusedGroupName,
+  isLast,
 }) => {
   const [focusedName, setFocusedName] = useState<string | undefined>();
   const { featureIds } = groupedFeatures[groupName];
@@ -103,6 +104,7 @@ const GroupedFeatures: React.FC<Props> = ({
         </Flex>
       </Pressable>
       {focused ? <Flex pl={6}>{flagsList}</Flex> : null}
+      {!isLast && focused ? <Divider /> : null}
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
@@ -1,0 +1,110 @@
+import { groupedFeatures } from "@ledgerhq/live-common/featureFlags/groupedFeatures";
+import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/provider";
+import { Flex, Link, Switch, Tag } from "@ledgerhq/native-ui";
+import { FeatureId } from "@ledgerhq/types-live";
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Pressable } from "react-native";
+import FeatureFlagDetails, { TagEnabled } from "./FeatureFlagDetails";
+
+type Props = {
+  groupName: string;
+  focused: boolean;
+  setFocusedGroupName: (name: string | undefined) => void;
+  isLast: boolean;
+};
+
+const GroupedFeatures: React.FC<Props> = ({
+  groupName,
+  focused,
+  setFocusedGroupName,
+}) => {
+  const [focusedName, setFocusedName] = useState<string | undefined>();
+  const { featureIds } = groupedFeatures[groupName];
+  const { t } = useTranslation();
+
+  const { getFeature, overrideFeature, resetFeature } = useFeatureFlags();
+
+  const flagsList = useMemo(
+    () =>
+      featureIds.map((flagName, index, arr) => (
+        <FeatureFlagDetails
+          key={flagName}
+          focused={focusedName === flagName}
+          flagName={flagName as FeatureId}
+          setFocusedName={setFocusedName}
+          isLast={index === arr.length - 1}
+        />
+      )),
+    [featureIds, focusedName],
+  );
+
+  let someEnabled = false;
+  let allEnabled = true;
+  let someOverridden = false;
+  featureIds.forEach(featureId => {
+    const val = getFeature(featureId);
+    const { enabled, overridesRemote } = val || {};
+    someEnabled ||= Boolean(enabled);
+    allEnabled &&= Boolean(enabled);
+    someOverridden ||= Boolean(overridesRemote);
+  });
+
+  const handleSwitchChange = useCallback(
+    enabled => {
+      featureIds.forEach(featureId =>
+        overrideFeature(featureId, { ...getFeature(featureId), enabled }),
+      );
+    },
+    [featureIds, getFeature, overrideFeature],
+  );
+
+  const handleReset = useCallback(() => {
+    featureIds.forEach(featureId => resetFeature(featureId));
+  }, [featureIds, resetFeature]);
+
+  return (
+    <Flex>
+      <Pressable
+        onPress={() => setFocusedGroupName(focused ? undefined : groupName)}
+      >
+        <Flex
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Flex flexDirection={"row"} alignItems="center">
+            <TagEnabled
+              backgroundColor={
+                allEnabled
+                  ? "success.c100"
+                  : someEnabled
+                  ? "warning.c100"
+                  : "error.c100"
+              }
+            >
+              {groupName}
+            </TagEnabled>
+            {someOverridden ? (
+              <Tag my={1} mr={2}>
+                overridden locally
+              </Tag>
+            ) : null}
+          </Flex>
+          <Flex flexDirection="row" alignItems={"center"}>
+            {someOverridden ? (
+              <Link size="small" type="color" onPress={handleReset}>
+                {t("settings.debug.featureFlagsRestore")}
+              </Link>
+            ) : null}
+            <Flex mr={3} />
+            <Switch checked={allEnabled} onChange={handleSwitchChange} />
+          </Flex>
+        </Flex>
+      </Pressable>
+      {focused ? <Flex pl={6}>{flagsList}</Flex> : null}
+    </Flex>
+  );
+};
+
+export default GroupedFeatures;

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -15,7 +15,6 @@ import {
   Tag,
 } from "@ledgerhq/native-ui";
 import { includes, lowerCase, trim } from "lodash";
-import { InputRenderLeftContainer } from "@ledgerhq/native-ui/components/Form/Input/BaseInput";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Keyboard } from "react-native";
 import NavigationScrollView from "../../components/NavigationScrollView";
@@ -28,32 +27,23 @@ import Alert from "../../components/Alert";
 
 const addFlagHint = `\
 If a feature flag is defined in the targeted Firebase environment \
-but it is missing from the list, you can type its name in \
-the input field "Add missing flag" above and it will appear in the list.\nType the \
+but it is missing from the list, you can type its **exact** name in \
+the search input field above and it will appear in the list.\nType the \
 flag name in camelCase without the "feature" prefix.\
 `;
 
 export default function DebugFeatureFlags() {
   const { t } = useTranslation();
   const [focusedName, setFocusedName] = useState<string | undefined>();
-  const [hiddenFlagName, setHiddenFlagName] = useState("");
-  const trimmedHiddenFlagName = trim(hiddenFlagName);
   const [searchInput, setSearchInput] = useState<string>("");
+  const searchInputTrimmed = trim(searchInput);
 
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
-    if (trimmedHiddenFlagName && !featureKeys.includes(trimmedHiddenFlagName))
-      featureKeys.push(trimmedHiddenFlagName);
+    if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed))
+      featureKeys.push(searchInputTrimmed);
     return featureKeys;
-  }, [trimmedHiddenFlagName]);
-
-  const handleAddHiddenFlag = useCallback(
-    value => {
-      setHiddenFlagName(trim(value));
-      setSearchInput(value);
-    },
-    [setSearchInput, setHiddenFlagName],
-  );
+  }, [searchInputTrimmed]);
 
   const handleSearch = useCallback(value => {
     setSearchInput(value);
@@ -83,7 +73,11 @@ export default function DebugFeatureFlags() {
   );
 
   const config = useFeature("firebaseEnvironmentReadOnly");
-  const project = config?.params?.project;
+  const params = config?.params;
+  const project =
+    params !== null && typeof params === "object" && "project" in params
+      ? (params as { project: string }).project
+      : "";
 
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   useEffect(() => {
@@ -117,18 +111,6 @@ export default function DebugFeatureFlags() {
             value={searchInput}
             placeholder="Search flag"
             onChange={handleSearch}
-            autoCapitalize="none"
-          />
-          <Flex mt={3} />
-          <BaseInput
-            value={undefined}
-            renderLeft={() => (
-              <InputRenderLeftContainer>
-                <Icons.PlusMedium color="neutral.c70" />
-              </InputRenderLeftContainer>
-            )}
-            placeholder="Add missing flag (instructions below)"
-            onChange={handleAddHiddenFlag}
             autoCapitalize="none"
           />
           <Flex flexDirection="row" mt={4}>

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -4,24 +4,24 @@ import {
   defaultFeatures,
   groupedFeatures,
   useFeature,
+  useFeatureFlags,
 } from "@ledgerhq/live-common/featureFlags/index";
 import type { FeatureId } from "@ledgerhq/types-live";
 
 import {
-  BaseInput,
   Text,
   Flex,
   SearchInput,
-  Icons,
+  Divider,
   Tag,
   ChipTabs,
+  Button,
 } from "@ledgerhq/native-ui";
 import { includes, lowerCase, trim } from "lodash";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Keyboard } from "react-native";
 import NavigationScrollView from "../../components/NavigationScrollView";
 import FeatureFlagDetails, {
-  Divider,
   TagDisabled,
   TagEnabled,
 } from "./FeatureFlagDetails";
@@ -42,6 +42,7 @@ export default function DebugFeatureFlags() {
   const [searchInput, setSearchInput] = useState<string>("");
   const searchInputTrimmed = trim(searchInput);
   const [activeTab, setActiveTab] = useState(0);
+  const { resetFeatures } = useFeatureFlags();
 
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
@@ -132,10 +133,15 @@ export default function DebugFeatureFlags() {
   return (
     <SafeAreaView edges={["bottom"]} style={{ flex: 1 }}>
       <NavigationScrollView>
-        <Flex p={16}>
-          <Alert type="primary">
-            <Text>{t("settings.debug.featureFlagsTitle")}</Text>
+        <Flex px={16}>
+          <Alert type="primary" noIcon>
+            {t("settings.debug.featureFlagsTitle")}
           </Alert>
+          <Flex flexDirection="row" mt={4}>
+            <Text>Legend: </Text>
+            <TagEnabled mx={2}>enabled flag</TagEnabled>
+            <TagDisabled mx={2}>disabled flag</TagDisabled>
+          </Flex>
           <Text my={3}>{t("settings.debug.firebaseProject")}</Text>
           <Tag uppercase={false} type="color" alignSelf={"flex-start"}>
             {project}
@@ -153,11 +159,15 @@ export default function DebugFeatureFlags() {
             onChange={handleSearch}
             autoCapitalize="none"
           />
-          <Flex flexDirection="row" mt={4}>
-            <Text>Legend: </Text>
-            <TagEnabled mx={2}>enabled flag</TagEnabled>
-            <TagDisabled mx={2}>disabled flag</TagDisabled>
-          </Flex>
+          <Button
+            mt={3}
+            size="small"
+            type="main"
+            outline
+            onPress={resetFeatures}
+          >
+            {t("settings.debug.featureFlagsRestoreAll")}
+          </Button>
           <Divider />
           {activeTab === 0 ? (
             <>

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -148,7 +148,10 @@ export default function DebugFeatureFlags() {
           </Tag>
           <Divider />
           <ChipTabs
-            labels={["All", "Groups"]}
+            labels={[
+              t("settings.debug.featureFlagsTabAll"),
+              t("settings.debug.featureFlagsTabGroups"),
+            ]}
             activeIndex={activeTab}
             onChange={setActiveTab}
           />

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -5,6 +5,7 @@ import {
   groupedFeatures,
   useFeature,
   useFeatureFlags,
+  useHasLocallyOverriddenFeatureFlags,
 } from "@ledgerhq/live-common/featureFlags/index";
 import type { FeatureId } from "@ledgerhq/types-live";
 
@@ -16,10 +17,12 @@ import {
   Tag,
   ChipTabs,
   Button,
+  Switch,
 } from "@ledgerhq/native-ui";
 import { includes, lowerCase, trim } from "lodash";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Keyboard } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
 import NavigationScrollView from "../../components/NavigationScrollView";
 import FeatureFlagDetails, {
   TagDisabled,
@@ -27,6 +30,8 @@ import FeatureFlagDetails, {
 } from "./FeatureFlagDetails";
 import Alert from "../../components/Alert";
 import GroupedFeatures from "./GroupedFeatures";
+import { featureFlagsBannerVisibleSelector } from "../../reducers/settings";
+import { setFeatureFlagsBannerVisible } from "../../actions/settings";
 
 const addFlagHint = `\
 If a feature flag is defined in the Firebase project \
@@ -130,6 +135,18 @@ export default function DebugFeatureFlags() {
 
   const additionalInfo = <Alert title={addFlagHint} type="hint" noIcon />;
 
+  const hasLocallyOverriddenFlags = useHasLocallyOverriddenFeatureFlags();
+  const featureFlagsBannerVisible = useSelector(
+    featureFlagsBannerVisibleSelector,
+  );
+  const dispatch = useDispatch();
+  const setFeatureFlagBannerVisible = useCallback(
+    newVal => {
+      dispatch(setFeatureFlagsBannerVisible(newVal));
+    },
+    [dispatch],
+  );
+
   return (
     <SafeAreaView edges={["bottom"]} style={{ flex: 1 }}>
       <NavigationScrollView>
@@ -146,6 +163,13 @@ export default function DebugFeatureFlags() {
           <Tag uppercase={false} type="color" alignSelf={"flex-start"}>
             {project}
           </Tag>
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Text mt={3}>{t("settings.debug.showBannerDesc")}</Text>
+            <Switch
+              checked={featureFlagsBannerVisible}
+              onChange={setFeatureFlagBannerVisible}
+            />
+          </Flex>
           <Divider />
           <ChipTabs
             labels={[
@@ -168,6 +192,7 @@ export default function DebugFeatureFlags() {
             type="main"
             outline
             onPress={resetFeatures}
+            disabled={!hasLocallyOverriddenFlags}
           >
             {t("settings.debug.featureFlagsRestoreAll")}
           </Button>

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -127,7 +127,7 @@ export default function DebugFeatureFlags() {
                 <Icons.PlusMedium color="neutral.c70" />
               </InputRenderLeftContainer>
             )}
-            placeholder="Add missing flag (instructions above)"
+            placeholder="Add missing flag (instructions below)"
             onChange={handleAddHiddenFlag}
             autoCapitalize="none"
           />

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -47,15 +47,22 @@ export default function DebugFeatureFlags() {
   const [searchInput, setSearchInput] = useState<string>("");
   const searchInputTrimmed = trim(searchInput);
   const [activeTab, setActiveTab] = useState(0);
-  const { resetFeatures } = useFeatureFlags();
+  const { resetFeatures, isFeature } = useFeatureFlags();
 
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
-    if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed))
-      // The search input is added to the `featureKeys` in order to check for "hidden" feature flags
-      featureKeys.push(searchInputTrimmed);
+
+    if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed)) {
+      const isHiddenFeature = isFeature(searchInputTrimmed);
+
+      // Only adds the search input value to the featureKeys if it is an existing hidden feature
+      if (isHiddenFeature) {
+        featureKeys.push(searchInputTrimmed);
+      }
+    }
+
     return featureKeys;
-  }, [searchInputTrimmed]);
+  }, [isFeature, searchInputTrimmed]);
 
   const handleSearch = useCallback(value => {
     setSearchInput(value);

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -52,6 +52,7 @@ export default function DebugFeatureFlags() {
   const featureFlags = useMemo(() => {
     const featureKeys = Object.keys(defaultFeatures);
     if (searchInputTrimmed && !featureKeys.includes(searchInputTrimmed))
+      // The search input is added to the `featureKeys` in order to check for "hidden" feature flags
       featureKeys.push(searchInputTrimmed);
     return featureKeys;
   }, [searchInputTrimmed]);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useRef } from "react";
 import { Icons, Alert as AlertBox } from "@ledgerhq/native-ui";
 import { Alert, TouchableWithoutFeedback, View } from "react-native";
 import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/provider";
-import { FeatureId } from "@ledgerhq/types-live";
+import { groupedFeatures } from "@ledgerhq/live-common/featureFlags/groupedFeatures";
 import { TrackScreen } from "../../../analytics";
 import SettingsRow from "../../../components/SettingsRow";
 import { ScreenName } from "../../../const";
@@ -23,15 +23,7 @@ export default function DebugSettings({
   const { getFeature, overrideFeature } = useFeatureFlags();
 
   const ruleThemAll = useCallback(() => {
-    (
-      [
-        "customImage",
-        "deviceInitialApps",
-        "syncOnboarding",
-        "llmNewDeviceSelection",
-        "staxWelcomeScreen",
-      ] as FeatureId[]
-    ).forEach(featureId =>
+    groupedFeatures.stax.featureIds.forEach(featureId =>
       overrideFeature(featureId, { ...getFeature(featureId), enabled: true }),
     );
     Alert.alert(

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/ExperimentalHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/ExperimentalHeader.tsx
@@ -2,18 +2,31 @@ import React, { useState, useCallback } from "react";
 import { StyleSheet, TouchableOpacity, Platform } from "react-native";
 import Animated, { Extrapolate } from "react-native-reanimated";
 import { Trans } from "react-i18next";
-import { useTheme } from "@react-navigation/native";
+import { useNavigation, useTheme } from "@react-navigation/native";
 import Config from "react-native-config";
+import { useHasLocallyOverriddenFeatureFlags } from "@ledgerhq/live-common/featureFlags/useHasOverriddenFeatureFlags";
+import { Flex } from "@ledgerhq/native-ui";
+import { useSelector } from "react-redux";
 import { useExperimental } from "../../../experimental";
 import { runCollapse } from "../../../components/CollapsibleList";
 import LText from "../../../components/LText";
 import ExperimentalIcon from "../../../icons/Experimental";
 import { rejections } from "../../../logic/debugReject";
+import { NavigatorName, ScreenName } from "../../../const";
+import { BaseNavigation } from "../../../components/RootNavigator/types/helpers";
+import { featureFlagsBannerVisibleSelector } from "../../../reducers/settings";
 
 const { cond, set, Clock, Value, interpolateNode, eq } = Animated;
 export const HEIGHT = Platform.OS === "ios" ? 70 : 30;
 
-function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
+function ExperimentalHeader({
+  isExperimental,
+  areFeatureFlagsOverridden,
+}: {
+  isExperimental: boolean;
+  areFeatureFlagsOverridden: boolean;
+}) {
+  const navigation = useNavigation<BaseNavigation>();
   const { colors } = useTheme();
   const clock = new Clock();
   // animation Open state
@@ -27,7 +40,7 @@ function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
     !Config.MOCK,
     cond(
       // @ts-expect-error Same thing here…
-      eq(isExperimental, true),
+      eq(isExperimental || areFeatureFlagsOverridden, true),
       [
         // opening
         set(openState, runCollapse(clock, openState, 1)),
@@ -50,6 +63,25 @@ function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
   const onPressMock = useCallback(() => {
     rejections.next();
   }, []);
+
+  const onPressExperimental: () => void = useCallback(() => {
+    navigation.navigate(NavigatorName.Base, {
+      screen: NavigatorName.Settings,
+      params: {
+        screen: ScreenName.ExperimentalSettings,
+      },
+    });
+  }, [navigation]);
+
+  const onPressFlags: () => void = useCallback(() => {
+    navigation.navigate(NavigatorName.Base, {
+      screen: NavigatorName.Settings,
+      params: {
+        screen: ScreenName.DebugFeatureFlags,
+      },
+    });
+  }, [navigation]);
+
   return (
     <Animated.View
       style={[
@@ -72,11 +104,19 @@ function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
         {isExperimental && (
           <>
             <ExperimentalIcon size={16} color={colors.live} />
-            <LText bold style={styles.label}>
+            <LText bold style={styles.label} onPress={onPressExperimental}>
               <Trans i18nKey="settings.experimental.title" />
             </LText>
           </>
         )}
+
+        {areFeatureFlagsOverridden ? (
+          <Flex px={4}>
+            <LText bold style={styles.label} onPress={onPressFlags}>
+              <Trans i18nKey="settings.debug.bannerTitle" />
+            </LText>
+          </Flex>
+        ) : null}
 
         {Config.MOCK ? (
           <TouchableOpacity onPress={onPressMock}>
@@ -92,8 +132,14 @@ function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
 
 export default function ExpHeader() {
   const isExperimental = useExperimental();
-  return isExperimental ? (
-    <ExperimentalHeader isExperimental={isExperimental} />
+  const hasLocallyOverriddenFlags = useHasLocallyOverriddenFeatureFlags();
+  const featureFlagsBannerVisible =
+    useSelector(featureFlagsBannerVisibleSelector) && hasLocallyOverriddenFlags;
+  return isExperimental || featureFlagsBannerVisible ? (
+    <ExperimentalHeader
+      isExperimental={isExperimental}
+      areFeatureFlagsOverridden={featureFlagsBannerVisible}
+    />
   ) : null;
 }
 const styles = StyleSheet.create({

--- a/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
@@ -13,15 +13,18 @@ export const groupedFeatures: Record<
     featureIds: [
       "customImage",
       "deviceInitialApps",
-      "syncOnboarding",
       "llmNewDeviceSelection",
+      "postOnboardingAssetsTransfer",
+      "postOnboardingClaimNft",
+      "staxWelcomeScreen",
+      "syncOnboarding",
     ],
   },
   disableNft: {
     featureIds: [
-      "disableNftSend",
       "disableNftLedgerMarket",
       "disableNftRaribleOpensea",
+      "disableNftSend",
     ],
   },
 };

--- a/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
@@ -5,11 +5,9 @@ export const groupedFeatures: Record<
   string,
   {
     featureIds: FeatureId[];
-    iconNameWeight?: string;
   }
 > = {
   stax: {
-    iconNameWeight: "StaxRegular",
     featureIds: [
       "customImage",
       "deviceInitialApps",

--- a/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
@@ -5,16 +5,23 @@ export const groupedFeatures: Record<
   string,
   {
     featureIds: FeatureId[];
-    iconName: string;
+    iconNameWeight?: string;
   }
 > = {
   stax: {
-    iconName: "staxRegular",
+    iconNameWeight: "StaxRegular",
     featureIds: [
       "customImage",
       "deviceInitialApps",
       "syncOnboarding",
       "llmNewDeviceSelection",
+    ],
+  },
+  disableNft: {
+    featureIds: [
+      "disableNftSend",
+      "disableNftLedgerMarket",
+      "disableNftRaribleOpensea",
     ],
   },
 };

--- a/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
@@ -1,0 +1,20 @@
+import { FeatureId } from "@ledgerhq/types-live";
+
+/** Helper to group several feature flag ids under a common feature flag */
+export const groupedFeatures: Record<
+  string,
+  {
+    featureIds: FeatureId[];
+    iconName: string;
+  }
+> = {
+  stax: {
+    iconName: "staxRegular",
+    featureIds: [
+      "customImage",
+      "deviceInitialApps",
+      "syncOnboarding",
+      "llmNewDeviceSelection",
+    ],
+  },
+};

--- a/libs/ledger-live-common/src/featureFlags/index.ts
+++ b/libs/ledger-live-common/src/featureFlags/index.ts
@@ -4,4 +4,5 @@ import FeatureToggle from "./FeatureToggle";
 export { useFeature, FeatureToggle };
 
 export * from "./defaultFeatures";
+export * from "./groupedFeatures";
 export * from "./provider";

--- a/libs/ledger-live-common/src/featureFlags/index.ts
+++ b/libs/ledger-live-common/src/featureFlags/index.ts
@@ -6,3 +6,4 @@ export { useFeature, FeatureToggle };
 export * from "./defaultFeatures";
 export * from "./groupedFeatures";
 export * from "./provider";
+export * from "./useHasOverriddenFeatureFlags";

--- a/libs/ledger-live-common/src/featureFlags/provider.tsx
+++ b/libs/ledger-live-common/src/featureFlags/provider.tsx
@@ -1,23 +1,18 @@
-import React, {
-  createContext,
-  ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
-
+import React, { createContext, ReactNode, useContext } from "react";
 import type { FeatureId, Feature } from "@ledgerhq/types-live";
 
 type State = {
   getFeature: (_: FeatureId) => Feature | null;
   overrideFeature: (_: FeatureId, value: Feature) => void;
   resetFeature: (_: FeatureId) => void;
+  resetFeatures: () => void;
 };
 
 const initialState: State = {
   getFeature: (_) => ({ enabled: false }),
   overrideFeature: (_) => {},
   resetFeature: (_) => {},
+  resetFeatures: () => {},
 };
 
 const FeatureFlagsContext = createContext<State>(initialState);
@@ -26,32 +21,16 @@ export function useFeatureFlags(): State {
   return useContext<State>(FeatureFlagsContext);
 }
 
-type Props = {
-  getFeature: (_: FeatureId) => Feature | null;
-  overrideFeature: (_: FeatureId, value: Feature) => void;
-  resetFeature: (_: FeatureId) => void;
+type Props = State & {
   children?: ReactNode;
 };
 
 export function FeatureFlagsProvider({
-  getFeature,
-  overrideFeature,
-  resetFeature,
   children,
+  ...providerState
 }: Props): JSX.Element {
-  const [state, setState] = useState<State>(initialState);
-
-  useEffect(() => {
-    setState((prev) => ({
-      ...prev,
-      getFeature,
-      overrideFeature,
-      resetFeature,
-    }));
-  }, [getFeature, overrideFeature, resetFeature]);
-
   return (
-    <FeatureFlagsContext.Provider value={state}>
+    <FeatureFlagsContext.Provider value={providerState}>
       {children}
     </FeatureFlagsContext.Provider>
   );

--- a/libs/ledger-live-common/src/featureFlags/provider.tsx
+++ b/libs/ledger-live-common/src/featureFlags/provider.tsx
@@ -2,6 +2,7 @@ import React, { createContext, ReactNode, useContext } from "react";
 import type { FeatureId, Feature } from "@ledgerhq/types-live";
 
 type State = {
+  isFeature: (_: string) => boolean;
   getFeature: (_: FeatureId) => Feature | null;
   overrideFeature: (_: FeatureId, value: Feature) => void;
   resetFeature: (_: FeatureId) => void;
@@ -9,6 +10,7 @@ type State = {
 };
 
 const initialState: State = {
+  isFeature: (_) => false,
   getFeature: (_) => ({ enabled: false }),
   overrideFeature: (_) => {},
   resetFeature: (_) => {},

--- a/libs/ledger-live-common/src/featureFlags/useHasOverriddenFeatureFlags.ts
+++ b/libs/ledger-live-common/src/featureFlags/useHasOverriddenFeatureFlags.ts
@@ -1,0 +1,24 @@
+import { useFeatureFlags } from "./provider";
+import { defaultFeatures } from "./defaultFeatures";
+import { useMemo } from "react";
+import { FeatureId } from "@ledgerhq/types-live";
+
+/**
+ *
+ * @returns whether one or more flags are locally overridden
+ */
+export function useHasLocallyOverriddenFeatureFlags(): boolean {
+  const { getFeature } = useFeatureFlags();
+  return useMemo(
+    () =>
+      Object.entries(defaultFeatures).some(([featureId]) => {
+        try {
+          const val = getFeature(featureId as FeatureId);
+          return val?.overridesRemote || val?.overriddenByEnv;
+        } catch (e) {
+          return false;
+        }
+      }),
+    [getFeature]
+  );
+}

--- a/libs/ledger-live-common/src/featureFlags/useHasOverriddenFeatureFlags.ts
+++ b/libs/ledger-live-common/src/featureFlags/useHasOverriddenFeatureFlags.ts
@@ -1,7 +1,7 @@
-import { useFeatureFlags } from "./provider";
-import { defaultFeatures } from "./defaultFeatures";
 import { useMemo } from "react";
 import { FeatureId } from "@ledgerhq/types-live";
+import { useFeatureFlags } from "./provider";
+import { defaultFeatures } from "./defaultFeatures";
 
 /**
  *

--- a/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingHubState.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingHubState.test.ts
@@ -22,6 +22,7 @@ const mockedGetFeatureWithMockFeatureEnabled = (enabled) => ({
   },
   overrideFeature: () => {},
   resetFeature: () => {},
+  resetFeatures: () => {},
 });
 
 const mockedUsePostOnboardingContext = jest.mocked(usePostOnboardingContext);

--- a/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingHubState.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingHubState.test.ts
@@ -16,6 +16,7 @@ jest.mock("../reducer");
 
 const mockedUseFeatureFlags = jest.mocked(useFeatureFlags);
 const mockedGetFeatureWithMockFeatureEnabled = (enabled) => ({
+  isFeature: () => true,
   getFeature: (id) => {
     if (id === mockedFeatureIdToTest) return { enabled };
     return { enabled: true };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -72,7 +72,7 @@ export type Feature = {
   /** Whether the remote value of this object was overriden by an environment variable */
   overriddenByEnv?: boolean;
   /** Additional params */
-  params?: unknown;
+  params?: any;
 };
 
 /** */

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -72,7 +72,7 @@ export type Feature = {
   /** Whether the remote value of this object was overriden by an environment variable */
   overriddenByEnv?: boolean;
   /** Additional params */
-  params?: any;
+  params?: unknown;
 };
 
 /** */


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- LLM+LLD: Overriding the configuration of feature flags is now **persistent over app restarts**. This is done using the settings property of the redux store.
- LLM: added a "Flags overridden locally" reusing the Experimental banner to signal whether some flags are overridden locally. This banner can be disabled in the FF debug menu.
- LLM: "Reset all" button to reset all locally overridden feature flags.
- LLM: Grouped features that can be toggled all at once

### ❓ Context

- **Impacted projects**: `mobile` `desktop` `common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-721] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

sound on 🔊

https://user-images.githubusercontent.com/91890529/207936443-1ffa0ce7-fae7-4d82-8e70-f6d96d4a5a1e.mov



### 🚀 Expectations to reach

The description of the PR and the demo above summarize what is new and to test on this PR.

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-721]: https://ledgerhq.atlassian.net/browse/FAT-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ