### PR TITLE
fix: LLD - improves performance of swap redux selector

### DIFF
--- a/.changeset/red-trains-fry.md
+++ b/.changeset/red-trains-fry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Improves performance of swap provider selector

--- a/apps/ledger-live-desktop/src/renderer/actions/swap.js
+++ b/apps/ledger-live-desktop/src/renderer/actions/swap.js
@@ -34,13 +34,20 @@ export const providersSelector: OutputSelector<
   swap => swap.providers,
 );
 
-const filterAvailableToAssets = (pairs, fromId?: string) => {
+export const filterAvailableToAssets = (pairs, fromId?: string) => {
   if (pairs === null || pairs === undefined) return null;
 
-  if (fromId)
-    return pairs.reduce((acc, pair) => (pair.from === fromId ? [...acc, pair.to] : acc), []);
+  const toAssets = [];
+  for (const pair of pairs) {
+    if (fromId && pair.from === fromId) {
+      toAssets.push(pair.to);
+    }
 
-  return pairs.reduce((acc, pair) => [...acc, pair.to], []);
+    if (!fromId) {
+      toAssets.push(pair.to);
+    }
+  }
+  return toAssets;
 };
 
 const filterAvailableFromAssets = (pairs, allAccounts) => {

--- a/apps/ledger-live-desktop/src/renderer/actions/swap.test.js
+++ b/apps/ledger-live-desktop/src/renderer/actions/swap.test.js
@@ -1,4 +1,4 @@
-import { sortAccountsByStatus } from "./swap";
+import { filterAvailableToAssets, sortAccountsByStatus } from "./swap";
 
 const accounts = [
   { type: "Account", name: "test1", disabled: false },
@@ -28,4 +28,27 @@ const expectedOrder = [
 
 test("SortAccountsByStatus should keep disable accounts with active subAccounts before disable accounts", () => {
   expect(sortAccountsByStatus(accounts).map(value => value.name)).toEqual(expectedOrder);
+});
+
+test("filterAvailableToAssets returns to assets with fromId", () => {
+  const toAssets = filterAvailableToAssets(
+    [
+      { from: "a", to: "b" },
+      { from: "b", to: "a" },
+      { from: "c", to: "d" },
+      { from: "a", to: "e" },
+    ],
+    "a",
+  );
+  expect(toAssets).toEqual(["b", "e"]);
+});
+
+test("filterAvailableToAssets returns to assets without fromId", () => {
+  const toAssets = filterAvailableToAssets([
+    { from: "a", to: "b" },
+    { from: "b", to: "a" },
+    { from: "c", to: "d" },
+    { from: "a", to: "e" },
+  ]);
+  expect(toAssets).toEqual(["b", "a", "d", "e"]);
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

filterAvailableToAssets is currently very slow when working with large arrays of `pairs` because of the array spreading inside the reduce statement. When profiling on a separate [branch](https://github.com/LedgerHQ/ledger-live/pull/2123/files) - it took around 15s for this function to execute. 
<img width="1400" alt="Screenshot 2022-12-16 at 11 44 47" src="https://user-images.githubusercontent.com/119950081/208110610-5fae9e10-00f0-44cd-a0af-96579c25e0d8.png">

With the changes done in this PR, this function now returns much faster (where there is no noticeable delay in the UI). 

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
