### PR TITLE
Fix margins for app update and firwmare update banners

### DIFF
--- a/.changeset/moody-flowers-enjoy.md
+++ b/.changeset/moody-flowers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Small fix on the margins on MyLedger screen for Frimware and Apps update banners

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -89,7 +89,7 @@ const FirmwareUpdateBanner = ({
     : "";
 
   return showBanner && hasCompletedOnboarding && hasConnectedDevice ? (
-    <Flex mt={8} {...containerProps}>
+    <Flex mt={5} {...containerProps}>
       <Alert type="info" showIcon={false}>
         <Text flexShrink={1} flexGrow={1}>
           {t("FirmwareUpdate.newVersion", {

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppUpdateAll.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppUpdateAll.tsx
@@ -34,7 +34,7 @@ const AppUpdateAll = ({
   }, [dispatch]);
 
   return (
-    <Flex>
+    <Flex mt={5}>
       <AppUpdateStepper state={state} />
       {appsToUpdate.length > 0 && updateAllQueue.length <= 0 && (
         <Flex

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo, memo } from "react";
 import { FlatList, StyleSheet } from "react-native";
+import { useSelector } from "react-redux";
 import {
   listTokens,
   isCurrencySupported,
@@ -38,6 +39,8 @@ import type {
 } from "../../components/RootNavigator/types/helpers";
 import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/types/ManagerNavigator";
 import { ScreenName } from "../../const";
+import { lastSeenDeviceSelector } from "../../reducers/settings";
+import useLatestFirmware from "../../hooks/useLatestFirmware";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<ManagerNavigatorStackParamList, ScreenName.ManagerMain>
@@ -261,6 +264,10 @@ const AppsScreen = ({
     ],
   );
 
+  const lastSeenDevice = useSelector(lastSeenDeviceSelector);
+  const latestFirmware = useLatestFirmware(lastSeenDevice?.deviceInfo);
+  const showFwUpdateBanner = Boolean(latestFirmware);
+
   const renderList = useCallback(
     (items?: App[]) => (
       <FlatList
@@ -282,13 +289,16 @@ const AppsScreen = ({
               onLanguageChange={onLanguageChange}
             />
             <Benchmarking state={state} />
-            <FirmwareUpdateBanner />
-            <AppUpdateAll
-              state={state}
-              appsToUpdate={update}
-              dispatch={dispatch}
-              isModalOpened={updateModalOpened}
-            />
+            {showFwUpdateBanner ? (
+              <FirmwareUpdateBanner />
+            ) : (
+              <AppUpdateAll
+                state={state}
+                appsToUpdate={update}
+                dispatch={dispatch}
+                isModalOpened={updateModalOpened}
+              />
+            )}
             <Flex
               flexDirection="row"
               mt={8}
@@ -330,6 +340,7 @@ const AppsScreen = ({
       device,
       deviceApps,
       onLanguageChange,
+      showFwUpdateBanner,
       update,
       updateModalOpened,
       query,


### PR DESCRIPTION
### 📝 Description
This is a small PR just to fix some weird spacing that was happening at the My Ledger page concerning the update banners for firmware and apps. Right now there should never be both the firmware update banner and the apps update banner at the same time. And the margins for the banner should be correct.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [FAT-744](https://ledgerhq.atlassian.net/browse/FAT-744)
### ✅ Checklist

- [N/A] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://user-images.githubusercontent.com/6013294/208451587-310c5309-d4bf-4ff9-94cf-1a7b9518a7a1.png)