### PR TITLE
bugfix/FAT-720 Use 670px height for custom lockscreen images

### DIFF
--- a/.changeset/early-owls-count.md
+++ b/.changeset/early-owls-count.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+670pixel instead of 672 for custom lockscreen images

--- a/.changeset/heavy-jobs-laugh.md
+++ b/.changeset/heavy-jobs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Custom images should padd 2 pixels per column to be the right size

--- a/.changeset/spicy-socks-sin.md
+++ b/.changeset/spicy-socks-sin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+670pixel instead of 672 for custom lockscreen images

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/FramedImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/FramedImage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Flex, Box, Text } from "@ledgerhq/react-ui";
 import styled, { useTheme } from "styled-components";
 import { scaleDimensions } from "./imageUtils";
-import { targetDimensions } from "./shared";
+import { targetDisplayDimensions } from "./shared";
 import StyleProviderV3 from "~/renderer/styles/StyleProviderV3";
 import { ImageDimensions } from "./types";
 
@@ -27,7 +27,7 @@ const absoluteFillObject = {
   right: 0,
 };
 
-const defaultImageDimensions = scaleDimensions(targetDimensions, 0.4);
+const defaultImageDimensions = scaleDimensions(targetDisplayDimensions, 0.4);
 
 const px = 3;
 const py = 3;

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageGrayscalePreview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/ImageGrayscalePreview.tsx
@@ -3,7 +3,7 @@ import { Flex } from "@ledgerhq/react-ui";
 import { ImageProcessingError } from "@ledgerhq/live-common/customImage/errors";
 import { createCanvas, scaleDimensions } from "./imageUtils";
 import { ImageBase64Data, ImageDimensions } from "./types";
-import { targetDimensions } from "./shared";
+import { targetDisplayDimensions } from "./shared";
 import ContrastChoice from "./ContrastChoice";
 import FramedImage from "./FramedImage";
 
@@ -22,7 +22,7 @@ const contrasts = [
   { val: 3, color: "neutral.c30" },
 ];
 
-const imageDimensions = scaleDimensions(targetDimensions, 0.45);
+const imageDimensions = scaleDimensions(targetDisplayDimensions, 0.45);
 
 function clamp(val: number, min: number, max: number) {
   return Math.min(max, Math.max(min, val));

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/TestImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/TestImage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Alert, Flex, Text } from "@ledgerhq/react-ui";
 import { ProcessorResult } from "~/renderer/components/CustomImage/ImageGrayscalePreview";
-import { targetDimensions } from "~/renderer/components/CustomImage/shared";
+import { targetDisplayDimensions } from "~/renderer/components/CustomImage/shared";
 import { ImageBase64Data } from "~/renderer/components/CustomImage/types";
 import { createCanvas } from "~/renderer/components/CustomImage/imageUtils";
 import { ImageProcessingError } from "@ledgerhq/live-common/customImage/errors";
@@ -95,7 +95,7 @@ const TestImage: React.FC<Props> = props => {
         {reconstructedImage ? (
           <img
             src={reconstructedImage?.imageBase64DataUri}
-            style={{ height: targetDimensions.height }}
+            style={{ height: targetDisplayDimensions.height }}
           />
         ) : null}
       </Flex>

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/shared.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/shared.ts
@@ -1,8 +1,13 @@
 import { ImageDownloadError } from "@ledgerhq/live-common/customImage/errors";
 
-export const targetDimensions = {
-  height: 672,
+export const targetDisplayDimensions = {
   width: 400,
+  height: 670,
+};
+
+export const targetDataDimensions = {
+  width: 400,
+  height: 672,
 };
 
 export async function urlContentToDataUri(url: string): Promise<string> {

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step2AdjustImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step2AdjustImage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { ImageBase64Data } from "~/renderer/components/CustomImage/types";
 import { Step, StepProps } from "./types";
 import ImageCropper, { CropParams } from "~/renderer/components/CustomImage/ImageCropper";
-import { targetDimensions } from "~/renderer/components/CustomImage/shared";
+import { targetDisplayDimensions } from "~/renderer/components/CustomImage/shared";
 import StepFooter from "./StepFooter";
 import { useTranslation } from "react-i18next";
 import StepContainer from "./StepContainer";
@@ -39,7 +39,7 @@ const StepAdjustImage: React.FC<Props> = props => {
           {...src}
           initialCropParams={initialCropParams}
           setCropParams={setCropParams}
-          targetDimensions={targetDimensions}
+          targetDimensions={targetDisplayDimensions}
           onResult={onResult}
           onError={onError}
           setLoading={setLoading}

--- a/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
@@ -30,7 +30,7 @@ import {
   importImageFromPhoneGallery,
 } from "../../components/CustomImage/imageUtils";
 import { ImageFileUri } from "../../components/CustomImage/types";
-import { targetDimensions } from "./shared";
+import { targetDisplayDimensions } from "./shared";
 import FramedImage, {
   previewConfig,
 } from "../../components/CustomImage/FramedImage";
@@ -146,7 +146,7 @@ const PreviewPreEdit = ({ navigation, route }: NavigationProps) => {
   );
 
   useCenteredImage({
-    targetDimensions,
+    targetDimensions: targetDisplayDimensions,
     imageFileUri: loadedImage?.imageFileUri,
     onError: handleResizeError,
     onResult: handleResizeResult,

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
@@ -8,7 +8,7 @@ import ImageCropper, {
   CropResult,
 } from "../../components/CustomImage/ImageCropper";
 import { ImageDimensions } from "../../components/CustomImage/types";
-import { targetDataDimensions, targetDisplayDimensions } from "./shared";
+import { targetDisplayDimensions } from "./shared";
 import Button from "../../components/Button";
 import { ScreenName } from "../../const";
 import BottomContainer from "../../components/CustomImage/BottomButtonsContainer";

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step1Crop.tsx
@@ -8,7 +8,7 @@ import ImageCropper, {
   CropResult,
 } from "../../components/CustomImage/ImageCropper";
 import { ImageDimensions } from "../../components/CustomImage/types";
-import { targetDimensions } from "./shared";
+import { targetDataDimensions, targetDisplayDimensions } from "./shared";
 import Button from "../../components/Button";
 import { ScreenName } from "../../const";
 import BottomContainer from "../../components/CustomImage/BottomButtonsContainer";
@@ -103,7 +103,7 @@ const Step1Cropping = ({ navigation, route }: NavigationProps) => {
           <ImageCropper
             ref={cropperRef}
             imageFileUri={baseImageFile.imageFileUri}
-            aspectRatio={targetDimensions}
+            aspectRatio={targetDisplayDimensions}
             /**
              * this native component needs absolute height & width values to
              * render properly

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step2Preview.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step2Preview.tsx
@@ -24,7 +24,7 @@ import ImageProcessor, {
   ProcessorPreviewResult,
   ProcessorRawResult,
 } from "../../components/CustomImage/ImageProcessor";
-import { targetDimensions } from "./shared";
+import { targetDisplayDimensions } from "./shared";
 import BottomButtonsContainer from "../../components/CustomImage/BottomButtonsContainer";
 import ContrastChoice from "../../components/CustomImage/ContrastChoice";
 import { ScreenName } from "../../const";
@@ -116,7 +116,7 @@ const Step2Preview = ({ navigation, route }: NavigationProps) => {
   );
 
   useResizedImage({
-    targetDimensions,
+    targetDimensions: targetDisplayDimensions,
     imageFileUri: croppedImage?.imageFileUri,
     onError: handleError,
     onResult: handleResizeResult,
@@ -214,7 +214,8 @@ const Step2Preview = ({ navigation, route }: NavigationProps) => {
             style={{
               width: previewDimensions.width,
               height:
-                (targetDimensions.height / targetDimensions.width) *
+                (targetDisplayDimensions.height /
+                  targetDisplayDimensions.width) *
                 previewDimensions.width,
             }}
             resizeMode="contain"

--- a/apps/ledger-live-mobile/src/screens/CustomImage/shared.ts
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/shared.ts
@@ -1,4 +1,9 @@
-export const targetDimensions = {
+export const targetDisplayDimensions = {
+  width: 400,
+  height: 670,
+};
+
+export const targetDataDimensions = {
   width: 400,
   height: 672,
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/CustomImageGraphics.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/CustomImageGraphics.tsx
@@ -24,7 +24,7 @@ import { downloadImageToFile } from "../../../../components/CustomImage/imageUti
 import useCenteredImage, {
   CenteredResult,
 } from "../../../../components/CustomImage/useCenteredImage";
-import { targetDimensions } from "../../../CustomImage/shared";
+import { targetDisplayDimensions } from "../../../CustomImage/shared";
 import confirmLockscreen from "../../../../animations/stax/customimage/confirmLockscreen.json";
 import allowConnection from "../../../../animations/stax/customimage/allowConnection.json";
 import { FramedImageWithLottieWithContext } from "../../../../components/CustomImage/FramedImageWithLottie";
@@ -58,7 +58,7 @@ export default function DebugCustomImageGraphics() {
 
   useCenteredImage({
     ...imageToCrop,
-    targetDimensions,
+    targetDimensions: targetDisplayDimensions,
     onResult: setCroppedImage,
     onError: setError,
   });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/FetchCustomImage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/FetchCustomImage.tsx
@@ -19,7 +19,7 @@ import SelectDevice from "../../../../components/SelectDevice";
 import CustomImageDeviceAction from "../../../../components/CustomImageDeviceAction";
 import ResultDataTester from "../../../../components/CustomImage/ResultDataTester";
 import { ProcessorPreviewResult } from "../../../../components/CustomImage/ImageProcessor";
-import { targetDimensions } from "../../../CustomImage/shared";
+import { targetDisplayDimensions } from "../../../CustomImage/shared";
 import FramedImage, {
   transferConfig,
 } from "../../../../components/CustomImage/FramedImage";
@@ -154,7 +154,7 @@ export default function DebugFetchCustomImage() {
           <>
             <ResultDataTester
               hexData={hex as string}
-              {...targetDimensions}
+              {...targetDisplayDimensions}
               onPreviewResult={handleImageSourceLoaded}
               onError={() => console.error(error)}
             />

--- a/libs/ledger-live-common/src/hw/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/staxLoadImage.ts
@@ -223,7 +223,10 @@ export const generateStaxImageFormat: (
   header.writeUInt16LE(height, 2); // height
   header.writeUInt8((bpp << 4) | compression, 4);
 
-  const imgData = Buffer.from(hexImage, "hex");
+  // Nb Display image data is missing 2 pixels from each column.
+  // padding every 670 characters with two fillers, should do the trick.
+  const paddedHexImage = hexImage.replace(/(.{670})/g, "$100");
+  const imgData = Buffer.from(paddedHexImage, "hex");
 
   if (!compressImage) {
     const dataLength = imgData.length;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Even though the display is 400x672, two of the pixels from the height are not visible. This resulted in minor cropping of the bottom part of the selected image and, in case there was some text there, rendered it illegible. This PR addresses the issue by modifying the image customization tool to only use the visible pixels and padding the data before sending it to match what the firmware expects from us.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile, ledger-live-desktop, ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-720` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Feel free to use this image for testing, it has pixel perfect size and content on the edges to guarantee it remains visible.
Maybe also play with other images to make sure the cropping doesn't mess with it.

![test](https://user-images.githubusercontent.com/4631227/208659975-69ba7800-2007-491c-8721-bf6e21c4df13.png)


### 🚀 Expectations to reach
We shouldn't lose the last two pixels of the image.