### PR TITLE
bugfix/FAT-742 Prevent crash when app tries to use stored nanoFTS ref

### DIFF
--- a/.changeset/pretty-suits-jump.md
+++ b/.changeset/pretty-suits-jump.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Prevent crash with reference to nanoFTS in app data

--- a/apps/ledger-live-mobile/src/reducers/ble.ts
+++ b/apps/ledger-live-mobile/src/reducers/ble.ts
@@ -57,7 +57,14 @@ const handlers: ReducerMap<BleState, BlePayload> = {
 };
 // Selectors
 export const exportSelector = (s: State) => s.ble;
-export const knownDevicesSelector = (s: State) => s.ble.knownDevices;
+export const knownDevicesSelector = (s: State) => {
+  // Nb workaround to prevent crash for dev/qa that have nanoFTS references.
+  // to be removed in a while.
+  return s.ble.knownDevices.map(knownDevice => ({
+    ...knownDevice,
+    modelId: knownDevice.modelId === "nanoFTS" ? "stax" : knownDevice.modelId,
+  }));
+};
 export const deviceNameByDeviceIdSelectorCreator =
   (deviceId: string) => (s: State) => {
     const d = s.ble.knownDevices.find(d => d.id === deviceId);

--- a/apps/ledger-live-mobile/src/reducers/ble.ts
+++ b/apps/ledger-live-mobile/src/reducers/ble.ts
@@ -1,5 +1,6 @@
 import { handleActions } from "redux-actions";
 import type { Action, ReducerMap } from "redux-actions";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { BleState, State } from "./types";
 import type {
   BleAddKnownDevicePayload,
@@ -62,7 +63,12 @@ export const knownDevicesSelector = (s: State) => {
   // to be removed in a while.
   return s.ble.knownDevices.map(knownDevice => ({
     ...knownDevice,
-    modelId: knownDevice.modelId === "nanoFTS" ? "stax" : knownDevice.modelId,
+    modelId:
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      knownDevice.modelId === "nanoFTS"
+        ? DeviceModelId.stax
+        : knownDevice.modelId,
   }));
 };
 export const deviceNameByDeviceIdSelectorCreator =

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -13,6 +13,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { ValidKYCStatus } from "@ledgerhq/live-common/exchange/swap/types";
 import type { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { CurrencySettings, SettingsState, State } from "./types";
 import { currencySettingsDefaults } from "../helpers/CurrencySettingsDefaults";
 // eslint-disable-next-line import/no-cycle
@@ -750,15 +751,29 @@ export const swapKYCSelector = (state: State) => state.settings.swap.KYC;
 export const lastSeenDeviceSelector = (state: State) => {
   // Nb workaround to prevent crash for dev/qa that have nanoFTS references.
   // to be removed in a while.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   if (state.settings.lastSeenDevice?.modelId === "nanoFTS") {
-    return { ...state.settings.lastSeenDevice, modelId: "stax" };
+    return { ...state.settings.lastSeenDevice, modelId: DeviceModelId.stax };
   }
   return state.settings.lastSeenDevice;
 };
 export const starredMarketCoinsSelector = (state: State) =>
   state.settings.starredMarketCoins;
-export const lastConnectedDeviceSelector = (state: State) =>
-  state.settings.lastConnectedDevice;
+export const lastConnectedDeviceSelector = (state: State) => {
+  // Nb workaround to prevent crash for dev/qa that have nanoFTS references.
+  // to be removed in a while.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (state.settings.lastConnectedDevice?.modelId === "nanoFTS") {
+    return {
+      ...state.settings.lastConnectedDevice,
+      modelId: DeviceModelId.stax,
+    };
+  }
+
+  return state.settings.lastConnectedDevice;
+};
 export const hasOrderedNanoSelector = (state: State) =>
   state.settings.hasOrderedNano;
 export const marketRequestParamsSelector = (state: State) =>

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -747,8 +747,14 @@ export const swapSelectableCurrenciesSelector = (state: State) =>
 export const swapAcceptedProvidersSelector = (state: State) =>
   state.settings.swap.acceptedProviders;
 export const swapKYCSelector = (state: State) => state.settings.swap.KYC;
-export const lastSeenDeviceSelector = (state: State) =>
-  state.settings.lastSeenDevice;
+export const lastSeenDeviceSelector = (state: State) => {
+  // Nb workaround to prevent crash for dev/qa that have nanoFTS references.
+  // to be removed in a while.
+  if (state.settings.lastSeenDevice?.modelId === "nanoFTS") {
+    return { ...state.settings.lastSeenDevice, modelId: "stax" };
+  }
+  return state.settings.lastSeenDevice;
+};
 export const starredMarketCoinsSelector = (state: State) =>
   state.settings.starredMarketCoins;
 export const lastConnectedDeviceSelector = (state: State) =>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When merging https://github.com/LedgerHQ/ledger-live/pull/2144 we missed a case where, when a user had seen a device with the codename `nanoFTS`, we tried to access the model information for that reference. Since https://github.com/LedgerHQ/ledger-live/pull/2144 replaced all references in favor of `stax` this is currently crashing the app for devs/qa. The pr prevents them from having to reinstall the app, this wouldn't reach prod . 
### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-742` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Even harder than the LLD version to reproduce, you would have to checkout an commit before the rename happened, pair a stax device, update your branch to right after the rename to reproduce the crash, then to this pr to reproduce the fix. Sorry I can't provide an easier test scenario.