### PR TITLE
Introduce "experimental networking" settings that runs all coin and app logic on renderer side

### DIFF
--- a/apps/ledger-live-desktop/src/internal/commands/index.js
+++ b/apps/ledger-live-desktop/src/internal/commands/index.js
@@ -11,6 +11,7 @@ import listenToHidDevices from "./listenToHidDevices";
 import listApps from "./listApps";
 import signMessage from "./signMessage";
 import ping from "./ping";
+import publicKeyTweakAdd from "./publicKeyTweakAdd";
 import connectApp from "./connectApp";
 import connectManager from "./connectManager";
 import networkTroubleshoot from "./networkTroubleshoot";
@@ -50,6 +51,7 @@ export const commandsById = {
   connectManager,
   listApps,
   ping,
+  publicKeyTweakAdd,
   networkTroubleshoot,
   testApdu,
   initSwap,

--- a/apps/ledger-live-desktop/src/internal/commands/publicKeyTweakAdd.js
+++ b/apps/ledger-live-desktop/src/internal/commands/publicKeyTweakAdd.js
@@ -1,0 +1,15 @@
+// @flow
+import { from } from "rxjs";
+import { getSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/wallet-btc/crypto/secp256k1";
+
+const cmd = ({ publicKey, tweak }) =>
+  from(
+    getSecp256k1Instance()
+      .publicKeyTweakAdd(
+        new Uint8Array(Buffer.from(publicKey, "hex").toJSON().data),
+        new Uint8Array(Buffer.from(tweak, "hex").toJSON().data),
+      )
+      .then(r => Buffer.from(r).toString("hex")),
+  );
+
+export default cmd;

--- a/apps/ledger-live-desktop/src/internal/commands/publicKeyTweakAdd.test.ts
+++ b/apps/ledger-live-desktop/src/internal/commands/publicKeyTweakAdd.test.ts
@@ -1,0 +1,12 @@
+import publicKeyTweakAdd from "./publicKeyTweakAdd";
+
+describe("publicKeyTweakAdd works as expected", () => {
+  test("basic usage", () => {
+    publicKeyTweakAdd({
+      publicKey: "02f1f90c3f8aca90f5c170c8920531c3c3518b9f2f00a076b2725509878e4343ca",
+      tweak: "08a41038ce3d801e38977b8f9ae9414511bf8f3b96895f884db9ecb533542cc8",
+    }).subscribe(r => {
+      expect(r).toBe("039042f99b168a3ed034c55e58ac2ac1ad11a0ef0883dc4ef219a94ea085fe6cb1");
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/internal/commands/publicKeyTweakAdd.ts
+++ b/apps/ledger-live-desktop/src/internal/commands/publicKeyTweakAdd.ts
@@ -1,8 +1,7 @@
-// @flow
-import { from } from "rxjs";
+import { from, Observable } from "rxjs";
 import { getSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/wallet-btc/crypto/secp256k1";
 
-const cmd = ({ publicKey, tweak }) =>
+const cmd = ({ publicKey, tweak }: { publicKey: string; tweak: string }): Observable<string> =>
   from(
     getSecp256k1Instance()
       .publicKeyTweakAdd(

--- a/apps/ledger-live-desktop/src/logger/logger-transport-in-memory.js
+++ b/apps/ledger-live-desktop/src/logger/logger-transport-in-memory.js
@@ -1,0 +1,17 @@
+import Transport from "winston-transport";
+
+export default class MemoryTransport extends Transport {
+  logs = [];
+  capacity = 3000;
+
+  log(info, callback) {
+    setImmediate(() => {
+      this.emit("logged", info);
+    });
+
+    this.logs.unshift(info);
+    this.logs.splice(this.capacity);
+
+    callback();
+  }
+}

--- a/apps/ledger-live-desktop/src/logger/logger-transport-main.js
+++ b/apps/ledger-live-desktop/src/logger/logger-transport-main.js
@@ -1,20 +1,2 @@
-import Transport from "winston-transport";
-
-export default class MainTransport extends Transport {
-  logs = [];
-  capacity = 3000;
-  blacklist = [];
-
-  log(info, callback) {
-    setImmediate(() => {
-      this.emit("logged", info);
-    });
-
-    if (!this.blacklist.includes(info.type)) {
-      this.logs.unshift(info);
-      this.logs.splice(this.capacity);
-    }
-
-    callback();
-  }
-}
+import MemoryTransport from "./logger-transport-in-memory";
+export default MemoryTransport;

--- a/apps/ledger-live-desktop/src/logger/logger-transport-renderer-instance.js
+++ b/apps/ledger-live-desktop/src/logger/logger-transport-renderer-instance.js
@@ -1,0 +1,4 @@
+import LoggerTransport from "./logger-transport-renderer";
+
+const instance = new LoggerTransport();
+export default instance;

--- a/apps/ledger-live-desktop/src/logger/logger-transport-renderer.js
+++ b/apps/ledger-live-desktop/src/logger/logger-transport-renderer.js
@@ -1,12 +1,29 @@
+import MemoryTransport from "./logger-transport-in-memory";
 import Transport from "winston-transport";
+import { getEnv } from "@ledgerhq/live-common/env";
 
 export default class RendererTransport extends Transport {
   ipcRenderer = require("electron").ipcRenderer;
+
+  constructor(...args) {
+    super(...args);
+    this.memory = new MemoryTransport(...args);
+  }
+
+  getMemoryLogs() {
+    return this.memory.logs;
+  }
 
   log(info, callback) {
     setImmediate(() => {
       this.emit("logged", info);
     });
+
+    // In case of experimental execution on renderer, we actually forward this whole action to memory
+    if (getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER")) {
+      this.memory.log(info, callback);
+      return;
+    }
 
     try {
       this.ipcRenderer.send("log", { log: info });

--- a/apps/ledger-live-desktop/src/main/setup.js
+++ b/apps/ledger-live-desktop/src/main/setup.js
@@ -41,12 +41,9 @@ ipcMain.on("updater", (e, type) => {
 ipcMain.handle(
   "save-logs",
   async (event, path: { canceled: boolean, filePath: string }, experimentalLogs: string | null) =>
-    Promise.resolve().then(
-      () =>
-        !path.canceled &&
-        path.filePath &&
-        fsWriteFile(path.filePath, experimentalLogs || JSON.stringify(loggerTransport.logs)),
-    ),
+    !path.canceled &&
+    path.filePath &&
+    fsWriteFile(path.filePath, experimentalLogs || JSON.stringify(loggerTransport.logs)),
 );
 
 ipcMain.handle(

--- a/apps/ledger-live-desktop/src/main/setup.js
+++ b/apps/ledger-live-desktop/src/main/setup.js
@@ -38,13 +38,15 @@ ipcMain.on("updater", (e, type) => {
   updater(type);
 });
 
-ipcMain.handle("save-logs", async (event, path: { canceled: boolean, filePath: string }) =>
-  Promise.resolve().then(
-    () =>
-      !path.canceled &&
-      path.filePath &&
-      fsWriteFile(path.filePath, JSON.stringify(loggerTransport.logs)),
-  ),
+ipcMain.handle(
+  "save-logs",
+  async (event, path: { canceled: boolean, filePath: string }, experimentalLogs: string | null) =>
+    Promise.resolve().then(
+      () =>
+        !path.canceled &&
+        path.filePath &&
+        fsWriteFile(path.filePath, experimentalLogs || JSON.stringify(loggerTransport.logs)),
+    ),
 );
 
 ipcMain.handle(

--- a/apps/ledger-live-desktop/src/renderer/bridge/proxy.js
+++ b/apps/ledger-live-desktop/src/renderer/bridge/proxy.js
@@ -23,6 +23,7 @@ import { patchAccount } from "@ledgerhq/live-common/reconciliation";
 import { fromScanAccountEventRaw } from "@ledgerhq/live-common/bridge/index";
 import * as bridgeImpl from "@ledgerhq/live-common/bridge/impl";
 import { command } from "~/renderer/commands";
+import { getEnv } from "@ledgerhq/live-common/env";
 
 const scanAccounts = ({ currency, deviceId, syncConfig }) =>
   command("CurrencyScanAccounts")({
@@ -33,6 +34,7 @@ const scanAccounts = ({ currency, deviceId, syncConfig }) =>
 
 export const getCurrencyBridge = (currency: CryptoCurrency): CurrencyBridge => {
   const bridge = bridgeImpl.getCurrencyBridge(currency);
+  if (getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER")) return bridge;
   const bridgeGetPreloadStrategy = bridge.getPreloadStrategy;
   const getPreloadStrategy = bridgeGetPreloadStrategy
     ? currency => bridgeGetPreloadStrategy.call(bridge, currency)
@@ -64,6 +66,9 @@ export const getAccountBridge = (
   account: AccountLike,
   parentAccount: ?Account,
 ): AccountBridge<any> => {
+  if (getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER"))
+    return bridgeImpl.getAccountBridge(account, parentAccount);
+
   const sync = (account, syncConfig) => {
     syncs[account.id] = true;
     const span = startSpan("sync", "toAccountRaw");

--- a/apps/ledger-live-desktop/src/renderer/bridge/proxy.js
+++ b/apps/ledger-live-desktop/src/renderer/bridge/proxy.js
@@ -66,8 +66,9 @@ export const getAccountBridge = (
   account: AccountLike,
   parentAccount: ?Account,
 ): AccountBridge<any> => {
-  if (getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER"))
+  if (getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER")) {
     return bridgeImpl.getAccountBridge(account, parentAccount);
+  }
 
   const sync = (account, syncConfig) => {
     syncs[account.id] = true;

--- a/apps/ledger-live-desktop/src/renderer/commands.js
+++ b/apps/ledger-live-desktop/src/renderer/commands.js
@@ -1,10 +1,31 @@
 // @flow
 import { ipcRenderer } from "electron";
 import type { Commands, CommandFn } from "~/internal/commands";
+
+import appOpExec from "~/internal/commands/appOpExec";
+import firmwarePrepare from "~/internal/commands/firmwarePrepare";
+import firmwareMain from "~/internal/commands/firmwareMain";
+import firmwareRepair from "~/internal/commands/firmwareRepair";
+import flushDevice from "~/internal/commands/flushDevice";
+import waitForDeviceInfo from "~/internal/commands/waitForDeviceInfo";
+import getLatestFirmwareForDevice from "~/internal/commands/getLatestFirmwareForDevice";
+import connectApp from "~/internal/commands/connectApp";
+import connectManager from "~/internal/commands/connectManager";
+import listApps from "~/internal/commands/listApps";
+import installLanguage from "~/internal/commands/installLanguage";
+import getAppAndVersion from "~/internal/commands/getAppAndVersion";
+import getDeviceInfo from "~/internal/commands/getDeviceInfo";
+import signMessage from "~/internal/commands/signMessage";
+import staxLoadImage from "~/internal/commands/staxLoadImage";
+import getOnboardingStatePolling from "~/internal/commands/getOnboardingStatePolling";
+import getGenuineCheckFromDeviceId from "~/internal/commands/getGenuineCheckFromDeviceId";
+import getLatestAvailableFirmwareFromDeviceId from "~/internal/commands/getLatestAvailableFirmwareFromDeviceId";
+
 import { v4 as uuidv4 } from "uuid";
 import { Observable } from "rxjs";
 import logger from "~/logger";
 import { deserializeError } from "@ledgerhq/errors";
+import { getEnv } from "@ledgerhq/live-common/env";
 
 // Implements command message of (Renderer proc -> Main proc)
 type Msg<A> = {
@@ -13,7 +34,31 @@ type Msg<A> = {
   data?: A,
 };
 
+const commandsOnRenderer = {
+  appOpExec,
+  firmwarePrepare,
+  firmwareMain,
+  firmwareRepair,
+  flushDevice,
+  waitForDeviceInfo,
+  getLatestFirmwareForDevice,
+  connectApp,
+  connectManager,
+  listApps,
+  installLanguage,
+  getAppAndVersion,
+  getDeviceInfo,
+  signMessage,
+  staxLoadImage,
+  getOnboardingStatePolling,
+  getGenuineCheckFromDeviceId,
+  getLatestAvailableFirmwareFromDeviceId,
+};
+
 export function command<Id: $Keys<Commands>>(id: Id): CommandFn<Id> {
+  if (getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER") && id in commandsOnRenderer) {
+    return commandsOnRenderer[id];
+  }
   // $FlowFixMe i'm not sure how to prove CommandFn to flow but it works
   return <A>(data: A) =>
     Observable.create(o => {

--- a/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.jsx
@@ -5,17 +5,24 @@ import * as remote from "@electron/remote";
 import React, { useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { getAllEnvs } from "@ledgerhq/live-common/env";
+import { getEnv, getAllEnvs } from "@ledgerhq/live-common/env";
 import type { Account } from "@ledgerhq/types-live";
 import KeyHandler from "react-key-handler";
 import logger from "~/logger";
+import loggerInstance from "~/logger/logger-transport-renderer-instance";
 import getUser from "~/helpers/user";
 import Button from "~/renderer/components/Button";
 import type { Props as ButtonProps } from "~/renderer/components/Button";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 
 const saveLogs = async (path: { canceled: boolean, filePath: string }) => {
-  await ipcRenderer.invoke("save-logs", path);
+  await ipcRenderer.invoke(
+    "save-logs",
+    path,
+    getEnv("EXPERIMENTAL_EXECUTION_ON_RENDERER")
+      ? JSON.stringify(loggerInstance.getMemoryLogs())
+      : null,
+  );
 };
 
 type RestProps = ButtonProps & {|

--- a/apps/ledger-live-desktop/src/renderer/experimental.jsx
+++ b/apps/ledger-live-desktop/src/renderer/experimental.jsx
@@ -158,6 +158,14 @@ export const experimentalFeatures: Feature[] = [
     minValue: 0,
     maxValue: 1,
   },
+  {
+    type: "toggle",
+    name: "EXPERIMENTAL_EXECUTION_ON_RENDERER",
+    title: <Trans i18nKey="settings.experimental.features.experimentalExecutionOnRenderer.title" />,
+    description: (
+      <Trans i18nKey="settings.experimental.features.experimentalExecutionOnRenderer.description" />
+    ),
+  },
 ];
 
 const lsKey = "experimentalFlags";

--- a/apps/ledger-live-desktop/src/renderer/init.jsx
+++ b/apps/ledger-live-desktop/src/renderer/init.jsx
@@ -25,7 +25,7 @@ import { prepareCurrency } from "~/renderer/bridge/cache";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 
 import logger, { enableDebugLogger } from "~/logger";
-import LoggerTransport from "~/logger/logger-transport-renderer";
+import loggerInstance from "~/logger/logger-transport-renderer-instance";
 import { enableGlobalTab, disableGlobalTab, isGlobalTabEnabled } from "~/config/global-tab";
 import sentry from "~/sentry/renderer";
 import { setEnvOnAllThreads } from "~/helpers/env";
@@ -47,9 +47,9 @@ import ReactRoot from "~/renderer/ReactRoot";
 import AppError from "~/renderer/AppError";
 import { expectOperatingSystemSupportStatus } from "~/support/os";
 
-logger.add(new LoggerTransport());
+logger.add(loggerInstance);
 
-if (process.env.NODE_ENV !== "production" || process.env.DEV_TOOLS) {
+if (process.env.DEV_TOOLS) {
   enableDebugLogger();
 }
 

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.js
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.js
@@ -2,11 +2,13 @@
 import "../live-common-setup";
 import { setBridgeProxy } from "@ledgerhq/live-common/bridge/index";
 import { registerTransportModule } from "@ledgerhq/live-common/hw/index";
+import { setSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/wallet-btc/crypto/secp256k1";
 import { retry } from "@ledgerhq/live-common/promise";
 import { getUserId } from "~/helpers/user";
 import { getAccountBridge, getCurrencyBridge } from "./bridge/proxy";
 import { setEnvOnAllThreads } from "./../helpers/env";
 import { IPCTransport } from "./IPCTransport";
+import { command } from "./commands";
 
 setEnvOnAllThreads("USER_ID", getUserId());
 
@@ -20,5 +22,15 @@ registerTransportModule({
   },
   disconnect: () => {
     return Promise.resolve();
+  },
+});
+
+setSecp256k1Instance({
+  async publicKeyTweakAdd(publicKey, tweak) {
+    const r = await command("publicKeyTweakAdd")({
+      publicKey: Buffer.from(publicKey).toString("hex"),
+      tweak: Buffer.from(tweak).toString("hex"),
+    }).toPromise();
+    return new Uint8Array(Buffer.from(r, "hex").toJSON().data);
   },
 });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3782,7 +3782,7 @@
         },
         "experimentalExecutionOnRenderer": {
           "title": "Experimental networking",
-          "description": "Use experimental networking to optimise your Ledger Live experience with your VPN. Activate this only if your current VPN causes system errors."
+          "description": "Use experimental networking to optimize your Ledger Live experience with your VPN. Activate this only if your current VPN causes system errors."
         },
         "experimentalLanguages": {
           "title": "Translation testing",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3780,6 +3780,10 @@
           "title": "Experimental integrations",
           "description": "Use available experimental crypto assets integrations."
         },
+        "experimentalExecutionOnRenderer": {
+          "title": "Experimental networking",
+          "description": "Use experimental networking to optimise your Ledger Live experience with your VPN. Activate this only if your current VPN causes system errors."
+        },
         "experimentalLanguages": {
           "title": "Translation testing",
           "description": "Adds unreleased languages to the language list in the general settings tab."

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -382,6 +382,11 @@ const envDefinitions = {
     parser: boolParser,
     desc: "enable an experimental swap interface",
   },
+  EXPERIMENTAL_EXECUTION_ON_RENDERER: {
+    def: false,
+    parser: boolParser,
+    desc: "enable an experimental execution of business logic to run on renderer side (LLD)",
+  },
   EXPLORER: {
     def: "https://explorers.api.live.ledger.com",
     parser: stringParser,


### PR DESCRIPTION
### 📝 Description

This is an **experimental** settings. When not activated, nothing changes (if dev review can double confirm this)
When activated, a bunch of LLD "commands" will execute directly on the renderer side instead of being requested through  `renderer<>main<>internal` process.

This is the first step of the fundamental work of ["Dismantling LLD "internal process" threading model"](https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3948118370/Technical+introduction) with a more urgent need to offer a fix for using Ledger Live through VPN (that historically has been [an issue](https://github.com/LedgerHQ/ledger-live-desktop/issues/1073)): the fact things run on Chromium side already help fixing the issue (node.js/axios isn't 100% bullet proof to support all cases of VPN and proxies)

Essential changes:
- the experimental is introduced as an env EXPERIMENTAL_EXECUTION_ON_RENDERER, it can also later be dropped. (see screenshot below)
- the "bridge/proxy" is shortcut by not proxying anymore when the experimental is on
- many commands are executed directly on renderer **but** we will start using @Justkant 's device ipc proxy that way (the hardware HID apdu are still ran in internal process), Full List:
```
  appOpExec,
  firmwarePrepare,
  firmwareMain,
  firmwareRepair,
  flushDevice,
  waitForDeviceInfo,
  getLatestFirmwareForDevice,
  connectApp,
  connectManager,
  listApps,
  installLanguage,
  getAppAndVersion,
  getDeviceInfo,
  signMessage,
  staxLoadImage,
  getOnboardingStatePolling,
  getGenuineCheckFromDeviceId,
  getLatestAvailableFirmwareFromDeviceId,
  ```
- Performance improvements (when that experimental is on)
  - logs are now only stored locally on renderer side. Exporting logs won't "see" the internal logs anymore. the previous architecture of "sending logs" over the IPC have a cost and it's pointless to keep this in context of renderer execution.
  - while most of the commands are no longer used, `publicKeyTweakAdd` command has been introduced to still keep the heavy computation of this crypto curve done on the internal process. It is passed to `setSecp256k1Instance` like we do for LLM. in the future we will need to give a try to Web Workers but it needs more work (as it means "building a webworker target" 🤔 ). Using a command is the easy first step here with big benefits for performance (it has a big cost for heavy accounts).

### ❓ Context

- **Impacted projects**: LLD <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-4624 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** we don't directly test the experimental settings <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
  - I tested this experimental myself on these features: adding accounts, using all mere denis accounts (all coins), add/remove apps, firmware update, send flow
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


![Screenshot 2023-01-10 at 10 34 35](https://user-images.githubusercontent.com/211411/211514770-0d8a4d80-5d88-4309-a691-8ea194ebe15c.png)



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
