### PR TITLE
Fix back navigation when entering CLS error screen

### DIFF
--- a/.changeset/khaki-walls-carry.md
+++ b/.changeset/khaki-walls-carry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the back navigation when entering the error screen in the custom lockscreen flow

--- a/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
@@ -131,7 +131,7 @@ const PreviewPreEdit = ({ navigation, route }: NavigationProps) => {
   const handleResizeError = useCallback(
     (error: Error) => {
       console.error(error);
-      navigation.navigate(ScreenName.CustomImageErrorScreen, { error, device });
+      navigation.replace(ScreenName.CustomImageErrorScreen, { error, device });
     },
     [navigation, device],
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/CustomImage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/CustomImage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
 import { useNavigation } from "@react-navigation/native";
+import { Icons } from "@ledgerhq/native-ui";
 import SettingsRow from "../../../../components/SettingsRow";
 import { NavigatorName, ScreenName } from "../../../../const";
 
@@ -17,7 +18,12 @@ export default function CustomImage() {
 
   return (
     <FeatureToggle feature="customImage" fallback={null}>
-      <SettingsRow title="Debug Custom Image" onPress={handlePress} />
+      <SettingsRow
+        title="Custom lockscreen"
+        desc="Convenient access to the flow"
+        iconLeft={<Icons.LedgerBlueMedium size={32} color="black" />}
+        onPress={handlePress}
+      />
     </FeatureToggle>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -27,17 +27,18 @@ export default function Debugging() {
         onPress={() => navigation.navigate(ScreenName.DebugExport)}
       />
       <BLEPairingFlow />
+      {/* Split all the custom lockscreen screens into a separate menu maybe? */}
       <CustomImage />
       <SettingsRow
         title="Custom lockscreen fetch"
         desc="Fetch & restore from a connected device"
-        iconLeft={<Icons.LedgerBlueMedium size={32} color="black" />}
-        onPress={() => navigation.navigate(ScreenName.DebugCustomImageGraphics)}
+        iconLeft={<Icons.BracketsMedium size={32} color="black" />}
+        onPress={() => navigation.navigate(ScreenName.DebugFetchCustomImage)}
       />
       <SettingsRow
         title="Custom lockscreen graphics"
         desc="Tool for testing the flow's graphics"
-        iconLeft={<Icons.LedgerBlueMedium size={32} color="black" />}
+        iconLeft={<Icons.BringFrontMedium size={32} color="black" />}
         onPress={() => navigation.navigate(ScreenName.DebugCustomImageGraphics)}
       />
       <SettingsRow


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When entering the custom lockscreen flow's error screen, the back arrow / back navigation brings back to an infinite loader because we used `navigate` instead of `replace`.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-710] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] ~**Test coverage**~: no UI testing on mobile yet <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A, see proper slack channels

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-710]: https://ledgerhq.atlassian.net/browse/FAT-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ