### PR TITLE
[BUGFIX] make sure currencies param of requestAccount is string array

### DIFF
--- a/.changeset/lazy-sloths-obey.md
+++ b/.changeset/lazy-sloths-obey.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix app crash in case requestAccount currencies array param contains non string values

--- a/.changeset/spotty-boxes-battle.md
+++ b/.changeset/spotty-boxes-battle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix app crash in case requestAccount currencies array param contains non string values

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/LiveAppSDKLogic.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/LiveAppSDKLogic.ts
@@ -38,7 +38,16 @@ export const requestAccountLogic = async (
   { currencies, includeTokens }: RequestAccountParams,
 ) => {
   tracking.platformRequestAccountRequested(manifest);
-  const { account, parentAccount } = await selectAccountAndCurrency(currencies, includeTokens);
+
+  /**
+   * make sure currencies are strings
+   * PS: yes `currencies` is properly typed as `string[]` but this typing only
+   * works at build time and the `currencies` array is received at runtime from
+   * JSONRPC requests. So we need to make sure the array is properly typed.
+   */
+  const safeCurrencies = currencies?.filter(c => typeof c === "string") ?? undefined;
+
+  const { account, parentAccount } = await selectAccountAndCurrency(safeCurrencies, includeTokens);
 
   return serializePlatformAccount(accountToPlatformAccount(account, parentAccount));
 };

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebView.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebView.tsx
@@ -163,14 +163,23 @@ export const WebView = ({ manifest, inputs }: Props) => {
       new Promise((resolve, reject) => {
         tracking.platformRequestAccountRequested(manifest);
 
+        /**
+         * make sure currencies are strings
+         * PS: yes `currencies` is properly typed as `string[]` but this typing only
+         * works at build time and the `currencies` array is received at runtime from
+         * JSONRPC requests. So we need to make sure the array is properly typed.
+         */
+        const safeCurrencyIds =
+          currencyIds?.filter(c => typeof c === "string") ?? undefined;
+
         const allCurrencies = listAndFilterCurrencies({
-          currencies: currencyIds,
+          currencies: safeCurrencyIds,
           includeTokens,
         });
         // handle no curencies selected case
         const cryptoCurrencyIds =
-          currencyIds && currencyIds.length > 0
-            ? currencyIds
+          safeCurrencyIds && safeCurrencyIds.length > 0
+            ? safeCurrencyIds
             : allCurrencies.map(currency => (currency as CryptoCurrency).id);
 
         const foundAccounts = cryptoCurrencyIds?.length


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

If the currencies array passed to `requestAccount` contains other values than string, the underlying function crashes (cf. demo). 

Make sure currencies param of requestAccount is a string array.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<details>
<summary>KO 💥 </summary>

https://user-images.githubusercontent.com/9203826/208966317-7a0a5d13-11ee-4e9c-bf53-67a099a5e05a.mov


</details>

<details>
<summary>OK ✅  </summary>

https://user-images.githubusercontent.com/9203826/208966376-6bfbf50d-d7f8-4f2d-b121-207e6c091f85.mov

</details>

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

LL should not crash even if invalid values passed as param for live-app-sdk functions

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
