### PR TITLE
🐛 [BUGFIX] : LIVE-5036 : LLM- 'Terms of Use Update' pop-up issue in some languages

### DIFF
--- a/.changeset/few-toes-appear.md
+++ b/.changeset/few-toes-appear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+'Terms of Use Update' pop-up issue in some languages

--- a/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
+++ b/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
@@ -49,12 +49,6 @@ const CheckTermOfUseUpdateModal = () => {
               <Update>{t("updatedTerms.body.bulletPoints.0")}</Update>
               <Update>{t("updatedTerms.body.bulletPoints.1")}</Update>
               <Update>{t("updatedTerms.body.bulletPoints.2")}</Update>
-              <Update>{t("updatedTerms.body.bulletPoints.3")}</Update>
-              <Update>{t("updatedTerms.body.bulletPoints.4")}</Update>
-              <Update>{t("updatedTerms.body.bulletPoints.5")}</Update>
-              <Update>{t("updatedTerms.body.bulletPoints.6")}</Update>
-              <Update>{t("updatedTerms.body.bulletPoints.7")}</Update>
-              <Update>{t("updatedTerms.body.bulletPoints.8")}</Update>
             </Flex>
             <Description>{t("updatedTerms.body.agreement")}</Description>
           </Flex>

--- a/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
+++ b/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback } from "react";
-import { Linking } from "react-native";
+import { Linking, ScrollView } from "react-native";
 import { useTranslation } from "react-i18next";
 import {
   BottomDrawer,
@@ -41,24 +41,39 @@ const CheckTermOfUseUpdateModal = () => {
       title={t("updatedTerms.title")}
       isOpen={!accepted}
     >
-      <Flex mb={6}>
-        <Description>{t("updatedTerms.body.intro")}</Description>
-        <Flex my={4}>
-          <Update>{t("updatedTerms.body.bulletPoints.0")}</Update>
-          <Update>{t("updatedTerms.body.bulletPoints.1")}</Update>
-          <Update>{t("updatedTerms.body.bulletPoints.2")}</Update>
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <Flex px={4}>
+          <Flex mb={6}>
+            <Description>{t("updatedTerms.body.intro")}</Description>
+            <Flex my={4}>
+              <Update>{t("updatedTerms.body.bulletPoints.0")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.1")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.2")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.3")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.4")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.5")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.6")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.7")}</Update>
+              <Update>{t("updatedTerms.body.bulletPoints.8")}</Update>
+            </Flex>
+            <Description>{t("updatedTerms.body.agreement")}</Description>
+          </Flex>
+
+          <Alert type="help" noIcon>
+            <Link
+              type="color"
+              onPress={handleLink}
+              Icon={Icons.ExternalLinkMedium}
+            >
+              {t("updatedTerms.link")}
+            </Link>
+          </Alert>
+          <Divider />
+          <Button type="main" outline={false} onPress={accept}>
+            {t("updatedTerms.cta")}
+          </Button>
         </Flex>
-        <Description>{t("updatedTerms.body.agreement")}</Description>
-      </Flex>
-      <Alert type="help" noIcon>
-        <Link type="color" onPress={handleLink} Icon={Icons.ExternalLinkMedium}>
-          {t("updatedTerms.link")}
-        </Link>
-      </Alert>
-      <Divider />
-      <Button type="main" outline={false} onPress={accept}>
-        {t("updatedTerms.cta")}
-      </Button>
+      </ScrollView>
     </BottomDrawer>
   );
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -56,6 +56,7 @@ import HiddenNftCollections from "../../screens/Settings/Accounts/HiddenNftColle
 import { useNoNanoBuyNanoWallScreenOptions } from "../../context/NoNanoBuyNanoWall";
 import PostOnboardingDebugScreen from "../../screens/PostOnboarding/PostOnboardingDebugScreen";
 import { SettingsNavigatorStackParamList } from "./types/SettingsNavigator";
+import DebugTermsOfUse from "../../screens/Settings/Debug/Features/TermsOfUse";
 
 const Stack = createStackNavigator<SettingsNavigatorStackParamList>();
 
@@ -355,6 +356,13 @@ export default function SettingsNavigator() {
         component={DebugStoryly}
         options={{
           title: "Debug Storyly",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugTermsOfUse}
+        component={DebugTermsOfUse}
+        options={{
+          title: "Debug Terms of Use",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -51,6 +51,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugHttpTransport]: undefined;
   [ScreenName.DebugLogs]: undefined;
   [ScreenName.DebugLottie]: undefined;
+  [ScreenName.DebugTermsOfUse]: undefined;
   [ScreenName.BenchmarkQRStream]: undefined;
   [ScreenName.OnboardingLanguage]: undefined;
   [ScreenName.PostOnboardingDebugScreen]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -44,6 +44,7 @@ export enum ScreenName {
   DebugInformation = "DebugInformation",
   DebugLogs = "DebugLogs",
   DebugLottie = "DebugLottie",
+  DebugTermsOfUse = "DebugTermsOfUse",
   DebugMockGenerateAccounts = "DebugMockGenerateAccounts",
   DebugNetwork = "DebugNetwork",
   DebugSettings = "DebugSettings",

--- a/apps/ledger-live-mobile/src/logic/terms.tsx
+++ b/apps/ledger-live-mobile/src/logic/terms.tsx
@@ -54,6 +54,10 @@ export async function isAcceptedLendingTerms() {
   );
 }
 
+export async function unAcceptTerms() {
+  await AsyncStorage.removeItem("acceptedTermsVersion");
+}
+
 export async function acceptTerms() {
   await AsyncStorage.setItem("acceptedTermsVersion", currentTermsRequired);
 }
@@ -74,6 +78,12 @@ export function useLocalizedTermsUrl() {
 export const useTermsAccept = () => {
   const [accepted, setAccepted] = useState(true);
 
+  const unAccept = useCallback(() => {
+    unAcceptTerms().then(() => {
+      setAccepted(false);
+    });
+  }, []);
+
   const accept = useCallback(() => {
     acceptTerms().then(() => {
       setAccepted(true);
@@ -84,5 +94,5 @@ export const useTermsAccept = () => {
     isAcceptedTerms().then(setAccepted);
   }, []);
 
-  return [accepted, accept] as const;
+  return [accepted, accept, unAccept] as const;
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/TermsOfUse.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/TermsOfUse.tsx
@@ -1,0 +1,43 @@
+import { Button, Text } from "@ledgerhq/native-ui";
+import React, { useEffect } from "react";
+import { View, StyleSheet } from "react-native";
+import CheckTermOfUseUpdate from "../../../../components/CheckTermOfUseUpdate";
+import { useTermsAccept } from "../../../../logic/terms";
+
+export default function DebugTermsOfUse() {
+  const [, , unAccept] = useTermsAccept();
+  useEffect(() => {
+    unAccept();
+  }, [unAccept]);
+
+  return (
+    <View style={styles.wrapper}>
+      <Text variant="large">
+        To display again, just click on the reset button and return to the page
+      </Text>
+      <Button mt={3} type="main" onPress={unAccept}>
+        Reset
+      </Button>
+      <CheckTermOfUseUpdate />
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  wrapper: {
+    padding: 20,
+  },
+  button: {
+    marginTop: 20,
+  },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    marginTop: 12,
+    marginBottom: 12,
+  },
+  switchLabel: {
+    marginLeft: 8,
+    fontSize: 13,
+    paddingRight: 16,
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -61,6 +61,13 @@ export default function Debugging() {
         iconLeft={<Icons.PlayMedium size={32} color="black" />}
         onPress={() => navigation.navigate(ScreenName.DebugStoryly)}
       />
+
+      <SettingsRow
+        title="Terms of Use"
+        desc="Trigger Terms of Use Popup"
+        iconLeft={<Icons.LinkMedium size={32} color="black" />}
+        onPress={() => navigation.navigate(ScreenName.DebugTermsOfUse)}
+      />
     </SettingsNavigationScrollView>
   );
 }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
'Terms of Use Update' pop-up issue in DE & ES and maybe some others languages

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-5036] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/112866305/209684933-93362551-4c1b-4571-9ebe-19b7bea12f55.mov

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

**Go To Debug > Features & Flows > Terms of Use (Last one)**


_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-5036]: https://ledgerhq.atlassian.net/browse/LIVE-5036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ