### PR TITLE
ethereum: log the unsigned raw tx

### DIFF
--- a/libs/ledger-live-common/src/families/ethereum/signOperation.ts
+++ b/libs/ledger-live-common/src/families/ethereum/signOperation.ts
@@ -116,6 +116,8 @@ export const signOperation = ({
                 ? m.getResolutionConfig(account, transaction)
                 : {};
 
+              log("rawtx", txHex);
+
               const resolution = await ethLedgerServices.resolveTransaction(
                 txHex,
                 loadConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3200,6 +3200,7 @@ importers:
       '@ledgerhq/cryptoassets': workspace:^
       '@ledgerhq/devices': workspace:^
       '@ledgerhq/errors': workspace:^
+      '@ledgerhq/hw-app-eth': workspace:^
       '@ledgerhq/hw-transport': workspace:^
       '@ledgerhq/hw-transport-http': workspace:^
       '@ledgerhq/hw-transport-u2f': 5.36.0-deprecated
@@ -3239,6 +3240,7 @@ importers:
       '@ledgerhq/cryptoassets': link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/devices': link:../../libs/ledgerjs/packages/devices
       '@ledgerhq/errors': link:../../libs/ledgerjs/packages/errors
+      '@ledgerhq/hw-app-eth': link:../../libs/ledgerjs/packages/hw-app-eth
       '@ledgerhq/hw-transport': link:../../libs/ledgerjs/packages/hw-transport
       '@ledgerhq/hw-transport-http': link:../../libs/ledgerjs/packages/hw-transport-http
       '@ledgerhq/hw-transport-u2f': 5.36.0-deprecated
@@ -24454,7 +24456,7 @@ packages:
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
       p-map: 3.0.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 7.1.1
       unique-filename: 1.1.1
@@ -45713,6 +45715,7 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+    dev: true
 
   /promise-inflight/1.0.1_bluebird@3.7.2:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}

--- a/tools/common-tools/package.json
+++ b/tools/common-tools/package.json
@@ -6,6 +6,7 @@
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/devices": "workspace:^",
     "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/hw-app-eth": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:^",
     "@ledgerhq/hw-transport-http": "workspace:^",
     "@ledgerhq/hw-transport-u2f": "5.36.0-deprecated",

--- a/tools/common-tools/src/demos/eth-tx-tools/index.js
+++ b/tools/common-tools/src/demos/eth-tx-tools/index.js
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { ledgerService } from "@ledgerhq/hw-app-eth";
+
+function App() {
+  const [unsignedTxHex, setUnsignedTxHex] = useState("");
+  const [result, setResult] = useState(null);
+
+  const resolveTransaction = async (unsignedTxHex) => {
+    const result = await ledgerService.resolveTransaction(
+      unsignedTxHex,
+      {},
+      {
+        nft: true,
+        erc20: true,
+        externalPlugins: true,
+      }
+    );
+    setResult(result);
+  };
+
+  return (
+    <div>
+      <label>
+        Unsigned Transaction Hex:
+        <input
+          type="text"
+          value={unsignedTxHex}
+          onChange={(e) => setUnsignedTxHex(e.target.value)}
+        />
+      </label>
+      <button onClick={() => resolveTransaction(unsignedTxHex)}>
+        Resolve Transaction
+      </button>
+      {result && (
+        <pre>
+          <code>{JSON.stringify(result, null, 2)}</code>
+        </pre>
+      )}
+    </div>
+  );
+}
+
+App.demo = {
+  title: "ETH tx tools",
+  url: "/eth-tx-tools",
+};
+
+export default App;

--- a/tools/common-tools/src/demos/index.js
+++ b/tools/common-tools/src/demos/index.js
@@ -1,9 +1,11 @@
 import LogsViewer from "./logsviewer";
 import lldSignature from "./lld-signature";
 import repl from "./repl";
+import ethtxtools from "./eth-tx-tools";
 
 export default {
   LogsViewer,
   lldSignature,
   repl,
+  ethtxtools,
 };


### PR DESCRIPTION
### 📝 Description

In certain circumstance, Ledger Live fails to sign the TX before even reaching the final device step (for instance during resolveTransaction or during the "provideNFTInformation" device phase).

In that case, we are clueless to look at reproducing it.

This add back the logs, we will be able to more easily build tooling if we have such log of the raw tx. I recommend to make this "rawtx" error code a convention for all coins.

I have made a page in our live tools to allow to debug it:

![Screenshot 2023-01-02 at 16 33 53](https://user-images.githubusercontent.com/211411/210252559-10e7b9ad-5cae-4515-a655-ee22b028b21f.png)


### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5054 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-5054]: https://ledgerhq.atlassian.net/browse/LIVE-5054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ