### PR TITLE
native TimerModule to prevent system time change to bypass lock screen

### DIFF
--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/NativeModulesPackage.java
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/NativeModulesPackage.java
@@ -23,6 +23,7 @@ public class NativeModulesPackage implements ReactPackage {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new BluetoothHelperModule(reactContext));
         modules.add(new ImagePickerModule(reactContext));
+        modules.add(new TimerModule(reactContext));
         return modules;
     }
 

--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/TimerModule.java
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/TimerModule.java
@@ -1,0 +1,30 @@
+package com.ledger.live;
+
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class TimerModule extends ReactContextBaseJavaModule {
+    public TimerModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "Timer";
+    }
+
+    /**
+     * Return a relative unit of time in seconds that cannot be influenced by the user
+     * @param promise
+     */
+    @ReactMethod
+    public void getRelativeTime(Promise promise) {
+        // System time in milliseconds
+        long time = android.os.SystemClock.elapsedRealtime();
+
+        // React Native bridge complains if we try to pass back a long directly
+        promise.resolve(Long.toString(time / 1000));
+    }
+}

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E55EFC09114D43B3AB041882 /* FontAwesome5_Pro_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 991AA9919E4840DBB799E117 /* FontAwesome5_Pro_Solid.ttf */; };
 		E8E0F5A941050BCF166FD663 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3509B77469C50660E4C1A7 /* ExpoModulesProvider.swift */; };
 		F837348722721A48009D747A /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F837348622721A48009D747A /* JavaScriptCore.framework */; };
+		F89A71402964881E002F3DDD /* TimerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = F89A713E2964881D002F3DDD /* TimerModule.m */; };
 		F99BEAC629E8441C83104922 /* FontAwesome5_Pro_Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6D891D99F1084D459DBF667F /* FontAwesome5_Pro_Light.ttf */; };
 /* End PBXBuildFile section */
 
@@ -114,6 +115,8 @@
 		F706F7BE3B5F9DD387AB929A /* Pods-ledgerlivemobile.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ledgerlivemobile.debug.xcconfig"; path = "Target Support Files/Pods-ledgerlivemobile/Pods-ledgerlivemobile.debug.xcconfig"; sourceTree = "<group>"; };
 		F77638C1F4BC132FB97FEEAF /* Pods-ledgerlivemobile.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ledgerlivemobile.release.xcconfig"; path = "Target Support Files/Pods-ledgerlivemobile/Pods-ledgerlivemobile.release.xcconfig"; sourceTree = "<group>"; };
 		F837348622721A48009D747A /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F89A713E2964881D002F3DDD /* TimerModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TimerModule.m; path = ledgerlivemobile/TimerModule.m; sourceTree = "<group>"; };
+		F89A713F2964881E002F3DDD /* TimerModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TimerModule.h; path = ledgerlivemobile/TimerModule.h; sourceTree = "<group>"; };
 		F91D74A42E59456DBB925283 /* Rubik-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Rubik-Regular.ttf"; path = "../assets/fonts/Rubik-Regular.ttf"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -181,6 +184,8 @@
 				3407D5D8215D2AB800C9D40B /* NeededForBLE.swift */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				F89A713F2964881E002F3DDD /* TimerModule.h */,
+				F89A713E2964881D002F3DDD /* TimerModule.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
@@ -672,6 +677,7 @@
 				17F58472269C64670070C475 /* RCTBluetoothHelperModule.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				2A2FAB56B85E5D2BFF574A32 /* ExpoModulesProvider.swift in Sources */,
+				F89A71402964881E002F3DDD /* TimerModule.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/TimerModule.h
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/TimerModule.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface TimerModule : NSObject <RCTBridgeModule>
+
+@end

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/TimerModule.m
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/TimerModule.m
@@ -1,0 +1,39 @@
+#import "TimerModule.h"
+#include <sys/sysctl.h>
+
+@implementation TimerModule
+
+RCT_EXPORT_MODULE(Timer);
+
+/**
+ * Return a relative time in seconds that can't be tampered with by the user
+ */
+RCT_EXPORT_METHOD(getRelativeTime: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    resolve([NSString stringWithFormat:@"%ld", [self uptime]]);
+}
+
+/**
+ * Get the system up time in seconds
+ *
+ * Method originally from here:
+ * http://stackoverflow.com/questions/12488481/getting-ios-system-uptime-that-doesnt-pause-when-asleep
+ */
+- (time_t)uptime
+{
+    struct timeval boottime;
+    int mib[2] = {CTL_KERN, KERN_BOOTTIME};
+    size_t size = sizeof(boottime);
+    time_t now;
+    time_t uptime = -1;
+
+    (void) time(&now);
+
+    if (sysctl(mib, 2, &boottime, &size, NULL, 0) != -1 && boottime.tv_sec != 0) {
+        uptime = now - (boottime.tv_sec);
+    }
+
+    return uptime;
+}
+
+@end


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

native TimerModule to prevent system time change to bypass lock screen. Using `Date.now()` is not safe to check if "enough time has past" when coming back to Ledger Live and changing the system time can bypass the lock screen mechanism.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5060 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
  - [ ] manual test on iOS to do
  - [ ] manual test on Android to do
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
