### PR TITLE
Support: LIVE-5092: Narrow theme type

### DIFF
--- a/.changeset/loud-garlics-kiss.md
+++ b/.changeset/loud-garlics-kiss.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": patch
+---
+
+chore: fix typing of theme "light" | "dark"
+
+- Removed unneeded "as" type casting, and used newly exported Theme type.
+- Migrated animations.js to animations.ts

--- a/.changeset/quiet-jobs-roll.md
+++ b/.changeset/quiet-jobs-roll.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/react-ui": patch
+---
+
+chore: narrow-typed theme to "dark"| "light"
+
+And exported Theme type from react-ui

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/animations.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/animations.ts
@@ -1,7 +1,6 @@
-// @flow
-import type { DeviceModelId } from "@ledgerhq/devices";
-
 /* eslint-disable camelcase */
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { Theme } from "@ledgerhq/react-ui";
 
 // NANO S
 import NANO_S_LIGHT_plugAndPinCode from "~/renderer/animations/nanoS/1PlugAndPinCode/light.json";
@@ -75,7 +74,20 @@ import STAX_allowConnection from "~/renderer/animations/stax/allowConnection.jso
 
 /* eslint-enable camelcase */
 
-const nanoS = {
+type ThemedAnimation = Record<Theme["theme"], Record<string, unknown>>;
+export type AnimationKey =
+  | "plugAndPinCode"
+  | "enterPinCode"
+  | "quitApp"
+  | "allowManager"
+  | "openApp"
+  | "verify"
+  | "sign"
+  | "firmwareUpdating"
+  | "installLoading";
+type DeviceAnimations = { [key in AnimationKey]: ThemedAnimation };
+
+const nanoS: DeviceAnimations = {
   plugAndPinCode: {
     light: NANO_S_LIGHT_plugAndPinCode,
     dark: NANO_S_DARK_plugAndPinCode,
@@ -113,7 +125,8 @@ const nanoS = {
     dark: NANO_S_DARK_installLoading,
   },
 };
-const nanoX = {
+
+const nanoX: DeviceAnimations = {
   plugAndPinCode: {
     light: NANO_X_LIGHT_plugAndPinCode,
     dark: NANO_X_DARK_plugAndPinCode,
@@ -152,7 +165,7 @@ const nanoX = {
   },
 };
 
-const nanoSP = {
+const nanoSP: DeviceAnimations = {
   plugAndPinCode: {
     light: NANO_SP_LIGHT_plugAndPinCode,
     dark: NANO_SP_DARK_plugAndPinCode,
@@ -191,7 +204,7 @@ const nanoSP = {
   },
 };
 
-const stax = {
+const stax: DeviceAnimations = {
   plugAndPinCode: {
     light: STAX_enterPin,
     dark: STAX_enterPin,
@@ -230,27 +243,34 @@ const stax = {
   },
 };
 
-const blue = {
+const blue: DeviceAnimations = {
   plugAndPinCode: {
     light: BLUE_LIGHT_plugAndPinCode,
+    dark: BLUE_LIGHT_plugAndPinCode,
   },
   enterPinCode: {
     light: BLUE_LIGHT_enterPinCode,
+    dark: BLUE_LIGHT_enterPinCode,
   },
   quitApp: {
     light: BLUE_LIGHT_quitApp,
+    dark: BLUE_LIGHT_quitApp,
   },
   allowManager: {
     light: BLUE_LIGHT_allowManager,
+    dark: BLUE_LIGHT_allowManager,
   },
   openApp: {
     light: BLUE_LIGHT_openApp,
+    dark: BLUE_LIGHT_openApp,
   },
   verify: {
     light: BLUE_LIGHT_validate,
+    dark: BLUE_LIGHT_validate,
   },
   sign: {
     light: BLUE_LIGHT_validate,
+    dark: BLUE_LIGHT_validate,
   },
   // Nb We are dropping the assets for blue soon, this is temp
   firmwareUpdating: {
@@ -263,19 +283,20 @@ const blue = {
   },
 };
 
-const animations = { nanoX, nanoS, nanoSP, stax, blue };
-
-type InferredKeys = $Keys<typeof nanoS>;
+type Animations = {
+  [modelId in DeviceModelId]: DeviceAnimations;
+};
+const animations: Animations = { nanoX, nanoS, nanoSP, stax, blue };
 
 export const getDeviceAnimation = (
   modelId: DeviceModelId,
-  theme: "light" | "dark",
-  key: InferredKeys,
+  theme: Theme["theme"],
+  key: AnimationKey,
 ) => {
-  // $FlowFixMe Ignore the type to allow override from env.
-  modelId = process.env.OVERRIDE_MODEL_ID || modelId;
-  const lvl1 = animations[modelId] || animations.nanoX;
-  const lvl2 = lvl1[key] || animations.nanoX[key];
-  if (theme === "dark" && lvl2.dark) return lvl2.dark;
-  return lvl2.light;
+  const animationModelId = (process.env.OVERRIDE_MODEL_ID as DeviceModelId) || modelId;
+
+  // Handles the case where OVERRIDE_MODEL_ID is incorrect
+  const animation = animations[animationModelId][key][theme] || animations.nanoX[key][theme];
+
+  return animation;
 };

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -49,6 +49,7 @@ import { context } from "~/renderer/drawers/Provider";
 import { track } from "~/renderer/analytics/segment";
 import { DrawerFooter } from "~/renderer/screens/exchange/Swap2/Form/DrawerFooter";
 import {
+  Theme,
   Button as ButtonV3,
   Flex,
   Icons,
@@ -187,7 +188,7 @@ export const renderRequestQuitApp = ({
   type,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
 }) => (
   <Wrapper>
     <Header />
@@ -207,7 +208,7 @@ export const renderVerifyUnwrapped = ({
   type,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
 }) => (
   <AnimationWrapper modelId={modelId}>
     <DeviceBlocker />
@@ -310,7 +311,7 @@ export const InstallingApp = ({
   analyticsPropertyFlow = "unknown",
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
   appName: string;
   progress: number;
   request: any;
@@ -391,7 +392,7 @@ export const renderAllowManager = ({
   wording,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
   wording: string;
 }) => (
   <Wrapper>
@@ -414,7 +415,7 @@ export const renderAllowLanguageInstallation = ({
   t,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
   t: TFunction;
 }) => (
   <Flex
@@ -442,7 +443,7 @@ export const renderAllowOpeningApp = ({
   isDeviceBlocker,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
   wording: string;
   tokenContext?: TokenCurrency;
   isDeviceBlocker?: boolean;
@@ -691,7 +692,7 @@ export const renderConnectYourDevice = ({
   unresponsive,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
   onRetry: () => void;
   onRepairModal: () => void;
   device: Device;
@@ -730,7 +731,7 @@ export const renderFirmwareUpdating = ({
   type,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
 }) => (
   <Wrapper>
     <Header />
@@ -756,7 +757,7 @@ export const renderSwapDeviceConfirmation = ({
   estimatedFees,
 }: {
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
   transaction: Transaction;
   status: TransactionStatus;
   exchangeRate: ExchangeRate;
@@ -872,7 +873,7 @@ export const renderSecureTransferDeviceConfirmation = ({
 }: {
   exchangeType: "sell" | "fund";
   modelId: DeviceModelId;
-  type: "light" | "dark";
+  type: Theme["theme"];
 }) => (
   <>
     <Alert type="primary" learnMoreUrl={urls.swap.learnMore} horizontal={false}>

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SoftwareCheckAllowSecureChannelModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SoftwareCheckAllowSecureChannelModal.tsx
@@ -24,13 +24,7 @@ const SoftwareCheckAllowSecureChannelModal = ({ isOpen, deviceModelId, productNa
             deviceName: productName,
           })}
         </Text>
-        <Animation
-          animation={getDeviceAnimation(
-            deviceModelId,
-            theme.theme as "light" | "dark",
-            "allowManager",
-          )}
-        />
+        <Animation animation={getDeviceAnimation(deviceModelId, theme.theme, "allowManager")} />
       </Flex>
     </Popin>
   );

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SoftwareCheckLockedDeviceModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SoftwareCheckLockedDeviceModal.tsx
@@ -28,13 +28,7 @@ const SoftwareCheckLockedDeviceModal = ({ isOpen, deviceModelId, productName, on
             deviceName: productName,
           })}
         </Text>
-        <Animation
-          animation={getDeviceAnimation(
-            deviceModelId,
-            theme.theme as "light" | "dark",
-            "enterPinCode",
-          )}
-        />
+        <Animation animation={getDeviceAnimation(deviceModelId, theme.theme, "enterPinCode")} />
       </Flex>
     </Popin>
   );

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/TroubleshootingDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/TroubleshootingDrawer.tsx
@@ -25,11 +25,7 @@ const TroubleshootingDrawer = ({ isOpen, onClose, lastKnownDeviceId }: Props) =>
         <Flex flexDirection="column" flex={1}>
           <Animation
             height="300px"
-            animation={getDeviceAnimation(
-              lastKnownDeviceId,
-              theme.theme as "light" | "dark",
-              "plugAndPinCode",
-            )}
+            animation={getDeviceAnimation(lastKnownDeviceId, theme.theme, "plugAndPinCode")}
           />
           <Text variant="h4Inter" textAlign="center" fontSize={24} fontWeight="semiBold">
             {t("syncOnboarding.manual.troubleshootingDrawer.title")}

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -360,7 +360,7 @@ const SyncOnboardingManual = ({ deviceModelId: strDeviceModelId }: SyncOnboardin
                 height="540px"
                 animation={getDeviceAnimation(
                   lastKnownDeviceModelId,
-                  theme.theme as "light" | "dark",
+                  theme.theme,
                   lockedDeviceDuringPolling ? "enterPinCode" : "plugAndPinCode",
                 )}
               />

--- a/libs/ui/packages/react/src/index.ts
+++ b/libs/ui/packages/react/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./components";
 export * from "./assets";
 export { StyleProvider, InvertTheme, InvertThemeV3 } from "./styles";
+export type { Theme } from "./styles";

--- a/libs/ui/packages/react/src/styles/index.ts
+++ b/libs/ui/packages/react/src/styles/index.ts
@@ -1,4 +1,5 @@
 export { default as defaultTheme } from "./theme";
+export type { Theme } from "./theme";
 export * from "./helpers";
 export * from "./global";
 export * from "./StyleProvider";

--- a/libs/ui/packages/react/src/styles/theme.ts
+++ b/libs/ui/packages/react/src/styles/theme.ts
@@ -235,7 +235,7 @@ declare module "styled-components" {
     style: string;
   }
   export interface DefaultTheme {
-    theme: string;
+    theme: "dark" | "light";
     animations: typeof animations;
     transition: typeof transition;
     overflow: typeof overflow;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In `react-ui`: 
- narrow-typed theme to "dark"| "light"
- and exported Theme type from react-ui

In LLD: fix typing of theme "light" | "dark"

- removed unneeded "as" type casting
- used newly exported `Theme` type.
- migrated `animations.js` to `animations.ts`

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage**: needs to be quickly QAed to be 100% on the animation
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Demo showing that theme and animations are not broken:

https://user-images.githubusercontent.com/15096913/210547644-15aa55f3-50b1-46fc-8066-94154ecb0ddd.mp4


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
