### PR TITLE
Fix desktop crash when accessing the manager

### DIFF
--- a/.changeset/silly-cars-remember.md
+++ b/.changeset/silly-cars-remember.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix a crash when accessing the manager coming from the animation loading

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/animations.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/animations.ts
@@ -296,7 +296,10 @@ export const getDeviceAnimation = (
   const animationModelId = (process.env.OVERRIDE_MODEL_ID as DeviceModelId) || modelId;
 
   // Handles the case where OVERRIDE_MODEL_ID is incorrect
-  const animation = animations[animationModelId][key][theme] || animations.nanoX[key][theme];
-
-  return animation;
+  const animationModel = animations[animationModelId] || animations.nanoX;
+  const animationKey = animationModel[key];
+  if (!animationKey) {
+    return null;
+  }
+  return animationKey[theme];
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There's a crash on develop when accessing the manager on LLD coming from the `animations.ts` file. This happens because of a nested object access without `undefined` or `null` checks. In theory the type system should prevent those from happening in this file but since desktop isn't yet fully TS migrated we need this check.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: N/A <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] ~**Test coverage**~ <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
