### PR TITLE
Proposal: use promiseAllBatched for less parallel calls on btc fam

### DIFF
--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/wallet.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/wallet.ts
@@ -19,6 +19,7 @@ import { TX, Address } from "./storage/types";
 import { blockchainBaseURL } from "../../../api/Ledger";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { promiseAllBatched } from "../../../promise";
 
 class BitcoinLikeWallet {
   explorers: { [currencyId: string]: IExplorer } = {};
@@ -175,8 +176,8 @@ class BitcoinLikeWallet {
   async getAccountPendings(account: Account): Promise<TX[]> {
     const addresses = await account.xpub.getXpubAddresses();
     return flatten(
-      await Promise.all(
-        addresses.map((address) => account.xpub.explorer.getPendings(address))
+      await promiseAllBatched(3, addresses, (address) =>
+        account.xpub.explorer.getPendings(address)
       )
     );
   }

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/xpub.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/xpub.ts
@@ -6,6 +6,7 @@ import { ICrypto } from "./crypto/types";
 import { PickingStrategy } from "./pickingstrategies/types";
 import { computeDustAmount, maxTxSizeCeil } from "./utils";
 import { TransactionInfo, InputInfo, OutputInfo } from "./types";
+import { promiseAllBatched } from "../../../promise";
 
 // names inside this class and discovery logic respect BIP32 standard
 class Xpub {
@@ -94,8 +95,10 @@ class Xpub {
   }
 
   async checkAddressesBlock(account: number, index: number): Promise<boolean> {
-    const addressesResults = await Promise.all(
-      range(this.GAP).map((_, key) => this.syncAddress(account, index + key))
+    const addressesResults = await promiseAllBatched(
+      3,
+      range(this.GAP),
+      (_, key) => this.syncAddress(account, index + key)
     );
     return some(addressesResults, (lastTx) => !!lastTx);
   }


### PR DESCRIPTION
### 📝 Description

- [ ] TODO: include the simplification work of removing the need to dep on https & pool as https://github.com/LedgerHQ/ledger-live/pull/2363 showed there are no reason for these anymore 🤔 

problem: a lot of parallel calls are produced due to bitcoin implementation.
promiseAllBatched was designed to solve this by limiting the number of parallelisation.

This PR acts a PoC to see if it can works, we should study the performance impact of this. this might increase the time to sync but at same time it might reduce the load on memory and cpu.

on mere denis runs, the impact on global time of sync is negligible:

![Screenshot 2023-01-05 at 16 39 09](https://user-images.githubusercontent.com/211411/210820572-5ec6216d-fd59-41d5-97dd-683f04bbb9fd.png)


### ❓ Context

- **Impacted projects**: `btc impl` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
