### PR TITLE
improved estimateMaxSpendable in case all utxo used

### DIFF
--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/wallet.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/wallet.ts
@@ -156,7 +156,7 @@ class BitcoinLikeWallet {
       utils.maxTxSizeCeil(
         usableUtxoCount,
         outputScripts,
-        outputScripts.length == 0,
+        false,
         account.xpub.crypto,
         account.xpub.derivationMode
       );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Remove useless check in estimateMaxSpendable when we use all the utxos

### ❓ Context

- **Impacted projects**: `LLC`
- **Linked resource(s)**: `N/A`

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
