### PR TITLE
Sentry: ignore HederaAddAccountError

### DIFF
--- a/apps/ledger-live-desktop/src/sentry/install.js
+++ b/apps/ledger-live-desktop/src/sentry/install.js
@@ -58,6 +58,7 @@ const ignoreErrors = [
   "Unexpected ''",
   "Unexpected '<'",
   "Service Unvailable",
+  "HederaAddAccountError",
   // timeouts
   "ERR_CONNECTION_TIMED_OUT",
   "request timed out",

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -65,6 +65,7 @@ const excludedErrorName = [
   "AccountNeedResync",
   "DeviceAppVerifyNotSupported",
   "AccountAwaitingSendPendingOperations",
+  "HederaAddAccountError",
   // API issues
   "LedgerAPI4xx",
   "LedgerAPI5xx",


### PR DESCRIPTION


### 📝 Description

HederaAddAccountError was added to unify many Hedera network errors, however it wasn't ignored to be sent to sentry. this fixes it.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** no need <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
