### PR TITLE
Fixed faulty assertions in Playwright tests

### DIFF
--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -1,5 +1,5 @@
 import { _electron as electron } from "playwright";
-import { test as base, expect, Page, ElectronApplication } from "@playwright/test";
+import { test as base, Page, ElectronApplication } from "@playwright/test";
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
@@ -119,7 +119,6 @@ const test = base.extend<TestFixtures>({
     });
 
     // app is loaded
-    // expect(await page.title()).toBe("Ledger Live");
     await page.waitForLoadState("domcontentloaded");
     await page.waitForSelector("#loader-container", { state: "hidden" });
 

--- a/apps/ledger-live-desktop/tests/models/TermsModal.ts
+++ b/apps/ledger-live-desktop/tests/models/TermsModal.ts
@@ -1,0 +1,15 @@
+import { Page, Locator } from "@playwright/test";
+
+export class TermsModal {
+  readonly page: Page;
+  readonly termsModal: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.termsModal = page.locator('[data-test-id="terms-update-popup"]');
+  }
+
+  async isVisible() {
+    await this.termsModal.waitFor({ state: "visible" });
+  }
+}

--- a/apps/ledger-live-desktop/tests/specs/general/passwordlock.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/general/passwordlock.spec.ts
@@ -96,6 +96,6 @@ test("Enable password lock", async ({ page, userdataFile }) => {
   });
 
   await test.step("User data shouldn't be encrypted", async () => {
-    expect.poll(() => typeof getUserdata().data.accounts).toBe("object");
+    await expect.poll(() => typeof getUserdata().data.accounts).toBe("object");
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/general/terms.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/general/terms.spec.ts
@@ -1,12 +1,14 @@
 import test from "../../fixtures/common";
 import { expect } from "@playwright/test";
+import { TermsModal } from "tests/models/TermsModal";
 
 test.use({ userdata: "skip-onboarding-with-terms" });
 
 test("Terms of Use", async ({ page }) => {
-  await test.step("check for popup", async () => {
-    const modal = page.locator('[data-test-id="terms-update-popup"]');
+  const termsModal = new TermsModal(page);
 
-    expect(await modal.isVisible()).toBe(true);
+  await test.step("check for popup", async () => {
+    await termsModal.isVisible();
+    await expect(termsModal.termsModal).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/general/updater.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/general/updater.spec.ts
@@ -15,7 +15,7 @@ test("Updater", async ({ page }) => {
   const appUpdater = new AppUpdater(page);
 
   await test.step("[idle] state should not be visible", async () => {
-    expect(await layout.appUpdateBanner.isHidden()).toBe(true);
+    await expect(layout.appUpdateBanner).toBeHidden();
     await expect
       .soft(page)
       .toHaveScreenshot("app-updater-idle.png", { mask: [page.locator("canvas")] });
@@ -55,9 +55,9 @@ test("Updater", async ({ page }) => {
   await test.step("[error] state (any) should be visible, without the carousel", async () => {
     await layout.goToSettings();
     await settingsPage.carouselSwitchButton.click();
-    expect(await settingsPage.carouselSwitchButton.locator("input").isChecked()).toBe(false);
+    await expect(settingsPage.carouselSwitchButton.locator("input")).not.toBeChecked();
     await layout.goToPortfolio();
-    expect(await layout.appUpdateBanner.isVisible()).toBe(true);
+    await expect(layout.appUpdateBanner).toBeVisible();
     await expect.soft(page).toHaveScreenshot("app-updater-error-without-carousel.png", {
       mask: [page.locator("canvas")],
     });

--- a/apps/ledger-live-desktop/tests/specs/services/discover.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/discover.spec.ts
@@ -68,13 +68,13 @@ test("Discover", async ({ page }) => {
 
   await test.step("Request Account drawer - open", async () => {
     await discoverPage.requestAsset();
-    await expect(await discoverPage.selectAssetTitle.isVisible()).toBe(true);
+    await expect(discoverPage.selectAssetTitle).toBeVisible();
   });
 
   await test.step("Request Account - select asset", async () => {
     await discoverPage.selectAsset();
-    await expect(await discoverPage.selectAccountTitle.isVisible()).toBe(true);
-    await expect(await discoverPage.selectAssetSearchBar.isEnabled()).toBe(true);
+    await expect(discoverPage.selectAccountTitle).toBeVisible();
+    await expect(discoverPage.selectAssetSearchBar).toBeEnabled();
   });
 
   await test.step("Request Account - select BTC", async () => {

--- a/apps/ledger-live-desktop/tests/specs/support/unsupported-os.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/support/unsupported-os.spec.ts
@@ -14,7 +14,7 @@ test("Unsupported OS", async ({ page }) => {
   const layout = new Layout(page);
   await test.step("displays the error page", async () => {
     await layout.renderError.waitFor({ state: "visible" });
-    expect(await layout.renderError.isVisible()).toBe(true);
-    expect(await layout.page.screenshot()).toMatchSnapshot("error-os-unsupported.png");
+    await expect(layout.renderError).toBeVisible();
+    await expect(await layout.page.screenshot()).toMatchSnapshot("error-os-unsupported.png");
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Some tests were resulting in the following errors:
<img width="895" alt="image" src="https://user-images.githubusercontent.com/87659842/211576721-b6fec96b-9f94-49fb-97f4-d2aa2610e809.png">

This is because we are waiting for a Promise and comparing that with a boolean instead of comparing two of the same object types. The fix is to change from `isVisible()` on the locator and asserting if it's `true`/`false`, to just asserting that a locator is visible with `toBeVisible()`.

**EDIT: actually it looks like the issue was an `expect.poll` that didn't have an await, which was causing some weird timing issues and therefore some checks were failing**

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
