### PR TITLE
fix: add static limit to format value

### DIFF
--- a/.changeset/nasty-years-pay.md
+++ b/.changeset/nasty-years-pay.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add static limit to format value in swap rates

--- a/.changeset/poor-glasses-destroy.md
+++ b/.changeset/poor-glasses-destroy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add static limit to format value

--- a/apps/ledger-live-desktop/src/renderer/components/FormattedVal.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FormattedVal.jsx
@@ -62,6 +62,7 @@ type OwnProps = {
   showAllDigits?: boolean,
   alwaysShowValue?: boolean, // overrides discreet mode
   dynamicSignificantDigits?: number,
+  staticSignificantDigits?: number,
 };
 
 const mapStateToProps = createStructuredSelector({
@@ -96,6 +97,7 @@ function FormattedVal(props: Props) {
     alwaysShowValue,
     discreet,
     dynamicSignificantDigits,
+    staticSignificantDigits,
     ...p
   } = props;
   const valProp = props.val;
@@ -130,6 +132,7 @@ function FormattedVal(props: Props) {
       discreet: alwaysShowValue ? false : discreet,
       showAllDigits,
       dynamicSignificantDigits,
+      staticSignificantDigits,
     });
   }
 

--- a/apps/ledger-live-desktop/src/renderer/components/Price.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Price.jsx
@@ -32,6 +32,8 @@ type Props = {
   fontWeight?: number,
   iconSize?: number,
   placeholder?: React$Node,
+  dynamicSignificantDigits?: number,
+  staticSignificantDigits?: number,
 };
 
 export default function Price({
@@ -50,6 +52,8 @@ export default function Price({
   showAllDigits,
   withIcon = true,
   rate,
+  dynamicSignificantDigits,
+  staticSignificantDigits,
 }: Props) {
   const effectiveUnit = unit || from.units[0];
   const valueNum = 10 ** effectiveUnit.magnitude;
@@ -102,6 +106,8 @@ export default function Price({
         value={counterValue}
         disableRounding={!!subMagnitude}
         subMagnitude={subMagnitude}
+        dynamicSignificantDigits={dynamicSignificantDigits}
+        staticSignificantDigits={staticSignificantDigits}
         showCode
       />
     </PriceWrapper>

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Rates/SwapRate.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Rates/SwapRate.jsx
@@ -63,6 +63,7 @@ function SwapRate({ value = {}, selected, onSelect, fromCurrency, toCurrency }: 
               rate={value.magnitudeAwareRate}
               fontWeight="600"
               color="palette.text.shade100"
+              staticSignificantDigits={7}
             />
           </Box>
           <SecondaryText fontSize={3}>
@@ -85,6 +86,7 @@ function SwapRate({ value = {}, selected, onSelect, fromCurrency, toCurrency }: 
             showCode={true}
             color="palette.text.shade100"
             fontWeight="600"
+            staticSignificantDigits={7}
           />
           <StyledCounterValue
             fontSize={3}

--- a/libs/ledger-live-common/src/currencies/formatCurrencyUnit.ts
+++ b/libs/ledger-live-common/src/currencies/formatCurrencyUnit.ts
@@ -27,6 +27,7 @@ const defaultFormatOptions = {
   joinFragmentsSeparator: "",
   // Increase the significant digits. Ex: For a value of 1.121212 BTC, dynamicSignificantDigits of 4 => 1.121 / dynamicSignificantDigits of 6 => 1.12121
   dynamicSignificantDigits: 6,
+  staticSignificantDigits: 8,
 };
 
 export type formatCurrencyUnitOptions = Partial<typeof defaultFormatOptions>;
@@ -88,6 +89,7 @@ export function formatCurrencyUnitFragment(
     subMagnitude,
     discreet,
     dynamicSignificantDigits,
+    staticSignificantDigits,
   } = { ...defaultFormatOptions, ...unit, ...options };
   const { magnitude, code } = unit;
   const floatValue = value.div(new BigNumber(10).pow(magnitude));
@@ -103,7 +105,7 @@ export function formatCurrencyUnitFragment(
             dynamicSignificantDigits -
               Math.ceil(Math.log10(floatValueAbs.toNumber())),
             magnitude + subMagnitude,
-            8
+            staticSignificantDigits
           )
         )
       );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In swap page after an estimation, providers quotes are exchange rates are not readable when too many decimals. Limit decimal to 7.

### ❓ Context

- **Impacted projects**: LLM & common
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-5151

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
