### PR TITLE
Feat/LIVE-4989 - Add tracking to RestoreWithProtect info modal

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RestoreWithProtect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RestoreWithProtect.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from "react-i18next";
 import { Icons, NumberedList } from "@ledgerhq/native-ui";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Linking } from "react-native";
-import Button from "../../../../../components/PreventDoubleClickButton";
 import InfoModal from "../../../../../modals/Info";
+import Button from "../../../../../components/wrappedUi/Button";
+import { TrackScreen } from "../../../../../analytics";
 
 const RestoreWithProtectScene = () => {
   const { t } = useTranslation();
@@ -93,14 +94,29 @@ const Next = ({ onNext }: { onNext: () => void }) => {
                   type="main"
                   size="large"
                   onPress={onManualSteps}
+                  Icon={Icons.ExternalLinkMedium}
                   mt={8}
                   mb={6}
+                  event={"button_clicked"}
+                  eventProperties={{ button: "Go through manual steps" }}
                 >
                   {t("onboarding.stepProtect.extraInfo.cta")}
                 </Button>
-                <Button type="default" size="large" onPress={onSupportLink}>
+                <Button
+                  type="default"
+                  size="large"
+                  onPress={onSupportLink}
+                  Icon={Icons.ExternalLinkMedium}
+                  event={"button_clicked"}
+                  eventProperties={{ button: "Contact Ledger support" }}
+                >
                   {t("onboarding.stepProtect.extraInfo.supportLink")}
                 </Button>
+                <TrackScreen
+                  category="Why can I not see Restore with Protect on my Ledger"
+                  refreshSource={false}
+                  type="drawer"
+                />
               </>
             ),
           },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add tracking to RestoreWithProtect info modal
because the modal was already done :doughnut: 

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-4989

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/89014981/212118278-d2bf2d88-8cff-40cf-a23b-5b4284807d3f.mp4




### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
