### PR TITLE
Bugfix/LIVE-5161 Cosmos tx type fix

### DIFF
--- a/.changeset/thirty-turtles-thank.md
+++ b/.changeset/thirty-turtles-thank.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+bugfix: cosmos delegate/unbond/redelegate tx are wrongly interpreted into claim reward tx

--- a/libs/ledger-live-common/src/families/cosmos/helpers.ts
+++ b/libs/ledger-live-common/src/families/cosmos/helpers.ts
@@ -5,10 +5,10 @@ type Message = {
 
 export const getMainMessage = (messages: Message[]): Message => {
   const messagePriorities: string[] = [
-    "withdraw_rewards",
     "unbond",
     "redelegate",
     "delegate",
+    "withdraw_rewards",
     "transfer",
   ];
   const sortedTypes = messages

--- a/libs/ledger-live-common/src/families/cosmos/helpers.unit.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/helpers.unit.test.ts
@@ -1,7 +1,7 @@
 import { getMainMessage } from "./helpers";
 
 describe("getMainMessage", () => {
-  it("should return reward message with delegate and reward messages (claim rewards, compound)", () => {
+  it("should return delegate message with delegate and reward messages (claim rewards, compound)", () => {
     const exec = getMainMessage([
       {
         type: "delegate",
@@ -12,7 +12,7 @@ describe("getMainMessage", () => {
         attributes: {},
       },
     ]);
-    expect(exec.type).toEqual("withdraw_rewards");
+    expect(exec.type).toEqual("delegate");
   });
 
   it("should return unbond message with unbound and transfer messages", () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Bugfix: cosmos delegate/undelegate/unbond is wrong interpreted into claim reward operation

### ❓ Context

- **Impacted projects**: `` LLD, Cosmos
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-5161

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
