### PR TITLE
fix: aligns 1inch swap rate with other rates in LLD

### DIFF
--- a/.changeset/hot-coins-laugh.md
+++ b/.changeset/hot-coins-laugh.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Aligns 1inch logo with others when showing swap rates on LLD

--- a/apps/ledger-live-desktop/src/renderer/icons/providers/Oneinch.jsx
+++ b/apps/ledger-live-desktop/src/renderer/icons/providers/Oneinch.jsx
@@ -3,7 +3,13 @@
 import React from "react";
 
 const Oneinch = ({ size }: { size: number }) => (
-  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
     <g clipPath="url(#clip0_1119_16756)">
       <path
         d="M5.71397 13.2253L6.34895 8.15617L0.841309 4.09363L5.87357 5.90482L7.06202 3.96736L11.4016 1.10626L20.9669 6.70578L21.4627 15.2494L17.2012 21.5416L13.8328 22.09L15.5748 18.7022V15.4406L14.3082 12.8934L13.0213 11.9878L11.0416 14.1562V16.4508L9.49666 17.9878L7.53401 18.2404L6.66474 18.7635L5.23859 18.28L4.64437 16.007L5.71397 14.4087V13.2253Z"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Aligns all swap rates in LLD. They were previously misaligned because the 1inch logo was rendered at 24px wide, whereas it should be 28px.

### ❓ Context

- **Impacted projects**:  Desktop
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-5152

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="625" alt="Screenshot 2023-01-13 at 10 20 20" src="https://user-images.githubusercontent.com/119950081/212297053-68cc2134-96a2-418b-8a8b-a5edf222bcea.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
