### PR TITLE
fix: fixes lld swap issue to only fetch dex rates from supported prov…

### DIFF
--- a/.changeset/stupid-news-clean.md
+++ b/.changeset/stupid-news-clean.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Only fetches swap rates for supported CEX and DEX providers.

--- a/libs/ledger-live-common/src/exchange/swap/getExchangeRates.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getExchangeRates.test.ts
@@ -17,7 +17,10 @@ const providers = [
     provider: "changelly",
     pairs: [{ from: "bitcoin", to: "ethereum", tradeMethod: "float" }],
   },
-  { provider: "oneinch", pairs: [] },
+  {
+    provider: "oneinch",
+    pairs: [{ from: "bitcoin", to: "ethereum", tradeMethod: "float" }],
+  },
 ];
 
 const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
@@ -225,6 +228,49 @@ describe("swap/getExchangeRates", () => {
         amountFrom: "0.0001",
         from: "bitcoin",
         providers: ["changelly", "oneinch"],
+        to: "ethereum",
+      },
+      headers: expect.anything(),
+    });
+  });
+  test("shout not query for providers which is not compatible with the requested pair", async () => {
+    const providers = [
+      {
+        provider: "changelly",
+        pairs: [{ from: "bitcoin", to: "ethereum", tradeMethod: "float" }],
+      },
+      {
+        provider: "oneinch",
+        pairs: [{ from: "binance", to: "ethereum", tradeMethod: "float" }],
+      },
+    ];
+
+    const resp = {
+      data: [],
+      status: 200,
+      statusText: "",
+      headers: {},
+      config: {},
+    };
+
+    mockedAxios.mockResolvedValue(Promise.resolve(resp));
+    mockedProviders.mockResolvedValue(Promise.resolve([]));
+    const includeDEX = true;
+    await getExchangeRates(
+      exchange,
+      transaction,
+      undefined,
+      undefined,
+      providers,
+      includeDEX
+    );
+    expect(mockedAxios).toHaveBeenCalledWith({
+      method: "POST",
+      url: "https://swap.ledger.com/v4/rate",
+      data: {
+        amountFrom: "0.0001",
+        from: "bitcoin",
+        providers: ["changelly"],
         to: "ethereum",
       },
       headers: expect.anything(),

--- a/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
@@ -17,10 +17,10 @@ import type { Transaction } from "../../generated/types";
 import { getProviderConfig, getSwapAPIBaseURL, getSwapAPIError } from "./";
 import { mockGetExchangeRates } from "./mock";
 import type {
+  AvailableProviderV3,
   CustomMinOrMaxError,
   Exchange,
   GetExchangeRates,
-  AvailableProviderV3,
 } from "./types";
 
 const getExchangeRates: GetExchangeRates = async (
@@ -44,18 +44,12 @@ const getExchangeRates: GetExchangeRates = async (
   const apiAmount = new BigNumber(amountFrom).div(tenPowMagnitude);
 
   const providerList = providers
-    .filter((provider) => {
-      const validDex = (provider: AvailableProviderV3) =>
-        includeDEX && getProviderConfig(provider.provider).type === "DEX";
-      const validCex = (provider: AvailableProviderV3) => {
-        if (getProviderConfig(provider.provider).type !== "CEX") return false;
-        const index = provider.pairs.findIndex(
-          (pair) => pair.from === from && pair.to === to
-        );
-        return index > -1;
-      };
-      return validDex(provider) || validCex(provider);
-    })
+    .filter((provider) =>
+      provider.pairs.some((pair) => pair.from === from && pair.to === to)
+    )
+    .filter((provider) =>
+      includeDEX ? true : !(getProviderConfig(provider.provider).type === "DEX")
+    )
     .map((item) => item.provider);
 
   const request = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently when a user is requesting a currency pair to swap, we are fetching rates from supported CEX providers and **all** DEX providers. This is not correct. This PR changes to only fetch rates from supported CEX and DEX providers.

Currently this issue manifests itself when you query for BSC/BUSD to Ethereum - we should not be showing any DEX rates as 1inch/paraswap are not supported.

### ❓ Context

- **Impacted projects**:  Desktop
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5183

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
#### Before (always fetching all rates)

<img width="1458" alt="Screenshot 2023-01-13 at 15 47 53" src="https://user-images.githubusercontent.com/119950081/212361459-0623d0ac-15f2-4bc4-a961-63665cdfd959.png">


#### After (we only fetched rates for changelly here as 1inch/paraswap don't support this pair according to the data returned from /providers)
<img width="1465" alt="Screenshot 2023-01-13 at 15 48 33" src="https://user-images.githubusercontent.com/119950081/212361303-380156f4-e9f6-4e43-b7d5-a4cad19b49ea.png">

#### After (we are querying for 1inch/paraswap as they support this pair)
<img width="1487" alt="Screenshot 2023-01-13 at 15 51 32" src="https://user-images.githubusercontent.com/119950081/212361917-8280885c-c5fa-474c-8160-f62ceb42c205.png">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
