### PR TITLE
fix: LLD - fixes back button whilst doing a DEX swap

### DIFF
--- a/.changeset/stupid-fans-vanish.md
+++ b/.changeset/stupid-fans-vanish.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fixes back button during DEX swap

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/App.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/App.jsx
@@ -38,8 +38,8 @@ export default function PlatformApp({ match, appId: propsAppId, location }: Prop
 
   const returnTo = useMemo(() => {
     const params = new URLSearchParams(search);
-    return params.get("returnTo");
-  }, [search]);
+    return params.get("returnTo") || internalParams?.returnTo;
+  }, [search, internalParams]);
 
   const handleClose = useCallback(() => history.push(returnTo || `/platform`), [history, returnTo]);
   const themeType = useTheme("colors.palette.type");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes an issue whereby when a user presses the close button when they're in doing a DEX swap in the 1inch/paraswap webview, they should be navigated back to the swap screen.

### ❓ Context

- **Impacted projects**:  LLD
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5213

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
