### PR TITLE
Bugfix: FAT-801 bluetooth connection failed

### DIFF
--- a/.changeset/wild-news-exist.md
+++ b/.changeset/wild-news-exist.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+Fix: incorrect usage of bleManager instance inside BleTransport

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -53,14 +53,21 @@ let connectOptions: Record<string, unknown> = {
   connectionPriority: 1,
 };
 const transportsCache = {};
-let bleManager;
 
+let _bleManager: BleManager | null = null;
+/**
+ * Allows lazy initialization of BleManager
+ * Useful for iOS to only ask for Bluetooth permission when needed
+ *
+ * Do not use _bleManager directly
+ * Only use this instance getter inside BleTransport
+ */
 const bleManagerInstance = (): BleManager => {
-  if (!bleManager) {
-    bleManager = new BleManager();
+  if (!_bleManager) {
+    _bleManager = new BleManager();
   }
 
-  return bleManager;
+  return _bleManager;
 };
 
 const retrieveInfos = (device) => {
@@ -97,8 +104,8 @@ async function open(deviceOrId: Device | string, needsReconnect: boolean) {
       return transportsCache[deviceOrId];
     }
 
-    log("ble-verbose", `open(${deviceOrId})`);
-    await awaitsBleOn(bleManager);
+    log("ble-verbose", `Tries to open device: ${deviceOrId}`);
+    await awaitsBleOn(bleManagerInstance());
 
     if (!device) {
       // works for iOS but not Android


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

On iOS some users are facing connection failed issues

In `BleTransport` we now use a singleton to handle the BLE manager, but one usage of it was not correctly updated.

The fact that with the new device selection screen we would not face the same problem can be explained by the fact that on the new device selection screen, a BLE scanning is done before trying to "open" the device. This scanning would have already set up an instance of `bleManager`, avoiding the issue.


### ❓ Context

- **Impacted projects**: `react-native-hw-transport-ble`
- **Linked resource(s)**: [FAT-801](https://ledgerhq.atlassian.net/browse/FAT-801)

### ✅ Checklist

- [ ] **Test coverage**: Should be tested by QA
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-801]: https://ledgerhq.atlassian.net/browse/FAT-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ