### PR TITLE
Switch to new Ledger headers & explicit usage from bot & cli

### DIFF
--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import winston from "winston";
-import { EnvName, setEnvUnsafe } from "@ledgerhq/live-common/env";
+import { EnvName, setEnv, setEnvUnsafe } from "@ledgerhq/live-common/env";
 import simple from "@ledgerhq/live-common/logs/simple";
 import { listen } from "@ledgerhq/logs";
 import { setSupportedCurrencies } from "@ledgerhq/live-common/currencies/index";
@@ -71,7 +71,10 @@ const { format } = winston;
 const { combine, json } = format;
 const winstonFormatJSON = json();
 const winstonFormatConsole = combine(
-  format(({ type, message, id: _id, date: _date, ...rest }) => ({ ...rest, message: `${type}: ${message}` }) )(),
+  format(({ type, message, id: _id, date: _date, ...rest }) => ({
+    ...rest,
+    message: `${type}: ${message}`,
+  }))(),
   format.colorize(),
   simple()
 );
@@ -138,3 +141,6 @@ listen((log) => {
   // @ts-ignore
   logger.log(level, log);
 });
+
+const value = "cli/0.0.0";
+setEnv("LEDGER_CLIENT_VERSION", value);

--- a/apps/ledger-live-desktop/src/live-common-setup-base.js
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.js
@@ -1,7 +1,6 @@
 // @flow
 import "./env";
-import axios from "axios";
-
+import { setEnv } from "@ledgerhq/live-common/env";
 import { listen as listenLogs } from "@ledgerhq/logs";
 import logger from "./logger";
 
@@ -11,5 +10,6 @@ listenLogs(({ id, date, ...log }) => {
 });
 
 if (process.env.NODE_ENV === "production") {
-  axios.defaults.headers.common["User-Agent"] = `Live-Desktop/${__APP_VERSION__}`;
+  const value = `lld/${__APP_VERSION__}`;
+  setEnv("LEDGER_CLIENT_VERSION", value);
 }

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -22,7 +22,6 @@ import { DescriptorEvent } from "@ledgerhq/hw-transport";
 import VersionNumber from "react-native-version-number";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import { Platform } from "react-native";
-import axios from "axios";
 import { setSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/wallet-btc/crypto/secp256k1";
 import { setGlobalOnBridgeError } from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { prepareCurrency } from "./bridge/cache";
@@ -166,10 +165,11 @@ registerTransportModule({
 });
 
 if (process.env.NODE_ENV === "production") {
-  axios.defaults.headers.common["User-Agent"] =
+  const value =
     Platform.OS === "ios"
-      ? `Live-IOS/${VersionNumber.appVersion}`
-      : `Live-Android/${VersionNumber.appVersion}`;
+      ? `llm-ios/${VersionNumber.appVersion}`
+      : `llm-android/${VersionNumber.appVersion}`;
+  setEnv("LEDGER_CLIENT_VERSION", value);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
@@ -6,6 +6,7 @@ import { EnvName, setEnvUnsafe } from "../../env";
 import { setWalletAPIVersion } from "../../wallet-api/version";
 import { WALLET_API_VERSION } from "../../wallet-api/constants";
 import { PLATFORM_VERSION } from "../../platform/constants";
+import { setEnv } from "../../env";
 
 setPlatformVersion(PLATFORM_VERSION);
 setWalletAPIVersion(WALLET_API_VERSION);
@@ -98,3 +99,6 @@ listen(({ type, message, ...rest }) => {
     ...rest,
   });
 });
+
+const value = "ll-ci/0.0.0";
+setEnv("LEDGER_CLIENT_VERSION", value);

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -422,6 +422,11 @@ const envDefinitions = {
     parser: intParser,
     desc: "overrides the gap limit specified by BIP44 (default to 20)",
   },
+  LEDGER_CLIENT_VERSION: {
+    def: "",
+    parser: stringParser,
+    desc: "the 'X-Ledger-Client-Version' HTTP header to use for queries to Ledger APIs",
+  },
   LEDGER_COUNTERVALUES_API: {
     def: "https://countervalues.live.ledger.com",
     parser: stringParser,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Switch HTTP headers to `X-Ledger-Client-Version` that will be standardized everywhere. That way, renderer (web env) can also set these headers (`User-Agent` can't be set on Chrome/Chromium)

### ❓ Context

- **Impacted projects**: `lld, llm, cli, bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5223 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** i have manually tested on LLD that the header are set on the network tab of renderer (in experimental renderer running) <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
