### PR TITLE
bugfix/LIVE-5273 Device name is not displayed properly in LLM

### DIFF
--- a/.changeset/smooth-walls-greet.md
+++ b/.changeset/smooth-walls-greet.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Prevent device name bug in LNX

--- a/libs/ledger-live-common/src/hw/getDeviceName.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceName.test.ts
@@ -1,6 +1,6 @@
 import getDeviceName from "./getDeviceName";
 
-const mockTransportGenerator = (out) => ({ send: () => out });
+const mockTransportGenerator = (out) => ({ send: async () => out });
 
 describe("getDeviceName", () => {
   test("should return name if available", async () => {

--- a/libs/ledger-live-common/src/hw/getDeviceName.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceName.ts
@@ -4,6 +4,9 @@ import Transport, {
 } from "@ledgerhq/hw-transport";
 
 export default async (transport: Transport): Promise<string> => {
+  // NB Prevents bad apdu response for LNX
+  await transport.send(0xe0, 0x50, 0x00, 0x00).catch(() => {});
+
   const res = await transport.send(0xe0, 0xd2, 0x00, 0x00, Buffer.from([]), [
     StatusCodes.OK,
     StatusCodes.DEVICE_NOT_ONBOARDED,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Due to unforeseen circumstances we need to bring back the suppossedly superflous apdu that we were sending before the get device name command. When used on a LNX it's sometimes glitching and returning the wrong value.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-5273` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Make sure device name looks ok with the old device selection on a nano x.