### PR TITLE
chore: add event on device action error

### DIFF
--- a/.changeset/popular-tables-jog.md
+++ b/.changeset/popular-tables-jog.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+chore: add events on device action errors

--- a/.changeset/silly-terms-decide.md
+++ b/.changeset/silly-terms-decide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+chore: add event on device action error for LLD

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -38,6 +38,7 @@ import {
   renderLockedDeviceError,
   RenderDeviceNotOnboardedError,
 } from "./rendering";
+import { track } from "~/renderer/analytics/segment";
 
 type Props<R, H, P> = {
   overridesPreferredDeviceModel?: DeviceModelId;
@@ -129,8 +130,12 @@ export const DeviceActionDefaultRendering = <R, H, P>({
   const { t } = useTranslation();
 
   useEffect(() => {
-    if (error && onError) {
-      onError(error);
+    if (error) {
+      track("DeviceActionError", error);
+
+      if (onError) {
+        onError(error);
+      }
     }
   }, [error, onError]);
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -62,6 +62,7 @@ import PreventNativeBack from "../PreventNativeBack";
 import SkipLock from "../behaviour/SkipLock";
 import DeviceActionProgress from "../DeviceActionProgress";
 import { PartialNullable } from "../../types/helpers";
+import { track } from "../../analytics";
 
 type LedgerError = InstanceType<
   LedgerErrorConstructor<{ [key: string]: unknown }>
@@ -235,8 +236,12 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   }, [dispatch, device, deviceInfo]);
 
   useEffect(() => {
-    if (error && onError) {
-      onError(error);
+    if (error) {
+      track("DeviceActionError", error);
+
+      if (onError) {
+        onError(error);
+      }
     }
   }, [error, onError]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add Segment event on error in `DeviceActionDefaultRendering` in both LLM and LLD

### ❓ Context

- **Impacted projects**:  LLM
- **Linked resource(s)**: [FAT-812](https://ledgerhq.atlassian.net/browse/FAT-812)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Screenshot from Mixpanel:
![Screenshot 2023-01-25 at 17 10 17](https://user-images.githubusercontent.com/15096913/214615270-cf896055-6f33-4836-8f65-a29c6c5597b6.png)



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-812]: https://ledgerhq.atlassian.net/browse/FAT-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ