### PR TITLE
bugfix/FAT-747 Better broken BLE pairing handling

### DIFF
--- a/.changeset/itchy-vans-fail.md
+++ b/.changeset/itchy-vans-fail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+Better error handling for broken pairing

--- a/.changeset/spicy-ravens-sleep.md
+++ b/.changeset/spicy-ravens-sleep.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Better error handling for broken pairing on iOS

--- a/.changeset/ten-ducks-provide.md
+++ b/.changeset/ten-ducks-provide.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/errors": patch
+---
+
+Added mising error for broken ble pairing

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -112,19 +112,9 @@
       "title": "Sorry, Bluetooth is disabled",
       "description": "Please enable Bluetooth in your phone settings. ({{state}} state)"
     },
-    "FwUpdateBluetoothNotSupported": {
-      "title": "Firmware updates are only supported for wired connections"
-    },
-    "BtcUnmatchedApp": {
-      "title": "That's the wrong app",
-      "description": "Please open the {{managerAppName}} app on your device."
-    },
     "CantOpenDevice": {
       "title": "Sorry, connection failed",
       "description": "Your Ledger device must be unlocked and in range to use Bluetooth."
-    },
-    "CantScanQRCode": {
-      "title": "Could not scan this QR code: auto-verification not supported by this address."
     },
     "ConnectAppTimeout": {
       "title": "Sorry, no device found",
@@ -324,11 +314,13 @@
     },
     "ImageCommitRefusedOnDevice": {
       "title": "Lock screen cancelled on Ledger Stax",
-      "description": "If this image wasn't the right fit, you can try again with another image."
+      "description": "If this image wasn't the right fit, you can try again with another image.",
+      "primaryCTA": "Upload another picture"
     },
     "ImageLoadRefusedOnDevice": {
       "title": "Lock screen cancelled on Ledger Stax",
-      "description": "If this image wasn't the right fit, you can try again with another image."
+      "description": "If this image wasn't the right fit, you can try again with another image.",
+      "primaryCTA": "Upload another picture"
     },
     "InvalidAddress": {
       "title": "This is not a valid {{currencyName}} address"
@@ -478,7 +470,7 @@
       "description": "Please try again."
     },
     "PeerRemovedPairing": {
-      "title": "You need to remove {{ productName }} from your phone's Bluetooth devices",
+      "title": "You need to remove '{{ deviceName }}' from your phone's Bluetooth devices",
       "description": "Your {{ productName }} changed its Bluetooth configuration. Remove it from your phone settings, then come back to Ledger Live and try pairing again."
     },
     "SelectExchangesLoadError": {
@@ -557,7 +549,8 @@
     },
     "UpdateYourApp": {
       "title": "App update needed",
-      "description": "Please uninstall then reinstall the {{managerAppName}} app in the Manager."
+      "description": "Please uninstall then reinstall the {{managerAppName}} app in the Manager.",
+      "primaryCTA": "Open Manager"
     },
     "UserRefusedAllowManager": {
       "title": "Manager disabled on device",
@@ -676,7 +669,8 @@
     },
     "generic": {
       "title": "{{message}}",
-      "description": "Something went wrong. Please try again. If the problem persists, please save your logs using the button below and provide them to Ledger Support."
+      "description": "Something went wrong. Please try again. If the problem persists, please save your logs using the button below and provide them to Ledger Support.",
+      "primaryCTA": "Retry"
     },
     "SolanaAccountNotFunded": {
       "title": "Account not funded"

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -477,6 +477,10 @@
       "title": "Password does not match",
       "description": "Please try again."
     },
+    "PeerRemovedPairing": {
+      "title": "You need to remove {{ productName }} from your phone's Bluetooth devices",
+      "description": "Your {{ productName }} changed its Bluetooth configuration. Remove it from your phone settings, then come back to Ledger Live and try pairing again."
+    },
     "SelectExchangesLoadError": {
       "title": "Unable to load",
       "description": "Cannot load the exchanges."
@@ -1818,7 +1822,8 @@
           "title": "Your device is locked",
           "subtitle": "Unlock your {{ productName }} and try again."
         },
-        "retryCta": "Try again"
+        "retryCta": "Retry",
+        "openSettingsCta": "Go to Bluetooth settings"
       }
     }
   },

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -484,7 +484,7 @@ const implementations = {
     Observable.create((o) => {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 20000;
+      const DEVICE_POLLING_TIMEOUT = 60000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
       const sub = deviceSubject.subscribe((d) => {

--- a/libs/ledger-live-common/src/hw/actions/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/actions/installLanguage.ts
@@ -141,7 +141,7 @@ const implementations = {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
       const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 30000;
+      const DEVICE_POLLING_TIMEOUT = 60000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
       const sub = deviceSubject.subscribe((d) => {

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -202,7 +202,7 @@ const implementations = {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
       const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 20000;
+      const DEVICE_POLLING_TIMEOUT = 60000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
       const sub = deviceSubject.subscribe((d) => {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -13,6 +13,7 @@ import {
   TransportStatusError,
   DeviceHalted,
   PeerRemovedPairing,
+  PairingFailed,
 } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { getEnv } from "../env";
@@ -140,6 +141,7 @@ export const withDevice =
           if (e instanceof TransportWebUSBGestureRequired) throw e;
           if (e instanceof TransportInterfaceNotAvailable) throw e;
           if (e instanceof PeerRemovedPairing) throw e;
+          if (e instanceof PairingFailed) throw e;
           throw new CantOpenDevice(e.message);
         })
         // Executes the job

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -12,6 +12,7 @@ import {
   FirmwareOrAppUpdateRequired,
   TransportStatusError,
   DeviceHalted,
+  PeerRemovedPairing,
 } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { getEnv } from "../env";
@@ -138,6 +139,7 @@ export const withDevice =
           if (e instanceof BluetoothRequired) throw e;
           if (e instanceof TransportWebUSBGestureRequired) throw e;
           if (e instanceof TransportInterfaceNotAvailable) throw e;
+          if (e instanceof PeerRemovedPairing) throw e;
           throw new CantOpenDevice(e.message);
         })
         // Executes the job

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -221,6 +221,7 @@ export const FeeTooHigh = createCustomErrorClass("FeeTooHigh");
 export const PendingOperation = createCustomErrorClass("PendingOperation");
 export const SyncError = createCustomErrorClass("SyncError");
 export const PairingFailed = createCustomErrorClass("PairingFailed");
+export const PeerRemovedPairing = createCustomErrorClass("PeerRemovedPairing");
 export const GenuineCheckFailed = createCustomErrorClass("GenuineCheckFailed");
 export const LedgerAPI4xx = createCustomErrorClass("LedgerAPI4xx");
 export const LedgerAPI5xx = createCustomErrorClass("LedgerAPI5xx");

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/remapErrors.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/remapErrors.ts
@@ -1,8 +1,21 @@
-import { DisconnectedDevice } from "@ledgerhq/errors";
-export const remapError = (error: Error | null | undefined) => {
+import {
+  DisconnectedDevice,
+  PairingFailed,
+  PeerRemovedPairing,
+} from "@ledgerhq/errors";
+
+export const remapError = (error: any) => {
   if (!error || !error.message) return error;
 
   if (
+    error.iosErrorCode === 14 ||
+    error.reason === "Peer removed pairing information"
+  ) {
+    return new PeerRemovedPairing();
+  } else if (error?.attErrorCode === 22) {
+    // It's not documented but seems to match a refusal on Android pairing
+    return new PairingFailed();
+  } else if (
     error.message.includes("was disconnected") ||
     error.message.includes("not found")
   ) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR improves the way we handled a broken ble pairing when it comes from the nano side. When it's iOS we need the user to forget the device in their phone's settings, but on Android we seem to be able to trigger a new pairing by retrying a connection. I'm cautious about this and how it behaves on older Android versions and other devices from Stax, so let's not merge this hastily.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile, live-common, errors, react-native-hw-transport-ble` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-747` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
This should be tested on as many Android versions and ledger devices as possible because I fear potentially introducing a reconnect loop in some odd case. Worst case scenario it should en up in an error screen like in production.

The steps to test are as follows, feel free to challenge them:
- Pair a device with your phone.
- Remove pairing on the Ledger device either by resetting pairing in the settings or by resetting the device itself.
- Try to connect to the device on LLM.
   - On Android it _should_ prompt the pairing again, in production it would fail the first time and work on a retry.
   - On iOS it should show a new error screen with a link to the settings and instructions for the user.

> 
