### PR TITLE
fixes old link to old repository

### DIFF
--- a/.changeset/odd-fireants-fix.md
+++ b/.changeset/odd-fireants-fix.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fixes old link to old repository

--- a/apps/ledger-live-desktop/src/config/urls.js
+++ b/apps/ledger-live-desktop/src/config/urls.js
@@ -21,7 +21,7 @@ export const urls = {
 
   social: {
     twitter: "https://twitter.com/Ledger",
-    github: "https://github.com/LedgerHQ/ledger-live-desktop",
+    github: "https://github.com/LedgerHQ/ledger-live",
     reddit: "https://www.reddit.com/r/ledgerwallet/",
     facebook: "https://www.facebook.com/Ledger/",
   },
@@ -153,7 +153,7 @@ export const urls = {
   coinControl:
     "https://support.ledger.com/hc/en-us/articles/360015996580?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=send_coincontrol",
   githubIssues:
-    "https://github.com/LedgerHQ/ledger-live-desktop/issues?q=is%3Aissue+is%3Aopen+label%3Abug+sort%3Acomments-desc",
+    "https://github.com/LedgerHQ/ledger-live/issues?q=is%3Aissue+is%3Aopen+label%3Abug+sort%3Acomments-desc",
   multipleDestinationAddresses:
     "https://support.ledger.com/hc/en-us/articles/360033802154-Change-addresses?support=true",
   updateDeviceFirmware: {


### PR DESCRIPTION

### 📝 Description

some link inside Ledger Live still lead to the old repository.

### ❓ Context

- **Impacted projects**: `lld` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** I have not tested it but there is no risk here <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
