### PR TITLE
Simplify network to only log network-error & improve perf

### DIFF
--- a/.changeset/heavy-donkeys-burn.md
+++ b/.changeset/heavy-donkeys-burn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Simplify network logs

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/explorer/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/explorer/index.ts
@@ -4,11 +4,7 @@ import axiosRetry, { isNetworkOrIdempotentRequestError } from "axios-retry";
 import genericPool, { Pool } from "generic-pool";
 import { Address, Block, TX } from "../storage/types";
 import { IExplorer } from "./types";
-import {
-  requestInterceptor,
-  responseInterceptor,
-  errorInterceptor,
-} from "../../../../network";
+import { errorInterceptor } from "../../../../network";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { blockchainBaseURL } from "../../../../api/Ledger";
 
@@ -78,8 +74,7 @@ class BitcoinLikeExplorer implements IExplorer {
     }
 
     // Logging
-    client.interceptors.request.use(requestInterceptor);
-    client.interceptors.response.use(responseInterceptor, errorInterceptor);
+    client.interceptors.response.use(undefined, errorInterceptor);
   }
 
   async broadcast(tx: string): Promise<{ data: { result: string } }> {

--- a/libs/ledger-live-common/src/families/stellar/api/horizon.ts
+++ b/libs/ledger-live-common/src/families/stellar/api/horizon.ts
@@ -15,7 +15,6 @@ import {
   getReservedBalance,
 } from "../logic";
 import { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
-import { requestInterceptor, responseInterceptor } from "../../../network";
 import type { BalanceAsset } from "../types";
 import { NetworkCongestionLevel, Signer } from "../types";
 
@@ -31,11 +30,7 @@ export const BASE_RESERVE = 0.5;
 export const BASE_RESERVE_MIN_COUNT = 2;
 export const MIN_BALANCE = 1;
 
-StellarSdk.HorizonAxiosClient.interceptors.request.use(requestInterceptor);
-
 StellarSdk.HorizonAxiosClient.interceptors.response.use((response) => {
-  responseInterceptor(response);
-
   // FIXME: workaround for the Stellar SDK not using the correct URL: the "next" URL
   // included in server responses points to the node itself instead of our reverse proxy...
   // (https://github.com/stellar/js-stellar-sdk/issues/637)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

the proposal is to no longer have `"network"` and `"network-success"` log in the exported logs but only keep the `"network-error"`. This also takes opportunity to start simplification of the networking interception (in parallel of other exploration like #2363 ) 

logging this represents an important part of performance in some contexts (in case where the logger is costly, like internal<>renderer architecture, or in VERBOSE mode).

Reduce the file size of the bot zip export from 257 to 233MB.

In the usecase of "knowing how much http query the bot do" we could in future implement a dedicated solution for this and I will note it somewhere as well

### ❓ Context

- **Impacted projects**: `lld/llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-5298 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** i'll run the bot against this PR <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
