### PR TITLE
fix: incorrect usage of bleManager instance

### DIFF
--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -53,14 +53,21 @@ let connectOptions: Record<string, unknown> = {
   connectionPriority: 1,
 };
 const transportsCache = {};
-let bleManager;
 
+let _bleManager: BleManager | null = null;
+/**
+ * Allows lazy initialization of BleManager
+ * Useful for iOS to only ask for Bluetooth permission when needed
+ *
+ * Do not use _bleManager directly
+ * Only use this instance getter inside BleTransport
+ */
 const bleManagerInstance = (): BleManager => {
-  if (!bleManager) {
-    bleManager = new BleManager();
+  if (!_bleManager) {
+    _bleManager = new BleManager();
   }
 
-  return bleManager;
+  return _bleManager;
 };
 
 const retrieveInfos = (device) => {
@@ -97,8 +104,8 @@ async function open(deviceOrId: Device | string, needsReconnect: boolean) {
       return transportsCache[deviceOrId];
     }
 
-    log("ble-verbose", `open(${deviceOrId})`);
-    await awaitsBleOn(bleManager);
+    log("ble-verbose", `Tries to open device: ${deviceOrId}`);
+    await awaitsBleOn(bleManagerInstance());
 
     if (!device) {
       // works for iOS but not Android


### PR DESCRIPTION
Fix the lazy initialization of the BleManager

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Merging fix done in https://github.com/LedgerHQ/ledger-live/pull/2376 into `release`

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
