### PR TITLE
Fix psbtv2 serializeMap function

### DIFF
--- a/libs/ledgerjs/packages/hw-app-btc/src/newops/psbtv2.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/newops/psbtv2.ts
@@ -540,9 +540,12 @@ function createKey(buf: Buffer): Key {
   return new Key(buf.readUInt8(0), buf.slice(1));
 }
 function serializeMap(buf: BufferWriter, map: Map<string, Buffer>) {
-  for (const k in map.keys) {
-    const value = map.get(k)!;
-    const keyPair = new KeyPair(createKey(Buffer.from(k, "hex")), value);
+   for (const k of map.keys()) {
+    const value = map.get(k);
+    if (!value) {
+      throw new Error(`Failed to serialize map. Missing value for key ${k}`)
+    }
+    const keyPair = new KeyPair(createKey(Buffer.from(k, 'hex')), value);
     keyPair.serialize(buf);
   }
   buf.writeUInt8(0);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The function `serializeMap` had some clear problems and because of it psbt serialization did not work. 
1) `map.keys` is a function, not a property of the map object
2) Should be using `for of` for a list of keys. Not `for in` 
3) `map.get(k)!;` I think this is trying to do some null check. Regardless I replaced it with an if and threw an error if the value did not exist

### ❓ Context

- **Impacted projects**: `` Any project interfacing with the new ledger 2.1.0 app using the js SDK
- **Linked resource(s)**: `` 

### ✅ Checklist

- [ ] **Test coverage** -- Happy to add a test, but I'm not seeing any coverage for the new psbtv2 class in newops 
- ✅ **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- ✅ **No breaking changes** 

### 📸 Demo
N/A


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
