### PR TITLE
Bugfix: ignore HwTransportError for Sentry

### DIFF
--- a/.changeset/nice-books-mate.md
+++ b/.changeset/nice-books-mate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+chore: ignore HwTransportError for Sentry on LLD

--- a/.changeset/tender-bats-join.md
+++ b/.changeset/tender-bats-join.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+ignore HwTransportError for Sentry on LLM

--- a/apps/ledger-live-desktop/src/sentry/install.js
+++ b/apps/ledger-live-desktop/src/sentry/install.js
@@ -84,6 +84,8 @@ const ignoreErrors = [
   "ManagerDeviceLocked",
   "PairingFailed",
   "Ledger device: UNKNOWN_ERROR",
+  // errors coming from the usage of a Transport implementation
+  "HwTransportError",
   // other
   "AccountAwaitingSendPendingOperations",
   "AccountNeedResync",

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -59,6 +59,8 @@ const excludedErrorName = [
   "GetAppAndVersionUnsupportedFormat",
   "BluetoothRequired",
   "ManagerDeviceLocked",
+  // errors coming from the usage of a Transport implementation
+  "HwTransportError",
   // other
   "InvalidAddressError",
   "SwapNoAvailableProviders",

--- a/libs/ledgerjs/packages/errors/README.md
+++ b/libs/ledgerjs/packages/errors/README.md
@@ -26,7 +26,7 @@ Type of a Transport error used to represent all equivalent errors coming from al
 
 **Extends Error**
 
-Represents an error coming from any Transport implementation.
+Represents an error coming from the usage of any Transport implementation.
 
 Needed to map a specific implementation error into an error that
 can be managed by any code unaware of the specific Transport implementation

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -252,7 +252,7 @@ export enum HwTransportErrorType {
 }
 
 /**
- * Represents an error coming from any Transport implementation.
+ * Represents an error coming from the usage of any Transport implementation.
  *
  * Needed to map a specific implementation error into an error that
  * can be managed by any code unaware of the specific Transport implementation


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

`HwTransportError` represents errors coming from the usage of a Transport implementation, and should not be sent to Sentry.

Fixed this for LLD and LLM

### ❓ Context

- **Impacted projects**: `LLM`, `LLD`
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
