### PR TITLE
bugfix/LIVE-5293 Dependency resolution for newly standalone currency apps

### DIFF
--- a/.changeset/hot-ants-explode.md
+++ b/.changeset/hot-ants-explode.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Base the dependency resolution on the minimum version and not the presence of Bitcoin Legacy

--- a/libs/ledger-live-common/src/apps/hw.ts
+++ b/libs/ledger-live-common/src/apps/hw.ts
@@ -294,11 +294,7 @@ export const listApps = (
         sortedCryptoCurrencies,
       ] = await Promise.all([
         installedP,
-        ManagerAPI.listApps().then((apps) =>
-          apps.map((app) => {
-            return polyfillApplication(app, provider);
-          })
-        ),
+        ManagerAPI.listApps().then((apps) => apps.map(polyfillApplication)),
         applicationsByDeviceP,
         firmwareP,
         currenciesByMarketcap(

--- a/libs/ledger-live-common/src/apps/polyfill.test.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.test.ts
@@ -74,3 +74,17 @@ describe("Dependency resolution for standalone currency apps", () => {
     expect(getDependencies(app.name, app.version)).toEqual([]);
   });
 });
+
+describe("Backwards compatibility, when not providing an app version", () => {
+  test("Dogecoin should have Bitcoin as dependency", () => {
+    const app: App = { ...baseSampleApp };
+    expect(getDependencies(app.name, undefined)).toEqual(["Bitcoin"]);
+  });
+  test("Polygon should have Ethereum as dependency, even when providing a version", () => {
+    // If this one is failing it means we've implemented a standalone polygon or a
+    // version exemption like for Bitcoin, in that case we can drop this test.
+    const app: App = { ...baseSampleApp, name: "Polygon" };
+    expect(getDependencies(app.name, undefined)).toEqual(["Ethereum"]);
+    expect(getDependencies(app.name, "4.3.2")).toEqual(["Ethereum"]);
+  });
+});

--- a/libs/ledger-live-common/src/apps/polyfill.test.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.test.ts
@@ -1,5 +1,8 @@
-import { Application } from "@ledgerhq/types-live";
-import { polyfillApplication } from "./polyfill";
+import { App, AppType, Application } from "@ledgerhq/types-live";
+import { getDependencies, polyfillApplication } from "./polyfill";
+import { calculateDependencies } from "./polyfill";
+
+calculateDependencies();
 
 test("polyfillApplication set ethereum currency for ethereum app", () => {
   const app: Application = {
@@ -19,6 +22,55 @@ test("polyfillApplication set ethereum currency for ethereum app", () => {
     sourceURL: undefined,
     compatibleWalletsJSON: undefined,
   };
-  const polyfilled = polyfillApplication(app, 1);
-  expect(polyfilled.currencyId).toEqual("ethereum");
+  const polyfilledApp = polyfillApplication(app);
+  expect(polyfilledApp.currencyId).toEqual("ethereum");
+});
+
+const baseSampleApp: App = {
+  id: 1,
+  name: "Dogecoin",
+  displayName: "Dogecoin",
+  version: "2.0.6",
+  currencyId: "",
+  description: "",
+  type: AppType.app,
+  dateModified: "2022-06-07T08:57:34.783551Z",
+  icon: "dogecoin",
+  authorName: "",
+  supportURL: "",
+  contactURL: "",
+  sourceURL: "",
+  compatibleWallets: [],
+  perso: "perso_11",
+  hash: "6298b2dc4b04d7aa4ddfeec2d98502c871f243af273463c5489ca89d4f2cf0ef",
+  firmware: "nanos+/1.0.3-rc1/dogecoin/app_2.0.6",
+  firmware_key: "nanos+/1.0.3-rc1/dogecoin/app_2.0.6_key",
+  delete: "nanos+/1.0.3-rc1/dogecoin/app_2.0.6_del",
+  delete_key: "nanos+/1.0.3-rc1/dogecoin/app_2.0.6_del_key",
+  dependencies: [],
+  bytes: 528,
+  warning: "",
+  indexOfMarketCap: 0,
+  isDevTools: false,
+};
+describe("Dependency resolution for standalone currency apps", () => {
+  test("Dogecoin 2.0.6 should have Bitcoin as dependency", () => {
+    const app: App = { ...baseSampleApp };
+    expect(getDependencies(app.name, app.version)).toEqual(["Bitcoin"]);
+  });
+
+  test("Dogecoin 2.0.6-rc1 should have Bitcoin as dependency", () => {
+    const app: App = { ...baseSampleApp, version: "2.0.6-rc1" };
+    expect(getDependencies(app.name, app.version)).toEqual(["Bitcoin"]);
+  });
+
+  test("Dogecoin 2.1.0 or greater should have no dependency", () => {
+    const app: App = { ...baseSampleApp, version: "2.1.0" };
+    expect(getDependencies(app.name, app.version)).toEqual([]);
+  });
+
+  test("Dogecoin 2.1.0-rc1 or greater should have no dependency", () => {
+    const app: App = { ...baseSampleApp, version: "2.1.0-rc1" };
+    expect(getDependencies(app.name, app.version)).toEqual([]);
+  });
 });

--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -68,6 +68,9 @@ export function declareDep(name: string, dep: string): void {
   ["Yearn", "Ethereum"],
 ].forEach(([name, dep]) => declareDep(name, dep));
 
+// Nb Starting on version 2.1.0 Bitcoin family apps no longer depend on
+// Bitcoin as a library. We will soon have the dependencies resolved from
+// back-end but until then we need to manually remove them.
 const versionBasedWhitelistDependencies = {
   Bitcoin: "2.1.0",
 };
@@ -76,18 +79,18 @@ export const getDependencies = (
   appName: string,
   appVersion?: string
 ): string[] => {
-  const maybeDirectDep = directDep[appName];
-  if (!maybeDirectDep) return [];
+  const maybeDirectDep = directDep[appName] || [];
 
-  // Nb Starting on version 2.1.0 Bitcoin family apps no longer depend on
-  // Bitcoin as a library. We will soon have the dependencies resolved from
-  // back-end but until then we need to manually remove them.
-  return (
-    maybeDirectDep.filter((dep) => {
-      const maybeDep = versionBasedWhitelistDependencies[dep];
-      return !maybeDep || semver.lt(semver.coerce(appVersion) || "", maybeDep);
-    }) || []
-  );
+  if (!appVersion || !maybeDirectDep.length) {
+    return maybeDirectDep;
+  }
+
+  // If we don't have any direct dependencies, or the caller didn't
+  // provide `appVersion` to compare against, we can skip the filter
+  return maybeDirectDep.filter((dep: string) => {
+    const maybeDep = versionBasedWhitelistDependencies[dep];
+    return !maybeDep || semver.lt(semver.coerce(appVersion) ?? "", maybeDep);
+  });
 };
 
 export const getDependents = (appName: string): string[] =>

--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -1,14 +1,14 @@
 // polyfill the unfinished support of apps logic
 import uniq from "lodash/uniq";
+import semver from "semver";
 import {
   listCryptoCurrencies,
   findCryptoCurrencyById,
 } from "@ledgerhq/cryptoassets";
 import { App, Application } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 const directDep = {};
 const reverseDep = {};
-// TODO remove newBitcoinApp logic after 2.1.0 bitcoin nano app
-let newBitcoinApp = false;
 
 // whitelist dependencies
 export const whitelistDependencies = [
@@ -67,14 +67,32 @@ export function declareDep(name: string, dep: string): void {
   ["Volta", "Ethereum"],
   ["Yearn", "Ethereum"],
 ].forEach(([name, dep]) => declareDep(name, dep));
-export const getDependencies = (appName: string): string[] =>
-  directDep[appName] || [];
+
+const versionBasedWhitelistDependencies = {
+  Bitcoin: "2.1.0",
+};
+
+export const getDependencies = (
+  appName: string,
+  appVersion?: string
+): string[] => {
+  const maybeDirectDep = directDep[appName];
+  if (!maybeDirectDep) return [];
+
+  // Nb Starting on version 2.1.0 Bitcoin family apps no longer depend on
+  // Bitcoin as a library. We will soon have the dependencies resolved from
+  // back-end but until then we need to manually remove them.
+  return (
+    maybeDirectDep.filter((dep) => {
+      const maybeDep = versionBasedWhitelistDependencies[dep];
+      return !maybeDep || semver.lt(semver.coerce(appVersion) || "", maybeDep);
+    }) || []
+  );
+};
+
 export const getDependents = (appName: string): string[] =>
   reverseDep[appName] || [];
-export const polyfillApplication = (
-  app: Application,
-  provider: number
-): Application => {
+export const polyfillApplication = (app: Application): Application => {
   const crypto = listCryptoCurrencies(true, true).find(
     (crypto) =>
       app.name.toLowerCase() === crypto.managerAppName.toLowerCase() &&
@@ -82,13 +100,6 @@ export const polyfillApplication = (
         // if it's ethereum, we have a specific case that we must only allow the Ethereum app
         app.name === "Ethereum")
   );
-  if (app.name === "Bitcoin Legacy") {
-    app.application_versions.forEach((version) => {
-      if (version.providers.includes(provider)) {
-        newBitcoinApp = true;
-      }
-    });
-  }
   let o = app;
 
   if (crypto && !app.currencyId) {
@@ -99,20 +110,17 @@ export const polyfillApplication = (
 };
 
 export const calculateDependencies = (): void => {
-  listCryptoCurrencies(true, true).forEach((a) => {
-    if (!a.managerAppName) return; // no app for this currency
+  listCryptoCurrencies(true, true).forEach((currency: CryptoCurrency) => {
+    if (!currency.managerAppName) return; // no app for this currency
 
-    const dep = findCryptoCurrencyById(a.family);
-    if (!dep || !dep.managerAppName) return; // no dep
+    const family = findCryptoCurrencyById(currency.family);
 
-    if (dep.managerAppName === a.managerAppName) return; // same app
-    if (a.family === "bitcoin" && newBitcoinApp) {
-      // all currencies in bitcoin family are standalone since 2.1.0
-      return;
-    }
-    declareDep(a.managerAppName, dep.managerAppName);
-    if (!a.isTestnetFor) {
-      declareDep(a.managerAppName + " Test", dep.managerAppName);
+    if (!family || !family.managerAppName) return; // no dep
+    if (family.managerAppName === currency.managerAppName) return; // same app
+
+    declareDep(currency.managerAppName, family.managerAppName);
+    if (!currency.isTestnetFor) {
+      declareDep(currency.managerAppName + " Test", family.managerAppName);
     }
   });
 };
@@ -124,6 +132,8 @@ export const polyfillApp = (app: App): App => {
 
   return {
     ...app,
-    dependencies: uniq(dependencies.concat(getDependencies(app.name))),
+    dependencies: uniq(
+      dependencies.concat(getDependencies(app.name, app.version))
+    ),
   };
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Starting on version `2.1.0` some of our apps that used to depend on Bitcoin have become independent. However, the current way of resolving dependencies is based on the currency family and does not support this. A first approach was introduced on [feat/LIVE-4625](https://github.com/LedgerHQ/ledger-live/pull/1959) but it was flawed in the sense that the presence of the Bitcoin Legacy app does not necessarily mean that the clone app is independent.

This PR introduces a check based on the version and drops the presence check, as well as adding some tests to cover that functionality.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-5293` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo, only logic.
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- We should be able to install and run apps that are Bitcoin clones on versions equal or higher than 2.1.0 without having Bitcoin installed. Uninstalling Bitcoin shouldn't impact these apps if installed. 
- Bitcoin clones on versions lower than 2.1.0 should still require Bitcoin app being installed as they've always done.