### PR TITLE
Make the Bot freeze objects to detect possible mistakes

### DIFF
--- a/libs/ledger-live-common/src/bot/cli.ts
+++ b/libs/ledger-live-common/src/bot/cli.ts
@@ -1,3 +1,5 @@
+"use strict";
+
 import "../__tests__/test-helpers/environment";
 import { bot } from ".";
 


### PR DESCRIPTION

### 📝 Description

from Slack discussion, we suspect some coins have bug where they modify the original `Account` object, that is supposed to be preserved as immutable.
To detect such issue, we introduce in the bot an usage of `Object.freeze` which in combination with `"use strict"` would make the bot crash on case of mutating the existing account fields in case they get written (it makes field "read-only")

### ❓ Context

- **Impacted projects**: `bot` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
