### PR TITLE
LIVE-5316 Target Trongrid API directly without using Ledger's reverse proxy

### DIFF
--- a/.changeset/famous-ligers-admire.md
+++ b/.changeset/famous-ligers-admire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Target Trongrid API directly without using Ledger's proxy (workaround)

--- a/libs/ledger-live-common/src/env.ts
+++ b/libs/ledger-live-common/src/env.ts
@@ -189,7 +189,10 @@ const envDefinitions = {
   },
   API_TRONGRID_PROXY: {
     parser: stringParser,
-    def: "https://tron.coin.ledger.com",
+    //def: "https://tron.coin.ledger.com",
+    // FIXME Temporary workaround for https://ledgerhq.atlassian.net/browse/LIVE-5316
+    // Some rate limiting is triggered when targeting Trongrid through Ledger's RP
+    def: "https://api.trongrid.io",
     desc: "proxy url for trongrid API",
   },
   API_SOLANA_PROXY: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This is a workaround for https://ledgerhq.atlassian.net/browse/LIVE-5316.
Identified root cause is that the overall network traffic for our Tron integration is too massive, when used through our reverse proxy it triggers Trongrid's rate limiting, which impacts most users.

A quick analysis of our implementation for Tron sync shows there's a good chance it can be optimized to reduce the number of network calls, but before this can be done this PR provides a quick workaround by bypassing the reverse proxy, therefore not triggering Trongrid's rate limiting.

### ❓ Context

- **Impacted projects**: LLC
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5316

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

<!-- If any of the expectations are not met please explain the reason in detail. -->
