### PR TITLE
Elrond: fixes immutability of syncESDTTokenAccountOperations

### DIFF
--- a/.changeset/slimy-foxes-brush.md
+++ b/.changeset/slimy-foxes-brush.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fixes ESDT Token Account sync immutability

--- a/libs/ledger-live-common/src/families/elrond/specs.ts
+++ b/libs/ledger-live-common/src/families/elrond/specs.ts
@@ -71,7 +71,6 @@ function expectCorrectOptimisticOperation(
   const opExpected: Record<string, any> = toOperationRaw({
     ...optimisticOperation,
   });
-  operation.extra = opExpected.extra;
   delete opExpected.value;
   delete opExpected.fee;
   delete opExpected.date;


### PR DESCRIPTION
### 📝 Description

https://github.com/LedgerHQ/ledger-live/pull/2473 have revealed problem in Elrond implementation that alters the original object (input of the sync) which can cause subtle bugs all over our stack.

sync must embrace the immutability paradigm and not alter the incoming objects / create copy of objects when necessary.

There were a few mutating issue:
- `tokenAccounts.operations` getting mutated if the token account already exists and it doesn't recreate a ref for that token account. (possible consequence: UI may not always refresh to show the latest state of the account if user stay on the token account, notably on LLM)
- same for `tokenAccounts.balance`
- `operation.extra` mutated in the spec for the bot. this may hide real bug on that test

### ❓ Context

- **Impacted projects**: `*` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** running the bot on this PR <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
