### PR TITLE
Fixes immutability of Tron in signOperation

### DIFF
--- a/.changeset/curly-papayas-itch.md
+++ b/.changeset/curly-papayas-itch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fixes Tron signOperation immutability

--- a/libs/ledger-live-common/src/families/tron/bridge/js.ts
+++ b/libs/ledger-live-common/src/families/tron/bridge/js.ts
@@ -117,9 +117,11 @@ const signOperation = ({
         const balance = subAccount
           ? subAccount.balance
           : BigNumber.max(0, account.spendableBalance.minus(fee));
-        transaction.amount = transaction.useAllAmount
-          ? balance
-          : transaction.amount;
+
+        if (transaction.useAllAmount) {
+          transaction = { ...transaction }; // transaction object must not be mutated
+          transaction.amount = balance; // force the amount to be the max
+        }
 
         // send trc20 to a new account is forbidden by us (because it will not activate the account)
         if (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes Tron signOperation to alter the input 'transaction' object during signOperation in order to make the bot pass with the extra restriction of a strict check on immutability ( https://github.com/LedgerHQ/ledger-live/pull/2473 )

```
necessary accounts resynced in 0.19ms
▬ Tron 0.3.8 on nanoS 2.1.0
→ FROM Tron 4: 2 TRX (499ops) (TBtPherJfuSMaJnWVtuuo2AvjgdfxzUhAb on 44'/195'/3'/0/0) #3 js:2:tron:TBtPherJfuSMaJnWVtuuo2AvjgdfxzUhAb:
max spendable ~0
★ using mutation 'unfreeze bandwith / energy'
✔️ transaction 
UNFREEZE BANDWIDTH  
TO 
STATUS (133ms)
  amount: 0 TRX
  estimated fees: 0 TRX
  total spent: 0 TRX
errors: 
errors: 
⚠️ TypeError: Cannot assign to read only property 'amount' of object '#<Object>'
(totally spent 136ms – ends at 2023-01-31T11:44:09.151Z) 
```

### ❓ Context

- **Impacted projects**: `*` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** via bot <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
