### PR TITLE
(bugfix) bitcoin bot spec - extract recipient address from op_return tx

### DIFF
--- a/libs/ledger-live-common/src/families/bitcoin/specs.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/specs.ts
@@ -91,7 +91,7 @@ const genericTest = ({
   botTest("operation matches tx senders and recipients", () => {
     if (transaction.opReturnData) {
       // transaction.recipient has format <coinId>:<address>
-      const [, recipientAddress] = transaction.recipient.split(":")[1];
+      const [, recipientAddress] = transaction.recipient.split(":");
       expect(operation.recipients).toContain(recipientAddress);
       expect(operation.recipients.length).toBe(2);
     } else {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The error `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))` because of incorrect read transaction object in the bitcoin bot spec.
The PR fixes the issue

### ❓ Context

- **Impacted projects**: `LLC` 
- **Linked resource(s)**: `N/A`

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
