### PR TITLE
Support/live 5078 ENS hooks + jest env change

### DIFF
--- a/.changeset/rare-fans-move.md
+++ b/.changeset/rare-fans-move.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add hooks for naming service in eth

--- a/.changeset/twelve-hounds-cross.md
+++ b/.changeset/twelve-hounds-cross.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+change jest to jsdom to test react hooks

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -27,7 +27,7 @@ export default {
       isolatedModules: true,
     },
   },
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
   coverageDirectory: "./coverage/",
   coverageReporters: ["json", "lcov", "clover"],
   reporters,

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -20,14 +20,14 @@ if (process.env.CI) {
   reporters.push("github-actions");
 }
 
-export default {
+const defaultConfig = {
   preset: "ts-jest",
   globals: {
     "ts-jest": {
       isolatedModules: true,
     },
   },
-  testEnvironment: "jsdom",
+  testEnvironment: "node",
   coverageDirectory: "./coverage/",
   coverageReporters: ["json", "lcov", "clover"],
   reporters,
@@ -41,4 +41,22 @@ export default {
   testRegex,
   transformIgnorePatterns: ["/node_modules/(?!|@babel/runtime/helpers/esm/)"],
   moduleDirectories: ["node_modules", "cli/node_modules"],
+};
+
+export default {
+  projects: [
+    {
+      ...defaultConfig,
+      testPathIgnorePatterns: [
+        ...testPathIgnorePatterns,
+        "(/__tests__/.*|(\\.|/)react\\.(test|spec))\\.[jt]sx?$",
+      ],
+    },
+    {
+      ...defaultConfig,
+      displayName: "dom",
+      testEnvironment: "jsdom",
+      testRegex: "(/__tests__/.*|(\\.|/)react\\.test|spec)\\.tsx?$",
+    },
+  ],
 };

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -49,14 +49,14 @@ export default {
       ...defaultConfig,
       testPathIgnorePatterns: [
         ...testPathIgnorePatterns,
-        "(/__tests__/.*|(\\.|/)react\\.(test|spec))\\.[jt]sx?$",
+        "(/__tests__/.*|(\\.|/)react\\.test|spec)\\.tsx",
       ],
     },
     {
       ...defaultConfig,
       displayName: "dom",
       testEnvironment: "jsdom",
-      testRegex: "(/__tests__/.*|(\\.|/)react\\.test|spec)\\.tsx?$",
+      testRegex: "(/__tests__/.*|(\\.|/)react\\.test|spec)\\.tsx",
     },
   ],
 };

--- a/libs/ledger-live-common/src/naming-service/api.integration.test.ts
+++ b/libs/ledger-live-common/src/naming-service/api.integration.test.ts
@@ -1,0 +1,30 @@
+import { getAddressByName } from "./api";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
+
+describe("Naming service api", () => {
+  it("getAddressByName", async () => {
+    expect(await getAddressByName("vitalik.eth")).toEqual(
+      "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+    );
+  });
+
+  it("Error 4xx with invalid name address", async () => {
+    try {
+      await getAddressByName("notanaddress");
+    } catch (e) {
+      expect(e).toEqual(
+        new LedgerAPI4xx(
+          'Invalid value for: path parameter name (expected value to pass validation, but got: "notanaddress")'
+        )
+      );
+    }
+  });
+
+  it("Error 4xx with invalid name address", async () => {
+    try {
+      await getAddressByName("notvitalikgoodaddress.eth");
+    } catch (e) {
+      expect(e).toEqual(new LedgerAPI4xx("API HTTP 404"));
+    }
+  });
+});

--- a/libs/ledger-live-common/src/naming-service/api.integration.test.ts
+++ b/libs/ledger-live-common/src/naming-service/api.integration.test.ts
@@ -11,6 +11,7 @@ describe("Naming service api", () => {
   it("Error 4xx with invalid name address", async () => {
     try {
       await getAddressByName("notagoodname");
+      fail("Promise should have failed with an invalid name");
     } catch (e) {
       expect(e).toEqual(
         new LedgerAPI4xx(
@@ -23,6 +24,7 @@ describe("Naming service api", () => {
   it("Error 4xx with invalid name address", async () => {
     try {
       await getAddressByName("notvitalikgoodaddress.eth");
+      fail("Promise should have failed with an not found");
     } catch (e) {
       expect(e).toEqual(new LedgerAPI4xx("API HTTP 404"));
     }

--- a/libs/ledger-live-common/src/naming-service/api.integration.test.ts
+++ b/libs/ledger-live-common/src/naming-service/api.integration.test.ts
@@ -10,11 +10,11 @@ describe("Naming service api", () => {
 
   it("Error 4xx with invalid name address", async () => {
     try {
-      await getAddressByName("notanaddress");
+      await getAddressByName("notagoodname");
     } catch (e) {
       expect(e).toEqual(
         new LedgerAPI4xx(
-          'Invalid value for: path parameter name (expected value to pass validation, but got: "notanaddress")'
+          'Invalid value for: path parameter name (expected value to pass validation, but got: "notagoodname")'
         )
       );
     }

--- a/libs/ledger-live-common/src/naming-service/api.ts
+++ b/libs/ledger-live-common/src/naming-service/api.ts
@@ -1,0 +1,11 @@
+import { blockchainBaseURL } from "../api/Ledger";
+import { getCryptoCurrencyById } from "../currencies";
+import network from "../network";
+
+export const getAddressByName = async (name: string): Promise<string> => {
+  const currency = getCryptoCurrencyById("ethereum");
+  const url = `${blockchainBaseURL(currency)}/ens/resolve/${name}`;
+  const address = (await network({ method: "GET", url })).data;
+
+  return address;
+};

--- a/libs/ledger-live-common/src/naming-service/api.ts
+++ b/libs/ledger-live-common/src/naming-service/api.ts
@@ -5,7 +5,7 @@ import network from "../network";
 export const getAddressByName = async (name: string): Promise<string> => {
   const currency = getCryptoCurrencyById("ethereum");
   const url = `${blockchainBaseURL(currency)}/ens/resolve/${name}`;
-  const address = (await network({ method: "GET", url })).data;
+  const { data: address } = await network({ method: "GET", url });
 
   return address;
 };

--- a/libs/ledger-live-common/src/naming-service/index.tsx
+++ b/libs/ledger-live-common/src/naming-service/index.tsx
@@ -1,0 +1,130 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { getAddressByName } from "./api";
+import {
+  NamingServiceContextAPI,
+  NamingServiceContextState,
+  NamingServiceContextType,
+  NamingServiceStatus,
+} from "./types";
+
+const NamingServiceContext = createContext<NamingServiceContextType>({
+  cache: {},
+  loadNamingServiceAPI: () => Promise.resolve(),
+  clearCache: () => {},
+});
+
+export const useNamingServiceAPI = (
+  name: string | undefined
+): NamingServiceStatus => {
+  const { cache, loadNamingServiceAPI } = useContext(NamingServiceContext);
+  const cachedData = name && name?.match(/[.*]\w{1,}/g) !== null && cache[name];
+
+  useEffect(() => {
+    if (name && name?.match(/[.*]\w{1,}/g) !== null) {
+      loadNamingServiceAPI(name);
+    }
+  }, [loadNamingServiceAPI, name]);
+
+  if (cachedData) {
+    return cachedData;
+  } else {
+    return { status: "queued" };
+  }
+};
+
+type UseNamingServiceResponse =
+  | { status: Exclude<NamingServiceStatus["status"], "loaded"> }
+  | { status: "loaded"; address: string };
+
+export function useNamingService(name: string): UseNamingServiceResponse {
+  const data = useNamingServiceAPI(name);
+
+  const { status } = data;
+  const address = useMemo(
+    () => (status === "loaded" ? data.address : null),
+    [data, status]
+  );
+
+  return status !== "loaded"
+    ? { status }
+    : {
+        status,
+        address: address as string, // should always
+      };
+}
+
+type NamingServiceProviderProps = {
+  children: React.ReactNode;
+};
+
+export function NamingServiceProvider({
+  children,
+}: NamingServiceProviderProps): React.ReactElement {
+  const [state, setState] = useState<NamingServiceContextState>({
+    cache: {},
+  });
+
+  const api: NamingServiceContextAPI = useMemo(
+    () => ({
+      loadNamingServiceAPI: async (name: string) => {
+        setState((oldState) => ({
+          ...oldState,
+          cache: {
+            ...oldState.cache,
+            [name]: {
+              status: "loading",
+            },
+          },
+        }));
+
+        try {
+          const address = await getAddressByName(name);
+          setState((oldState) => ({
+            ...oldState,
+            cache: {
+              ...oldState.cache,
+              [name]: {
+                status: "loaded",
+                address,
+                updatedAt: Date.now(),
+              },
+            },
+          }));
+        } catch (error) {
+          setState((oldState) => ({
+            ...oldState,
+            cache: {
+              ...oldState.cache,
+              [name]: {
+                status: "error",
+                error,
+                updatedAt: Date.now(),
+              },
+            },
+          }));
+        }
+      },
+      clearCache: () => {
+        setState((oldState) => ({
+          ...oldState,
+          cache: {},
+        }));
+      },
+    }),
+    []
+  );
+
+  const value = { ...state, ...api };
+
+  return (
+    <NamingServiceContext.Provider value={value}>
+      {children}
+    </NamingServiceContext.Provider>
+  );
+}

--- a/libs/ledger-live-common/src/naming-service/index.tsx
+++ b/libs/ledger-live-common/src/naming-service/index.tsx
@@ -20,8 +20,10 @@ const NamingServiceContext = createContext<NamingServiceContextType>({
   clearCache: () => {},
 });
 
-const isNameValid = (name: string | undefined): boolean =>
-  !!(name && name?.match(/[.*]\w{1,}/g) !== null);
+const isNameValid = (name: string | undefined): boolean => {
+  const regex = /[.*]\w{1,}/g;
+  return regex.test(name);
+}
 
 export const useNamingServiceAPI = (
   name: string | undefined

--- a/libs/ledger-live-common/src/naming-service/index.tsx
+++ b/libs/ledger-live-common/src/naming-service/index.tsx
@@ -22,8 +22,8 @@ const NamingServiceContext = createContext<NamingServiceContextType>({
 
 const isNameValid = (name: string | undefined): boolean => {
   const regex = /[.*]\w{1,}/g;
-  return regex.test(name);
-}
+  return !!(name && regex.test(name));
+};
 
 export const useNamingServiceAPI = (
   name: string | undefined

--- a/libs/ledger-live-common/src/naming-service/index.tsx
+++ b/libs/ledger-live-common/src/naming-service/index.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { isOutdated } from "./logic";
+import { isNameValid, isOutdated } from "./logic";
 import { getAddressByName } from "./api";
 import {
   NamingServiceContextAPI,
@@ -19,11 +19,6 @@ const NamingServiceContext = createContext<NamingServiceContextType>({
   loadNamingServiceAPI: () => Promise.resolve(),
   clearCache: () => {},
 });
-
-const isNameValid = (name: string | undefined): boolean => {
-  const regex = /[.*]\w{1,}/g;
-  return !!(name && regex.test(name));
-};
 
 export const useNamingServiceAPI = (
   name: string | undefined

--- a/libs/ledger-live-common/src/naming-service/logic.ts
+++ b/libs/ledger-live-common/src/naming-service/logic.ts
@@ -8,7 +8,7 @@ export function isOutdated(resource: NamingServiceStatus): boolean {
 
   switch (resource.status) {
     case "loaded": {
-      return now - resource.updatedAt >  60 * 1000; // 1 minute
+      return now - resource.updatedAt > 60 * 1000; // 1 minute
     }
     case "error": {
       return now - resource.updatedAt > 1 * 1000; // 1 second

--- a/libs/ledger-live-common/src/naming-service/logic.ts
+++ b/libs/ledger-live-common/src/naming-service/logic.ts
@@ -1,0 +1,18 @@
+// Handle lifecycle of cached data.
+
+import { NamingServiceStatus } from "./types";
+
+// Expiration date depend on the resource's status.
+export function isOutdated(resource: NamingServiceStatus): boolean {
+  const now = Date.now();
+
+  switch (resource.status) {
+    case "loaded": {
+      return now - resource.updatedAt >  60 * 1000; // 1 minute
+    }
+    case "error": {
+      return now - resource.updatedAt > 1 * 1000; // 1 second
+    }
+  }
+  return false;
+}

--- a/libs/ledger-live-common/src/naming-service/logic.ts
+++ b/libs/ledger-live-common/src/naming-service/logic.ts
@@ -16,3 +16,8 @@ export function isOutdated(resource: NamingServiceStatus): boolean {
   }
   return false;
 }
+
+export const isNameValid = (name: string | undefined): boolean => {
+  const regex = /[.*]\w{1,}/g;
+  return !!(name && regex.test(name));
+};

--- a/libs/ledger-live-common/src/naming-service/naming-service.react.test.tsx
+++ b/libs/ledger-live-common/src/naming-service/naming-service.react.test.tsx
@@ -58,7 +58,7 @@ describe("useNamingService", () => {
     expect(result.current.status).toBe("queued");
   });
 
-  test("should be loading", async () => {
+  test("success", async () => {
     mockedGetAddressByName.mockImplementation(async () => {
       return "forced mocked address";
     });
@@ -77,23 +77,5 @@ describe("useNamingService", () => {
     expect(screen.getByTestId("result").textContent).toBe(
       "forced mocked address"
     );
-  });
-
-  test("should be an error", async () => {
-    mockedGetAddressByName.mockImplementation(async () => {
-      throw new LedgerAPI4xx();
-    });
-
-    render(
-      <NamingServiceProvider>
-        <CustomTest name="vitalik.eth" />
-      </NamingServiceProvider>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).not.toBe("loading");
-    });
-
-    expect(screen.getByTestId("status").textContent).toBe("error");
   });
 });

--- a/libs/ledger-live-common/src/naming-service/naming-service.unit.test.tsx
+++ b/libs/ledger-live-common/src/naming-service/naming-service.unit.test.tsx
@@ -1,0 +1,79 @@
+import { NamingServiceProvider, useNamingService } from ".";
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { render, screen, waitFor } from "@testing-library/react";
+import { getAddressByName } from "./api";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
+
+jest.mock("./api");
+
+const mockedGetAddressByName = jest.mocked(getAddressByName, true);
+
+const CustomTest = ({ name }: { name: string }) => {
+  const data = useNamingService(name);
+
+  let result: string | undefined;
+
+  const status = data.status;
+  if (data.status === "loaded") {
+    result = data.address;
+  } else {
+    result = undefined;
+  }
+
+  return (
+    <div>
+      <div data-testid="status">{status}</div>
+      <div data-testid="result">{result}</div>
+    </div>
+  );
+};
+
+describe("useNamingService", () => {
+  test("should be queue", () => {
+    const { result } = renderHook(useNamingService, {
+      initialProps: "vitalik.eth",
+    });
+
+    expect(result.current.status).toBe("queued");
+  });
+
+  test("should be loading", async () => {
+    mockedGetAddressByName.mockImplementation(async () => {
+      return "forced mocked address";
+    });
+
+    render(
+      <NamingServiceProvider>
+        <CustomTest name="vitalik.eth" />
+      </NamingServiceProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).not.toBe("loading");
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("loaded");
+    expect(screen.getByTestId("result").textContent).toBe(
+      "forced mocked address"
+    );
+  });
+
+  test("should be an error", async () => {
+    mockedGetAddressByName.mockImplementation(async () => {
+      throw new LedgerAPI4xx();
+    });
+
+    render(
+      <NamingServiceProvider>
+        <CustomTest name="vitalik.eth" />
+      </NamingServiceProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).not.toBe("loading");
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("error");
+  });
+});

--- a/libs/ledger-live-common/src/naming-service/naming-service.unit.test.tsx
+++ b/libs/ledger-live-common/src/naming-service/naming-service.unit.test.tsx
@@ -76,4 +76,22 @@ describe("useNamingService", () => {
 
     expect(screen.getByTestId("status").textContent).toBe("error");
   });
+
+  test("should be an error", async () => {
+    mockedGetAddressByName.mockImplementation(async () => {
+      throw new LedgerAPI4xx();
+    });
+
+    render(
+      <NamingServiceProvider>
+        <CustomTest name="notavalideth" />
+      </NamingServiceProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).not.toBe("loading");
+    });
+
+    expect(screen.getByTestId("status").textContent).toBe("error");
+  });
 });

--- a/libs/ledger-live-common/src/naming-service/naming-service.unit.test.tsx
+++ b/libs/ledger-live-common/src/naming-service/naming-service.unit.test.tsx
@@ -30,6 +30,26 @@ const CustomTest = ({ name }: { name: string }) => {
 };
 
 describe("useNamingService", () => {
+  test("should be an error", async () => {
+    mockedGetAddressByName.mockImplementation(async () => {
+      throw new LedgerAPI4xx();
+    });
+
+    render(
+      <NamingServiceProvider>
+        <CustomTest name="notavalideth" />
+      </NamingServiceProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).not.toBe("loading");
+    });
+
+    // this test should be first otherwise mock call will be more than 0
+    expect(mockedGetAddressByName).toBeCalledTimes(0);
+    expect(screen.getByTestId("status").textContent).toBe("error");
+  });
+
   test("should be queue", () => {
     const { result } = renderHook(useNamingService, {
       initialProps: "vitalik.eth",
@@ -67,24 +87,6 @@ describe("useNamingService", () => {
     render(
       <NamingServiceProvider>
         <CustomTest name="vitalik.eth" />
-      </NamingServiceProvider>
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId("status").textContent).not.toBe("loading");
-    });
-
-    expect(screen.getByTestId("status").textContent).toBe("error");
-  });
-
-  test("should be an error", async () => {
-    mockedGetAddressByName.mockImplementation(async () => {
-      throw new LedgerAPI4xx();
-    });
-
-    render(
-      <NamingServiceProvider>
-        <CustomTest name="notavalideth" />
       </NamingServiceProvider>
     );
 

--- a/libs/ledger-live-common/src/naming-service/types.ts
+++ b/libs/ledger-live-common/src/naming-service/types.ts
@@ -1,0 +1,17 @@
+export type NamingServiceStatus =
+  | { status: "queued" }
+  | { status: "loading" }
+  | { status: "loaded"; address: string; updatedAt: number }
+  | { status: "error"; error: any; updatedAt: number };
+
+export type NamingServiceContextState = {
+  cache: Record<string, NamingServiceStatus>;
+};
+
+export type NamingServiceContextAPI = {
+  loadNamingServiceAPI: (name: string) => Promise<void>;
+  clearCache: () => void;
+};
+
+export type NamingServiceContextType = NamingServiceContextState &
+  NamingServiceContextAPI;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Able to use our explorer to get ENS for a specific `*.*` name

We first create some hooks to be use in LLM and LLD.
But for testing we needed to have a change jsdom in jest live-common env to test React hook we have in live-common.

### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
