### PR TITLE
fix: LIVE-5352 remove balance info redundant button in portafolio page

### DIFF
--- a/.changeset/bright-roses-own.md
+++ b/.changeset/bright-roses-own.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove "SWAP" and "BUY" redundant buttons when portafolio exchange banner is available

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.jsx
@@ -117,6 +117,8 @@ export default function BalanceInfos({ totalBalance, valueChange, isAvailable, u
 
   // PTX smart routing feature flag - buy sell live app flag
   const ptxSmartRouting = useFeature("ptxSmartRouting");
+  // Remove "SWAP" and "BUY" redundant buttons when portafolio exchange banner is available
+  const portfolioExchangeBanner = useFeature("portfolioExchangeBanner");
 
   const onBuy = useCallback(() => {
     setTrackingSource("Page Portfolio");
@@ -150,23 +152,26 @@ export default function BalanceInfos({ totalBalance, valueChange, isAvailable, u
         >
           <Sub>{t("dashboard.totalBalance")}</Sub>
         </BalanceTotal>
-        <Button data-test-id="portfolio-buy-button" variant="color" mr={1} onClick={onBuy}>
-          {t("accounts.contextMenu.buy")}
-        </Button>
-
-        <Button
-          data-test-id="portfolio-swap-button"
-          variant="color"
-          event="button_clicked"
-          eventProperties={{
-            button: "swap",
-            page: "Page Portfolio",
-            ...swapDefaultTrack,
-          }}
-          onClick={onSwap}
-        >
-          {t("accounts.contextMenu.swap")}
-        </Button>
+        {!portfolioExchangeBanner?.enabled && (
+          <>
+            <Button data-test-id="portfolio-buy-button" variant="color" mr={1} onClick={onBuy}>
+              {t("accounts.contextMenu.buy")}
+            </Button>
+            <Button
+              data-test-id="portfolio-swap-button"
+              variant="color"
+              event="button_clicked"
+              eventProperties={{
+                button: "swap",
+                page: "Page Portfolio",
+                ...swapDefaultTrack,
+              }}
+              onClick={onSwap}
+            >
+              {t("accounts.contextMenu.swap")}
+            </Button>
+          </>
+        )}
       </Box>
       <Box horizontal alignItems="center" justifyContent="space-between">
         <BalanceDiff


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

If feature_portfolio_exchange_banner is enabled, we shouldn’t see the ‘Buy’ and the 'Swap` buttons on the portfolio screen

### ❓ Context

- **Impacted projects**: LLD
  - https://ledgerhq.atlassian.net/browse/LIVE-5352
### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
