### PR TITLE
fix: lld - fixes learn more link in cosmos staking flow

### DIFF
--- a/.changeset/six-teachers-listen.md
+++ b/.changeset/six-teachers-listen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fixes cosmos staking modal to only open url when link is clicked

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Info/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Info/index.jsx
@@ -53,7 +53,7 @@ export default function CosmosEarnRewardsInfoModal({ name, account, parentAccoun
       footerLeft={
         <LinkWithExternalIcon
           label={t("delegation.howItWorks")}
-          onClick={onLearnMore(account.currency.id)}
+          onClick={() => onLearnMore(account.currency.id)}
         />
       }
     />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR fixes an issue when opening the cosmos stake modal. Currently it opens a URL in a browser multiple times without clicking on the link. This PR changes this behaviour to only open the link when it is clicked.

### ❓ Context

- **Impacted projects**:  LLD
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-5358

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/119950081/216098829-cbccdb72-1ea4-43bd-a2a1-2852d81cf5f0.mov



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
