### PR TITLE
Support: FAT-815 handle successive drawers

### DIFF
--- a/.changeset/eleven-cycles-crash.md
+++ b/.changeset/eleven-cycles-crash.md
@@ -1,0 +1,11 @@
+---
+"live-mobile": patch
+---
+
+feat: QueueDrawer to queue drawers that should be displayed
+
+`QueuedDrawer` replacing existing `BottomModal`. `QueuedDrawer` is a drawer taking into account the currently displayed drawer and other drawers waiting to be displayed.
+
+This is made possible thanks to a queue of drawers waiting to be displayed. Once the currently displayed drawer is not displayed anymore (hidden), the next drawer in the queue is notified, and it updates its state to be make itself visible.
+
+Also updated all the components consuming `BottomModal` and `BottomDrawer`

--- a/.changeset/strange-phones-study.md
+++ b/.changeset/strange-phones-study.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+fix: onModalHide passed down to ReactNativeModal
+
+`BaseModal` was not passing down `onModalHide` to `ReactNativeModal`. Until this, `onModalHide={onClose}`, making `onClose` being called twice (once when the user closes the modal, once when the modal is hidden) and `onModalHide` being never called.
+
+The fix is a workaround so we don't break legacy components that use `BaseModal`. The long-term fix would be to have `onModalHide={onModalHide}` and make sure every usage on `onClose` in the consumers of this component expect the correct behavior.

--- a/apps/ledger-live-mobile/docs/llm_e2e_testing.md
+++ b/apps/ledger-live-mobile/docs/llm_e2e_testing.md
@@ -163,7 +163,7 @@ Ideally these are placed at development time so tests are easier to write in fut
 For example:
 
 ```js
-<BottomDrawer
+<QueuedDrawer
   testId="AddAccountsModal"
   isOpen={isOpened}
   onClose={onClose}

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -72,6 +72,7 @@ import {
   SettingsSetOverriddenFeatureFlagPlayload,
   SettingsSetOverriddenFeatureFlagsPlayload,
   SettingsSetFeatureFlagsBannerVisiblePayload,
+  SettingsSetDebugAppLevelDrawerOpenedPayload,
 } from "./types";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";
 
@@ -530,6 +531,14 @@ const setFeatureFlagsBannerVisibleAction =
 export const setFeatureFlagsBannerVisible = (
   featureFlagsBannerVisible: boolean,
 ) => setFeatureFlagsBannerVisibleAction({ featureFlagsBannerVisible });
+
+const setDebugAppLevelDrawerOpenedAction =
+  createAction<SettingsSetDebugAppLevelDrawerOpenedPayload>(
+    SettingsActionTypes.SET_DEBUG_APP_LEVEL_DRAWER_OPENED,
+  );
+export const setDebugAppLelevelDrawerOpened = (
+  debugAppLevelDrawerOpened: boolean,
+) => setDebugAppLevelDrawerOpenedAction({ debugAppLevelDrawerOpened });
 
 const dangerouslyOverrideStateAction =
   createAction<DangerouslyOverrideStatePayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -307,6 +307,7 @@ export enum SettingsActionTypes {
   SET_OVERRIDDEN_FEATURE_FLAG = "SET_OVERRIDDEN_FEATURE_FLAG",
   SET_OVERRIDDEN_FEATURE_FLAGS = "SET_OVERRIDDEN_FEATURE_FLAGS",
   SET_FEATURE_FLAGS_BANNER_VISIBLE = "SET_FEATURE_FLAGS_BANNER_VISIBLE",
+  SET_DEBUG_APP_LEVEL_DRAWER_OPENED = "SET_DEBUG_APP_LEVEL_DRAWER_OPENED",
 }
 
 export type SettingsImportPayload = Partial<SettingsState>;
@@ -471,6 +472,11 @@ export type SettingsSetFeatureFlagsBannerVisiblePayload = Pick<
   SettingsState,
   "featureFlagsBannerVisible"
 >;
+export type SettingsSetDebugAppLevelDrawerOpenedPayload = Pick<
+  SettingsState,
+  "debugAppLevelDrawerOpened"
+>;
+
 export type SettingsPayload =
   | SettingsImportPayload
   | SettingsImportDesktopPayload
@@ -519,7 +525,8 @@ export type SettingsPayload =
   | DangerouslyOverrideStatePayload
   | SettingsSetOverriddenFeatureFlagPlayload
   | SettingsSetOverriddenFeatureFlagsPlayload
-  | SettingsSetFeatureFlagsBannerVisiblePayload;
+  | SettingsSetFeatureFlagsBannerVisiblePayload
+  | SettingsSetDebugAppLevelDrawerOpenedPayload;
 
 // === WALLET CONNECT ACTIONS ===
 

--- a/apps/ledger-live-mobile/src/components/AccountSubHeader/AccountSubHeaderDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/AccountSubHeader/AccountSubHeaderDrawer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Box, Text } from "@ledgerhq/native-ui";
+import { Box, Text } from "@ledgerhq/native-ui";
+import QueuedDrawer from "../QueuedDrawer";
 
 type Props = {
   isOpen: boolean;
@@ -17,8 +18,8 @@ export default function AccountSubHeaderDrawer({
 }: Props) {
   const { t } = useTranslation();
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       onClose={onClose}
       title={t("account.subHeader.drawer.title", { family })}
       description={t("account.subHeader.drawer.subTitle", { family, team })}
@@ -34,6 +35,6 @@ export default function AccountSubHeaderDrawer({
           {t("account.subHeader.drawer.description3", { team })}
         </Text>
       </Box>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/components/BottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/BottomModal.tsx
@@ -122,7 +122,7 @@ const BottomModal = ({
       modalStyle={style}
       containerStyle={containerStyle}
       isOpen={isDisplayed}
-      // {...rest}
+      {...rest}
     >
       {children}
     </BottomDrawer>

--- a/apps/ledger-live-mobile/src/components/BottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/BottomModal.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { StyleProp, ViewStyle } from "react-native";
 import { BottomDrawer } from "@ledgerhq/native-ui";
+import { useFocusEffect } from "@react-navigation/native";
 import type { BaseModalProps } from "@ledgerhq/native-ui/components/Layout/Modals/BaseModal";
 import { useSelector } from "react-redux";
 import { isModalLockedSelector } from "../reducers/appstate";
 import { Merge } from "../types/helpers";
-
-let isModalOpenedref: boolean | undefined = false;
 
 export type Props = Merge<
   BaseModalProps,
@@ -14,57 +13,116 @@ export type Props = Merge<
     isOpened?: boolean;
     style?: StyleProp<ViewStyle>;
     containerStyle?: StyleProp<ViewStyle>;
+    debugName?: string;
   }
 >;
 
+/**
+ * A drawer taking into account the currently displayed drawer and other drawers waiting to be displayed.
+ *
+ * This is made possible thanks to a queue of drawers waiting to be displayed. Once the currently displayed drawer
+ * is not displayed anymore (hidden), the next drawer in the queue is notified, and it updates its state
+ * to be make itself visible.
+ *
+ * Setting to true the isOpened prop will add the drawer to the queue. Setting to false will remove it from the queue.
+ *
+ * The queue is cleaned when its associated screen loses its navigation focus.
+ *
+ * Note: never conditionally render this component. Always render it and use isOpened to control its visibility.
+ * Note: to avoid a UI glitch on Android, do not put this drawer inside NavigationScrollView (and probably any other ScrollView)
+ *
+ * @param isOpened: to use in place of isOpen. The wording isOpened is misleading.
+ *   In the future, to rename to isRequestingToBeOpened
+ * @returns
+ */
 const BottomModal = ({
   isOpened,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onClose = () => {},
+  onClose,
   children,
   style,
   preventBackdropClick,
   onModalHide,
   containerStyle,
   noCloseButton,
+  isOpen,
+  debugName,
   ...rest
 }: Props) => {
-  const [open, setIsOpen] = useState(false);
   const modalLock = useSelector(isModalLockedSelector);
+  // Actual state that choses if the drawer is displayed or not
+  const [isDisplayed, setIsDisplayed] = useState(false);
+  const [onCloseAlreadyCalled, setOnCloseAlreadyCalled] = useState(false);
 
-  // workaround to make sure no double modal can be opened at same time
-  useEffect(
-    () => () => {
-      isModalOpenedref = false;
-    },
-    [],
+  // Makes sure that the drawer system is cleaned when navigating to a new (or back to a) screen
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        console.log(
+          `🦕 BottomModal ${debugName}: cleaning onBottomDrawerFocus 🧹`,
+        );
+        setIsDisplayed(false);
+        cleanWaitingDrawers();
+      };
+    }, [debugName]),
   );
 
-  useEffect(() => {
-    if (!!isModalOpenedref && isOpened) {
-      onClose();
-    } else {
-      setIsOpen(isOpened ?? false);
-    }
-    isModalOpenedref = isOpened;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpened]); // do not add onClose it might cause some issues on modals ie: filter manager modal
-
   const handleClose = useCallback(() => {
+    // Blocks the closing of the modal
     if (modalLock) return;
+
+    if (onCloseAlreadyCalled) {
+      setOnCloseAlreadyCalled(false);
+      return;
+    }
+    console.log(`🦕 👋 BottomModal onClose`);
+    setOnCloseAlreadyCalled(true);
     onClose && onClose();
+  }, [modalLock, onClose, onCloseAlreadyCalled]);
+
+  const handleModalHide = useCallback(() => {
+    console.log(`🦕 ✅ BottomModal ${debugName}: onBottomDrawerHide`);
     onModalHide && onModalHide();
-  }, [modalLock, onClose, onModalHide]);
+    notifyNextDrawer();
+  }, [onModalHide, debugName]);
+
+  useEffect(() => {
+    let id: number | undefined;
+
+    if (isOpened) {
+      console.log(
+        `🦕 BottomModal: ${debugName} adding to waiting list of drawer ...`,
+      );
+      id = addToWaitingDrawers(() => {
+        setIsDisplayed(true);
+      });
+    }
+
+    return () => {
+      console.log(
+        `🦕 BottomModal: ${debugName} cleanup id=${id} wasOpened=${isOpened}`,
+      );
+
+      if (id !== undefined) {
+        removeFromWaitingDrawers(id);
+        setIsDisplayed(false);
+      }
+    };
+  }, [debugName, isOpened]);
+
+  console.log(
+    `🦕🔥 BottomModal: isOpened: ${isOpened} isDisplayed: ${isDisplayed}`,
+  );
 
   return (
     <BottomDrawer
       preventBackdropClick={modalLock || preventBackdropClick}
-      isOpen={open}
       onClose={handleClose}
+      onModalHide={handleModalHide}
       noCloseButton={modalLock || noCloseButton}
       modalStyle={style}
       containerStyle={containerStyle}
-      {...rest}
+      isOpen={isDisplayed}
+      // {...rest}
     >
       {children}
     </BottomDrawer>
@@ -72,3 +130,90 @@ const BottomModal = ({
 };
 
 export default BottomModal;
+
+type WaitingDrawer = {
+  id: number;
+  onDrawerReady: () => void;
+};
+
+let currentDisplayedDrawerId: number | null = null;
+let drawersCounter = 0;
+const waitingDrawers: WaitingDrawer[] = [];
+
+/**
+ * Adds a drawer to the waiting list. If there is no currently displayed drawer,
+ * it will be displayed by calling notifyNextDrawer.
+ *
+ * This function is used internally by BottomModal and should not be used directly.
+ *
+ * @param onDrawerReady callback to call when it's the turn of this drawer to be displayed.
+ *   It should set a state that makes the drawer visible.
+ * @returns the id of the drawer
+ */
+function addToWaitingDrawers(onDrawerReady: WaitingDrawer["onDrawerReady"]) {
+  const id = drawersCounter++;
+
+  waitingDrawers.push({ id, onDrawerReady });
+
+  if (currentDisplayedDrawerId === null) {
+    notifyNextDrawer();
+  }
+
+  return id;
+}
+
+/**
+ * Removes the drawer from the waiting list. If it's the currently displayed drawer, nothing is done.
+ *
+ * This function is used internally by BottomModal and should not be used directly.
+ *
+ * @param id the id of the drawer to remove
+ */
+function removeFromWaitingDrawers(id: WaitingDrawer["id"]) {
+  // Does not remove the currently displayed drawer
+  // T_is drawer will be cleaned up when onModalHide is triggered
+  if (currentDisplayedDrawerId === id) {
+    return;
+  }
+
+  const index = waitingDrawers.findIndex(
+    waitingDrawer => waitingDrawer.id === id,
+  );
+
+  console.log(`🤝 removeFromWaitingDrawers index:${index}`);
+  if (index >= 0) {
+    waitingDrawers.splice(index, 1);
+  }
+}
+
+/**
+ * Notifies the next drawer in the waiting list that it's its turn to be displayed.
+ *
+ * If there is no drawer in the waiting list, it sets the counter of drawers to 0.
+ *
+ * This function is used internally by BottomModal and should not be used directly.
+ */
+function notifyNextDrawer() {
+  const nextDrawer = waitingDrawers.shift();
+
+  if (nextDrawer) {
+    currentDisplayedDrawerId = nextDrawer.id;
+    nextDrawer.onDrawerReady();
+  } else {
+    // No more drawer to display
+    currentDisplayedDrawerId = null;
+    // Not necessary, but avoids increasing infinitely the counter
+    drawersCounter = 0;
+  }
+}
+
+/**
+ * Helper function to clean the waiting list of drawers.
+ *
+ * This function is used internally by BottomModal and should not be used directly.
+ */
+function cleanWaitingDrawers() {
+  waitingDrawers.splice(0, waitingDrawers.length);
+  currentDisplayedDrawerId = null;
+  drawersCounter = 0;
+}

--- a/apps/ledger-live-mobile/src/components/BottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/BottomModal.tsx
@@ -13,7 +13,6 @@ export type Props = Merge<
     isOpened?: boolean;
     style?: StyleProp<ViewStyle>;
     containerStyle?: StyleProp<ViewStyle>;
-    debugName?: string;
   }
 >;
 
@@ -45,7 +44,6 @@ const BottomModal = ({
   containerStyle,
   noCloseButton,
   isOpen,
-  debugName,
   ...rest
 }: Props) => {
   const modalLock = useSelector(isModalLockedSelector);
@@ -57,13 +55,10 @@ const BottomModal = ({
   useFocusEffect(
     useCallback(() => {
       return () => {
-        console.log(
-          `🦕 BottomModal ${debugName}: cleaning onBottomDrawerFocus 🧹`,
-        );
         setIsDisplayed(false);
         cleanWaitingDrawers();
       };
-    }, [debugName]),
+    }, []),
   );
 
   const handleClose = useCallback(() => {
@@ -74,44 +69,31 @@ const BottomModal = ({
       setOnCloseAlreadyCalled(false);
       return;
     }
-    console.log(`🦕 👋 BottomModal onClose`);
     setOnCloseAlreadyCalled(true);
     onClose && onClose();
   }, [modalLock, onClose, onCloseAlreadyCalled]);
 
   const handleModalHide = useCallback(() => {
-    console.log(`🦕 ✅ BottomModal ${debugName}: onBottomDrawerHide`);
     onModalHide && onModalHide();
     notifyNextDrawer();
-  }, [onModalHide, debugName]);
+  }, [onModalHide]);
 
   useEffect(() => {
     let id: number | undefined;
 
     if (isOpened) {
-      console.log(
-        `🦕 BottomModal: ${debugName} adding to waiting list of drawer ...`,
-      );
       id = addToWaitingDrawers(() => {
         setIsDisplayed(true);
       });
     }
 
     return () => {
-      console.log(
-        `🦕 BottomModal: ${debugName} cleanup id=${id} wasOpened=${isOpened}`,
-      );
-
       if (id !== undefined) {
         removeFromWaitingDrawers(id);
         setIsDisplayed(false);
       }
     };
-  }, [debugName, isOpened]);
-
-  console.log(
-    `🦕🔥 BottomModal: isOpened: ${isOpened} isDisplayed: ${isDisplayed}`,
-  );
+  }, [isOpened]);
 
   return (
     <BottomDrawer
@@ -180,7 +162,6 @@ function removeFromWaitingDrawers(id: WaitingDrawer["id"]) {
     waitingDrawer => waitingDrawer.id === id,
   );
 
-  console.log(`🤝 removeFromWaitingDrawers index:${index}`);
   if (index >= 0) {
     waitingDrawers.splice(index, 1);
   }

--- a/apps/ledger-live-mobile/src/components/CheckLanguageAvailability.tsx
+++ b/apps/ledger-live-mobile/src/components/CheckLanguageAvailability.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { Icons } from "@ledgerhq/native-ui";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import ModalBottomAction from "./ModalBottomAction";
 import {
   languageSelector,
@@ -59,7 +59,7 @@ export default function CheckLanguageAvailability() {
         event={`Discoverability - Prompt - ${defaultLanguage}`}
         eventProperties={{ language: defaultLanguage }}
       />
-      <BottomModal isOpened onClose={onRequestClose}>
+      <QueuedDrawer isRequestingToBeOpened onClose={onRequestClose}>
         <ModalBottomAction
           title={<Trans i18nKey="systemLanguageAvailable.title" />}
           icon={<Icons.LanguageMedium color="primary.c80" size={50} />}
@@ -103,7 +103,7 @@ export default function CheckLanguageAvailability() {
             </View>
           }
         />
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
+++ b/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
@@ -2,7 +2,6 @@ import React, { ReactNode, useCallback } from "react";
 import { Linking, ScrollView } from "react-native";
 import { useTranslation } from "react-i18next";
 import {
-  BottomDrawer,
   Flex,
   Icons,
   Link,
@@ -14,6 +13,7 @@ import styled from "styled-components/native";
 import { useLocalizedTermsUrl, useTermsAccept } from "../logic/terms";
 import Button from "./Button";
 import Alert from "./Alert";
+import QueuedDrawer from "./QueuedDrawer";
 
 const Description = styled(Text).attrs(() => ({
   color: "neutral.c70",
@@ -36,10 +36,10 @@ const CheckTermOfUseUpdateModal = () => {
   }, [termsUrl]);
 
   return (
-    <BottomDrawer
+    <QueuedDrawer
       noCloseButton={true}
       title={t("updatedTerms.title")}
-      isOpen={!accepted}
+      isRequestingToBeOpened={!accepted}
     >
       <ScrollView showsVerticalScrollIndicator={false}>
         <Flex px={4}>
@@ -68,7 +68,7 @@ const CheckTermOfUseUpdateModal = () => {
           </Button>
         </Flex>
       </ScrollView>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
+++ b/apps/ledger-live-mobile/src/components/CheckTermOfUseUpdate.tsx
@@ -1,13 +1,7 @@
 import React, { ReactNode, useCallback } from "react";
 import { Linking, ScrollView } from "react-native";
 import { useTranslation } from "react-i18next";
-import {
-  Flex,
-  Icons,
-  Link,
-  Text,
-  Divider,
-} from "@ledgerhq/native-ui";
+import { Flex, Icons, Link, Text, Divider } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
 
 import { useLocalizedTermsUrl, useTermsAccept } from "../logic/terms";

--- a/apps/ledger-live-mobile/src/components/ConfirmationModal.tsx
+++ b/apps/ledger-live-mobile/src/components/ConfirmationModal.tsx
@@ -2,10 +2,10 @@ import React, { PureComponent } from "react";
 import { Trans } from "react-i18next";
 import { View, StyleSheet, Image } from "react-native";
 import { rgba, Theme, withTheme } from "../colors";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import LText from "./LText";
 import Button, { BaseButtonProps } from "./Button";
-import type { Props as BottomModalProps } from "./BottomModal";
+import type { Props as BottomModalProps } from "./QueuedDrawer";
 
 type Props = {
   isOpened: boolean;
@@ -51,8 +51,8 @@ class ConfirmationModal extends PureComponent<Props> {
     } = this.props;
     const iColor = iconColor || colors.live;
     return (
-      <BottomModal
-        isOpened={isOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isOpened}
         onClose={onClose}
         style={styles.confirmationModal}
         {...rest}
@@ -107,7 +107,7 @@ class ConfirmationModal extends PureComponent<Props> {
             onPress={onConfirm}
           />
         </View>
-      </BottomModal>
+      </QueuedDrawer>
     );
   }
 }

--- a/apps/ledger-live-mobile/src/components/CounterValue.tsx
+++ b/apps/ledger-live-mobile/src/components/CounterValue.tsx
@@ -19,7 +19,7 @@ import type { CurrencyUnitValueProps } from "./CurrencyUnitValue";
 import LText from "./LText";
 import Circle from "./Circle";
 import IconHelp from "../icons/Info";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 
 type Props = {
   // wich market to query
@@ -45,8 +45,8 @@ export const NoCountervaluePlaceholder = () => {
   return (
     <TouchableOpacity style={styles.placeholderButton} onPress={openModal}>
       <LText style={styles.placeholderLabel}>-</LText>
-      <BottomModal
-        isOpened={modalOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={modalOpened}
         onClose={closeModal}
         style={[styles.modal]}
       >
@@ -57,7 +57,7 @@ export const NoCountervaluePlaceholder = () => {
         <LText style={styles.modalTitle} semiBold>
           <Trans i18nKey="errors.countervaluesUnavailable.title" />
         </LText>
-      </BottomModal>
+      </QueuedDrawer>
     </TouchableOpacity>
   );
 };

--- a/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/types-devices";
 import { NavigatorName, ScreenName } from "../../const";
-import BottomModal, { Props as BottomModalProps } from "../BottomModal";
+import QueuedDrawer, { Props as BottomModalProps } from "../QueuedDrawer";
 import ModalChoice from "./ModalChoice";
 import { importImageFromPhoneGallery } from "./imageUtils";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
@@ -70,7 +70,7 @@ const CustomImageBottomModal: React.FC<Props> = props => {
   }, [navigation, device, onClose]);
 
   return (
-    <BottomModal isOpened={isOpened} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={!!isOpened} onClose={onClose}>
       <TrackScreen
         category={analyticsDrawerName}
         type="drawer"
@@ -99,7 +99,7 @@ const CustomImageBottomModal: React.FC<Props> = props => {
           />
         </>
       )}
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/DebugAppLevelDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/DebugAppLevelDrawer.tsx
@@ -1,0 +1,27 @@
+import React, { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Alert } from "@ledgerhq/native-ui";
+import QueuedDrawer from "./QueuedDrawer";
+import { setDebugAppLelevelDrawerOpened } from "../actions/settings";
+import { debugAppLevelDrawerOpenedSelector } from "../reducers/settings";
+
+/**
+ * Only for debug purposes. This drawer is called at the App level (= above the react-navigation system).
+ * It is meant to imitate drawers like /screens/Modals/index.tsx and test them with QueueDrawer.
+ */
+const DebugAppLevelDrawer = () => {
+  const dispatch = useDispatch();
+  const handleClose = useCallback(() => {
+    dispatch(setDebugAppLelevelDrawerOpened(false));
+  }, [dispatch]);
+
+  const isOpen = useSelector(debugAppLevelDrawerOpenedSelector);
+
+  return (
+    <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={handleClose}>
+      <Alert type="info" title="This is a drawer at the App level ⛰" />
+    </QueuedDrawer>
+  );
+};
+
+export default DebugAppLevelDrawer;

--- a/apps/ledger-live-mobile/src/components/DelegationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/DelegationDrawer.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "@react-navigation/native";
 import DelegatingContainer from "../families/tezos/DelegatingContainer";
 import { rgba } from "../colors";
 import getWindowDimensions from "../logic/getWindowDimensions";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import Circle from "./Circle";
 import Touchable from "./Touchable";
 import LText from "./LText";
@@ -56,7 +56,11 @@ export default function DelegationDrawer({
   const unit = getAccountUnit(account);
   const iconWidth = normalize(64);
   return (
-    <BottomModal style={styles.modal} isOpened={isOpen} onClose={onClose}>
+    <QueuedDrawer
+      style={styles.modal}
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+    >
       <View style={styles.root}>
         <DelegatingContainer
           left={
@@ -110,7 +114,7 @@ export default function DelegationDrawer({
           ))}
         </View>
       </View>
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 export type FieldType = {

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -10,7 +10,7 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelInfo } from "@ledgerhq/types-live";
 
 import { DeviceActionDefaultRendering } from "..";
-import BottomModal from "../../BottomModal";
+import QueuedDrawer from "../../QueuedDrawer";
 
 import Item from "./Item";
 import Confirmation from "./Confirmation";
@@ -30,7 +30,7 @@ const action = createAction(connectApp);
 /**
  * This component overrides the default rendering for device actions in some
  * cases, falling back to the default one for the rest. Actions such as user blocking
- * requests, errors and such will be rendered in a BottomModal whereas installation
+ * requests, errors and such will be rendered in a QueuedDrawer whereas installation
  * progress and loading states will be handled inline as part of the screen where this
  * this is rendered.
  */
@@ -140,8 +140,8 @@ const InstallSetOfApps = ({
       <Text variant="paragraphLineHeight" color="neutral.c70">
         <Trans i18nKey="installSetOfApps.ongoing.disclaimer" />
       </Text>
-      <BottomModal
-        isOpened={!!allowManagerRequestedWording || !!error}
+      <QueuedDrawer
+        isRequestingToBeOpened={!!allowManagerRequestedWording || !!error}
         onClose={onWrappedError}
         onModalHide={onWrappedError}
       >
@@ -153,7 +153,7 @@ const InstallSetOfApps = ({
             />
           </Flex>
         </Flex>
-      </BottomModal>
+      </QueuedDrawer>
     </Flex>
   ) : shouldRestoreApps ? (
     <Restore

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components/native";
 import { PartialNullable } from "../types/helpers";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import DeviceAction from "./DeviceAction";
 
 const DeviceActionContainer = styled(Flex).attrs({
@@ -56,8 +56,8 @@ export default function DeviceActionModal<Req, Stt, Res>({
   }, [onClose, result]);
 
   return (
-    <BottomModal
-      isOpened={result ? false : !!device}
+    <QueuedDrawer
+      isRequestingToBeOpened={result ? false : !!device}
       onClose={handleClose}
       onModalHide={handleModalHide}
     >
@@ -85,6 +85,6 @@ export default function DeviceActionModal<Req, Stt, Res>({
             </Flex>
           )}
       {device && <SyncSkipUnderPriority priority={100} />}
-    </BottomModal>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/components/DoubleCountervalue.tsx
+++ b/apps/ledger-live-mobile/src/components/DoubleCountervalue.tsx
@@ -10,7 +10,7 @@ import { counterValueCurrencySelector } from "../reducers/settings";
 import CurrencyUnitValue, { CurrencyUnitValueProps } from "./CurrencyUnitValue";
 import LText from "./LText";
 import InfoIcon from "../icons/Info";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import Circle from "./Circle";
 import FormatDate from "./FormatDate";
 
@@ -71,8 +71,8 @@ function DoubleCounterValue({
     return withPlaceholder ? (
       <TouchableOpacity style={styles.placeholderButton} onPress={openModal}>
         <LText style={styles.placeholderLabel}>-</LText>
-        <BottomModal
-          isOpened={placeholderModalOpened}
+        <QueuedDrawer
+          isRequestingToBeOpened={placeholderModalOpened}
           onClose={closeModal}
           style={[styles.modal]}
         >
@@ -83,7 +83,7 @@ function DoubleCounterValue({
           <LText style={styles.modalTitle} semiBold>
             <Trans i18nKey="errors.countervaluesUnavailable.title" />
           </LText>
-        </BottomModal>
+        </QueuedDrawer>
       </TouchableOpacity>
     ) : null;
   }
@@ -101,7 +101,11 @@ function DoubleCounterValue({
 
         <InfoIcon size={16} color={colors.grey} />
       </TouchableOpacity>
-      <BottomModal isOpened={isOpened} onClose={onClose} style={styles.modal}>
+      <QueuedDrawer
+        isRequestingToBeOpened={isOpened}
+        onClose={onClose}
+        style={styles.modal}
+      >
         <View style={styles.row}>
           <View style={styles.column}>
             <LText bold style={styles.title}>
@@ -148,7 +152,7 @@ function DoubleCounterValue({
             <LText style={styles.placeholder}>-</LText>
           )}
         </View>
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 

--- a/apps/ledger-live-mobile/src/components/EditFeeUnit.tsx
+++ b/apps/ledger-live-mobile/src/components/EditFeeUnit.tsx
@@ -14,7 +14,7 @@ import SettingsRow from "./SettingsRow";
 import LText from "./LText";
 import CurrencyInput from "./CurrencyInput";
 import Touchable from "./Touchable";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import Button from "./Button";
 import {
   BaseComposite,
@@ -131,7 +131,10 @@ export default function EditFreeUnit({ account, field }: Props) {
           />
         </View>
       </View>
-      <BottomModal isOpened={isModalOpened} onClose={onRequestClose}>
+      <QueuedDrawer
+        isRequestingToBeOpened={isModalOpened}
+        onClose={onRequestClose}
+      >
         <View style={styles.editFeesUnitsModalTitleRow}>
           <LText secondary semiBold style={styles.editFeesUnitModalTitle}>
             {t("send.fees.edit.title")}
@@ -160,7 +163,7 @@ export default function EditFreeUnit({ account, field }: Props) {
         >
           {account.unit.code}
         </FlatList>
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/components/FabActions/modals/ZeroBalanceDisabledModalContent.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/modals/ZeroBalanceDisabledModalContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { BottomDrawer, Flex } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useNavigation } from "@react-navigation/native";
@@ -13,6 +13,7 @@ import {
   StackNavigatorNavigation,
 } from "../../RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "../../RootNavigator/types/BaseNavigator";
+import QueuedDrawer from "../../QueuedDrawer";
 
 function ZeroBalanceDisabledModalContent({
   account,
@@ -67,8 +68,8 @@ function ZeroBalanceDisabledModalContent({
   }, [account, parentAccount?.id, actionCurrency, navigation, onClose]);
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={!!isOpen}
       onClose={onClose}
       title={t("account.modals.zeroBalanceDisabledAction.title", {
         currencyTicker: actionCurrency?.ticker,
@@ -102,7 +103,7 @@ function ZeroBalanceDisabledModalContent({
           {t("account.receive")}
         </Button>
       </Flex>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdate/index.tsx
@@ -16,7 +16,7 @@ import {
   clearBackgroundEvents,
   dequeueBackgroundEvent,
 } from "../../actions/appstate";
-import BottomModal from "../BottomModal";
+import QueuedDrawer from "../QueuedDrawer";
 import GenericErrorView from "../GenericErrorView";
 import useLatestFirmware from "../../hooks/useLatestFirmware";
 import ConfirmRecoveryStep from "./ConfirmRecoveryStep";
@@ -194,9 +194,9 @@ export default function FirmwareUpdate({
   const firmwareVersion = latestFirmware?.final?.name ?? "";
 
   return (
-    <BottomModal
+    <QueuedDrawer
       noCloseButton={!canClose}
-      isOpened={isOpen}
+      isRequestingToBeOpened={isOpen}
       onClose={onCloseSilently}
       onModalHide={onCloseSilently}
     >
@@ -269,6 +269,6 @@ export default function FirmwareUpdate({
       {step === "downloadingUpdate" && (
         <DownloadingUpdateStep progress={progress} />
       )}
-    </BottomModal>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -4,7 +4,7 @@ import { useNavigation, useRoute } from "@react-navigation/native";
 import { DeviceModelInfo } from "@ledgerhq/types-live";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Alert, BottomDrawer, Text, Flex } from "@ledgerhq/native-ui";
+import { Alert, Text, Flex } from "@ledgerhq/native-ui";
 import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
@@ -20,6 +20,7 @@ import {
 import { hasConnectedDeviceSelector } from "../reducers/appstate";
 import Button from "./Button";
 import useLatestFirmware from "../hooks/useLatestFirmware";
+import QueuedDrawer from "./QueuedDrawer";
 
 const FirmwareUpdateBanner = ({
   containerProps,
@@ -111,8 +112,8 @@ const FirmwareUpdateBanner = ({
         />
       </Alert>
 
-      <BottomDrawer
-        isOpen={showDrawer}
+      <QueuedDrawer
+        isRequestingToBeOpened={showDrawer}
         onClose={onCloseDrawer}
         Icon={fwUpdateActivatedButNotWired ? UsbMedium : DownloadMedium}
         title={
@@ -134,7 +135,7 @@ const FirmwareUpdateBanner = ({
           title={t("common.close")}
           onPress={onCloseDrawer}
         />
-      </BottomDrawer>
+      </QueuedDrawer>
     </Flex>
   ) : null;
 };

--- a/apps/ledger-live-mobile/src/components/GenericErrorBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/GenericErrorBottomModal.tsx
@@ -1,10 +1,10 @@
 import React, { memo } from "react";
 import { View, StyleSheet } from "react-native";
-import BottomModal from "./BottomModal";
-import type { Props as BottomModalProps } from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
+import type { Props as BottomModalProps } from "./QueuedDrawer";
 import GenericErrorView from "./GenericErrorView";
 
-type Props = BottomModalProps & {
+type Props = Omit<BottomModalProps, "isRequestingToBeOpened"> & {
   error: Error | null | undefined;
   onClose?: () => void;
   footerButtons?: React.ReactNode;
@@ -19,7 +19,11 @@ function GenericErrorBottomModal({
   ...otherProps
 }: Props) {
   return (
-    <BottomModal {...otherProps} isOpened={!!error} onClose={onClose}>
+    <QueuedDrawer
+      {...otherProps}
+      isRequestingToBeOpened={!!error}
+      onClose={onClose}
+    >
       {error ? (
         <View style={styles.root}>
           <GenericErrorView
@@ -31,7 +35,7 @@ function GenericErrorBottomModal({
           ) : null}
         </View>
       ) : null}
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/components/HeaderRightClose.tsx
+++ b/apps/ledger-live-mobile/src/components/HeaderRightClose.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { StyleSheet } from "react-native";
 import { useNavigation, useTheme } from "@react-navigation/native";
-import type { Props as BottomModalProps } from "./BottomModal";
+import type { Props as BottomModalProps } from "./QueuedDrawer";
 import Touchable from "./Touchable";
 import CloseIcon from "../icons/Close";
 import ConfirmationModal from "./ConfirmationModal";

--- a/apps/ledger-live-mobile/src/components/InfoModal.tsx
+++ b/apps/ledger-live-mobile/src/components/InfoModal.tsx
@@ -5,10 +5,10 @@ import { Trans } from "react-i18next";
 import { useTheme } from "styled-components/native";
 import { Icons, IconBox, Flex } from "@ledgerhq/native-ui";
 import type { Props as IconBoxProps } from "@ledgerhq/native-ui/components/Icon/IconBox";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import LText from "./LText";
 import IconArrowRight from "../icons/ArrowRight";
-import type { Props as ModalProps } from "./BottomModal";
+import type { Props as ModalProps } from "./QueuedDrawer";
 import Button, { WrappedButtonProps } from "./wrappedUi/Button";
 import { Merge } from "../types/helpers";
 
@@ -18,8 +18,9 @@ type BulletItem = {
 };
 
 type InfoModalProps = Merge<
-  ModalProps,
+  Omit<ModalProps, "isRequestingToBeOpened">,
   {
+    isOpened: boolean;
     id?: string;
     title?: React.ReactNode;
     desc?: React.ReactNode;
@@ -49,8 +50,8 @@ const InfoModal = ({
   style,
   containerStyle,
 }: InfoModalProps) => (
-  <BottomModal
-    isOpened={isOpened}
+  <QueuedDrawer
+    isRequestingToBeOpened={isOpened}
     onClose={onClose}
     style={[styles.modal, style || {}]}
   >
@@ -105,7 +106,7 @@ const InfoModal = ({
         {confirmLabel || <Trans i18nKey="common.gotit" />}
       </Button>
     </Flex>
-  </BottomModal>
+  </QueuedDrawer>
 );
 
 function BulletLine({ children }: { children?: React.ReactNode }) {

--- a/apps/ledger-live-mobile/src/components/Nft/HideNftDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/HideNftDrawer.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 
-import { BottomDrawer, Button, Icons } from "@ledgerhq/native-ui";
+import { Button, Icons } from "@ledgerhq/native-ui";
 import { useDispatch, useSelector } from "react-redux";
 import { Account } from "@ledgerhq/types-live";
 import { decodeNftId } from "@ledgerhq/live-common/nft/index";
@@ -10,6 +10,7 @@ import { track, TrackScreen } from "../../analytics";
 import { hideNftCollection } from "../../actions/settings";
 import { accountSelector } from "../../reducers/accounts";
 import { State } from "../../reducers/types";
+import QueuedDrawer from "../QueuedDrawer";
 
 type Props = {
   nftId?: string;
@@ -61,8 +62,8 @@ const HideNftDrawer = ({
     onClose();
   }, [onClose]);
   return (
-    <BottomDrawer
-      isOpen={isOpened}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpened}
       onClose={onPressClose}
       Icon={Icons.EyeNoneMedium}
       title={t("wallet.nftGallery.hideNftModal.title")}
@@ -95,7 +96,7 @@ const HideNftDrawer = ({
       >
         {t("common.cancel")}
       </Button>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/Nft/NftCollectionOptionsMenu.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftCollectionOptionsMenu.tsx
@@ -1,13 +1,7 @@
 import React, { useCallback } from "react";
 
 import { useDispatch } from "react-redux";
-import {
-  Text,
-  Icons,
-  BoxedIcon,
-  Button,
-  Flex,
-} from "@ledgerhq/native-ui";
+import { Text, Icons, BoxedIcon, Button, Flex } from "@ledgerhq/native-ui";
 import { Account, ProtoNFT } from "@ledgerhq/types-live";
 import { useTranslation } from "react-i18next";
 import { hideNftCollection } from "../../actions/settings";

--- a/apps/ledger-live-mobile/src/components/Nft/NftCollectionOptionsMenu.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftCollectionOptionsMenu.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 
 import { useDispatch } from "react-redux";
 import {
-  BottomDrawer,
   Text,
   Icons,
   BoxedIcon,
@@ -12,6 +11,7 @@ import {
 import { Account, ProtoNFT } from "@ledgerhq/types-live";
 import { useTranslation } from "react-i18next";
 import { hideNftCollection } from "../../actions/settings";
+import QueuedDrawer from "../QueuedDrawer";
 
 type Props = {
   isOpen: boolean;
@@ -35,7 +35,7 @@ const NftCollectionOptionsMenu = ({
   }, [dispatch, account.id, collection, onClose]);
 
   return (
-    <BottomDrawer isOpen={isOpen} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose}>
       <Flex alignItems="center">
         <BoxedIcon Icon={Icons.EyeNoneMedium} size={48} />
         <Text variant="h1" mt={20}>
@@ -51,7 +51,7 @@ const NftCollectionOptionsMenu = ({
           {t("common.cancel")}
         </Button>
       </Flex>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/Nft/NftLinksPanel.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftLinksPanel.tsx
@@ -17,7 +17,7 @@ import ExternalLinkIcon from "../../icons/ExternalLink";
 import OpenSeaIcon from "../../icons/OpenSea";
 import RaribleIcon from "../../icons/Rarible";
 import GlobeIcon from "../../icons/Globe";
-import BottomModal from "../BottomModal";
+import QueuedDrawer from "../QueuedDrawer";
 import { rgba } from "../../colors";
 import HideNftDrawer from "./HideNftDrawer";
 import { track, TrackScreen } from "../../analytics";
@@ -280,14 +280,14 @@ const NftLinksPanel = ({
   };
 
   return (
-    <BottomModal
+    <QueuedDrawer
       style={[
         styles.root,
         {
           backgroundColor: colors.background.drawer,
         },
       ]}
-      isOpened={isOpen}
+      isRequestingToBeOpened={isOpen}
       onClose={onClose}
     >
       <TrackScreen
@@ -303,7 +303,7 @@ const NftLinksPanel = ({
         isOpened={bottomHideCollectionOpen}
         onClose={closeHideModal}
       />
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -7,8 +7,9 @@ import { useSelector } from "react-redux";
 import { isModalLockedSelector } from "../reducers/appstate";
 import { Merge } from "../types/helpers";
 
+// Purposefully removes isOpen prop so consumers can't use it directly
 export type Props = Merge<
-  BaseModalProps,
+  Omit<BaseModalProps, "isOpen">,
   {
     isRequestingToBeOpened: boolean;
     style?: StyleProp<ViewStyle>;

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -133,6 +133,7 @@ const QueuedDrawer = ({
     return () => {
       if (id !== undefined) {
         removeFromWaitingDrawers(id);
+        // If this was the currently displayed drawer, only notifyNextDrawer once the drawer is hidden
         setIsDisplayed(false);
       }
     };
@@ -208,7 +209,7 @@ function addToWaitingDrawers(
  */
 function removeFromWaitingDrawers(id: ToBeDisplayedDrawer["id"]) {
   // Does not remove the currently displayed drawer
-  // T_is drawer will be cleaned up when onModalHide is triggered
+  // This drawer will be cleaned up when onModalHide is triggered
   if (currentDisplayedDrawer?.id === id) {
     return;
   }

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -55,7 +55,6 @@ const QueuedDrawer = ({
   const modalLock = useSelector(isModalLockedSelector);
   // Actual state that choses if the drawer is displayed or not
   const [isDisplayed, setIsDisplayed] = useState(false);
-  const [onCloseAlreadyCalled, setOnCloseAlreadyCalled] = useState(false);
 
   // Makes sure that the drawer system is cleaned when navigating to a new (or back to a) screen
   useFocusEffect(
@@ -71,13 +70,8 @@ const QueuedDrawer = ({
     // Blocks the closing of the modal
     if (modalLock) return;
 
-    if (onCloseAlreadyCalled) {
-      setOnCloseAlreadyCalled(false);
-      return;
-    }
-    setOnCloseAlreadyCalled(true);
     onClose && onClose();
-  }, [modalLock, onClose, onCloseAlreadyCalled]);
+  }, [modalLock, onClose]);
 
   const handleModalHide = useCallback(() => {
     onModalHide && onModalHide();

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -30,6 +30,8 @@ export type Props = Merge<
  * Note: avoid conditionally render this component. Always render it and use isRequestingToBeOpened to control its visibility.
  * Note: to avoid a UI glitch on Android, do not put this drawer inside NavigationScrollView (and probably any other ScrollView)
  *
+ * Dev: internal functions can be wrapped in useCallback once BottomDrawer and BaseModal are memoized components
+ *
  * @param isRequestingToBeOpened: to use in place of isOpen. Setting to true will add the drawer to the queue.
  *   Setting to false will remove it from the queue.
  * @param onClose: when the user closes the drawer (by clicking on the backdrop or the close button) + when the drawer is hidden
@@ -57,6 +59,7 @@ const QueuedDrawer = ({
   const [isDisplayed, setIsDisplayed] = useState(false);
 
   // Makes sure that the drawer system is cleaned when navigating to a new (or back to a) screen
+  // According to reactnavigation documentation, a useCallback should wrap the function passed to useFocusEffect
   useFocusEffect(
     useCallback(() => {
       return () => {
@@ -66,17 +69,17 @@ const QueuedDrawer = ({
     }, []),
   );
 
-  const handleClose = useCallback(() => {
-    // Blocks the closing of the modal
+  const handleClose = () => {
+    // Blocks the drawer from closing
     if (modalLock) return;
 
     onClose && onClose();
-  }, [modalLock, onClose]);
+  };
 
-  const handleModalHide = useCallback(() => {
+  const handleModalHide = () => {
     onModalHide && onModalHide();
     notifyNextDrawer();
-  }, [onModalHide]);
+  };
 
   useEffect(() => {
     let id: number | undefined;

--- a/apps/ledger-live-mobile/src/components/RequiresBLE/AndroidRequiresBluetoothPermissions.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresBLE/AndroidRequiresBluetoothPermissions.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AppState, Linking, PermissionsAndroid } from "react-native";
 import { useIsMounted } from "../../helpers/useIsMounted";
-import BottomModal from "../BottomModal";
+import QueuedDrawer from "../QueuedDrawer";
 import {
   bluetoothPermissions,
   checkBluetoothPermissions,
@@ -77,7 +77,11 @@ const AndroidRequiresBluetoothPermissions: React.FC<{
   return (
     <>
       <BluetoothDisabled onRetry={showModal} />
-      <BottomModal isOpen={modalOpened} onClose={closeModal} noCloseButton>
+      <QueuedDrawer
+        isRequestingToBeOpened={modalOpened}
+        onClose={closeModal}
+        noCloseButton
+      >
         <Flex flexDirection="row">
           <Flex
             flexDirection="column"
@@ -110,7 +114,7 @@ const AndroidRequiresBluetoothPermissions: React.FC<{
             </Link>
           </Flex>
         </Flex>
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -60,6 +60,7 @@ import PostOnboardingDebugScreen from "../../screens/PostOnboarding/PostOnboardi
 import { SettingsNavigatorStackParamList } from "./types/SettingsNavigator";
 import DebugTermsOfUse from "../../screens/Settings/Debug/Features/TermsOfUse";
 import CameraPermissions from "../../screens/Settings/Debug/Debugging/CameraPermissions";
+import DebugDrawers from "../../screens/Settings/Debug/Features/Drawers";
 
 const Stack = createStackNavigator<SettingsNavigatorStackParamList>();
 
@@ -404,6 +405,13 @@ export default function SettingsNavigator() {
         component={DebugPerformance}
         options={{
           title: "Performance",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugDrawers}
+        component={DebugDrawers}
+        options={{
+          title: "Debug bottom drawers",
         }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -60,7 +60,7 @@ import PostOnboardingDebugScreen from "../../screens/PostOnboarding/PostOnboardi
 import { SettingsNavigatorStackParamList } from "./types/SettingsNavigator";
 import DebugTermsOfUse from "../../screens/Settings/Debug/Features/TermsOfUse";
 import CameraPermissions from "../../screens/Settings/Debug/Debugging/CameraPermissions";
-import DebugDrawers from "../../screens/Settings/Debug/Features/Drawers";
+import DebugQueuedDrawers from "../../screens/Settings/Debug/Features/QueuedDrawers";
 
 const Stack = createStackNavigator<SettingsNavigatorStackParamList>();
 
@@ -408,8 +408,8 @@ export default function SettingsNavigator() {
         }}
       />
       <Stack.Screen
-        name={ScreenName.DebugDrawers}
-        component={DebugDrawers}
+        name={ScreenName.DebugQueuedDrawers}
+        component={DebugQueuedDrawers}
         options={{
           title: "Debug bottom drawers",
         }}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -61,5 +61,5 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugFetchCustomImage]: undefined;
   [ScreenName.DebugCustomImageGraphics]: undefined;
   [ScreenName.DebugCameraPermissions]: undefined;
-  [ScreenName.DebugDrawers]: undefined;
+  [ScreenName.DebugQueuedDrawers]: undefined;
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -61,4 +61,5 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugFetchCustomImage]: undefined;
   [ScreenName.DebugCustomImageGraphics]: undefined;
   [ScreenName.DebugCameraPermissions]: undefined;
+  [ScreenName.DebugDrawers]: undefined;
 };

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/RemoveDeviceMenu.tsx
@@ -14,7 +14,7 @@ import Stax from "../../images/devices/Stax";
 import NanoX from "../../images/devices/NanoX";
 
 import Trash from "../../icons/Trash";
-import BottomModal from "../BottomModal";
+import QueuedDrawer from "../QueuedDrawer";
 import { removeKnownDevice } from "../../actions/ble";
 
 const illustrations = {
@@ -55,7 +55,7 @@ const RemoveDeviceMenu = ({
   }, [device, dispatch, onHideMenu]);
 
   return (
-    <BottomModal isOpened={open} onClose={onHideMenu}>
+    <QueuedDrawer isRequestingToBeOpened={open} onClose={onHideMenu}>
       <Flex alignItems="center" mb={8}>
         {illustration}
       </Flex>
@@ -66,7 +66,7 @@ const RemoveDeviceMenu = ({
         title={<Trans i18nKey="common.forgetDevice" />}
         onPress={onRemoveDevice}
       />
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -8,7 +8,6 @@ import {
   Text,
   Flex,
   Icons,
-  BottomDrawer,
   Box,
   ScrollContainer,
 } from "@ledgerhq/native-ui";
@@ -37,6 +36,7 @@ import { MainNavigatorParamList } from "../RootNavigator/types/MainNavigator";
 import PostOnboardingEntryPointCard from "../PostOnboarding/PostOnboardingEntryPointCard";
 import BleDevicePairingFlow from "../BleDevicePairingFlow";
 import BuyDeviceCTA from "../BuyDeviceCTA";
+import QueuedDrawer from "../QueuedDrawer";
 
 type Navigation = BaseComposite<
   CompositeScreenProps<
@@ -271,8 +271,8 @@ export default function SelectDevice({ onSelect, stopBleScanning }: Props) {
               )}
           </ScrollContainer>
           <BuyDeviceCTA />
-          <BottomDrawer
-            isOpen={isAddNewDrawerOpen}
+          <QueuedDrawer
+            isRequestingToBeOpened={isAddNewDrawerOpen}
             onClose={() => setIsAddNewDrawerOpen(false)}
           >
             <Flex>
@@ -346,7 +346,7 @@ export default function SelectDevice({ onSelect, stopBleScanning }: Props) {
                 </Flex>
               </Touchable>
             </Flex>
-          </BottomDrawer>
+          </QueuedDrawer>
         </>
       )}
     </Flex>

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -4,13 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { discoverDevices } from "@ledgerhq/live-common/hw/index";
 import { CompositeScreenProps, useNavigation } from "@react-navigation/native";
-import {
-  Text,
-  Flex,
-  Icons,
-  Box,
-  ScrollContainer,
-} from "@ledgerhq/native-ui";
+import { Text, Flex, Icons, Box, ScrollContainer } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useBleDevicesScanning } from "@ledgerhq/live-common/ble/hooks/useBleDevicesScanning";
 import { usePostOnboardingEntryPointVisibleOnWallet } from "@ledgerhq/live-common/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet";

--- a/apps/ledger-live-mobile/src/components/SelectFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectFeesStrategy.tsx
@@ -23,7 +23,7 @@ import SummaryRow from "../screens/SendFunds/SummaryRow";
 import CounterValue from "./CounterValue";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import SectionSeparator from "./SectionSeparator";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import Info from "../icons/Info";
 import TachometerSlow from "../icons/TachometerSlow";
 import TachometerMedium from "../icons/TachometerMedium";
@@ -155,13 +155,13 @@ export default function SelectFeesStrategy({
 
   return (
     <>
-      <BottomModal
-        isOpened={isNetworkFeeHelpOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isNetworkFeeHelpOpened}
         preventBackdropClick={false}
         onClose={closeNetworkFeeHelpModal}
       >
         <NetworkFeeInfo />
-      </BottomModal>
+      </QueuedDrawer>
 
       <View>
         <SectionSeparator lineColor={colors.lightFog} />

--- a/apps/ledger-live-mobile/src/components/StorylyStories/StoriesConfig.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/StoriesConfig.tsx
@@ -7,7 +7,7 @@ import { Flex, Switch, BaseInput, Text, Icons } from "@ledgerhq/native-ui";
 import { TouchableOpacity } from "react-native";
 import { InputRenderRightContainer } from "@ledgerhq/native-ui/components/Form/Input/BaseInput";
 import { CameraType } from "expo-camera/build/Camera.types";
-import BottomModal from "../BottomModal";
+import QueuedDrawer from "../QueuedDrawer";
 
 type Props = {
   instanceID: StorylyInstanceID;
@@ -105,8 +105,8 @@ const StoriesConfig: React.FC<Props> = ({ instanceID }) => {
         }
         value={token}
       />
-      <BottomModal
-        isOpen={showCameraModal}
+      <QueuedDrawer
+        isRequestingToBeOpened={showCameraModal}
         onClose={() => setShowCameraModal(false)}
       >
         <Flex>
@@ -121,7 +121,7 @@ const StoriesConfig: React.FC<Props> = ({ instanceID }) => {
             onBarCodeScanned={handleBarCodeScanned}
           />
         </Flex>
-      </BottomModal>
+      </QueuedDrawer>
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
@@ -18,14 +18,16 @@ import {
   hasOrderedNanoSelector,
   readOnlyModeEnabledSelector,
 } from "../../reducers/settings";
-import { Props as ModalProps } from "../BottomModal";
+import { Props as ModalProps } from "../QueuedDrawer";
 import TransferButton from "./TransferButton";
 import BuyDeviceBanner, { IMAGE_PROPS_SMALL_NANO } from "../BuyDeviceBanner";
 import SetupDeviceBanner from "../SetupDeviceBanner";
 import { useAnalytics } from "../../analytics";
 import { sharedSwapTracking } from "../../screens/Swap/utils";
 
-export default function TransferDrawer({ onClose }: ModalProps) {
+export default function TransferDrawer({
+  onClose,
+}: Omit<ModalProps, "isRequestingToBeOpened">) {
   const navigation = useNavigation();
   const { t } = useTranslation();
 

--- a/apps/ledger-live-mobile/src/components/TooltipLabel.tsx
+++ b/apps/ledger-live-mobile/src/components/TooltipLabel.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, StyleSheet } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import Icon from "react-native-vector-icons/FontAwesome";
 import LText, { Opts as LTextProps } from "./LText";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 
 type Props = {
   label: React.ReactNode;
@@ -29,11 +29,15 @@ const TooltipLabel = ({ label, tooltip, color = "grey", style }: Props) => {
           name={"info-circle"}
         />
       </TouchableOpacity>
-      <BottomModal isOpened={isOpened} onClose={close} style={styles.modal}>
+      <QueuedDrawer
+        isRequestingToBeOpened={isOpened}
+        onClose={close}
+        style={styles.modal}
+      >
         <LText semiBold style={styles.tooltip}>
           {tooltip}
         </LText>
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/components/TransactionsPendingConfirmationWarning.tsx
+++ b/apps/ledger-live-mobile/src/components/TransactionsPendingConfirmationWarning.tsx
@@ -6,7 +6,7 @@ import { isAccountBalanceUnconfirmed } from "@ledgerhq/live-common/account/index
 import { Trans } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
 import { accountsSelector } from "../reducers/accounts";
-import BottomModal from "./BottomModal";
+import QueuedDrawer from "./QueuedDrawer";
 import LText from "./LText";
 import Circle from "./Circle";
 import ClockIcon from "../icons/Clock";
@@ -37,9 +37,9 @@ const TransactionsPendingConfirmationWarning = ({
       >
         <ClockIcon color={colors.grey} size={12} />
       </TouchableOpacity>
-      <BottomModal
+      <QueuedDrawer
         style={styles.modal}
-        isOpened={isModalOpened}
+        isRequestingToBeOpened={isModalOpened}
         onClose={() => setIsModalOpened(false)}
       >
         <Circle style={styles.circle} bg={rgba(colors.live, 0.1)} size={56}>
@@ -51,7 +51,7 @@ const TransactionsPendingConfirmationWarning = ({
         <LText style={styles.modalDesc} color="smoke">
           <Trans i18nKey={"portfolio.transactionsPendingConfirmation.desc"} />
         </LText>
-      </BottomModal>
+      </QueuedDrawer>
     </View>
   ) : null;
 };

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/InfoPanel.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/InfoPanel.tsx
@@ -8,7 +8,7 @@ import type { TranslatableString } from "@ledgerhq/live-common/platform/types";
 import { languageSelector } from "../../reducers/settings";
 import ExternalLinkIcon from "../../icons/ExternalLink";
 import AppIcon from "../../screens/Platform/AppIcon";
-import BottomModal from "../BottomModal";
+import QueuedDrawer from "../QueuedDrawer";
 import LText from "../LText";
 
 type Props = {
@@ -39,9 +39,9 @@ const InfoPanel = ({
     Linking.openURL(url);
   }, []);
   return (
-    <BottomModal
+    <QueuedDrawer
       style={{ ...styles.root, backgroundColor: colors.card }}
-      isOpened={isOpened}
+      isRequestingToBeOpened={isOpened}
       onClose={onClose}
     >
       <View style={{ ...styles.flexRow, ...styles.titleContainer }}>
@@ -107,7 +107,7 @@ const InfoPanel = ({
           </TouchableOpacity>
         </>
       ) : null}
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -34,6 +34,7 @@ export enum ScreenName {
   DebugCrash = "DebugCrash",
   DebugCustomImageGraphics = "DebugCustomImageGraphics",
   DebugDebugging = "DebugDebugging",
+  DebugDrawers = "DebugDrawers",
   DebugEnv = "DebugEnv",
   DebugExport = "DebugExport",
   DebugFeatureFlags = "DebugFeatureFlags",

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -34,7 +34,7 @@ export enum ScreenName {
   DebugCrash = "DebugCrash",
   DebugCustomImageGraphics = "DebugCustomImageGraphics",
   DebugDebugging = "DebugDebugging",
-  DebugDrawers = "DebugDrawers",
+  DebugQueuedDrawers = "DebugQueuedDrawers",
   DebugEnv = "DebugEnv",
   DebugExport = "DebugExport",
   DebugFeatureFlags = "DebugFeatureFlags",

--- a/apps/ledger-live-mobile/src/context/AuthPass/AuthScreen.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/AuthScreen.tsx
@@ -21,7 +21,7 @@ import LText from "../../components/LText";
 import TranslatedError from "../../components/TranslatedError";
 import { BaseButton } from "../../components/Button";
 import PoweredByLedger from "../../screens/Settings/PoweredByLedger";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import HardResetModal from "../../components/HardResetModal";
 import Touchable from "../../components/Touchable";
 import PasswordInput from "../../components/PasswordInput";
@@ -272,9 +272,12 @@ class AuthScreen extends PureComponent<Props, State> {
               <PoweredByLedger />
             </View>
           )}
-          <BottomModal isOpened={isModalOpened} onClose={this.onRequestClose}>
+          <QueuedDrawer
+            isRequestingToBeOpened={isModalOpened}
+            onClose={this.onRequestClose}
+          >
             <HardResetModal />
-          </BottomModal>
+          </QueuedDrawer>
         </SafeAreaView>
       </KeyboardBackgroundDismiss>
     );

--- a/apps/ledger-live-mobile/src/families/algorand/OptInFlow/01-SelectToken.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/OptInFlow/01-SelectToken.tsx
@@ -27,7 +27,7 @@ import FirstLetterIcon from "../../../components/FirstLetterIcon";
 import KeyboardView from "../../../components/KeyboardView";
 import InfoIcon from "../../../components/InfoIcon";
 import Info from "../../../icons/Info";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import type { StackNavigatorProps } from "../../../components/RootNavigator/types/helpers";
 import type { AlgorandOptInFlowParamList } from "./types";
 
@@ -179,7 +179,10 @@ export default function DelegationStarted({ navigation, route }: Props) {
           />
         </View>
       </KeyboardView>
-      <BottomModal isOpened={!!infoModalOpen} onClose={closeModal}>
+      <QueuedDrawer
+        isRequestingToBeOpened={!!infoModalOpen}
+        onClose={closeModal}
+      >
         <View style={styles.modal}>
           <View style={styles.infoIcon}>
             <InfoIcon bg={colors.lightLive}>
@@ -202,7 +205,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
             </LText>
           </View>
         </View>
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -22,7 +22,7 @@ import Touchable from "../../../components/Touchable";
 import SendRowsFee from "../SendRowsFee";
 import Clock from "../../../icons/Clock";
 import LText from "../../../components/LText";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import InfoIcon from "../../../components/InfoIcon";
 import Line from "../components/Line";
 import Words from "../components/Words";
@@ -200,7 +200,10 @@ export default function WithdrawAmount({ navigation, route }: Props) {
           pending={bridgePending}
         />
       </View>
-      <BottomModal isOpened={!!infoModalOpen} onClose={closeModal}>
+      <QueuedDrawer
+        isRequestingToBeOpened={!!infoModalOpen}
+        onClose={closeModal}
+      >
         <View style={styles.modal}>
           <View style={styles.infoIcon}>
             <InfoIcon bg={colors.lightLive}>
@@ -219,7 +222,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
             </LText>
           </View>
         </View>
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/families/hedera/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Confirmation.tsx
@@ -19,7 +19,7 @@ import PreventNativeBack from "../../components/PreventNativeBack";
 import LText from "../../components/LText/index";
 import DisplayAddress from "../../components/DisplayAddress";
 import Alert from "../../components/Alert";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import Close from "../../icons/Close";
 import QRcodeZoom from "../../icons/QRcodeZoom";
 import Touchable from "../../components/Touchable";
@@ -235,8 +235,8 @@ export default function ReceiveConfirmation({ navigation, route }: Props) {
           <QRCode size={width - 66} value={address} ecl="H" />
         </View>
       </ReactNativeModal>
-      <BottomModal
-        isOpened={isModalOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isModalOpened}
         onClose={onModalClose}
         onModalHide={onModalHide.current}
       >
@@ -261,7 +261,7 @@ export default function ReceiveConfirmation({ navigation, route }: Props) {
         >
           <Close color={colors.fog} size={20} />
         </Touchable>
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/families/polkadot/components/NominationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/components/NominationDrawer.tsx
@@ -9,7 +9,7 @@ import { useTheme } from "@react-navigation/native";
 import DelegatingContainer from "../../tezos/DelegatingContainer";
 import { rgba } from "../../../colors";
 import getWindowDimensions from "../../../logic/getWindowDimensions";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import Circle from "../../../components/Circle";
 import LText from "../../../components/LText";
 import CurrencyIcon from "../../../components/CurrencyIcon";
@@ -41,7 +41,11 @@ export default function NominationDrawer({
   const color = getCurrencyColor(currency);
   const iconWidth = normalize(64);
   return (
-    <BottomModal style={styles.modal} isOpened={isOpen} onClose={onClose}>
+    <QueuedDrawer
+      style={styles.modal}
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+    >
       <View style={styles.root}>
         {isNominated ? (
           <DelegatingContainer
@@ -77,7 +81,7 @@ export default function NominationDrawer({
           ))}
         </ScrollView>
       </View>
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 type FieldType = {

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/01-SelectAsset.tsx
@@ -26,7 +26,7 @@ import FirstLetterIcon from "../../../components/FirstLetterIcon";
 import KeyboardView from "../../../components/KeyboardView";
 import InfoIcon from "../../../components/InfoIcon";
 import Info from "../../../icons/Info";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import { StackNavigatorProps } from "../../../components/RootNavigator/types/helpers";
 import { StellarAddAssetFlowParamList } from "./types";
 
@@ -187,7 +187,10 @@ export default function DelegationStarted({ navigation, route }: Props) {
           />
         </View>
       </KeyboardView>
-      <BottomModal isOpened={!!infoModalOpen} onClose={closeModal}>
+      <QueuedDrawer
+        isRequestingToBeOpened={!!infoModalOpen}
+        onClose={closeModal}
+      >
         <View style={styles.modal}>
           <View style={styles.infoIcon}>
             <InfoIcon bg={colors.lightLive}>
@@ -210,7 +213,7 @@ export default function DelegationStarted({ navigation, route }: Props) {
             </LText>
           </View>
         </View>
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationDetailsModal.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationDetailsModal.tsx
@@ -25,7 +25,7 @@ import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import CounterValue from "../../components/CounterValue";
 import CurrencyIcon from "../../components/CurrencyIcon";
 import Touchable from "../../components/Touchable";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import Circle from "../../components/Circle";
 import NavigationScrollView from "../../components/NavigationScrollView";
 import { rgba } from "../../colors";
@@ -204,7 +204,11 @@ export default function DelegationDetailsModal({
   const height = Math.min(getWindowDimensions().height - 400, 280);
   return (
     // TODO use DelegationDrawer component
-    <BottomModal isOpened={isOpened} onClose={onClose} style={styles.modal}>
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpened}
+      onClose={onClose}
+      style={styles.modal}
+    >
       <View style={styles.root}>
         <DelegatingContainer
           left={
@@ -339,6 +343,6 @@ export default function DelegationDetailsModal({
           </View>
         )}
       </View>
-    </BottomModal>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/families/tron/VoteFlow/02-VoteModal.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/VoteFlow/02-VoteModal.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet, TextInput } from "react-native";
 import { Trans, useTranslation } from "react-i18next";
 import { Vote } from "@ledgerhq/live-common/families/tron/types";
 import { useTheme } from "@react-navigation/native";
-import { BottomDrawer, Flex, Link } from "@ledgerhq/native-ui";
+import { Flex, Link } from "@ledgerhq/native-ui";
 import { TrashMedium } from "@ledgerhq/native-ui/assets/icons";
 import Switch from "../../../components/Switch";
 import LText from "../../../components/LText";
@@ -12,6 +12,7 @@ import getFontStyle from "../../../components/LText/getFontStyle";
 import KeyboardView from "../../../components/KeyboardView";
 
 import Button from "../../../components/wrappedUi/Button";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type Props = {
   vote: Vote;
@@ -81,8 +82,8 @@ const VoteModal = ({
   const error = value <= 0 || value > votesAvailable;
 
   return (
-    <BottomDrawer
-      isOpen={!!vote}
+    <QueuedDrawer
+      isRequestingToBeOpened={!!vote}
       onClose={onClose}
       onModalShow={focusInput}
       title={name || address}
@@ -193,7 +194,7 @@ const VoteModal = ({
           </View>
         </KeyboardView>
       </View>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/modals/Info.tsx
+++ b/apps/ledger-live-mobile/src/modals/Info.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
-import BottomModal from "../components/BottomModal";
+import QueuedDrawer from "../components/QueuedDrawer";
 import LText, { Opts } from "../components/LText";
 
 type Props = {
@@ -21,7 +21,11 @@ export type ModalInfo = {
 };
 export default function InfoModal({ data, isOpened, onClose }: Props) {
   return (
-    <BottomModal style={styles.root} isOpened={isOpened} onClose={onClose}>
+    <QueuedDrawer
+      style={styles.root}
+      isRequestingToBeOpened={isOpened}
+      onClose={onClose}
+    >
       {data.map(
         (
           {
@@ -57,7 +61,7 @@ export default function InfoModal({ data, isOpened, onClose }: Props) {
           </View>
         ),
       )}
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 const styles = StyleSheet.create({

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -69,6 +69,7 @@ import type {
   SettingsSetOverriddenFeatureFlagsPlayload,
   SettingsSetFeatureFlagsBannerVisiblePayload,
   DangerouslyOverrideStatePayload,
+  SettingsSetDebugAppLevelDrawerOpenedPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -164,6 +165,7 @@ export const INITIAL_STATE: SettingsState = {
   displayStatusCenter: false,
   overriddenFeatureFlags: {},
   featureFlagsBannerVisible: false,
+  debugAppLevelDrawerOpened: false,
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -623,6 +625,15 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
       featureFlagsBannerVisible,
     };
   },
+  [SettingsActionTypes.SET_DEBUG_APP_LEVEL_DRAWER_OPENED]: (state, action) => {
+    const {
+      payload: { debugAppLevelDrawerOpened },
+    } = action as Action<SettingsSetDebugAppLevelDrawerOpenedPayload>;
+    return {
+      ...state,
+      debugAppLevelDrawerOpened,
+    };
+  },
 };
 
 export default handleActions<SettingsState, SettingsPayload>(
@@ -850,3 +861,5 @@ export const overriddenFeatureFlagsSelector = (state: State) =>
   state.settings.overriddenFeatureFlags;
 export const featureFlagsBannerVisibleSelector = (state: State) =>
   state.settings.featureFlagsBannerVisible;
+export const debugAppLevelDrawerOpenedSelector = (state: State) =>
+  state.settings.debugAppLevelDrawerOpened;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -226,6 +226,7 @@ export type SettingsState = {
   displayStatusCenter: boolean;
   overriddenFeatureFlags: { [key in FeatureId]?: Feature | undefined };
   featureFlagsBannerVisible: boolean;
+  debugAppLevelDrawerOpened: boolean;
 };
 
 export type NotificationsSettings = {

--- a/apps/ledger-live-mobile/src/screens/AccountSettings/DeleteAccountModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/AccountSettings/DeleteAccountModal.tsx
@@ -1,9 +1,10 @@
 import React, { memo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Account } from "@ledgerhq/types-live";
-import { BottomDrawer, Flex, Text } from "@ledgerhq/native-ui";
+import { Flex, Text } from "@ledgerhq/native-ui";
 import { InfoMedium } from "@ledgerhq/native-ui/assets/icons";
 import Button from "../../components/wrappedUi/Button";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 type Props = {
   onRequestClose: () => void;
@@ -16,8 +17,8 @@ function DeleteAccountModal({ isOpen, onRequestClose, deleteAccount }: Props) {
   const { t } = useTranslation();
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       onClose={onRequestClose}
       Icon={InfoMedium}
       iconColor={"error.c100"}
@@ -47,7 +48,7 @@ function DeleteAccountModal({ isOpen, onRequestClose, deleteAccount }: Props) {
           <Trans i18nKey="common.cancel" />
         </Button>
       </Flex>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Accounts/AccountOrderModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/AccountOrderModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer } from "@ledgerhq/native-ui";
 import OrderOption from "./OrderOption";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 const choices = ["balance|desc", "balance|asc", "name|asc", "name|desc"];
 
@@ -13,14 +13,14 @@ type Props = {
 export default function AccountOrderModal({ onClose, isOpened }: Props) {
   const { t } = useTranslation();
   return (
-    <BottomDrawer
+    <QueuedDrawer
       onClose={onClose}
-      isOpen={isOpened}
+      isRequestingToBeOpened={isOpened}
       title={t("common.sortBy")}
     >
       {choices.map(id => (
         <OrderOption key={id} id={id} />
       ))}
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
@@ -48,7 +48,7 @@ import GenericErrorBottomModal from "../../components/GenericErrorBottomModal";
 import NavigationScrollView from "../../components/NavigationScrollView";
 import { prepareCurrency } from "../../bridge/cache";
 import { blacklistedTokenIdsSelector } from "../../reducers/settings";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import { urls } from "../../config/urls";
 import noAssociatedAccountsByFamily from "../../generated/NoAssociatedAccounts";
 import { State } from "../../reducers/types";
@@ -500,7 +500,11 @@ const AddressTypeTooltip = ({
         onPress={onOpen}
         IconRight={Info}
       />
-      <BottomModal isOpened={isOpen} onClose={onClose} style={styles.modal}>
+      <QueuedDrawer
+        isRequestingToBeOpened={isOpen}
+        onClose={onClose}
+        style={styles.modal}
+      >
         <View style={styles.modalContainer}>
           <LText style={styles.subtitle} color="grey">
             <Trans i18nKey="addAccounts.addressTypeInfo.subtitle" />
@@ -534,7 +538,7 @@ const AddressTypeTooltip = ({
             onPress={() => Linking.openURL(urls.bitcoinAddressType)}
           />
         ) : null}
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/AddAccountsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/AddAccountsModal.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { BottomDrawer, Text } from "@ledgerhq/native-ui";
+import { Text } from "@ledgerhq/native-ui";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { NavigatorName } from "../../const";
 import { readOnlyModeEnabledSelector } from "../../reducers/settings";
 
+import QueuedDrawer from "../../components/QueuedDrawer";
 import { track, TrackScreen } from "../../analytics";
 import AddAccountsModalCard from "./AddAccountsModalCard";
 import { BaseNavigation } from "../../components/RootNavigator/types/helpers";
@@ -67,7 +68,7 @@ export default function AddAccountsModal({
   }, [onClose]);
 
   return (
-    <BottomDrawer isOpen={isOpened} onClose={onPressClose}>
+    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={onPressClose}>
       <TrackScreen category="Add/Import accounts" type="drawer" />
       <Text variant="h4" fontWeight="semiBold" fontSize="24px" mb={2}>
         {t("addAccountsModal.title")}
@@ -98,6 +99,6 @@ export default function AddAccountsModal({
         onPress={onClickImport}
         imageSource={syncCryptoImg}
       />
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Lending/Dashboard/InfoModalBottom.tsx
+++ b/apps/ledger-live-mobile/src/screens/Lending/Dashboard/InfoModalBottom.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet } from "react-native";
 import { DefaultTheme } from "styled-components/native";
 import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
 import { rgba, Theme, withTheme } from "../../../colors";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import LText from "../../../components/LText";
 import Button from "../../../components/Button";
 import TrackScreen from "../../../analytics/TrackScreen";
@@ -44,9 +44,9 @@ class ConfirmationModal extends PureComponent<Props> {
       ...rest
     } = this.props;
     return (
-      <BottomModal
+      <QueuedDrawer
         {...rest}
-        isOpened={isOpened}
+        isRequestingToBeOpened={isOpened}
         onClose={onClose}
         style={styles.confirmationModal}
       >
@@ -95,7 +95,7 @@ class ConfirmationModal extends PureComponent<Props> {
             />
           ) : null}
         </View>
-      </BottomModal>
+      </QueuedDrawer>
     );
   }
 }

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -5,7 +5,7 @@ import { Language, DeviceInfo } from "@ledgerhq/types-live";
 import { useAvailableLanguagesForDevice } from "@ledgerhq/live-common/manager/hooks";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import DeviceLanguageSelection from "./DeviceLanguageSelection";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import ChangeDeviceLanguageActionModal from "../../../components/ChangeDeviceLanguageActionModal";
 import { track } from "../../../analytics";
 import DeviceOptionRow from "./DeviceOptionRow";
@@ -87,8 +87,8 @@ const DeviceLanguage: React.FC<Props> = ({
           )
         }
       />
-      <BottomModal
-        isOpened={isChangeLanguageOpen}
+      <QueuedDrawer
+        isRequestingToBeOpened={isChangeLanguageOpen}
         onClose={closeChangeLanguageModal}
         onModalHide={openDeviceActionModal}
       >
@@ -100,7 +100,7 @@ const DeviceLanguage: React.FC<Props> = ({
           onConfirmInstall={confirmInstall}
           availableLanguages={availableLanguages}
         />
-      </BottomModal>
+      </QueuedDrawer>
       <ChangeDeviceLanguageActionModal
         onClose={closeDeviceActionModal}
         device={deviceForActionModal}

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/ActionModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/ActionModal.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { StyleSheet, View } from "react-native";
 import type { BaseButtonProps } from "../../../components/Button";
 import Button from "../../../components/Button";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import getWindowDimensions from "../../../logic/getWindowDimensions";
 
 const { height } = getWindowDimensions();
@@ -20,9 +20,9 @@ const ActionModal = ({
   actions = [],
   ...rest
 }: Props) => (
-  <BottomModal
+  <QueuedDrawer
     {...rest}
-    isOpened={isOpened}
+    isRequestingToBeOpened={isOpened}
     onClose={onClose}
     preventBackdropClick={false}
     containerStyle={{
@@ -46,7 +46,7 @@ const ActionModal = ({
         </View>
       )}
     </View>
-  </BottomModal>
+  </QueuedDrawer>
 );
 
 const styles = StyleSheet.create({

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/AppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/AppDependenciesModal.tsx
@@ -11,7 +11,7 @@ import { Flex, Icons, Text, Button } from "@ledgerhq/native-ui";
 import { hasInstalledAnyAppSelector } from "../../../reducers/settings";
 import { installAppFirstTime } from "../../../actions/settings";
 import AppIcon from "../AppsList/AppIcon";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type Props = {
   appInstallWithDependencies: { app: App; dependencies: App[] };
@@ -79,7 +79,7 @@ function AppDependenciesModal({
   }, [dispatch, dispatchProps, onClose, name, hasInstalledAnyApp]);
 
   return (
-    <BottomModal isOpened={!!app} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={!!app} onClose={onClose}>
       <Flex alignItems="center">
         {!!dependencies.length && (
           <>
@@ -128,7 +128,7 @@ function AppDependenciesModal({
           </>
         )}
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppModal.tsx
@@ -14,7 +14,7 @@ import { NavigatorName, ScreenName } from "../../../const";
 
 import AppIcon from "../AppsList/AppIcon";
 
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import type {
   BaseComposite,
   StackNavigatorProps,
@@ -101,7 +101,10 @@ const InstallSuccessBar = ({ state, navigation, disable }: Props) => {
   const onClose = useCallback(() => setHasBeenShown(true), []);
 
   return (
-    <BottomModal isOpened={successInstalls.length >= 1} onClose={onClose}>
+    <QueuedDrawer
+      isRequestingToBeOpened={successInstalls.length >= 1}
+      onClose={onClose}
+    >
       <Flex alignItems="center">
         {app && <AppIcon app={app} size={48} radius={14} />}
         <TextContainer>
@@ -131,7 +134,7 @@ const InstallSuccessBar = ({ state, navigation, disable }: Props) => {
           )}
         </ButtonsContainer>
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/QuitManagerModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/QuitManagerModal.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity } from "react-native";
 import { Trans } from "react-i18next";
 import styled from "styled-components/native";
 import { Flex, Icons, Text, Button } from "@ledgerhq/native-ui";
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type Props = {
   isOpened: boolean;
@@ -61,7 +61,11 @@ const QuitManagerModal = ({
   );
 
   return (
-    <BottomModal isOpened={!!isOpened} onClose={onClose} noCloseButton>
+    <QueuedDrawer
+      isRequestingToBeOpened={!!isOpened}
+      onClose={onClose}
+      noCloseButton
+    >
       <Flex alignItems="center">
         <IconContainer borderColor="neutral.c40">
           <Icons.QuitMedium size={24} color="neutral.c100" />
@@ -92,7 +96,7 @@ const QuitManagerModal = ({
           </CancelButton>
         </ButtonsContainer>
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/StorageWarningModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/StorageWarningModal.tsx
@@ -3,7 +3,7 @@ import { Trans } from "react-i18next";
 import styled from "styled-components/native";
 import { Text, Flex, Icons, Button } from "@ledgerhq/native-ui";
 
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type Props = {
   warning: string | null;
@@ -36,7 +36,7 @@ const ButtonsContainer = styled(Flex).attrs({
 })``;
 
 const StorageWarningModal = ({ warning, onClose }: Props) => (
-  <BottomModal isOpened={!!warning} onClose={onClose}>
+  <QueuedDrawer isRequestingToBeOpened={!!warning} onClose={onClose}>
     <Flex alignItems="center">
       <IconContainer borderColor="neutral.c40">
         <Icons.StorageMedium size={24} color="error.c100" />
@@ -58,7 +58,7 @@ const StorageWarningModal = ({ warning, onClose }: Props) => (
         </Button>
       </ButtonsContainer>
     </Flex>
-  </BottomModal>
+  </QueuedDrawer>
 );
 
 export default memo(StorageWarningModal);

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallDependenciesModal.tsx
@@ -10,7 +10,7 @@ import { Flex, Text, Button } from "@ledgerhq/native-ui";
 import AppTree from "../../../icons/AppTree";
 import AppIcon from "../AppsList/AppIcon";
 
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import CollapsibleList from "../../../components/CollapsibleList";
 import ListTreeLine from "../../../icons/ListTreeLine";
 
@@ -91,7 +91,7 @@ const UninstallDependenciesModal = ({
     [colors.grey],
   );
   return (
-    <BottomModal isOpened={!!app} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={!!app} onClose={onClose}>
       <Flex alignItems="center">
         {app && dependents.length && (
           <View style={{ width: "100%" }}>
@@ -137,7 +137,7 @@ const UninstallDependenciesModal = ({
           </View>
         )}
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UpdateAllModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UpdateAllModal.tsx
@@ -6,7 +6,7 @@ import { App } from "@ledgerhq/types-live";
 import styled from "styled-components/native";
 import { Flex, Icons, Text, Button } from "@ledgerhq/native-ui";
 
-import BottomModal from "../../../components/BottomModal";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 import AppIcon from "../AppsList/AppIcon";
 import ByteSize from "../../../components/ByteSize";
@@ -152,7 +152,7 @@ const UpdateAllModal = ({
   );
 
   return (
-    <BottomModal isOpened={!!isOpened} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={!!isOpened} onClose={onClose}>
       <Flex alignItems="center">
         <IconContainer borderColor="neutral.c40">
           <Icons.RefreshMedium size={24} color="neutral.c100" />
@@ -177,7 +177,7 @@ const UpdateAllModal = ({
           </Button>
         </ButtonsContainer>
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Market/SortBadge.tsx
+++ b/apps/ledger-live-mobile/src/screens/Market/SortBadge.tsx
@@ -1,8 +1,9 @@
 import React, { memo, useState, useCallback } from "react";
 import { TouchableOpacity } from "react-native";
 import styled from "styled-components/native";
-import { Flex, Text, BottomDrawer, Icon as IconUI } from "@ledgerhq/native-ui";
+import { Flex, Text, Icon as IconUI } from "@ledgerhq/native-ui";
 import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export const Badge = styled(Flex).attrs((p: { bg?: string }) => ({
   bg: p.bg ?? "neutral.c30",
@@ -76,7 +77,11 @@ function SortBadge({
           ) : null}
         </Badge>
       </TouchableOpacity>
-      <BottomDrawer isOpen={isDrawerOpen} onClose={closeDrawer} title={label}>
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawerOpen}
+        onClose={closeDrawer}
+        title={label}
+      >
         {options.map(
           ({ label, value: optValue, requestParam }: Option, index) => (
             <TouchableOpacity
@@ -113,7 +118,7 @@ function SortBadge({
             </TouchableOpacity>
           ),
         )}
-      </BottomDrawer>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Modals/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Modals/index.tsx
@@ -8,6 +8,7 @@ import PushNotificationsModal from "../PushNotificationsModal";
 import RatingsModal from "../RatingsModal";
 import useRatings from "../../logic/ratings";
 import useNotifications from "../../logic/notifications";
+import DebugAppLevelDrawer from "../../components/DebugAppLevelDrawer";
 
 const getCurrentRouteName = (
   state: NavigationState | Required<NavigationState["routes"][0]>["state"],
@@ -79,6 +80,7 @@ const Modals = () => {
       <FeatureToggle feature="ratingsPrompt">
         <RatingsModal />
       </FeatureToggle>
+      <DebugAppLevelDrawer />
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/Nft/NftGallery/ReceiveNFTsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Nft/NftGallery/ReceiveNFTsModal.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Button, Text } from "@ledgerhq/native-ui";
+import { Button, Text } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
 import { Linking } from "react-native";
 import Svg, { G, Path, Rect, Mask } from "react-native-svg";
 import { NavigatorName, ScreenName } from "../../../const";
 import { track, TrackScreen } from "../../../analytics";
 import { urls } from "../../../config/urls";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type Props = {
   isOpened: boolean;
@@ -59,9 +60,9 @@ export default function ReceiveNFTsModal({ onClose, isOpened }: Props) {
   }, [onClose, openSupportLink]);
 
   return (
-    <BottomDrawer
+    <QueuedDrawer
       title={t("wallet.nftGallery.receiveModal.title")}
-      isOpen={isOpened}
+      isRequestingToBeOpened={isOpened}
       onClose={onPressClose}
       Icon={<EthPolygonIcons />}
     >
@@ -89,7 +90,7 @@ export default function ReceiveNFTsModal({ onClose, isOpened }: Props) {
       <Button size="large" type="default" onPress={onClickLearnMore}>
         {t("wallet.nftGallery.receiveModal.info")}
       </Button>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/NotificationCenter/Status.tsx
+++ b/apps/ledger-live-mobile/src/screens/NotificationCenter/Status.tsx
@@ -2,10 +2,11 @@ import React, { useCallback } from "react";
 import { Linking } from "react-native";
 import { Trans, useTranslation } from "react-i18next";
 import { useFilteredServiceStatus } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/index";
-import { BottomDrawer, Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
+import { Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
 
 import styled, { useTheme } from "styled-components/native";
 
+import QueuedDrawer from "../../components/QueuedDrawer";
 import { urls } from "../../config/urls";
 import { track, TrackScreen } from "../../analytics";
 
@@ -47,7 +48,7 @@ export default function StatusCenter({ onClose, isOpened }: Props) {
   }, [onClose]);
 
   return (
-    <BottomDrawer isOpen={isOpened} onClose={onPressClose}>
+    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={onPressClose}>
       <TrackScreen
         category={DATA_TRACKING_DRAWER_NAME}
         type="drawer"
@@ -112,7 +113,7 @@ export default function StatusCenter({ onClose, isOpened }: Props) {
       <Button type="main" size="large" onPress={onPressOk} mt={8} mb={4}>
         {t("notificationCenter.status.cta.ok")}
       </Button>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/shared/SeedWarning.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/shared/SeedWarning.tsx
@@ -5,7 +5,6 @@ import { Trans } from "react-i18next";
 import { getDeviceModel, DeviceModelId } from "@ledgerhq/devices";
 import {
   Text,
-  BottomDrawer,
   Button,
   Alert,
   Flex,
@@ -13,6 +12,7 @@ import {
   Icons,
 } from "@ledgerhq/native-ui";
 import { urls } from "../../../config/urls";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 const SeedWarning = ({ deviceModelId }: { deviceModelId: DeviceModelId }) => {
   const deviceName = getDeviceModel(deviceModelId).productName;
@@ -23,7 +23,7 @@ const SeedWarning = ({ deviceModelId }: { deviceModelId: DeviceModelId }) => {
   }, []);
 
   return (
-    <BottomDrawer isOpen={isOpened} onClose={() => setIsOpened(false)}>
+    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={() => setIsOpened(false)}>
       <Flex alignItems="center">
         <IconBox
           Icon={Icons.WarningMedium}
@@ -55,7 +55,7 @@ const SeedWarning = ({ deviceModelId }: { deviceModelId: DeviceModelId }) => {
       <Button type="default" outline={false} onPress={onContactSupport}>
         <Trans i18nKey="onboarding.warning.seed.contactSupportCTA" />
       </Button>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Onboarding/shared/SeedWarning.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/shared/SeedWarning.tsx
@@ -3,14 +3,7 @@ import React, { useState, useCallback } from "react";
 import { Linking } from "react-native";
 import { Trans } from "react-i18next";
 import { getDeviceModel, DeviceModelId } from "@ledgerhq/devices";
-import {
-  Text,
-  Button,
-  Alert,
-  Flex,
-  IconBox,
-  Icons,
-} from "@ledgerhq/native-ui";
+import { Text, Button, Alert, Flex, IconBox, Icons } from "@ledgerhq/native-ui";
 import { urls } from "../../../config/urls";
 import QueuedDrawer from "../../../components/QueuedDrawer";
 
@@ -23,7 +16,10 @@ const SeedWarning = ({ deviceModelId }: { deviceModelId: DeviceModelId }) => {
   }, []);
 
   return (
-    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={() => setIsOpened(false)}>
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpened}
+      onClose={() => setIsOpened(false)}
+    >
       <Flex alignItems="center">
         <IconBox
           Icon={Icons.WarningMedium}

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { I18nManager, ScrollView } from "react-native";
 import { Trans } from "react-i18next";
-import { Flex, SelectableList, BottomDrawer } from "@ledgerhq/native-ui";
+import { Flex, SelectableList } from "@ledgerhq/native-ui";
 import i18next from "i18next";
 import RNRestart from "react-native-restart";
 import { useDispatch, useSelector } from "react-redux";
@@ -37,6 +37,7 @@ import {
 import { OnboardingNavigatorParamList } from "../../../components/RootNavigator/types/OnboardingNavigator";
 import { BaseOnboardingNavigatorParamList } from "../../../components/RootNavigator/types/BaseOnboardingNavigator";
 import Button from "../../../components/Button";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type NavigationProps = CompositeScreenProps<
   StackNavigatorProps<
@@ -185,8 +186,8 @@ function OnboardingStepLanguage({ navigation }: NavigationProps) {
           </Flex>
         </ScrollView>
       </Flex>
-      <BottomDrawer
-        isOpen={isDeviceLanguagePromptOpen}
+      <QueuedDrawer
+        isRequestingToBeOpened={isDeviceLanguagePromptOpen}
         onClose={closeDeviceLanguagePrompt}
         preventBackdropClick={preventPromptBackdropClick}
       >
@@ -226,9 +227,9 @@ function OnboardingStepLanguage({ navigation }: NavigationProps) {
             />
           )}
         </Flex>
-      </BottomDrawer>
-      <BottomDrawer
-        isOpen={isRestartPromptOpened}
+      </QueuedDrawer>
+      <QueuedDrawer
+        isRequestingToBeOpened={isRestartPromptOpened}
         preventBackdropClick={false}
         title={<Trans i18nKey={"onboarding.stepLanguage.RestartModal.title"} />}
         description={
@@ -253,7 +254,7 @@ function OnboardingStepLanguage({ navigation }: NavigationProps) {
             onPress={changeLanguageRTL}
           />
         </Flex>
-      </BottomDrawer>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Modal.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Modal.tsx
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import { Currency } from "@ledgerhq/types-cryptoassets";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import Circle from "../../components/Circle";
 import IconInfo from "../../icons/Info";
 import LText from "../../components/LText";
@@ -23,7 +23,7 @@ function Modal({ isOpened, onClose, currency }: Props) {
   const tokenType =
     currency.type === "TokenCurrency" ? currency.tokenType : "erc20";
   return (
-    <BottomModal isOpened={isOpened} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={onClose}>
       <SafeAreaView style={styles.modal}>
         <Circle bg={rgba(colors.live, 0.1)} size={56}>
           <IconInfo size={24} color={colors.live} />
@@ -54,7 +54,7 @@ function Modal({ isOpened, onClose, currency }: Props) {
           />
         </View>
       </SafeAreaView>
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Platform/DAppDisclaimer.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/DAppDisclaimer.tsx
@@ -8,7 +8,7 @@ import {
   Icons,
   Button,
 } from "@ledgerhq/native-ui";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import AppIcon from "./AppIcon";
 import LedgerIcon from "../../icons/Ledger";
 
@@ -62,7 +62,7 @@ const DAppDisclaimer = ({
   }, [disableDisclaimerChecked, closeDisclaimer, disableDisclaimer, next]);
 
   return (
-    <BottomModal isOpened={isOpened} onClose={onClose}>
+    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={onClose}>
       <Flex
         flexDirection="row"
         justifyContent="center"
@@ -131,7 +131,7 @@ const DAppDisclaimer = ({
           {t("platform.disclaimer.CTA")}
         </Button>
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/PurchaseDevice/DebugMessageDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PurchaseDevice/DebugMessageDrawer.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Flex, Text } from "@ledgerhq/native-ui";
+import { Flex, Text } from "@ledgerhq/native-ui";
 
+import QueuedDrawer from "../../components/QueuedDrawer";
 import { PurchaseMessage } from "./types";
 
 export type Props = {
@@ -18,8 +19,8 @@ const DebugMessageDrawer = ({ isOpen, message, onClose }: Props) => {
   }, [onClose]);
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       onClose={handleClose}
       title={t(
         `purchaseDevice.debugDrawers.message.${
@@ -58,7 +59,7 @@ const DebugMessageDrawer = ({ isOpen, message, onClose }: Props) => {
           })}
         </Text>
       )}
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/PurchaseDevice/DebugURLDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PurchaseDevice/DebugURLDrawer.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Button } from "@ledgerhq/native-ui";
+import { Button } from "@ledgerhq/native-ui";
 
+import QueuedDrawer from "../../components/QueuedDrawer";
 import TextInput from "../../components/TextInput";
 
 export type Props = {
@@ -26,8 +27,8 @@ const DebugURLDrawer = ({ isOpen, value, onClose, onChange }: Props) => {
   }, [inputValue, onClose, onChange]);
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       onClose={handleClose}
       title={t("purchaseDevice.debugDrawers.url.title")}
       subtitle={t("purchaseDevice.debugDrawers.url.subtitle")}
@@ -41,7 +42,7 @@ const DebugURLDrawer = ({ isOpen, value, onClose, onChange }: Props) => {
       <Button type="main" mt={4} onPress={handleSave}>
         {t("purchaseDevice.debugDrawers.url.cta")}
       </Button>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/PushNotificationsModal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PushNotificationsModal/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  BottomDrawer,
   Flex,
   Text,
   Link as TextLink,
@@ -14,6 +13,7 @@ import PromptNotifGenericLight from "../../images/illustration/Light/_PromptNoti
 import PromptNotifMarketDark from "../../images/illustration/Dark/_PromptNotifMarket.png";
 import PromptNotifMarketLight from "../../images/illustration/Light/_PromptNotifMarket.png";
 import { TrackScreen } from "../../analytics";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 const PushNotificationsModal = () => {
   const { t } = useTranslation();
@@ -48,7 +48,7 @@ const PushNotificationsModal = () => {
       />
     );
   return (
-    <BottomDrawer isOpen={isPushNotificationsModalOpen} noCloseButton>
+    <QueuedDrawer isRequestingToBeOpened={isPushNotificationsModalOpen} noCloseButton>
       <TrackScreen
         category="Notification Prompt"
         name={
@@ -82,7 +82,7 @@ const PushNotificationsModal = () => {
           {t("notifications.prompt.later")}
         </TextLink>
       </Flex>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/PushNotificationsModal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PushNotificationsModal/index.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Flex,
-  Text,
-  Link as TextLink,
-  Button,
-} from "@ledgerhq/native-ui";
+import { Flex, Text, Link as TextLink, Button } from "@ledgerhq/native-ui";
 import useNotifications from "../../logic/notifications";
 import Illustration from "../../images/illustration/Illustration";
 import PromptNotifGenericDark from "../../images/illustration/Dark/_PromptNotifGeneric.png";
@@ -48,7 +43,10 @@ const PushNotificationsModal = () => {
       />
     );
   return (
-    <QueuedDrawer isRequestingToBeOpened={isPushNotificationsModalOpen} noCloseButton>
+    <QueuedDrawer
+      isRequestingToBeOpened={isPushNotificationsModalOpen}
+      noCloseButton
+    >
       <TrackScreen
         category="Notification Prompt"
         name={

--- a/apps/ledger-live-mobile/src/screens/RatingsModal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/RatingsModal/index.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
-import { BottomDrawer } from "@ledgerhq/native-ui";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
 } from "react-native-reanimated";
 import useRatings from "../../logic/ratings";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import Init from "./Init";
 import Enjoy from "./Enjoy";
 import Disappointed from "./Disappointed";
@@ -78,8 +78,8 @@ const RatingsModal = () => {
   }, [closeModal, setStep, step]);
 
   return (
-    <BottomDrawer
-      isOpen={isRatingsModalOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isRatingsModalOpen}
       onClose={closeModal}
       onBackdropPress={handleBackdropClose}
       onBackButtonPress={handleBackdropClose}
@@ -89,7 +89,7 @@ const RatingsModal = () => {
       <Animated.ScrollView style={animatedStyle}>
         <Animated.View onLayout={onLayout}>{component}</Animated.View>
       </Animated.ScrollView>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/AdditionalInfoModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/AdditionalInfoModal.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
-import { BottomDrawer, Flex, Text, Button } from "@ledgerhq/native-ui";
+import { Flex, Text, Button } from "@ledgerhq/native-ui";
 import { track, TrackScreen } from "../../analytics";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 type Props = {
   isOpen: boolean;
@@ -27,7 +28,7 @@ const AdditionalInfoModal = ({ isOpen, onClose, currencyTicker }: Props) => {
   }, [onClose]);
 
   return (
-    <BottomDrawer isOpen={isOpen} onClose={handleClose}>
+    <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={handleClose}>
       <TrackScreen
         category="Receive"
         name="Explication Account Import/Creation"
@@ -58,7 +59,7 @@ const AdditionalInfoModal = ({ isOpen, onClose, currencyTicker }: Props) => {
           <Trans i18nKey="transfer.receive.additionalInfoModal.closeCta" />
         </Button>
       </Flex>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/ReceiveSecurityModal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/ReceiveSecurityModal/index.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useState, useMemo } from "react";
-import { BottomDrawer } from "@ledgerhq/native-ui";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
 } from "react-native-reanimated";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 import InitMessage from "./InitMessage";
 import ConfirmUnverified from "./ConfirmUnverified";
 
@@ -86,8 +86,8 @@ const ReceiveSecurityModal = ({
   }, [closeModal, onVerify, step]);
 
   return (
-    <BottomDrawer
-      isOpen={isModalOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isModalOpen}
       onClose={closeModal}
       noCloseButton
       preventBackdropClick
@@ -95,7 +95,7 @@ const ReceiveSecurityModal = ({
       <Animated.ScrollView style={animatedStyle}>
         <Animated.View onLayout={onLayout}>{component}</Animated.View>
       </Animated.ScrollView>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SendFunds/SummaryTotalSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/SummaryTotalSection.tsx
@@ -11,7 +11,7 @@ import SummaryRow from "./SummaryRow";
 import CounterValue from "../../components/CounterValue";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import LText from "../../components/LText";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import ModalBottomAction from "../../components/ModalBottomAction";
 import Button from "../../components/Button";
 import Circle from "../../components/Circle";
@@ -77,7 +77,10 @@ class SummaryTotalSection extends PureComponent<Props, State> {
             </LText>
           </View>
         </SummaryRow>
-        <BottomModal isOpened={isModalOpened} onClose={this.onRequestClose}>
+        <QueuedDrawer
+          isRequestingToBeOpened={isModalOpened}
+          onClose={this.onRequestClose}
+        >
           <ModalBottomAction
             title={<Trans i18nKey="send.summary.infoTotalTitle" />}
             icon={
@@ -97,7 +100,7 @@ class SummaryTotalSection extends PureComponent<Props, State> {
               </View>
             }
           />
-        </BottomModal>
+        </QueuedDrawer>
       </>
     );
   }

--- a/apps/ledger-live-mobile/src/screens/SendFunds/TooMuchUTXOBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/TooMuchUTXOBottomModal.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { View, StyleSheet } from "react-native";
 import { Trans } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import LText from "../../components/LText";
 import Button from "../../components/Button";
 import Info from "../../icons/Info";
@@ -17,9 +17,9 @@ type Props = {
 function ConfirmationModal({ isOpened, onClose, onPress, ...rest }: Props) {
   const { colors } = useTheme();
   return (
-    <BottomModal
+    <QueuedDrawer
       {...rest}
-      isOpened={isOpened}
+      isRequestingToBeOpened={isOpened}
       onClose={onClose}
       style={styles.confirmationModal}
     >
@@ -51,7 +51,7 @@ function ConfirmationModal({ isOpened, onClose, onPress, ...rest }: Props) {
           onPress={onPress}
         />
       </View>
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Accounts/TokenContextualModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Accounts/TokenContextualModal.tsx
@@ -12,7 +12,6 @@ import {
   getDefaultExplorerView,
 } from "@ledgerhq/live-common/explorers";
 import { createStructuredSelector } from "reselect";
-import { BottomDrawer } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
 import LText from "../../../components/LText";
 import { blacklistToken } from "../../../actions/settings";
@@ -25,6 +24,7 @@ import { NavigatorName } from "../../../const";
 import { StackNavigatorNavigation } from "../../../components/RootNavigator/types/helpers";
 import { PortfolioNavigatorStackParamList } from "../../../components/RootNavigator/types/PortfolioNavigator";
 import { State } from "../../../reducers/types";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 const mapDispatchToProps = {
   blacklistToken,
@@ -74,8 +74,8 @@ const TokenContextualModal = ({
     ? getAccountContractExplorer(explorerView, account, parentAccount!)
     : null;
   return (
-    <BottomDrawer
-      isOpen={isOpened}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpened}
       preventBackdropClick={false}
       Icon={
         showingContextMenu ? (
@@ -148,7 +148,7 @@ const TokenContextualModal = ({
           )}
         </>
       )}
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Connectivity/CommandSender.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Connectivity/CommandSender.tsx
@@ -17,7 +17,7 @@ import { SettingsNavigatorStackParamList } from "../../../../components/RootNavi
 
 import NavigationScrollView from "../../../../components/NavigationScrollView";
 import LText from "../../../../components/LText";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 
 const commandsById: { [key: string]: (transport: Transport) => unknown } = {
   getDeviceInfo,
@@ -92,8 +92,8 @@ const CommandSender = ({ route }: Props) => {
             {"Show commands"}
           </Button>
         ) : null}
-        <BottomModal
-          isOpened={modalVisible}
+        <QueuedDrawer
+          isRequestingToBeOpened={modalVisible}
           onClose={setModalVisible as () => void}
         >
           <ScrollView>
@@ -111,7 +111,7 @@ const CommandSender = ({ route }: Props) => {
               </Button>
             ))}
           </ScrollView>
-        </BottomModal>
+        </QueuedDrawer>
       </Flex>
     </NavigationScrollView>
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
@@ -14,7 +14,7 @@ import { dangerouslyOverrideState } from "../../../../actions/settings";
 import Button from "../../../../components/Button";
 import { SettingsActionTypes } from "../../../../actions/types";
 import { State } from "../../../../reducers/types";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 import TextInput from "../../../../components/FocusedTextInput";
 
 const Separator = styled(Flex).attrs({
@@ -186,7 +186,7 @@ export default function Store() {
       <ScrollView contentContainerStyle={{ flex: 0, paddingBottom: 170 }}>
         <Node data={modifiedState} onEdit={onEdit} />
       </ScrollView>
-      <BottomModal isOpened={isModalOpen} onClose={onRestore}>
+      <QueuedDrawer isRequestingToBeOpened={isModalOpen} onClose={onRestore}>
         <Alert
           type="error"
           title="Setting an invalid value may corrupt your app state requiring a full app reinstall."
@@ -210,7 +210,7 @@ export default function Store() {
           disabled={!hasMadeChanges}
           onPress={onConfirm}
         />
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/BLEPairingFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/BLEPairingFlow.tsx
@@ -145,7 +145,10 @@ export default () => {
         pairedDevice?.deviceName ?? pairedDevice?.deviceId ?? "no device"
       }`}
     >
-      <QueuedDrawer isRequestingToBeOpened={isDrawerOpen} onClose={onCloseDrawer}>
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawerOpen}
+        onClose={onCloseDrawer}
+      >
         <Flex mb="8">
           <Text variant="body" mb="8">
             Choose which device model to filter on:

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/BLEPairingFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/BLEPairingFlow.tsx
@@ -1,7 +1,6 @@
 import { useNavigation, useRoute } from "@react-navigation/native";
 import React, { useCallback, useState } from "react";
 import {
-  BottomDrawer,
   Text,
   Icons,
   Button,
@@ -23,6 +22,7 @@ import {
   StackNavigatorRoute,
 } from "../../../../components/RootNavigator/types/helpers";
 import { usePromptBluetoothCallback } from "../../../../logic/usePromptBluetoothCallback";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 
 const availableDeviceModelFilter = [
   "none",
@@ -145,7 +145,7 @@ export default () => {
         pairedDevice?.deviceName ?? pairedDevice?.deviceId ?? "no device"
       }`}
     >
-      <BottomDrawer isOpen={isDrawerOpen} onClose={onCloseDrawer}>
+      <QueuedDrawer isRequestingToBeOpened={isDrawerOpen} onClose={onCloseDrawer}>
         <Flex mb="8">
           <Text variant="body" mb="8">
             Choose which device model to filter on:
@@ -179,7 +179,7 @@ export default () => {
         <Button type="color" onPress={goToBlePairingFlow}>
           Go to pairing flow
         </Button>
-      </BottomDrawer>
+      </QueuedDrawer>
     </SettingsRow>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Drawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Drawers.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useState } from "react";
-import { Flex, Alert, Switch } from "@ledgerhq/native-ui";
+import { useNavigation } from "@react-navigation/native";
+import { Flex, Alert, Switch, Button, Text } from "@ledgerhq/native-ui";
 import BottomModal from "../../../../components/BottomModal";
+import { StackNavigatorNavigation } from "../../../../components/RootNavigator/types/helpers";
+import { SettingsNavigatorStackParamList } from "../../../../components/RootNavigator/types/SettingsNavigator";
+import { ScreenName } from "../../../../const";
 
 /**
  * Debugging screen to test:
@@ -9,6 +13,9 @@ import BottomModal from "../../../../components/BottomModal";
  * - opening/closing drawers after navigating and coming back
  */
 export default function DebugDrawers() {
+  const navigation =
+    useNavigation<StackNavigatorNavigation<SettingsNavigatorStackParamList>>();
+
   const [isDrawer1Open, setIsDrawer1Open] = useState(false);
   const [isDrawer2Open, setIsDrawer2Open] = useState(false);
   const [isDrawer3Open, setIsDrawer3Open] = useState(false);
@@ -60,6 +67,23 @@ export default function DebugDrawers() {
           type="info"
           title="Hey 🧙‍♀️ Test successive opening/closing drawers !"
         />
+        <Flex mt="6">
+          <Text>
+            Also, try navigating to a new screen by clicking on the button and
+            come back here with the back arrow. To check if the drawers are
+            still working.
+          </Text>
+
+          <Button
+            type="main"
+            onPress={() => navigation.navigate(ScreenName.DebugLottie)}
+            mt="4"
+            size="small"
+            outline
+          >
+            Navigate somewhere 🧞‍♂️
+          </Button>
+        </Flex>
       </Flex>
 
       <BottomModal

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Drawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Drawers.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useState } from "react";
+import { Flex, Alert, Switch } from "@ledgerhq/native-ui";
+import BottomModal from "../../../../components/BottomModal";
+
+/**
+ * Debugging screen to test:
+ * - opening/closing 1 drawer
+ * - opening/closing successive drawers
+ * - opening/closing drawers after navigating and coming back
+ */
+export default function DebugDrawers() {
+  const [isDrawer1Open, setIsDrawer1Open] = useState(false);
+  const [isDrawer2Open, setIsDrawer2Open] = useState(false);
+  const [isDrawer3Open, setIsDrawer3Open] = useState(false);
+
+  const handleDrawer1Close = useCallback(() => {
+    setIsDrawer1Open(false);
+  }, []);
+
+  const handleDrawer2Close = useCallback(() => {
+    setIsDrawer2Open(false);
+  }, []);
+
+  const handleDrawer3Close = useCallback(() => {
+    setIsDrawer3Open(false);
+  }, []);
+
+  return (
+    <>
+      <Flex p="4">
+        <Flex mb="2">
+          <Switch
+            checked={isDrawer1Open}
+            onChange={val => setIsDrawer1Open(val)}
+            label={"Open the 1st drawer"}
+          />
+        </Flex>
+        <Flex mb="2">
+          <Switch
+            checked={isDrawer2Open}
+            onChange={val => {
+              setIsDrawer1Open(val);
+              setIsDrawer2Open(val);
+            }}
+            label={"Open the 1st then 2nd drawers"}
+          />
+        </Flex>
+        <Flex mb="6">
+          <Switch
+            checked={isDrawer3Open}
+            onChange={val => {
+              setIsDrawer1Open(val);
+              setIsDrawer2Open(val);
+              setIsDrawer3Open(val);
+            }}
+            label={"Open the 1st then 2nd then 3rd drawers"}
+          />
+        </Flex>
+        <Alert
+          type="info"
+          title="Hey 🧙‍♀️ Test successive opening/closing drawers !"
+        />
+      </Flex>
+
+      <BottomModal
+        isOpened={isDrawer1Open}
+        onClose={handleDrawer1Close}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="1st drawer" />
+        </Flex>
+      </BottomModal>
+
+      <BottomModal
+        isOpened={isDrawer2Open}
+        onClose={handleDrawer2Close}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="2nd drawer" />
+        </Flex>
+      </BottomModal>
+
+      <BottomModal
+        isOpened={isDrawer3Open}
+        onClose={handleDrawer3Close}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="3rd drawer" />
+        </Flex>
+      </BottomModal>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Drawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Drawers.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Flex, Alert, Switch, Button, Text } from "@ledgerhq/native-ui";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 import { StackNavigatorNavigation } from "../../../../components/RootNavigator/types/helpers";
 import { SettingsNavigatorStackParamList } from "../../../../components/RootNavigator/types/SettingsNavigator";
 import { ScreenName } from "../../../../const";
@@ -86,35 +86,35 @@ export default function DebugDrawers() {
         </Flex>
       </Flex>
 
-      <BottomModal
-        isOpened={isDrawer1Open}
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawer1Open}
         onClose={handleDrawer1Close}
         preventBackdropClick
       >
         <Flex p="4">
           <Alert type="info" title="1st drawer" />
         </Flex>
-      </BottomModal>
+      </QueuedDrawer>
 
-      <BottomModal
-        isOpened={isDrawer2Open}
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawer2Open}
         onClose={handleDrawer2Close}
         preventBackdropClick
       >
         <Flex p="4">
           <Alert type="info" title="2nd drawer" />
         </Flex>
-      </BottomModal>
+      </QueuedDrawer>
 
-      <BottomModal
-        isOpened={isDrawer3Open}
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawer3Open}
         onClose={handleDrawer3Close}
         preventBackdropClick
       >
         <Flex p="4">
           <Alert type="info" title="3rd drawer" />
         </Flex>
-      </BottomModal>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Lottie.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Lottie.tsx
@@ -9,7 +9,7 @@ import Button from "../../../../components/Button";
 import LText from "../../../../components/LText";
 import Animation from "../../../../components/Animation";
 import { getDeviceAnimation } from "../../../../helpers/getDeviceAnimation";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 import Touchable from "../../../../components/Touchable";
 import Check from "../../../../icons/Check";
 import { lottieAnimations } from "../../../Onboarding/shared/infoPagesData";
@@ -196,8 +196,8 @@ const DebugLottie = () => {
           Icon={Icons.ChevronRightMedium}
         />
       </Flex>
-      <BottomModal
-        isOpened={keyModalVisible}
+      <QueuedDrawer
+        isRequestingToBeOpened={keyModalVisible}
         onClose={setKeyModalVisible as () => void}
       >
         <ScrollView style={styles.modal}>
@@ -229,7 +229,7 @@ const DebugLottie = () => {
             </Touchable>
           ))}
         </ScrollView>
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
@@ -12,7 +12,7 @@ import { ScreenName } from "../../../../const";
  * - opening/closing successive drawers
  * - opening/closing drawers after navigating and coming back
  */
-export default function DebugDrawers() {
+export default function DebugQueuedDrawers() {
   const navigation =
     useNavigation<StackNavigatorNavigation<SettingsNavigatorStackParamList>>();
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
@@ -1,16 +1,24 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Flex, Alert, Switch, Button, Text } from "@ledgerhq/native-ui";
+import { useDispatch, useSelector } from "react-redux";
 import QueuedDrawer from "../../../../components/QueuedDrawer";
 import { StackNavigatorNavigation } from "../../../../components/RootNavigator/types/helpers";
 import { SettingsNavigatorStackParamList } from "../../../../components/RootNavigator/types/SettingsNavigator";
 import { ScreenName } from "../../../../const";
+import { setDebugAppLelevelDrawerOpened } from "../../../../actions/settings";
+import { debugAppLevelDrawerOpenedSelector } from "../../../../reducers/settings";
 
 /**
  * Debugging screen to test:
  * - opening/closing 1 drawer
  * - opening/closing successive drawers
  * - opening/closing drawers after navigating and coming back
+ * - opening/closing a drawer that requests to be opened after x seconds
+ * - opening/closing a drawer that forces other drawers to close after x seconds
+ * - opening/closing a drawer located at the App level (like the notification or ratings drawers)
+ *
+ * Also possible to navigate to another screen directly or after x seconds to test how the queued drawer system handles it.
  */
 export default function DebugQueuedDrawers() {
   const navigation =
@@ -19,6 +27,68 @@ export default function DebugQueuedDrawers() {
   const [isDrawer1Open, setIsDrawer1Open] = useState(false);
   const [isDrawer2Open, setIsDrawer2Open] = useState(false);
   const [isDrawer3Open, setIsDrawer3Open] = useState(false);
+
+  const [isDrawer4Started, setIsDrawer4Started] = useState(false);
+  const [isDrawer4RequestingToBeOpened, setDrawer4IsRequestingToBeOpened] =
+    useState(false);
+
+  const [isDrawer5Started, setIsDrawer5Started] = useState(false);
+  const [isDrawer5ForcingToBeOpened, setDrawer5IsForcingToBeOpened] =
+    useState(false);
+
+  const [isNavigatingAfter3s, setIsNavigatingAfter3s] = useState(false);
+
+  // Handles 4th drawer opening after x seconds
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    // Adds the 4th drawer to the queue after 3 seconds
+    if (isDrawer4Started) {
+      timeoutId = setTimeout(() => {
+        setDrawer4IsRequestingToBeOpened(true);
+      }, 3000);
+    }
+
+    // Not cleaning on navigation-lost-focus to test what happens when navigating
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      setDrawer4IsRequestingToBeOpened(false);
+    };
+  }, [isDrawer4Started]);
+
+  // Handles 5th drawer opening after x seconds
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    // Forces the 5th drawer to be opened after 3 seconds
+    if (isDrawer5Started) {
+      timeoutId = setTimeout(() => {
+        setDrawer5IsForcingToBeOpened(true);
+      }, 3000);
+    }
+
+    // Not cleaning on navigation-lost-focus to test what happens when navigating
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      setDrawer5IsForcingToBeOpened(false);
+    };
+  }, [isDrawer5Started]);
+
+  // Handles navigation after x seconds
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    if (isNavigatingAfter3s) {
+      timeoutId = setTimeout(() => {
+        setIsNavigatingAfter3s(false);
+        navigation.navigate(ScreenName.DebugLottie);
+      }, 3000);
+    }
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [isNavigatingAfter3s, navigation]);
 
   const handleDrawer1Close = useCallback(() => {
     setIsDrawer1Open(false);
@@ -31,6 +101,23 @@ export default function DebugQueuedDrawers() {
   const handleDrawer3Close = useCallback(() => {
     setIsDrawer3Open(false);
   }, []);
+
+  const handleDrawer5Close = useCallback(() => {
+    // Updating isDrawer5ForcingToBeOpened is handled in the useEffect
+    setIsDrawer5Started(false);
+  }, []);
+
+  const isDebugAppLevelDrawerOpened = useSelector(
+    debugAppLevelDrawerOpenedSelector,
+  );
+
+  const dispatch = useDispatch();
+  const handleDebugAppLevelDrawerOpenedChange = useCallback(
+    (val: boolean) => {
+      dispatch(setDebugAppLelevelDrawerOpened(val));
+    },
+    [dispatch],
+  );
 
   return (
     <>
@@ -52,7 +139,7 @@ export default function DebugQueuedDrawers() {
             label={"Open the 1st then 2nd drawers"}
           />
         </Flex>
-        <Flex mb="6">
+        <Flex mb="2">
           <Switch
             checked={isDrawer3Open}
             onChange={val => {
@@ -63,25 +150,64 @@ export default function DebugQueuedDrawers() {
             label={"Open the 1st then 2nd then 3rd drawers"}
           />
         </Flex>
+        <Flex mt="6" mb="6">
+          <Switch
+            checked={isDrawer4Started}
+            onChange={val => {
+              setIsDrawer4Started(val);
+            }}
+            label={
+              "Open a 4th drawer after 3sec that adds itself to the queue of drawers, without forcing 🧑‍🎓"
+            }
+          />
+        </Flex>
+        <Flex mb="6">
+          <Switch
+            checked={isDrawer5Started}
+            onChange={val => {
+              setIsDrawer5Started(val);
+            }}
+            label={
+              "Open a 5th drawer after 3sec that forces all the other open drawers to close ⚔️"
+            }
+          />
+        </Flex>
+        <Flex mb="6">
+          <Switch
+            checked={isDebugAppLevelDrawerOpened}
+            onChange={handleDebugAppLevelDrawerOpenedChange}
+            label={
+              "Open a a drawer equivalent to the notification or ratings drawer 📲"
+            }
+          />
+        </Flex>
         <Alert
           type="info"
-          title="Hey 🧙‍♀️ Test successive opening/closing drawers !"
+          title="Hey 🧙‍♀️ Test successive opening/closing of drawers !"
         />
-        <Flex mt="6">
+        <Flex mt="8">
           <Text>
-            Also, try navigating to a new screen by clicking on the button and
-            come back here with the back arrow. To check if the drawers are
-            still working.
+            Also, try navigating to a new screen by clicking on one of the buttons below and
+            come back here with the back arrow. To check if the drawers are still working.
           </Text>
 
           <Button
             type="main"
             onPress={() => navigation.navigate(ScreenName.DebugLottie)}
-            mt="4"
+            mt="8"
             size="small"
             outline
           >
             Navigate somewhere 🧞‍♂️
+          </Button>
+          <Button
+            type="main"
+            onPress={() => setIsNavigatingAfter3s(true)}
+            mt="8"
+            size="small"
+            outline
+          >
+            Navigate somewhere after 3s ⏳
           </Button>
         </Flex>
       </Flex>
@@ -113,6 +239,29 @@ export default function DebugQueuedDrawers() {
       >
         <Flex p="4">
           <Alert type="info" title="3rd drawer" />
+        </Flex>
+      </QueuedDrawer>
+
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawer4RequestingToBeOpened}
+        onClose={() => {
+          // Updating setDrawer4IsRequestingToBeOpened is handled in the useEffect
+          setIsDrawer4Started(false);
+        }}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="4th drawer waited to be displayed 🧑‍🎓" />
+        </Flex>
+      </QueuedDrawer>
+
+      <QueuedDrawer
+        isForcingToBeOpened={isDrawer5ForcingToBeOpened}
+        onClose={handleDrawer5Close}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="5th drawer forced its way up here ⚔️" />
         </Flex>
       </QueuedDrawer>
     </>

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
@@ -168,7 +168,7 @@ export default function DebugQueuedDrawers() {
               setIsDrawer5Started(val);
             }}
             label={
-              "Open a 5th drawer after 3sec that forces all the other open drawers to close ⚔️"
+              "Open a 5th drawer after 3sec that forces all the other opened drawers to close ⚔️"
             }
           />
         </Flex>
@@ -187,8 +187,9 @@ export default function DebugQueuedDrawers() {
         />
         <Flex mt="8">
           <Text>
-            Also, try navigating to a new screen by clicking on one of the buttons below and
-            come back here with the back arrow. To check if the drawers are still working.
+            Also, try navigating to a new screen by clicking on one of the
+            buttons below and come back here with the back arrow. To check if
+            the drawers are still working.
           </Text>
 
           <Button

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Videos.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/Videos.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "@react-navigation/native";
 import Video from "react-native-video";
 import { Flex, Icons, Text } from "@ledgerhq/native-ui";
 import Button from "../../../../components/Button";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 import Touchable from "../../../../components/Touchable";
 import Check from "../../../../icons/Check";
 import videos from "../../../../../assets/videos";
@@ -103,8 +103,8 @@ const DebugVideos = () => {
           />
         </Flex>
       </Flex>
-      <BottomModal
-        isOpened={keyModalVisible}
+      <QueuedDrawer
+        isRequestingToBeOpened={keyModalVisible}
         onClose={setKeyModalVisible as () => void}
       >
         <ScrollView style={styles.modal}>
@@ -131,7 +131,7 @@ const DebugVideos = () => {
             </Touchable>
           ))}
         </ScrollView>
-      </BottomModal>
+      </QueuedDrawer>
     </SafeAreaView>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -76,6 +76,13 @@ export default function Debugging() {
         iconLeft={<Icons.LinkMedium size={32} color="black" />}
         onPress={() => navigation.navigate(ScreenName.DebugTermsOfUse)}
       />
+
+      <SettingsRow
+        title="Successive drawers opening/closing"
+        desc="Open and close several bottom drawers"
+        iconLeft={<Icons.BracketsMedium size={32} color="black" />}
+        onPress={() => navigation.navigate(ScreenName.DebugDrawers)}
+      />
     </SettingsNavigationScrollView>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -81,7 +81,7 @@ export default function Debugging() {
         title="Successive drawers opening/closing"
         desc="Open and close several bottom drawers"
         iconLeft={<Icons.LayersMedium size={32} color="black" />}
-        onPress={() => navigation.navigate(ScreenName.DebugDrawers)}
+        onPress={() => navigation.navigate(ScreenName.DebugQueuedDrawers)}
       />
     </SettingsNavigationScrollView>
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -80,7 +80,7 @@ export default function Debugging() {
       <SettingsRow
         title="Successive drawers opening/closing"
         desc="Open and close several bottom drawers"
-        iconLeft={<Icons.BracketsMedium size={32} color="black" />}
+        iconLeft={<Icons.LayersMedium size={32} color="black" />}
         onPress={() => navigation.navigate(ScreenName.DebugDrawers)}
       />
     </SettingsNavigationScrollView>

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateAnnouncementMockData.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/GenerateAnnouncementMockData.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "@react-navigation/native";
 import { Icons } from "@ledgerhq/native-ui";
 import { addMockAnnouncement } from "../__mocks__/announcements";
 import SettingsRow from "../../../../components/SettingsRow";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 import TextInput from "../../../../components/TextInput";
 import Touchable from "../../../../components/Touchable";
 import LText from "../../../../components/LText";
@@ -111,7 +111,11 @@ export default function AddMockAnnouncementButton({
         iconLeft={<Icons.NewsMedium size={24} color="black" />}
         onPress={onOpen}
       />
-      <BottomModal isOpened={open} onClose={onClose} style={styles.root}>
+      <QueuedDrawer
+        isRequestingToBeOpened={open}
+        onClose={onClose}
+        style={styles.root}
+      >
         <TextInput
           placeholder="platform separated by ','"
           value={notifPlatform}
@@ -173,7 +177,7 @@ export default function AddMockAnnouncementButton({
         >
           <LText color="white">Confirm</LText>
         </Touchable>
-      </BottomModal>
+      </QueuedDrawer>
     </>
   ) : null;
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/General/AnalyticsRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/AnalyticsRow.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
-import { Alert, BottomDrawer, Button, Text, Switch } from "@ledgerhq/native-ui";
+import { Alert, Button, Text, Switch } from "@ledgerhq/native-ui";
 import { GraphGrowAltMedium } from "@ledgerhq/native-ui/assets/icons";
 import { View } from "react-native";
 import SettingsRow from "../../../components/SettingsRow";
 import { setAnalytics } from "../../../actions/settings";
 import { analyticsEnabledSelector } from "../../../reducers/settings";
 import Track from "../../../analytics/Track";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 const AnalyticsRow = () => {
   const { t } = useTranslation();
@@ -72,8 +73,8 @@ const AnalyticsRow = () => {
           onChange={value => dispatch(setAnalytics(value))}
         />
       </SettingsRow>
-      <BottomDrawer
-        isOpen={isOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isOpened}
         onClose={() => setIsOpened(false)}
         Icon={GraphGrowAltMedium}
         iconColor={"primary.c80"}
@@ -98,7 +99,7 @@ const AnalyticsRow = () => {
         <Button type={"main"} mt={8} onPress={() => setIsOpened(false)}>
           <Trans i18nKey="common.close" />
         </Button>
-      </BottomDrawer>
+      </QueuedDrawer>
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/General/ThemeSettingsRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/ThemeSettingsRow.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Checkbox, Text } from "@ledgerhq/native-ui";
+import { Checkbox, Text } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
 import { themeSelector } from "../../../reducers/settings";
 import SettingsRow from "../../../components/SettingsRow";
 import Touchable from "../../../components/Touchable";
 import { setTheme } from "../../../actions/settings";
 import { Theme } from "../../../reducers/types";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 const StyledTouchableThemeRow = styled(Touchable)`
   align-items: center;
@@ -39,8 +40,8 @@ export default function ThemeSettingsRow() {
           {t(`settings.display.themes.${currentTheme}`)}
         </Text>
       </SettingsRow>
-      <BottomDrawer
-        isOpen={isOpen}
+      <QueuedDrawer
+        isRequestingToBeOpened={isOpen}
         onClose={onClose}
         title={t("settings.display.theme")}
       >
@@ -61,7 +62,7 @@ export default function ThemeSettingsRow() {
             {currentTheme === theme && <Checkbox checked={true} />}
           </StyledTouchableThemeRow>
         ))}
-      </BottomDrawer>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Help/ClearCacheRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Help/ClearCacheRow.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer } from "@ledgerhq/native-ui";
 import { InfoMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useCleanCache } from "../../../actions/general";
 import SettingsRow from "../../../components/SettingsRow";
 import { useReboot } from "../../../context/Reboot";
 import Button from "../../../components/wrappedUi/Button";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 export default function ClearCacheRow() {
   const { t } = useTranslation();
@@ -36,8 +36,8 @@ export default function ClearCacheRow() {
         onPress={onPress}
         arrowRight
       />
-      <BottomDrawer
-        isOpen={isModalOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isModalOpened}
         onClose={onRequestClose}
         Icon={InfoMedium}
         iconColor={"primary.c80"}
@@ -60,7 +60,7 @@ export default function ClearCacheRow() {
         >
           {t("common.cancel")}
         </Button>
-      </BottomDrawer>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Help/HardResetRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Help/HardResetRow.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
-import { BottomDrawer } from "@ledgerhq/native-ui";
 import { InfoMedium } from "@ledgerhq/native-ui/assets/icons";
 import SettingsRow from "../../../components/SettingsRow";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 export default function HardResetRow() {
   const { colors } = useTheme();
@@ -29,8 +29,8 @@ export default function HardResetRow() {
         onPress={onPress}
         arrowRight
       />
-      <BottomDrawer
-        isOpen={isModalOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isModalOpened}
         onClose={onRequestClose}
         Icon={InfoMedium}
         iconColor={"error.c100"}

--- a/apps/ledger-live-mobile/src/screens/Settings/Help/ResetThirdPartyDataRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Help/ResetThirdPartyDataRow.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch } from "react-redux";
-import { BottomDrawer, Icons } from "@ledgerhq/native-ui";
+import { Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import SettingsRow from "../../../components/SettingsRow";
 import Button from "../../../components/wrappedUi/Button";
 import { resetSwapLoginAndKYCData } from "../../../actions/settings";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 export default function ResetThirdPartyDataRow() {
   const { t } = useTranslation();
@@ -33,8 +34,8 @@ export default function ResetThirdPartyDataRow() {
         onPress={onPress}
         arrowRight
       />
-      <BottomDrawer
-        isOpen={isModalOpened}
+      <QueuedDrawer
+        isRequestingToBeOpened={isModalOpened}
         onClose={onRequestClose}
         Icon={Icons.InfoMedium}
         iconColor={"primary.c80"}
@@ -52,7 +53,7 @@ export default function ResetThirdPartyDataRow() {
         >
           {t("common.cancel")}
         </Button>
-      </BottomDrawer>
+      </QueuedDrawer>
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
@@ -38,7 +38,7 @@ import { InstalledItem } from "@ledgerhq/live-common/apps/types";
 import { renderLoading } from "../../../../components/DeviceAction/rendering";
 import { updateAccountWithUpdater } from "../../../../actions/accounts";
 import DeviceAction from "../../../../components/DeviceAction";
-import BottomModal from "../../../../components/BottomModal";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 import ModalBottomAction from "../../../../components/ModalBottomAction";
 import { useBroadcast } from "../../../../components/useBroadcast";
 import { swapKYCSelector } from "../../../../reducers/settings";
@@ -198,7 +198,11 @@ export function Confirmation({
   const { t } = useTranslation();
 
   return (
-    <BottomModal isOpened={isOpen} preventBackdropClick onClose={onCancel}>
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
+      preventBackdropClick
+      onClose={onCancel}
+    >
       <SyncSkipUnderPriority priority={100} />
       <ModalBottomAction
         footer={
@@ -256,7 +260,7 @@ export function Confirmation({
           </View>
         }
       />
-    </BottomModal>
+    </QueuedDrawer>
   );
 }
 

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Terms.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Terms.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback } from "react";
 import { Linking } from "react-native";
-import { BottomDrawer, Button, Icons, Link } from "@ledgerhq/native-ui";
+import { Button, Icons, Link } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { urls } from "../../../../config/urls";
+import QueuedDrawer from "../../../../components/QueuedDrawer";
 
 export function Terms({
   provider,
@@ -24,8 +25,8 @@ export function Terms({
   }, [provider]);
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       noCloseButton
       Icon={Icons.InfoMedium}
       iconColor="warning.c100"
@@ -43,6 +44,6 @@ export function Terms({
       <Button type="main" onPress={onClose} outline>
         {t("common.close")}
       </Button>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/index.tsx
@@ -106,9 +106,7 @@ export function Modal({
         />
       )}
 
-      {error && (
-        <GenericErrorBottomModal error={error} isOpened onClose={resetError} />
-      )}
+      {error && <GenericErrorBottomModal error={error} onClose={resetError} />}
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/AllowManagerDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/AllowManagerDrawer.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Flex } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "styled-components/native";
 import { renderAllowManager as AllowManager } from "../../components/DeviceAction/rendering";
+import BottomModal from "../../components/BottomModal";
 
 export type Props = {
   isOpen: boolean;
@@ -12,14 +13,14 @@ export type Props = {
   device: Device;
 };
 
-const UnlockDeviceDrawer = ({ isOpen, device, onClose }: Props) => {
+const AllowManagerDrawer = ({ isOpen, device, onClose }: Props) => {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const theme = colors.type as "dark" | "light";
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <BottomModal
+      isOpened={isOpen}
       onClose={onClose}
       preventBackdropClick
       noCloseButton
@@ -34,8 +35,8 @@ const UnlockDeviceDrawer = ({ isOpen, device, onClose }: Props) => {
           theme={theme}
         />
       </Flex>
-    </BottomDrawer>
+    </BottomModal>
   );
 };
 
-export default UnlockDeviceDrawer;
+export default AllowManagerDrawer;

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/AllowManagerDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/AllowManagerDrawer.tsx
@@ -4,7 +4,7 @@ import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "styled-components/native";
 import { renderAllowManager as AllowManager } from "../../components/DeviceAction/rendering";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -19,8 +19,8 @@ const AllowManagerDrawer = ({ isOpen, device, onClose }: Props) => {
   const theme = colors.type as "dark" | "light";
 
   return (
-    <BottomModal
-      isOpened={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       onClose={onClose}
       preventBackdropClick
       noCloseButton
@@ -35,7 +35,7 @@ const AllowManagerDrawer = ({ isOpen, device, onClose }: Props) => {
           theme={theme}
         />
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/DesyncDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/DesyncDrawer.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback } from "react";
 import { Linking } from "react-native";
-import { BottomDrawer, Button, Link, Text } from "@ledgerhq/native-ui";
+import { Button, Link, Text } from "@ledgerhq/native-ui";
 import { ExternalLinkMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTranslation } from "react-i18next";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { urls } from "../../config/urls";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -24,9 +25,9 @@ const DesyncDrawer = ({ isOpen, onClose, onRetry, device }: Props) => {
   }, []);
 
   return (
-    <BottomDrawer
+    <QueuedDrawer
       onClose={onClose}
-      isOpen={isOpen}
+      isRequestingToBeOpened={isOpen}
       preventBackdropClick
       noCloseButton
     >
@@ -42,7 +43,7 @@ const DesyncDrawer = ({ isOpen, onClose, onRetry, device }: Props) => {
       <Link Icon={ExternalLinkMedium} onPress={handleSupportPress}>
         {t("syncOnboarding.desyncDrawer.helpCta")}
       </Link>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/FirmwareUpdateDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/FirmwareUpdateDrawer.tsx
@@ -1,13 +1,8 @@
 import React from "react";
-import {
-  BottomDrawer,
-  BoxedIcon,
-  Button,
-  Flex,
-  Text,
-} from "@ledgerhq/native-ui";
+import { BoxedIcon, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { NanoFirmwareUpdateMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTranslation } from "react-i18next";
+import BottomModal from "../../components/BottomModal";
 
 export type Props = {
   isOpen: boolean;
@@ -27,12 +22,12 @@ const FirmwareUpdateDrawer = ({
   const { t } = useTranslation();
 
   return (
-    <BottomDrawer
+    <BottomModal
       onClose={() => {
         onClose?.();
         onSkip?.();
       }}
-      isOpen={isOpen}
+      isOpened={isOpen}
       preventBackdropClick
     >
       <Flex justifyContent="center" alignItems="center">
@@ -63,7 +58,7 @@ const FirmwareUpdateDrawer = ({
           "syncOnboarding.softwareChecksSteps.updateAvailableDrawer.updateCta",
         )}
       </Button>
-    </BottomDrawer>
+    </BottomModal>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/FirmwareUpdateDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/FirmwareUpdateDrawer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BoxedIcon, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { NanoFirmwareUpdateMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTranslation } from "react-i18next";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -22,12 +22,12 @@ const FirmwareUpdateDrawer = ({
   const { t } = useTranslation();
 
   return (
-    <BottomModal
+    <QueuedDrawer
       onClose={() => {
         onClose?.();
         onSkip?.();
       }}
-      isOpened={isOpen}
+      isRequestingToBeOpened={isOpen}
       preventBackdropClick
     >
       <Flex justifyContent="center" alignItems="center">
@@ -58,7 +58,7 @@ const FirmwareUpdateDrawer = ({
           "syncOnboarding.softwareChecksSteps.updateAvailableDrawer.updateCta",
         )}
       </Button>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckCancelledDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckCancelledDrawer.tsx
@@ -1,13 +1,8 @@
 import React from "react";
-import {
-  BottomDrawer,
-  BoxedIcon,
-  Button,
-  Flex,
-  Text,
-} from "@ledgerhq/native-ui";
+import { BoxedIcon, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { WarningSolidMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTranslation } from "react-i18next";
+import BottomModal from "../../components/BottomModal";
 
 export type Props = {
   isOpen: boolean;
@@ -27,8 +22,8 @@ const GenuineCheckCancelledDrawer = ({
   const { t } = useTranslation();
 
   return (
-    <BottomDrawer
-      isOpen={isOpen}
+    <BottomModal
+      isOpened={isOpen}
       onClose={onClose}
       preventBackdropClick
       noCloseButton
@@ -68,7 +63,7 @@ const GenuineCheckCancelledDrawer = ({
           "syncOnboarding.softwareChecksSteps.genuineCheckCancelledDrawer.skipCta",
         )}
       </Button>
-    </BottomDrawer>
+    </BottomModal>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckCancelledDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckCancelledDrawer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { BoxedIcon, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { WarningSolidMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTranslation } from "react-i18next";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -22,8 +22,8 @@ const GenuineCheckCancelledDrawer = ({
   const { t } = useTranslation();
 
   return (
-    <BottomModal
-      isOpened={isOpen}
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
       onClose={onClose}
       preventBackdropClick
       noCloseButton
@@ -63,7 +63,7 @@ const GenuineCheckCancelledDrawer = ({
           "syncOnboarding.softwareChecksSteps.genuineCheckCancelledDrawer.skipCta",
         )}
       </Button>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckDrawer.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { BottomDrawer, Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
+import { Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
+import BottomModal from "../../components/BottomModal";
 
 export type Props = {
   isOpen: boolean;
@@ -18,9 +19,9 @@ const GenuineCheckDrawer = ({
   const { t } = useTranslation();
 
   return (
-    <BottomDrawer
+    <BottomModal
       onClose={onClose}
-      isOpen={isOpen}
+      isOpened={isOpen}
       preventBackdropClick
       noCloseButton
     >
@@ -43,7 +44,7 @@ const GenuineCheckDrawer = ({
           "syncOnboarding.softwareChecksSteps.genuineCheckRequestDrawer.checkCta",
         )}
       </Button>
-    </BottomDrawer>
+    </BottomModal>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckDrawer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -19,9 +19,9 @@ const GenuineCheckDrawer = ({
   const { t } = useTranslation();
 
   return (
-    <BottomModal
+    <QueuedDrawer
       onClose={onClose}
-      isOpened={isOpen}
+      isRequestingToBeOpened={isOpen}
       preventBackdropClick
       noCloseButton
     >
@@ -44,7 +44,7 @@ const GenuineCheckDrawer = ({
           "syncOnboarding.softwareChecksSteps.genuineCheckRequestDrawer.checkCta",
         )}
       </Button>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/HelpDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/HelpDrawer.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback } from "react";
-import { BottomDrawer, Button, Link, Text } from "@ledgerhq/native-ui";
+import { Button, Link, Text } from "@ledgerhq/native-ui";
 import { ExternalLinkMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTranslation } from "react-i18next";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -20,7 +21,7 @@ const HelpDrawer = ({ isOpen, onClose }: Props) => {
   }, []);
 
   return (
-    <BottomDrawer onClose={onClose} isOpen={isOpen}>
+    <QueuedDrawer onClose={onClose} isRequestingToBeOpened={isOpen}>
       <Text variant="h4" fontWeight="semiBold" mb={4}>
         {t("syncOnboarding.helpDrawer.title")}
       </Text>
@@ -33,7 +34,7 @@ const HelpDrawer = ({ isOpen, onClose }: Props) => {
       <Link Icon={ExternalLinkMedium} onPress={handleSupportPress}>
         {t("syncOnboarding.helpDrawer.supportCta")}
       </Link>
-    </BottomDrawer>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/LanguageSelect.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/LanguageSelect.tsx
@@ -1,12 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { ScrollView } from "react-native";
-import {
-  BottomDrawer,
-  Button,
-  Flex,
-  SelectableList,
-  Text,
-} from "@ledgerhq/native-ui";
+import { Button, Flex, SelectableList, Text } from "@ledgerhq/native-ui";
 import { useDispatch } from "react-redux";
 import {
   ArrowLeftMedium,
@@ -24,6 +18,7 @@ import Illustration from "../../images/illustration/Illustration";
 import DeviceDark from "../../images/illustration/Dark/_FamilyPackX.png";
 import DeviceLight from "../../images/illustration/Light/_FamilyPackX.png";
 import { updateIdentify } from "../../analytics";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 type UiDrawerStatus =
   | "none"
@@ -51,9 +46,6 @@ const LanguageSelect = ({ device, productName }: Props) => {
   const dispatch = useDispatch();
   const { availableLanguages: firmwareAvailableLanguages, loaded } =
     useAvailableLanguagesForDevice(device);
-
-  const [currentDisplayedDrawer, setCurrentDisplayedDrawer] =
-    useState<UiDrawerStatus>("none");
 
   // Will be computed depending on the states. Updating nextDrawerToDisplay
   // triggers the current displayed drawer to close
@@ -109,18 +101,10 @@ const LanguageSelect = ({ device, productName }: Props) => {
   } else {
     nextDrawerToDisplay = "none";
 
-    // Resets entirely the drawer mechanism
-    if (currentDisplayedDrawer !== "none") {
-      setCurrentDisplayedDrawer("none");
-    }
-  }
-
-  // If there is already a displayed drawer, the currentDisplayedDrawer would be
-  // synchronized with nextDrawerToDisplay during the displayed drawer onClose event.
-  // Otherwise, currentDisplayDrawer needs to be set to nextDrawerToDisplay outside of
-  // the onClose event (that does not exist, because there is no current displayed drawer).
-  if (currentDisplayedDrawer === "none" && nextDrawerToDisplay !== "none") {
-    setCurrentDisplayedDrawer(nextDrawerToDisplay);
+    // // Resets entirely the drawer mechanism
+    // if (currentDisplayedDrawer !== "none") {
+    //   setCurrentDisplayedDrawer("none");
+    // }
   }
 
   return (
@@ -135,14 +119,10 @@ const LanguageSelect = ({ device, productName }: Props) => {
       >
         {currentLocale.toLocaleUpperCase()}
       </Button>
-      <BottomDrawer
+      <QueuedDrawer
         noCloseButton
         preventBackdropClick
-        isOpen={
-          currentDisplayedDrawer === "language-selection" &&
-          nextDrawerToDisplay === "language-selection"
-        }
-        onClose={() => setCurrentDisplayedDrawer(nextDrawerToDisplay)}
+        isRequestingToBeOpened={nextDrawerToDisplay === "language-selection"}
       >
         <Flex
           mb={4}
@@ -150,6 +130,7 @@ const LanguageSelect = ({ device, productName }: Props) => {
           alignItems="center"
           justifyContent="space-between"
         >
+          <Text>Hola</Text>
           <Flex flex={1}>
             <Button
               Icon={ArrowLeftMedium}
@@ -175,11 +156,10 @@ const LanguageSelect = ({ device, productName }: Props) => {
             </SelectableList>
           </Flex>
         </ScrollViewContainer>
-      </BottomDrawer>
-      <BottomDrawer
+      </QueuedDrawer>
+      <QueuedDrawer
         preventBackdropClick
-        isOpen={
-          currentDisplayedDrawer === "firmware-language-update" &&
+        isRequestingToBeOpened={
           nextDrawerToDisplay === "firmware-language-update"
         }
         onClose={handleFirmwareLanguageCancel}
@@ -208,7 +188,7 @@ const LanguageSelect = ({ device, productName }: Props) => {
         <Button onPress={handleFirmwareLanguageCancel}>
           {t("syncOnboarding.firmwareLanguageUpdateDrawer.cancelCta")}
         </Button>
-      </BottomDrawer>
+      </QueuedDrawer>
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/SoftwareChecksStep.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/SoftwareChecksStep.tsx
@@ -95,10 +95,6 @@ const SoftwareChecksStep = ({ device, isDisplayed, onComplete }: Props) => {
   const productName =
     getDeviceModel(device.modelId).productName || device.modelId;
 
-  const [currentDisplayedDrawer, setCurrentDisplayedDrawer] = useState<
-    GenuineCheckUiDrawerStatus | FirmwareUpdateUiDrawerStatus
-  >("none");
-
   // Will be computed depending on the states. Updating nextDrawerToDisplay
   // triggers the current displayed drawer to close
   let nextDrawerToDisplay:
@@ -326,38 +322,20 @@ const SoftwareChecksStep = ({ device, isDisplayed, onComplete }: Props) => {
       break;
   }
 
-  // If there is already a displayed drawer, the currentDisplayedDrawer would be
-  // synchronized with nextDrawerToDisplay during the displayed drawer onClose event.
-  // Otherwise, currentDisplayDrawer needs to be set to nextDrawerToDisplay manually:
-  if (currentDisplayedDrawer === "none" && nextDrawerToDisplay !== "none") {
-    setCurrentDisplayedDrawer(nextDrawerToDisplay);
-  }
-
   return (
     <Flex>
       {isDisplayed && (
         <Flex>
           <GenuineCheckDrawer
             productName={productName}
-            isOpen={
-              currentDisplayedDrawer === "requested" &&
-              nextDrawerToDisplay === "requested"
-            }
+            isOpen={nextDrawerToDisplay === "requested"}
             onPress={() => setGenuineCheckStatus("ongoing")}
-            onClose={() => setCurrentDisplayedDrawer(nextDrawerToDisplay)}
           />
           <UnlockDeviceDrawer
-            isOpen={
-              currentDisplayedDrawer === "unlock-needed" &&
-              nextDrawerToDisplay === "unlock-needed"
-            }
+            isOpen={nextDrawerToDisplay === "unlock-needed"}
             onClose={() => {
-              // Closing because the condition to be opened are not true anymore
-              if (nextDrawerToDisplay !== "unlock-needed") {
-                setCurrentDisplayedDrawer(nextDrawerToDisplay);
-              }
               // Closing because the user pressed on close button, and the genuine check is ongoing
-              else if (genuineCheckStatus === "ongoing") {
+              if (genuineCheckStatus === "ongoing") {
                 // Fails the genuine check entirely
                 setGenuineCheckStatus("failed");
               }
@@ -369,35 +347,23 @@ const SoftwareChecksStep = ({ device, isDisplayed, onComplete }: Props) => {
             device={device}
           />
           <AllowManagerDrawer
-            isOpen={
-              currentDisplayedDrawer === "allow-manager" &&
-              nextDrawerToDisplay === "allow-manager"
-            }
-            onClose={() => setCurrentDisplayedDrawer(nextDrawerToDisplay)}
+            isOpen={nextDrawerToDisplay === "allow-manager"}
             device={device}
           />
           <GenuineCheckCancelledDrawer
             productName={productName}
-            isOpen={
-              currentDisplayedDrawer === "cancelled" &&
-              nextDrawerToDisplay === "cancelled"
-            }
+            isOpen={nextDrawerToDisplay === "cancelled"}
             onRetry={() => {
               resetGenuineCheckState();
               setGenuineCheckStatus("unchecked");
             }}
             onSkip={() => setGenuineCheckStatus("failed")}
-            onClose={() => setCurrentDisplayedDrawer(nextDrawerToDisplay)}
           />
           <FirmwareUpdateDrawer
             productName={productName}
-            isOpen={
-              currentDisplayedDrawer === "new-firmware-available" &&
-              nextDrawerToDisplay === "new-firmware-available"
-            }
+            isOpen={nextDrawerToDisplay === "new-firmware-available"}
             onSkip={() => setFirmwareUpdateStatus("completed")}
             onUpdate={() => setFirmwareUpdateStatus("completed")}
-            onClose={() => setCurrentDisplayedDrawer(nextDrawerToDisplay)}
           />
         </Flex>
       )}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/UnlockDeviceDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/UnlockDeviceDrawer.tsx
@@ -4,7 +4,7 @@ import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "styled-components/native";
 import { renderConnectYourDevice as ConnectYourDevice } from "../../components/DeviceAction/rendering";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;
@@ -19,7 +19,11 @@ const UnlockDeviceDrawer = ({ isOpen, device, onClose }: Props) => {
   const theme = colors.type as "dark" | "light";
 
   return (
-    <BottomModal isOpened={isOpen} onClose={onClose} preventBackdropClick>
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      preventBackdropClick
+    >
       <Flex mb={250} pt={120}>
         <ConnectYourDevice
           t={t}
@@ -28,7 +32,7 @@ const UnlockDeviceDrawer = ({ isOpen, device, onClose }: Props) => {
           theme={theme}
         />
       </Flex>
-    </BottomModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/UnlockDeviceDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/UnlockDeviceDrawer.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { BottomDrawer, Flex } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "styled-components/native";
 import { renderConnectYourDevice as ConnectYourDevice } from "../../components/DeviceAction/rendering";
+import BottomModal from "../../components/BottomModal";
 
 export type Props = {
   isOpen: boolean;
@@ -18,7 +19,7 @@ const UnlockDeviceDrawer = ({ isOpen, device, onClose }: Props) => {
   const theme = colors.type as "dark" | "light";
 
   return (
-    <BottomDrawer isOpen={isOpen} onClose={onClose} preventBackdropClick>
+    <BottomModal isOpened={isOpen} onClose={onClose} preventBackdropClick>
       <Flex mb={250} pt={120}>
         <ConnectYourDevice
           t={t}
@@ -27,7 +28,7 @@ const UnlockDeviceDrawer = ({ isOpen, device, onClose }: Props) => {
           theme={theme}
         />
       </Flex>
-    </BottomDrawer>
+    </BottomModal>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
@@ -21,7 +21,7 @@ import NavigationScrollView from "../../components/NavigationScrollView";
 import GenericErrorView from "../../components/GenericErrorView";
 import SkipDeviceVerification from "./SkipDeviceVerification";
 import VerifyAddress from "./VerifyAddress";
-import BottomModal from "../../components/BottomModal";
+import QueuedDrawer from "../../components/QueuedDrawer";
 import {
   RootComposite,
   StackNavigatorNavigation,
@@ -137,7 +137,7 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
           )}
         />
       ) : !device && skipDevice ? (
-        <BottomModal isOpened={true}>
+        <QueuedDrawer isRequestingToBeOpened={true}>
           <View style={styles.modalContainer}>
             <SkipDeviceVerification
               onCancel={handleClose}
@@ -145,7 +145,7 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
               account={account}
             />
           </View>
-        </BottomModal>
+        </QueuedDrawer>
       ) : null}
     </SafeAreaView>
   );

--- a/libs/ui/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/libs/ui/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import ReactNativeModal, { ModalProps } from "react-native-modal";
 import styled from "styled-components/native";
 import { StyleProp, ViewStyle } from "react-native";
@@ -136,6 +136,7 @@ export default function BaseModal({
   description,
   subtitle,
   children,
+  onModalHide,
   ...rest
 }: BaseModalProps): React.ReactElement {
   const backDropProps = preventBackdropClick
@@ -145,6 +146,14 @@ export default function BaseModal({
         onBackButtonPress: onClose,
         onSwipeComplete: onClose,
       };
+
+  // Workaround: until this, onModalHide={onClose}, making onClose being called twice and onModalHide being never called
+  // The real fix would be to have onModalHide={onModalHide} and make sure every usage on onClose in the consumers of this component
+  // expect the correct behavior
+  const onModalHideWithClose = useCallback(() => {
+    onClose();
+    onModalHide && onModalHide();
+  }, [onClose, onModalHide]);
 
   return (
     <ReactNativeModal
@@ -156,7 +165,7 @@ export default function BaseModal({
       useNativeDriver
       useNativeDriverForBackdrop
       hideModalContentWhileAnimating
-      onModalHide={onClose}
+      onModalHide={onModalHideWithClose}
       style={[defaultModalStyle, modalStyle]}
     >
       <SafeContainer style={safeContainerStyle}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Context: trying to display several drawers was currently blocked, and managing to display successive opening/closing of drawers on iOS was making components using those drawers too complex

#### On `@ledgerhq/native-ui`

`BaseModal` was not passing down `onModalHide` to `ReactNativeModal`. Until this, `onModalHide={onClose}`, making `onClose` being called twice (once when the user closes the modal, once when the modal is hidden) and `onModalHide` being never called. 
⚠️ The fix is a workaround so we don't break legacy components that uses `BaseModal`. The long-term fix would be to have `onModalHide={onModalHide}` and make sure every usage on onClose in the consumers of this component expect the correct behavior.

#### On `live-mobile`

`QueuedDrawer` replacing existing `BottomModal`. `QueuedDrawer` is a drawer taking into account the currently displayed drawer and other drawers waiting to be displayed.

This is made possible thanks to a queue of drawers waiting to be displayed. Once the currently displayed drawer is not displayed anymore (hidden), the next drawer in the queue is notified, and it updates its state to be make itself visible.

Also added a system to forcefully close the currently displayed drawer + clean the queue to display a new drawer

##### Update of components consuming BottomModal or BottomDrawer

⚠️ I updated all the components that used `BottomModal` and `libs/ui/packages/native/src/components/Layout/Modals/BottomDrawer/index.tsx`. 

The full power of `QueuedDrawer` can only occur if it is used everywhere (if some components would still used `BottomModal`, while for example a device actions uses the new `QueuedDrawer`, the behavior of those drawers would be incorrect).

##### Update of the logic of drawer opening/closing in Sync Onboarding

As you can see on the different components of the sync onboarding (located `apps/ledger-live-mobile/src/screens/SyncOnboarding/`), this new implementation removes a lot of complexity to have successive opening/closing of drawers 🦾

##### Debug screen 🧙‍♂️

As you can see in the demo videos, a debug screen has also been added to test successive opening/closing of drawers

### ❓ Context

- **Impacted projects**: `@ledgerhq/native-ui` and `live-mobile`
- **Linked resource(s)**: [FAT-815](https://ledgerhq.atlassian.net/browse/FAT-815)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<details>
  <summary>iOS showing the latest queued drawer system (with possibility to forcefully open a drawer)</summary>


https://user-images.githubusercontent.com/15096913/217215945-1c662807-6607-4eb6-b446-75406e15d30b.mp4



</details>

<details>
  <summary>iOS before changes made to be able to forcefully open a drawer</summary>


https://user-images.githubusercontent.com/15096913/216623862-120f70b9-5850-4e9e-b749-6d2e2ec5dd18.mp4



</details>

<details>
  <summary>Android before changes made to be able to forcefully open a drawer</summary>

https://user-images.githubusercontent.com/15096913/216623645-1e91aea7-6ad6-4ddd-a2ff-6f608ab7ba45.mp4


</details>

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-815]: https://ledgerhq.atlassian.net/browse/FAT-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ