### PR TITLE
bugfix(react-ui): remove input padding

### DIFF
--- a/libs/ui/packages/react/src/components/form/BaseInput/index.tsx
+++ b/libs/ui/packages/react/src/components/form/BaseInput/index.tsx
@@ -108,8 +108,6 @@ export const BaseInput = styled.input.attrs<
   outline: none;
   cursor: ${(p) => (p.disabled ? "not-allowed" : "text")};
   flex-shrink: 1;
-  padding-top: 14px;
-  padding-bottom: 14px;
   padding-left: 20px;
   padding-right: 20px;
   &::placeholder {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
Removes the input padding added to inputs in the react-ui package.
This padding is not needed and causes the text inside the input to be aligned at the bottom of the input instead of the center:
![Screenshot from 2023-02-06 14-19-11](https://user-images.githubusercontent.com/12260492/216982490-a9317ac9-b048-4cfd-a06f-a1f965dd3715.png)
 


### ❓ Context

- **Impacted projects**: `@ledgerhq/react-ui` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: - <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![Screenshot from 2023-02-06 14-18-42](https://user-images.githubusercontent.com/12260492/216982504-4061b304-80d2-4ed0-a097-e974185c333b.png)
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
