### PR TITLE
bugfix: lld - changes copy of Earn button to Stake

### DIFF
--- a/.changeset/eighty-gifts-speak.md
+++ b/.changeset/eighty-gifts-speak.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Changes the Earn button copy on portfolio screen to say stake

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1399,7 +1399,7 @@
         "label": "Popular"
       },
       "earn": {
-        "title": "Earn",
+        "title": "Stake",
         "description": "Grow your crypto with Ledger"
       }
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Changes the Earn button on the portfolio screen to say Stake - so it is consistent with other stake buttons.

### ❓ Context

- **Impacted projects**: Desktop
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/119950081/217213170-3034b156-496f-406a-a3de-f8e323f84917.png">


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
