### PR TITLE
LIVE-5457 Cosmos testnet cleanup

### DIFF
--- a/.changeset/chilly-snails-exist.md
+++ b/.changeset/chilly-snails-exist.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+cosmos_testnet cleanup

--- a/.changeset/five-fireants-lay.md
+++ b/.changeset/five-fireants-lay.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/cryptoassets": patch
+---
+
+cosmos_testnet cleanup

--- a/.changeset/young-pumpkins-do.md
+++ b/.changeset/young-pumpkins-do.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+cosmos_testnet cleanup

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -44,7 +44,6 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "ethereum_goerli",
-  "cosmos_testnet",
   "crypto_org",
   "crypto_org_croeseid",
   "celo",

--- a/apps/ledger-live-desktop/src/live-common-set-supported-currencies.js
+++ b/apps/ledger-live-desktop/src/live-common-set-supported-currencies.js
@@ -43,7 +43,6 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "ethereum_goerli",
-  "cosmos_testnet",
   "hedera",
   "cardano",
   "filecoin",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -67,7 +67,6 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "ethereum_goerli",
-  "cosmos_testnet",
   "elrond",
   "hedera",
   "cardano",

--- a/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
@@ -45,7 +45,6 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "ethereum_goerli",
-  "cosmos_testnet",
   "crypto_org_croeseid",
   "crypto_org",
   "filecoin",

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/crypto/factory.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/crypto/factory.ts
@@ -101,3 +101,4 @@ export default function cryptoFactory(currency: Currency): ICrypto {
   }
   return res;
 }
+// TODO: Currently, all bitcoin currencies included setSupportedCurrencies must be supported here. We are working on a new way to support/enable new currencies

--- a/libs/ledger-live-common/src/families/cosmos/chain/chain.ts
+++ b/libs/ledger-live-common/src/families/cosmos/chain/chain.ts
@@ -23,4 +23,5 @@ export default function cryptoFactory(currencyId: string): CosmosBase {
   } else {
     throw new Error(`${currencyId} is not supported`);
   }
+  // TODO: Currently, all cosmos currencies included setSupportedCurrencies must be supported here. We are working on a new way to support/enable new currencies
 }

--- a/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/abandonseed.ts
@@ -9,7 +9,6 @@ import invariant from "invariant";
 const abandonSeedAddresses: Record<string, string> = {
   algorand: "PSHLIWQKDEETIIBQEOTLGCT5IF7BTTOKCUULONOGVGF2HYDT2IHW3H4CCI",
   cosmos: "cosmos19rl4cm2hmr8afy4kldpxz3fka4jguq0auqdal4",
-  cosmos_testnet: "cosmos19rl4cm2hmr8afy4kldpxz3fka4jguq0auqdal4",
   ripple: "rHsMGQEkVNJmpGWs8XUBoTBiAAbwxZN5v3",
   stellar: "GDYPMQMYW2JTLPWAUAHIDY3E4VHP5SGTFC5SMA45L7ZPOTHWQ2PHEW3E",
   tezos: "tz1VJitLYB31fEC82efFkLRU4AQUH9QgH3q6",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

As we’ve dropped the cosmos_testnet during the cosmos SDK integration recently. We need to remove cosmos_testnet completely in our codebase.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5457

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
