### PR TITLE
Bugfix: FAT-827 fix queued drawer on react-navigation focus change - and for select language

### DIFF
--- a/.changeset/mighty-drinks-listen.md
+++ b/.changeset/mighty-drinks-listen.md
@@ -4,5 +4,9 @@
 
 fix: several bugs on new system of queued drawers
 
-- QueuedDrawer is forcefully cleaned only if lost focus AND the drawer was trying to be opened
+On QueuedDrawer:
+- When loosing focus: all drawers are cleaned, and it now tries to call the onClose of the QueuedDrawer if it tried to be opened after the navigation occurred
+- When getting focus: we now check if the drawer was not added just before (drawerId) to avoid adding it several time, because useFocusEffect can be triggered several time in certain cases
+
+On other components:
 - For a consumer drawer: onClose needed even if noCloseButton was set to handle lost of screen focus or if other drawer forced it to close

--- a/.changeset/mighty-drinks-listen.md
+++ b/.changeset/mighty-drinks-listen.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": patch
+---
+
+fix: several bugs on new system of queued drawers
+
+- QueuedDrawer is forcefully cleaned only if lost focus AND the drawer was trying to be opened
+- For a consumer drawer: onClose needed even if noCloseButton was set to handle lost of screen focus or if other drawer forced it to close

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -101,9 +101,9 @@ const QueuedDrawer = ({
     let id: number | undefined;
 
     // Protects against adding a drawer to the queue when its associated screen has not the focus
-    if (!hasFocus) {
+    if (!hasFocus && (isRequestingToBeOpened || isForcingToBeOpened)) {
       setWasForcefullyCleaned(true);
-    } else {
+    } else if (hasFocus) {
       // If the drawer is forcing to be opened, first clean the waiting queue
       if (isForcingToBeOpened) {
         cleanWaitingDrawers(true);

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -77,7 +77,7 @@ const QueuedDrawer = ({
   /**
    * Makes sure that the drawer system is cleaned when navigating to a new (or back to a) screen
    *
-   * According to reactnavigation documentation, a useCallback should wrap the function passed to useFocusEffect
+   * According to react-navigation documentation, a useCallback should wrap the function passed to useFocusEffect
    * useFocusEffect is called each time a dependency of the callback changes, necessary to keep this dependency array empty
    *
    * useFocusEffect (return) clean up function is the last function to be called if a navigation change occurs and the
@@ -100,8 +100,8 @@ const QueuedDrawer = ({
         cleanWaitingDrawers();
         cleanCurrentDisplayedDrawer();
 
-        // If a navigation occured and the drawer was not closed, this won't trigger any useEffect depending on wasForcefullyCleaned.
-        // But necessary if the navigation occured and the drawer, coming from the previous screen, tries to be opened.
+        // If a navigation occurred and the drawer was not closed, this won't trigger any useEffect depending on wasForcefullyCleaned.
+        // But necessary if the navigation occurred and the drawer, coming from the previous screen, tries to be opened.
         // This will call its onClose function and clean the state that tried to open it.
         setWasForcefullyCleaned(true);
       };

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -44,7 +44,9 @@ export type Props = Merge<
  *   and displays itself. It should only be used when the drawer has priority over the other drawers in the queue.
  *   Prefer using isRequestingToBeOpened insted to respect the queue order. Default to false.
  * @param onClose: when the user closes the drawer (by clicking on the backdrop or the close button) + when the drawer is hidden
- *   (this is currently due to a legacy behavior of the BaseModal component. It might change in the future)
+ *   (this is currently due to a legacy behavior of the BaseModal component. It might change in the future).
+ *   Even if you set noCloseButton, the drawer can be closed for other reasons (lost screen focus, other drawer forced it to close).
+ *   It is a good practice to always clean the state that tried to open the drawer when onClose is called.
  * @param onModalHide: when the drawer is fully hidden
  * @param noCloseButton: whether to display the close button or not
  * @param preventBackdropClick: whether to prevent the user from closing the drawer by clicking somewhere on the screen

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -143,7 +143,7 @@ const QueuedDrawer = ({
 
   // Handles the case where the drawer has been removed forcefully from the queue by another drawer
   // or where the displayed drawer was forcefully closed.
-  // Handled separatly to avoid calling addToWaitingDrawers on every onClose changes (if not memoized).
+  // Handled separately to avoid calling addToWaitingDrawers on every onClose changes (if not memoized).
   useEffect(() => {
     if (wasForcefullyCleaned) {
       onClose && onClose();

--- a/apps/ledger-live-mobile/src/screens/Onboarding/shared/SeedWarning.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/shared/SeedWarning.tsx
@@ -15,11 +15,12 @@ const SeedWarning = ({ deviceModelId }: { deviceModelId: DeviceModelId }) => {
     Linking.openURL(urls.contact);
   }, []);
 
+  const onClose = useCallback(() => {
+    setIsOpened(false);
+  }, []);
+
   return (
-    <QueuedDrawer
-      isRequestingToBeOpened={isOpened}
-      onClose={() => setIsOpened(false)}
-    >
+    <QueuedDrawer isRequestingToBeOpened={isOpened} onClose={onClose}>
       <Flex alignItems="center">
         <IconBox
           Icon={Icons.WarningMedium}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
@@ -38,6 +38,9 @@ export default function DebugQueuedDrawers() {
 
   const [isNavigatingAfter3s, setIsNavigatingAfter3s] = useState(false);
 
+  const [isDrawer6AOpen, setIsDrawer6AOpen] = useState(false);
+  const [isDrawer6BOpen, setIsDrawer6BOpen] = useState(false);
+
   // Handles 4th drawer opening after x seconds
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | null = null;
@@ -105,6 +108,15 @@ export default function DebugQueuedDrawers() {
   const handleDrawer5Close = useCallback(() => {
     // Updating isDrawer5ForcingToBeOpened is handled in the useEffect
     setIsDrawer5Started(false);
+  }, []);
+
+  const handleDrawer6AClose = useCallback(() => {
+    setIsDrawer6AOpen(false);
+    setIsDrawer6BOpen(true);
+  }, []);
+
+  const handleDrawer6BClose = useCallback(() => {
+    setIsDrawer6BOpen(false);
   }, []);
 
   const isDebugAppLevelDrawerOpened = useSelector(
@@ -177,7 +189,19 @@ export default function DebugQueuedDrawers() {
             checked={isDebugAppLevelDrawerOpened}
             onChange={handleDebugAppLevelDrawerOpenedChange}
             label={
-              "Open a a drawer equivalent to the notification or ratings drawer 📲"
+              "Open a drawer equivalent to the notification or ratings drawer 📲"
+            }
+          />
+        </Flex>
+        <Flex mb="6">
+          <Switch
+            checked={isDrawer6AOpen || isDrawer6BOpen}
+            onChange={val => {
+              // Only opens the 1st drawer, the 2nd one will be opened on user close
+              setIsDrawer6AOpen(val);
+            }}
+            label={
+              "Open a 1st drawer, and on user close, open a 2nd drawer after closing the 1st one. To test on iOS"
             }
           />
         </Flex>
@@ -263,6 +287,26 @@ export default function DebugQueuedDrawers() {
       >
         <Flex p="4">
           <Alert type="info" title="5th drawer forced its way up here ⚔️" />
+        </Flex>
+      </QueuedDrawer>
+
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawer6AOpen}
+        onClose={handleDrawer6AClose}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="Drawer A" />
+        </Flex>
+      </QueuedDrawer>
+
+      <QueuedDrawer
+        isRequestingToBeOpened={isDrawer6BOpen}
+        onClose={handleDrawer6BClose}
+        preventBackdropClick
+      >
+        <Flex p="4">
+          <Alert type="info" title="Drawer B 🥳" />
         </Flex>
       </QueuedDrawer>
     </>

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/LanguageSelect.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/LanguageSelect.tsx
@@ -93,6 +93,11 @@ const LanguageSelect = ({ device, productName }: Props) => {
     setLanguageSelectStatus("completed");
   }, []);
 
+  // Needed because the drawer can close if it loses the screen focus, or another drawer forces it to close
+  const handleLanguageSelectOnClose = useCallback(() => {
+    setLanguageSelectStatus("unrequested");
+  }, []);
+
   // Handles the UI logic
   if (languageSelectStatus === "language-selection-requested") {
     nextDrawerToDisplay = "language-selection";
@@ -123,6 +128,7 @@ const LanguageSelect = ({ device, productName }: Props) => {
         noCloseButton
         preventBackdropClick
         isRequestingToBeOpened={nextDrawerToDisplay === "language-selection"}
+        onClose={handleLanguageSelectOnClose}
       >
         <Flex
           mb={4}
@@ -130,7 +136,6 @@ const LanguageSelect = ({ device, productName }: Props) => {
           alignItems="center"
           justifyContent="space-between"
         >
-          <Text>Hola</Text>
           <Flex flex={1}>
             <Button
               Icon={ArrowLeftMedium}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The new queue drawer had a logic error in how it handles the lost of (react-navigation) screen focus

Fixed:

On `QueuedDrawer`:
- When loosing focus: all drawers are cleaned, and it now tries to call the `onClose` of the QueuedDrawer if it tried to be opened after the navigation occurred  
- When getting focus: we now check if the drawer was not added just before (`drawerId`) to avoid adding it several time, because `useFocusEffect` can be triggered several time in certain cases

On other components:
- For a consuming component: onClose needed even if noCloseButton was set to handle lost of screen focus or if other drawer forced it to close

### ❓ Context

- **Impacted projects**: `LLM`
- **Linked resource(s)**: [FAT-827](https://ledgerhq.atlassian.net/browse/FAT-827)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/15096913/218086426-c648c05c-9a2d-46b7-bf9c-bbaae63dcacc.mp4



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-827]: https://ledgerhq.atlassian.net/browse/FAT-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ