### PR TITLE
fix: lld - redirect to dex live-app using state instead of params

### DIFF
--- a/.changeset/stupid-keys-bake.md
+++ b/.changeset/stupid-keys-bake.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Refactors how params are passed from swap screen to live-app.

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.jsx
@@ -389,7 +389,7 @@ const SwapForm = () => {
         `/platform/${getProviderName(exchangeRate.provider).toLowerCase()}`;
       history.push({
         pathname: providerURL,
-        params: {
+        state: {
           returnTo: "/swap",
           accountId: fromAddress,
         },

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/App.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/App.jsx
@@ -40,8 +40,8 @@ export default function PlatformApp({ match, appId: propsAppId, location }: Prop
 
   const returnTo = useMemo(() => {
     const params = new URLSearchParams(search);
-    return params.get("returnTo") || internalParams?.returnTo;
-  }, [search, internalParams]);
+    return urlParams?.returnTo || params.get("returnTo") || internalParams?.returnTo;
+  }, [search, urlParams?.returnTo, internalParams?.returnTo]);
 
   const handleClose = useCallback(() => history.push(returnTo || `/platform`), [history, returnTo]);
   const themeType = useTheme("colors.palette.type");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Refactors how we pass params from swap screen to live-app. According to typescript, `history.push` does not take in a `params` value (even though it seems to work). 

### ❓ Context

- **Impacted projects**: LLD
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-3880

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/119950081/217870331-0e711051-d84f-4996-838f-9b1bed8715b5.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
