### PR TITLE
fix(wallet-api): broken ble on LLM

### DIFF
--- a/.changeset/five-poets-confess.md
+++ b/.changeset/five-poets-confess.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": patch
+---
+
+fix(wallet-api): broken ble on LLM
+
+We had to remove the reset of the device to undefined
+It avoids starting the ble scanning again on success
+The ble scanning is disconnecting all device which was causing the issue

--- a/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
@@ -38,12 +38,12 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
 
   const newDeviceSelectionFeatureFlag = useFeature("llmNewDeviceSelection");
 
-  const onShowMenu = (device: Device) => {
+  const onShowMenu = useCallback((device: Device) => {
     setChosenDevice(device);
     setShowMenu(true);
-  };
+  }, []);
 
-  const onHideMenu = () => setShowMenu(false);
+  const onHideMenu = useCallback(() => setShowMenu(false), []);
 
   const onDone = useCallback(() => {
     const n =
@@ -57,9 +57,6 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
   const handleSuccess = useCallback(
     (result: AppResult) => {
       onSuccess(result);
-      // Resets the device to avoid having
-      // the bottom modal popping up again
-      setDevice(undefined);
       onDone();
     },
     [onDone, onSuccess],


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We had to remove the reset of the device to undefined
It avoids starting the ble scanning again on success
The ble scanning is disconnecting all device which was causing the issue

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** Tested manually, you might need to be on top of https://github.com/LedgerHQ/ledger-live/pull/2566 <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
