### PR TITLE
fix ci concurrency inputs

### DIFF
--- a/.github/workflows/build-desktop-external.yml
+++ b/.github/workflows/build-desktop-external.yml
@@ -14,8 +14,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref }}
-  cancel-in-progress: ${{ inputs.ref != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref }}
+  cancel-in-progress: ${{ github.event.inputs.ref != 'develop' }}
 
 jobs:
   build-desktop-app:

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -20,8 +20,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.event.inputs.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
 
 jobs:
   start-runner:

--- a/.github/workflows/build-mobile-external.yml
+++ b/.github/workflows/build-mobile-external.yml
@@ -14,8 +14,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ inputs.ref != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event.inputs.ref != 'develop' }}
 
 jobs:
   build-mobile-app-android:

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -20,8 +20,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
 
 jobs:
   start-runner:

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -18,7 +18,8 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || inputs.number }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.event.inputs.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/regen-doc.yml
+++ b/.github/workflows/regen-doc.yml
@@ -18,7 +18,8 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || inputs.number }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.event.inputs.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/regen-pods.yml
+++ b/.github/workflows/regen-pods.yml
@@ -18,7 +18,8 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || inputs.number }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.event.inputs.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-desktop-external.yml
+++ b/.github/workflows/test-desktop-external.yml
@@ -14,8 +14,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref }}
-  cancel-in-progress: ${{ inputs.ref != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref }}
+  cancel-in-progress: ${{ github.event.inputs.ref != 'develop' }}
 
 jobs:
   typecheck:

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -20,8 +20,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
 
 jobs:
   typecheck:

--- a/.github/workflows/test-mobile-e2e.yml
+++ b/.github/workflows/test-mobile-e2e.yml
@@ -28,8 +28,9 @@ on:
 #   DEBUG_DETOX: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
 
 jobs:
   detox-tests-ios:

--- a/.github/workflows/test-mobile.yml
+++ b/.github/workflows/test-mobile.yml
@@ -20,8 +20,9 @@ on:
         description: The base branch to merge the head into when checking out the code
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
 
 jobs:
   codecheck:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,9 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  # See: https://github.com/orgs/community/discussions/35341
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
 
 jobs:
   test-docs:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We used to have `inputs.xxx` calls in the `concurrency` part of the github actions workflow yaml file.
[**(Like here)**](https://github.com/LedgerHQ/ledger-live/blob/8ee24c5a03f570c03f1e6ef0c3e499766e88b3e6/.github/workflows/generate-screenshots.yml#L21)
Unfortunately even though the [**official documentation**](https://docs.github.com/en/actions/learn-github-actions/contexts#about-contexts) says it is fine, it's [**not**](https://github.com/orgs/community/discussions/35341).

This caused concurrency issues with the generate screenshot workflow cancelling previous runs on different PRs.

Using `github.event.inputs.xxx` calls instead supposedly works though.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: 
  - https://github.com/orgs/community/discussions/35341

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
