### PR TITLE
fix: reset device on close instead of navigating back

### DIFF
--- a/.changeset/healthy-pillows-joke.md
+++ b/.changeset/healthy-pillows-joke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: reset device on close instead of navigating back

--- a/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
@@ -31,7 +31,7 @@ type NavigationProps = RootComposite<
 export default function DeviceConnect({ navigation, route }: NavigationProps) {
   const { colors } = useTheme();
   const [device, setDevice] = useState<Device | null | undefined>();
-  const { appName = "BOLOS", onSuccess, onError, onClose } = route.params;
+  const { appName = "BOLOS", onSuccess, onError } = route.params;
 
   const [chosenDevice, setChosenDevice] = useState<Device | null>();
   const [showMenu, setShowMenu] = useState<boolean>(false);
@@ -62,10 +62,9 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
     [onDone, onSuccess],
   );
 
-  const handleClose = useCallback(() => {
-    onClose();
-    onDone();
-  }, [onClose, onDone]);
+  const resetDevice = useCallback(() => {
+    setDevice(undefined);
+  }, []);
 
   return (
     <SafeAreaView
@@ -104,7 +103,7 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
         action={action}
         device={device}
         onResult={handleSuccess}
-        onClose={handleClose}
+        onClose={resetDevice}
         onError={onError}
         request={{
           appName,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Use the same logic as the manager screen, we reset the device in order to close the `DeviceActionModal` when `onClose` is called

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** Tested manually on the dummy-wallet-app <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
