### PR TITLE
[LIVE-5490] Fix eth sync and perf

### DIFF
--- a/.changeset/rare-peas-sing.md
+++ b/.changeset/rare-peas-sing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Reduce redundant calls for ethereum synchronization

--- a/libs/ledger-live-common/src/families/ethereum/synchronisation.ts
+++ b/libs/ledger-live-common/src/families/ethereum/synchronisation.ts
@@ -580,18 +580,27 @@ const fetchCurrentBlock = ((perCurrencyId) => (currency) => {
   return f();
 })({});
 
-// FIXME we need to figure out how to optimize this
-// but nothing can easily be done until we have a better api
+// FIXME : We need to use the pagination token from backend
 const fetchAllTransactions = async (api: API, address, blockHeight) => {
   let getTransactionsResult: Tx[];
   let txs: Tx[] = [];
   let maxIteration = 20; // safe limit
+  let lastRequestTxHash: string | undefined;
 
   do {
     getTransactionsResult = await api.getTransactions(address, blockHeight);
     if (getTransactionsResult.length === 0) return txs;
+    if (
+      lastRequestTxHash &&
+      getTransactionsResult[getTransactionsResult.length - 1].hash ===
+        lastRequestTxHash
+    ) {
+      return txs;
+    }
+
     txs = txs.concat(getTransactionsResult);
     blockHeight = txs[txs.length - 1].block?.height;
+    lastRequestTxHash = txs[txs.length - 1].hash;
 
     if (!blockHeight) {
       log("ethereum", "block.height missing!");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix eth perf problems

We were calling 20 times the same page

This time we call the same page maximum 2 times

If last tx of last request is the same as the current one we stop calling the backend

The real fix is using the token pagination mechanism

### ❓ Context

- **Impacted projects**: `LLC` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5490 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
