### PR TITLE
Fix: add new device drawer closing in new device selection

### DIFF
--- a/.changeset/big-bats-visit.md
+++ b/.changeset/big-bats-visit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: onClose called when forcefully cleaned only if drawer was trying to be opened

--- a/.changeset/neat-oranges-exercise.md
+++ b/.changeset/neat-oranges-exercise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: explicitly close drawer on navigation to add new device

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -173,10 +173,19 @@ const QueuedDrawer = ({
   // Handled separately to avoid calling addToWaitingDrawers or triggering useFocusEffect on every onClose changes (if not memoized).
   useEffect(() => {
     if (wasForcefullyCleaned) {
-      onClose && onClose();
       setWasForcefullyCleaned(false);
+
+      // Only call onClose if the drawer was trying to be opened
+      if (isRequestingToBeOpened || isForcingToBeOpened) {
+        onClose && onClose();
+      }
     }
-  }, [wasForcefullyCleaned, onClose]);
+  }, [
+    wasForcefullyCleaned,
+    onClose,
+    isRequestingToBeOpened,
+    isForcingToBeOpened,
+  ]);
 
   return (
     <BottomDrawer

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -180,12 +180,10 @@ const QueuedDrawer = ({
         onClose && onClose();
       }
     }
-  }, [
-    wasForcefullyCleaned,
-    onClose,
-    isRequestingToBeOpened,
-    isForcingToBeOpened,
-  ]);
+    // Only needs to be triggered when wasForcefullyCleaned is set to true.
+    // Avoids triggering when isRequestingToBeOpened or isForcingToBeOpened change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wasForcefullyCleaned, onClose]);
 
   return (
     <BottomDrawer

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -158,6 +158,7 @@ export default function SelectDevice({ onSelect, stopBleScanning }: Props) {
   const onAddNewPress = useCallback(() => setIsAddNewDrawerOpen(true), []);
 
   const openBlePairingFlow = useCallback(() => {
+    setIsAddNewDrawerOpen(false);
     setIsPairingDevices(true);
   }, []);
 
@@ -167,6 +168,8 @@ export default function SelectDevice({ onSelect, stopBleScanning }: Props) {
   }, []);
 
   const onSetUpNewDevice = useCallback(() => {
+    setIsAddNewDrawerOpen(false);
+
     navigation.navigate(NavigatorName.BaseOnboarding, {
       screen: NavigatorName.Onboarding,
       params: {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/language.tsx
@@ -56,6 +56,10 @@ function OnboardingStepLanguage({ navigation }: NavigationProps) {
   const [preventPromptBackdropClick, setPreventPromptBackdropClick] =
     useState<boolean>(false);
 
+  // Watchdog to prevent navigating back twice due onClose being called when user closes the drawer
+  // and when the drawer is hidden (see BaseModal)
+  const [wasNextCalled, setWasNextCalled] = useState<boolean>(false);
+
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(
     lastSeenDeviceSelector,
   );
@@ -99,8 +103,11 @@ function OnboardingStepLanguage({ navigation }: NavigationProps) {
   };
 
   const next = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+    if (!wasNextCalled) {
+      setWasNextCalled(true);
+      navigation.goBack();
+    }
+  }, [navigation, wasNextCalled]);
 
   // no useCallBack around RNRRestart, or the app might crash.
   const changeLanguageRTL = async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix 2 issues:
- drawer "add new device" on new device selection is not correctly closed
- `onClose` was called on a drawer that did not tried to be opened if this drawer was forcefully closed (for ex: on navigation/change of screen focus)
  - this created an issue if the `onClose` triggers a navigation
- encountered also again a problem with the legacy `onModalHide` calling `onClose` in `BaseModal` for the language selection  
  - added a watchdog to avoid calling twice `onClose`

### ❓ Context

- **Impacted projects**: `LLM`
- **Linked resource(s)**: [FAT-827](https://ledgerhq.atlassian.net/browse/FAT-827)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<details>
  <summary>Issue 1: android: drawer add new in device selection</summary>


https://user-images.githubusercontent.com/15096913/218483290-b281d87a-22fd-40a2-bae9-0c0a1c1e71b9.mp4




</details>

<details>
  <summary>Issue 2: android: language selection</summary>

https://user-images.githubusercontent.com/15096913/218482704-211a9114-e76b-4684-93a6-1f0492b0fa19.mp4




</details>

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-827]: https://ledgerhq.atlassian.net/browse/FAT-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ