### PR TITLE
ci: use standard github token in the gate

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -27,20 +27,14 @@ jobs:
         id: affected
         with:
           head-ref: ${{ format('origin/{0}', github.event.pull_request.base.ref) }}
-      - name: generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.GH_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       # Labeller
       - uses: actions/labeler@v4
         with:
-          repo-token: "${{ steps.generate-token.outputs.token }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/github-script@v6
         if: github.event.pull_request.head.repo.fork
         with:
-          github-token: ${{ steps.generate-token.outputs.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
               const { data: rawLabels } = await github.rest.issues.listLabelsOnIssue({


### PR DESCRIPTION
should fix forked prs

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This is what PRs coming from forked repos get as of today: 

```
Run tibdex/github-app-token@v1
Error: Error: Input required and not supplied: app_id
```

Using a standard github token should hopefully solve this.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

N/A

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
