### PR TITLE
feat: add in web tools a way to check network troubleshooting

### DIFF
--- a/tools/common-tools/src/demos/index.js
+++ b/tools/common-tools/src/demos/index.js
@@ -3,6 +3,7 @@ import lldSignature from "./lld-signature";
 import repl from "./repl";
 import ethtxtools from "./eth-tx-tools";
 import sync from "./sync";
+import networkTroubleshoot from "./networkTroubleshooting";
 
 export default {
   LogsViewer,
@@ -10,4 +11,5 @@ export default {
   repl,
   ethtxtools,
   sync,
+  networkTroubleshoot,
 };

--- a/tools/common-tools/src/demos/networkTroubleshooting/index.js
+++ b/tools/common-tools/src/demos/networkTroubleshooting/index.js
@@ -1,0 +1,72 @@
+import React, { useEffect, useReducer } from "react";
+import {
+  troubleshootOverObservable,
+  troubleshootOverObservableReducer,
+} from "@ledgerhq/live-common/lib/network-troubleshooting";
+
+function useTroubleshootState() {
+  const [state, dispatch] = useReducer(troubleshootOverObservableReducer, []);
+  useEffect(() => {
+    const s = troubleshootOverObservable().subscribe(dispatch);
+    return () => s.unsubscribe();
+  }, []);
+  return state;
+}
+
+function App() {
+  const state = useTroubleshootState();
+
+  return (
+    <div>
+      <h1>Network Troubleshoot</h1>
+
+      <table>
+        <thead>
+          <tr>
+            <th>TEST</th>
+            <th>RESULT</th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.map((s) => {
+            return (
+              <tr key={s.title}>
+                <td>{s.title}</td>
+                <td>
+                  <Status status={s} />
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const Status = ({ status }) => {
+  switch (status?.status) {
+    case "success":
+      return "✅";
+    case "error":
+      return (
+        <span
+          style={{ color: "red" }}
+          role="img"
+          aria-label="Error"
+          title={status.error}
+        >
+          ❌
+        </span>
+      );
+    default:
+      return "⏳";
+  }
+};
+
+App.demo = {
+  title: "Network Troubleshooting",
+  url: "/networkTroubleshoot",
+};
+
+export default App;


### PR DESCRIPTION

### 📝 Description

makes the networkTroubleshoot tool that we find in Ledger Live settings also available standalone on a web page.

<img width="370" alt="Screenshot 2023-02-14 at 13 41 06" src="https://user-images.githubusercontent.com/211411/218741927-e0edbe3d-ad3b-47f3-8d3c-bb765f993dc1.png">


### ❓ Context

- **Impacted projects**: `tools` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
