### PR TITLE
FAT-824 LLM Post onboarding analytics

### DIFF
--- a/.changeset/two-jars-study.md
+++ b/.changeset/two-jars-study.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Post onboarding analytics

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
@@ -519,7 +519,10 @@ export default function Tutorial({ useCase }: Props) {
        */
       const timeout: ReturnType<typeof setTimeout> = setTimeout(() => {
         if (history.location.pathname !== "/")
-          handleStartPostOnboarding(connectedDevice.modelId, true, () => history.push("/"));
+          handleStartPostOnboarding({
+            deviceModelId: connectedDevice.modelId,
+            fallbackIfNoAction: () => history.push("/"),
+          });
       }, 0);
       return () => {
         clearTimeout(timeout);

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingActionRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/PostOnboardingActionRow.tsx
@@ -14,28 +14,18 @@ const ActionRowWrapper = styled(Flex)<{ completed: boolean }>`
 `;
 
 const PostOnboardingActionRow: React.FC<Props> = props => {
-  const {
-    id,
-    navigationParams,
-    Icon,
-    title,
-    description,
-    tagLabel,
-    startAction,
-    startEvent,
-    startEventProperties,
-    completed,
-  } = props;
+  const { id, Icon, title, description, tagLabel, buttonLabelForAnalyticsEvent, completed } = props;
   const { t } = useTranslation();
   const history = useHistory();
 
   const handleStartAction = useCallback(() => {
-    if (navigationParams) history.push(navigationParams);
-    else if (startAction) {
-      startAction();
-      startEvent && track(startEvent, startEventProperties);
+    if ("navigationParams" in props && props.navigationParams) history.push(props.navigationParams);
+    else if ("startAction" in props) {
+      props.startAction();
+      buttonLabelForAnalyticsEvent &&
+        track("button_clicked", { button: buttonLabelForAnalyticsEvent });
     }
-  }, [history, navigationParams, startAction, startEvent, startEventProperties]);
+  }, [props, history, buttonLabelForAnalyticsEvent]);
 
   return (
     <ActionRowWrapper

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
@@ -9,6 +9,7 @@ const claimMock: PostOnboardingAction = {
   id: PostOnboardingActionId.claimMock,
   Icon: Icons.GiftCardMedium,
   title: "Claim my NFT",
+  titleCompleted: "Claim my NFT",
   description: "A special NFT for you.",
   tagLabel: "Free",
   actionCompletedPopupLabel: "NFT claimed",
@@ -20,6 +21,7 @@ const personalizeMock: PostOnboardingAction = {
   Icon: Icons.BracketsMedium,
   featureFlagId: "customImage",
   title: `Personalize my ${getDeviceModel(DeviceModelId.stax).productName}`,
+  titleCompleted: `Personalize my ${getDeviceModel(DeviceModelId.stax).productName}`,
   description: "By customizing the screen.",
   actionCompletedPopupLabel: "Device personalized",
   startAction: () =>
@@ -30,6 +32,7 @@ const migrateAssetsMock: PostOnboardingAction = {
   id: PostOnboardingActionId.migrateAssetsMock,
   Icon: Icons.TransferMedium,
   title: "Transfer assets to my Ledger",
+  titleCompleted: "Transfer assets to my Ledger",
   description: "Easily secure assets from coinbase or another exchange.",
   actionCompletedPopupLabel: "Assets transfered",
   startAction: () =>
@@ -41,6 +44,7 @@ const customImage: PostOnboardingAction = {
   Icon: Icons.BracketsMedium,
   featureFlagId: "customImage",
   title: "customImage.postOnboarding.title",
+  titleCompleted: "customImage.postOnboarding.title",
   description: "customImage.postOnboarding.description",
   actionCompletedPopupLabel: "customImage.postOnboarding.actionCompletedPopupLabel",
   startAction: () => setDrawer(CustomImage, { isFromPostOnboardingEntryPoint: true }),
@@ -49,7 +53,7 @@ const customImage: PostOnboardingAction = {
 /**
  * All implemented post onboarding actions.
  */
-const postOnboardingActions: Record<PostOnboardingActionId, PostOnboardingAction> = {
+const postOnboardingActions: { [id in PostOnboardingActionId]?: PostOnboardingAction } = {
   claimMock,
   migrateAssetsMock,
   personalizeMock,
@@ -65,7 +69,9 @@ const staxPostOnboardingActionsMock: PostOnboardingAction[] = [
   migrateAssetsMock,
 ];
 
-export function getPostOnboardingAction(id: PostOnboardingActionId): PostOnboardingAction {
+export function getPostOnboardingAction(
+  id: PostOnboardingActionId,
+): PostOnboardingAction | undefined {
   return postOnboardingActions[id];
 }
 

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/CompletionScreen.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/CompletionScreen.tsx
@@ -21,9 +21,10 @@ const CompletionScreen = () => {
     dispatch(saveSettings({ hasCompletedOnboarding: true }));
     const timeout = setTimeout(
       () =>
-        handleInitPostOnboarding(device?.modelId || DeviceModelId.nanoX, false, () =>
-          history.push("/"),
-        ),
+        handleInitPostOnboarding({
+          deviceModelId: device?.modelId || DeviceModelId.nanoX,
+          fallbackIfNoAction: () => history.push("/"),
+        }),
       GO_TO_POSTONBOARDING_TIMEOUT,
     );
     return () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/PostOnboardingHubTester.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/PostOnboardingHubTester.tsx
@@ -11,7 +11,7 @@ const PostOnboardingHubTester = () => {
   const { t } = useTranslation();
   const history = useHistory();
 
-  const handleInitStax = useStartPostOnboardingCallback();
+  const handleInitPostOnboarding = useStartPostOnboardingCallback();
 
   return (
     <SettingsSectionRow
@@ -20,7 +20,13 @@ const PostOnboardingHubTester = () => {
     >
       <Button
         data-test-id="postonboarding-tester-button"
-        onClick={() => handleInitStax(DeviceModelId.stax, true, () => history.push("/"))}
+        onClick={() =>
+          handleInitPostOnboarding({
+            deviceModelId: DeviceModelId.stax,
+            mock: true,
+            fallbackIfNoAction: () => history.push("/"),
+          })
+        }
         primary
       >
         {t("postOnboardingDebugger.buttonTitle")}

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -74,6 +74,7 @@ import {
   SettingsSetDebugAppLevelDrawerOpenedPayload,
   SettingsFilterTokenOperationsZeroAmountPayload,
   SettingsLastSeenDeviceLanguagePayload,
+  SettingsCompleteOnboardingPayload,
 } from "./types";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";
 
@@ -199,10 +200,14 @@ export const setLastSeenCustomImage = ({
 export const clearLastSeenCustomImage = () =>
   setLastSeenCustomImageAction({ imageSize: 0, imageHash: "" });
 
-const completeOnboardingAction = createAction(
-  SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING,
-);
-export const completeOnboarding = () => completeOnboardingAction();
+const completeOnboardingAction =
+  createAction<SettingsCompleteOnboardingPayload>(
+    SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING,
+  );
+export const completeOnboarding = (hasCompletedOnboarding = true) =>
+  completeOnboardingAction({
+    hasCompletedOnboarding,
+  });
 
 const installAppFirstTimeAction =
   createAction<SettingsInstallAppFirstTimePayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -481,7 +481,10 @@ export type SettingsSetDebugAppLevelDrawerOpenedPayload = Pick<
   SettingsState,
   "debugAppLevelDrawerOpened"
 >;
-export type SettingsCompleteOnboardingPayload = Pick<SettingsState, "hasCompletedOnboarding">;
+export type SettingsCompleteOnboardingPayload = Pick<
+  SettingsState,
+  "hasCompletedOnboarding"
+>;
 
 export type SettingsPayload =
   | SettingsImportPayload

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -481,6 +481,7 @@ export type SettingsSetDebugAppLevelDrawerOpenedPayload = Pick<
   SettingsState,
   "debugAppLevelDrawerOpened"
 >;
+export type SettingsCompleteOnboardingPayload = Pick<SettingsState, "hasCompletedOnboarding">;
 
 export type SettingsPayload =
   | SettingsImportPayload
@@ -531,6 +532,7 @@ export type SettingsPayload =
   | SettingsSetOverriddenFeatureFlagPlayload
   | SettingsSetOverriddenFeatureFlagsPlayload
   | SettingsSetFeatureFlagsBannerVisiblePayload
+  | SettingsCompleteOnboardingPayload
   | SettingsSetDebugAppLevelDrawerOpenedPayload;
 
 // === WALLET CONNECT ACTIONS ===

--- a/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingActionRow.tsx
+++ b/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingActionRow.tsx
@@ -25,10 +25,9 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
     titleCompleted,
     description,
     tagLabel,
-    startEvent,
-    startEventProperties,
     completed,
     disabled,
+    buttonLabelForAnalyticsEvent,
   } = props;
   const { t } = useTranslation();
   const navigation =
@@ -41,9 +40,10 @@ const PostOnboardingActionRow: React.FC<Props> = props => {
   const handlePress = useCallback(() => {
     if (navigationParams) {
       navigation.navigate(...navigationParams);
-      startEvent && track(startEvent, startEventProperties);
+      buttonLabelForAnalyticsEvent &&
+        track("button_clicked", { button: buttonLabelForAnalyticsEvent });
     }
-  }, [navigationParams, navigation, startEvent, startEventProperties]);
+  }, [navigationParams, navigation, buttonLabelForAnalyticsEvent]);
 
   return (
     <Touchable

--- a/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingEntryPointCard.tsx
+++ b/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingEntryPointCard.tsx
@@ -53,7 +53,7 @@ const PostOnboardingEntryPointCard: React.FC<Record<string, never>> = () => {
           alignSelf="stretch"
           type="main"
           outline
-          onPress={openHub}
+          onPress={() => openHub()}
           event="button_clicked"
           eventProperties={{ button: "Access" }}
         >

--- a/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingEntryPointCard.tsx
+++ b/apps/ledger-live-mobile/src/components/PostOnboarding/PostOnboardingEntryPointCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Flex, Icons, Text, Button } from "@ledgerhq/native-ui";
+import { Flex, Icons, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { useDispatch, useSelector } from "react-redux";
@@ -8,6 +8,7 @@ import { hidePostOnboardingWalletEntryPoint } from "@ledgerhq/live-common/postOn
 import { postOnboardingDeviceModelIdSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { useNavigateToPostOnboardingHubCallback } from "../../logic/postOnboarding/useNavigateToPostOnboardingHubCallback";
 import Touchable from "../Touchable";
+import Button from "../wrappedUi/Button";
 
 const PostOnboardingEntryPointCard: React.FC<Record<string, never>> = () => {
   const { t } = useTranslation();
@@ -48,7 +49,14 @@ const PostOnboardingEntryPointCard: React.FC<Record<string, never>> = () => {
         >
           {t("postOnboarding.entryPointCard.description", { productName })}
         </Text>
-        <Button alignSelf="stretch" type="main" outline onPress={openHub}>
+        <Button
+          alignSelf="stretch"
+          type="main"
+          outline
+          onPress={openHub}
+          event="button_clicked"
+          eventProperties={{ button: "Access" }}
+        >
           {t("postOnboarding.entryPointCard.buttonLabel")}
         </Button>
       </Flex>

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/actions.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/actions.ts
@@ -22,6 +22,7 @@ export const customImageAction: PostOnboardingAction = {
       },
     },
   ],
+  buttonLabelForAnalyticsEvent: "Set lock screen picture",
 };
 
 export const claimNftAction: PostOnboardingAction = {
@@ -40,6 +41,7 @@ export const claimNftAction: PostOnboardingAction = {
       screen: ScreenName.ClaimNftWelcome,
     },
   ],
+  buttonLabelForAnalyticsEvent: "Claim Ledger NFT",
 };
 
 export const assetsTransferAction: PostOnboardingAction = {
@@ -51,4 +53,5 @@ export const assetsTransferAction: PostOnboardingAction = {
   titleCompleted: "postOnboarding.actions.assetsTransfer.titleCompleted",
   description: "postOnboarding.actions.assetsTransfer.description",
   actionCompletedPopupLabel: "postOnboarding.actions.assetsTransfer.popupLabel",
+  buttonLabelForAnalyticsEvent: "Secure your assets on Ledger",
 };

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/useNavigateToPostOnboardingHubCallback.ts
@@ -1,12 +1,44 @@
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
+import { RootNavigation } from "../../components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "../../const";
 
 export function useNavigateToPostOnboardingHubCallback() {
   const navigation = useNavigation();
-  return useCallback(() => {
-    navigation.navigate(NavigatorName.PostOnboarding, {
-      screen: ScreenName.PostOnboardingHub,
-    });
-  }, [navigation]);
+  return useCallback(
+    (resetNavigationStack?: boolean) => {
+      if (resetNavigationStack) {
+        (navigation as unknown as RootNavigation).reset({
+          index: 0,
+          routes: [
+            {
+              name: NavigatorName.Base,
+              state: {
+                routes: [
+                  {
+                    name: NavigatorName.Main,
+                  },
+                  {
+                    name: NavigatorName.PostOnboarding,
+                    state: {
+                      routes: [
+                        {
+                          name: ScreenName.PostOnboardingHub,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        });
+      } else {
+        navigation.navigate(NavigatorName.PostOnboarding, {
+          screen: ScreenName.PostOnboardingHub,
+        });
+      }
+    },
+    [navigation],
+  );
 }

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -69,6 +69,7 @@ import type {
   DangerouslyOverrideStatePayload,
   SettingsSetDebugAppLevelDrawerOpenedPayload,
   SettingsLastSeenDeviceLanguagePayload,
+  SettingsCompleteOnboardingPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -287,9 +288,11 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     },
   }),
 
-  [SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING]: state => ({
+  [SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING]: (state, action) => ({
     ...state,
-    hasCompletedOnboarding: true,
+    hasCompletedOnboarding: (
+      action as Action<SettingsCompleteOnboardingPayload>
+    ).payload.hasCompletedOnboarding,
   }),
 
   [SettingsActionTypes.SETTINGS_INSTALL_APP_FIRST_TIME]: (state, action) => ({

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
@@ -125,12 +125,9 @@ function OnboardingStepPairNew() {
       parentNav.popToTop();
     }
 
-    navigation.replace(NavigatorName.Base, {
-      screen: NavigatorName.Main,
-    });
-
     startPostOnboarding({
       deviceModelId: deviceModelId as DeviceModelId,
+      resetNavigationStack: true,
       fallbackIfNoAction: () =>
         navigation.navigate(NavigatorName.Base, {
           screen: NavigatorName.Main,

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
@@ -129,11 +129,13 @@ function OnboardingStepPairNew() {
       screen: NavigatorName.Main,
     });
 
-    startPostOnboarding(deviceModelId as DeviceModelId, false, () =>
-      navigation.navigate(NavigatorName.Base, {
-        screen: NavigatorName.Main,
-      }),
-    );
+    startPostOnboarding({
+      deviceModelId: deviceModelId as DeviceModelId,
+      fallbackIfNoAction: () =>
+        navigation.navigate(NavigatorName.Base, {
+          screen: NavigatorName.Main,
+        }),
+    });
 
     triggerJustFinishedOnboardingNewDevicePushNotificationModal();
   }, [

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingDebugScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingDebugScreen.tsx
@@ -14,9 +14,11 @@ export default () => {
 
   const handleInitPostOnboardingHub = useCallback(
     (deviceId: DeviceModelId, mock: boolean) =>
-      startPostOnboarding(deviceId, mock, () =>
-        navigation.navigate(NavigatorName.Main),
-      ),
+      startPostOnboarding({
+        deviceModelId: deviceId,
+        mock,
+        fallbackIfNoAction: () => navigation.navigate(NavigatorName.Main),
+      }),
     [navigation, startPostOnboarding],
   );
 

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -30,6 +30,8 @@ import {
 import { PostOnboardingNavigatorParamList } from "../../components/RootNavigator/types/PostOnboardingNavigator";
 import DeviceSetupView from "../../components/DeviceSetupView";
 import { useCompleteActionCallback } from "../../logic/postOnboarding/useCompleteAction";
+import { TrackScreen } from "../../analytics";
+import Link from "../../components/wrappedUi/Link";
 
 const AnimatedFlex = Animated.createAnimatedComponent(Flex);
 
@@ -168,6 +170,14 @@ const PostOnboardingHub = ({ navigation, route }: NavigationProps) => {
 
   return (
     <DeviceSetupView hasCloseButton>
+      <TrackScreen
+        key={allDone.toString()}
+        category={
+          allDone
+            ? "User has completed all post-onboarding actions"
+            : "Post-onboarding hub"
+        }
+      />
       <Flex px={6} py={7} justifyContent="space-between" flex={1}>
         <Text variant="h1Inter" fontWeight="semiBold" mb={8}>
           {allDone
@@ -184,17 +194,16 @@ const PostOnboardingHub = ({ navigation, route }: NavigationProps) => {
             </React.Fragment>
           ))}
         </ScrollView>
-        <Flex mt={8}>
+        <Flex mt={8} alignItems="center" justifyContent="center">
           {allDone ? null : (
-            <Text
-              variant="large"
-              fontWeight="semiBold"
-              alignSelf="center"
+            <Link
+              size="large"
               onPress={navigateToMainScreen}
-              color="neutral.c100"
+              event="button_clicked"
+              eventProperties={{ button: "I'll do this later" }}
             >
               {t("postOnboarding.hub.skip")}
-            </Text>
+            </Link>
           )}
         </Flex>
       </Flex>

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ReadOnlyModeRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ReadOnlyModeRow.tsx
@@ -24,7 +24,7 @@ const mapDispatchToProps = {
   setReadOnlyMode,
 };
 
-class DeveloperModeRow extends PureComponent<Props> {
+class ReadOnlyModeRow extends PureComponent<Props> {
   setReadOnlyModeAndReset = async (enabled: boolean) => {
     const { setReadOnlyMode, reboot } = this.props;
     await setReadOnlyMode(enabled);
@@ -58,5 +58,5 @@ class DeveloperModeRow extends PureComponent<Props> {
 const m = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(withReboot(DeveloperModeRow));
+)(withReboot(ReadOnlyModeRow));
 export default m;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ResetOnboardingStateRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ResetOnboardingStateRow.tsx
@@ -1,0 +1,32 @@
+import React, { useContext } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import SettingsRow from "../../../../components/SettingsRow";
+import {
+  completeOnboarding,
+  setHasOrderedNano,
+  setReadOnlyMode,
+} from "../../../../actions/settings";
+import { RebootContext } from "../../../../context/Reboot";
+import { knownDevicesSelector } from "../../../../reducers/ble";
+import { removeKnownDevices } from "../../../../actions/ble";
+
+export default function ResetOnboardingStateRow() {
+  const dispatch = useDispatch();
+  const reboot = useContext(RebootContext);
+  const knownDevices = useSelector(knownDevicesSelector);
+  return (
+    <SettingsRow
+      title="Reset onboarding state"
+      desc="Sets the app as if the onboarding was never completed"
+      onPress={() => {
+        dispatch(setReadOnlyMode(true));
+        dispatch(setHasOrderedNano(false));
+        dispatch(completeOnboarding(false));
+        dispatch(removeKnownDevices(knownDevices.map(d => d.id)));
+        requestAnimationFrame(() => {
+          reboot();
+        });
+      }}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
@@ -13,6 +13,7 @@ import MockModeRow from "../../General/MockModeRow";
 import HasOrderedNanoRow from "./HasOrderedNanoRow";
 import { StackNavigatorNavigation } from "../../../../components/RootNavigator/types/helpers";
 import { SettingsNavigatorStackParamList } from "../../../../components/RootNavigator/types/SettingsNavigator";
+import ResetOnboardingStateRow from "./ResetOnboardingStateRow";
 
 export default function Configuration() {
   const navigation =
@@ -33,6 +34,7 @@ export default function Configuration() {
         onPress={() => navigation.navigate(ScreenName.DebugEnv)}
       />
       <Alert type={"info"} title={"Quick toggles for common settings."} />
+      <ResetOnboardingStateRow />
       <ReadOnlyModeRow />
       <HasOrderedNanoRow />
       <MockModeRow />

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
@@ -46,28 +46,28 @@ const CompletionScreen = ({ navigation, route }: Props) => {
   const videoSource = theme === "light" ? sourceLight : sourceDark;
 
   const redirectToPostOnboarding = useCallback(() => {
-    // Resets the navigation stack to avoid allowing to go back to the onboarding welcome screen
-    // FIXME: bindings to react-navigation seem to have issues with composites
-    (navigation as unknown as RootNavigation).reset({
-      index: 0,
-      routes: [
-        {
-          name: NavigatorName.Base,
-          state: {
-            routes: [
-              {
-                name: NavigatorName.Main,
+    startPostOnboarding({
+      deviceModelId: device.modelId,
+      resetNavigationStack: true,
+      fallbackIfNoAction: () =>
+        // Resets the navigation stack to avoid allowing to go back to the onboarding welcome screen
+        // FIXME: bindings to react-navigation seem to have issues with composites
+        (navigation as unknown as RootNavigation).reset({
+          index: 0,
+          routes: [
+            {
+              name: NavigatorName.Base,
+              state: {
+                routes: [
+                  {
+                    name: NavigatorName.Main,
+                  },
+                ],
               },
-            ],
-          },
-        },
-      ],
+            },
+          ],
+        }),
     });
-    startPostOnboarding(device.modelId, false, () =>
-      navigation.navigate(NavigatorName.Base, {
-        screen: NavigatorName.Main,
-      }),
-    );
   }, [device.modelId, navigation, startPostOnboarding]);
 
   const skipDelay = useCallback(() => {

--- a/libs/ledger-live-common/src/postOnboarding/PostOnboardingProvider.tsx
+++ b/libs/ledger-live-common/src/postOnboarding/PostOnboardingProvider.tsx
@@ -7,7 +7,7 @@ import {
 
 export type PostOnboardingDependencies = {
   /** function to navigate to the post onboarding hub */
-  navigateToPostOnboardingHub: () => void;
+  navigateToPostOnboardingHub: (resetNavigationStack?: boolean) => void;
   /**
    * function that returns a `PostOnboardingAction` for the given
    * `PostOnboardingActionId` parameter.

--- a/libs/ledger-live-common/src/postOnboarding/PostOnboardingProvider.tsx
+++ b/libs/ledger-live-common/src/postOnboarding/PostOnboardingProvider.tsx
@@ -14,7 +14,7 @@ export type PostOnboardingDependencies = {
    * */
   getPostOnboardingAction?: (
     id: PostOnboardingActionId
-  ) => PostOnboardingAction;
+  ) => PostOnboardingAction | undefined;
   /**
    * function that returns an array of `PostOnboardingAction` for the given
    * `DeviceModelId` parameter.

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useAllPostOnboardingActionsCompleted.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useAllPostOnboardingActionsCompleted.ts
@@ -4,7 +4,6 @@ import { usePostOnboardingHubState } from "./usePostOnboardingHubState";
  *
  * @returns a boolean representing whether all the post onboarding actions have
  * been completed.
- * TODO: unit test this
  */
 export function useAllPostOnboardingActionsCompleted(): boolean {
   const { actionsState } = usePostOnboardingHubState();

--- a/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet.ts
@@ -9,7 +9,6 @@ import { useAllPostOnboardingActionsCompleted } from "./useAllPostOnboardingActi
  *
  * @returns a boolean representing whether the post onboarding entry point
  * should be visible on the wallet page.
- * TODO: unit test this
  */
 export function usePostOnboardingEntryPointVisibleOnWallet(): boolean {
   const deviceModelId = useSelector(postOnboardingDeviceModelIdSelector);

--- a/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingHubState.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/usePostOnboardingHubState.ts
@@ -12,7 +12,6 @@ import { usePostOnboardingContext } from "./usePostOnboardingContext";
  * This takes feature flagging into account so the logic is
  * resistant to flags getting enabled/disabled over time (for a given disabled
  * feature flag, the actions pointing to it will be excluded).
- * TODO: unit test this
  * */
 export function usePostOnboardingHubState(): PostOnboardingHubState {
   const hubState = useSelector(hubStateSelector);

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
@@ -5,6 +5,13 @@ import { useCallback } from "react";
 import { useFeatureFlags } from "../../featureFlags";
 import { initPostOnboarding } from "../actions";
 
+type StartPostOnboardingOptions = {
+  deviceModelId: DeviceModelId;
+  mock?: boolean;
+  fallbackIfNoAction?: () => void;
+  resetNavigationStack?: boolean;
+};
+
 /**
  * Use this to initialize AND navigate to the post onboarding hub for a given
  * device model.
@@ -16,9 +23,7 @@ import { initPostOnboarding } from "../actions";
  * TODO: unit test this
  */
 export function useStartPostOnboardingCallback(): (
-  deviceModelId: DeviceModelId,
-  mock?: boolean,
-  fallbackIfNoAction?: () => void
+  options: StartPostOnboardingOptions
 ) => void {
   const dispatch = useDispatch();
   const { getFeature } = useFeatureFlags();
@@ -26,11 +31,13 @@ export function useStartPostOnboardingCallback(): (
     usePostOnboardingContext();
 
   return useCallback(
-    (
-      deviceModelId: DeviceModelId,
-      mock = false,
-      fallbackIfNoAction?: () => void
-    ) => {
+    (options: StartPostOnboardingOptions) => {
+      const {
+        deviceModelId,
+        mock = false,
+        fallbackIfNoAction,
+        resetNavigationStack,
+      } = options;
       const actions = getPostOnboardingActionsForDevice(
         deviceModelId,
         mock
@@ -52,7 +59,7 @@ export function useStartPostOnboardingCallback(): (
         }
         return;
       }
-      navigateToPostOnboardingHub();
+      navigateToPostOnboardingHub(resetNavigationStack);
     },
     [
       dispatch,

--- a/libs/ledger-live-common/src/postOnboarding/reducer.ts
+++ b/libs/ledger-live-common/src/postOnboarding/reducer.ts
@@ -5,6 +5,7 @@ import {
 } from "@ledgerhq/types-live";
 import { handleActions } from "redux-actions";
 import type { ReducerMap } from "redux-actions";
+import { createSelector, Selector } from "reselect";
 
 export const initialState: PostOnboardingState = {
   deviceModelId: null,
@@ -82,49 +83,41 @@ function sanitizeDeviceModelId(
   return deviceModelId;
 }
 
-export const postOnboardingSelector = ({
-  postOnboarding,
-}: {
-  postOnboarding: PostOnboardingState;
-}): PostOnboardingState => ({
-  ...postOnboarding,
-  deviceModelId: sanitizeDeviceModelId(postOnboarding.deviceModelId),
-});
+export const postOnboardingSelector: Selector<
+  { postOnboarding: PostOnboardingState },
+  PostOnboardingState
+> = createSelector(
+  (state) => state.postOnboarding,
+  (postOnboarding) => ({
+    ...postOnboarding,
+    deviceModelId: sanitizeDeviceModelId(postOnboarding.deviceModelId),
+  })
+);
 
-export const hubStateSelector = ({
-  postOnboarding,
-}: {
-  postOnboarding: PostOnboardingState;
-}): {
-  deviceModelId: PostOnboardingState["deviceModelId"];
-  actionsToComplete: PostOnboardingState["actionsToComplete"];
-  actionsCompleted: PostOnboardingState["actionsCompleted"];
-  lastActionCompleted: PostOnboardingState["lastActionCompleted"];
-} => {
-  const {
-    deviceModelId,
-    actionsToComplete,
-    actionsCompleted,
-    lastActionCompleted,
-  } = postOnboarding;
-  return {
-    deviceModelId: sanitizeDeviceModelId(deviceModelId),
-    actionsToComplete,
-    actionsCompleted,
-    lastActionCompleted,
-  };
-};
+export const hubStateSelector = createSelector(
+  postOnboardingSelector,
+  (postOnboarding) => {
+    const {
+      deviceModelId,
+      actionsToComplete,
+      actionsCompleted,
+      lastActionCompleted,
+    } = postOnboarding;
+    return {
+      deviceModelId: sanitizeDeviceModelId(deviceModelId),
+      actionsToComplete,
+      actionsCompleted,
+      lastActionCompleted,
+    };
+  }
+);
 
-export const postOnboardingDeviceModelIdSelector = ({
-  postOnboarding,
-}: {
-  postOnboarding: PostOnboardingState;
-}): PostOnboardingState["deviceModelId"] =>
-  sanitizeDeviceModelId(postOnboarding.deviceModelId);
+export const postOnboardingDeviceModelIdSelector = createSelector(
+  postOnboardingSelector,
+  (postOnboarding) => sanitizeDeviceModelId(postOnboarding.deviceModelId)
+);
 
-export const walletPostOnboardingEntryPointDismissedSelector = ({
-  postOnboarding,
-}: {
-  postOnboarding: PostOnboardingState;
-}): PostOnboardingState["walletEntryPointDismissed"] =>
-  postOnboarding.walletEntryPointDismissed;
+export const walletPostOnboardingEntryPointDismissedSelector = createSelector(
+  postOnboardingSelector,
+  (postOnboarding) => postOnboarding.walletEntryPointDismissed
+);

--- a/libs/ledgerjs/packages/types-live/README.md
+++ b/libs/ledgerjs/packages/types-live/README.md
@@ -163,8 +163,7 @@ Ledger Live main types.
     *   [description](#description)
     *   [tagLabel](#taglabel)
     *   [actionCompletedPopupLabel](#actioncompletedpopuplabel)
-    *   [startEvent](#startevent)
-    *   [startEventProperties](#starteventproperties)
+    *   [buttonLabelForAnalyticsEvent](#buttonlabelforanalyticsevent)
 *   [PostOnboardingActionState](#postonboardingactionstate)
     *   [Properties](#properties-44)
     *   [completed](#completed)
@@ -1277,17 +1276,12 @@ after completing this action.
 
 Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
-#### startEvent
+#### buttonLabelForAnalyticsEvent
 
-Event that will be dispatched when starting this action.
+Value to use in the "button" property of the event sent when the user
+triggers the action by pressing the button in the post onboarding hub.
 
 Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
-
-#### startEventProperties
-
-Event properties that will be dispatched when starting this action.
-
-Type: any
 
 ### PostOnboardingActionState
 

--- a/libs/ledgerjs/packages/types-live/src/postOnboarding.ts
+++ b/libs/ledgerjs/packages/types-live/src/postOnboarding.ts
@@ -82,14 +82,10 @@ export type PostOnboardingAction = {
   actionCompletedPopupLabel: string;
 
   /**
-   * Event that will be dispatched when starting this action.
+   * Value to use in the "button" property of the event sent when the user
+   * triggers the action by pressing the button in the post onboarding hub.
    */
-  startEvent?: string;
-
-  /**
-   * Event properties that will be dispatched when starting this action.
-   */
-  startEventProperties?: any;
+  buttonLabelForAnalyticsEvent?: string;
 } & (WithNavigationParams | WithStartActionFunction);
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Implementation of analytics in the post onboarding, and some refactoring of the post onboarding selectors which were bad because creating a new ref at each update of the store.

also:
- had to implement a way to reset the navigation stack when navigating from the sync onboarding completion screen to the post onboarding
  - the way it was done before, we were calling `navigation.reset(/* params to main navigator */)` and right after that calling `navigation.navigate(/* params to post onboarding hub*/)` so the main screen of the app was effectively rendered first (due to navigation.reset)
  - I added a way to reset the navigation stack at once when navigating to the post onboarding hub
- implemented a "reset onboarding state" button in the debug settings to allow going back to a "not onboarded state" without having to clear the app's data

### ❓ Context

- **Impacted projects**: `common` `desktop` `mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-824] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** the analytics aren't covered but the selectors are (by unit and e2e testing)
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-824]: https://ledgerhq.atlassian.net/browse/FAT-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ