### PR TITLE
bugfix/LIVE-5364: Fix bug in device language change prompt

### DIFF
--- a/.changeset/forty-icons-fetch.md
+++ b/.changeset/forty-icons-fetch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix bug in device language prompt detection

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -73,6 +73,7 @@ import {
   SettingsSetFeatureFlagsBannerVisiblePayload,
   SettingsSetDebugAppLevelDrawerOpenedPayload,
   SettingsFilterTokenOperationsZeroAmountPayload,
+  SettingsLastSeenDeviceLanguagePayload,
 } from "./types";
 import { WalletTabNavigatorStackParamList } from "../components/RootNavigator/types/WalletTabNavigator";
 
@@ -378,6 +379,13 @@ const setLastSeenDeviceInfoAction =
   );
 export const setLastSeenDeviceInfo = (dmi: DeviceModelInfo) =>
   setLastSeenDeviceInfoAction({ dmi });
+
+const setLastSeenDeviceLanguageIdAction =
+  createAction<SettingsLastSeenDeviceLanguagePayload>(
+    SettingsActionTypes.LAST_SEEN_DEVICE_LANGUAGE_ID,
+  );
+export const setLastSeenDeviceLanguageId = (languageId: number) =>
+  setLastSeenDeviceLanguageIdAction({ languageId });
 
 const addStarredMarketCoinsAction =
   createAction<SettingsAddStarredMarketcoinsPayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -7,6 +7,7 @@ import type {
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type {
   Account,
+  DeviceInfo,
   DeviceModelInfo,
   Feature,
   FeatureId,
@@ -290,6 +291,7 @@ export enum SettingsActionTypes {
   ACCEPT_SWAP_PROVIDER = "ACCEPT_SWAP_PROVIDER",
   LAST_SEEN_DEVICE = "LAST_SEEN_DEVICE",
   LAST_SEEN_DEVICE_INFO = "LAST_SEEN_DEVICE_INFO",
+  LAST_SEEN_DEVICE_LANGUAGE_ID = "LAST_SEEN_DEVICE_LANGUAGE_ID",
   SET_LAST_SEEN_CUSTOM_IMAGE = "SET_LAST_SEEN_CUSTOM_IMAGE",
   ADD_STARRED_MARKET_COINS = "ADD_STARRED_MARKET_COINS",
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
@@ -407,6 +409,8 @@ export type SettingsLastSeenDevicePayload = {
 export type SettingsLastSeenDeviceInfoPayload = {
   dmi: DeviceModelInfo;
 };
+export type SettingsLastSeenDeviceLanguagePayload = Partial<DeviceInfo>;
+
 export type SettingsAddStarredMarketcoinsPayload = {
   starredMarketCoin: Unpacked<SettingsState["starredMarketCoins"]>;
 };
@@ -508,6 +512,7 @@ export type SettingsPayload =
   | SettingsSetSwapKycPayload
   | SettingsAcceptSwapProviderPayload
   | SettingsLastSeenDevicePayload
+  | SettingsLastSeenDeviceLanguagePayload
   | SettingsLastSeenDeviceInfoPayload
   | SettingsSetLastSeenCustomImagePayload
   | SettingsAddStarredMarketcoinsPayload

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -62,6 +62,7 @@ import PreventNativeBack from "../PreventNativeBack";
 import SkipLock from "../behaviour/SkipLock";
 import DeviceActionProgress from "../DeviceActionProgress";
 import { PartialNullable } from "../../types/helpers";
+import ModalLock from "../ModalLock";
 
 type LedgerError = InstanceType<
   LedgerErrorConstructor<{ [key: string]: unknown }>
@@ -280,6 +281,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
         <Flex mt={5}>
           <Text variant="h4">{t("deviceLocalization.installingLanguage")}</Text>
         </Flex>
+        <ModalLock />
       </Flex>
     );
   }

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Platform, ScrollView, StyleSheet } from "react-native";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import styled from "styled-components/native";
 import { LockedDeviceError, WrongDeviceForAccount } from "@ledgerhq/errors";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -45,7 +45,6 @@ import { StackNavigationProp } from "@react-navigation/stack";
 import { ParamListBase } from "@react-navigation/native";
 import isFirmwareUpdateVersionSupported from "@ledgerhq/live-common/hw/isFirmwareUpdateVersionSupported";
 import { lastSeenDeviceSelector } from "../../reducers/settings";
-import { setModalLock } from "../../actions/appstate";
 import { urls } from "../../config/urls";
 import Alert from "../Alert";
 import { lighten, Theme } from "../../colors";
@@ -71,6 +70,7 @@ import {
   Props as FramedImageWithLottieProps,
   FramedImageWithLottieWithContext,
 } from "../CustomImage/FramedImageWithLottie";
+import ModalLock from "../ModalLock";
 
 const confirmLockscreen = require("../animations/stax/customimage/confirmLockscreen.json"); // eslint-disable-line @typescript-eslint/no-var-requires, import/no-unresolved
 const allowConnection = require("../animations/stax/customimage/allowConnection.json"); // eslint-disable-line @typescript-eslint/no-var-requires, import/no-unresolved
@@ -893,6 +893,7 @@ export function renderLoading({
         <InfiniteLoader />
       </SpinnerContainer>
       <CenteredText>{description ?? t("DeviceAction.loading")}</CenteredText>
+      <ModalLock />
     </Wrapper>
   );
 }
@@ -955,17 +956,6 @@ export function LoadingAppInstall({
   description?: string;
   request?: AppRequest;
 }) {
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    // Nb Blocks closing the modal while the install is happening.
-    // releases the block on onmount.
-    dispatch(setModalLock(true));
-    return () => {
-      dispatch(setModalLock(false));
-    };
-  }, [dispatch]);
-
   const currency = request?.currency || request?.account?.currency;
   const appName = request?.appName || currency?.managerAppName;
   useEffect(() => {
@@ -975,6 +965,7 @@ export function LoadingAppInstall({
     ] as const;
     track(...trackingArgs);
   }, [appName, analyticsPropertyFlow]);
+
   return renderLoading(props);
 }
 

--- a/apps/ledger-live-mobile/src/components/DeviceLanguageInstalled.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceLanguageInstalled.tsx
@@ -1,15 +1,22 @@
 import React, { useEffect } from "react";
 
-import { Language } from "@ledgerhq/types-live";
+import { Language, languageIds } from "@ledgerhq/types-live";
 import { useTranslation } from "react-i18next";
 import { Flex, Text, Button, Icons } from "@ledgerhq/native-ui";
+import { useDispatch } from "react-redux";
+import { setLastSeenDeviceLanguageId } from "../actions/settings";
 
 const DeviceLanguageInstalled: React.FC<{
   onContinue?: () => void;
   onMount?: () => void;
   installedLanguage: Language;
 }> = ({ onContinue, onMount, installedLanguage }) => {
+  const dispatch = useDispatch();
+
   useEffect(() => {
+    // Nb Update the stored information for the last seen device to match this new language.
+    dispatch(setLastSeenDeviceLanguageId(languageIds[installedLanguage]));
+
     if (onMount) {
       onMount();
     }

--- a/apps/ledger-live-mobile/src/components/ModalLock.tsx
+++ b/apps/ledger-live-mobile/src/components/ModalLock.tsx
@@ -6,7 +6,7 @@ import { setModalLock } from "../actions/appstate";
 /**
  * If mounted, lock all drawers using the modalLock redux app state (components/QueuedDrawer)
  *
- * The modal lock is reset when loosing the react-navigation screen focus.
+ * The modal lock is reset when losing the react-navigation screen focus.
  *
  * Used in some DeviceAction displayed in drawers:
  * All steps of a DeviceAction that have an ongoing operation on

--- a/apps/ledger-live-mobile/src/components/ModalLock.tsx
+++ b/apps/ledger-live-mobile/src/components/ModalLock.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { setModalLock } from "../actions/appstate";
+
+/**
+ * All steps of a DeviceAction that have an ongoing operation on
+ * the device should disable the closing of the modal. If we are
+ * transfering something (installing an app, a language, CLS, etc)
+ * we don't want to break the flow.
+ */
+const LockModal = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(setModalLock(true));
+    return () => {
+      dispatch(setModalLock(false));
+    };
+  }, [dispatch]);
+
+  return null;
+};
+
+export default LockModal;

--- a/apps/ledger-live-mobile/src/components/ModalLock.tsx
+++ b/apps/ledger-live-mobile/src/components/ModalLock.tsx
@@ -1,24 +1,34 @@
-import { useEffect } from "react";
+import { useCallback } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import { useDispatch } from "react-redux";
 import { setModalLock } from "../actions/appstate";
 
 /**
+ * If mounted, lock all drawers using the modalLock redux app state (components/QueuedDrawer)
+ *
+ * The modal lock is reset when loosing the react-navigation screen focus.
+ *
+ * Used in some DeviceAction displayed in drawers:
  * All steps of a DeviceAction that have an ongoing operation on
  * the device should disable the closing of the modal. If we are
  * transfering something (installing an app, a language, CLS, etc)
  * we don't want to break the flow.
  */
-const LockModal = () => {
+const ModalLock = () => {
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    dispatch(setModalLock(true));
-    return () => {
-      dispatch(setModalLock(false));
-    };
-  }, [dispatch]);
+  // Triggered when the screen gets the (react-navigation) focus
+  useFocusEffect(
+    useCallback(() => {
+      dispatch(setModalLock(true));
+
+      return () => {
+        dispatch(setModalLock(false));
+      };
+    }, [dispatch]),
+  );
 
   return null;
 };
 
-export default LockModal;
+export default ModalLock;

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -33,10 +33,12 @@ export type Props = Merge<
  * The queue is cleaned when its associated screen loses its navigation focus. If a drawer is requesting to be opened while
  * its associated screen has not the focus, it is not added to the queue and its onClose prop is called.
  *
+ * You can also block the drawer for closing by setting the modalLock redux app state.
+ * To do this, you can use the component components/ModalLock.
+ * A drawer can still forcefully close other drawers and opens itself while the modalLock is set to true.
+ *
  * Note: avoid conditionally render this component. Always render it and use isRequestingToBeOpened to control its visibility.
  * Note: to avoid a UI glitch on Android, do not put this drawer inside NavigationScrollView (and probably any other ScrollView)
- *
- * Dev: internal functions can be wrapped in useCallback once BottomDrawer and BaseModal are memoized components
  *
  * @param isRequestingToBeOpened: to use in place of isOpen. Setting to true will add the drawer to the queue.
  *   Setting to false will remove it from the queue. Default to false.
@@ -66,7 +68,8 @@ const QueuedDrawer = ({
   children,
   ...rest
 }: Props) => {
-  const modalLock = useSelector(isModalLockedSelector);
+  // If the drawer system is locked to the currently opened drawer
+  const areDrawersLocked = useSelector(isModalLockedSelector);
   const [hasFocus, setHasFocus] = useState(false);
   // Actual state that choses if the drawer is displayed or not
   const [isDisplayed, setIsDisplayed] = useState(false);
@@ -110,10 +113,10 @@ const QueuedDrawer = ({
 
   const handleClose = useCallback(() => {
     // Blocks the drawer from closing
-    if (modalLock) return;
+    if (areDrawersLocked) return;
 
     onClose && onClose();
-  }, [modalLock, onClose]);
+  }, [areDrawersLocked, onClose]);
 
   const handleModalHide = useCallback(() => {
     onModalHide && onModalHide();
@@ -187,10 +190,10 @@ const QueuedDrawer = ({
 
   return (
     <BottomDrawer
-      preventBackdropClick={modalLock || preventBackdropClick}
+      preventBackdropClick={areDrawersLocked || preventBackdropClick}
       onClose={handleClose}
       onModalHide={handleModalHide}
-      noCloseButton={modalLock || noCloseButton}
+      noCloseButton={areDrawersLocked || noCloseButton}
       modalStyle={style}
       containerStyle={containerStyle}
       isOpen={isDisplayed}

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -68,6 +68,7 @@ import type {
   SettingsSetFeatureFlagsBannerVisiblePayload,
   DangerouslyOverrideStatePayload,
   SettingsSetDebugAppLevelDrawerOpenedPayload,
+  SettingsLastSeenDeviceLanguagePayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -484,6 +485,20 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
       ...(action as Action<SettingsLastSeenDeviceInfoPayload>).payload.dmi,
     },
   }),
+
+  [SettingsActionTypes.LAST_SEEN_DEVICE_LANGUAGE_ID]: (state, action) => {
+    if (!state.lastSeenDevice) return state;
+    return {
+      ...state,
+      lastSeenDevice: {
+        ...state.lastSeenDevice,
+        deviceInfo: {
+          ...state.lastSeenDevice.deviceInfo,
+          ...(action as Action<SettingsLastSeenDeviceLanguagePayload>).payload,
+        },
+      },
+    };
+  },
 
   [SettingsActionTypes.ADD_STARRED_MARKET_COINS]: (state, action) => ({
     ...state,

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguageSelection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguageSelection.tsx
@@ -52,6 +52,7 @@ const DeviceLanguageSelection: React.FC<Props> = ({
                 currentLanguage === deviceLanguage;
               return (
                 <SelectableList.Element
+                  key={currentLanguage}
                   value={currentLanguage}
                   renderRight={() =>
                     isCurrentDeviceLanguage ? (

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/QueuedDrawers.tsx
@@ -8,6 +8,8 @@ import { SettingsNavigatorStackParamList } from "../../../../components/RootNavi
 import { ScreenName } from "../../../../const";
 import { setDebugAppLelevelDrawerOpened } from "../../../../actions/settings";
 import { debugAppLevelDrawerOpenedSelector } from "../../../../reducers/settings";
+import LockModal from "../../../../components/ModalLock";
+import NavigationScrollView from "../../../../components/NavigationScrollView";
 
 /**
  * Debugging screen to test:
@@ -40,6 +42,9 @@ export default function DebugQueuedDrawers() {
 
   const [isDrawer6AOpen, setIsDrawer6AOpen] = useState(false);
   const [isDrawer6BOpen, setIsDrawer6BOpen] = useState(false);
+
+  const [areDrawersLockedStarted, setAreDrawersLockedStarted] = useState(false);
+  const [areDrawersLocked, setAreDrawersLocked] = useState(false);
 
   // Handles 4th drawer opening after x seconds
   useEffect(() => {
@@ -93,6 +98,27 @@ export default function DebugQueuedDrawers() {
     };
   }, [isNavigatingAfter3s, navigation]);
 
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    if (areDrawersLockedStarted) {
+      setAreDrawersLocked(true);
+
+      timeoutId = setTimeout(() => {
+        setAreDrawersLocked(false);
+        setAreDrawersLockedStarted(false);
+      }, 10000);
+    }
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      if (areDrawersLockedStarted) {
+        setAreDrawersLockedStarted(false);
+        setAreDrawersLocked(false);
+      }
+    };
+  }, [areDrawersLockedStarted]);
+
   const handleDrawer1Close = useCallback(() => {
     setIsDrawer1Open(false);
   }, []);
@@ -133,110 +159,122 @@ export default function DebugQueuedDrawers() {
 
   return (
     <>
-      <Flex p="4">
-        <Flex mb="2">
-          <Switch
-            checked={isDrawer1Open}
-            onChange={val => setIsDrawer1Open(val)}
-            label={"Open the 1st drawer"}
+      <NavigationScrollView>
+        <Flex p="4">
+          <Flex mb="2">
+            <Switch
+              checked={isDrawer1Open}
+              onChange={val => setIsDrawer1Open(val)}
+              label={"Open the 1st drawer"}
+            />
+          </Flex>
+          <Flex mb="2">
+            <Switch
+              checked={isDrawer2Open}
+              onChange={val => {
+                setIsDrawer1Open(val);
+                setIsDrawer2Open(val);
+              }}
+              label={"Open the 1st then 2nd drawers"}
+            />
+          </Flex>
+          <Flex mb="2">
+            <Switch
+              checked={isDrawer3Open}
+              onChange={val => {
+                setIsDrawer1Open(val);
+                setIsDrawer2Open(val);
+                setIsDrawer3Open(val);
+              }}
+              label={"Open the 1st then 2nd then 3rd drawers"}
+            />
+          </Flex>
+          <Flex mt="6" mb="6">
+            <Switch
+              checked={isDrawer4Started}
+              onChange={val => {
+                setIsDrawer4Started(val);
+              }}
+              label={
+                "Open a 4th drawer after 3sec that adds itself to the queue of drawers, without forcing 🧑‍🎓"
+              }
+            />
+          </Flex>
+          <Flex mb="6">
+            <Switch
+              checked={isDrawer5Started}
+              onChange={val => {
+                setIsDrawer5Started(val);
+              }}
+              label={
+                "Open a 5th drawer after 3sec that forces all the other opened drawers to close ⚔️"
+              }
+            />
+          </Flex>
+          <Flex mb="6">
+            <Switch
+              checked={isDebugAppLevelDrawerOpened}
+              onChange={handleDebugAppLevelDrawerOpenedChange}
+              label={
+                "Open a drawer equivalent to the notification or ratings drawer 📲"
+              }
+            />
+          </Flex>
+          <Flex mb="6">
+            <Switch
+              checked={isDrawer6AOpen || isDrawer6BOpen}
+              onChange={val => {
+                // Only opens the 1st drawer, the 2nd one will be opened on user close
+                setIsDrawer6AOpen(val);
+              }}
+              label={
+                "Open a 1st drawer, and on user close, open a 2nd drawer after closing the 1st one. To test on iOS"
+              }
+            />
+          </Flex>
+          <Flex mb="6">
+            <Switch
+              checked={areDrawersLockedStarted}
+              onChange={val => {
+                setAreDrawersLockedStarted(val);
+              }}
+              label={`Lock all drawer for 10sec, then unlock them: currently ${
+                areDrawersLocked ? "locked 🔒" : "unlocked 🔓"
+              }`}
+            />
+          </Flex>
+          <Alert
+            type="info"
+            title="Hey 🧙‍♀️ Test successive opening/closing of drawers !"
           />
-        </Flex>
-        <Flex mb="2">
-          <Switch
-            checked={isDrawer2Open}
-            onChange={val => {
-              setIsDrawer1Open(val);
-              setIsDrawer2Open(val);
-            }}
-            label={"Open the 1st then 2nd drawers"}
-          />
-        </Flex>
-        <Flex mb="2">
-          <Switch
-            checked={isDrawer3Open}
-            onChange={val => {
-              setIsDrawer1Open(val);
-              setIsDrawer2Open(val);
-              setIsDrawer3Open(val);
-            }}
-            label={"Open the 1st then 2nd then 3rd drawers"}
-          />
-        </Flex>
-        <Flex mt="6" mb="6">
-          <Switch
-            checked={isDrawer4Started}
-            onChange={val => {
-              setIsDrawer4Started(val);
-            }}
-            label={
-              "Open a 4th drawer after 3sec that adds itself to the queue of drawers, without forcing 🧑‍🎓"
-            }
-          />
-        </Flex>
-        <Flex mb="6">
-          <Switch
-            checked={isDrawer5Started}
-            onChange={val => {
-              setIsDrawer5Started(val);
-            }}
-            label={
-              "Open a 5th drawer after 3sec that forces all the other opened drawers to close ⚔️"
-            }
-          />
-        </Flex>
-        <Flex mb="6">
-          <Switch
-            checked={isDebugAppLevelDrawerOpened}
-            onChange={handleDebugAppLevelDrawerOpenedChange}
-            label={
-              "Open a drawer equivalent to the notification or ratings drawer 📲"
-            }
-          />
-        </Flex>
-        <Flex mb="6">
-          <Switch
-            checked={isDrawer6AOpen || isDrawer6BOpen}
-            onChange={val => {
-              // Only opens the 1st drawer, the 2nd one will be opened on user close
-              setIsDrawer6AOpen(val);
-            }}
-            label={
-              "Open a 1st drawer, and on user close, open a 2nd drawer after closing the 1st one. To test on iOS"
-            }
-          />
-        </Flex>
-        <Alert
-          type="info"
-          title="Hey 🧙‍♀️ Test successive opening/closing of drawers !"
-        />
-        <Flex mt="8">
-          <Text>
-            Also, try navigating to a new screen by clicking on one of the
-            buttons below and come back here with the back arrow. To check if
-            the drawers are still working.
-          </Text>
+          <Flex mt="8">
+            <Text>
+              Also, try navigating to a new screen by clicking on one of the
+              buttons below and come back here with the back arrow. To check if
+              the drawers are still working.
+            </Text>
 
-          <Button
-            type="main"
-            onPress={() => navigation.navigate(ScreenName.DebugLottie)}
-            mt="8"
-            size="small"
-            outline
-          >
-            Navigate somewhere 🧞‍♂️
-          </Button>
-          <Button
-            type="main"
-            onPress={() => setIsNavigatingAfter3s(true)}
-            mt="8"
-            size="small"
-            outline
-          >
-            Navigate somewhere after 3s ⏳
-          </Button>
+            <Button
+              type="main"
+              onPress={() => navigation.navigate(ScreenName.DebugLottie)}
+              mt="8"
+              size="small"
+              outline
+            >
+              Navigate somewhere 🧞‍♂️
+            </Button>
+            <Button
+              type="main"
+              onPress={() => setIsNavigatingAfter3s(true)}
+              mt="8"
+              size="small"
+              outline
+            >
+              Navigate somewhere after 3s ⏳
+            </Button>
+          </Flex>
         </Flex>
-      </Flex>
-
+      </NavigationScrollView>
       <QueuedDrawer
         isRequestingToBeOpened={isDrawer1Open}
         onClose={handleDrawer1Close}
@@ -309,6 +347,8 @@ export default function DebugQueuedDrawers() {
           <Alert type="info" title="Drawer B 🥳" />
         </Flex>
       </QueuedDrawer>
+
+      {areDrawersLocked && <LockModal />}
     </>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We were not storing the changed language on the last seen device information leaving to a missed opportunity to prompt the user to also change the device language when they changed the app language and we can offer it. It's easier to understand with the test instructions really.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-5364 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/219421109-18a0d5a4-49ed-4aa3-a6b5-ec5660668b3f.mp4

### 🚀 Expectations to reach
- LLM should remember the last seen device language now.
- Changing LLM to a language supported by FW should prompt the user.
- If the last seen device language is already LLM's language, no prompt.