### PR TITLE
bugfix/crypto_org: Fix automated test failure on Crypto.org Chain App 

### DIFF
--- a/libs/ledger-live-common/src/families/crypto_org/api/sdk.types.ts
+++ b/libs/ledger-live-common/src/families/crypto_org/api/sdk.types.ts
@@ -1,6 +1,6 @@
 export const CryptoOrgAccountTransactionTypeEnum = {
-  MsgSend: "MsgSend",
-  MgsMultiSend: "MsgMultiSend",
+  MsgSend: "/cosmos.bank.v1beta1.MsgSend",
+  MgsMultiSend: "/cosmos.bank.v1beta1.MsgMultiSend",
 };
 export const CryptoOrgCurrency = "basecro";
 export const CryptoOrgTestnetCurrency = "basetcro";


### PR DESCRIPTION
## Issue
Automated tests for Crypto.org Chain App now see failures on the [crypto.org](http://crypto.org/) integration: https://github.com/LedgerHQ/ledger-live/commit/65e1f628865f969ab05a4f7898b6ef8c8bc1b2cf#commitcomment-99160026
```
▬ Crypto.orgChain 2.16.7 on nanoS 2.1.0
→ FROM Crypto.org 1 cross: 0.999925 CRO (0ops) (cro1zputcjqlxpkg7sa4aymwvv3qj8mcejk06recc7 on 44'/394'/0'/0/0) #0 js:2:crypto_org:cro1zputcjqlxpkg7sa4aymwvv3qj8mcejk06recc7: (! sum of ops 0 CRO) 0.999925 CRO spendable. 

max spendable ~0.999875
★ using mutation 'move 50%'
→ TO Crypto.org 2: 2.99997 CRO (0ops) (cro10fpefw9ghxm0skumpspm86wc4fgrm769rtvssr on 44'/394'/1'/0/0) #1 js:2:crypto_org:cro10fpefw9ghxm0skumpspm86wc4fgrm769rtvssr:
✔️ transaction 
SEND  0.4999625 CRO
TO cro10fpefw9ghxm0skumpspm86wc4fgrm769rtvssr
STATUS (2.89ms)
  amount: 0.4999625 CRO
  estimated fees: 0.00005 CRO
  total spent: 0.5000125 CRO
errors: 
errors: 
✔️ has been signed! (2643ms) 
✔️ broadcasted! (7.3s) optimistic operation: 
  -0.5000125 CRO     OUT        923158B0B558C82B047F429A48A464C945D7C6474BCB46DA85D3EE59B4B7B7DB 2023-02-03T09:31
⚠️ TEST waiting operation id to appear after broadcast
Error: could not find optimisticOperation js:2:crypto_org:cro1zputcjqlxpkg7sa4aymwvv3qj8mcejk06recc7:-923158B0B558C82B047F429A48A464C945D7C6474BCB46DA85D3EE59B4B7B7DB-OUT
```

## Reason
The transaction `messageTypes` returns from the [Indexing API](https://crypto.org/explorer/croeseid4/api/v1/accounts/tcro1e23r5ln290ur8e3ct87zkyg8khqu2z56whrj62/transactions?pagination=offset&page=1) changes into a full path:
`MsgSend` => `/cosmos.bank.v1beta1.MsgSend`

## Other potential changes
The original node endpoints are deprecated soon: 
| Network | Deprecated Endpoint | New Endpoint (In operation) |
|--|--|--|
| Mainnet | https://mainnet.crypto.org:26657 | https://rpc.mainnet.crypto.org |
| Testnet Croeseid 4 | https://testnet-croeseid-4.crypto.org:26657 | https://rpc-testnet-croeseid-4.crypto.org |
