### PR TITLE
LLM - Lock issue fix

### DIFF
--- a/.changeset/healthy-pets-complain.md
+++ b/.changeset/healthy-pets-complain.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Removed timeout value when app goes into background

--- a/apps/ledger-live-mobile/src/constants.ts
+++ b/apps/ledger-live-mobile/src/constants.ts
@@ -10,6 +10,5 @@ export const BLE_SCANNING_NOTHING_TIMEOUT = 30 * 1000;
 export const GENUINE_CHECK_TIMEOUT = 120 * 1000;
 export const GET_CALLS_RETRY = 3;
 export const GET_CALLS_TIMEOUT = 60000;
-export const AUTOLOCK_TIMEOUT = 60000;
 export const LEDGER_REST_API_BASE = "https://explorers.api.live.ledger.com";
 export const VIBRATION_PATTERN_ERROR = [0, 150];

--- a/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
@@ -5,10 +5,8 @@ import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { compose } from "redux";
-import { getEnv } from "@ledgerhq/live-common/env";
 import { privacySelector } from "../../reducers/settings";
 import { SkipLockContext } from "../../components/behaviour/SkipLock";
-import { AUTOLOCK_TIMEOUT } from "../../constants";
 import type { Privacy, State as GlobalState } from "../../reducers/types";
 import AuthScreen from "./AuthScreen";
 import RequestBiometricAuth from "../../components/RequestBiometricAuth";
@@ -76,22 +74,12 @@ class AuthPass extends PureComponent<Props, State> {
     this.state.mounted = false;
   }
 
-  appInBg: number | undefined;
   handleAppStateChange = (nextAppState: string) => {
-    const timeoutValue = getEnv("MOCK") ? 5000 : AUTOLOCK_TIMEOUT;
     if (
       this.state.appState.match(/inactive|background/) &&
-      nextAppState === "active" &&
-      !!this.appInBg &&
-      this.appInBg + timeoutValue < Date.now()
+      nextAppState === "active"
     ) {
       this.lock();
-      this.appInBg = Date.now();
-    } else if (
-      nextAppState === "background" ||
-      this.state.appState === "active"
-    ) {
-      this.appInBg = Date.now();
     }
 
     if (this.state.mounted)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When using LLM password prompt feature, we're currently logging current time when the application goes background. When coming back to the app, we compare the time the app went background to the current time. If the delay is big enough, we prompt the user for his password.
A vulnerability was reported in our bugbounty program : the password prompt can be defeated by setting the device time to a date before the app went background.
The proposed solution was : instead of comparing times, we use an unchangeable value, the device uptime. If the uptime retained when the app went background is smaller than the current uptime, we prompt for the password. That solution didn't worked well.
New solution is an anticipation of a new FaceID feature coming up in the next weeks. The background timeout has been deprecated and the app is now locked each time it goes in background.


### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: LIVE-5060
### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
