### PR TITLE
BACK-4796: Prefix testnet token ticker with "t" in transaction config

### DIFF
--- a/libs/ledgerjs/script/crypto-assets-importer/importers/erc20-signatures.js
+++ b/libs/ledgerjs/script/crypto-assets-importer/importers/erc20-signatures.js
@@ -5,10 +5,6 @@ const {
   getCryptoCurrencyById,
 } = require("../../../packages/cryptoassets/lib/currencies");
 
-const inferChainId = (common, folder) =>
-  getCryptoCurrencyById(path.basename(path.dirname(folder))).ethereumLikeInfo
-    .chainId;
-
 module.exports = {
   paths: [
     "tokens/ethereum/erc20",
@@ -38,14 +34,19 @@ module.exports = {
       readFileJSON(path.join(folder, id, "common.json")),
       readFileJSON(path.join(signatureFolder, id, "ledger_signature.json")),
     ]).then(([common, ledgerSignature]) => {
+
+      const currency = getCryptoCurrencyById(path.basename(path.dirname(folder)));
+
+      // match crypto-assets convention for tickers: testnet tokens are prefixed with "t"
+      // https://github.com/LedgerHQ/crypto-assets/blob/d2fe1cf9a110614650191555b846a2e43eb67b8f/scripts/hsm/coin_parameters/coin_parameters.py#L163
+      const prefix = currency.isTestnetFor !== undefined ? 't': '';
+      const ticker = Buffer.from(prefix + common.ticker, "ascii");
+
       const decimals = asUint4be(common.decimals);
-      const contractAddress = Buffer.from(
-        common.contract_address.slice(2),
-        "hex"
-      );
-      const ticker = Buffer.from(common.ticker, "ascii");
-      const chainId = asUint4be(inferChainId(common, folder));
+      const chainId = asUint4be(currency.ethereumLikeInfo.chainId);
+      const contractAddress = Buffer.from(common.contract_address.slice(2), "hex");
       const signature = Buffer.from(ledgerSignature, "hex");
+
       return Buffer.concat([
         Buffer.from([ticker.length]),
         ticker,


### PR DESCRIPTION
### 📝 Description

See https://ledgerhq.atlassian.net/wiki/spaces/~623066f962dc1e006801f92c/pages/4071784452/BACK-4796+Ledger+Live+signature+mismatch+for+Go+rli+tokens

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
