### PR TITLE
Feat/LIVE-5459 : Add go to live app button inside webview

### DIFF
--- a/.changeset/cyan-trains-attack.md
+++ b/.changeset/cyan-trains-attack.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add back to live app option in webview

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -36,6 +36,7 @@ const ExchangeBuy = (
           account: _props.route.params?.defaultAccountId,
         },
       }}
+      config={{ shouldDisplayBackToLiveApp: true }}
     />
   );
 };
@@ -63,6 +64,7 @@ const ExchangeSell = (
           account: _props.route.params?.defaultAccountId,
         },
       }}
+      config={{ shouldDisplayBackToLiveApp: true }}
     />
   );
 };

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebView.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebView.tsx
@@ -136,8 +136,9 @@ export const WebView = ({ manifest, inputs }: Props) => {
         StackNavigatorNavigation<BaseNavigatorStackParamList>
       >
     >();
-  const lastLedgerLiveAppURL = useRef("");
-  const [isLedgerLiveAppURL, setIsLedgerLiveAppURL] = useState(true);
+  const { displayBackToManifestApp } = manifest;
+  const lastManifestAppURL = useRef("");
+  const [isManifestAppURL, setIsManifestAppURL] = useState(true);
   const [loadDate, setLoadDate] = useState(new Date());
   const [widgetLoaded, setWidgetLoaded] = useState(false);
   const [isInfoPanelOpened, setIsInfoPanelOpened] = useState(false);
@@ -592,26 +593,23 @@ export const WebView = ({ manifest, inputs }: Props) => {
     tracking.platformLoadFail(manifest);
   }, [manifest]);
 
-  const handleNavigateBackToLedgerLiveApp = () => {
-    const redirectTo = `window.location = "${lastLedgerLiveAppURL.current}"`;
+  const handleNavigateBackToManifestApp = () => {
+    const redirectTo = `window.location = "${lastManifestAppURL.current}"`;
     targetRef.current && targetRef.current.injectJavaScript(redirectTo);
   };
 
   const handleOnNavigationStateChange = ({ url }: { url: string }) => {
-    const isOriginUrl = url.includes(manifest.url.toString());
-    if (isOriginUrl) lastLedgerLiveAppURL.current = url;
-    setIsLedgerLiveAppURL(isOriginUrl);
+    const manifestHostname = new URL(manifest.url).hostname;
+    const isOriginUrl = url.includes(manifestHostname);
+    if (isOriginUrl) lastManifestAppURL.current = url;
+    setIsManifestAppURL(isOriginUrl);
   };
-
-  const shouldDisplayBackToLedgerLiveApp = manifest.params?.includes(
-    "shouldDisplayBackToLedgerLiveApp",
-  );
 
   useEffect(() => {
     navigation.setOptions(
-      shouldDisplayBackToLedgerLiveApp
+      displayBackToManifestApp
         ? {
-            headerTitle: isLedgerLiveAppURL ? manifest.name : "",
+            headerTitle: isManifestAppURL ? manifest.name : "",
             headerRight: () => (
               <View style={styles.headerRightLedgerLiveApp}>
                 <TouchableOpacity
@@ -627,10 +625,10 @@ export const WebView = ({ manifest, inputs }: Props) => {
             ),
             headerLeft: () => (
               <View style={styles.headerLeftLedgerLiveApp}>
-                {!isLedgerLiveAppURL && (
+                {!isManifestAppURL && (
                   <Flex alignItems={"center"}>
                     <Text
-                      onPress={handleNavigateBackToLedgerLiveApp}
+                      onPress={handleNavigateBackToManifestApp}
                       fontWeight="semiBold"
                       fontSize={16}
                       color="neutral.c100"
@@ -660,8 +658,8 @@ export const WebView = ({ manifest, inputs }: Props) => {
     widgetLoaded,
     handleReload,
     isInfoPanelOpened,
-    isLedgerLiveAppURL,
-    shouldDisplayBackToLedgerLiveApp,
+    displayBackToManifestApp,
+    isManifestAppURL,
     manifest,
     t,
   ]);

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebView.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebView.tsx
@@ -73,12 +73,14 @@ import {
   StackNavigatorNavigation,
 } from "../RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
+import { WebPlatformPlayerConfig } from "./types";
 
 const tracking = trackingWrapper(track);
 
 type Props = {
   manifest: LiveAppManifest;
   inputs?: Record<string, string>;
+  config?: WebPlatformPlayerConfig;
 };
 
 const ReloadButton = ({
@@ -124,7 +126,7 @@ const InfoPanelButton = ({
   );
 };
 
-export const WebView = ({ manifest, inputs }: Props) => {
+export const WebView = ({ manifest, inputs, config = {} }: Props) => {
   const targetRef: {
     current: null | RNWebView;
   } = useRef(null);
@@ -136,9 +138,9 @@ export const WebView = ({ manifest, inputs }: Props) => {
         StackNavigatorNavigation<BaseNavigatorStackParamList>
       >
     >();
-  const { displayBackToManifestApp } = manifest;
-  const lastManifestAppURL = useRef("");
-  const [isManifestAppURL, setIsManifestAppURL] = useState(true);
+  const { shouldDisplayBackToLiveApp } = config;
+  const lastliveAppURL = useRef("");
+  const [isLiveAppURL, setIsLiveAppURL] = useState(true);
   const [loadDate, setLoadDate] = useState(new Date());
   const [widgetLoaded, setWidgetLoaded] = useState(false);
   const [isInfoPanelOpened, setIsInfoPanelOpened] = useState(false);
@@ -593,23 +595,23 @@ export const WebView = ({ manifest, inputs }: Props) => {
     tracking.platformLoadFail(manifest);
   }, [manifest]);
 
-  const handleNavigateBackToManifestApp = () => {
-    const redirectTo = `window.location = "${lastManifestAppURL.current}"`;
+  const handleNavigateBackToliveApp = () => {
+    const redirectTo = `window.location = "${lastliveAppURL.current}"`;
     targetRef.current && targetRef.current.injectJavaScript(redirectTo);
   };
 
   const handleOnNavigationStateChange = ({ url }: { url: string }) => {
     const manifestHostname = new URL(manifest.url).hostname;
     const isOriginUrl = url.includes(manifestHostname);
-    if (isOriginUrl) lastManifestAppURL.current = url;
-    setIsManifestAppURL(isOriginUrl);
+    if (isOriginUrl) lastliveAppURL.current = url;
+    setIsLiveAppURL(isOriginUrl);
   };
 
   useEffect(() => {
     navigation.setOptions(
-      displayBackToManifestApp
+      shouldDisplayBackToLiveApp
         ? {
-            headerTitle: isManifestAppURL ? manifest.name : "",
+            headerTitle: isLiveAppURL ? manifest.name : "",
             headerRight: () => (
               <View style={styles.headerRightLedgerLiveApp}>
                 <TouchableOpacity
@@ -625,10 +627,10 @@ export const WebView = ({ manifest, inputs }: Props) => {
             ),
             headerLeft: () => (
               <View style={styles.headerLeftLedgerLiveApp}>
-                {!isManifestAppURL && (
+                {!isLiveAppURL && (
                   <Flex alignItems={"center"}>
                     <Text
-                      onPress={handleNavigateBackToManifestApp}
+                      onPress={handleNavigateBackToliveApp}
                       fontWeight="semiBold"
                       fontSize={16}
                       color="neutral.c100"
@@ -658,8 +660,8 @@ export const WebView = ({ manifest, inputs }: Props) => {
     widgetLoaded,
     handleReload,
     isInfoPanelOpened,
-    displayBackToManifestApp,
-    isManifestAppURL,
+    shouldDisplayBackToLiveApp,
+    isLiveAppURL,
     manifest,
     t,
   ]);

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
@@ -4,17 +4,19 @@ import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import React from "react";
 import { WebView as WebViewV2 } from "./WebViewV2";
 import { WebView } from "./WebView";
+import { WebPlatformPlayerConfig } from "./types";
 
 type Props = {
   manifest: LiveAppManifest;
   inputs?: Record<string, string>;
+  config?: WebPlatformPlayerConfig;
 };
 
-const WebViewWrapper = ({ manifest, inputs }: Props) => {
+const WebViewWrapper = ({ manifest, inputs, config }: Props) => {
   if (semver.satisfies(WALLET_API_VERSION, manifest.apiVersion)) {
     return <WebViewV2 manifest={manifest} inputs={inputs} />;
   }
-  return <WebView manifest={manifest} inputs={inputs} />;
+  return <WebView manifest={manifest} inputs={inputs} config={config} />;
 };
 
 export default WebViewWrapper;

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/types.ts
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/types.ts
@@ -1,0 +1,3 @@
+export type WebPlatformPlayerConfig = {
+  shouldDisplayBackToLiveApp?: boolean;
+};

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -11,6 +11,7 @@
     "no": "No",
     "gotit": "Got it",
     "continue": "Continue",
+    "backToLiveApp": "Back to {{liveApp}}",
     "retry": "Retry",
     "done": "Done",
     "sortBy": "Sort by",
@@ -811,7 +812,7 @@
       "title": "Your device is locked",
       "description": "Unlock your device and try again.",
       "descriptionWithProductName": "Unlock your {{ productName }} and try again."
-    },    
+    },
     "EtherscanAPIError": {
       "title": "Fetching transactions failed",
       "description": "An unexpected error occurred with the explorers. Please try again later"

--- a/apps/ledger-live-mobile/src/screens/Platform/App.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/App.tsx
@@ -16,16 +16,24 @@ import { ScreenName } from "../../const";
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { StackNavigatorProps } from "../../components/RootNavigator/types/helpers";
 import { ExchangeNavigatorParamList } from "../../components/RootNavigator/types/ExchangeNavigator";
+import { WebPlatformPlayerConfig } from "../../components/WebPlatformPlayer/types";
 
 const appManifestNotFoundError = new Error("App not found"); // FIXME move this elsewhere.
-type Props =
-  | StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PlatformApp>
-  | StackNavigatorProps<
-      ExchangeNavigatorParamList,
-      ScreenName.ExchangeBuy | ScreenName.ExchangeSell
-    >;
 
-const PlatformApp = ({ route }: Props) => {
+type Config = {
+  config?: WebPlatformPlayerConfig;
+};
+
+type Props = Config &
+  (
+    | StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PlatformApp>
+    | StackNavigatorProps<
+        ExchangeNavigatorParamList,
+        ScreenName.ExchangeBuy | ScreenName.ExchangeSell
+      >
+  );
+
+const PlatformApp = ({ route, config }: Props) => {
   const { theme } = useTheme();
   const { platform: appId, ...params } = route.params || {};
   const { setParams } = useNavigation<Props["navigation"]>();
@@ -52,6 +60,7 @@ const PlatformApp = ({ route }: Props) => {
           lang: locale,
           ...params,
         }}
+        config={config}
       />
     </>
   ) : (

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -70,7 +70,7 @@ export type LiveAppManifest = {
     shortDescription: TranslatableString;
     description: TranslatableString;
   };
-  displayBackToManifestApp: boolean;
+  displayBackToManifestApp?: boolean;
 };
 
 export type PlatformApi = {

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -70,6 +70,7 @@ export type LiveAppManifest = {
     shortDescription: TranslatableString;
     description: TranslatableString;
   };
+  displayBackToManifestApp: boolean;
 };
 
 export type PlatformApi = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add the option inside manifest to render a button to go back to live app when the app redirects the user to external url
### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-5459` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

![image](https://user-images.githubusercontent.com/104982457/220100954-9f569813-8b3b-4c28-befb-b415b8c395a5.png)
![image](https://user-images.githubusercontent.com/104982457/220100979-5e295aee-6ee4-455a-8b02-5af300061a5e.png)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
