### PR TITLE
LIVE-5681 Increase gas estimation for claim rewards for cosmos

### DIFF
--- a/.changeset/strange-fireants-fly.md
+++ b/.changeset/strange-fireants-fly.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+increase gas estimation for claim rewards

--- a/libs/ledger-live-common/src/families/cosmos/chain/cosmosBase.ts
+++ b/libs/ledger-live-common/src/families/cosmos/chain/cosmosBase.ts
@@ -15,11 +15,12 @@ abstract class cosmosBase {
     [Key in CosmosOperationMode]: number;
   } = {
     // refer to https://github.com/chainapsis/keplr-wallet/blob/master/packages/stores/src/account/cosmos.ts#L113 for the gas fees
+    // TODO use simulate endpoint to evaluate tx gas instead of constant gas
     send: 90000,
     delegate: 250000,
     undelegate: 250000,
     redelegate: 300000,
-    claimReward: 140000,
+    claimReward: 180000,
     claimRewardCompound: 400000,
   };
   public static COSMOS_FAMILY_LEDGER_VALIDATOR_ADDRESSES: string[] = [];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Increase gas estimation for claim rewards for cosmos to avoid "out of gas" error from users

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5681

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
