### PR TITLE
ci: remove now useless ref input

### DIFF
--- a/.github/workflows/build-desktop-external.yml
+++ b/.github/workflows/build-desktop-external.yml
@@ -1,12 +1,12 @@
 name: "@Desktop • Build App (external)"
-run-name: "@Desktop • Build App (external) triggered by ${{ inputs.login }}  ${{ format('on branch {0}', inputs.ref) }}"
+run-name: "@Desktop • Build App (external) triggered by ${{ inputs.login }}  ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   workflow_dispatch:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -15,8 +15,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref }}
-  cancel-in-progress: ${{ github.event.inputs.ref != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   build-desktop-app:
@@ -47,7 +47,7 @@ jobs:
             }
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.event.push.head.sha }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - name: Set git user
         run: |

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,5 +1,5 @@
 name: "@Desktop • Build App"
-run-name: "@Desktop • Build App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ github.event_name == 'workflow_dispatch' && format('on branch {0}', inputs.ref) || format('on ref {0}', github.ref) }}"
+run-name: "@Desktop • Build App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -21,8 +21,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   start-runner:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - name: Set git user
         run: |
@@ -106,7 +106,7 @@ jobs:
           echo "C:\Program Files\Git\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: actions/setup-dotnet@v2
         with:
@@ -141,7 +141,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
           persist-credentials: false
       - name: Set git user

--- a/.github/workflows/build-mobile-external.yml
+++ b/.github/workflows/build-mobile-external.yml
@@ -1,12 +1,12 @@
 name: "@Mobile • Build App (external)"
-run-name: "@Mobile • Build App (external) triggered by ${{ inputs.login }} ${{ format('on branch {0}', inputs.ref) }}"
+run-name: "@Mobile • Build App (external) triggered by ${{ inputs.login }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   workflow_dispatch:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -15,8 +15,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event.inputs.ref != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   build-mobile-app-android:
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.event.push.head.sha }}
+          ref: ${{ github.ref_name }}
           base_ref: ${{ inputs.base_ref }}
       - name: set git user
         run: |
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.event.push.head.sha }}
+          ref: ${{ github.ref_name }}
           base_ref: ${{ inputs.base_ref }}
       - name: set git user
         run: |

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -1,5 +1,5 @@
 name: "@Mobile • Build App"
-run-name: "@Mobile • Build App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ github.event_name == 'workflow_dispatch' && format('on branch {0}', inputs.ref) || format('on ref {0}', github.ref) }}"
+run-name: "@Mobile • Build App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -21,8 +21,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   start-runner:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - name: set git user
         run: |
@@ -143,7 +143,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - name: set git user
         run: |

--- a/.github/workflows/test-desktop-external.yml
+++ b/.github/workflows/test-desktop-external.yml
@@ -1,12 +1,12 @@
 name: "@Desktop • Test App (external)"
-run-name: "@Desktop • Test App (external) triggered by ${{ inputs.login }} ${{ format('on branch {0}', inputs.ref) }}"
+run-name: "@Desktop • Test App (external) triggered by ${{ inputs.login }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   workflow_dispatch:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -15,8 +15,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref }}
-  cancel-in-progress: ${{ github.event.inputs.ref != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   typecheck:
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -188,7 +188,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -238,7 +238,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
           base: ${{ inputs.base_ref }}
       - name: download images artifacts
         uses: actions/download-artifact@v3
@@ -394,7 +394,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.ref_name }}
       - name: Download Allure Report - Windows
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -1,5 +1,5 @@
 name: "@Desktop • Test App"
-run-name: "@Desktop • Test App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ github.event_name == 'workflow_dispatch' && format('on branch {0}', inputs.ref) || format('on ref {0}', github.ref) }}"
+run-name: "@Desktop • Test App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -21,8 +21,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   typecheck:
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -171,7 +171,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -229,7 +229,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
@@ -280,7 +280,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - name: download images artifacts
         uses: actions/download-artifact@v3
@@ -438,7 +438,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
       - name: Download Allure Report - Windows
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test-mobile-e2e.yml
+++ b/.github/workflows/test-mobile-e2e.yml
@@ -1,5 +1,5 @@
 name: "@Mobile • Test App End-2-End"
-run-name: "@Mobile • Test App End-2-End triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ github.event_name == 'workflow_dispatch' && format('on branch {0}', inputs.ref) || format('on ref {0}', github.ref) }}"
+run-name: "@Mobile • Test App End-2-End triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -26,8 +26,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   detox-tests-ios:
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: pnpm/action-setup@v2
         with:
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
       - uses: ./tools/actions/composites/upload-allure-report
         with:
           platform: ios
@@ -129,7 +129,7 @@ jobs:
   #     - name: checkout
   #       uses: actions/checkout@v3
   #       with:
-  #         ref: ${{ inputs.ref || 'develop' }}
+  #         ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
   #     - uses: pnpm/action-setup@v2
   #       with:
   #         version: latest
@@ -219,7 +219,7 @@ jobs:
   #     - name: checkout
   #       uses: actions/checkout@v3
   #       with:
-  #         ref: ${{ inputs.ref || 'develop' }}
+  #         ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
   #     - uses: ./tools/actions/composites/upload-allure-report
   #       with:
   #         platform: android
@@ -234,7 +234,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: actions/github-script@v6
         name: prepare status

--- a/.github/workflows/test-mobile.yml
+++ b/.github/workflows/test-mobile.yml
@@ -1,5 +1,5 @@
 name: "@Mobile • Test App"
-run-name: "@Mobile • Test App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ github.event_name == 'workflow_dispatch' && format('on branch {0}', inputs.ref) || format('on ref {0}', github.ref) }}"
+run-name: "@Mobile • Test App triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
     inputs:
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
@@ -21,8 +21,8 @@ on:
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   codecheck:
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.base_ref }}
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: "@Libraries • Tests"
-run-name: "@Libraries • Tests triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ github.event_name == 'workflow_dispatch' && format('on branch {0}', inputs.ref) || format('on ref {0}', github.ref) }}"
+run-name: "@Libraries • Tests triggered by ${{ github.event_name == 'workflow_dispatch' && inputs.login || github.actor }} ${{ format('on ref {0}', github.ref_name) }}"
 
 on:
   push:
@@ -15,15 +15,15 @@ on:
         default: "develop"
       ref:
         description: the branch which triggered this workflow
-        required: true
+        required: false
       login:
         description: The GitHub username that triggered the workflow
         required: true
 
 concurrency:
   # See: https://github.com/orgs/community/discussions/35341
-  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref != 'develop' || github.ref_name != 'develop' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'develop' }}
 
 jobs:
   test-docs:
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.since_branch }}
       - uses: pnpm/action-setup@v2
         with:
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.since_branch }}
       - uses: pnpm/action-setup@v2
         with:
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.sha }}
           base: ${{ inputs.since_branch }}
           fetch-depth: 0
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Remove on every workflow triggered by the orchestrator the `inputs.ref` parameter. 
It should now be superseded by the `github.ref` / `github.ref_name` context variables.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
