### PR TITLE
fix(react-native-hid): support usb otg connectivity for android 12+

### DIFF
--- a/.changeset/soft-cats-smell.md
+++ b/.changeset/soft-cats-smell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hid": minor
+---
+
+Support Android S+ for USB OTG connectivity on the react-native-hid transport

--- a/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/HIDDevice.java
+++ b/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/HIDDevice.java
@@ -20,14 +20,13 @@ import java.nio.ByteBuffer;
 
 public class HIDDevice {
 
-    private UsbDeviceConnection connection;
-    private UsbInterface dongleInterface;
-    private UsbEndpoint in;
-    private UsbEndpoint out;
-    private byte transferBuffer[];
+    private final UsbDeviceConnection connection;
+    private final UsbInterface dongleInterface;
+    private final UsbEndpoint in;
+    private final UsbEndpoint out;
+    private final byte[] transferBuffer;
     private boolean debug;
-    private boolean ledger;
-    private ExecutorService executor;
+    private final ExecutorService executor;
 
     public HIDDevice(UsbManager manager, UsbDevice device) {
 
@@ -72,7 +71,7 @@ public class HIDDevice {
                         throw new Exception("I/O error");
                     }
                     while (offset != command.length) {
-                        int blockSize = (command.length - offset > HID_BUFFER_SIZE ? HID_BUFFER_SIZE : command.length - offset);
+                        int blockSize = (Math.min(command.length - offset, HID_BUFFER_SIZE));
                         System.arraycopy(command, offset, transferBuffer, 0, blockSize);
                         if (!request.queue(ByteBuffer.wrap(transferBuffer), HID_BUFFER_SIZE)) {
                             request.close();
@@ -117,15 +116,15 @@ public class HIDDevice {
     }
 
     public static String toHex(byte[] buffer, int offset, int length) {
-        String result = "";
+        StringBuilder result = new StringBuilder();
         for (int i = 0; i < length; i++) {
             String temp = Integer.toHexString((buffer[offset + i]) & 0xff);
             if (temp.length() < 2) {
                 temp = "0" + temp;
             }
-            result += temp;
+            result.append(temp);
         }
-        return result;
+        return result.toString();
     }
 
     public static String toHex(byte[] buffer) {
@@ -145,6 +144,5 @@ public class HIDDevice {
 
     private static final int HID_BUFFER_SIZE = 64;
     private static final int LEDGER_DEFAULT_CHANNEL = 1;
-    private static final int SW1_DATA_AVAILABLE = 0x61;
 
 }

--- a/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/LedgerHelper.java
+++ b/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/LedgerHelper.java
@@ -21,7 +21,7 @@ public class LedgerHelper {
         sequenceIdx++;
         output.write(command.length >> 8);
         output.write(command.length);
-        int blockSize = (command.length > packetSize - 7 ? packetSize - 7 : command.length);
+        int blockSize = (Math.min(command.length, packetSize - 7));
         output.write(command, offset, blockSize);
         offset += blockSize;
         while (offset != command.length) {
@@ -31,7 +31,7 @@ public class LedgerHelper {
             output.write(sequenceIdx >> 8);
             output.write(sequenceIdx);
             sequenceIdx++;
-            blockSize = (command.length - offset > packetSize - 5 ? packetSize - 5 : command.length - offset);
+            blockSize = (Math.min(command.length - offset, packetSize - 5));
             output.write(command, offset, blockSize);
             offset += blockSize;
         }
@@ -70,7 +70,7 @@ public class LedgerHelper {
         if (data.length < 7 + responseLength) {
             return null;
         }
-        int blockSize = (responseLength > packetSize - 7 ? packetSize - 7 : responseLength);
+        int blockSize = (Math.min(responseLength, packetSize - 7));
         response.write(data, offset, blockSize);
         offset += blockSize;
         while (response.size() != responseLength) {
@@ -93,7 +93,7 @@ public class LedgerHelper {
             if (data[offset++] != (sequenceIdx & 0xff)) {
                 throw new Exception("Invalid sequence");
             }
-            blockSize = (responseLength - response.size() > packetSize - 5 ? packetSize - 5 : responseLength - response.size());
+            blockSize = (Math.min(responseLength - response.size(), packetSize - 5));
             if (blockSize > data.length - offset) {
                 return null;
             }

--- a/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDPackage.java
+++ b/libs/ledgerjs/packages/react-native-hid/android/src/main/java/com/ledgerwallet/hid/ReactHIDPackage.java
@@ -1,7 +1,6 @@
 package com.ledgerwallet.hid;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;

--- a/libs/ledgerjs/packages/react-native-hid/src/index.ts
+++ b/libs/ledgerjs/packages/react-native-hid/src/index.ts
@@ -18,6 +18,7 @@ const disconnectedErrors = [
   "I/O error",
   "Attempt to invoke virtual method 'int android.hardware.usb.UsbDevice.getDeviceClass()' on a null object reference",
   "Invalid channel",
+  "Permission denied by user for device",
 ];
 
 const listLedgerDevices = async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

With the changes in Android 12 we lost support for USB OTG on LLM. This PR introduces the now mandatory flag to continue supporting this connection channel since it's the only one for Android with LNS/LNS+ (plus wired LNX/Stax).

### ❓ Context

- **Impacted projects**: `react-native-hid` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/FAT-828

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Not needed.

### 🚀 Expectations to reach
- USB OTG Should work on all versions of Android.
- Please test old and new because perhaps fixing the new broke the old and I only have a 13 to test with me.