### PR TITLE
fix(errors): rendering of errors in device actions

### DIFF
--- a/.changeset/thirty-dancers-appear.md
+++ b/.changeset/thirty-dancers-appear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(errors): Fix rendering for errors in device actions

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -44,7 +44,6 @@ import ProgressCircle from "~/renderer/components/ProgressCircle";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import { getProviderIcon } from "~/renderer/screens/exchange/Swap2/utils";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
-import { useGetSwapTrackingProperties } from "~/renderer/screens/exchange/Swap2/utils/index";
 import { context } from "~/renderer/drawers/Provider";
 import { track } from "~/renderer/analytics/segment";
 import { DrawerFooter } from "~/renderer/screens/exchange/Swap2/Form/DrawerFooter";
@@ -631,10 +630,10 @@ export const renderError = ({
         <ErrorIcon size={44} error={error} />
       </Logo>
       <ErrorTitle>
-        <TranslatedError error={error} />
+        <TranslatedError error={error} noLink />
       </ErrorTitle>
       <ErrorDescription>
-        <TranslatedError error={error} field="description" /> <SupportLinkError error={error} />
+        <TranslatedError error={error} field="description" />
       </ErrorDescription>
       {list ? (
         <ErrorDescription>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There was a bug in the rendering of errors in the Onboarding device action, probably on some other device action flows too but it was caught during the onboarding one. The easiest way to trigger is to have repl running or another app that wants to access the nano since we need to throw an error that has support links, but this is just a coincidence.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5818 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://user-images.githubusercontent.com/4631227/220370048-bf7e6e6e-52a8-4ce0-94fa-c0b99d44ddd6.png)
![image](https://user-images.githubusercontent.com/4631227/220370066-09504a7d-de81-456b-b9b4-f2da8e736a23.png)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
