### PR TITLE
LLM - Fix on E2E tests

### DIFF
--- a/.changeset/big-bats-battle.md
+++ b/.changeset/big-bats-battle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixed detox E2E test after removing autolock-timeout

--- a/apps/ledger-live-mobile/e2e/specs/password.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/password.spec.ts
@@ -43,15 +43,8 @@ describe("Password Lock Screen", () => {
     await generalSettingsPage.enterNewPassword(CORRECT_PASSWORD + "\n"); // confirm password step
   });
 
-  it("should not require the password if the user exits the app for less than the lock timeout", async () => {
-    await device.sendToHome(); // leave LLM app and go to phone's home screen
-    await device.launchApp(); // launch app within the lock timeout (60 secs on prod, 5 secs with MOCK=1)
-    await expect(generalSettingsPage.preferredCurrencyButton()).toBeVisible();
-  });
-
   it("should need to enter password to unlock app", async () => {
     await device.sendToHome();
-    await delay(5500); // Wait for AUTOLOCK_TIMEOUT to activate, which is 5 secs on MOCK mode
     await device.launchApp(); // restart LLM
     await passwordEntryPage.enterPassword(CORRECT_PASSWORD);
     await passwordEntryPage.login();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixed E2E tests  - removed a scenario after having removed the autolock timeout for password lock.

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: N/A

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
