### PR TITLE
LLM - AuthScreen not showing on Android

### DIFF
--- a/.changeset/chatty-glasses-bow.md
+++ b/.changeset/chatty-glasses-bow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixed hierarchy issue causing Auth screen to render behind app in Android

--- a/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
@@ -173,8 +173,8 @@ class AuthPass extends PureComponent<Props, State> {
 
     return (
       <SkipLockContext.Provider value={setEnabled}>
-        {lockScreen}
         {children}
+        {lockScreen}
       </SkipLockContext.Provider>
     );
   }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixed hierarchy issue causing Auth screen to render behind app in Android

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: LIVE-5837

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
