### PR TITLE
Support/LIVE-5810 - Newsfeed - Use already implemented feature flag param instead of custom one

### DIFF
--- a/.changeset/lazy-frogs-guess.md
+++ b/.changeset/lazy-frogs-guess.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Newsfeed - Use already implemented feature flag param to handle whitelisted language instead of a custom param

--- a/apps/ledger-live-mobile/src/hooks/newsfeed/useIsNewsfeedAvailable.ts
+++ b/apps/ledger-live-mobile/src/hooks/newsfeed/useIsNewsfeedAvailable.ts
@@ -14,7 +14,6 @@ export function useIsNewsfeedAvailable() {
     newsfeedPageFeature?.params?.cryptopanicApiKey &&
     cryptopanicAvailableRegions.includes(
       locale as CryptopanicAvailableRegionsType,
-    ) &&
-    newsfeedPageFeature?.params?.whitelistedLocales?.includes(locale)
+    )
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Use already implemented feature flag param to handle newsfeed whitelisted language instead of a custom param

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-5810

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
