### PR TITLE
fix: allows coin modal to be closed on swap screen

### DIFF
--- a/.changeset/violet-pandas-grab.md
+++ b/.changeset/violet-pandas-grab.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fixes the coin modal close button on the swap screen

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.jsx
@@ -115,15 +115,19 @@ const SectionFees = ({
           page: "Page Swap Form",
           ...swapDefaultTrack,
         });
-        setDrawer(FeesDrawer, {
-          setTransaction,
-          updateTransaction,
-          mainAccount: mainFromAccount,
-          currency,
-          status,
-          disableSlowStrategy: exchangeRate?.tradeMethod === "fixed",
-          provider,
-        });
+        setDrawer(
+          FeesDrawer,
+          {
+            setTransaction,
+            updateTransaction,
+            mainAccount: mainFromAccount,
+            currency,
+            status,
+            disableSlowStrategy: exchangeRate?.tradeMethod === "fixed",
+            provider,
+          },
+          { forceDisableFocusTrap: true },
+        );
       }),
     [
       canEdit,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes the close button (and all other buttons) on the coin modal.
### ❓ Context

- **Impacted projects**:  LLD
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5310

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/119950081/220974037-fabf1c71-a99b-442d-b227-c640c402a416.mov



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
