### PR TITLE
fix: prevent back from ledger recover webview

### DIFF
--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebViewV2.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/WebViewV2.tsx
@@ -183,7 +183,8 @@ function useWebView({
   manifest,
   inputs,
   hideHeader,
-}: Pick<Props, "manifest" | "inputs" | "hideHeader">) {
+  onBackButtonPress,
+}: Pick<Props, "manifest" | "inputs" | "hideHeader" | "onBackButtonPress">) {
   const accounts = useSelector(flattenAccountsSelector);
   const navigation = useNavigation();
   const [loadDate, setLoadDate] = useState(new Date());
@@ -260,6 +261,15 @@ function useWebView({
     });
   }, [navigation, widgetLoaded, onReload, isInfoPanelOpened, hideHeader]);
 
+  useEffect(() => {
+    const unsubcribe = navigation.addListener(
+      "beforeRemove",
+      onBackButtonPress,
+    );
+
+    return unsubcribe;
+  }, [navigation, onBackButtonPress]);
+
   return {
     uri: url.toString(),
     isInfoPanelOpened,
@@ -329,11 +339,17 @@ function renderLoading() {
 
 interface Props {
   manifest: AppManifest;
+  onBackButtonPress: (event: any) => void;
   inputs?: Record<string, string>;
   hideHeader?: boolean;
 }
 
-export function WebView({ manifest, inputs, hideHeader = false }: Props) {
+export function WebView({
+  manifest,
+  inputs,
+  hideHeader = false,
+  onBackButtonPress,
+}: Props) {
   const {
     uri,
     isInfoPanelOpened,
@@ -346,6 +362,7 @@ export function WebView({ manifest, inputs, hideHeader = false }: Props) {
     manifest,
     inputs,
     hideHeader,
+    onBackButtonPress,
   });
 
   const source = useMemo(() => {

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
@@ -1,7 +1,7 @@
 import semver from "semver";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
-import React from "react";
+import React, { useCallback } from "react";
 import { WebView as WebViewV2 } from "./WebViewV2";
 import { WebView } from "./WebView";
 
@@ -19,12 +19,21 @@ const ledgerRecoverIds = [
 const WebViewWrapper = ({ manifest, inputs }: Props) => {
   const isManifestOfLedgerRecover = ledgerRecoverIds.includes(manifest.id);
 
+  const onBackButtonPress = useCallback(
+    (event: any) => {
+      if (!isManifestOfLedgerRecover) return;
+      event.preventDefault();
+    },
+    [isManifestOfLedgerRecover],
+  );
+
   if (semver.satisfies(WALLET_API_VERSION, manifest.apiVersion)) {
     return (
       <WebViewV2
         manifest={manifest}
         inputs={inputs}
         hideHeader={isManifestOfLedgerRecover}
+        onBackButtonPress={onBackButtonPress}
       />
     );
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Prevents default behavior of closing the WebView upon pressing the OS back button.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-5131](https://ledgerhq.atlassian.net/browse/LIVE-5131)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-5131]: https://ledgerhq.atlassian.net/browse/LIVE-5131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ