### PR TITLE
fix: prevent back from ledger recover webview

### DIFF
--- a/.changeset/cold-scissors-roll.md
+++ b/.changeset/cold-scissors-roll.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Prevent WebView closure from OS back button if Ledger Recover

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
@@ -1,7 +1,8 @@
 import semver from "semver";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
+import { useNavigation } from "@react-navigation/native";
 import { WebView as WebViewV2 } from "./WebViewV2";
 import { WebView } from "./WebView";
 
@@ -21,6 +22,16 @@ const WebViewWrapper = ({ manifest, inputs }: Props) => {
     () => ledgerRecoverIds.includes(manifest.id),
     [manifest.id],
   );
+  const navigation = useNavigation();
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (isManifestOfLedgerRecover) {
+      return navigation.addListener("beforeRemove", event => {
+        event.preventDefault();
+      });
+    }
+  }, [isManifestOfLedgerRecover, navigation]);
 
   if (semver.satisfies(WALLET_API_VERSION, manifest.apiVersion)) {
     return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Prevents default behavior of closing the WebView upon pressing the OS back button.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-5131](https://ledgerhq.atlassian.net/browse/LIVE-5131)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-5131]: https://ledgerhq.atlassian.net/browse/LIVE-5131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ