### PR TITLE
feat: LIVE-5929 Enable localization flags for stax devices

### DIFF
--- a/.changeset/tough-cougars-suffer.md
+++ b/.changeset/tough-cougars-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Enable Localization flags for stax

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -447,7 +447,7 @@ export function renderAllowLanguageInstallation({
   device: Device;
 }) {
   const deviceName = getDeviceModel(device.modelId).productName;
-  const key = device.modelId === "stax" ? "allowConnection" : "sign";
+  const key = device.modelId === "stax" ? "allowManager" : "sign";
 
   return (
     <Wrapper>

--- a/libs/ledger-live-common/src/deviceSDK/commands/getVersion.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getVersion.test.ts
@@ -54,8 +54,9 @@ test("isBootloaderVersionSupported", () => {
   /**
    * Stax
    * */
-  expect(isBootloaderVersionSupported("1.0.0", stax)).toBe(false);
-  expect(isBootloaderVersionSupported("1.0.0-whatever0", stax)).toBe(false);
+  expect(isBootloaderVersionSupported("0.9.0", stax)).toBe(false);
+  expect(isBootloaderVersionSupported("1.0.0", stax)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.0-whatever0", stax)).toBe(true);
 });
 
 test("isHardwareVersionSupported", () => {

--- a/libs/ledger-live-common/src/deviceSDK/commands/getVersion.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getVersion.ts
@@ -174,6 +174,7 @@ const deviceVersionRangesForBootloaderVersion: {
   nanoS: ">=2.0.0",
   nanoX: ">=2.0.0",
   nanoSP: ">=1.0.0",
+  stax: ">=1.0.0",
 };
 
 /**

--- a/libs/ledger-live-common/src/hw/getVersion.test.ts
+++ b/libs/ledger-live-common/src/hw/getVersion.test.ts
@@ -54,8 +54,9 @@ test("isBootloaderVersionSupported", () => {
   /**
    * Stax
    * */
-  expect(isBootloaderVersionSupported("1.0.0", stax)).toBe(false);
-  expect(isBootloaderVersionSupported("1.0.0-whatever0", stax)).toBe(false);
+  expect(isBootloaderVersionSupported("0.9.0", stax)).toBe(false);
+  expect(isBootloaderVersionSupported("1.0.0", stax)).toBe(true);
+  expect(isBootloaderVersionSupported("1.0.0-whatever0", stax)).toBe(true);
 });
 
 test("isHardwareVersionSupported", () => {

--- a/libs/ledger-live-common/src/hw/getVersion.ts
+++ b/libs/ledger-live-common/src/hw/getVersion.ts
@@ -10,6 +10,7 @@ const deviceVersionRangesForBootloaderVersion: {
   nanoS: ">=2.0.0",
   nanoX: ">=2.0.0",
   nanoSP: ">=1.0.0",
+  stax: ">=1.0.0",
 };
 export const isBootloaderVersionSupported = (
   seVersion: string,

--- a/libs/ledger-live-common/src/manager/localization.test.ts
+++ b/libs/ledger-live-common/src/manager/localization.test.ts
@@ -36,8 +36,9 @@ test("isDeviceLocalizationSupported", () => {
   /**
    * Stax
    * */
-  expect(isDeviceLocalizationSupported("9.0.0", stax)).toBe(false);
-  expect(isDeviceLocalizationSupported("9.0.0-whatever", stax)).toBe(false);
+  expect(isDeviceLocalizationSupported("0.9.0", stax)).toBe(false);
+  expect(isDeviceLocalizationSupported("9.0.0", stax)).toBe(true);
+  expect(isDeviceLocalizationSupported("9.0.0-whatever", stax)).toBe(true);
 
   /**
    * NanoS

--- a/libs/ledger-live-common/src/manager/localization.ts
+++ b/libs/ledger-live-common/src/manager/localization.ts
@@ -5,6 +5,7 @@ const deviceVersionRangesForLocalization: { [key in DeviceModelId]?: string } =
   {
     nanoX: ">=2.1.0",
     nanoSP: ">=1.1.0",
+    stax: ">=1.0.0",
   };
 
 export const isDeviceLocalizationSupported = (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Starting on `rc8` stax devices are able to have localization features, this PR enables the installation via our dev builds, cli and once propagated our repl tool.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-5929` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo.

### 🚀 Expectations to reach
Localization UI and functionality should be enabled and working with RC8 upwards.