### PR TITLE
fix(llm claimNft): timeout logic depending on focused state

### DIFF
--- a/.changeset/metal-tips-shop.md
+++ b/.changeset/metal-tips-shop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix claim NFT "redirection after a timeout if no QR code scan" which was still effective outside of the QR code scan screen

--- a/apps/ledger-live-mobile/src/screens/ClaimNft/ClaimNftQrScan.tsx
+++ b/apps/ledger-live-mobile/src/screens/ClaimNft/ClaimNftQrScan.tsx
@@ -88,12 +88,16 @@ const ClaimNftQrScan = () => {
     });
   }, [cameraDimensions]);
 
-  useEffect(() => {
-    if (!isInFocus) return;
-    const redirectionTimeout = setTimeout(navigateToHub, 120000);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
+  useEffect(() => {
+    if (isInFocus) {
+      timeoutRef.current = setTimeout(navigateToHub, 3000);
+    }
     return () => {
-      clearTimeout(redirectionTimeout);
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
     };
   }, [navigateToHub, isInFocus]);
 

--- a/apps/ledger-live-mobile/src/screens/ClaimNft/ClaimNftQrScan.tsx
+++ b/apps/ledger-live-mobile/src/screens/ClaimNft/ClaimNftQrScan.tsx
@@ -89,12 +89,13 @@ const ClaimNftQrScan = () => {
   }, [cameraDimensions]);
 
   useEffect(() => {
-    const redirectionTimeout = setTimeout(() => navigateToHub(), 120000);
+    if (!isInFocus) return;
+    const redirectionTimeout = setTimeout(navigateToHub, 120000);
 
     return () => {
       clearTimeout(redirectionTimeout);
     };
-  }, [navigateToHub]);
+  }, [navigateToHub, isInFocus]);
 
   const handleBarCodeScanned = useCallback(({ data }) => {
     try {

--- a/apps/ledger-live-mobile/src/screens/ClaimNft/ClaimNftQrScan.tsx
+++ b/apps/ledger-live-mobile/src/screens/ClaimNft/ClaimNftQrScan.tsx
@@ -92,7 +92,7 @@ const ClaimNftQrScan = () => {
 
   useEffect(() => {
     if (isInFocus) {
-      timeoutRef.current = setTimeout(navigateToHub, 3000);
+      timeoutRef.current = setTimeout(navigateToHub, 120000);
     }
     return () => {
       if (timeoutRef.current) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the claim NFT flow, at the step of scanning a QR code, there is a logic to redirect the user to the post onboarding hub in case no QR code gets scanned (after 2 minutes).
The issue is that this timeout was cleared when the screen gets unmounted, but not necessarily when the screen is out of focus (which is the case when we navigate to a live app for instance), so the timeout was still running even after a successful scan of the QR code.

### ❓ Context

- **Impacted projects**: `mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [FAT-849] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** this flow is not covered at all by e2e tests and it seems very complicated to do so as it would require mocking the camera behaviour (to scan a fake QR code) and the behaviour of the Linkdrop live app
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[FAT-849]: https://ledgerhq.atlassian.net/browse/FAT-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ