### PR TITLE
feat/FAT-793 UX Improvement for install set of apps

### DIFF
--- a/.changeset/famous-walls-beg.md
+++ b/.changeset/famous-walls-beg.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+updated param name for installSetOfApps call

--- a/.changeset/sharp-oranges-hammer.md
+++ b/.changeset/sharp-oranges-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Adapt UX of install set of apps for missing dependencies

--- a/.changeset/silly-impalas-turn.md
+++ b/.changeset/silly-impalas-turn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Expose listedApps flag from connectApp for better UX on inline install apps

--- a/.changeset/young-apes-knock.md
+++ b/.changeset/young-apes-knock.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Adapt UX of install set of apps for missing dependencies

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/AppInstallItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/AppInstallItem.tsx
@@ -1,17 +1,26 @@
 import React, { memo } from "react";
-import { Icons, Flex, ProgressLoader, Text } from "@ledgerhq/react-ui";
+import { Icons, Flex, ProgressLoader, Text, InfiniteLoader } from "@ledgerhq/react-ui";
+import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
+
+export enum ItemState {
+  Installed,
+  Skipped,
+  Active,
+  Idle,
+}
 
 type Props = {
   appName: string;
-  isActive?: boolean;
-  installed?: boolean;
   itemProgress?: number;
-  index: number;
+  productName: string;
+  state: ItemState;
+  i: number;
 };
 
-const AppInstallItem = ({ appName, isActive, installed, itemProgress, index }: Props) => {
+const AppInstallItem = ({ appName, state, itemProgress, productName, i }: Props) => {
   const { colors } = useTheme();
+  const { t } = useTranslation();
 
   return (
     <Flex key={appName} flexDirection={"row"} alignItems="center" mb={6}>
@@ -22,24 +31,37 @@ const AppInstallItem = ({ appName, isActive, installed, itemProgress, index }: P
         size={40}
         bg={colors.neutral.c30}
       >
-        {isActive ? (
-          <ProgressLoader
-            showPercentage={false}
-            stroke={2}
-            progress={(itemProgress || 0) * 100}
-            radius={12}
-          />
-        ) : installed ? (
-          <Icons.CheckAloneMedium size={18} color="success.c80" />
+        {state === ItemState.Active ? (
+          !itemProgress || itemProgress === 1 ? (
+            <InfiniteLoader size={20} />
+          ) : (
+            <ProgressLoader
+              progress={itemProgress * 100}
+              showPercentage={false}
+              radius={10}
+              stroke={2}
+            />
+          )
+        ) : state === ItemState.Installed ? (
+          <Icons.CheckAloneMedium size={20} color={"success.c100"} />
+        ) : state === ItemState.Skipped ? (
+          <Icons.InfoAltMedium size={20} color={"neutral.c100"} />
         ) : (
           <Text color="neutral.c100" variant="body">
-            {index + 1}
+            {i + 1}
           </Text>
         )}
       </Flex>
-      <Text ml={3} variant="paragraphLineHeight" textTransform="capitalize">
-        {appName}
-      </Text>
+      <Flex flexDirection="column">
+        <Text ml={3} fontSize={3}>
+          {appName}
+        </Text>
+        {state === ItemState.Skipped ? (
+          <Text ml={3} color="neutral.c70" fontSize={2}>
+            {t("onboardingAppInstall.progress.skipped", { productName })}
+          </Text>
+        ) : null}
+      </Flex>
     </Flex>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect, useMemo } from "react";
-import { Flex, Text } from "@ledgerhq/react-ui";
+import { Alert, Flex, InfiniteLoader, Text } from "@ledgerhq/react-ui";
 import { createAction } from "@ledgerhq/live-common/hw/actions/app";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { SkipReason } from "@ledgerhq/live-common/apps/types";
+import connectApp from "@ledgerhq/live-common/hw/connectApp";
+import { getDeviceModel } from "@ledgerhq/devices";
+
 import { useTranslation } from "react-i18next";
 import { UserRefusedAllowManager } from "@ledgerhq/errors";
 
-import AppInstallItem from "./AppInstallItem";
+import AppInstallItem, { ItemState } from "./AppInstallItem";
 import AllowManagerModal from "./AllowManagerModal";
 
 const action = createAction(connectApp);
@@ -29,8 +32,9 @@ const InstallSetOfApps = ({
   onError,
 }: Props) => {
   const { t } = useTranslation();
+  const productName = getDeviceModel(device.modelId).productName;
 
-  const request = useMemo(
+  const commandRequest = useMemo(
     () => ({
       dependencies: dependencies.map(appName => ({ appName })),
       appName: "BOLOS",
@@ -40,19 +44,21 @@ const InstallSetOfApps = ({
     [dependencies],
   );
 
-  const status = action.useHook(device, request);
+  const status = action.useHook(device, commandRequest);
 
   const {
-    isLoading,
-    allowManagerGranted,
-    listingApps,
+    skippedAppOps,
+    installQueue,
+    listedApps,
     error,
     currentAppOp,
     itemProgress,
     progress,
     opened,
-    installQueue,
+
     isLocked,
+    allowManagerGranted,
+    isLoading,
   } = status;
 
   useEffect(() => {
@@ -69,13 +75,13 @@ const InstallSetOfApps = ({
     }
   }, [error, onError, onCancel]);
 
-  useEffect(() => {
-    if (opened) {
-      onComplete();
-    }
-  }, [opened, onComplete]);
+  const installing = !opened && typeof progress === "number" && currentAppOp;
+  const missingApps = skippedAppOps?.some(
+    skippedAppOp => skippedAppOp.reason === SkipReason.NoSuchAppOnProvider,
+  );
 
   if (opened) {
+    onComplete();
     return null;
   }
 
@@ -84,39 +90,50 @@ const InstallSetOfApps = ({
       <AllowManagerModal
         isOpen={!isLoading && !allowManagerGranted && !error}
         status={status}
-        request={request}
+        request={commandRequest}
       />
-      <Flex height="100%" flexDirection="column">
-        <Flex flex={1} alignItems="center">
-          <Flex mb={2} alignSelf="flex-start">
-            <Text mb={5} variant="paragraphLineHeight">
-              {listingApps
-                ? t("onboardingAppInstall.progress.resolving")
-                : typeof progress === "number" && currentAppOp
-                ? t("onboardingAppInstall.progress.progress", {
-                    progress: Math.round(progress * 100),
-                  })
-                : t("onboardingAppInstall.progress.loading")}
-            </Text>
+      <Flex height="100%">
+        <Flex flex={1} alignItems="flex-start" flexDirection="column">
+          <Flex style={{ width: "100%" }} flexDirection="row" justifyContent="space-between" mb={6}>
+            {installing ? (
+              <Text>{t("onboardingAppInstall.progress.progress")}</Text>
+            ) : (
+              <>
+                <Text>{t("onboardingAppInstall.progress.resolving")}</Text>
+                <InfiniteLoader size={20} />
+              </>
+            )}
           </Flex>
+          {missingApps ? (
+            <Alert title={t("onboardingAppInstall.progress.skippedInfo", { productName })} />
+          ) : null}
+          {!!missingApps && <Flex mb={6} />}
+          {dependencies?.map((appName, i) => {
+            const skipped = skippedAppOps.find(skippedAppOp => skippedAppOp.appOp.name === appName);
+
+            const state = !listedApps
+              ? ItemState.Idle
+              : currentAppOp?.name === appName
+              ? ItemState.Active
+              : skipped?.reason === SkipReason.NoSuchAppOnProvider
+              ? ItemState.Skipped
+              : !installQueue?.includes(appName) ||
+                skipped?.reason === SkipReason.AppAlreadyInstalled
+              ? ItemState.Installed
+              : ItemState.Idle;
+
+            return (
+              <AppInstallItem
+                key={appName}
+                i={i}
+                appName={appName}
+                state={state}
+                productName={productName}
+                itemProgress={itemProgress}
+              />
+            );
+          })}
         </Flex>
-        <Flex flexDirection="column" mt={2} mb={4}>
-          {itemProgress !== undefined
-            ? dependencies.map((appName, index) => (
-                <AppInstallItem
-                  key={appName}
-                  appName={appName}
-                  index={index}
-                  isActive={currentAppOp?.name === appName}
-                  installed={progress ? !installQueue?.includes(appName) : undefined}
-                  itemProgress={itemProgress}
-                />
-              ))
-            : null}
-        </Flex>
-        <Text variant="paragraphLineHeight" color="neutral.c70">
-          {t("onboardingAppInstall.progress.disclaimer")}
-        </Text>
       </Flex>
     </>
   );

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
@@ -35,7 +35,7 @@ const InstallSetOfApps = ({
       dependencies: dependencies.map(appName => ({ appName })),
       appName: "BOLOS",
       withInlineInstallProgress: true,
-      skipAppInstallIfNotFound: true,
+      allowPartialDependencies: true,
     }),
     [dependencies],
   );

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5756,8 +5756,10 @@
     "progress": {
       "loading": "Loading ...",
       "resolving": "Resolving dependencies",
-      "progress": "Installing apps {{progress}}%",
-      "disclaimer": "Add or remove apps at any time from Ledger Live."
+      "progress": "Stay in Ledger Live while apps are installing.",
+      "disclaimer": "Add or remove apps at any time from Ledger Live.",
+      "skippedInfo": "Some apps aren’t available. They are yet to be developed for {{ productName }}.",
+      "skipped": "Not yet available for {{ productName }}"
     },
     "cancelled": {
       "title": "App installation was cancelled on {{productName}}",

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/Item.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/Item.tsx
@@ -1,39 +1,58 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Icons, Flex, ProgressLoader, Text } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import Circle from "../../Circle";
 
+export enum ItemState {
+  Installed,
+  Skipped,
+  Active,
+  Idle,
+}
+
 type Props = {
   appName: string;
-  isActive?: boolean;
-  installed?: boolean;
   itemProgress?: number;
+  productName: string;
+  state: ItemState;
   i: number;
 };
 
-const Item = ({ appName, isActive, installed, itemProgress, i }: Props) => {
+const Item = ({ appName, state, itemProgress, productName, i }: Props) => {
   const { colors } = useTheme();
+  const { t } = useTranslation();
+
   return (
     <Flex key={appName} flexDirection={"row"} alignItems="center" mb={4}>
       <Circle size={40} bg={colors.neutral.c30}>
-        {isActive ? (
+        {state === ItemState.Active ? (
           <ProgressLoader
             progress={itemProgress}
             infinite={!itemProgress || itemProgress === 1}
-            radius={12}
-            strokeWidth={3}
+            radius={10}
+            strokeWidth={2}
           />
-        ) : installed ? (
-          <Icons.CheckAloneMedium size={22} color={"success.c100"} />
+        ) : state === ItemState.Installed ? (
+          <Icons.CheckAloneMedium size={20} color={"success.c100"} />
+        ) : state === ItemState.Skipped ? (
+          <Icons.InfoAltMedium size={20} color={"neutral.c100"} />
         ) : (
           <Text color="neutral.c100" variant="body">
             {i + 1}
           </Text>
         )}
       </Circle>
-      <Text ml={3} variant="paragraphLineHeight" textTransform="capitalize">
-        {appName}
-      </Text>
+      <Flex flexDirection="column">
+        <Text ml={3} fontSize={3}>
+          {appName}
+        </Text>
+        {state === ItemState.Skipped ? (
+          <Text ml={3} color="neutral.c70" fontSize={2}>
+            {t("installSetOfApps.ongoing.skipped", { productName })}
+          </Text>
+        ) : null}
+      </Flex>
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -69,7 +69,7 @@ const InstallSetOfApps = ({
       dependencies: dependenciesToInstall.map(appName => ({ appName })),
       appName: "BOLOS",
       withInlineInstallProgress: true,
-      skipAppInstallIfNotFound: true,
+      allowPartialDependencies: true,
     }),
     [dependenciesToInstall],
   );

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -1,11 +1,12 @@
 import React, { useCallback, useState, useMemo } from "react";
-import { Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { SkipReason } from "@ledgerhq/live-common/apps/types";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
-import { Flex, Text } from "@ledgerhq/native-ui";
+import { Alert, Flex, ProgressLoader, Text } from "@ledgerhq/native-ui";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelInfo } from "@ledgerhq/types-live";
 
@@ -13,7 +14,7 @@ import { TrackScreen, track } from "../../../analytics";
 import { DeviceActionDefaultRendering } from "..";
 import QueuedDrawer from "../../QueuedDrawer";
 
-import Item from "./Item";
+import Item, { ItemState } from "./Item";
 import Confirmation from "./Confirmation";
 import Restore from "./Restore";
 import { lastSeenDeviceSelector } from "../../../reducers/settings";
@@ -43,6 +44,7 @@ const InstallSetOfApps = ({
   onError,
   remountMe,
 }: Props & { remountMe: () => void }) => {
+  const { t } = useTranslation();
   const [userConfirmed, setUserConfirmed] = useState(false);
   const productName = getDeviceModel(selectedDevice.modelId).productName;
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(
@@ -81,13 +83,14 @@ const InstallSetOfApps = ({
 
   const {
     allowManagerRequestedWording,
-    listingApps,
+    skippedAppOps,
+    installQueue,
+    listedApps,
     error,
     currentAppOp,
     itemProgress,
     progress,
     opened,
-    installQueue,
   } = status;
 
   const onWrappedError = useCallback(() => {
@@ -101,6 +104,11 @@ const InstallSetOfApps = ({
     }
   }, [remountMe, error, onError]);
 
+  const installing = !opened && typeof progress === "number" && currentAppOp;
+  const missingApps = skippedAppOps?.some(
+    skippedAppOp => skippedAppOp.reason === SkipReason.NoSuchAppOnProvider,
+  );
+
   if (opened) {
     onResult(true);
     return error ? null : (
@@ -110,47 +118,61 @@ const InstallSetOfApps = ({
 
   return userConfirmed ? (
     <Flex height="100%">
-      <Flex flex={1} alignItems="center" justifyContent="center">
-        <Flex mb={2} alignSelf="flex-start">
-          <Text mb={5} variant="paragraphLineHeight">
-            {listingApps ? (
-              <Trans i18nKey="installSetOfApps.ongoing.resolving" />
-            ) : typeof progress === "number" && currentAppOp ? (
-              <Trans
-                i18nKey="installSetOfApps.ongoing.progress"
-                values={{ progress: Math.round(progress * 100) }}
-              />
-            ) : (
-              <Trans i18nKey="installSetOfApps.ongoing.loading" />
-            )}
-          </Text>
-          {itemProgress !== undefined
-            ? dependenciesToInstall?.map((appName, i) => {
-                const isActive = currentAppOp?.name === appName;
-                return (
-                  <>
-                    {!shouldRestoreApps && isActive && (
-                      <TrackScreen category={`Installing ${appName}`} />
-                    )}
-                    <Item
-                      key={appName}
-                      i={i}
-                      appName={appName}
-                      isActive={isActive}
-                      installed={
-                        progress ? !installQueue?.includes(appName) : undefined
-                      }
-                      itemProgress={itemProgress}
-                    />
-                  </>
-                );
-              })
-            : null}
+      <Flex flex={1} alignItems="flex-start">
+        <Flex
+          style={{ width: "100%" }}
+          flexDirection="row"
+          justifyContent="space-between"
+          mb={6}
+        >
+          {installing ? (
+            <Text>{t("installSetOfApps.ongoing.progress")}</Text>
+          ) : (
+            <>
+              <Text>{t("installSetOfApps.ongoing.resolving")}</Text>
+              <ProgressLoader infinite radius={10} strokeWidth={2} />
+            </>
+          )}
         </Flex>
+        {missingApps ? (
+          <Alert
+            title={t("installSetOfApps.ongoing.skippedInfo", { productName })}
+          />
+        ) : null}
+        {!!missingApps && <Flex mb={6} />}
+        {dependenciesToInstall?.map((appName, i) => {
+          const skipped = skippedAppOps.find(
+            skippedAppOp => skippedAppOp.appOp.name === appName,
+          );
+
+          const state = !listedApps
+            ? ItemState.Idle
+            : currentAppOp?.name === appName
+            ? ItemState.Active
+            : skipped?.reason === SkipReason.NoSuchAppOnProvider
+            ? ItemState.Skipped
+            : !installQueue?.includes(appName) ||
+              skipped?.reason === SkipReason.AppAlreadyInstalled
+            ? ItemState.Installed
+            : ItemState.Idle;
+
+          return (
+            <>
+              {!shouldRestoreApps && currentAppOp?.name === appName && (
+                <TrackScreen category={`Installing ${appName}`} />
+              )}
+              <Item
+                key={appName}
+                i={i}
+                appName={appName}
+                state={state}
+                productName={productName}
+                itemProgress={itemProgress}
+              />
+            </>
+          );
+        })}
       </Flex>
-      <Text variant="paragraphLineHeight" color="neutral.c70">
-        <Trans i18nKey="installSetOfApps.ongoing.disclaimer" />
-      </Text>
       <QueuedDrawer
         isRequestingToBeOpened={!!allowManagerRequestedWording || !!error}
         onClose={onWrappedError}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -24,6 +24,7 @@ import DebugFirmwareUpdate from "../../screens/Settings/Debug/Features/FirmwareU
 import DebugGenerators from "../../screens/Settings/Debug/Generators";
 import DebugHttpTransport from "../../screens/Settings/Debug/Connectivity/DebugHttpTransport";
 import DebugInformation from "../../screens/Settings/Debug/Information";
+import DebugInstallSetOfApps from "../../screens/Settings/Debug/Features/InstallSetOfApps";
 import DebugPerformance from "../../screens/Settings/Debug/Performance";
 import DebugLogs from "../../screens/Settings/Debug/Debugging/Logs";
 import DebugLottie from "../../screens/Settings/Debug/Features/Lottie";
@@ -243,6 +244,13 @@ export default function SettingsNavigator() {
         component={DebugFeatureFlags}
         options={{
           title: "Feature Flags",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugInstallSetOfApps}
+        component={DebugInstallSetOfApps}
+        options={{
+          title: "Install set of apps",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SettingsNavigator.ts
@@ -54,6 +54,7 @@ export type SettingsNavigatorStackParamList = {
   [ScreenName.DebugLottie]: undefined;
   [ScreenName.DebugTermsOfUse]: undefined;
   [ScreenName.DebugVideos]: undefined;
+  [ScreenName.DebugInstallSetOfApps]: undefined;
   [ScreenName.BenchmarkQRStream]: undefined;
   [ScreenName.OnboardingLanguage]: undefined;
   [ScreenName.PostOnboardingDebugScreen]: undefined;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -38,6 +38,7 @@ export enum ScreenName {
   DebugEnv = "DebugEnv",
   DebugExport = "DebugExport",
   DebugFeatureFlags = "DebugFeatureFlags",
+  DebugInstallSetOfApps = "DebugInstallSetOfApps",
   DebugFeatures = "DebugFeatures",
   DebugFetchCustomImage = "DebugFetchCustomImage",
   DebugFirmwareUpdate = "DebugFirmwareUpdate",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1162,7 +1162,7 @@
     "restore": {
       "title": "Install the same apps as on {{deviceName}}?",
       "titleNoDeviceName": "Install the same apps as on previous Ledger device?",
-      "installCTA": "Install now",
+      "installCTA": "Restore now",
       "skipCTA": "I'll do this later"
     },
     "landing": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1173,10 +1173,10 @@
       "skipCTA": "I'll do this later"
     },
     "ongoing": {
-      "loading": "Loading ...",
       "resolving": "Resolving dependencies",
-      "progress": "Installing apps {{progress}}%",
-      "disclaimer": "Add or remove apps at any time from Ledger Live."
+      "progress": "Stay in Ledger Live while apps are installing.",
+      "skippedInfo": "Some apps aren’t available. They are yet to be developed for {{ productName }}.",
+      "skipped": "Not yet available for {{ productName }}"
     }
   },
   "onboarding": {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/InstallSetOfApps.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/InstallSetOfApps.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { useTheme } from "@react-navigation/native";
+import { Button, Flex, VerticalTimeline } from "@ledgerhq/native-ui";
+import { useTranslation } from "react-i18next";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
+
+import NavigationScrollView from "../../../../components/NavigationScrollView";
+import InstallSetOfApps from "../../../../components/DeviceAction/InstallSetOfApps";
+import SelectDevice from "../../../../components/SelectDevice";
+
+export default function DebugMultiAppInstall() {
+  const feature = useFeature("deviceInitialApps");
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const [isCompleted, setOnCompleted] = useState(false);
+  const [override, setOverride] = useState(true);
+  const [nonce, setNonce] = useState(0);
+
+  const onReset = useCallback(() => {
+    setNonce(nonce => nonce + 1);
+  }, []);
+
+  const onOverrideDependencies = useCallback(() => {
+    setOverride(value => !value);
+  }, []);
+
+  const [device, setDevice] = useState<Device | null>(null);
+  const list = override
+    ? ["Puerto", "Bitcoin", "Ethereum", "Ripple"]
+    : feature?.params?.apps || [];
+
+  const formatEstimatedTime = (estimatedTime: number) =>
+    t("installSetOfApps.landing.estimatedTime", {
+      minutes: estimatedTime / 60,
+    });
+
+  const onComplete = useCallback(() => {
+    setOnCompleted(true);
+  }, []);
+
+  return (
+    <NavigationScrollView>
+      <View style={[styles.root, { backgroundColor: colors.background }]}>
+        {device ? (
+          <VerticalTimeline
+            steps={[
+              {
+                key: "fakeStep0",
+                title: "Dummy step completed #1",
+                status: "completed",
+              },
+              {
+                key: "fakeStep1",
+                title: "Dummy step completed #2",
+                status: "completed",
+              },
+              feature?.enabled
+                ? {
+                    key: "fakeStep2",
+                    title: isCompleted
+                      ? "Blockchain apps installed"
+                      : "Install Blockchain apps",
+                    status: isCompleted ? "completed" : "active",
+                    estimatedTime: 180,
+                    renderBody: (isDisplayed: boolean) =>
+                      isDisplayed ? (
+                        <InstallSetOfApps
+                          key={nonce}
+                          device={device}
+                          onResult={onComplete}
+                          onError={onReset}
+                          dependencies={list}
+                        />
+                      ) : (
+                        <View
+                          style={{
+                            height: Math.max(90 + list.length * 50, 300),
+                          }}
+                        />
+                      ),
+                  }
+                : null,
+              {
+                key: "fakeStep3",
+                title: `End of setup`,
+                status: isCompleted ? "active" : "inactive",
+              },
+            ].filter(Boolean)}
+            formatEstimatedTime={formatEstimatedTime}
+          />
+        ) : (
+          <Flex>
+            <SelectDevice onSelect={setDevice} />
+            <Button type="main" onPress={onOverrideDependencies}>
+              {override
+                ? "Use app list from feature flag"
+                : "Use known bad app list"}
+            </Button>
+          </Flex>
+        )}
+      </View>
+    </NavigationScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flexGrow: 1,
+    padding: 16,
+  },
+  box: {
+    padding: 10,
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -64,6 +64,12 @@ export default function Features() {
         onPress={() => navigation.navigate(ScreenName.DebugLottie)}
       />
       <SettingsRow
+        title="Install set of apps"
+        desc="Multi app install feature test"
+        iconLeft={<Icons.MugHotMedium size={32} color="black" />}
+        onPress={() => navigation.navigate(ScreenName.DebugInstallSetOfApps)}
+      />
+      <SettingsRow
         title="Videos"
         desc="See all video assets"
         iconLeft={<Icons.PlayMedium size={32} color="black" />}

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -331,11 +331,6 @@ const envDefinitions: Record<
     parser: boolParser,
     desc: "enable experimental explorer APIs",
   },
-  EXPERIMENTAL_FALLBACK_APDU_LISTAPPS: {
-    def: false,
-    parser: boolParser,
-    desc: "if HSM list apps fails, fallback on APDU version (>=1.6.0)",
-  },
   EXPERIMENTAL_LANGUAGES: {
     def: false,
     parser: boolParser,

--- a/libs/ledger-live-common/src/apps/hw.ts
+++ b/libs/ledger-live-common/src/apps/hw.ts
@@ -87,7 +87,7 @@ export type InlineAppInstallEvent =
  * @param transport Transport instance
  * @param appNames List of app names to install
  * @param onSuccessObs Optional observable to run after the installation
- * @param skipAppInstallIfNotFound If true, skip the installation of any app that were not found from the provider. Default to false.
+ * @param allowPartialDependencies If true, keep installing apps even if some are missing
  * @returns Observable of InlineAppInstallEvent or ConnectAppEvent
  * - Event "inline-install" contains a global progress of the installation
  */
@@ -95,12 +95,12 @@ export const inlineAppInstall = ({
   transport,
   appNames,
   onSuccessObs,
-  skipAppInstallIfNotFound = false,
+  allowPartialDependencies = false,
 }: {
   transport: Transport;
   appNames: string[];
   onSuccessObs?: () => Observable<any>;
-  skipAppInstallIfNotFound?: boolean;
+  allowPartialDependencies?: boolean;
 }): Observable<InlineAppInstallEvent | ConnectAppEvent> =>
   concat(
     of({
@@ -124,7 +124,7 @@ export const inlineAppInstall = ({
               reducer(state, {
                 type: "install",
                 name,
-                skip: skipAppInstallIfNotFound,
+                allowPartialDependencies,
               }),
             initState(e.result)
           );

--- a/libs/ledger-live-common/src/apps/hw.ts
+++ b/libs/ledger-live-common/src/apps/hw.ts
@@ -53,7 +53,7 @@ export const execWithTransport =
 
 const appsThatKeepChangingHashes = ["Fido U2F", "Security Key"];
 
-export type StreamAppInstallEvent =
+export type InlineAppInstallEvent =
   | {
       type: "device-permission-requested";
       wording: string;
@@ -74,7 +74,7 @@ export type StreamAppInstallEvent =
       skippedAppOps: SkippedAppOp[];
     }
   | {
-      type: "stream-install";
+      type: "inline-install";
       progress: number;
       itemProgress: number;
       currentAppOp: AppOp;
@@ -88,10 +88,10 @@ export type StreamAppInstallEvent =
  * @param appNames List of app names to install
  * @param onSuccessObs Optional observable to run after the installation
  * @param skipAppInstallIfNotFound If true, skip the installation of any app that were not found from the provider. Default to false.
- * @returns Observable of StreamAppInstallEvent or ConnectAppEvent
- * - Event "stream-install" contains a global progress of the installation
+ * @returns Observable of InlineAppInstallEvent or ConnectAppEvent
+ * - Event "inline-install" contains a global progress of the installation
  */
-export const streamAppInstall = ({
+export const inlineAppInstall = ({
   transport,
   appNames,
   onSuccessObs,
@@ -101,7 +101,7 @@ export const streamAppInstall = ({
   appNames: string[];
   onSuccessObs?: () => Observable<any>;
   skipAppInstallIfNotFound?: boolean;
-}): Observable<StreamAppInstallEvent | ConnectAppEvent> =>
+}): Observable<InlineAppInstallEvent | ConnectAppEvent> =>
   concat(
     of({
       type: "listing-apps",
@@ -131,7 +131,7 @@ export const streamAppInstall = ({
 
           // Failed appOps in this flow will throw by default but if we're here
           // it means we didn't throw, so we wan't to notify the action about it.
-          const maybeSkippedEvent: Observable<StreamAppInstallEvent> = state
+          const maybeSkippedEvent: Observable<InlineAppInstallEvent> = state
             .skippedAppOps.length
             ? of({
                 type: "some-apps-skipped",
@@ -166,7 +166,7 @@ export const streamAppInstall = ({
                   installQueue,
                   currentAppOp,
                 }) => ({
-                  type: "stream-install",
+                  type: "inline-install",
                   progress: globalProgress,
                   itemProgress,
                   installQueue,

--- a/libs/ledger-live-common/src/apps/hw.ts
+++ b/libs/ledger-live-common/src/apps/hw.ts
@@ -62,6 +62,10 @@ export type InlineAppInstallEvent =
       type: "listing-apps";
     }
   | {
+      type: "listed-apps";
+      installQueue: string[];
+    }
+  | {
       type: "device-permission-granted";
     }
   | {
@@ -157,6 +161,10 @@ export const inlineAppInstall = ({
 
           const exec = execWithTransport(transport);
           return concat(
+            of({
+              type: "listed-apps",
+              installQueue: state.installQueue,
+            }),
             maybeSkippedEvent,
             runAllWithProgress(state, exec).pipe(
               map(

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -274,7 +274,7 @@ export const reducer = (state: State, action: Action): State => {
     }
 
     case "install": {
-      const { name, skip } = action;
+      const { name, allowPartialDependencies } = action;
 
       if (state.installQueue.includes(name)) {
         // already queued for install
@@ -316,7 +316,7 @@ export const reducer = (state: State, action: Action): State => {
 
       // The target application was not found in the specified provider.
       if (!appToInstall) {
-        if (skip) {
+        if (allowPartialDependencies) {
           // Some flows are resillient to missing operations.
           skippedAppOps.push({
             reason: SkipReason.NoSuchAppOnProvider,

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -3,12 +3,13 @@ import { Subject } from "rxjs";
 import flatMap from "lodash/flatMap";
 import semver from "semver";
 import { getDeviceModel } from "@ledgerhq/devices";
-import type {
+import {
   AppOp,
   State,
   Action,
   ListAppsResult,
   AppsDistribution,
+  SkipReason,
 } from "./types";
 import {
   findCryptoCurrency,
@@ -41,6 +42,7 @@ export const initState = (
     currentProgressSubject: new Subject(),
     currentError: null,
     currentAppOp: null,
+    skippedAppOps: [],
   };
 
   if (appsToRestore) {
@@ -272,7 +274,7 @@ export const reducer = (state: State, action: Action): State => {
     }
 
     case "install": {
-      const { name } = action;
+      const { name, skip } = action;
 
       if (state.installQueue.includes(name)) {
         // already queued for install
@@ -280,17 +282,23 @@ export const reducer = (state: State, action: Action): State => {
       }
 
       const existing = state.installed.find((app) => app.name === name);
+      const skippedAppOps = [...state.skippedAppOps];
 
       if (existing && existing.updated && state.installedAvailable) {
         // already installed and up to date
-        return state;
+        skippedAppOps.push({
+          reason: SkipReason.AppAlreadyInstalled,
+          appOp: action,
+        });
+        return { ...state, skippedAppOps };
       }
 
-      const depApp: App | null | undefined = state.appByName[name];
+      const appToInstall: App | null | undefined = state.appByName[name];
 
-      // No app found but fw update is available
+      // The target application was not found in the specified provider BUT
+      // we can update the firmware instead, and perhaps in the new FW it is available.
       if (
-        !depApp &&
+        !appToInstall &&
         state.firmware?.updateAvailable?.final?.version &&
         semver.lt(
           state.deviceInfo.version,
@@ -306,21 +314,33 @@ export const reducer = (state: State, action: Action): State => {
         );
       }
 
-      if (!depApp) {
-        throw new NoSuchAppOnProvider("", { appName: name });
+      // The target application was not found in the specified provider.
+      if (!appToInstall) {
+        if (skip) {
+          // Some flows are resillient to missing operations.
+          skippedAppOps.push({
+            reason: SkipReason.NoSuchAppOnProvider,
+            appOp: action,
+          });
+          return { ...state, skippedAppOps };
+        } else {
+          // Some flows are not, and we want to stop with an error.
+          throw new NoSuchAppOnProvider("", { appName: name });
+        }
       }
 
-      const deps = depApp.dependencies;
-      const dependentsOfDep = flatMap(deps, (dep) =>
+      const dependencies = appToInstall.dependencies;
+      const dependentsOfDep = flatMap(dependencies, (dep) =>
         findDependents(state.appByName, dep)
       );
       const depsInstalledOutdated = state.installed.filter(
-        (a) => deps.includes(a.name) && !a.updated
+        (a) => dependencies.includes(a.name) && !a.updated
       );
       let installList = state.installQueue;
+
       // installing an app will remove if planned for uninstalling
       let uninstallList = state.uninstallQueue.filter(
-        (u) => name !== u && !deps.includes(u)
+        (u) => name !== u && !dependencies.includes(u)
       );
 
       if (state.uninstallQueue.length !== uninstallList.length) {
@@ -339,7 +359,7 @@ export const reducer = (state: State, action: Action): State => {
                 !a.updated &&
                 [
                   name,
-                  ...deps,
+                  ...dependencies,
                   ...directDependents,
                   ...dependentsOfDep,
                 ].includes(a.name)
@@ -350,7 +370,9 @@ export const reducer = (state: State, action: Action): State => {
         }
 
         installList = installList.concat([
-          ...deps.filter((d) => !state.installed.some((a) => a.name === d)),
+          ...dependencies.filter(
+            (d) => !state.installed.some((a) => a.name === d)
+          ),
           name,
         ]);
       }

--- a/libs/ledger-live-common/src/apps/runner.ts
+++ b/libs/ledger-live-common/src/apps/runner.ts
@@ -112,11 +112,7 @@ export const runAllWithProgress = (
     scan(reducer, state),
     mergeMap((s) => {
       // Nb if you also want to expose the uninstall queue, feel free.
-      const {
-        currentProgressSubject,
-        currentAppOp,
-        installQueue,
-      } = s;
+      const { currentProgressSubject, currentAppOp, installQueue } = s;
 
       if (!currentProgressSubject)
         return of({

--- a/libs/ledger-live-common/src/apps/runner.ts
+++ b/libs/ledger-live-common/src/apps/runner.ts
@@ -112,7 +112,11 @@ export const runAllWithProgress = (
     scan(reducer, state),
     mergeMap((s) => {
       // Nb if you also want to expose the uninstall queue, feel free.
-      const { currentProgressSubject, currentAppOp, installQueue } = s;
+      const {
+        currentProgressSubject,
+        currentAppOp,
+        installQueue,
+      } = s;
 
       if (!currentProgressSubject)
         return of({

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -103,7 +103,7 @@ export type Action =  // recover from an error
   | {
       type: "install";
       name: string;
-      skip?: boolean;
+      allowPartialDependencies?: boolean;
     } // update all
   | {
       type: "updateAll";

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -55,8 +55,8 @@ export type State = {
   recentlyInstalledApps: string[];
   installQueue: string[];
   uninstallQueue: string[];
-  // queue saved at the time of a "updateAll" action
-  updateAllQueue: string[];
+  skippedAppOps: SkippedAppOp[]; // Nb If an AppOp couldn't be completed, track why.
+  updateAllQueue: string[]; // queue saved at the time of a "updateAll" action
   currentAppOp: AppOp | null | undefined;
   currentProgressSubject: Subject<number> | null | undefined;
   currentError:
@@ -76,6 +76,18 @@ export type AppOp =
       type: "uninstall";
       name: string;
     };
+
+export enum SkipReason {
+  NoSuchAppOnProvider,
+  AppAlreadyInstalled,
+  NotEnoughSpace,
+}
+
+export type SkippedAppOp = {
+  reason: SkipReason;
+  appOp: AppOp;
+};
+
 export type Action =  // recover from an error
   | {
       type: "recover";
@@ -91,6 +103,7 @@ export type Action =  // recover from an error
   | {
       type: "install";
       name: string;
+      skip?: boolean;
     } // update all
   | {
       type: "updateAll";

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -89,6 +89,7 @@ export type State = {
   itemProgress?: number;
   isLocked: boolean;
   skippedAppOps: SkippedAppOp[];
+  listedApps?: boolean;
 };
 
 export type AppState = State & {
@@ -184,11 +185,13 @@ const getInitialState = (
   request,
   currentAppOp: undefined,
   installQueue: [],
+  listedApps: false, // Nb maybe expose the result
   skippedAppOps: [],
   itemProgress: 0,
 });
 
 const reducer = (state: State, e: Event): State => {
+  console.log("event", e)
   switch (e.type) {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true };
@@ -218,6 +221,7 @@ const reducer = (state: State, e: Event): State => {
       return {
         ...state,
         skippedAppOps: e.skippedAppOps,
+        installQueue: state.installQueue,
       };
     case "inline-install":
       return {
@@ -244,6 +248,7 @@ const reducer = (state: State, e: Event): State => {
         request: state.request,
         skippedAppOps: state.skippedAppOps,
         currentAppOp: e.currentAppOp,
+        listedApps: state.listedApps,
         itemProgress: e.itemProgress || 0,
         installQueue: e.installQueue || [],
       };
@@ -251,6 +256,7 @@ const reducer = (state: State, e: Event): State => {
     case "listing-apps":
       return {
         ...state,
+        listedApps: false,
         listingApps: true,
         unresponsive: false,
         isLocked: false,
@@ -335,6 +341,7 @@ const reducer = (state: State, e: Event): State => {
 
         request: state.request,
         skippedAppOps: state.skippedAppOps,
+        installQueue: state.installQueue,
       };
 
     case "device-permission-granted":
@@ -358,6 +365,8 @@ const reducer = (state: State, e: Event): State => {
 
         request: state.request,
         skippedAppOps: state.skippedAppOps,
+        installQueue: state.installQueue,
+        listedApps: state.listedApps,
       };
 
     case "app-not-installed":
@@ -386,6 +395,13 @@ const reducer = (state: State, e: Event): State => {
         skippedAppOps: state.skippedAppOps,
       };
 
+    case "listed-apps":
+      return {
+        ...state,
+        listedApps: true,
+        installQueue: e.installQueue,
+      };
+
     case "opened":
       return {
         requestQuitApp: false,
@@ -406,6 +422,7 @@ const reducer = (state: State, e: Event): State => {
 
         request: state.request,
         skippedAppOps: state.skippedAppOps,
+        listedApps: state.listedApps,
         displayUpgradeWarning:
           state.device && e.app
             ? shouldUpgrade(state.device.modelId, e.app.name, e.app.version)

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -110,7 +110,7 @@ export type AppRequest = {
   dependencies?: AppRequest[];
   withInlineInstallProgress?: boolean;
   requireLatestFirmware?: boolean;
-  skipAppInstallIfNotFound?: boolean;
+  allowPartialDependencies?: boolean;
 };
 
 export type AppResult = {
@@ -420,7 +420,7 @@ function inferCommandParams(appRequest: AppRequest) {
   let derivationMode;
   let derivationPath;
 
-  const { account, requireLatestFirmware, skipAppInstallIfNotFound } =
+  const { account, requireLatestFirmware, allowPartialDependencies } =
     appRequest;
   let { appName, currency, dependencies } = appRequest;
 
@@ -443,7 +443,7 @@ function inferCommandParams(appRequest: AppRequest) {
       appName,
       dependencies,
       requireLatestFirmware,
-      skipAppInstallIfNotFound,
+      allowPartialDependencies,
     };
   }
 
@@ -479,7 +479,7 @@ function inferCommandParams(appRequest: AppRequest) {
       currencyId: currency.id,
       ...extra,
     },
-    skipAppInstallIfNotFound,
+    allowPartialDependencies,
   };
 }
 

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -191,7 +191,6 @@ const getInitialState = (
 });
 
 const reducer = (state: State, e: Event): State => {
-  console.log("event", e)
   switch (e.type) {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true };

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -219,7 +219,7 @@ const reducer = (state: State, e: Event): State => {
         ...state,
         skippedAppOps: e.skippedAppOps,
       };
-    case "stream-install":
+    case "inline-install":
       return {
         isLoading: false,
         requestQuitApp: false,

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -20,7 +20,7 @@ import type { AppOp, SkippedAppOp } from "../apps/types";
 import { getCryptoCurrencyById } from "../currencies";
 import appSupportsQuitApp from "../appSupportsQuitApp";
 import { withDevice } from "./deviceAccess";
-import { streamAppInstall } from "../apps/hw";
+import { inlineAppInstall } from "../apps/hw";
 import { isDashboardName } from "./isDashboardName";
 import getAppAndVersion from "./getAppAndVersion";
 import getDeviceInfo from "./getDeviceInfo";
@@ -80,7 +80,7 @@ export type ConnectAppEvent =
       appName: string;
     }
   | {
-      type: "stream-install";
+      type: "inline-install";
       progress: number;
       itemProgress: number;
       currentAppOp: AppOp;
@@ -158,7 +158,7 @@ export const openAppFromDashboard = (
                 switch (e.statusCode) {
                   case 0x6984: // No StatusCodes definition
                   case 0x6807: // No StatusCodes definition
-                    return streamAppInstall({
+                    return inlineAppInstall({
                       transport,
                       appNames: [appName],
                       onSuccessObs: () =>
@@ -372,7 +372,7 @@ const cmd = ({
                 // check if we meet dependencies
                 if (dependencies?.length) {
                   const completesInDashboard = isDashboardName(appName);
-                  return streamAppInstall({
+                  return inlineAppInstall({
                     transport,
                     appNames: [
                       ...(completesInDashboard ? [] : [appName]),

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -16,7 +16,7 @@ import type Transport from "@ledgerhq/hw-transport";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import type { DerivationMode } from "@ledgerhq/coin-framework/derivation";
-import type { AppOp } from "../apps/types";
+import type { AppOp, SkippedAppOp } from "../apps/types";
 import { getCryptoCurrencyById } from "../currencies";
 import appSupportsQuitApp from "../appSupportsQuitApp";
 import { withDevice } from "./deviceAccess";
@@ -85,6 +85,10 @@ export type ConnectAppEvent =
       itemProgress: number;
       currentAppOp: AppOp;
       installQueue: string[];
+    }
+  | {
+      type: "some-apps-skipped";
+      skippedAppOps: SkippedAppOp[];
     }
   | {
       type: "listing-apps";

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -47,7 +47,7 @@ export type Input = {
   dependencies?: string[];
   requireLatestFirmware?: boolean;
   outdatedApp?: AppAndVersion;
-  skipAppInstallIfNotFound?: boolean;
+  allowPartialDependencies: boolean;
 };
 export type AppAndVersion = {
   name: string;
@@ -273,7 +273,7 @@ const derivationLogic = (
   );
 
 /**
- * @param skipAppInstallIfNotFound If some dependencies need to be installed, and if set to true,
+ * @param allowPartialDependencies If some dependencies need to be installed, and if set to true,
  *   skip any app install if the app is not found from the provider.
  */
 const cmd = ({
@@ -284,7 +284,7 @@ const cmd = ({
   dependencies,
   requireLatestFirmware,
   outdatedApp,
-  skipAppInstallIfNotFound = false,
+  allowPartialDependencies = false,
 }: Input): Observable<ConnectAppEvent> =>
   withDevice(devicePath)(
     (transport) =>
@@ -386,7 +386,7 @@ const cmd = ({
                         appName,
                       }); // NB without deps
                     },
-                    skipAppInstallIfNotFound,
+                    allowPartialDependencies,
                   });
                 }
 

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -94,6 +94,10 @@ export type ConnectAppEvent =
       type: "listing-apps";
     }
   | {
+      type: "listed-apps";
+      installQueue: string[];
+    }
+  | {
       type: "dependencies-resolved";
     }
   | {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The original functionality of inline app installation was tightly coupled to a flow that had a hard dependency on a set of applications. For instance, accessing a swap flow for BTC-ETH would **need** all of the apps installed in order to succeed. However, with the use that we are giving it on the sync onboarding flow this dependency is no longer as strong. 

#### Install set of apps
This step of the onboarding will attempt to install a list of applications that can change between users since it's either something we provide from firebase or a "recover" list of apps from another device the user has interacted with. There is an odd chance that these apps are not available for installation in the newly onboarded device either because they're not developed, or not compatible, or even already installed.

#### More granular exposed state
The way inline app installations worked was very closed in terms of progress publishing, adapting it to `install-set-of-apps` required exposing a few flags, like dependency resolution, partial failures with reasons, etc. This means we can know what will be installed and what won't and why. This can also be used for other flows that attempt to install an app if we wanted, and LLD will also have to take advantage of this soon.

#### Tooling
Apart from the feature itself which can be hard to access, this PR provides a tool in the debugging menu to facilitate access to it. It has two modes, one of which takes the list from firebase and one which takes a known invalid list to debug the UI of failures.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile, live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-793` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/222235948-9376fba1-a217-4da5-bc2b-7cc369a0c24e.mov


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
There are some discrepancies in the design that come from an outdated design system. Components no longer matching what our designers are working with, and it's out of the scope of this feature to update them. Everyone is aware of this fact and the UI will adapt once the components are updated.
