### PR TITLE
bugfix: FAT-740 fix user prompt loop on receive flow

### DIFF
--- a/.changeset/forty-toes-smell.md
+++ b/.changeset/forty-toes-smell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the prompt loop on receive flow

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/01-SelectCrypto.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/01-SelectCrypto.tsx
@@ -169,7 +169,7 @@ export default function AddAccountsSelectCrypto({ navigation, route }: Props) {
   return (
     <>
       <TrackScreen category="Receive" name="Select Crypto" />
-      <LText fontSize={"32"} fontFamily="InterMedium" semiBold px={6} my={3}>
+      <LText fontSize="32px" fontFamily="InterMedium" semiBold px={6} my={3}>
         {t("transfer.receive.selectCrypto.title")}
       </LText>
       <FilteredSearchBar

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03a-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03a-ConnectDevice.tsx
@@ -62,7 +62,11 @@ export default function ConnectDevice({
       if (!account) {
         return null;
       }
-      setDevice(undefined);
+
+      // Nb Unsetting device here caused the scanning to start again,
+      // scanning causes a disconnect, which throws an error when we try to talk
+      // to the device on the next step.
+
       return navigation.navigate(ScreenName.ReceiveVerifyAddress, {
         ...route.params,
         ...payload,

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
@@ -13,6 +13,7 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import styled, { useTheme } from "styled-components/native";
 import { Flex } from "@ledgerhq/native-ui";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { track, TrackScreen } from "../../analytics";
 import { accountScreenSelector } from "../../reducers/accounts";
 import PreventNativeBack from "../../components/PreventNativeBack";
@@ -143,6 +144,7 @@ export default function ReceiveVerifyAddress({ navigation, route }: Props) {
     <>
       <PreventNativeBack />
       <SkipLock />
+      <SyncSkipUnderPriority priority={100} />
       {error ? (
         <>
           <TrackScreen category="Receive" name="Address Verification Denied" />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

An incorrect dependency was causing the code that triggered the user prompt to verify an address to render again whenever the accounts sync'ed in the background. This pr fixes it.

In the process I also addressed https://ledgerhq.atlassian.net/browse/LIVE-5196 which is only available with the feature flag enabled. Feel free to test it too.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/FAT-740` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- Do a receive flow
- After confirmation, wait
- There should be no extra prompt