### PR TITLE
LIVE-5706 [Solana] Set max validators to 2000, set cache duration to 10min

### DIFF
--- a/libs/ledger-live-common/src/families/solana/bridge/bridge.ts
+++ b/libs/ledger-live-common/src/families/solana/bridge/bridge.ts
@@ -19,7 +19,7 @@ import { broadcastWithAPI } from "../js-broadcast";
 import createTransaction, { updateTransaction } from "../js-createTransaction";
 import estimateMaxSpendableWithAPI from "../js-estimateMaxSpendable";
 import getTransactionStatus from "../js-getTransactionStatus";
-import { hydrate, preloadWithAPI } from "../js-preload";
+import { PRELOAD_MAX_AGE, hydrate, preloadWithAPI } from "../js-preload";
 import { prepareTransaction as prepareTransactionWithAPI } from "../js-prepareTransaction";
 import { signOperationWithAPI } from "../js-signOperation";
 import { getAccountShapeWithAPI } from "../js-synchronization";
@@ -143,6 +143,12 @@ function makePreload(
   return preload;
 }
 
+function getPreloadStrategy() {
+  return {
+    preloadMaxAge: PRELOAD_MAX_AGE,
+  };
+}
+
 export function makeBridges({
   getAPI,
   getQueuedAPI,
@@ -173,6 +179,7 @@ export function makeBridges({
     preload: makePreload(getQueuedAndCachedAPI),
     hydrate,
     scanAccounts: scan,
+    getPreloadStrategy,
   };
 
   return {

--- a/libs/ledger-live-common/src/families/solana/js-preload.ts
+++ b/libs/ledger-live-common/src/families/solana/js-preload.ts
@@ -11,6 +11,8 @@ import {
 } from "./utils";
 import { getValidators, ValidatorsAppValidator } from "./validator-app";
 
+export const PRELOAD_MAX_AGE = 10 * 60 * 1000; // 10min
+
 export async function preloadWithAPI(
   currency: CryptoCurrency,
   getAPI: () => Promise<ChainAPI>

--- a/libs/ledger-live-common/src/families/solana/validator-app/index.ts
+++ b/libs/ledger-live-common/src/families/solana/validator-app/index.ts
@@ -4,6 +4,8 @@ import { compact } from "lodash/fp";
 import { getEnv } from "../../../env";
 import network from "../../../network";
 
+const MAX_VALIDATORS_NB = 2000; // Max number of validators to fetch
+
 export type ValidatorsAppValidatorRaw = {
   active_stake?: number | null;
   commission?: number | null;
@@ -57,7 +59,7 @@ const URLS = {
   validatorList: (cluster: Extract<Cluster, "mainnet-beta" | "testnet">) => {
     const clusterSlug = cluster === "mainnet-beta" ? "mainnet" : cluster;
     const baseUrl = getEnv("SOLANA_VALIDATORS_APP_BASE_URL");
-    return `${baseUrl}/${clusterSlug}.json?order=score`;
+    return `${baseUrl}/${clusterSlug}.json?order=score&limit=${MAX_VALIDATORS_NB}`;
   },
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently Solana fetches 4000+ validators (4.3Mo) every 5min, which causes a massive and useless bandwidth consumption.
As a quick-win reduce this to 2000 validators every 10min.

### ❓ Context

- **Impacted projects**: LLC <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-5706 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach


<!-- If any of the expectations are not met please explain the reason in detail. -->
