### PR TITLE
Fix services widget location on device selection screen

### DIFF
--- a/.changeset/chilly-pigs-retire.md
+++ b/.changeset/chilly-pigs-retire.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Minor bug fix to prevent the ServiceWidget to appear below the new device selection screen when scanning and pairing in the My Ledger tab.

--- a/apps/ledger-live-mobile/src/components/BuyDeviceCTA.tsx
+++ b/apps/ledger-live-mobile/src/components/BuyDeviceCTA.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 
 import { Linking } from "react-native";
-import { Flex, Text } from "@ledgerhq/native-ui";
+import { Text } from "@ledgerhq/native-ui";
 import { Trans } from "react-i18next";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useNavigation } from "@react-navigation/native";
@@ -24,16 +24,14 @@ const BuyDeviceCTA: React.FC<Record<string, never>> = () => {
   }, [navigation, buyDeviceFromLive?.enabled]);
 
   return (
-    <Flex alignItems="center" mt={8}>
-      <Text variant="paragraph" fontWeight="semiBold">
-        <Trans i18nKey="manager.selectDevice.buyDeviceCTA">
-          <Text>{"Need a new Ledger? "}</Text>
-          <Text color="primary.c90" onPress={onBuyDevicePress}>
-            {"Buy now"}
-          </Text>
-        </Trans>
-      </Text>
-    </Flex>
+    <Text variant="paragraph" fontWeight="semiBold">
+      <Trans i18nKey="manager.selectDevice.buyDeviceCTA">
+        <Text>{"Need a new Ledger? "}</Text>
+        <Text color="primary.c90" onPress={onBuyDevicePress}>
+          {"Buy now"}
+        </Text>
+      </Trans>
+    </Text>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -31,6 +31,7 @@ import PostOnboardingEntryPointCard from "../PostOnboarding/PostOnboardingEntryP
 import BleDevicePairingFlow from "../BleDevicePairingFlow";
 import BuyDeviceCTA from "../BuyDeviceCTA";
 import QueuedDrawer from "../QueuedDrawer";
+import ServicesWidget from "../ServicesWidget";
 
 type Navigation = BaseComposite<
   CompositeScreenProps<
@@ -46,9 +47,14 @@ type Props = {
   // Other component using this component needs to stop the BLE scanning before starting
   // to communicate to a device via BLE.
   stopBleScanning?: boolean;
+  displayServicesWidget?: boolean;
 };
 
-export default function SelectDevice({ onSelect, stopBleScanning }: Props) {
+export default function SelectDevice({
+  onSelect,
+  stopBleScanning,
+  displayServicesWidget,
+}: Props) {
   const [USBDevice, setUSBDevice] = useState<Device | undefined>();
   const [ProxyDevice, setProxyDevice] = useState<Device | undefined>();
 
@@ -266,8 +272,11 @@ export default function SelectDevice({ onSelect, stopBleScanning }: Props) {
                   <Trans i18nKey="manager.selectDevice.otgBanner" />
                 </Text>
               )}
+            {displayServicesWidget && <ServicesWidget />}
           </ScrollContainer>
-          <BuyDeviceCTA />
+          <Flex alignItems="center" mt={5}>
+            <BuyDeviceCTA />
+          </Flex>
           <QueuedDrawer
             isRequestingToBeOpened={isAddNewDrawerOpen}
             onClose={() => setIsAddNewDrawerOpen(false)}

--- a/apps/ledger-live-mobile/src/screens/Manager/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/index.tsx
@@ -107,36 +107,36 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
           <Trans i18nKey="manager.title" />
         </Text>
       </Flex>
-      <NavigationScrollView
-        style={{ paddingBottom: insets.bottom + TAB_BAR_SAFE_HEIGHT }}
-        contentContainerStyle={styles.scrollContainer}
-      >
-        {newDeviceSelectionFeatureFlag?.enabled ? (
-          <Flex flex={1} pb={insets.bottom + TAB_BAR_SAFE_HEIGHT}>
-            <SelectDevice2
-              onSelect={onSelectDevice}
-              stopBleScanning={!!device}
+
+      {newDeviceSelectionFeatureFlag?.enabled ? (
+        <Flex flex={1} px={16} pb={insets.bottom + TAB_BAR_SAFE_HEIGHT}>
+          <SelectDevice2
+            onSelect={onSelectDevice}
+            stopBleScanning={!!device}
+            displayServicesWidget
+          />
+        </Flex>
+      ) : (
+        <NavigationScrollView
+          style={{ paddingBottom: insets.bottom + TAB_BAR_SAFE_HEIGHT }}
+          contentContainerStyle={styles.scrollContainer}
+        >
+          <SelectDevice
+            usbOnly={params?.firmwareUpdate}
+            autoSelectOnAdd
+            onSelect={onSelectDevice}
+            onBluetoothDeviceAction={onShowMenu}
+          />
+          {chosenDevice ? (
+            <RemoveDeviceMenu
+              open={showMenu}
+              device={chosenDevice as Device}
+              onHideMenu={onHideMenu}
             />
-          </Flex>
-        ) : (
-          <>
-            <SelectDevice
-              usbOnly={params?.firmwareUpdate}
-              autoSelectOnAdd
-              onSelect={onSelectDevice}
-              onBluetoothDeviceAction={onShowMenu}
-            />
-            {chosenDevice ? (
-              <RemoveDeviceMenu
-                open={showMenu}
-                device={chosenDevice as Device}
-                onHideMenu={onHideMenu}
-              />
-            ) : null}
-          </>
-        )}
-        <ServicesWidget />
-      </NavigationScrollView>
+          ) : null}
+          <ServicesWidget />
+        </NavigationScrollView>
+      )}
       <DeviceActionModal
         onClose={() => onSelectDevice()}
         device={device}


### PR DESCRIPTION
### 📝 Description
This PR is a small fix for the interaction between the Services widget and the new device selection screen on the My Ledger tab. Instead of putting it below the SelectDevice2 component (which is the entire new device selection screen), I've put it inside id. This way we can display it only in the first step where we list the known devices and it doesn't appear when we're scanning or pairing a new device. There's an extra prop to the SelectDevice2 component in order to control the display of the widgets otherwise it would appear in every SelectDevice2 usage and not only in the MyLedger tab.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-6658](https://ledgerhq.atlassian.net/browse/LIVE-6658)

### ✅ Checklist

- [ ] **Test coverage** 
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://user-images.githubusercontent.com/6013294/222677379-d03b84a3-5b7b-455d-81cf-0d8d2ab42ae3.mp4



[LIVE-6658]: https://ledgerhq.atlassian.net/browse/LIVE-6658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ