### PR TITLE
Fix - LLM - AuthLoop with FaceId

### DIFF
--- a/.changeset/tasty-dodos-remember.md
+++ b/.changeset/tasty-dodos-remember.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bugfix : FaceId is triggered in loop.

--- a/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
@@ -75,10 +75,7 @@ class AuthPass extends PureComponent<Props, State> {
   }
 
   handleAppStateChange = (nextAppState: string) => {
-    if (
-      this.state.appState.match(/inactive|background/) &&
-      nextAppState === "active"
-    ) {
+    if (this.state.appState === "background" && nextAppState === "active") {
       this.lock();
     }
 

--- a/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { StyleSheet, View, AppState } from "react-native";
+import { StyleSheet, View, AppState, Platform } from "react-native";
 import type { TFunction } from "i18next";
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
@@ -74,8 +74,17 @@ class AuthPass extends PureComponent<Props, State> {
     this.state.mounted = false;
   }
 
+  // The state lifecycle differs between iOS and Android. This is to prevent FaceId from triggering an inactive state and looping.
+  checkAppStateChange = (appState: string) =>
+    Platform.OS === "ios"
+      ? appState === "background"
+      : appState.match(/inactive|background/);
+
   handleAppStateChange = (nextAppState: string) => {
-    if (this.state.appState === "background" && nextAppState === "active") {
+    if (
+      this.checkAppStateChange(this.state.appState) &&
+      nextAppState === "active"
+    ) {
       this.lock();
     }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

FaceId prompt results in app becoming inactive. Inactive is only for Incoming calls, multitasking (eg iPad, non applicable for LLM), and FaceID prompts. FaceID prompt is usually less than a minute, so the bug wasn't visible before removing the timeout delay. Now that it's gone, the faceId prompts and related appstate change triggered an app lock. Removed the appstate Inactive from the condition that triggers an app lock, keeping Background appstate (and next state active).

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: LIVE-6270

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
