### PR TITLE
chore: exchangeBulk unsubscribe support

### DIFF
--- a/.changeset/red-poets-sneeze.md
+++ b/.changeset/red-poets-sneeze.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+exchangeBulk renderer execution to properly be interruptable.

--- a/apps/ledger-live-desktop/src/config/transportChannels.ts
+++ b/apps/ledger-live-desktop/src/config/transportChannels.ts
@@ -1,4 +1,5 @@
 export const transportOpenChannel = "transport:open";
 export const transportExchangeChannel = "transport:exchange";
 export const transportExchangeBulkChannel = "transport:exchangeBulk";
+export const transportExchangeBulkUnsubscribeChannel = "transport:exchangeBulk:unsubscribe";
 export const transportCloseChannel = "transport:close";

--- a/apps/ledger-live-desktop/src/internal/index.js
+++ b/apps/ledger-live-desktop/src/internal/index.js
@@ -15,11 +15,13 @@ import {
   transportClose,
   transportExchange,
   transportExchangeBulk,
+  transportExchangeBulkUnsubscribe,
   transportOpen,
 } from "~/internal/transportHandler";
 import {
   transportCloseChannel,
   transportExchangeBulkChannel,
+  transportExchangeBulkUnsubscribeChannel,
   transportExchangeChannel,
   transportOpenChannel,
 } from "~/config/transportChannels";
@@ -70,6 +72,9 @@ process.on("message", m => {
       break;
     case transportExchangeBulkChannel:
       transportExchangeBulk(m);
+      break;
+    case transportExchangeBulkUnsubscribeChannel:
+      transportExchangeBulkUnsubscribe(m);
       break;
     case transportCloseChannel:
       transportClose(m);

--- a/apps/ledger-live-desktop/src/main/internal-lifecycle.js
+++ b/apps/ledger-live-desktop/src/main/internal-lifecycle.js
@@ -11,6 +11,7 @@ import {
   transportExchangeChannel,
   transportExchangeBulkChannel,
   transportOpenChannel,
+  transportExchangeBulkUnsubscribeChannel,
 } from "~/config/transportChannels";
 
 // ~~~ Local state that main thread keep
@@ -230,7 +231,15 @@ const internalHandlerObservable = channel => {
   });
 };
 
+// simple event routing
+const internalHandlerEvent = channel => {
+  ipcMain.on(channel, (event, { data, requestId }) => {
+    internal.send({ type: channel, data, requestId });
+  });
+};
+
 internalHandlerPromise(transportOpenChannel);
 internalHandlerPromise(transportExchangeChannel);
 internalHandlerPromise(transportCloseChannel);
 internalHandlerObservable(transportExchangeBulkChannel);
+internalHandlerEvent(transportExchangeBulkUnsubscribeChannel);

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.js
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.js
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import {
   transportCloseChannel,
   transportExchangeBulkChannel,
+  transportExchangeBulkUnsubscribeChannel,
   transportExchangeChannel,
   transportOpenChannel,
 } from "~/config/transportChannels";
@@ -101,6 +102,12 @@ export class IPCTransport extends Transport {
     return {
       unsubscribe: () => {
         ipcRenderer.removeListener(replyChannel, handler);
+        ipcRenderer.send(transportExchangeBulkUnsubscribeChannel, {
+          data: {
+            descriptor: this.id,
+          },
+          requestId,
+        });
       },
     };
   }


### PR DESCRIPTION

### 📝 Description

this is a tiny part of https://github.com/LedgerHQ/ledger-live/pull/2721 , this PR can be safely merged, if it's not merged in time it would get by the other PR otherwise.

This restore the feature for experimental users (experimental execution on renderer) that a bulk flow like installing an app would properly be interrupted when user cancel in the middle of the install. This was accidentally reverted when we peer program that feature back in january with @gsoares-ledger  (i managed to find the historical code at https://github.com/LedgerHQ/ledger-live/commit/4f5bc0a46ebdadb7db90cb5d8fa9800e83b9b68d but I must have messed up a push force at the time in https://github.com/LedgerHQ/ledger-live/pull/2342 )

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** I have tested it manually & confirm it now properly interrupts <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
