### PR TITLE
chore: only run the staging explorer btc/eth runs 1/week

### DIFF
--- a/.github/workflows/bot-staging-explorer-btc.yml
+++ b/.github/workflows/bot-staging-explorer-btc.yml
@@ -2,7 +2,7 @@ name: "[Bot] Bitcoin on Staging"
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 8 * * 1-5
+    - cron: 0 8 * * 3
 
 concurrency:
   group: bot-seed2

--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -2,7 +2,7 @@ name: "[Bot] Ethereum on Staging"
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 8 * * 1-5
+    - cron: 0 8 * * 3
 
 concurrency:
   group: bot-seed2


### PR DESCRIPTION

### 📝 Description

as a general effort to overall reduce the number of bot runs, this moves to a weekly run instead of daily of the staging btc/eth bots.

### ❓ Context

- **Impacted projects**: `none` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
