### PR TITLE
Fix the @ledgerhq/native-ui storybook

### DIFF
--- a/libs/ui/packages/native/.storybook/webpack.config.js
+++ b/libs/ui/packages/native/.storybook/webpack.config.js
@@ -21,5 +21,8 @@ module.exports = ({ config }) => {
   config.resolve.alias["victory-native"] = "victory";
   config.resolve.modules = [path.resolve(__dirname, "..", "node_modules"), "node_modules"];
 
+  // This is needed because the storybook reads the public path from the "homepage" package.json field…
+  config.output.publicPath = "/";
+
   return config;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Storybook infers the webpack public path from the `homepage` package.json field, which is obviously wrong.
This PR fixes that.

Proof: https://native-ui-storybook-k1tjpfxaw-ledgerhq.vercel.app/?path=/story/cards--full-background-card

### ❓ Context

- **Impacted projects**: `ui-native` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [jira](https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3959455989/Fix+ledgerhq+native-ui+storybook+deployment) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
