### PR TITLE
feat: live-6698 improve account generator to support delisted tokens

### DIFF
--- a/.changeset/cold-roses-whisper.md
+++ b/.changeset/cold-roses-whisper.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/coin-framework": patch
+---
+
+Improve account generator to support delisted tokens

--- a/apps/ledger-live-mobile/src/components/AssetCentricGraphCard.tsx
+++ b/apps/ledger-live-mobile/src/components/AssetCentricGraphCard.tsx
@@ -13,6 +13,7 @@ import { useTimeRange } from "../actions/settings";
 import Delta from "./Delta";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import getWindowDimensions from "../logic/getWindowDimensions";
+import { NoCountervaluePlaceholder } from "./CounterValue";
 import Graph from "./Graph";
 import { TransactionsPendingConfirmationWarningAllAccounts } from "./TransactionsPendingConfirmationWarning";
 import ParentCurrencyIcon from "./ParentCurrencyIcon";
@@ -159,9 +160,11 @@ function AssetCentricGraphCard({
                       mt={3}
                       minHeight={25}
                     >
-                      {items[1].value !== undefined ? (
+                      {items[1].value ? (
                         <CurrencyUnitValue {...items[1]} />
-                      ) : null}
+                      ) : (
+                        <NoCountervaluePlaceholder />
+                      )}
                     </Text>
                     <Text
                       fontFamily="Inter"

--- a/apps/ledger-live-mobile/src/components/CounterValue.tsx
+++ b/apps/ledger-live-mobile/src/components/CounterValue.tsx
@@ -9,6 +9,7 @@ import {
 import { TouchableOpacity, StyleSheet } from "react-native";
 import { Trans } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
+import { Flex } from "@ledgerhq/native-ui";
 import { counterValueCurrencySelector } from "../reducers/settings";
 import {
   useTrackingPairs,
@@ -50,9 +51,11 @@ export const NoCountervaluePlaceholder = () => {
         onClose={closeModal}
         style={[styles.modal]}
       >
-        <Circle bg={colors.lightLive} size={70}>
-          <IconHelp size={30} color={colors.live} />
-        </Circle>
+        <Flex alignItems="center">
+          <Circle bg={colors.lightLive} size={70}>
+            <IconHelp size={30} color={colors.live} />
+          </Circle>
+        </Flex>
 
         <LText style={styles.modalTitle} semiBold>
           <Trans i18nKey="errors.countervaluesUnavailable.title" />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In order to test something reported on Slack about some countervalue mishaps for unsupported tokens I improved the account generator to support specifying delisted (or listed) token ids.


### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6698` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/223703354-8278e46e-84f8-4ccc-abb8-ebd53bf18bd3.mov


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Choose some token ids and see if the accounts generated respect them, it will only add the tokens if they exist for that currency, but that's common sense. It also addresses https://ledgerhq.atlassian.net/browse/LIVE-6699 which I've added here since it's a PITA to test otherwise.