### PR TITLE
fix: update stored ble device name when accessing the manager

### DIFF
--- a/.changeset/lazy-beans-kick.md
+++ b/.changeset/lazy-beans-kick.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Refresh the stored device name when accessing manager

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -26,6 +26,7 @@ import {
   BaseComposite,
   StackNavigatorProps,
 } from "../../components/RootNavigator/types/helpers";
+import { saveBleDeviceName } from "../../actions/ble";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<ManagerNavigatorStackParamList, ScreenName.ManagerMain>
@@ -46,6 +47,11 @@ const Manager = ({ navigation, route }: NavigationProps) => {
   const { deviceId, deviceName, modelId } = device;
   const [state, dispatch] = useApps(result, deviceId, appsToRestore);
   const reduxDispatch = useDispatch();
+
+  useEffect(() => {
+    // Newly fetched device name from accessing the manager, gets updated.
+    reduxDispatch(saveBleDeviceName(device.deviceId, result.deviceName));
+  }, [reduxDispatch, device.deviceId, result.deviceName]);
 
   const refreshDeviceInfo = useCallback(() => {
     withDevice(deviceId)(transport => from(getDeviceInfo(transport)))


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Modifying the device name from the device itself, or from the repl tool resulted in an outdated name when accessing the manager on LLM. This PR adds the logic to saving the new name so that it's updated the next time we enter the manager.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6440` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo needed.
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
