### PR TITLE
bugfix/lld: fixes side drawer close button

### DIFF
--- a/.changeset/large-pianos-divide.md
+++ b/.changeset/large-pianos-divide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fixes the side drawer close button on MacOS

--- a/apps/ledger-live-desktop/src/renderer/components/SideDrawer.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SideDrawer.jsx
@@ -20,6 +20,7 @@ const TouchButton = styled.button`
   background-color: rgba(0, 0, 0, 0);
   display: inline-flex;
   max-height: 100%;
+  -webkit-app-region: no-drag;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
   color: ${p => p.theme.colors.palette.text.shade80};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The side drawer close button is broken on MacOS because it is in the draggable area of the window. This PR changes this button to allow this to be clickable. 

### ❓ Context

- **Impacted projects**: Desktop
- **Linked resource(s)**:  https://ledgerhq.atlassian.net/browse/LIVE-6707

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/119950081/224049987-ec589173-b83d-4161-b2f4-656c250aa63d.mov



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
