### PR TITLE
feat: introduce the first set of destructors on debug menu

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
@@ -3,8 +3,7 @@ import config from "react-native-config";
 import { getEnv } from "@ledgerhq/live-common/env";
 import { Alert as Confirmation } from "react-native";
 import { Alert, Icons } from "@ledgerhq/native-ui";
-import { useDispatch, useSelector } from "react-redux";
-import { State } from "../../../../reducers/types";
+import { useDispatch } from "react-redux";
 import GenerateMockAccounts from "./GenerateMockAccounts";
 import GenerateMockAccountsNft from "./GenerateMockAccountsNFTs";
 import ImportBridgeStreamData from "./ImportBridgeStreamData";
@@ -21,7 +20,6 @@ import { INITIAL_STATE as INITIAL_ACCOUNTS_STATE } from "../../../../reducers/ac
 import { INITIAL_STATE as INITIAL_BLE_STATE } from "../../../../reducers/ble";
 
 export default function Generators() {
-  const state = useSelector<State, State>(s => s);
   const dispatch = useDispatch();
   const reboot = useReboot();
 
@@ -50,34 +48,31 @@ export default function Generators() {
     onCallbackWithConfirmation(() => {
       dispatch(
         dangerouslyOverrideState({
-          ...state,
           settings: INITIAL_SETTINGS_STATE,
         }),
       );
     });
-  }, [dispatch, state]);
+  }, [dispatch]);
 
   const onWipeUsers = useCallback(() => {
     onCallbackWithConfirmation(() => {
       dispatch(
         dangerouslyOverrideState({
-          ...state,
           accounts: INITIAL_ACCOUNTS_STATE,
         }),
       );
     });
-  }, [dispatch, state]);
+  }, [dispatch]);
 
   const onWipeBLE = useCallback(() => {
     onCallbackWithConfirmation(() => {
       dispatch(
         dangerouslyOverrideState({
-          ...state,
           ble: INITIAL_BLE_STATE,
         }),
       );
     });
-  }, [dispatch, state]);
+  }, [dispatch]);
 
   const onForceRefresh = useCallback(() => {
     reboot();

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
@@ -30,7 +30,7 @@ export default function Generators() {
       [
         {
           text: "Destroy",
-          onPress: () => callback(),
+          onPress: callback,
         },
         {
           text: "Cancel",


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
During a recent app refactoring, I encountered a challenge with resetting the application's state. It required either uninstalling the application or manually resetting the settings to their expected values, which was a tedious and time-consuming process. However, by including destructors in the code, we can streamline this process, benefiting both development and quality assurance teams. Destructors allow for the automatic reset of an application's state, reducing the need for manual intervention and saving time during testing cycles. Thus, utilizing destructors can improve the efficiency and accuracy of debugging tools for both development and QA purposes.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6732` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://user-images.githubusercontent.com/4631227/224574727-2f8fbb07-4622-4e61-beee-bef74bcb89c4.mov

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- You should now be able to wipe the accounts, the settings, the known devices in a few clicks without uninstalling. More destructors could be created if needed, we are not limited by the normal destruction.
