### PR TITLE
fix(sync-onboarding): handle X as completion if onboarding is completed

### DIFF
--- a/.changeset/twenty-vans-call.md
+++ b/.changeset/twenty-vans-call.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Handle closing sync onboarding after completion

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -222,10 +222,6 @@ export const SyncOnboarding = ({
     };
   }, []);
 
-  const handleClose = useCallback(() => {
-    goBackToPairingFlow();
-  }, [goBackToPairingFlow]);
-
   const handleDesyncTimedOut = useCallback(() => {
     setDesyncDrawerOpen(true);
   }, []);
@@ -260,6 +256,10 @@ export const SyncOnboarding = ({
 
     navigation.navigate(ScreenName.SyncOnboardingCompletion, { device });
   }, [device, dispatchRedux, navigation]);
+
+  const handleClose = useCallback(() => {
+    readyRedirectTimerRef.current ? handleDeviceReady() : goBackToPairingFlow();
+  }, [goBackToPairingFlow, handleDeviceReady]);
 
   useEffect(() => {
     if (!fatalError) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Closing the sync onboarding even though it was finished would take the user back to the initial step. This is because there's a 2.5 second delay in order for the user to acknowledge they've completed the step (I guess). This PR makes the X trigger the navigation early instead of taking the user back to the beginning of the flow.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6737` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/224689900-52ff7b6c-97fb-44ac-883e-6f508992ddf9.mov


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- Do a sync onboarding
- Reach the step where you have the green “Your device is ready”
- Close the onboarding before the cofetti animation kicks in
- It should go to confetti now, not to the onboarding initial step.