### PR TITLE
feat: drop importDataString feature from LLM

### DIFF
--- a/.changeset/olive-cherries-occur.md
+++ b/.changeset/olive-cherries-occur.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Drop importDatString from LLM

--- a/apps/ledger-live-mobile/README.md
+++ b/apps/ledger-live-mobile/README.md
@@ -68,11 +68,6 @@ or open `android/` in Android Studio.
 
 Delete the application data for Ledger Live Mobile, equivalent to doing it manually through settings
 
-### `pnpm mobile android:import importDataString`
-
-Passing a base64 encoded export string (the export from desktop) will trigger an import activity and allow
-easy data setting for development.
-
 ### `pnpm build:llm:ios` 
 
 Produces a development .ipa signed with the developer's current certificates (can be installed on phones added to our apple dev center). Not eligible for AppStore/TestFlight

--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -21,8 +21,6 @@ import com.facebook.react.modules.i18nmanager.I18nUtil;
 
 public class MainActivity extends ReactActivity {
 
-    String importDataString = null;
-
     /**
      * Returns the name of the main component registered from JavaScript. This is
      * used to schedule rendering of the component.
@@ -66,12 +64,6 @@ public class MainActivity extends ReactActivity {
 
         if (!BuildConfig.DEBUG) {
             SplashScreen.show(this, true);
-        } else {
-            // Allow data override for debug builds
-            Bundle extras = getIntent().getExtras();
-            if (extras != null) {
-                this.importDataString = extras.getString("importDataString");
-            }
         }
         super.onCreate(null);
         /*

--- a/apps/ledger-live-mobile/scripts/android-import.sh
+++ b/apps/ledger-live-mobile/scripts/android-import.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-OVERRIDE=$1
-adb shell am force-stop "com.ledger.live";
-adb shell am start -n "com.ledger.live/.MainActivity" --es "importDataString" $OVERRIDE -t "text/plain"

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import Config from "react-native-config";
 import { createStackNavigator } from "@react-navigation/stack";
@@ -6,23 +6,12 @@ import { NavigatorName } from "../../const";
 import { hasCompletedOnboardingSelector } from "../../reducers/settings";
 import BaseNavigator from "./BaseNavigator";
 import BaseOnboardingNavigator from "./BaseOnboardingNavigator";
-import ImportAccountsNavigator from "./ImportAccountsNavigator";
 import { RootStackParamList } from "./types/RootNavigator";
 import { AnalyticsContext } from "../../analytics/AnalyticsContext";
 import { StartupTimeMarker } from "../../StartupTimeMarker";
 
-type Props = {
-  importDataString?: string;
-};
-export default function RootNavigator({ importDataString }: Props) {
+export default function RootNavigator() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  const data = useMemo<string | false>(() => {
-    if (!__DEV__ || !importDataString) {
-      return false;
-    }
-
-    return JSON.parse(Buffer.from(importDataString, "base64").toString("utf8"));
-  }, [importDataString]);
   const goToOnboarding = !hasCompletedOnboarding && !Config.SKIP_ONBOARDING;
   const [analyticsSource, setAnalyticsSource] = useState<undefined | string>(
     undefined,
@@ -45,12 +34,7 @@ export default function RootNavigator({ importDataString }: Props) {
             headerShown: false,
           }}
         >
-          {data ? (
-            <Stack.Screen
-              name={NavigatorName.ImportAccounts}
-              component={ImportAccountsNavigator}
-            />
-          ) : goToOnboarding ? (
+          {goToOnboarding ? (
             <Stack.Screen
               name={NavigatorName.BaseOnboarding}
               component={BaseOnboardingNavigator}

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -102,11 +102,7 @@ const styles = StyleSheet.create({
   },
 });
 
-type AppProps = {
-  importDataString?: string;
-};
-
-function App({ importDataString }: AppProps) {
+function App() {
   useAppStateListener();
   useListenToHidDevices();
 
@@ -188,7 +184,7 @@ function App({ importDataString }: AppProps) {
     <GestureHandlerRootView style={styles.root}>
       <SyncNewAccounts priority={5} />
       <ExperimentalHeader />
-      <RootNavigator importDataString={importDataString} />
+      <RootNavigator />
       <AnalyticsConsole />
       <PerformanceConsole />
       <DebugTheme />
@@ -251,9 +247,7 @@ const StylesProvider = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
-export default class Root extends Component<{
-  importDataString?: string;
-}> {
+export default class Root extends Component {
   initTimeout: ReturnType<typeof setTimeout> | undefined;
 
   componentWillUnmount() {
@@ -273,7 +267,6 @@ export default class Root extends Component<{
   };
 
   render() {
-    const importDataString = __DEV__ ? this.props.importDataString : "";
     return (
       <RebootProvider onRebootStart={this.onRebootStart}>
         <LedgerStoreProvider onInitFinished={this.onInitFinished}>
@@ -313,11 +306,7 @@ export default class Root extends Component<{
                                                     <SnackbarContainer />
                                                     <NftMetadataProvider>
                                                       <MarketDataProvider>
-                                                        <App
-                                                          importDataString={
-                                                            importDataString
-                                                          }
-                                                        />
+                                                        <App />
                                                       </MarketDataProvider>
                                                     </NftMetadataProvider>
                                                   </NotificationsProvider>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We have a method of manipulating data in our app through an environment variable called BRIDGESTREAM_DATA. This allows us to override the data contained in a QR code and import the modified data from the debug menu. We also have a way of launching the app from the command line with specific flags that convert LLD data into bridgestream data. This enables us to access the data at launch.

These methods were developed as improvement tools for development purposes, but they were not widely utilized. The command line method is no longer operational, and we haven't maintained it. Let’s drop the code :axe:

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6754` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->


### 🚀 Expectations to reach
No impact