### PR TITLE
hw-app-btc: Improve app version detection of Btc::changeImplIfNecessary

### DIFF
--- a/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
@@ -269,12 +269,28 @@ export default class Btc {
   }
 
   async changeImplIfNecessary(): Promise<BtcOld | BtcNew> {
+    // if BtcOld was instantiated, stick with it
+    if (this._impl instanceof BtcOld) return this._impl;
+
     const appAndVersion = await getAppAndVersion(this._transport);
-    if (appAndVersion.name === "Exchange" && this._impl instanceof BtcNew) {
-      const isBtcLegacy = await checkIsBtcLegacy(this._transport);
-      if (isBtcLegacy) {
-        this._impl = new BtcOld(this._transport);
-      }
+    let isBtcLegacy = true; // default for all altcoins
+
+    if (appAndVersion.name === "Bitcoin" || appAndVersion.name === "Bitcoin Test") {
+      const [major, minor] = appAndVersion.version.split(".");
+      // we use the legacy protocol for versions below 2.1.0 of the Bitcoin app.
+      isBtcLegacy = parseInt(major) <= 1 || (parseInt(major) == 2 && parseInt(minor) == 0);
+    } else if (appAndVersion.name === "Bitcoin Legacy" || appAndVersion.name === "Bitcoin Test Legacy") {
+      // the "Bitcoin Legacy" and "Bitcoin Testnet Legacy" app use the legacy protocol, regardless of the version
+      isBtcLegacy = true;
+    } else if (appAndVersion.name === "Exchange") {
+      // We can't query the version of the Bitcoin app if we're coming from Exchange;
+      // therefore, we use a workaround to distinguish legacy and new versions.
+      // This can be removed once Ledger Live enforces minimum bitcoin version >= 2.1.0.
+      isBtcLegacy = await checkIsBtcLegacy(this._transport);
+    }
+
+    if (isBtcLegacy) {
+      this._impl = new BtcOld(this._transport);
     }
     return this._impl;
   }


### PR DESCRIPTION
### 📝 Description

`changeImplIfNecessary` only switches to the legacy implementation for bitcoin during the Exchange flow. This works well enough in Ledger Live, but is not optimal for external integrations relying on `hw-app-btc`, which would break if using a recent `hw-app-btc` on an older app version.

This does not change the behaviour for any case where `BtcOld` was already instantiated, but it makes sure to use the legacy protocol for versions below 2.1.0 of `"Bitcoin"`/`"Bitcoin Test"`.

I also added legacy default for altcoins, ` "Bitcoin Legacy"` or `"Bitcoin Test Legacy"`; that's redundant since the constructor would already use `BtcOld`, so it's only added to be defensive in this function.

### ❓ Context

- **Impacted projects**: external integrations using `hw-app-btc`.

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
