### PR TITLE
bugfix(usb-otg): LIVE-6771 multiple fixes to USB OTG on LLM

### DIFF
--- a/.changeset/yellow-days-brush.md
+++ b/.changeset/yellow-days-brush.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": patch
+---
+
+Prevent duplicated USB entries on old device selector.
+Fix broken device action modals caused by nanoFTS state hack.
+Fix UI for Android empty USB state, text overflowing.
+Fix add account flow undismissable modal (x/back drop) close.

--- a/apps/ledger-live-mobile/src/components/SelectDevice/USBEmpty.android.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/USBEmpty.android.tsx
@@ -7,7 +7,7 @@ export default function USBEmpty({ usbOnly }: { usbOnly: boolean }) {
   return (
     <Flex alignItems={"center"} flexDirection={"row"}>
       <UsbMedium size={24} color={"neutral.c100"} />
-      <Box ml={6}>
+      <Box ml={6} pr={4}>
         {!usbOnly && (
           <Text variant={"large"} fontWeight={"semiBold"}>
             <Trans i18nKey="SelectDevice.usb" />

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -101,12 +101,18 @@ export default function SelectDevice({
       if (e.type === "remove") setDevice(undefined);
       if (e.type === "add") {
         const { name, deviceModel, id, wired } = e;
-        setDevice({
-          deviceName: name,
-          modelId: deviceModel?.id,
-          deviceId: id,
-          wired,
-        } as Device);
+
+        setDevice((maybeDevice: Device | undefined) => {
+          return (
+            maybeDevice ||
+            ({
+              deviceName: name,
+              modelId: deviceModel?.id,
+              deviceId: id,
+              wired,
+            } as Device)
+          );
+        });
       }
     });
     return () => sub.unsubscribe();

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -1,6 +1,6 @@
 import Config from "react-native-config";
-import { Observable } from "rxjs";
-import { map } from "rxjs/operators";
+import { Observable, timer } from "rxjs";
+import { map, debounce } from "rxjs/operators";
 import { listen } from "@ledgerhq/logs";
 import HIDTransport from "@ledgerhq/react-native-hid";
 import withStaticURLs from "@ledgerhq/hw-transport-http";
@@ -123,6 +123,7 @@ registerTransportModule({
         name,
       };
     }),
+    debounce(e => timer(e.type === "remove" ? 2000 : 0)),
   ),
 });
 // Add dev mode support of an http proxy

--- a/apps/ledger-live-mobile/src/reducers/ble.ts
+++ b/apps/ledger-live-mobile/src/reducers/ble.ts
@@ -1,6 +1,5 @@
 import { handleActions } from "redux-actions";
 import type { Action, ReducerMap } from "redux-actions";
-import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { BleState, State } from "./types";
 import type {
   BleAddKnownDevicePayload,
@@ -67,19 +66,7 @@ const handlers: ReducerMap<BleState, BlePayload> = {
 };
 // Selectors
 export const exportSelector = (s: State) => s.ble;
-export const knownDevicesSelector = (s: State) => {
-  // Nb workaround to prevent crash for dev/qa that have nanoFTS references.
-  // to be removed in a while.
-  return s.ble.knownDevices.map(knownDevice => ({
-    ...knownDevice,
-    modelId:
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      knownDevice.modelId === "nanoFTS"
-        ? DeviceModelId.stax
-        : knownDevice.modelId,
-  }));
-};
+export const knownDevicesSelector = (s: State) => s.ble.knownDevices;
 export const deviceNameByDeviceIdSelectorCreator =
   (deviceId: string) => (s: State) => {
     const d = s.ble.knownDevices.find(d => d.id === deviceId);

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
@@ -459,6 +459,7 @@ function AddAccountsAccounts({
       )}
       <GenericErrorBottomModal
         error={error}
+        onClose={onCancel}
         onModalHide={onModalHide}
         footerButtons={
           <>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

While addressing the original bug reported on https://ledgerhq.atlassian.net/browse/LIVE-6275 I encountered several issues with the USB OTG integration on LLM so while QA'ing this, please take into account the following bugs and topics:
- Duplicated devices when plugging/removing on the legacy device selector.
- Flashing device row on the select list when entering exiting apps in any flow.
- Entering an app breaks the device action on the new device selector (open app BTC, modal closes).
- Text overflow to the right on the empty state for USB on the legacy device selector screen.
- Disconnect during add accounts shows a "Device disconnected" error modal that can't be closed with the X.


### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6771` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Go over several flows with USB OTG on Android, while being in the wrong app, play with connecting and disconnecting and see if there's a bad behaviour somewhere. The disconnect event is currently debounced to two seconds in order to prevent the flashing so it's expected that after you unplug there's a delay on the device selector screen until you see the device disappear.