### PR TITLE
fix(debug): allow for symbols to be used on debug env override

### DIFF
--- a/.changeset/chilly-owls-boil.md
+++ b/.changeset/chilly-owls-boil.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+allow symbols in env override debug menu

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/DebugEnv.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/DebugEnv.tsx
@@ -43,7 +43,7 @@ export default function DebugEnv() {
   const onSetEnv = useCallback(() => {
     if (!value) return;
     // Attempt to parse this input
-    const match = /([\w]+)=([\w]+)/.exec(value);
+    const match = /([\w]+)=(.+)/.exec(value);
     setStatus("");
 
     if (!match || match.length !== 3) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The way the debug env screen was written only allowed for values that were alphanumeric, this change allows us to use any symbol too, like for URLs.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6798` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="400" alt="image" src="https://user-images.githubusercontent.com/4631227/225914582-2d0429d7-bf5d-419e-91f2-282ac1992950.png">


### 🚀 Expectations to reach
Not sure if it will work on prod builds, but overriding the env variable certainly works in dev builds.