### PR TITLE
chore: prevent release flow failing because of admin rights

### DIFF
--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -73,21 +73,14 @@ jobs:
           git merge ${{ inputs.ref }}
           git push origin main
 
-      - name: merge into develop
+      - name: create PR to develop
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git checkout develop
-          if git merge ${{ github.event.inputs.ref }}
-          then
-            git push origin develop
-          else
-            git merge --abort
-            git checkout ${{ github.event.inputs.ref }}
-            git checkout -b support/hotfix-merge-conflicts
-            git push origin support/hotfix-merge-conflicts
-            gh pr create --title ":rotating_light: Hotfix merge conflicts" -F .github/templates/hotfix-conflicts.md --base develop --head support/hotfix-merge-conflicts
-          fi
+          git checkout ${{ github.event.inputs.ref }}
+          git checkout -b support/hotfix-merge-conflicts
+          git push origin support/hotfix-merge-conflicts
+          gh pr create --title ":rotating_light: Hotfix merge conflicts" -F .github/templates/hotfix-conflicts.md --base develop --head support/hotfix-merge-conflicts
 
       - name: merge into release if present
         env:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -73,18 +73,11 @@ jobs:
           git merge ${{ inputs.ref }}
           git push origin main
 
-      - name: merge into develop
+      - name: create PR to develop
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git checkout develop
-          if git merge ${{ github.event.inputs.ref }}
-          then
-            git push origin develop
-          else
-            git merge --abort
-            git checkout ${{ github.event.inputs.ref }}
-            git checkout -b support/release-merge-conflicts
-            git push origin support/release-merge-conflicts
-            gh pr create --title ":rotating_light: Release merge conflicts" -F .github/templates/release-conflicts.md --base develop --head support/release-merge-conflicts
-          fi
+          git checkout ${{ github.event.inputs.ref }}
+          git checkout -b support/release-merge-conflicts
+          git push origin support/release-merge-conflicts
+          gh pr create --title ":rotating_light: Release merge conflicts" -F .github/templates/release-conflicts.md --base develop --head support/release-merge-conflicts


### PR DESCRIPTION
### 📝 Description

Since moving away from a service account to a github app to handle all git related tasks in our automation, github apps cannot have `roles` and thus cannot bypass the _required checks_ (branch protection rules) without having admin access to the repo (which we do not want to give).
To prevent the release flow from failing, instead of attempting a merge of the `release` branch on `develop` then pushing, we just create a PR targeting `develop` directly.

### ❓ Context

- **Impacted projects**: `release` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** no tests to provide
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Next release flow should happen without a fail when trying to merge to develop, and instead just create a PR

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
