### PR TITLE
Add a way to debug the synchronisation status

### DIFF
--- a/apps/ledger-live-desktop/release-notes.json
+++ b/apps/ledger-live-desktop/release-notes.json
@@ -1,6 +1,6 @@
 [
   {
-    "tag_name": "2.54.0",
-    "body": "\n### 🚀 Features\n\n- Starting today, you can manage 100+ tokens on Cronos, Fantom, and Moonbeam networks with Ledger Live. \n- Ledger Live will no longer display zero-amount transactions in the transaction history. If you want to view zero-amount transactions nonetheless, navigate to Settings -> Accounts -> Zero-amount transactions and flip the toggle switch to the on position.\n\n### 🐛 Fixes\n\n- We squished the bug that was triggering an error message instead of undelegating ATOM. \n"
+    "tag_name": "2.55.0",
+    "body": "\nThis release includes performance improvements and minor bug fixes. \n"
   }
 ]

--- a/apps/ledger-live-desktop/src/renderer/components/TroubleshootSyncButton.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TroubleshootSyncButton.jsx
@@ -1,0 +1,48 @@
+// @flow
+import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import Button from "~/renderer/components/Button";
+import { openModal } from "../actions/modals";
+
+type Props = ButtonProps & {|
+  icon?: boolean,
+  inverted?: boolean, // only used with primary for now
+  lighterPrimary?: boolean,
+  danger?: boolean,
+  lighterDanger?: boolean,
+  disabled?: boolean,
+  isLoading?: boolean,
+  event?: string,
+  eventProperties?: Object,
+  outline?: boolean,
+  outlineGrey?: boolean,
+  primary?: boolean,
+  small?: boolean,
+  title?: React$Node,
+|};
+
+const TroubleshootSyncBtn = ({ primary = true, small = true, title, ...rest }: Props) => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  const troubleshootSync = useCallback(async () => {
+    dispatch(openModal("MODAL_TROUBLESHOOT_SYNC"));
+  }, [dispatch]);
+
+  const text = title || t("settings.troubleshootSync.btn");
+
+  return (
+    <Button
+      small={small}
+      primary={primary}
+      event="TroubleshootSync"
+      onClick={troubleshootSync}
+      {...rest}
+    >
+      {text}
+    </Button>
+  );
+};
+
+export default TroubleshootSyncBtn;

--- a/apps/ledger-live-desktop/src/renderer/modals/TroubleshootSync/Body.jsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/TroubleshootSync/Body.jsx
@@ -1,0 +1,53 @@
+// @flow
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useBridgeSync } from "@ledgerhq/live-common/bridge/react/context";
+import { ModalBody } from "~/renderer/components/Modal";
+import Box from "~/renderer/components/Box";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Button from "~/renderer/components/Button";
+
+type Props = {
+  onClose: () => void,
+};
+
+const Body = ({ onClose }: Props) => {
+  const { t } = useTranslation();
+  const sync = useBridgeSync();
+  const [status, setStatus] = useState("");
+
+  useEffect(() => {
+    function update() {
+      const status = sync({ type: "GET_QUEUE_STATUS" });
+      setStatus(JSON.stringify(status, null, 2));
+    }
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  }, [sync]);
+
+  return (
+    <ModalBody
+      onClose={onClose}
+      title={t("troubleshootSync.title")}
+      render={() => (
+        <Box relative style={{ height: 500 }} px={5} pb={8}>
+          <TrackPage category="Modal" name="TroubleshootSync" />
+          <textarea
+            style={{ color: "black", font: "normal 10px monospace", width: "100%", height: "100%" }}
+            value={status}
+          />
+        </Box>
+      )}
+      renderFooter={() => (
+        <Box horizontal justifyContent="flex-end">
+          <Button onClick={onClose} primary>
+            {t("common.continue")}
+          </Button>
+        </Box>
+      )}
+    />
+  );
+};
+
+export default Body;

--- a/apps/ledger-live-desktop/src/renderer/modals/TroubleshootSync/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/TroubleshootSync/index.jsx
@@ -1,0 +1,15 @@
+// @flow
+
+import React from "react";
+import Modal from "~/renderer/components/Modal";
+import Body from "./Body";
+
+const TroubleshootModal = () => (
+  <Modal
+    name="MODAL_TROUBLESHOOT_SYNC"
+    centered
+    render={({ onClose }) => <Body onClose={onClose} />}
+  />
+);
+
+export default TroubleshootModal;

--- a/apps/ledger-live-desktop/src/renderer/modals/index.js
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.js
@@ -21,6 +21,7 @@ import MODAL_SHARE_ANALYTICS from "./ShareAnalytics";
 import MODAL_SETTINGS_ACCOUNT from "./SettingsAccount";
 import MODAL_RELEASE_NOTES from "./ReleaseNotes";
 import MODAL_TROUBLESHOOT_NETWORK from "./TroubleshootNetwork";
+import MODAL_TROUBLESHOOT_SYNC from "./TroubleshootSync";
 import MODAL_SYSTEM_LANGUAGE_AVAILABLE from "./SystemLanguageAvailable";
 // $FlowFixMe
 import MODAL_START_STAKE from "./StartStake";
@@ -131,6 +132,7 @@ const modals: { [_: string]: React$ComponentType<any> } = {
   MODAL_SETTINGS_ACCOUNT,
   MODAL_RELEASE_NOTES,
   MODAL_TROUBLESHOOT_NETWORK,
+  MODAL_TROUBLESHOOT_SYNC,
   MODAL_SYSTEM_LANGUAGE_AVAILABLE,
   MODAL_TERM_OF_USE_UPDATE,
   MODAL_CLAIM_REWARDS,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/index.jsx
@@ -8,6 +8,7 @@ import { languageSelector, swapKYCSelector } from "~/renderer/reducers/settings"
 import TrackPage from "~/renderer/analytics/TrackPage";
 import ExportLogsBtn from "~/renderer/components/ExportLogsButton";
 import TroubleshootNetworkBtn from "~/renderer/components/TroubleshootNetworkButton";
+import TroubleshootSyncBtn from "~/renderer/components/TroubleshootSyncButton";
 import OpenUserDataDirectoryBtn from "~/renderer/components/OpenUserDataDirectoryBtn";
 import RowItem from "../../RowItem";
 import { SettingsSectionBody as Body, SettingsSectionRow as Row } from "../../SettingsSection";
@@ -47,6 +48,12 @@ const SectionHelp = () => {
           desc={t("settings.troubleshootNetwork.desc")}
         >
           <TroubleshootNetworkBtn />
+        </Row>
+        <Row
+          title={t("settings.troubleshootSync.title")}
+          desc={t("settings.troubleshootSync.desc")}
+        >
+          <TroubleshootSyncBtn />
         </Row>
         <Row
           title={t("settings.profile.launchOnboarding")}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2260,6 +2260,9 @@
   "troubleshootNetwork": {
     "title": "Troubleshoot networking"
   },
+  "troubleshootSync": {
+    "title": "Troubleshoot synchronisation"
+  },
   "systemLanguageAvailable": {
     "title": "Change your app's language?",
     "description": {
@@ -3976,6 +3979,11 @@
     "troubleshootNetwork": {
       "title": "Troubleshoot networking",
       "desc": "Run a checklist to assess networking conditions for troubleshooting purposes.",
+      "btn": "Troubleshoot"
+    },
+    "troubleshootSync": {
+      "title": "Troubleshoot synchronisation",
+      "desc": "Show the current synchronisation technical update queue.",
       "btn": "Troubleshoot"
     },
     "accounts": {

--- a/libs/coin-framework/src/env.ts
+++ b/libs/coin-framework/src/env.ts
@@ -581,7 +581,7 @@ const envDefinitions: Record<
     desc: "Swap API base",
   },
   SYNC_ALL_INTERVAL: {
-    def: 2 * 60 * 1000,
+    def: 8 * 60 * 1000,
     parser: intParser,
     desc: "delay between successive sync",
   },
@@ -596,7 +596,7 @@ const envDefinitions: Record<
     desc: "delay between sync when an operation is still pending",
   },
   SYNC_OUTDATED_CONSIDERED_DELAY: {
-    def: 2 * 60 * 1000,
+    def: 10 * 60 * 1000,
     parser: intParser,
     desc: "delay until Live consider a sync outdated",
   },

--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
@@ -356,16 +356,25 @@ function useSync({ syncQueue, accounts }) {
       }) => {
         schedule(accountIds, priority, reason);
       },
+      GET_QUEUE_STATUS: () => {
+        return {
+          length: syncQueue.length(),
+          running: syncQueue.running(),
+          workersList: syncQueue.workersList(),
+        };
+      },
     };
     return (action: SyncAction) => {
       const handler = handlers[action.type];
 
       if (handler) {
-        log("bridge", `action ${action.type}`, {
-          action,
-          type: "syncQueue",
-        });
-        handler(action as any);
+        if (action.type !== "GET_QUEUE_STATUS") {
+          log("bridge", `action ${action.type}`, {
+            action,
+            type: "syncQueue",
+          });
+        }
+        return handler(action as any);
       } else {
         log("warn", "BridgeSyncContext unsupported action", {
           action,

--- a/libs/ledger-live-common/src/bridge/react/types.ts
+++ b/libs/ledger-live-common/src/bridge/react/types.ts
@@ -23,6 +23,9 @@ export type SyncAction =
       type: "SYNC_ALL_ACCOUNTS";
       priority: number;
       reason: string;
+    }
+  | {
+      type: "GET_QUEUE_STATUS";
     };
 export type SyncState = {
   pending: boolean;

--- a/libs/ledger-live-common/src/countervalues/react.tsx
+++ b/libs/ledger-live-common/src/countervalues/react.tsx
@@ -101,8 +101,8 @@ export function useTrackingPairForAccounts(
 export function Countervalues({
   children,
   userSettings,
-  pollInitDelay = 1 * 1000,
-  autopollInterval = 120 * 1000,
+  pollInitDelay = 3 * 1000,
+  autopollInterval = 8 * 60 * 1000,
   debounceDelay = 1000,
   savedState,
 }: Props): ReactElement {


### PR DESCRIPTION

### 📝 Description

not sure if we will merge this. but this was made to debug the synchronisation queue.

I have an example with 120 accounts and it can be huge to sync them all with the current settings of 4 parallel max.

That UI reveals the problem and show you how much is queued, what are the current jobs, etc..

![Screenshot 2023-03-20 at 15 27 27](https://user-images.githubusercontent.com/211411/226371133-91b462b6-490e-4bfd-ad5d-7edfa8302451.png)


### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-6795 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
