### PR TITLE
Remove recover webview header on prod

### DIFF
--- a/.changeset/brown-worms-perform.md
+++ b/.changeset/brown-worms-perform.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Hide recover webview header for prod env

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
@@ -13,8 +13,9 @@ type Props = {
 
 const ledgerRecoverIds = [
   "protect",
-  "ledger-recover",
-  "ledger-recover-preprod",
+  "protect-preprod",
+  "protect-prod",
+  "protect-sit",
 ];
 
 const WebViewWrapper = ({ manifest, inputs }: Props) => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Hide Recover Webview header on PROD env. Also hides it on SIT env (pentes).

### ❓ Context

- **Impacted projects**: `ledger-live`
- **Linked resource(s)**: [LIVE-6822](https://ledgerhq.atlassian.net/browse/LIVE-6822)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6822]: https://ledgerhq.atlassian.net/browse/LIVE-6822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ