### PR TITLE
fix: LIVE-6749 Handle the device full case on language pack install

### DIFF
--- a/.changeset/light-suns-stare.md
+++ b/.changeset/light-suns-stare.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/errors": patch
+"@ledgerhq/live-common": patch
+---
+
+Support 5102 status on language pack installation (full device)

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -5,6 +5,8 @@ import {
   TransportError,
   TransportStatusError,
   LanguageNotFound,
+  StatusCodes,
+  ManagerNotEnoughSpaceError,
 } from "@ledgerhq/errors";
 
 import ManagerAPI from "../api/Manager";
@@ -103,11 +105,13 @@ export default function installLanguage({
                 const statusStr = status.toString(16);
 
                 // Some error handling
-                if (status === 0x5501) {
+                if (status === StatusCodes.USER_REFUSED_ON_DEVICE) {
                   return subscriber.error(
                     new LanguageInstallRefusedOnDevice(statusStr)
                   );
-                } else if (status !== 0x9000) {
+                } else if (status === StatusCodes.NOT_ENOUGH_SPACE) {
+                  return subscriber.error(new ManagerNotEnoughSpaceError());
+                } else if (status !== StatusCodes.OK) {
                   return subscriber.error(
                     new TransportError("Unexpected device response", statusStr)
                   );

--- a/libs/ledger-live-common/src/hw/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/staxLoadImage.ts
@@ -2,6 +2,8 @@ import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
 import {
   DeviceOnDashboardExpected,
+  ManagerNotEnoughSpaceError,
+  StatusCodes,
   TransportError,
   TransportStatusError,
 } from "@ledgerhq/errors";
@@ -76,7 +78,11 @@ export default function loadImage({
                 0x00,
                 0x00,
                 imageSize,
-                [0x9000, 0x5501]
+                [
+                  StatusCodes.NOT_ENOUGH_SPACE,
+                  StatusCodes.USER_REFUSED_ON_DEVICE,
+                  StatusCodes.OK,
+                ]
               );
 
               const createImageStatus = createImageResponse.readUInt16BE(
@@ -85,11 +91,13 @@ export default function loadImage({
               const createImageStatusStr = createImageStatus.toString(16);
               // reads last 2 bytes which correspond to the status
 
-              if (createImageStatus === 0x5501) {
+              if (createImageStatus === StatusCodes.USER_REFUSED_ON_DEVICE) {
                 return subscriber.error(
                   new ImageLoadRefusedOnDevice(createImageStatusStr)
                 );
-              } else if (createImageStatus !== 0x9000) {
+              } else if (createImageStatus === StatusCodes.NOT_ENOUGH_SPACE) {
+                return subscriber.error(new ManagerNotEnoughSpaceError());
+              } else if (createImageStatus !== StatusCodes.OK) {
                 return subscriber.error(
                   new TransportError(
                     "Unexpected device response",

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -331,6 +331,7 @@ export const StatusCodes = {
   TECHNICAL_PROBLEM: 0x6f00,
   UNKNOWN_APDU: 0x6d02,
   USER_REFUSED_ON_DEVICE: 0x5501,
+  NOT_ENOUGH_SPACE: 0x5102,
 };
 
 export function getAltStatusMessage(code: number): string | undefined | null {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently if a device is full and we try to install a language pack the error is an unexpected response from the device, we had no reference to `5102` meaning the device was full in this context. I'm taking a guess that it is and mapping the error accordingly. Also tackles the https://ledgerhq.atlassian.net/browse/LIVE-6830 topic covering CLS on full device, same issue.

### ❓ Context

- **Impacted projects**: `ledger-live-common errors` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6749` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/226449251-c90ba04e-e7c5-4b9c-a0dd-9050a67859f1.mov


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
This can be tested on either LLD or LLM, on a full device, installing a language pack.