### PR TITLE
chore: make exported logs formatted by default

### DIFF
--- a/.changeset/odd-kangaroos-give.md
+++ b/.changeset/odd-kangaroos-give.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Make exported logs formatted by default

--- a/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.jsx
@@ -15,7 +15,11 @@ import type { Props as ButtonProps } from "~/renderer/components/Button";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 
 const saveLogs = async (path: { canceled: boolean, filePath: string }) => {
-  await ipcRenderer.invoke("save-logs", path, JSON.stringify(memoryLogger.getMemoryLogs()));
+  await ipcRenderer.invoke(
+    "save-logs",
+    path,
+    JSON.stringify(memoryLogger.getMemoryLogs(), null, 4),
+  );
 };
 
 type RestProps = ButtonProps & {|

--- a/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.jsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.jsx
@@ -18,7 +18,7 @@ const saveLogs = async (path: { canceled: boolean, filePath: string }) => {
   await ipcRenderer.invoke(
     "save-logs",
     path,
-    JSON.stringify(memoryLogger.getMemoryLogs(), null, 4),
+    JSON.stringify(memoryLogger.getMemoryLogs(), null, 2),
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/useExportLogs.tsx
+++ b/apps/ledger-live-mobile/src/components/useExportLogs.tsx
@@ -8,7 +8,7 @@ export default function useExportLogs() {
   return useCallback(() => {
     const exportLogs = async () => {
       const logs = logReport.getLogs();
-      const base64 = Buffer.from(JSON.stringify(logs, null, 4)).toString(
+      const base64 = Buffer.from(JSON.stringify(logs, null, 2)).toString(
         "base64",
       );
       const version = getFullAppVersion(undefined, undefined, "-");

--- a/apps/ledger-live-mobile/src/components/useExportLogs.tsx
+++ b/apps/ledger-live-mobile/src/components/useExportLogs.tsx
@@ -8,7 +8,9 @@ export default function useExportLogs() {
   return useCallback(() => {
     const exportLogs = async () => {
       const logs = logReport.getLogs();
-      const base64 = Buffer.from(JSON.stringify(logs)).toString("base64");
+      const base64 = Buffer.from(JSON.stringify(logs, null, 4)).toString(
+        "base64",
+      );
       const version = getFullAppVersion(undefined, undefined, "-");
       const date = new Date().toISOString().split("T")[0];
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
Two minute chore, makes the exported logs readable by default so I can read them on my phone and also open them without having to worry about formatting them. I can also refer to a specific line without needing the other party to have formatted the log the same way my editor did. Longer to write this than implement it.

### ❓ Context

- **Impacted projects**: `dekstop, mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6856` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://user-images.githubusercontent.com/4631227/226956585-a15b4bc7-2d0a-4352-a7fb-888a9a88c03c.png)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Merge it