### PR TITLE
Add button to import a mocked account per currency in developer settings

### DIFF
--- a/.changeset/polite-buckets-sleep.md
+++ b/.changeset/polite-buckets-sleep.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add button to import a mocked account per currency in developer settings

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/MockedAccounts.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/MockedAccounts.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { Button as ButtonRaw } from "@ledgerhq/react-ui";
+import accountModel from "~/helpers/accountModel";
+import { replaceAccounts } from "~/renderer/actions/accounts";
+import { accountsSelector } from "~/renderer/reducers/accounts";
+import { SettingsSectionRow as Row } from "../../SettingsSection";
+import mockedData from "../../../../../../tests/userdata/bot-accounts.json";
+import { Account } from "~/../../../libs/ledgerjs/packages/types-live/lib";
+
+const Button = styled(ButtonRaw)`
+  border-radius: 4px;
+`;
+
+function useImportMockedAccounts() {
+  const dispatch = useDispatch();
+  const accounts = useSelector(accountsSelector);
+  const mockedAccounts = useMemo(() => {
+    const res = mockedData.data.accounts.reduce<{
+      [key: string]: Account;
+    }>(
+      (prev, a) =>
+        prev[a.data.currencyId]
+          ? prev
+          : { ...prev, [a.data.currencyId]: accountModel.decode(a as any) },
+      {},
+    );
+    return Object.values(res);
+  }, []);
+
+  return useCallback(() => {
+    dispatch(replaceAccounts([...accounts, ...mockedAccounts]));
+  }, [dispatch, accounts, mockedAccounts]);
+}
+
+export function MockedAccounts() {
+  const { t } = useTranslation();
+  const importMockedAccounts = useImportMockedAccounts();
+
+  return (
+    <Row
+      title={t("settings.developer.mockedAccounts.title")}
+      desc={t("settings.developer.mockedAccounts.desc")}
+    >
+      <Button
+        variant="color"
+        size="small"
+        onClick={importMockedAccounts}
+        data-test-id="settings-import-mocked-accounts"
+      >
+        {t("settings.developer.mockedAccounts.cta")}
+      </Button>
+    </Row>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.jsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/index.jsx
@@ -16,6 +16,7 @@ import RunLocalAppButton from "./RunLocalAppButton";
 import FeatureFlagsSettings from "./FeatureFlagsSettings";
 import EnableLearnPageStagingUrlToggle from "./EnableLearnPageStagingUrlToggle";
 import OnboardingAppInstallDebugButton from "./OnboardingAppInstallDebug";
+import { MockedAccounts } from "./MockedAccounts";
 
 const Default = () => {
   const { t } = useTranslation();
@@ -63,6 +64,7 @@ const Default = () => {
       >
         <OnboardingAppInstallDebugButton />
       </Row>
+      <MockedAccounts />
     </Body>
   );
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3836,7 +3836,12 @@
       "enableLearnStagingUrl": "Learn page staging URL",
       "enableLearnStagingUrlDesc": "Enable the staging URL for the learn page.",
       "openOnboardingAppInstallDebug": "Open onboarding app install debug screen",
-      "openOnboardingAppInstallDebugDesc": "Open a screen with the components from the sync onboarding app installation step"
+      "openOnboardingAppInstallDebugDesc": "Open a screen with the components from the sync onboarding app installation step",
+      "mockedAccounts": {
+       "title": "Import mocked accounts", 
+        "desc": "Import a mocked account per currency and merge them with existing accounts",
+        "cta": "Import"
+      }
     },
     "currencies": {
       "selectPlaceholder": "Select crypto asset",

--- a/apps/ledger-live-desktop/tsconfig.json
+++ b/apps/ledger-live-desktop/tsconfig.json
@@ -18,7 +18,7 @@
     "rootDir": "."
   },
   "include": ["tests", "**/*.d.ts"],
-  "files": ["package.json", "release-notes.json"],
+  "files": ["package.json", "release-notes.json", "tests/userdata/bot-accounts.json"],
   "exclude": [
     "node_modules",
     "babel.config.js",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add a new button under developer settings which imports a mocked account per currency and merged with already existing accounts.

### Concern

We may not want to include `bot-accounts.json` in production bundle 🤔

### ❓ Context

- **Impacted projects**: `ledger-live-desktop`
- **Linked resource(s)**: 

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/8398372/227227361-9d2b146f-3afd-4547-90e0-84a6b7afa01f.mov

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
