### PR TITLE
LLD: chore: add a rule that prevent 'lodash' to be directly imported

### DIFF
--- a/apps/ledger-live-desktop/.eslintrc.js
+++ b/apps/ledger-live-desktop/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
     "react-hooks/exhaustive-deps": "error", // Checks effect dependencies
     "jest/no-done-callback": 0,
     "react/jsx-filename-extension": "error",
+    "no-restricted-imports": ["error", { paths: ["lodash"] }],
   },
   overrides: [
     {


### PR DESCRIPTION


### 📝 Description

add a rule that prevent 'lodash' to be directly imported
instead, you should use 'lodash/memoize' module import (or whatever function you need)


### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
