### PR TITLE
Bugfix: Live-6889 Request for a specific MTU when trying to BLE connect

### DIFF
--- a/.changeset/purple-kids-do.md
+++ b/.changeset/purple-kids-do.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+fix: request for a specific MTU when trying to BLE connect
+
+ConnectionOptions was commented as "not used" in react-native-ble-plx,
+but it is actually used and needed when connecting to a device.

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -91,6 +91,15 @@ const delay = (ms: number | undefined) =>
  */
 const transportsCache: { [deviceId: string]: BleTransport } = {};
 
+// connectOptions is actually used by react-native-ble-plx even if comment above ConnectionOptions says it's not used
+let connectOptions: Record<string, unknown> = {
+  // 156 bytes to max the iOS < 10 limit (158 bytes)
+  // (185 bytes for iOS >= 10)(up to 512 bytes for Android, but could be blocked at 23 bytes)
+  requestMTU: 156,
+  // Priority 1 = high. TODO: Check firmware update over BLE PR before merging
+  connectionPriority: 1,
+};
+
 /**
  * Returns the instance of the Bluetooth Low Energy Manager. It initializes it only
  * when it's first needed, preventing the permission prompt happening prematurely.
@@ -153,10 +162,15 @@ async function open(deviceOrId: Device | string, needsReconnect: boolean) {
       log(TAG, `connectToDevice(${deviceOrId})`);
       // Nb ConnectionOptions dropped since it's not used internally by ble-plx.
       try {
-        device = await bleManagerInstance().connectToDevice(deviceOrId);
+        device = await bleManagerInstance().connectToDevice(
+          deviceOrId,
+          connectOptions
+        );
       } catch (e: any) {
         log(TAG, `error code ${e.errorCode}`);
         if (e.errorCode === BleErrorCode.DeviceMTUChangeFailed) {
+          // If the MTU update did not work, we try to connect without requesting for a specific MTU
+          connectOptions = {};
           device = await bleManagerInstance().connectToDevice(deviceOrId);
         } else {
           throw e;
@@ -175,10 +189,11 @@ async function open(deviceOrId: Device | string, needsReconnect: boolean) {
   if (!(await device.isConnected())) {
     log(TAG, "not connected. connecting...");
     try {
-      await device.connect();
+      await device.connect(connectOptions);
     } catch (e: any) {
       if (e.errorCode === BleErrorCode.DeviceMTUChangeFailed) {
-        // Retry once for this specific error.
+        // If the MTU update did not work, we try to connect without requesting for a specific MTU
+        connectOptions = {};
         await device.connect();
       } else {
         throw e;
@@ -291,6 +306,7 @@ async function open(deviceOrId: Device | string, needsReconnect: boolean) {
     deviceModel
   );
 
+  // Keeping it as a comment for now but if no new bluetooth issues occur, we will be able to remove it
   // await transport.requestConnectionPriority("High");
   // eslint-disable-next-line prefer-const
   let disconnectedSub: Subscription;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description


Requesting for a specific MTU when trying to BLE connect was removed in this PR https://github.com/LedgerHQ/ledger-live/pull/2911 because `ConnectionOptions` was commented as "not used" in `react-native-ble-plx` [here](https://github.com/dotintent/react-native-ble-plx/blob/c8af4dba2ec02a822b6ef3bb4199244498b88326/index.d.ts#L168)

It is actually used and needed when connecting to a device.

🚨 Before merging, and after test with QA, check the connection priority (set to high with the `connectOptions`) with the firmware update over BLE PR

### ❓ Context

- **Impacted projects**: `@ledgerhq/react-native-hw-transport-ble` but also LLM and LLD indirectly
- **Linked resource(s)**: [LIVE-6889](https://ledgerhq.atlassian.net/browse/LIVE-6889?atlOrigin=eyJpIjoiNzUzOGE0OWM3ZDZmNGE5Zjk1YTk0ZmViNDYxOGQ5YTgiLCJwIjoiaiJ9)

### ✅ Checklist

- [ ] **Test coverage** Need to be QAed
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6889]: https://ledgerhq.atlassian.net/browse/LIVE-6889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ