### PR TITLE
LIVE-6309: Backup and restore Stax background image on firmware update

### DIFF
--- a/.changeset/fuzzy-experts-kneel.md
+++ b/.changeset/fuzzy-experts-kneel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add restoration of apps step on the new firmware update UX

--- a/.changeset/gentle-queens-hope.md
+++ b/.changeset/gentle-queens-hope.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": minor
+---
+
+Memo vertical timeline component and export ItemStatus differently

--- a/.changeset/gentle-spiders-promise.md
+++ b/.changeset/gentle-spiders-promise.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Minor changes on several device actions to allow for retries and to better manage the state in memory

--- a/.changeset/kind-melons-tan.md
+++ b/.changeset/kind-melons-tan.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add language restoration to the new firmware update UX

--- a/.changeset/new-radios-tap.md
+++ b/.changeset/new-radios-tap.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Minor code style fixes

--- a/.changeset/seven-grapes-own.md
+++ b/.changeset/seven-grapes-own.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Retrieve the updated firmware info after the execution of the new firmware update device action

--- a/.changeset/silly-olives-tan.md
+++ b/.changeset/silly-olives-tan.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add custom lock screen restore feature to the new firmware update UX

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -449,14 +449,22 @@ export function renderAllowLanguageInstallation({
   t,
   device,
   theme,
+  fullScreen = true,
 }: RawProps & {
   device: Device;
+  fullScreen?: boolean;
 }) {
   const deviceName = getDeviceModel(device.modelId).productName;
   const key = device.modelId === "stax" ? "allowManager" : "sign";
 
   return (
-    <Wrapper>
+    <Flex
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      alignSelf="stretch"
+      flex={fullScreen ? 1 : undefined}
+    >
       <TrackScreen category="Allow language installation on Stax" />
       <Text variant="h4" textAlign="center">
         {t("deviceLocalization.allowLanguageInstallation", { deviceName })}
@@ -464,7 +472,7 @@ export function renderAllowLanguageInstallation({
       <AnimationContainer>
         <Animation source={getDeviceAnimation({ device, key, theme })} />
       </AnimationContainer>
-    </Wrapper>
+    </Flex>
   );
 }
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -877,14 +877,22 @@ export function renderConnectYourDevice({
   device,
   theme,
   onSelectDeviceLink,
+  fullScreen = true,
 }: RawProps & {
   unresponsive?: boolean | null;
   isLocked?: boolean;
   device: Device;
+  fullScreen?: boolean;
   onSelectDeviceLink?: () => void;
 }) {
   return (
-    <Wrapper>
+    <Flex
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      alignSelf="stretch"
+      flex={fullScreen ? 1 : undefined}
+    >
       <AnimationContainer
         withConnectDeviceHeight={
           ![DeviceModelId.blue, DeviceModelId.stax].includes(device.modelId)
@@ -919,7 +927,7 @@ export function renderConnectYourDevice({
           />
         </ConnectDeviceExtraContentWrapper>
       ) : null}
-    </Wrapper>
+    </Flex>
   );
 }
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -1127,19 +1127,20 @@ export const AutoRepair = ({
 
 const ImageLoadingGeneric: React.FC<{
   title: string;
+  fullScreen?: boolean;
   children?: React.ReactNode | undefined;
   progress?: number;
   lottieSource?: FramedImageWithLottieProps["lottieSource"];
-}> = ({ title, children, progress, lottieSource }) => {
+}> = ({ title, fullScreen = true, children, progress, lottieSource }) => {
   return (
     <Flex
       flexDirection="column"
       justifyContent="center"
       alignItems="center"
-      flex={1}
       alignSelf="stretch"
+      flex={fullScreen ? 1 : undefined}
     >
-      <Flex {...StyleSheet.absoluteFillObject}>
+      <Flex {...(fullScreen ? StyleSheet.absoluteFillObject : {})}>
         <Text
           textAlign="center"
           variant="h4"
@@ -1174,9 +1175,11 @@ const ImageLoadingGeneric: React.FC<{
 export const renderImageLoadRequested = ({
   t,
   device,
-}: RawProps & { device: Device }) => {
+  fullScreen = true,
+}: RawProps & { device: Device; fullScreen: boolean }) => {
   return (
     <ImageLoadingGeneric
+      fullScreen={fullScreen}
       title={t("customImage.allowPreview", {
         productName:
           device.deviceName || getDeviceModel(device.modelId)?.productName,
@@ -1211,9 +1214,11 @@ export const renderLoadingImage = ({
 export const renderImageCommitRequested = ({
   t,
   device,
-}: RawProps & { device: Device }) => {
+  fullScreen = true,
+}: RawProps & { device: Device; fullScreen: boolean }) => {
   return (
     <ImageLoadingGeneric
+      fullScreen={fullScreen}
       title={t("customImage.commitRequested", {
         productName:
           device.deviceName || getDeviceModel(device.modelId)?.productName,

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -1192,7 +1192,7 @@ export const renderImageLoadRequested = ({
   t,
   device,
   fullScreen = true,
-}: RawProps & { device: Device; fullScreen: boolean }) => {
+}: RawProps & { device: Device; fullScreen?: boolean }) => {
   return (
     <ImageLoadingGeneric
       fullScreen={fullScreen}
@@ -1231,7 +1231,7 @@ export const renderImageCommitRequested = ({
   t,
   device,
   fullScreen = true,
-}: RawProps & { device: Device; fullScreen: boolean }) => {
+}: RawProps & { device: Device; fullScreen?: boolean }) => {
   return (
     <ImageLoadingGeneric
       fullScreen={fullScreen}

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4036,17 +4036,21 @@
   "FirmwareUpdate": {
     "title": "Update firmware",
     "updateDevice": "Update {{deviceName}}",
+    "updateDone": "All done! Your {{deviceName}} is up to date",
+    "updateDoneDescription": "New OS Version: {{firmwareVersion}}",
     "preparing": "Preparing the firmware update, please keep your device awake and connected. We will notify you of the progress",
     "confirmIdentifierText": "Verify that the identifier on your device is the same as the identifier below. Confirm and enter your PIN code if requested.",
     "pleaseReinstallApps": "Please reinstall the apps on your device.",
     "pleaseConfirmUpdate": "Confirm the update on your device",
     "pleaseConfirmUpdateOnYourDevice": "Confirm installation on {{deviceName}}",
+    "finishUpdateCTA": "Finish",
     "finishUpdate": "Finish the update on your {{deviceName}}",
     "identifierTitle": "Identifier:",
     "pleaseWaitDownload": "Please wait for the installer to be downloaded",
     "doNotLeaveLedgerLive": "Do not leave the Ledger Live app until the update is complete.",
     "preparingDevice": "Preparing your device",
     "pleaseWaitUpdate": "Please wait for the update to finish",
+    "viewUpdateChangelog": "View update changelog",
     "waitForFirmwareUpdate": "Wait for the firmware update to finish on your device",
     "waitForInstallationToFinish": "Wait for installation to finish on your {{deviceName}}",
     "staxBatteryLow": "Ledger Stax battery too low to update",
@@ -4083,7 +4087,7 @@
       "firmware": "Downloading update",
       "prepareUpdate":  {
         "titleActive": "Preparing update for install",
-        "description": "Transferring the update package to {{deviceName}}"
+        "description": "Backing up your configuration and transferring the update to {{deviceName}}."
       },
       "installUpdate":  {
         "titleInactive": "Install update",
@@ -4092,7 +4096,8 @@
       },
       "restoreSettings":  {
         "titleInactive": "Restore apps and settings",
-        "description": "Your settings and blockchain apps will be restored."
+        "description": "Your settings and blockchain apps will be restored.",
+        "restoreLockScreenPicture": "Restoring lock screen picture"
       }
     },
     "newVersion": "Update {{version}} available for your {{deviceName}}",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4098,7 +4098,8 @@
         "titleInactive": "Restore apps and settings",
         "description": "Your settings and blockchain apps will be restored.",
         "restoreLockScreenPicture": "Restoring lock screen picture",
-        "restoreLanguage": "Restoring language"
+        "restoreLanguage": "Restoring language",
+        "installingApps": "Installing apps"
       }
     },
     "newVersion": "Update {{version}} available for your {{deviceName}}",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4097,7 +4097,8 @@
       "restoreSettings":  {
         "titleInactive": "Restore apps and settings",
         "description": "Your settings and blockchain apps will be restored.",
-        "restoreLockScreenPicture": "Restoring lock screen picture"
+        "restoreLockScreenPicture": "Restoring lock screen picture",
+        "restoreLanguage": "Restoring language"
       }
     },
     "newVersion": "Update {{version}} available for your {{deviceName}}",

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -15,6 +15,7 @@ import {
   VerticalStepper,
   ItemStatus,
 } from "@ledgerhq/native-ui";
+import { useTheme } from "@react-navigation/native";
 import { Item } from "@ledgerhq/native-ui/components/Layout/List/types";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 
@@ -39,6 +40,7 @@ import {
 import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/types/ManagerNavigator";
 import { ScreenName } from "../../const";
 import {
+  renderAllowLanguageInstallation,
   renderImageCommitRequested,
   renderImageLoadRequested,
 } from "../../components/DeviceAction/rendering";
@@ -118,6 +120,8 @@ export const FirmwareUpdate = ({
 }: FirmwareUpdateProps) => {
   const navigation = useNavigation();
   const { t } = useTranslation();
+  const { dark } = useTheme();
+  const theme: "dark" | "light" = dark ? "dark" : "light";
   const dispatch = useDispatch();
 
   const quitUpdate = useCallback(() => {
@@ -136,11 +140,17 @@ export const FirmwareUpdate = ({
 
   const [fullUpdateComplete, setFullUpdateComplete] = useState(false);
 
-  const { updateActionState, updateStep, retryUpdate, staxLoadImageState } =
-    useUpdateFirmwareAndRestoreSettings({
-      updateFirmwareAction,
-      device,
-    });
+  const {
+    updateActionState,
+    updateStep,
+    retryUpdate,
+    staxLoadImageState,
+    installLanguageState,
+  } = useUpdateFirmwareAndRestoreSettings({
+    updateFirmwareAction,
+    device,
+    deviceInfo,
+  });
 
   useEffect(() => {
     if (updateStep === "completed") {
@@ -162,6 +172,19 @@ export const FirmwareUpdate = ({
           start: ItemStatus.inactive,
           imageBackup: ItemStatus.inactive,
           firmwareUpdate: ItemStatus.inactive,
+          languageRestore: ItemStatus.active,
+          imageRestore: ItemStatus.completed,
+          appsRestore: ItemStatus.completed,
+          completed: ItemStatus.completed,
+        }[updateStep],
+        progress: installLanguageState.progress,
+        title: t("FirmwareUpdate.steps.restoreSettings.restoreLanguage"),
+      },
+      {
+        status: {
+          start: ItemStatus.inactive,
+          imageBackup: ItemStatus.inactive,
+          firmwareUpdate: ItemStatus.inactive,
           languageRestore: ItemStatus.inactive,
           imageRestore: ItemStatus.active,
           appsRestore: ItemStatus.completed,
@@ -172,9 +195,8 @@ export const FirmwareUpdate = ({
           "FirmwareUpdate.steps.restoreSettings.restoreLockScreenPicture",
         ),
       },
-      // TODO: add here the apps and language steps when they're implemented
     ],
-    [staxLoadImageState.progress, t, updateStep],
+    [updateStep, installLanguageState.progress, t, staxLoadImageState.progress],
   );
 
   const defaultSteps: UpdateSteps = useMemo(
@@ -423,6 +445,15 @@ export const FirmwareUpdate = ({
       return renderImageCommitRequested({ t, device, fullScreen: false });
     }
 
+    if (installLanguageState.languageInstallationRequested) {
+      return renderAllowLanguageInstallation({
+        t,
+        device,
+        theme,
+        fullScreen: false,
+      });
+    }
+
     return undefined;
   }, [
     updateActionState.error,
@@ -430,6 +461,7 @@ export const FirmwareUpdate = ({
     updateActionState.progress,
     staxLoadImageState.imageLoadRequested,
     staxLoadImageState.imageCommitRequested,
+    installLanguageState.languageInstallationRequested,
     device,
     t,
     quitUpdate,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -16,7 +16,6 @@ import {
   ItemStatus,
 } from "@ledgerhq/native-ui";
 import { Item } from "@ledgerhq/native-ui/components/Layout/List/types";
-// import { log } from "@ledgerhq/logs";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 
 import { useNavigation, useRoute } from "@react-navigation/native";
@@ -24,7 +23,6 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Observable } from "rxjs";
-// import { scan, tap } from "rxjs/operators";
 import { updateMainNavigatorVisibility } from "../../actions/appstate";
 import {
   AllowManager,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -17,7 +17,11 @@ import {
 } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import { Item } from "@ledgerhq/native-ui/components/Layout/List/types";
-import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import {
+  DeviceInfo,
+  FirmwareUpdateContext,
+  languageIds,
+} from "@ledgerhq/types-live";
 
 import { useNavigation, useRoute } from "@react-navigation/native";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -41,6 +45,7 @@ import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/t
 import { ScreenName } from "../../const";
 import {
   renderAllowLanguageInstallation,
+  renderConnectYourDevice,
   renderImageCommitRequested,
   renderImageLoadRequested,
 } from "../../components/DeviceAction/rendering";
@@ -143,9 +148,14 @@ export const FirmwareUpdate = ({
   const {
     updateActionState,
     updateStep,
-    retryUpdate,
+    retryCurrentStep,
+    staxFetchImageState,
     staxLoadImageState,
     installLanguageState,
+    restoreAppsState,
+    noOfAppsToReinstall,
+    deviceLockedOrUnresponsive,
+    hasReconnectErrors,
   } = useUpdateFirmwareAndRestoreSettings({
     updateFirmwareAction,
     device,
@@ -165,11 +175,14 @@ export const FirmwareUpdate = ({
     return undefined;
   });
 
-  const restoreSteps = useMemo(
-    () => [
-      {
+  const restoreSteps = useMemo(() => {
+    const steps = [];
+
+    if (deviceInfo.languageId !== languageIds["english"]) {
+      steps.push({
         status: {
           start: ItemStatus.inactive,
+          appsBackup: ItemStatus.inactive,
           imageBackup: ItemStatus.inactive,
           firmwareUpdate: ItemStatus.inactive,
           languageRestore: ItemStatus.active,
@@ -179,10 +192,14 @@ export const FirmwareUpdate = ({
         }[updateStep],
         progress: installLanguageState.progress,
         title: t("FirmwareUpdate.steps.restoreSettings.restoreLanguage"),
-      },
-      {
+      });
+    }
+
+    if (staxFetchImageState.hexImage) {
+      steps.push({
         status: {
           start: ItemStatus.inactive,
+          appsBackup: ItemStatus.inactive,
           imageBackup: ItemStatus.inactive,
           firmwareUpdate: ItemStatus.inactive,
           languageRestore: ItemStatus.inactive,
@@ -194,10 +211,48 @@ export const FirmwareUpdate = ({
         title: t(
           "FirmwareUpdate.steps.restoreSettings.restoreLockScreenPicture",
         ),
-      },
-    ],
-    [updateStep, installLanguageState.progress, t, staxLoadImageState.progress],
-  );
+      });
+    }
+
+    if (noOfAppsToReinstall > 0) {
+      steps.push({
+        status: {
+          start: ItemStatus.inactive,
+          appsBackup: ItemStatus.inactive,
+          imageBackup: ItemStatus.inactive,
+          firmwareUpdate: ItemStatus.inactive,
+          languageRestore: ItemStatus.inactive,
+          imageRestore: ItemStatus.inactive,
+          appsRestore: ItemStatus.active,
+          completed: ItemStatus.completed,
+        }[updateStep],
+        progress: restoreAppsState.itemProgress,
+        title:
+          t("FirmwareUpdate.steps.restoreSettings.installingApps") +
+          ` ${
+            !restoreAppsState.listedApps
+              ? 0
+              : restoreAppsState.installQueue !== undefined &&
+                restoreAppsState.installQueue.length > 0
+              ? noOfAppsToReinstall - (restoreAppsState.installQueue.length - 1)
+              : noOfAppsToReinstall
+          }/${noOfAppsToReinstall}`,
+      });
+    }
+
+    return steps;
+  }, [
+    updateStep,
+    installLanguageState.progress,
+    t,
+    staxFetchImageState.hexImage,
+    staxLoadImageState.progress,
+    restoreAppsState.listedApps,
+    restoreAppsState.itemProgress,
+    restoreAppsState.installQueue,
+    noOfAppsToReinstall,
+    deviceInfo.languageId,
+  ]);
 
   const defaultSteps: UpdateSteps = useMemo(
     () => ({
@@ -231,8 +286,9 @@ export const FirmwareUpdate = ({
             <Text color="neutral.c80">
               {t("FirmwareUpdate.steps.restoreSettings.description")}
             </Text>
-            {/* TODO: create custom component here with its own state for the restoring */}
-            <VerticalStepper nested steps={restoreSteps} />
+            {restoreSteps.length > 0 && (
+              <VerticalStepper nested steps={restoreSteps} />
+            )}
           </Flex>
         ),
       },
@@ -375,7 +431,12 @@ export const FirmwareUpdate = ({
 
   const deviceInteractionDisplay = useMemo(() => {
     const error = updateActionState.error;
-    if (error) {
+
+    // a TransportRaceCondition error is to be expected since we chain multiple
+    // device actions that use different transport acquisition paradigms
+    // the action should, however, retry to execute and resolve the error by itself
+    // no need to present the error to the user
+    if (error && error.name !== "TransportRaceCondition") {
       return (
         <DeviceActionError
           device={device}
@@ -418,7 +479,7 @@ export const FirmwareUpdate = ({
           <FirmwareUpdateDenied
             device={device}
             newFirmwareVersion={firmwareUpdateContext.final.name}
-            onPressRestart={retryUpdate}
+            onPressRestart={retryCurrentStep}
             onPressQuit={quitUpdate}
             t={t}
           />
@@ -437,12 +498,46 @@ export const FirmwareUpdate = ({
         break;
     }
 
+    if (deviceLockedOrUnresponsive || hasReconnectErrors) {
+      return (
+        <Flex>
+          {renderConnectYourDevice({
+            t,
+            device,
+            theme,
+            fullScreen: false,
+          })}
+          <Button
+            type="main"
+            outline={false}
+            onPress={retryCurrentStep}
+            mt={6}
+            alignSelf="stretch"
+          >
+            {t("common.retry")}
+          </Button>
+          <Button type="default" outline={false} onPress={quitUpdate} mt={6}>
+            {t("FirmwareUpdate.quitUpdate")}
+          </Button>
+        </Flex>
+      );
+    }
+
     if (staxLoadImageState.imageLoadRequested) {
       return renderImageLoadRequested({ t, device, fullScreen: false });
     }
 
     if (staxLoadImageState.imageCommitRequested) {
       return renderImageCommitRequested({ t, device, fullScreen: false });
+    }
+
+    if (restoreAppsState.allowManagerRequestedWording) {
+      return (
+        <AllowManager
+          device={device}
+          wording={t("DeviceAction.allowSecureConnection")}
+        />
+      );
     }
 
     if (installLanguageState.languageInstallationRequested) {
@@ -462,13 +557,17 @@ export const FirmwareUpdate = ({
     staxLoadImageState.imageLoadRequested,
     staxLoadImageState.imageCommitRequested,
     installLanguageState.languageInstallationRequested,
+    restoreAppsState.allowManagerRequestedWording,
     device,
     t,
+    theme,
     quitUpdate,
     deviceInfo.seVersion,
     firmwareUpdateContext.final.name,
     firmwareUpdateContext.shouldFlashMCU,
-    retryUpdate,
+    retryCurrentStep,
+    hasReconnectErrors,
+    deviceLockedOrUnresponsive,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -81,7 +81,12 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     connectManagerRequest,
   );
 
-  const staxFetchImageRequest = useMemo(() => ({}), []);
+  const staxFetchImageRequest = useMemo(
+    () => ({
+      allowedEmpty: true,
+    }),
+    [],
+  );
   const staxFetchImageState = staxFetchImageAction.useHook(
     updateStep === "imageBackup" ? device : null,
     staxFetchImageRequest,
@@ -313,7 +318,6 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     restoreAppsState.opened,
     proceedToAppsBackup,
     connectManagerState.error,
-    staxFetchImageState.hexImage,
   ]);
 
   const hasReconnectErrors = useMemo(

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -1,0 +1,125 @@
+import staxLoadImage from "@ledgerhq/live-common/hw/staxLoadImage";
+import staxFetchImage from "@ledgerhq/live-common/hw/staxFetchImage";
+import { createAction as createStaxLoadImageAction } from "@ledgerhq/live-common/hw/actions/staxLoadImage";
+import { createAction as createStaxFetchImageAction } from "@ledgerhq/live-common/hw/actions/staxFetchImage";
+import { useUpdateFirmware } from "@ledgerhq/live-common/deviceSDK/hooks/useUpdateFirmware";
+import { Device, DeviceModelId } from "@ledgerhq/types-devices";
+import {
+  UpdateFirmwareActionState,
+  updateFirmwareActionArgs,
+} from "@ledgerhq/live-common/deviceSDK/actions/updateFirmware";
+import { Observable } from "rxjs";
+import { useEffect, useMemo, useState } from "react";
+
+export type FirmwareUpdateParams = {
+  device: Device;
+  updateFirmwareAction?: (
+    args: updateFirmwareActionArgs,
+  ) => Observable<UpdateFirmwareActionState>;
+};
+
+export type UpdateStep =
+  | "start"
+  | "imageBackup"
+  | "firmwareUpdate"
+  | "languageRestore"
+  | "imageRestore"
+  | "appsRestore"
+  | "completed";
+
+const staxLoadImageAction = createStaxLoadImageAction(staxLoadImage);
+const staxFetchImageAction = createStaxFetchImageAction(staxFetchImage);
+
+export const useUpdateFirmwareAndRestoreSettings = ({
+  updateFirmwareAction,
+  device,
+}: FirmwareUpdateParams) => {
+  const [updateStep, setUpdateStep] = useState<UpdateStep>("start");
+
+  const staxFetchImageRequest = useMemo(() => ({}), []);
+  const staxFetchImageState = staxFetchImageAction.useHook(
+    updateStep === "imageBackup" ? device : null,
+    staxFetchImageRequest,
+  );
+
+  const { triggerUpdate, updateState: updateActionState } = useUpdateFirmware({
+    deviceId: device?.deviceId ?? "",
+    updateFirmwareAction,
+  });
+
+  const staxLoadImageRequest = useMemo(
+    () => ({
+      hexImage: staxFetchImageState.hexImage ?? "",
+      padImage: false,
+    }),
+    [staxFetchImageState.hexImage],
+  );
+  const staxLoadImageState = staxLoadImageAction.useHook(
+    updateStep === "imageRestore" && staxFetchImageState.hexImage
+      ? device
+      : null,
+    staxLoadImageRequest,
+  );
+
+  useEffect(() => {
+    switch (updateStep) {
+      case "start":
+        if (device.modelId === DeviceModelId.stax) {
+          setUpdateStep("imageBackup");
+        } else {
+          setUpdateStep("firmwareUpdate");
+        }
+        break;
+      case "imageBackup":
+        if (staxFetchImageState.imageFetched || staxFetchImageState.error) {
+          // TODO: check if we want to do something with error, maybe just log it
+          setUpdateStep("firmwareUpdate");
+        }
+        break;
+      case "firmwareUpdate":
+        if (updateActionState.step === "preparingUpdate") {
+          triggerUpdate();
+        } else if (updateActionState.step === "firmwareUpdateCompleted") {
+          setUpdateStep("languageRestore");
+        }
+        break;
+      case "languageRestore":
+        // TODO: implement image restore
+        setUpdateStep("imageRestore");
+        break;
+      case "imageRestore":
+        if (
+          staxLoadImageState.imageLoaded ||
+          staxLoadImageState.error ||
+          !staxFetchImageState.hexImage
+        ) {
+          // TODO: check if we want to do something with error, maybe just log it
+          setUpdateStep("appsRestore");
+        }
+        break;
+      case "appsRestore":
+        setUpdateStep("completed");
+        break;
+      default:
+        break;
+    }
+  }, [
+    device.modelId,
+    staxFetchImageState.error,
+    staxFetchImageState.imageFetched,
+    staxFetchImageState.hexImage,
+    staxLoadImageState.error,
+    staxLoadImageState.imageLoaded,
+    triggerUpdate,
+    updateActionState.step,
+    updateStep,
+  ]);
+
+  return {
+    updateStep,
+    staxFetchImageState,
+    updateActionState,
+    staxLoadImageState,
+    retryUpdate: triggerUpdate,
+  };
+};

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -10,6 +10,7 @@ import {
 } from "@ledgerhq/live-common/deviceSDK/actions/updateFirmware";
 import { Observable } from "rxjs";
 import { useEffect, useMemo, useState } from "react";
+import { log } from "@ledgerhq/logs";
 
 export type FirmwareUpdateParams = {
   device: Device;
@@ -71,6 +72,15 @@ export const useUpdateFirmwareAndRestoreSettings = ({
         }
         break;
       case "imageBackup":
+        // Only logging for now
+        if (staxLoadImageState.error) {
+          log(
+            "UpdateFirmwareAndRestoreSettings",
+            "Unable to fetch image",
+            staxFetchImageState.error,
+          );
+        }
+
         if (staxFetchImageState.imageFetched || staxFetchImageState.error) {
           // TODO: check if we want to do something with error, maybe just log it
           setUpdateStep("firmwareUpdate");
@@ -88,12 +98,20 @@ export const useUpdateFirmwareAndRestoreSettings = ({
         setUpdateStep("imageRestore");
         break;
       case "imageRestore":
+        // Only logging for now
+        if (staxLoadImageState.error) {
+          log(
+            "UpdateFirmwareAndRestoreSettings",
+            "Unable to restore image",
+            staxLoadImageState.error,
+          );
+        }
+
         if (
           staxLoadImageState.imageLoaded ||
           staxLoadImageState.error ||
           !staxFetchImageState.hexImage
         ) {
-          // TODO: check if we want to do something with error, maybe just log it
           setUpdateStep("appsRestore");
         }
         break;

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -175,6 +175,14 @@ const Manager = ({ navigation, route }: NavigationProps) => {
     [device, installedApps, navigation, refreshDeviceInfo],
   );
 
+  const onBackFromNewUpdateUx = useCallback(
+    () => {
+      navigation.replace(ScreenName.Manager, {
+        device
+      });
+    }, [device, navigation]
+  )
+
   return (
     <>
       <TrackScreen
@@ -203,7 +211,7 @@ const Manager = ({ navigation, route }: NavigationProps) => {
         tab={tab}
         result={result}
         onLanguageChange={refreshDeviceInfo}
-        onBackFromUpdate={refreshDeviceInfo}
+        onBackFromUpdate={onBackFromNewUpdateUx}
       />
       <GenericErrorBottomModal error={error} onClose={closeErrorModal} />
       <QuitManagerModal

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -112,6 +112,8 @@ const findDependents = (
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
+    case "reset":
+      return action.initialState;
     case "onRunnerEvent": {
       // an app operation was correctly prefered. update state accordingly
       const { event } = action;

--- a/libs/ledger-live-common/src/apps/react.ts
+++ b/libs/ledger-live-common/src/apps/react.ts
@@ -25,6 +25,14 @@ export const useAppsRunner = (
   );
   const nextAppOp = useMemo(() => getNextAppOp(state), [state]);
   const appOp = state.currentAppOp || nextAppOp;
+
+  useEffect(() => {
+    dispatch({
+      type: "reset",
+      initialState: initState(listResult, appsToRestore),
+    });
+  }, [listResult, appsToRestore]);
+
   useEffect(() => {
     if (appOp) {
       const sub = runAppOp(state, appOp, exec).subscribe((event) => {

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -130,6 +130,10 @@ export type SkippedAppOp = {
 
 export type Action =  // recover from an error
   | {
+      type: "reset";
+      initialState: State;
+    }
+  | {
       type: "recover";
     } // wipe will remove all apps of the device
   | {

--- a/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
@@ -1,4 +1,4 @@
-import { DeviceId } from "@ledgerhq/types-live";
+import { DeviceId, DeviceInfo } from "@ledgerhq/types-live";
 import { concat, Observable, of } from "rxjs";
 import { scan, switchMap } from "rxjs/operators";
 import {
@@ -45,6 +45,7 @@ export type UpdateFirmwareActionState = FullActionState<{
   // final step when the device has reconnected after the firwmare update has been completed
 
   progress: number;
+  updatedDeviceInfo?: DeviceInfo;
   error: { type: "UpdateFirmwareError"; name: string };
 }>;
 
@@ -109,8 +110,13 @@ export function updateFirmwareAction({
           case "installOsuDevicePermissionRequested":
           case "installOsuDevicePermissionGranted":
           case "installOsuDevicePermissionDenied":
-          case "firmwareUpdateCompleted":
             return { ...currentState, step: event.type };
+          case "firmwareUpdateCompleted":
+            return {
+              ...currentState,
+              step: event.type,
+              updatedDeviceInfo: event.updatedDeviceInfo,
+            };
           default:
             return {
               ...currentState,

--- a/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
@@ -88,7 +88,7 @@ export function updateFirmwareAction({
         | GetLatestFirmwareTaskErrorEvent
         | GetDeviceInfoTaskErrorEvent,
         UpdateFirmwareActionState
-      >((currentState, event) => {
+      >((_, event) => {
         switch (event.type) {
           case "taskError":
             return {
@@ -102,7 +102,7 @@ export function updateFirmwareAction({
           case "flashingMcu":
           case "flashingBootloader":
             return {
-              ...currentState,
+              ...initialState,
               step: event.type,
               progress: event.progress,
             };
@@ -110,16 +110,16 @@ export function updateFirmwareAction({
           case "installOsuDevicePermissionRequested":
           case "installOsuDevicePermissionGranted":
           case "installOsuDevicePermissionDenied":
-            return { ...currentState, step: event.type };
+            return { ...initialState, step: event.type };
           case "firmwareUpdateCompleted":
             return {
-              ...currentState,
+              ...initialState,
               step: event.type,
               updatedDeviceInfo: event.updatedDeviceInfo,
             };
           default:
             return {
-              ...currentState,
+              ...initialState,
               ...sharedReducer({
                 event,
               }),

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -2,6 +2,7 @@ import {
   CantOpenDevice,
   DisconnectedDevice,
   LockedDeviceError,
+  TransportRaceCondition,
   createCustomErrorClass,
 } from "@ledgerhq/errors";
 import { Observable, from, of, throwError, timer } from "rxjs";
@@ -50,7 +51,8 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
                 if (
                   error instanceof LockedDeviceError ||
                   error instanceof CantOpenDevice ||
-                  error instanceof DisconnectedDevice
+                  error instanceof DisconnectedDevice ||
+                  error instanceof TransportRaceCondition
                 ) {
                   // Emits to the action a locked device error event so it is aware of it before retrying
                   subscriber.next({ type: "error", error });

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -508,6 +508,7 @@ export const createAction = (
         appRequest.appName, // eslint-disable-next-line react-hooks/exhaustive-deps
         appRequest.account && appRequest.account.id, // eslint-disable-next-line react-hooks/exhaustive-deps
         appRequest.currency && appRequest.currency.id,
+        appRequest.dependencies,
       ]
     );
 

--- a/libs/ledger-live-common/src/hw/actions/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/actions/installLanguage.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 import { scan, tap } from "rxjs/operators";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { useReplaySubject } from "../../observable";
@@ -26,9 +26,13 @@ type State = {
   progress?: number;
 };
 
+type ActionState = State & {
+  onRetry: () => void;
+}
+
 type InstallLanguageAction = Action<
   InstallLanguageRequest,
-  State,
+  ActionState,
   boolean | undefined
 >;
 
@@ -111,8 +115,9 @@ export const createAction = (
   const useHook = (
     device: Device | null | undefined,
     request: InstallLanguageRequest
-  ): State => {
+  ): ActionState => {
     const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
     const deviceSubject = useReplaySubject(device);
 
     useEffect(() => {
@@ -136,10 +141,16 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, request, state.languageInstalled]);
+    }, [deviceSubject, request, state.languageInstalled, resetIndex]);
+
+    const onRetry = useCallback(() => {
+      setResetIndex((currIndex) => currIndex + 1);
+      setState((s) => getInitialState(s.device));
+    }, []);
 
     return {
       ...state,
+      onRetry
     };
   };
 

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -43,6 +43,7 @@ type ManagerState = State & {
 export type ManagerRequest =
   | {
       autoQuitAppDisabled?: boolean;
+      cancelExecution?: boolean;
     }
   | null
   | undefined;
@@ -183,6 +184,8 @@ export const createAction = (
     } | null>(null);
 
     useEffect(() => {
+      if(request?.cancelExecution) return;
+
       const impl = getImplementation(currentMode)<
         ConnectManagerEvent,
         ManagerRequest

--- a/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
@@ -48,7 +48,7 @@ type Event =
       device: Device | null | undefined;
     };
 
-const getInitialState = (device?: Device | null | undefined): State => ({
+export const getInitialState = (device?: Device | null | undefined): State => ({
   isLoading: !!device,
   requestQuitApp: false,
   unresponsive: false,
@@ -59,7 +59,7 @@ const getInitialState = (device?: Device | null | undefined): State => ({
   imageHash: "",
 });
 
-const reducer = (state: State, e: Event): State => {
+export const reducer = (state: State, e: Event): State => {
   switch (e.type) {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true, isLoading: false };

--- a/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 import { scan, tap } from "rxjs/operators";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { useReplaySubject } from "../../observable";
@@ -30,7 +30,11 @@ type State = {
   progress?: number;
 };
 
-type LoadImageAction = Action<LoadImageRequest, State, LoadimageResult>;
+type ActionState = State & {
+  onRetry: () => void;
+};
+
+type LoadImageAction = Action<LoadImageRequest, ActionState, LoadimageResult>;
 
 const mapResult = ({ imageHash, imageSize }: State) => ({
   imageHash,
@@ -127,8 +131,9 @@ export const createAction = (
   const useHook = (
     device: Device | null | undefined,
     request: LoadImageRequest
-  ): State => {
+  ): ActionState => {
     const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
     const deviceSubject = useReplaySubject(device);
 
     useEffect(() => {
@@ -152,10 +157,16 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, request, state.imageLoaded]);
+    }, [deviceSubject, request, state.imageLoaded, resetIndex]);
+
+    const onRetry = useCallback(() => {
+      setResetIndex((currIndex) => currIndex + 1);
+      setState((s) => getInitialState(s.device));
+    }, []);
 
     return {
       ...state,
+      onRetry,
     };
   };
 

--- a/libs/ui/packages/native/src/components/Layout/List/VerticalStepper/index.tsx
+++ b/libs/ui/packages/native/src/components/Layout/List/VerticalStepper/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import StepperItem from "./StepperItem";
 import { Flex } from "../..";
 import { BaseStyledProps } from "src/components/styled";
-import { Item, ItemStatus } from "../types";
+import { Item } from "../types";
 
 export type Props = BaseStyledProps & {
   steps?: Item[];
@@ -11,7 +11,7 @@ export type Props = BaseStyledProps & {
   nested?: boolean;
 };
 
-export default function VerticalStepper({ steps, onTapIndex, nested, ...props }: Props) {
+export default React.memo(function VerticalStepper({ steps, onTapIndex, nested, ...props }: Props) {
   return (
     <Flex {...props} flexDirection="column">
       {nested && <Flex mt={7} mb={4} borderBottomWidth={1} borderBottomColor="neutral.c40" />}
@@ -28,6 +28,4 @@ export default function VerticalStepper({ steps, onTapIndex, nested, ...props }:
       ))}
     </Flex>
   );
-}
-
-VerticalStepper.ItemStatus = ItemStatus;
+});

--- a/libs/ui/packages/native/src/components/Layout/List/index.ts
+++ b/libs/ui/packages/native/src/components/Layout/List/index.ts
@@ -3,4 +3,5 @@ export { default as IconBoxList } from "./IconBoxList";
 export { default as TipList } from "./TipList";
 export { default as NumberedList } from "./NumberedList";
 export { default as VerticalTimeline } from "./VerticalTimeline";
+export { ItemStatus } from "./types";
 export { default as VerticalStepper } from "./VerticalStepper";

--- a/libs/ui/packages/native/storybook/stories/Layout/List/VerticalStepper.stories.tsx
+++ b/libs/ui/packages/native/storybook/stories/Layout/List/VerticalStepper.stories.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { ScrollView } from "react-native";
-import { Flex, VerticalStepper, Text, Switch, Divider } from "../../../../src/components";
-
-const { ItemStatus } = VerticalStepper;
+import { Flex, VerticalStepper, Text, Switch, Divider } from "../../../../src";
+import { ItemStatus } from "../../../../src";
 
 const restoreSteps = [
   {

--- a/libs/ui/packages/native/storybook/stories/Layout/List/VerticalTimeline.stories.tsx
+++ b/libs/ui/packages/native/storybook/stories/Layout/List/VerticalTimeline.stories.tsx
@@ -1,21 +1,10 @@
 import { ComponentStory } from "@storybook/react-native";
 import React, { useCallback, useEffect, useState } from "react";
 import { View } from "react-native";
-import {
-  Flex,
-  VerticalTimeline,
-  Button,
-  Switch,
-  Divider,
-  ContinueOnDevice,
-} from "../../../../src/components";
+import { Flex, VerticalTimeline, Button, Switch, Divider, ContinueOnDevice } from "../../../../src";
+import { ItemStatus } from "../../../../src";
 
-export default {
-  title: "Layout/List/VerticalTimeline",
-  component: VerticalTimeline,
-};
-
-const { BodyText, SubtitleText, ItemStatus } = VerticalTimeline;
+const { BodyText, SubtitleText } = VerticalTimeline;
 
 const defaultItems = [
   {


### PR DESCRIPTION
### 📝 Description
This PR adds an extra step at the beginning and at the end of the new firmware update (implemented on https://github.com/LedgerHQ/ledger-live/pull/2977). 
In case the device being update is a Stax, we back up the custom lock screen image before launching the update and after the update is finished we trigger the load of the image back to the device.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-6309]

### ✅ Checklist

- [N/A] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** - Not an atomic delivery but rather a part of a larger feature that is being implemented of overhauling the UX of the firmware update on LLM. The feature is under feature flag, so this change will not impact the user as long as the feature flag is set to `false`
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://user-images.githubusercontent.com/6013294/228571273-e8ccb75a-7d17-4e3a-bae3-49221ffec95d.mp4



[LIVE-6309]: https://ledgerhq.atlassian.net/browse/LIVE-6309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ