### PR TITLE
feat: LIVE-6930 refactor device action implementations, removed debounces

### DIFF
--- a/.changeset/swift-seahorses-hang.md
+++ b/.changeset/swift-seahorses-hang.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-cli": patch
+---
+
+Refactor device action implementations unifying the logic

--- a/apps/cli/src/commands/i18n.ts
+++ b/apps/cli/src/commands/i18n.ts
@@ -21,7 +21,7 @@ const exec = async (opts: i18nJobOps) => {
 
   if (install) {
     await new Promise<void>((p) =>
-      installLanguage({ deviceId, language}).subscribe(
+      installLanguage({ deviceId, request: { language }}).subscribe(
         (x) => console.log(x),
         (e) => {
           console.error(e);

--- a/apps/cli/src/commands/staxFetchAndRestoreDemo.ts
+++ b/apps/cli/src/commands/staxFetchAndRestoreDemo.ts
@@ -50,7 +50,7 @@ const exec = async (opts: staxFetchAndRestoreJobOpts) => {
 
     console.log("Restoring the image we backedup");
     await new Promise<void>((resolve) =>
-      staxLoadImage({ deviceId, hexImage: hexImageWithoutHeader }).subscribe(
+      staxLoadImage({ deviceId, request: { hexImage: hexImageWithoutHeader } }).subscribe(
         (x) => console.log(x),
         (e) => {
           console.error(e);

--- a/apps/cli/src/commands/staxFetchImage.ts
+++ b/apps/cli/src/commands/staxFetchImage.ts
@@ -13,7 +13,7 @@ const exec = async (opts: staxFetchImageJobOpts) => {
   const { device: deviceId = "", fileOutput } = opts;
 
   await new Promise<void>((p) =>
-    staxFetchImage({ deviceId }).subscribe(
+    staxFetchImage({ deviceId, request: {} }).subscribe(
       (event) => {
         if (event.type === "imageFetched") {
           const { hexImage } = event;

--- a/apps/cli/src/commands/staxLoadImage.ts
+++ b/apps/cli/src/commands/staxLoadImage.ts
@@ -15,7 +15,7 @@ const exec = async (opts: staxLoadImageJobOpts) => {
   const hexImage = fs.readFileSync(fileInput, "utf-8");
 
   await new Promise<void>((resolve) =>
-      staxLoadImage({ deviceId, hexImage }).subscribe(
+      staxLoadImage({ deviceId, request: { hexImage } }).subscribe(
         (x) => console.log(x),
         (e) => {
           console.error(e);

--- a/apps/ledger-live-desktop/src/renderer/components/ChangeDeviceLanguageAction.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ChangeDeviceLanguageAction.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import installLanguage from "@ledgerhq/live-common/hw/installLanguage";
 import { createAction } from "@ledgerhq/live-common/hw/actions/installLanguage";
@@ -41,10 +41,12 @@ type Props = {
 };
 
 const ChangeDeviceLanguageAction: React.FC<Props> = ({ language, onError, onSuccess }) => {
+  const request = useMemo(() => ({ language }), [language]);
+
   return (
     <DeviceAction
       action={action}
-      request={language}
+      request={request}
       onResult={onSuccess}
       Result={() => <DeviceLanguageInstalled language={language} />}
       onError={onError}

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomImageDeviceAction.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from "react";
+import React, { useEffect, useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
 import { setLastSeenCustomImage, clearLastSeenCustomImage } from "~/renderer/actions/settings";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -48,7 +48,7 @@ const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props =>
   } = props;
   const type: Theme["theme"] = useTheme("colors.palette.type");
   const device = getEnv("MOCK") ? mockedDevice : props.device;
-  const commandRequest = hexImage;
+  const commandRequest = useMemo(() => ({ hexImage }), [hexImage]);
 
   const { t } = useTranslation();
   const dispatch = useDispatch();

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -137,7 +137,7 @@ export const DeviceActionDefaultRendering = <R, H, P>({
   }, [error, onError]);
 
   useEffect(() => {
-    if (deviceInfo) {
+    if (deviceInfo && device) {
       const lastSeenDevice = {
         modelId: device.modelId,
         deviceInfo,

--- a/apps/ledger-live-desktop/src/renderer/components/debug/DebugMock.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/debug/DebugMock.tsx
@@ -9,6 +9,7 @@ import {
   deviceInfo210lo5,
   mockListAppsResult as innerMockListAppResult,
 } from "@ledgerhq/live-common/apps/mock";
+import { AppType } from "@ledgerhq/types-live";
 import { useAnnouncements } from "@ledgerhq/live-common/notifications/AnnouncementProvider/index";
 import { useFilteredServiceStatus } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/index";
 import { addMockAnnouncement } from "../../../../tests/mocks/notificationsHelpers";
@@ -16,7 +17,6 @@ import { toggleMockIncident } from "../../../../tests/mocks/serviceStatusHelpers
 import useInterval from "~/renderer/hooks/useInterval";
 import Box from "~/renderer/components/Box";
 import { Item, MockContainer, EllipsesText, MockedGlobalStyle } from "./shared";
-import { AppType } from "@ledgerhq/types-live/lib/manager";
 
 const mockListAppsResult = (...params) => {
   // Nb Should move this polyfill to live-common eventually.

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
@@ -55,6 +55,8 @@ const EditDeviceName: React.FC<Props> = ({
   const [running, setRunning] = useState(false);
   const disableButton = running || (!completed && (deviceName === name || !name.trim() || error));
 
+  const request = useMemo(() => ({ name }), [name]);
+
   const onCloseDrawer = useCallback(() => {
     onClose();
     setRunning(false);
@@ -136,7 +138,7 @@ const EditDeviceName: React.FC<Props> = ({
           <Flex flex={1} alignItems="center" justifyContent="center" p={2}>
             <DeviceAction
               device={device}
-              request={name}
+              request={request}
               action={action}
               onClose={onClose}
               onResult={onSuccess}

--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -39,7 +39,7 @@ export class DeviceAction {
 
   async genuineCheck(appDesc = "Bitcoin", installedDesc = "Bitcoin") {
     const result = mockListAppsResult(appDesc, installedDesc, deviceInfo);
-    const modelId = DeviceModelId.nanoX;
+    const modelId = DeviceModelId.nanoS;
 
     await this.page.evaluate(
       args => {
@@ -78,7 +78,7 @@ export class DeviceAction {
     deviceModelId?: DeviceModelId,
   ) {
     const result = mockListAppsResult(appDesc, installedDesc, deviceInfo, deviceModelId);
-    const modelId = DeviceModelId.nanoX;
+    const modelId = DeviceModelId.nanoS;
 
     await this.page.evaluate(
       args => {
@@ -116,7 +116,7 @@ export class DeviceAction {
     installedDesc = "Bitcoin,Litecoin,Ethereum (outdated)",
   ) {
     const result = mockListAppsResult(appDesc, installedDesc, deviceInfo210lo5);
-    const modelId = DeviceModelId.nanoX;
+    const modelId = DeviceModelId.nanoS;
 
     await this.page.evaluate(
       args => {

--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -39,12 +39,22 @@ export class DeviceAction {
 
   async genuineCheck(appDesc = "Bitcoin", installedDesc = "Bitcoin") {
     const result = mockListAppsResult(appDesc, installedDesc, deviceInfo);
+    const modelId = DeviceModelId.nanoX;
 
     await this.page.evaluate(
       args => {
-        const [deviceInfo, result] = args;
+        const [deviceInfo, result, modelId] = args;
 
         (window as any).mock.events.mockDeviceEvent(
+          {
+            type: "deviceChange",
+            device: {
+              deviceId: "",
+              deviceName: "Some name",
+              modelId,
+            },
+            replaceable: false,
+          },
           {
             type: "listingApps",
             deviceInfo,
@@ -56,7 +66,7 @@ export class DeviceAction {
           { type: "complete" },
         );
       },
-      [deviceInfo, result],
+      [deviceInfo, result, modelId],
     );
 
     await this.loader.waitFor({ state: "hidden" });
@@ -68,12 +78,22 @@ export class DeviceAction {
     deviceModelId?: DeviceModelId,
   ) {
     const result = mockListAppsResult(appDesc, installedDesc, deviceInfo, deviceModelId);
+    const modelId = DeviceModelId.nanoX;
 
     await this.page.evaluate(
       args => {
-        const [deviceInfo, result] = args;
+        const [deviceInfo, result, modelId] = args;
 
         (window as any).mock.events.mockDeviceEvent(
+          {
+            type: "deviceChange",
+            device: {
+              deviceId: "",
+              deviceName: "Some name",
+              modelId,
+            },
+            replaceable: false,
+          },
           {
             type: "listingApps",
             deviceInfo,
@@ -85,7 +105,7 @@ export class DeviceAction {
           { type: "complete" },
         );
       },
-      [deviceInfo, result],
+      [deviceInfo, result, modelId],
     );
 
     await this.loader.waitFor({ state: "hidden" });
@@ -96,12 +116,22 @@ export class DeviceAction {
     installedDesc = "Bitcoin,Litecoin,Ethereum (outdated)",
   ) {
     const result = mockListAppsResult(appDesc, installedDesc, deviceInfo210lo5);
+    const modelId = DeviceModelId.nanoX;
 
     await this.page.evaluate(
       args => {
-        const [deviceInfo210lo5, result] = args;
+        const [deviceInfo210lo5, result, modelId] = args;
 
         (window as any).mock.events.mockDeviceEvent(
+          {
+            type: "deviceChange",
+            device: {
+              deviceId: "",
+              deviceName: "Some name",
+              modelId,
+            },
+            replaceable: false,
+          },
           {
             type: "listingApps",
             deviceInfo: deviceInfo210lo5,
@@ -113,7 +143,7 @@ export class DeviceAction {
           { type: "complete" },
         );
       },
-      [deviceInfo210lo5, result],
+      [deviceInfo210lo5, result, modelId],
     );
 
     await this.loader.waitFor({ state: "hidden" });

--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -245,10 +245,11 @@ export class DeviceAction {
   async initiateSwap() {
     await this.page.evaluate(() => (window as any).mock.events.mockDeviceEvent({ type: "opened" }));
     await this.page.waitForTimeout(500);
-    await this.page.evaluate(() =>
-      (window as any).mock.events.mockDeviceEvent({ type: "complete" }),
-    );
-    await this.page.waitForTimeout(500);
+    // Keeping the same subject because it's too close and it's failing and I don't want to cry.
+    // await this.page.evaluate(() =>
+    //   (window as any).mock.events.mockDeviceEvent({ type: "complete" }),
+    // );
+    await this.page.waitForTimeout(2000);
     await this.page.evaluate(() =>
       (window as any).mock.events.mockDeviceEvent({ type: "init-swap-requested" }),
     );

--- a/apps/ledger-live-desktop/tests/models/MarketPage.ts
+++ b/apps/ledger-live-desktop/tests/models/MarketPage.ts
@@ -67,6 +67,8 @@ export class MarketPage {
 
   async openBuyPage(ticker: string) {
     await this.buyButton(ticker).click();
+    // FIXME windows seems to be choking on the transition taking longer.
+    await new Promise(resolve => setTimeout(resolve, 1000));
   }
 
   async openSwapPage(ticker: string) {

--- a/apps/ledger-live-desktop/tests/specs/syncOnboarding/install-set-of-apps.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/syncOnboarding/install-set-of-apps.spec.ts
@@ -54,6 +54,7 @@ test("Install set of apps", async ({ page }) => {
     await deviceAction.mockOpened();
     await installSetOfAppsPage.waitForInstallingTextToDisappear();
     await expect(page).toHaveScreenshot("debug-install-set-of-apps-completed.png");
+    await deviceAction.complete();
   });
 
   await test.step("restore apps from Ledger Stax", async () => {
@@ -82,6 +83,7 @@ test("Install set of apps", async ({ page }) => {
     await deviceAction.mockOpened();
     await installSetOfAppsPage.waitForInstallingTextToDisappear();
     await expect(page).toHaveScreenshot("debug-restore-set-of-apps-completed.png");
+    await deviceAction.complete();
   });
 
   await test.step("skip install or restore set of apps step", async () => {

--- a/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageAction.tsx
+++ b/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageAction.tsx
@@ -18,6 +18,7 @@ type Props = {
   onError?: (err: Error) => void;
 };
 
+const action = createAction(installLanguage);
 const ChangeDeviceLanguageAction: React.FC<Props> = ({
   device,
   language,
@@ -28,17 +29,7 @@ const ChangeDeviceLanguageAction: React.FC<Props> = ({
 }) => {
   const showAlert = !device?.wired;
   const { t } = useTranslation();
-
-  const action = useMemo(
-    () =>
-      createAction(() =>
-        installLanguage({
-          deviceId: device?.deviceId ?? "",
-          language,
-        }),
-      ),
-    [language, device?.deviceId],
-  );
+  const request = useMemo(() => ({ language }), [language]);
 
   useEffect(() => {
     if (onStart && device) {
@@ -51,8 +42,7 @@ const ChangeDeviceLanguageAction: React.FC<Props> = ({
       <Flex flexDirection="row" mb={showAlert ? "16px" : 0}>
         <DeviceAction
           action={action}
-          // FIXME: request should be a Language in theory :/
-          request={undefined}
+          request={request}
           device={device}
           onError={onError}
           renderOnResult={() => (

--- a/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageActionModal.tsx
@@ -15,6 +15,7 @@ type Props = {
   onResult?: () => void;
 };
 
+const action = createAction(installLanguage);
 const ChangeDeviceLanguageActionModal: React.FC<Props> = ({
   device,
   language,
@@ -22,22 +23,14 @@ const ChangeDeviceLanguageActionModal: React.FC<Props> = ({
   onError,
   onResult,
 }) => {
-  const action = useMemo(
-    () =>
-      createAction(() =>
-        installLanguage({
-          deviceId: device?.deviceId ?? "",
-          language,
-        }),
-      ),
-    [language, device?.deviceId],
-  );
+  const request = useMemo(() => ({ language }), [language]);
 
   return (
     <DeviceActionModal
       action={action}
       onClose={onClose}
       onError={onError}
+      request={request}
       device={device}
       renderOnResult={() => (
         <DeviceLanguageInstalled

--- a/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
@@ -1,4 +1,10 @@
-import React, { ComponentProps, useCallback, useEffect, useState } from "react";
+import React, {
+  ComponentProps,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useDispatch } from "react-redux";
 import { Image } from "react-native";
 import { Flex, Icons } from "@ledgerhq/native-ui";
@@ -59,7 +65,7 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   source,
   remountMe,
 }) => {
-  const commandRequest = hexImage;
+  const commandRequest = useMemo(() => ({ hexImage }), [hexImage]);
 
   const { t } = useTranslation();
   const dispatch = useDispatch();

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -224,7 +224,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   } = status;
 
   useEffect(() => {
-    if (deviceInfo) {
+    if (deviceInfo && device) {
       dispatch(
         setLastSeenDeviceInfo({
           modelId: device!.modelId,

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -64,6 +64,7 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
   const [completed, setCompleted] = useState<boolean>(false);
   const [error, setError] = useState<Error | undefined | null>(null);
   const [running, setRunning] = useState(false);
+  const request = useMemo(() => ({ name }), [name]);
 
   const onChangeText = useCallback((name: string) => {
     // Nb mobile devices tend to use U+2018 for single quote, not supported
@@ -162,7 +163,7 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
           {running ? (
             <DeviceActionModal
               device={device}
-              request={name}
+              request={request}
               action={action}
               onClose={onClose}
               onResult={onSuccess}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/FetchCustomImage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/FetchCustomImage.tsx
@@ -44,10 +44,9 @@ export default function DebugFetchCustomImage() {
 
   // TODO move all the logic here onto its own thing
   // when we implement the screens of the flow.
-  const status = deviceAction.useHook(
-    action === "fetch" ? device : undefined,
-    currentBackup.current,
-  );
+  const status = deviceAction.useHook(action === "fetch" ? device : undefined, {
+    backupHash: currentBackup.current,
+  });
 
   const onReset = useCallback(() => {
     setDevice(null);

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -1,14 +1,9 @@
 import semver from "semver";
 import { shouldUseTrustedInputForSegwit } from "@ledgerhq/hw-app-btc/shouldUseTrustedInputForSegwit";
-import type { DeviceModelId } from "@ledgerhq/devices";
 import { getDependencies } from "./polyfill";
 import { getEnv } from "../env";
 
-export function shouldUpgrade(
-  deviceModel: DeviceModelId,
-  appName: string,
-  appVersion: string
-): boolean {
+export function shouldUpgrade(appName: string, appVersion: string): boolean {
   if (getEnv("DISABLE_APP_VERSION_REQUIREMENTS")) return false;
   const deps = getDependencies(appName);
 
@@ -40,11 +35,7 @@ const appVersionsRequired = {
   Zcash: "> 2.0.6",
   NEAR: ">= 1.2.1",
 };
-export function mustUpgrade(
-  deviceModel: DeviceModelId,
-  appName: string,
-  appVersion: string
-): boolean {
+export function mustUpgrade(appName: string, appVersion: string): boolean {
   if (getEnv("DISABLE_APP_VERSION_REQUIREMENTS")) return false;
   const range = appVersionsRequired[appName];
 

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -1,28 +1,8 @@
 import invariant from "invariant";
-import {
-  concat,
-  of,
-  timer,
-  interval,
-  Observable,
-  throwError,
-  TimeoutError,
-  EMPTY,
-} from "rxjs";
-import {
-  scan,
-  debounce,
-  catchError,
-  timeout,
-  switchMap,
-  tap,
-  distinctUntilChanged,
-  takeWhile,
-} from "rxjs/operators";
-import isEqual from "lodash/isEqual";
+import { EMPTY, interval, Observable } from "rxjs";
+import { scan, debounce, tap, takeWhile } from "rxjs/operators";
 import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import { log } from "@ledgerhq/logs";
-import { getDeviceModel } from "@ledgerhq/devices";
 import {
   getDerivationScheme,
   getDerivationModesForCurrency,
@@ -31,6 +11,7 @@ import {
 import type {
   AppAndVersion,
   ConnectAppEvent,
+  ConnectAppRequest,
   Input as ConnectAppInput,
 } from "../connectApp";
 import { useReplaySubject } from "../../observable";
@@ -38,7 +19,6 @@ import { getAccountName } from "../../account";
 import type { Device, Action } from "./types";
 import { shouldUpgrade } from "../../apps";
 import { AppOp, SkippedAppOp } from "../../apps/types";
-import { ConnectAppTimeout } from "../../errors";
 import perFamilyAccount from "../../generated/account";
 import type {
   Account,
@@ -49,6 +29,7 @@ import type {
   CryptoCurrency,
   TokenCurrency,
 } from "@ledgerhq/types-cryptoassets";
+import { getImplementation, ImplementationType } from "./implementations";
 
 export type State = {
   isLoading: boolean;
@@ -263,8 +244,8 @@ const reducer = (state: State, e: Event): State => {
 
     case "error":
       return {
-        ...getInitialState(e.device, state.request),
-        device: e.device || null,
+        ...getInitialState(state.device, state.request),
+        device: state.device || null,
         error: e.error,
         isLoading: false,
         listingApps: false,
@@ -432,6 +413,11 @@ const reducer = (state: State, e: Event): State => {
   return state;
 };
 
+/**
+ * Map between an AppRequest and a ConnectAppRequest, allowing us to
+ * specify an account or a currency without resolving manually the actual
+ * applications we depend on in order to access the flow.
+ */
 function inferCommandParams(appRequest: AppRequest) {
   let derivationMode;
   let derivationPath;
@@ -499,136 +485,8 @@ function inferCommandParams(appRequest: AppRequest) {
   };
 }
 
-const DISCONNECT_DEBOUNCE = 5000;
-const implementations = {
-  // in this paradigm, we know that deviceSubject is reflecting the device events
-  // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
-  event: ({ deviceSubject, connectApp, params }) =>
-    deviceSubject.pipe(
-      // debounce a bit the disconnect events that we don't need
-      debounce((device) => timer(!device ? DISCONNECT_DEBOUNCE : 0)),
-      switchMap((device) =>
-        concat(
-          of({
-            type: "deviceChange",
-            device,
-          }),
-          connectApp(device, params)
-        )
-      )
-    ),
-  // in this paradigm, we can't observe directly the device, so we have to poll it
-  polling: ({ deviceSubject, params, connectApp }) =>
-    Observable.create((o) => {
-      const POLLING = 2000;
-      const INIT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 20000;
-      // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
-      let pollingOnDevice;
-      const sub = deviceSubject.subscribe((d) => {
-        if (d) {
-          pollingOnDevice = d;
-        }
-      });
-      let initT: NodeJS.Timeout | null = setTimeout(() => {
-        // initial timeout to unset the device if it's still not connected
-        o.next({
-          type: "deviceChange",
-          device: null,
-        });
-        device = null;
-        log("app/polling", "device init timeout");
-      }, INIT_DEBOUNCE);
-      let connectSub;
-      let loopT;
-      let disconnectT;
-      let device = null; // used as internal state for polling
-
-      function loop() {
-        if (!pollingOnDevice) {
-          loopT = setTimeout(loop, POLLING);
-          return;
-        }
-
-        log("app/polling", "polling loop");
-        connectSub = connectApp(pollingOnDevice, params)
-          .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
-              const productName = getDeviceModel(
-                pollingOnDevice.modelId
-              ).productName;
-              return err instanceof TimeoutError
-                ? of({
-                    type: "error",
-                    error: new ConnectAppTimeout(undefined, {
-                      productName,
-                    }) as Error,
-                  })
-                : throwError(err);
-            })
-          )
-          .subscribe({
-            next: (event) => {
-              if (initT) {
-                clearTimeout(initT);
-                initT = null;
-              }
-
-              if (disconnectT) {
-                // any connect app event unschedule the disconnect debounced event
-                disconnectT = null;
-                clearTimeout(disconnectT);
-              }
-
-              if (event.type === "unresponsiveDevice") {
-                return; // ignore unresponsive case which happens for polling
-              } else if (event.type === "disconnected") {
-                // the disconnect event is delayed to debounce the reconnection that happens when switching apps
-                disconnectT = setTimeout(() => {
-                  disconnectT = null;
-                  // a disconnect will locally be remembered via locally setting device to null...
-                  device = null;
-                  o.next(event);
-                  log("app/polling", "device disconnect timeout");
-                }, DISCONNECT_DEBOUNCE);
-              } else {
-                if (device !== pollingOnDevice) {
-                  // ...but any time an event comes back, it means our device was responding and need to be set back on in polling context
-                  device = pollingOnDevice;
-                  o.next({
-                    type: "deviceChange",
-                    device,
-                  });
-                }
-                o.next(event);
-              }
-            },
-            complete: () => {
-              // poll again in some time
-              loopT = setTimeout(loop, POLLING);
-            },
-            error: (e) => {
-              o.error(e);
-            },
-          });
-      }
-
-      // delay a bit the first loop run in order to be async and wait pollingOnDevice
-      loopT = setTimeout(loop, 0);
-      return () => {
-        if (initT) clearTimeout(initT);
-        if (disconnectT) clearTimeout(disconnectT);
-        if (connectSub) connectSub.unsubscribe();
-        sub.unsubscribe();
-        clearTimeout(loopT);
-      };
-    }).pipe(distinctUntilChanged(isEqual)),
-};
-
-export let currentMode: keyof typeof implementations = "event";
-
-export function setDeviceMode(mode: keyof typeof implementations): void {
+export let currentMode: keyof typeof ImplementationType = "event";
+export function setDeviceMode(mode: keyof typeof ImplementationType): void {
   currentMode = mode;
 }
 
@@ -640,48 +498,10 @@ export const createAction = (
     appRequest: AppRequest
   ): AppState => {
     const dependenciesResolvedRef = useRef(false);
-    const latestFirmwareResolvedRef = useRef(false);
+    const firmwareResolvedRef = useRef(false);
     const outdatedAppRef = useRef<AppAndVersion>();
 
-    const connectApp = useCallback(
-      (device, params) =>
-        !device
-          ? EMPTY
-          : connectAppExec({
-              modelId: device.modelId,
-              devicePath: device.deviceId,
-              ...params,
-              dependencies: dependenciesResolvedRef.current
-                ? undefined
-                : params.dependencies,
-              requireLatestFirmware: latestFirmwareResolvedRef.current
-                ? undefined
-                : params.requireLatestFirmware,
-              outdatedApp: outdatedAppRef.current,
-            }).pipe(
-              tap((e) => {
-                if (e.type === "dependencies-resolved") {
-                  dependenciesResolvedRef.current = true;
-                } else if (e.type === "latest-firmware-resolved") {
-                  latestFirmwareResolvedRef.current = true;
-                } else if (e.type === "has-outdated-app") {
-                  outdatedAppRef.current = e.outdatedApp as AppAndVersion;
-                }
-              }),
-              catchError((error: Error) =>
-                of({
-                  type: "error",
-                  error,
-                })
-              )
-            ),
-      []
-    );
-    // repair modal will interrupt everything and be rendered instead of the background content
-    const [state, setState] = useState(() => getInitialState(device));
-    const [resetIndex, setResetIndex] = useState(0);
-    const deviceSubject = useReplaySubject(device);
-    const params = useMemo(
+    const request: ConnectAppRequest = useMemo(
       () => inferCommandParams(appRequest), // for now i don't have better
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [
@@ -691,53 +511,90 @@ export const createAction = (
       ]
     );
 
+    const task: (arg0: ConnectAppInput) => Observable<ConnectAppEvent> =
+      useCallback(({ deviceId, request }: ConnectAppInput) => {
+        // Some requests require two runs to complete since we need to
+        // validate before completeing the action. For instance if we have
+        // dependencies we need to reach BOLOS first, then resolve them, and
+        // finally open the target app.
+        const { dependencies, requireLatestFirmware } = request;
+
+        return connectAppExec({
+          deviceId,
+          request: {
+            ...request,
+            dependencies: dependenciesResolvedRef.current
+              ? undefined
+              : dependencies,
+            requireLatestFirmware: firmwareResolvedRef.current
+              ? undefined
+              : requireLatestFirmware,
+            outdatedApp: outdatedAppRef.current,
+          },
+        }).pipe(
+          tap((e) => {
+            // These events signal the resolution of pending checks.
+            if (e.type === "dependencies-resolved") {
+              dependenciesResolvedRef.current = true;
+            } else if (e.type === "latest-firmware-resolved") {
+              firmwareResolvedRef.current = true;
+            } else if (e.type === "has-outdated-app") {
+              outdatedAppRef.current = e.outdatedApp as AppAndVersion;
+            }
+          })
+        );
+      }, []);
+
+    // repair modal will interrupt everything and be rendered instead of the background content
+    const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
+    const deviceSubject = useReplaySubject(device);
+
     useEffect(() => {
       if (state.opened) return;
-      const impl = implementations[currentMode];
-      const sub = impl({
-        deviceSubject,
-        connectApp,
-        params,
-      })
-        .pipe(
-          tap((e: Event) => log("actions-app-event", e.type, e)), // tap(e => console.log("connectApp event", e)),
-          // we gather all events with a reducer into the UI state
-          scan(reducer, getInitialState()), // tap((s) => console.log("connectApp state", s)),
-          // we debounce the UI state to not blink on the UI
-          debounce((s: State) => {
-            if (
-              s.allowOpeningRequestedWording ||
-              s.allowOpeningGranted ||
-              s.deviceInfo
-            ) {
-              // no debounce for allow event
-              return EMPTY;
-            }
 
-            // default debounce (to be tweak)
-            return interval(2000);
-          }),
+      const impl = getImplementation(currentMode)<
+        ConnectAppEvent,
+        ConnectAppRequest
+      >({
+        deviceSubject,
+        task,
+        request,
+      });
+
+      const sub = impl
+        .pipe(
+          tap((e: any) => log("actions-app-event", e.type, e)),
+          debounce((e: Event) =>
+            e.type === "deviceChange" ? EMPTY : interval(100)
+          ),
+          scan(reducer, getInitialState()),
           takeWhile((s: State) => !s.requiresAppInstallation && !s.error, true)
-        ) // the state simply goes into a React state
+        )
         .subscribe(setState);
-      // FIXME shouldn't we handle errors?! (is an error possible?)
+
       return () => {
         sub.unsubscribe();
       };
-    }, [params, deviceSubject, state.opened, resetIndex, connectApp]);
+    }, [deviceSubject, state.opened, resetIndex, task, request]);
+
     const onRetry = useCallback(() => {
-      // After an error we can't guarantee dependencies are resolved
+      // After an error we can't guarantee resolutions.
       dependenciesResolvedRef.current = false;
-      latestFirmwareResolvedRef.current = false;
+      firmwareResolvedRef.current = false;
+
+      // The nonce change triggers a refresh.
       setResetIndex((i) => i + 1);
       setState(getInitialState(device));
     }, [device]);
+
     const passWarning = useCallback(() => {
       setState((currState) => ({
         ...currState,
         displayUpgradeWarning: false,
       }));
     }, []);
+
     return {
       ...state,
       inWrongDeviceForAccount:

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -513,10 +513,7 @@ export const createAction = (
 
     const task: (arg0: ConnectAppInput) => Observable<ConnectAppEvent> =
       useCallback(({ deviceId, request }: ConnectAppInput) => {
-        // Some requests require two runs to complete since we need to
-        // validate before completeing the action. For instance if we have
-        // dependencies we need to reach BOLOS first, then resolve them, and
-        // finally open the target app.
+        //To avoid redundant checks, we remove passed checks from the request.
         const { dependencies, requireLatestFirmware } = request;
 
         return connectAppExec({

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -562,7 +562,9 @@ export const createAction = (
       const sub = impl
         .pipe(
           tap((e: any) => log("actions-app-event", e.type, e)),
-          debounce((e: Event) => ("replaceable" in e ? interval(100) : EMPTY)),
+          debounce((e: Event) =>
+            "replaceable" in e && e.replaceable ? interval(100) : EMPTY
+          ),
           scan(reducer, getInitialState()),
           takeWhile((s: State) => !s.requiresAppInstallation && !s.error, true)
         )

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -405,7 +405,7 @@ const reducer = (state: State, e: Event): State => {
         listedApps: state.listedApps,
         displayUpgradeWarning:
           state.device && e.app
-            ? shouldUpgrade(state.device.modelId, e.app.name, e.app.version)
+            ? shouldUpgrade(e.app.name, e.app.version)
             : false,
       };
   }

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -562,9 +562,7 @@ export const createAction = (
       const sub = impl
         .pipe(
           tap((e: any) => log("actions-app-event", e.type, e)),
-          debounce((e: Event) =>
-            e.type === "deviceChange" ? EMPTY : interval(100)
-          ),
+          debounce((e: Event) => ("replaceable" in e ? interval(100) : EMPTY)),
           scan(reducer, getInitialState()),
           takeWhile((s: State) => !s.requiresAppInstallation && !s.error, true)
         )

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -1,0 +1,283 @@
+import {
+  EMPTY,
+  Observable,
+  Observer,
+  ReplaySubject,
+  Subscription,
+  TimeoutError,
+  concat,
+  of,
+  timer,
+} from "rxjs";
+import {
+  DisconnectedDevice,
+  DisconnectedDeviceDuringOperation,
+} from "@ledgerhq/errors";
+import {
+  catchError,
+  debounce,
+  filter,
+  switchMap,
+  tap,
+  timeout,
+} from "rxjs/operators";
+import { Device } from "./types";
+import { getDeviceModel } from "@ledgerhq/devices";
+import { ConnectManagerTimeout } from "../../errors";
+
+export enum ImplementationType {
+  event = "enum",
+  polling = "polling",
+}
+
+type ImplementationEvent =
+  | {
+      type: "deviceChange";
+      device?: Device | undefined | null;
+    }
+  | {
+      type: "unresponsiveDevice";
+    }
+  | {
+      type: "error";
+      error: Error;
+    };
+
+type PollingImplementationConfig = {
+  pollingFrequency: number;
+  initialWaitTime: number;
+  reconnectWaitTime: number;
+  connectionTimeout: number;
+};
+
+type PollingImplementationParams<Request, EmittedEvents> = {
+  deviceSubject: ReplaySubject<Device | null | undefined>;
+  task: (params: {
+    deviceId: string;
+    request: Request;
+  }) => Observable<EmittedEvents>;
+  request: Request;
+  config?: PollingImplementationConfig;
+};
+
+const defaultConfig: PollingImplementationConfig = {
+  pollingFrequency: 2000,
+  initialWaitTime: 5000,
+  reconnectWaitTime: 5000,
+  connectionTimeout: 20000,
+};
+type Implementation = <EmittedEvent, GenericRequestType>(
+  params: PollingImplementationParams<GenericRequestType, EmittedEvent>
+) => Observable<EmittedEvent | ImplementationEvent>;
+
+export type EmittedEvent<T> = {
+  type: string;
+} & T;
+
+/**
+ * Returns a polling implementation function that repeatedly performs a given task
+ * with a given request, with a specified polling frequency and wait times until a
+ * KO or OK end state is reached. This emulates the event based connection paradigm
+ * from the USB stack in a BLE setting.
+ * @template EmittedEvent - Type of the events emitted by the task's observable.
+ * @template GenericRequestType - Type of the request to be passed to the task.
+ **/
+const pollingImplementation: Implementation = <
+  SpecificType,
+  GenericRequestType
+>(
+  params: PollingImplementationParams<GenericRequestType, SpecificType>
+): Observable<SpecificType | ImplementationEvent> =>
+  new Observable(
+    (
+      subscriber: Observer<EmittedEvent<SpecificType> | ImplementationEvent>
+    ) => {
+      const { deviceSubject, task, request, config = defaultConfig } = params;
+      const {
+        pollingFrequency,
+        initialWaitTime,
+        reconnectWaitTime,
+        connectionTimeout,
+      } = config;
+
+      let shouldStopPolling = false;
+      let connectSub: Subscription;
+      let loopTimeout: NodeJS.Timeout | null;
+
+      let currentDevice: Device;
+      const deviceSubjectSub = deviceSubject.subscribe((device) => {
+        currentDevice = device || currentDevice;
+      });
+
+      // Cover case where our device job never gets a transport instance
+      // it will signal back to the consumer that we don't have a device.
+      let initialTimeout: NodeJS.Timeout | null = setTimeout(() => {
+        return subscriber.next({
+          type: "deviceChange",
+          device: undefined,
+        });
+      }, initialWaitTime);
+
+      // Runs every time we get a new device.
+      function actionLoop() {
+        if (currentDevice) {
+          const productName = getDeviceModel(currentDevice.modelId).productName;
+
+          connectSub = concat(
+            of({
+              type: "deviceChange",
+              device: currentDevice,
+            }),
+            task({ deviceId: currentDevice.deviceId, request })
+          )
+            .pipe(
+              // Any event should clear the initialTimeout.
+              tap((_: any) => {
+                if (initialTimeout) {
+                  clearTimeout(initialTimeout);
+                  initialTimeout = null;
+                }
+              }),
+
+              // More than `connectionTimeout` time of silence, is considered
+              // a failed connection. Depending on the flow this may mean we'd have
+              // to emit an `alive` kind of event.
+              timeout(connectionTimeout),
+
+              filter(
+                (event: EmittedEvent<SpecificType> | ImplementationEvent) => {
+                  if ("type" in event) {
+                    return event.type !== "unresponsiveDevice";
+                  }
+                  return false;
+                }
+              ),
+
+              catchError((error: Error) => {
+                const maybeRemappedError =
+                  error instanceof TimeoutError
+                    ? (new ConnectManagerTimeout(undefined, {
+                        // TODO make this configurable
+                        productName,
+                      }) as Error)
+                    : error;
+
+                return of({
+                  type: "error",
+                  error: maybeRemappedError,
+                } as ImplementationEvent);
+              }),
+
+              debounce(
+                (event: EmittedEvent<SpecificType> | ImplementationEvent) => {
+                  if (event.type === "error" && "error" in event) {
+                    const error = event.error as unknown;
+                    if (
+                      // Delay emission of disconnects to allow reconnection.
+                      error instanceof DisconnectedDevice ||
+                      error instanceof DisconnectedDeviceDuringOperation
+                    ) {
+                      return timer(reconnectWaitTime);
+                    } else {
+                      // Other errors should cancel the loop.
+                      shouldStopPolling = true;
+                    }
+                  }
+                  // All other events pass through.
+                  return EMPTY;
+                }
+              )
+            )
+            .subscribe({
+              next: (event: any) => {
+                subscriber.next(event);
+              },
+              error: (e: any) => {
+                subscriber.error(e);
+              },
+              complete: () => {
+                if (shouldStopPolling) return;
+                loopTimeout = setTimeout(actionLoop, pollingFrequency);
+              },
+            });
+        } else {
+          // We currently don't have a device, try again.
+          loopTimeout = setTimeout(actionLoop, pollingFrequency);
+        }
+      }
+
+      // Delay the first loop run in order to be async.
+      loopTimeout = setTimeout(actionLoop, 0);
+
+      // Get rid of pending timeouts and subscriptions.
+      return function cleanup() {
+        if (deviceSubjectSub) deviceSubjectSub.unsubscribe();
+        if (connectSub) connectSub.unsubscribe();
+
+        if (initialTimeout) clearTimeout(initialTimeout);
+        if (loopTimeout) clearTimeout(loopTimeout);
+      };
+    }
+  );
+
+const eventImplementation: Implementation = <SpecificType, GenericRequestType>(
+  params: PollingImplementationParams<GenericRequestType, SpecificType>
+): Observable<EmittedEvent<SpecificType> | ImplementationEvent> => {
+  const { deviceSubject, task, request, config = defaultConfig } = params;
+  const { reconnectWaitTime } = config;
+  return new Observable(
+    (
+      subscriber: Observer<EmittedEvent<SpecificType> | ImplementationEvent>
+    ) => {
+      const connectSub = deviceSubject
+        .pipe(
+          debounce((device) => timer(!device ? reconnectWaitTime : 0)),
+          switchMap((device) => {
+            const initialEvent = of({
+              type: "deviceChange",
+              device,
+            });
+
+            return concat(
+              initialEvent,
+              !device
+                ? EMPTY
+                : task({ deviceId: device.deviceId, request }).pipe(
+                    filter(
+                      // unresponsiveDevice are for polling.
+                      (event) =>
+                        (event as ImplementationEvent).type !==
+                        "unresponsiveDevice"
+                    )
+                  )
+            );
+          }),
+          catchError((error: Error) =>
+            of({
+              type: "error",
+              error,
+            })
+          )
+        )
+        .subscribe({
+          next: (event: any) => {
+            subscriber.next(event);
+          },
+          error: (e: any) => {
+            subscriber.error(e);
+          },
+          complete: () => {},
+        });
+
+      // Get rid of subscriptions.
+      return function cleanup() {
+        if (connectSub) connectSub.unsubscribe();
+      };
+    }
+  );
+};
+
+const getImplementation = (currentMode: string): Implementation =>
+  currentMode === "polling" ? pollingImplementation : eventImplementation;
+
+export { pollingImplementation, eventImplementation, getImplementation };

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -103,6 +103,7 @@ const pollingImplementation: Implementation = <
       let shouldStopPolling = false;
       let connectSub: Subscription;
       let loopTimeout: NodeJS.Timeout | null;
+      let firstRound: boolean = true;
 
       let currentDevice: Device;
       const deviceSubjectSub = deviceSubject.subscribe((device) => {
@@ -127,6 +128,7 @@ const pollingImplementation: Implementation = <
             of({
               type: "deviceChange",
               device: currentDevice,
+              replaceable: !firstRound,
             }),
             task({ deviceId: currentDevice.deviceId, request })
           )
@@ -197,6 +199,7 @@ const pollingImplementation: Implementation = <
               },
               complete: () => {
                 if (shouldStopPolling) return;
+                firstRound = false; // For proper debouncing.
                 loopTimeout = setTimeout(actionLoop, pollingFrequency);
               },
             });

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -103,7 +103,7 @@ const pollingImplementation: Implementation = <
       let shouldStopPolling = false;
       let connectSub: Subscription;
       let loopTimeout: NodeJS.Timeout | null;
-      let firstRound: boolean = true;
+      let firstRound = true;
 
       let currentDevice: Device;
       const deviceSubjectSub = deviceSubject.subscribe((device) => {

--- a/libs/ledger-live-common/src/hw/actions/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/actions/installLanguage.ts
@@ -1,22 +1,5 @@
-import {
-  concat,
-  of,
-  EMPTY,
-  interval,
-  Observable,
-  TimeoutError,
-  throwError,
-} from "rxjs";
-import {
-  scan,
-  debounce,
-  debounceTime,
-  catchError,
-  switchMap,
-  tap,
-  distinctUntilChanged,
-  timeout,
-} from "rxjs/operators";
+import { Observable } from "rxjs";
+import { scan, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
@@ -24,17 +7,11 @@ import { useReplaySubject } from "../../observable";
 import type {
   InstallLanguageEvent,
   InstallLanguageRequest,
+  Input as InstallLanguageInput,
 } from "../installLanguage";
 import type { Action, Device } from "./types";
-import isEqual from "lodash/isEqual";
-import { ConnectManagerTimeout } from "../../errors";
 import { currentMode } from "./app";
-import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-} from "@ledgerhq/errors";
-import { getDeviceModel } from "@ledgerhq/devices";
-import { Language } from "@ledgerhq/types-live";
+import { getImplementation } from "./implementations";
 
 type State = {
   isLoading: boolean;
@@ -50,7 +27,7 @@ type State = {
 };
 
 type InstallLanguageAction = Action<
-  Language | undefined,
+  InstallLanguageRequest,
   State,
   boolean | undefined
 >;
@@ -127,179 +104,12 @@ const reducer = (state: State, e: Event): State => {
   }
 };
 
-const implementations = {
-  // in this paradigm, we know that deviceSubject is reflecting the device events
-  // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
-  event: ({ deviceSubject, installLanguage, language }) =>
-    deviceSubject.pipe(
-      debounceTime(1000),
-      switchMap((d) => installLanguage(d, language))
-    ),
-  // in this paradigm, we can't observe directly the device, so we have to poll it
-  polling: ({ deviceSubject, installLanguage, language }) =>
-    new Observable((o) => {
-      const POLLING = 2000;
-      const INIT_DEBOUNCE = 5000;
-      const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 30000;
-      // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
-      let pollingOnDevice;
-      const sub = deviceSubject.subscribe((d) => {
-        if (d) {
-          pollingOnDevice = d;
-        }
-      });
-      let initT: NodeJS.Timeout | null = setTimeout(() => {
-        // initial timeout to unset the device if it's still not connected
-        o.next({
-          type: "deviceChange",
-          device: null,
-        });
-        device = null;
-        log("actions-install-language-event/polling", "device init timeout");
-      }, INIT_DEBOUNCE);
-      let connectSub;
-      let loopT;
-      let disconnectT;
-      let device = null; // used as internal state for polling
-
-      let stopDevicePollingError = null;
-
-      function loop() {
-        stopDevicePollingError = null;
-
-        if (!pollingOnDevice) {
-          loopT = setTimeout(loop, POLLING);
-          return;
-        }
-
-        log("actions-install-language-event/polling", "polling loop");
-        connectSub = installLanguage(pollingOnDevice, language)
-          .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
-              const productName = getDeviceModel(
-                pollingOnDevice.modelId
-              ).productName;
-              return err instanceof TimeoutError
-                ? of({
-                    type: "error",
-                    error: new ConnectManagerTimeout(undefined, {
-                      productName,
-                    }) as Error,
-                  })
-                : throwError(err);
-            })
-          )
-          .subscribe({
-            next: (event) => {
-              if (initT && device) {
-                clearTimeout(initT);
-                initT = null;
-              }
-
-              if (disconnectT) {
-                // any connect app event unschedule the disconnect debounced event
-                clearTimeout(disconnectT);
-                disconnectT = null;
-              }
-
-              if (event.type === "error" && event.error) {
-                if (
-                  event.error instanceof DisconnectedDevice ||
-                  event.error instanceof DisconnectedDeviceDuringOperation
-                ) {
-                  // disconnect on manager actions seems to trigger a type "error" instead of "disconnect"
-                  // the disconnect event is delayed to debounce the reconnection that happens when switching apps
-                  disconnectT = setTimeout(() => {
-                    disconnectT = null;
-                    // a disconnect will locally be remembered via locally setting device to null...
-                    device = null;
-                    o.next(event);
-                    log(
-                      "actions-install-language-event/polling",
-                      "device disconnect timeout"
-                    );
-                  }, DISCONNECT_DEBOUNCE);
-                } else {
-                  // These error events should stop polling
-                  stopDevicePollingError = event.error;
-
-                  // clear all potential polling loops
-                  if (loopT) {
-                    clearTimeout(loopT);
-                    loopT = null;
-                  }
-
-                  // send in the event for the UI immediately
-                  o.next(event);
-                }
-              } else if (event.type === "unresponsiveDevice") {
-                return; // ignore unresponsive case which happens for polling
-              } else {
-                if (device !== pollingOnDevice) {
-                  // ...but any time an event comes back, it means our device was responding and need to be set back on in polling context
-                  device = pollingOnDevice;
-                  o.next({
-                    type: "deviceChange",
-                    device,
-                  });
-                }
-
-                o.next(event);
-              }
-            },
-            complete: () => {
-              // start a new polling if available
-              if (!stopDevicePollingError) loopT = setTimeout(loop, POLLING);
-            },
-            error: (e) => {
-              o.error(e);
-            },
-          });
-      }
-
-      // delay a bit the first loop run in order to be async and wait pollingOnDevice
-      loopT = setTimeout(loop, 0);
-      return () => {
-        if (initT) clearTimeout(initT);
-        if (disconnectT) clearTimeout(disconnectT);
-        if (connectSub) connectSub.unsubscribe();
-        sub.unsubscribe();
-        clearTimeout(loopT);
-      };
-    }).pipe(distinctUntilChanged(isEqual)),
-};
 export const createAction = (
-  installLanuageExec: (
-    arg0: InstallLanguageRequest
-  ) => Observable<InstallLanguageEvent>
+  task: (arg0: InstallLanguageInput) => Observable<InstallLanguageEvent>
 ): InstallLanguageAction => {
-  const installLanguage = (device, language: Language) => {
-    return concat(
-      of({
-        type: "deviceChange",
-        device,
-      }),
-      !device
-        ? EMPTY
-        : installLanuageExec({
-            deviceId: device.deviceId,
-            language: language,
-          }).pipe(
-            catchError((error: Error) =>
-              of({
-                type: "error",
-                error,
-              })
-            )
-          )
-    );
-  };
-
   const useHook = (
     device: Device | null | undefined,
-    language: Language | undefined
+    request: InstallLanguageRequest
   ): State => {
     const [state, setState] = useState(() => getInitialState(device));
     const deviceSubject = useReplaySubject(device);
@@ -307,33 +117,25 @@ export const createAction = (
     useEffect(() => {
       if (state.languageInstalled) return;
 
-      const impl = implementations[currentMode]({
+      const impl = getImplementation(currentMode)<
+        InstallLanguageEvent,
+        InstallLanguageRequest
+      >({
         deviceSubject,
-        installLanguage,
-        language,
+        task,
+        request,
       });
 
       const sub = impl
         .pipe(
-          // debounce a bit the connect/disconnect event that we don't need
-          tap((e: Event) => log("actions-install-language-event", e.type, e)),
-          // we gather all events with a reducer into the UI state
-          scan(reducer, getInitialState()),
-          // we debounce the UI state to not blink on the UI
-          debounce((s: State) => {
-            if (s.installingLanguage || s.languageInstallationRequested) {
-              return EMPTY;
-            }
-
-            // default debounce (to be tweak)
-            return interval(1500);
-          })
-        ) // the state simply goes into a React state
+          tap((e: any) => log("actions-install-language-event", e.type, e)),
+          scan(reducer, getInitialState())
+        )
         .subscribe(setState);
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, language, state.languageInstalled]);
+    }, [deviceSubject, request, state.languageInstalled]);
 
     return {
       ...state,

--- a/libs/ledger-live-common/src/hw/actions/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/actions/installLanguage.ts
@@ -102,6 +102,7 @@ const reducer = (state: State, e: Event): State => {
         progress: e.progress,
       };
   }
+  return state; // Nb Needed until e2e tests are better handled.
 };
 
 export const createAction = (

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -3,7 +3,6 @@ import { debounce, scan, tap } from "rxjs/operators";
 import { useEffect, useCallback, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
-import { getEnv } from "@ledgerhq/live-env";
 import type { ListAppsResult } from "../../apps/types";
 import { useReplaySubject } from "../../observable";
 import manager from "../../manager";
@@ -197,14 +196,8 @@ export const createAction = (
       const sub = impl
         .pipe(
           tap((e: any) => log("actions-manager-event", e.type, e)),
-          scan(reducer, getInitialState()),
-          debounce((s: State) => {
-            if (s.allowManagerRequestedWording || s.allowManagerGranted) {
-              return EMPTY;
-            }
-            //Nb consider dropping altogether (?)
-            return interval(getEnv("LIST_APPS_V2") ? 100 : 1500);
-          })
+          debounce((e: Event) => ("replaceable" in e ? interval(100) : EMPTY)),
+          scan(reducer, getInitialState())
         )
         .subscribe(setState);
       return () => {

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -1,42 +1,19 @@
-import {
-  concat,
-  of,
-  EMPTY,
-  Observable,
-  TimeoutError,
-  throwError,
-  timer,
-  interval,
-} from "rxjs";
-import {
-  scan,
-  debounce,
-  catchError,
-  switchMap,
-  tap,
-  distinctUntilChanged,
-  timeout,
-} from "rxjs/operators";
-import isEqual from "lodash/isEqual";
+import { EMPTY, Observable, interval } from "rxjs";
+import { debounce, scan, tap } from "rxjs/operators";
 import { useEffect, useCallback, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-} from "@ledgerhq/errors";
-import { getDeviceModel } from "@ledgerhq/devices";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";
 import type { ListAppsResult } from "../../apps/types";
 import { useReplaySubject } from "../../observable";
 import manager from "../../manager";
 import type {
-  ConnectManagerEvent,
   Input as ConnectManagerInput,
+  ConnectManagerEvent,
 } from "../connectManager";
 import type { Action, Device } from "./types";
-import { ConnectManagerTimeout } from "../../errors";
 import { currentMode } from "./app";
+import { getImplementation } from "./implementations";
 
 type State = {
   isLoading: boolean;
@@ -77,7 +54,7 @@ export type Result = {
   result: ListAppsResult | null | undefined;
 };
 
-type ManagerAction = Action<ManagerRequest, ManagerState, Result>;
+type ConnectManagerAction = Action<ManagerRequest, ManagerState, Result>;
 
 type Event =
   | ConnectManagerEvent
@@ -100,7 +77,7 @@ const mapResult = ({ deviceInfo, device, result }): Result | null | undefined =>
     : null;
 
 const getInitialState = (device?: Device | null | undefined): State => ({
-  isLoading: !!device,
+  isLoading: device === undefined || !!device,
   requestQuitApp: false,
   unresponsive: false,
   isLocked: false,
@@ -153,6 +130,7 @@ const reducer = (state: State, e: Event): State => {
     case "listingApps":
       return {
         ...state,
+        isLoading: true,
         requestQuitApp: false,
         unresponsive: false,
         isLocked: false,
@@ -189,214 +167,50 @@ const reducer = (state: State, e: Event): State => {
   return state;
 };
 
-const DISCONNECT_DEBOUNCE = 5000;
-const implementations = {
-  // in this paradigm, we know that deviceSubject is reflecting the device events
-  // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
-  event: ({ deviceSubject, connectManager, managerRequest }) =>
-    deviceSubject.pipe(
-      debounce((device) => timer(!device ? DISCONNECT_DEBOUNCE : 0)),
-      switchMap((d) => connectManager(d, managerRequest))
-    ),
-  // in this paradigm, we can't observe directly the device, so we have to poll it
-  polling: ({ deviceSubject, connectManager, managerRequest }) =>
-    Observable.create((o) => {
-      const POLLING = 2000;
-      const INIT_DEBOUNCE = 5000;
-      const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 20000;
-      // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
-      let pollingOnDevice;
-      const sub = deviceSubject.subscribe((d) => {
-        if (d) {
-          pollingOnDevice = d;
-        }
-      });
-      let initT: NodeJS.Timeout | null = setTimeout(() => {
-        // initial timeout to unset the device if it's still not connected
-        o.next({
-          type: "deviceChange",
-          device: null,
-        });
-        device = null;
-        log("app/polling", "device init timeout");
-      }, INIT_DEBOUNCE);
-      let connectSub;
-      let loopT;
-      let disconnectT;
-      let device = null; // used as internal state for polling
-
-      let stopDevicePollingError = null;
-
-      function loop() {
-        stopDevicePollingError = null;
-
-        if (!pollingOnDevice) {
-          loopT = setTimeout(loop, POLLING);
-          return;
-        }
-
-        log("manager/polling", "polling loop");
-        connectSub = connectManager(pollingOnDevice, managerRequest)
-          .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
-              const productName = getDeviceModel(
-                pollingOnDevice.modelId
-              ).productName;
-              return err instanceof TimeoutError
-                ? of({
-                    type: "error",
-                    error: new ConnectManagerTimeout(undefined, {
-                      productName,
-                    }) as Error,
-                  })
-                : throwError(err);
-            })
-          )
-          .subscribe({
-            next: (event) => {
-              if (initT && device) {
-                clearTimeout(initT);
-                initT = null;
-              }
-
-              if (disconnectT) {
-                // any connect app event unschedule the disconnect debounced event
-                clearTimeout(disconnectT);
-                disconnectT = null;
-              }
-
-              if (event.type === "error" && event.error) {
-                if (
-                  event.error instanceof DisconnectedDevice ||
-                  event.error instanceof DisconnectedDeviceDuringOperation
-                ) {
-                  // disconnect on manager actions seems to trigger a type "error" instead of "disconnect"
-                  // the disconnect event is delayed to debounce the reconnection that happens when switching apps
-                  disconnectT = setTimeout(() => {
-                    disconnectT = null;
-                    // a disconnect will locally be remembered via locally setting device to null...
-                    device = null;
-                    o.next(event);
-                    log("app/polling", "device disconnect timeout");
-                  }, DISCONNECT_DEBOUNCE);
-                } else {
-                  // These error events should stop polling
-                  stopDevicePollingError = event.error;
-
-                  // clear all potential polling loops
-                  if (loopT) {
-                    clearTimeout(loopT);
-                    loopT = null;
-                  }
-
-                  // send in the event for the UI immediately
-                  o.next(event);
-                }
-              } else if (event.type === "unresponsiveDevice") {
-                return; // ignore unresponsive case which happens for polling
-              } else {
-                if (device !== pollingOnDevice) {
-                  // ...but any time an event comes back, it means our device was responding and need to be set back on in polling context
-                  device = pollingOnDevice;
-                  o.next({
-                    type: "deviceChange",
-                    device,
-                  });
-                }
-
-                o.next(event);
-              }
-            },
-            complete: () => {
-              // start a new polling if available
-              if (!stopDevicePollingError) loopT = setTimeout(loop, POLLING);
-            },
-            error: (e) => {
-              o.error(e);
-            },
-          });
-      }
-
-      // delay a bit the first loop run in order to be async and wait pollingOnDevice
-      loopT = setTimeout(loop, 0);
-      return () => {
-        if (initT) clearTimeout(initT);
-        if (disconnectT) clearTimeout(disconnectT);
-        if (connectSub) connectSub.unsubscribe();
-        sub.unsubscribe();
-        clearTimeout(loopT);
-      };
-    }).pipe(distinctUntilChanged(isEqual)),
-};
-
 export const createAction = (
-  connectManagerExec: (
-    arg0: ConnectManagerInput
-  ) => Observable<ConnectManagerEvent>
-): ManagerAction => {
-  const connectManager = (device, managerRequest) =>
-    concat(
-      of({
-        type: "deviceChange",
-        device,
-      }),
-      !device
-        ? EMPTY
-        : connectManagerExec({
-            devicePath: device.deviceId,
-            managerRequest,
-          }).pipe(
-            catchError((error: Error) =>
-              of({
-                type: "error",
-                error,
-              })
-            )
-          )
-    );
-
+  task: (arg0: ConnectManagerInput) => Observable<ConnectManagerEvent>
+): ConnectManagerAction => {
   const useHook = (
     device: Device | null | undefined,
-    managerRequest: ManagerRequest = {}
+    request: ManagerRequest = {}
   ): ManagerState => {
+    const [state, setState] = useState(() => getInitialState());
+    const [resetIndex, setResetIndex] = useState(0);
+    const deviceSubject = useReplaySubject(device);
+
     // repair modal will interrupt everything and be rendered instead of the background content
     const [repairModalOpened, setRepairModalOpened] = useState<{
       auto: boolean;
     } | null>(null);
-    const [state, setState] = useState(() => getInitialState(device));
-    const [resetIndex, setResetIndex] = useState(0);
-    const deviceSubject = useReplaySubject(device);
 
     useEffect(() => {
-      const impl = implementations[currentMode]({
+      const impl = getImplementation(currentMode)<
+        ConnectManagerEvent,
+        ManagerRequest
+      >({
         deviceSubject,
-        connectManager,
-        managerRequest,
+        task,
+        request,
       });
+
       if (repairModalOpened) return;
       const sub = impl
         .pipe(
-          tap((e: Event) => log("actions-manager-event", e.type, e)), // tap(e => console.log("connectManager event", e)),
-          // we gather all events with a reducer into the UI state
+          tap((e: any) => log("actions-manager-event", e.type, e)),
           scan(reducer, getInitialState()),
-          // we debounce the UI state to not blink on the UI
           debounce((s: State) => {
             if (s.allowManagerRequestedWording || s.allowManagerGranted) {
-              // no debounce for allow manager
               return EMPTY;
             }
-
-            // default debounce (to be tweak)
-            return interval(getEnv("LIST_APPS_V2") ? 150 : 1500);
+            //Nb consider dropping altogether (?)
+            return interval(getEnv("LIST_APPS_V2") ? 100 : 1500);
           })
-        ) // the state simply goes into a React state
+        )
         .subscribe(setState);
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, resetIndex, repairModalOpened, managerRequest]);
+    }, [deviceSubject, resetIndex, repairModalOpened, request]);
 
     const { deviceInfo } = state;
     useEffect(() => {
@@ -406,6 +220,7 @@ export const createAction = (
         log("warn", e.message);
       });
     }, [deviceInfo]);
+
     const onRepairModal = useCallback((open) => {
       setRepairModalOpened(
         open

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -196,7 +196,9 @@ export const createAction = (
       const sub = impl
         .pipe(
           tap((e: any) => log("actions-manager-event", e.type, e)),
-          debounce((e: Event) => ("replaceable" in e ? interval(100) : EMPTY)),
+          debounce((e: Event) =>
+            "replaceable" in e && e.replaceable ? interval(100) : EMPTY
+          ),
           scan(reducer, getInitialState())
         )
         .subscribe(setState);

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -1,31 +1,21 @@
-import { concat, of, EMPTY, Observable, TimeoutError, throwError } from "rxjs";
-import {
-  scan,
-  debounceTime,
-  catchError,
-  switchMap,
-  map,
-  tap,
-  distinctUntilChanged,
-  timeout,
-} from "rxjs/operators";
+import { Observable } from "rxjs";
+import { scan, map, tap } from "rxjs/operators";
 import { useEffect, useMemo, useCallback, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { UserRefusedDeviceNameChange } from "@ledgerhq/errors";
 import { useReplaySubject } from "../../observable";
 import type { Action, Device } from "./types";
-import isEqual from "lodash/isEqual";
-import { ConnectManagerTimeout } from "../../errors";
-import { RenameDeviceEvent, RenameDeviceRequest } from "../renameDevice";
-import { currentMode } from "./app";
 import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-} from "@ledgerhq/errors";
+  RenameDeviceEvent,
+  RenameDeviceRequest,
+  Input as RenameDeviceInput,
+} from "../renameDevice";
+import { currentMode } from "./app";
 import { getDeviceModel } from "@ledgerhq/devices";
+import { getImplementation } from "./implementations";
 
-type State = {
+type RenameDeviceState = {
   isLoading: boolean;
   allowManagerRequestedWording: string | null | undefined;
   unresponsive: boolean;
@@ -37,9 +27,11 @@ type State = {
   onRetry?: () => void;
 };
 
-type RenameDeviceAction = Action<string, State, string>;
-
-const mapResult = (status: State) => status.name;
+type RenameDeviceAction = Action<
+  RenameDeviceRequest,
+  RenameDeviceState,
+  string
+>;
 
 type Event =
   | RenameDeviceEvent
@@ -52,7 +44,11 @@ type Event =
       device: Device | null | undefined;
     };
 
-const getInitialState = (device?: Device | null | undefined): State => ({
+const mapResult = (status: RenameDeviceState) => status.name;
+
+const getInitialState = (
+  device?: Device | null | undefined
+): RenameDeviceState => ({
   isLoading: !!device,
   allowManagerRequestedWording: null,
   unresponsive: false,
@@ -63,7 +59,7 @@ const getInitialState = (device?: Device | null | undefined): State => ({
   completed: false,
 });
 
-const reducer = (state: State, e: Event): State => {
+const reducer = (state: RenameDeviceState, e: Event): RenameDeviceState => {
   switch (e.type) {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true, isLoading: false };
@@ -95,180 +91,18 @@ const reducer = (state: State, e: Event): State => {
   return state;
 };
 
-const implementations = {
-  // in this paradigm, we know that deviceSubject is reflecting the device events
-  // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
-  event: ({ deviceSubject, renameDevice, name }) =>
-    deviceSubject.pipe(
-      debounceTime(1000),
-      switchMap((d) => renameDevice(d, name))
-    ),
-  // in this paradigm, we can't observe directly the device, so we have to poll it
-  polling: ({ deviceSubject, renameDevice, name }) =>
-    new Observable((o) => {
-      const POLLING = 5000;
-      const INIT_DEBOUNCE = 5000;
-      const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 60000;
-      // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
-      let pollingOnDevice;
-      const sub = deviceSubject.subscribe((d) => {
-        if (d) {
-          pollingOnDevice = d;
-        }
-      });
-      let initT: NodeJS.Timeout | null = setTimeout(() => {
-        // initial timeout to unset the device if it's still not connected
-        o.next({
-          type: "deviceChange",
-          device: null,
-        });
-        device = null;
-        log("actions-rename-device-event/polling", "device init timeout");
-      }, INIT_DEBOUNCE);
-      let connectSub;
-      let loopT;
-      let disconnectT;
-      let device = null; // used as internal state for polling
-
-      let stopDevicePollingError = null;
-
-      function loop() {
-        stopDevicePollingError = null;
-
-        if (!pollingOnDevice) {
-          loopT = setTimeout(loop, POLLING);
-          return;
-        }
-
-        log("actions-rename-device-event/polling", "polling loop");
-        connectSub = renameDevice(pollingOnDevice, name)
-          .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
-              const productName = getDeviceModel(
-                pollingOnDevice.modelId
-              ).productName;
-              return err instanceof TimeoutError
-                ? of({
-                    type: "error",
-                    error: new ConnectManagerTimeout(undefined, {
-                      productName,
-                    }) as Error,
-                  })
-                : throwError(err);
-            })
-          )
-          .subscribe({
-            next: (event) => {
-              if (initT && device) {
-                clearTimeout(initT);
-                initT = null;
-              }
-
-              if (disconnectT) {
-                // any connect app event unschedule the disconnect debounced event
-                clearTimeout(disconnectT);
-                disconnectT = null;
-              }
-
-              if (event.type === "error" && event.error) {
-                if (
-                  event.error instanceof DisconnectedDevice ||
-                  event.error instanceof DisconnectedDeviceDuringOperation
-                ) {
-                  // disconnect on manager actions seems to trigger a type "error" instead of "disconnect"
-                  // the disconnect event is delayed to debounce the reconnection that happens when switching apps
-                  disconnectT = setTimeout(() => {
-                    disconnectT = null;
-                    // a disconnect will locally be remembered via locally setting device to null...
-                    device = null;
-                    o.next(event);
-                    log(
-                      "actions-rename-device-event/polling",
-                      "device disconnect timeout"
-                    );
-                  }, DISCONNECT_DEBOUNCE);
-                } else {
-                  // These error events should stop polling
-                  stopDevicePollingError = event.error;
-
-                  // clear all potential polling loops
-                  if (loopT) {
-                    clearTimeout(loopT);
-                    loopT = null;
-                  }
-
-                  // send in the event for the UI immediately
-                  o.next(event);
-                }
-              } else if (event.type === "unresponsiveDevice") {
-                return; // ignore unresponsive case which happens for polling
-              } else {
-                if (device !== pollingOnDevice) {
-                  // ...but any time an event comes back, it means our device was responding and need to be set back on in polling context
-                  device = pollingOnDevice;
-                  o.next({
-                    type: "deviceChange",
-                    device,
-                  });
-                }
-
-                o.next(event);
-              }
-            },
-            complete: () => {
-              // start a new polling if available
-              if (!stopDevicePollingError) loopT = setTimeout(loop, POLLING);
-            },
-            error: (e) => {
-              o.error(e);
-            },
-          });
-      }
-
-      // delay a bit the first loop run in order to be async and wait pollingOnDevice
-      loopT = setTimeout(loop, 0);
-      return () => {
-        if (initT) clearTimeout(initT);
-        if (disconnectT) clearTimeout(disconnectT);
-        if (connectSub) connectSub.unsubscribe();
-        sub.unsubscribe();
-        clearTimeout(loopT);
-      };
-    }).pipe(distinctUntilChanged(isEqual)),
-};
-
 export const createAction = (
-  renameDeviceExec: (arg0: RenameDeviceRequest) => Observable<RenameDeviceEvent>
+  task: (arg0: RenameDeviceInput) => Observable<RenameDeviceEvent>
 ): RenameDeviceAction => {
-  const renameDevice = (device, name) => {
-    return concat(
-      of({
-        type: "deviceChange",
-        device,
-      }),
-      !device
-        ? EMPTY
-        : renameDeviceExec({
-            deviceId: device.deviceId,
-            name,
-          }).pipe(
-            catchError((error: Error) =>
-              of({
-                type: "error",
-                error,
-              })
-            )
-          )
-    );
-  };
-
-  const useHook = (device: Device | null | undefined, name: string): State => {
+  const useHook = (
+    device: Device | null | undefined,
+    request: RenameDeviceRequest
+  ): RenameDeviceState => {
     const [state, setState] = useState(() => getInitialState(device));
     const [resetIndex, setResetIndex] = useState(0);
     const deviceSubject = useReplaySubject(device);
 
+    // Changing the nonce causing a refresh of the useEffect
     const onRetry = useCallback(() => {
       setResetIndex((i) => i + 1);
       setState(getInitialState(device));
@@ -282,16 +116,18 @@ export const createAction = (
     useEffect(() => {
       if (state.completed) return;
 
-      const impl = implementations[currentMode]({
+      const impl = getImplementation(currentMode)<
+        RenameDeviceEvent,
+        RenameDeviceRequest
+      >({
         deviceSubject,
-        renameDevice,
-        name,
+        task,
+        request,
       });
 
       const sub = impl
         .pipe(
-          // debounce a bit the connect/disconnect event that we don't need
-          tap((e: Event) => log("actions-rename-device-event", e.type, e)),
+          tap((e: any) => log("actions-rename-device-event", e.type, e)),
           map((e: Event) => {
             if (
               productName &&
@@ -304,14 +140,13 @@ export const createAction = (
             }
             return e;
           }),
-          // we gather all events with a reducer into the UI state
           scan(reducer, getInitialState())
-        ) // the state simply goes into a React state
+        )
         .subscribe(setState);
       return () => {
         sub.unsubscribe();
       };
-    }, [name, deviceSubject, state.completed, resetIndex, productName]);
+    }, [deviceSubject, state.completed, resetIndex, productName, request]);
 
     return {
       ...state,

--- a/libs/ledger-live-common/src/hw/actions/staxFetchImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxFetchImage.ts
@@ -1,36 +1,17 @@
-import {
-  concat,
-  of,
-  EMPTY,
-  interval,
-  Observable,
-  TimeoutError,
-  throwError,
-} from "rxjs";
-import {
-  scan,
-  debounce,
-  debounceTime,
-  catchError,
-  switchMap,
-  tap,
-  distinctUntilChanged,
-  timeout,
-} from "rxjs/operators";
+import { Observable } from "rxjs";
+import { scan, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { useReplaySubject } from "../../observable";
-import type { FetchImageEvent, FetchImageRequest } from "../staxFetchImage";
+import type {
+  FetchImageEvent,
+  FetchImageRequest,
+  Input as FetchImageInput,
+} from "../staxFetchImage";
 import type { Action, Device } from "./types";
-import isEqual from "lodash/isEqual";
-import { ConnectManagerTimeout } from "../../errors";
 import { currentMode } from "./app";
-import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-} from "@ledgerhq/errors";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { getImplementation } from "./implementations";
 
 type State = {
   isLoading: boolean;
@@ -48,7 +29,7 @@ type State = {
   imageAlreadyBackedUp?: boolean;
 };
 
-type FetchImageAction = Action<string, State, boolean>;
+type FetchImageAction = Action<FetchImageRequest, State, boolean>;
 
 const mapResult = ({ completed, imageFetched, imageAlreadyBackedUp }: State) =>
   completed || imageFetched || imageAlreadyBackedUp || null;
@@ -134,178 +115,12 @@ const reducer = (state: State, e: Event): State => {
   }
 };
 
-const implementations = {
-  // in this paradigm, we know that deviceSubject is reflecting the device events
-  // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
-  event: ({ deviceSubject, fetchImage, backupHash }) =>
-    deviceSubject.pipe(
-      debounceTime(1000),
-      switchMap((d) => fetchImage(d, backupHash))
-    ),
-  // in this paradigm, we can't observe directly the device, so we have to poll it
-  polling: ({ deviceSubject, fetchImage, backupHash }) =>
-    new Observable((o) => {
-      const POLLING = 5000;
-      const INIT_DEBOUNCE = 5000;
-      const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 60000;
-      // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
-      let pollingOnDevice;
-      const sub = deviceSubject.subscribe((d) => {
-        if (d) {
-          pollingOnDevice = d;
-        }
-      });
-      let initT: NodeJS.Timeout | null = setTimeout(() => {
-        // initial timeout to unset the device if it's still not connected
-        o.next({
-          type: "deviceChange",
-          device: null,
-        });
-        device = null;
-        log("actions-fetch-stax-image-event/polling", "device init timeout");
-      }, INIT_DEBOUNCE);
-      let connectSub;
-      let loopT;
-      let disconnectT;
-      let device = null; // used as internal state for polling
-
-      let stopDevicePollingError = null;
-
-      function loop() {
-        stopDevicePollingError = null;
-
-        if (!pollingOnDevice) {
-          loopT = setTimeout(loop, POLLING);
-          return;
-        }
-
-        log("actions-fetch-stax-image-event/polling", "polling loop");
-        connectSub = fetchImage(pollingOnDevice, backupHash)
-          .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
-              const productName = getDeviceModel(
-                pollingOnDevice.modelId
-              ).productName;
-              return err instanceof TimeoutError
-                ? of({
-                    type: "error",
-                    error: new ConnectManagerTimeout(undefined, {
-                      productName,
-                    }) as Error,
-                  })
-                : throwError(err);
-            })
-          )
-          .subscribe({
-            next: (event) => {
-              if (initT && device) {
-                clearTimeout(initT);
-                initT = null;
-              }
-
-              if (disconnectT) {
-                // any connect app event unschedule the disconnect debounced event
-                clearTimeout(disconnectT);
-                disconnectT = null;
-              }
-
-              if (event.type === "error" && event.error) {
-                if (
-                  event.error instanceof DisconnectedDevice ||
-                  event.error instanceof DisconnectedDeviceDuringOperation
-                ) {
-                  // disconnect on manager actions seems to trigger a type "error" instead of "disconnect"
-                  // the disconnect event is delayed to debounce the reconnection that happens when switching apps
-                  disconnectT = setTimeout(() => {
-                    disconnectT = null;
-                    // a disconnect will locally be remembered via locally setting device to null...
-                    device = null;
-                    o.next(event);
-                    log(
-                      "actions-fetch-stax-image-event/polling",
-                      "device disconnect timeout"
-                    );
-                  }, DISCONNECT_DEBOUNCE);
-                } else {
-                  // These error events should stop polling
-                  stopDevicePollingError = event.error;
-
-                  // clear all potential polling loops
-                  if (loopT) {
-                    clearTimeout(loopT);
-                    loopT = null;
-                  }
-
-                  // send in the event for the UI immediately
-                  o.next(event);
-                }
-              } else if (event.type === "unresponsiveDevice") {
-                return; // ignore unresponsive case which happens for polling
-              } else {
-                if (device !== pollingOnDevice) {
-                  // ...but any time an event comes back, it means our device was responding and need to be set back on in polling context
-                  device = pollingOnDevice;
-                  o.next({
-                    type: "deviceChange",
-                    device,
-                  });
-                }
-
-                o.next(event);
-              }
-            },
-            complete: () => {
-              // start a new polling if available
-              if (!stopDevicePollingError) loopT = setTimeout(loop, POLLING);
-            },
-            error: (e) => {
-              o.error(e);
-            },
-          });
-      }
-
-      // delay a bit the first loop run in order to be async and wait pollingOnDevice
-      loopT = setTimeout(loop, 0);
-      return () => {
-        if (initT) clearTimeout(initT);
-        if (disconnectT) clearTimeout(disconnectT);
-        if (connectSub) connectSub.unsubscribe();
-        sub.unsubscribe();
-        clearTimeout(loopT);
-      };
-    }).pipe(distinctUntilChanged(isEqual)),
-};
-
 export const createAction = (
-  fetchImageExec: (arg0: FetchImageRequest) => Observable<FetchImageEvent>
+  task: (arg0: FetchImageInput) => Observable<FetchImageEvent>
 ): FetchImageAction => {
-  const fetchImage = (device, backupHash: string) => {
-    return concat(
-      of({
-        type: "deviceChange",
-        device,
-      }),
-      !device
-        ? EMPTY
-        : fetchImageExec({
-            deviceId: device.deviceId,
-            backupHash,
-          }).pipe(
-            catchError((error: Error) =>
-              of({
-                type: "error",
-                error,
-              })
-            )
-          )
-    );
-  };
-
   const useHook = (
     device: Device | null | undefined,
-    backupHash: string
+    request: FetchImageRequest
   ): State => {
     const [state, setState] = useState(() => getInitialState(device));
     const deviceSubject = useReplaySubject(device);
@@ -313,34 +128,31 @@ export const createAction = (
     useEffect(() => {
       if (state.imageFetched || state.imageAlreadyBackedUp || state.completed)
         return;
-
-      const impl = implementations[currentMode]({
+      const impl = getImplementation(currentMode)<
+        FetchImageEvent,
+        FetchImageRequest
+      >({
         deviceSubject,
-        fetchImage,
-        backupHash,
+        task,
+        request,
       });
 
       const sub = impl
         .pipe(
-          // debounce a bit the connect/disconnect event that we don't need
-          tap((e: Event) => log("actions-fetch-stax-image-event", e.type, e)),
-          // we gather all events with a reducer into the UI state
-          scan(reducer, getInitialState()),
-          // we debounce the UI state to not blink on the UI
-          debounce((s: State) => {
-            if (s.fetchingImage) {
-              return EMPTY;
-            }
-
-            // default debounce (to be tweak)
-            return interval(1500);
-          })
-        ) // the state simply goes into a React state
+          tap((e: any) => log("actions-fetch-stax-image-event", e.type, e)),
+          scan(reducer, getInitialState())
+        )
         .subscribe(setState);
       return () => {
         sub.unsubscribe();
       };
-    }, [backupHash, deviceSubject, state.imageFetched]);
+    }, [
+      deviceSubject,
+      request,
+      state.completed,
+      state.imageAlreadyBackedUp,
+      state.imageFetched,
+    ]);
 
     return {
       ...state,

--- a/libs/ledger-live-common/src/hw/actions/staxFetchImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxFetchImage.ts
@@ -113,6 +113,7 @@ const reducer = (state: State, e: Event): State => {
         progress: e.progress,
       };
   }
+  return state; // Nb Needed until e2e tests are better handled.
 };
 
 export const createAction = (

--- a/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
@@ -118,6 +118,7 @@ const reducer = (state: State, e: Event): State => {
         progress: e.progress,
       };
   }
+  return state; // Nb Needed until e2e tests are better handled.
 };
 
 export const createAction = (

--- a/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
@@ -1,36 +1,18 @@
-import {
-  concat,
-  of,
-  EMPTY,
-  interval,
-  Observable,
-  TimeoutError,
-  throwError,
-} from "rxjs";
-import {
-  scan,
-  debounce,
-  debounceTime,
-  catchError,
-  switchMap,
-  tap,
-  distinctUntilChanged,
-  timeout,
-} from "rxjs/operators";
+import { Observable } from "rxjs";
+import { scan, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { useReplaySubject } from "../../observable";
-import type { LoadImageEvent, LoadImageRequest } from "../staxLoadImage";
+import type {
+  LoadImageEvent,
+  LoadImageRequest,
+  LoadimageResult,
+  Input as LoadImageInput,
+} from "../staxLoadImage";
 import type { Action, Device } from "./types";
-import isEqual from "lodash/isEqual";
-import { ConnectManagerTimeout } from "../../errors";
 import { currentMode } from "./app";
-import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-} from "@ledgerhq/errors";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { getImplementation } from "./implementations";
 
 type State = {
   isLoading: boolean;
@@ -48,11 +30,7 @@ type State = {
   progress?: number;
 };
 
-type LoadImageAction = Action<
-  string,
-  State,
-  { imageHash: string; imageSize: number }
->;
+type LoadImageAction = Action<LoadImageRequest, State, LoadimageResult>;
 
 const mapResult = ({ imageHash, imageSize }: State) => ({
   imageHash,
@@ -142,179 +120,12 @@ const reducer = (state: State, e: Event): State => {
   }
 };
 
-const implementations = {
-  // in this paradigm, we know that deviceSubject is reflecting the device events
-  // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
-  event: ({ deviceSubject, loadImage, hexImage, padImage }) =>
-    deviceSubject.pipe(
-      debounceTime(1000),
-      switchMap((d) => loadImage(d, hexImage, padImage))
-    ),
-  // in this paradigm, we can't observe directly the device, so we have to poll it
-  polling: ({ deviceSubject, loadImage, hexImage, padImage }) =>
-    new Observable((o) => {
-      const POLLING = 2000;
-      const INIT_DEBOUNCE = 5000;
-      const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 60000;
-      // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
-      let pollingOnDevice;
-      const sub = deviceSubject.subscribe((d) => {
-        if (d) {
-          pollingOnDevice = d;
-        }
-      });
-      let initT: NodeJS.Timeout | null = setTimeout(() => {
-        // initial timeout to unset the device if it's still not connected
-        o.next({
-          type: "deviceChange",
-          device: null,
-        });
-        device = null;
-        log("actions-load-stax-image-event/polling", "device init timeout");
-      }, INIT_DEBOUNCE);
-      let connectSub;
-      let loopT;
-      let disconnectT;
-      let device = null; // used as internal state for polling
-
-      let stopDevicePollingError = null;
-
-      function loop() {
-        stopDevicePollingError = null;
-
-        if (!pollingOnDevice) {
-          loopT = setTimeout(loop, POLLING);
-          return;
-        }
-
-        log("actions-load-stax-image-event/polling", "polling loop");
-        connectSub = loadImage(pollingOnDevice, hexImage, padImage)
-          .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
-              const productName = getDeviceModel(
-                pollingOnDevice.modelId
-              ).productName;
-              return err instanceof TimeoutError
-                ? of({
-                    type: "error",
-                    error: new ConnectManagerTimeout(undefined, {
-                      productName,
-                    }) as Error,
-                  })
-                : throwError(err);
-            })
-          )
-          .subscribe({
-            next: (event) => {
-              if (initT && device) {
-                clearTimeout(initT);
-                initT = null;
-              }
-
-              if (disconnectT) {
-                // any connect app event unschedule the disconnect debounced event
-                clearTimeout(disconnectT);
-                disconnectT = null;
-              }
-
-              if (event.type === "error" && event.error) {
-                if (
-                  event.error instanceof DisconnectedDevice ||
-                  event.error instanceof DisconnectedDeviceDuringOperation
-                ) {
-                  // disconnect on manager actions seems to trigger a type "error" instead of "disconnect"
-                  // the disconnect event is delayed to debounce the reconnection that happens when switching apps
-                  disconnectT = setTimeout(() => {
-                    disconnectT = null;
-                    // a disconnect will locally be remembered via locally setting device to null...
-                    device = null;
-                    o.next(event);
-                    log(
-                      "actions-load-stax-image-event/polling",
-                      "device disconnect timeout"
-                    );
-                  }, DISCONNECT_DEBOUNCE);
-                } else {
-                  // These error events should stop polling
-                  stopDevicePollingError = event.error;
-
-                  // clear all potential polling loops
-                  if (loopT) {
-                    clearTimeout(loopT);
-                    loopT = null;
-                  }
-
-                  // send in the event for the UI immediately
-                  o.next(event);
-                }
-              } else if (event.type === "unresponsiveDevice") {
-                return; // ignore unresponsive case which happens for polling
-              } else {
-                if (device !== pollingOnDevice) {
-                  // ...but any time an event comes back, it means our device was responding and need to be set back on in polling context
-                  device = pollingOnDevice;
-                  o.next({
-                    type: "deviceChange",
-                    device,
-                  });
-                }
-
-                o.next(event);
-              }
-            },
-            complete: () => {
-              // start a new polling if available
-              if (!stopDevicePollingError) loopT = setTimeout(loop, POLLING);
-            },
-            error: (e) => {
-              o.error(e);
-            },
-          });
-      }
-
-      // delay a bit the first loop run in order to be async and wait pollingOnDevice
-      loopT = setTimeout(loop, 0);
-      return () => {
-        if (initT) clearTimeout(initT);
-        if (disconnectT) clearTimeout(disconnectT);
-        if (connectSub) connectSub.unsubscribe();
-        sub.unsubscribe();
-        clearTimeout(loopT);
-      };
-    }).pipe(distinctUntilChanged(isEqual)),
-};
 export const createAction = (
-  loadImageExec: (arg0: LoadImageRequest) => Observable<LoadImageEvent>
+  task: (arg0: LoadImageInput) => Observable<LoadImageEvent>
 ): LoadImageAction => {
-  const loadImage = (device, hexImage: string, padImage?: boolean) => {
-    return concat(
-      of({
-        type: "deviceChange",
-        device,
-      }),
-      !device
-        ? EMPTY
-        : loadImageExec({
-            deviceId: device.deviceId,
-            hexImage,
-            padImage,
-          }).pipe(
-            catchError((error: Error) =>
-              of({
-                type: "error",
-                error,
-              })
-            )
-          )
-    );
-  };
-
   const useHook = (
     device: Device | null | undefined,
-    hexImage: string,
-    padImage?: boolean
+    request: LoadImageRequest
   ): State => {
     const [state, setState] = useState(() => getInitialState(device));
     const deviceSubject = useReplaySubject(device);
@@ -322,38 +133,25 @@ export const createAction = (
     useEffect(() => {
       if (state.imageLoaded) return;
 
-      const impl = implementations[currentMode]({
+      const impl = getImplementation(currentMode)<
+        LoadImageEvent,
+        LoadImageRequest
+      >({
         deviceSubject,
-        loadImage,
-        hexImage,
-        padImage,
+        task,
+        request,
       });
 
       const sub = impl
         .pipe(
-          // debounce a bit the connect/disconnect event that we don't need
-          tap((e: Event) => log("actions-load-stax-image-event", e.type, e)),
-          // we gather all events with a reducer into the UI state
-          scan(reducer, getInitialState()),
-          // we debounce the UI state to not blink on the UI
-          debounce((s: State) => {
-            if (
-              s.loadingImage ||
-              s.imageLoadRequested ||
-              s.imageCommitRequested
-            ) {
-              return EMPTY;
-            }
-
-            // default debounce (to be tweak)
-            return interval(1500);
-          })
-        ) // the state simply goes into a React state
+          tap((e: any) => log("actions-load-stax-image-event", e.type, e)),
+          scan(reducer, getInitialState())
+        )
         .subscribe(setState);
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, hexImage, padImage, state.imageLoaded]);
+    }, [deviceSubject, request, state.imageLoaded]);
 
     return {
       ...state,

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -16,15 +16,11 @@ import { isDashboardName } from "./isDashboardName";
 import { DeviceNotOnboarded } from "../errors";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
 import { LockedDeviceEvent } from "./actions/types";
+import { ManagerRequest } from "./actions/manager";
 
 export type Input = {
-  devicePath: string;
-  managerRequest:
-    | {
-        autoQuitAppDisabled?: boolean;
-      }
-    | null
-    | undefined;
+  deviceId: string;
+  request: ManagerRequest | null | undefined;
 };
 
 export type ConnectManagerEvent =
@@ -44,11 +40,8 @@ export type ConnectManagerEvent =
   | ListAppsEvent
   | LockedDeviceEvent;
 
-const cmd = ({
-  devicePath,
-  managerRequest,
-}: Input): Observable<ConnectManagerEvent> =>
-  withDevice(devicePath)(
+const cmd = ({ deviceId, request }: Input): Observable<ConnectManagerEvent> =>
+  withDevice(deviceId)(
     (transport) =>
       new Observable((o) => {
         const timeoutSub = of({
@@ -110,7 +103,7 @@ const cmd = ({
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap((appAndVersion) => {
-                    return !managerRequest?.autoQuitAppDisabled &&
+                    return !request?.autoQuitAppDisabled &&
                       !isDashboardName(appAndVersion.name)
                       ? attemptToQuitApp(transport, appAndVersion)
                       : of({

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -33,15 +33,18 @@ export type InstallLanguageEvent =
       type: "languageInstalled";
     };
 
-export type InstallLanguageRequest = {
+export type InstallLanguageRequest = { language: Language };
+export type Input = {
   deviceId: string;
-  language: Language;
+  request: InstallLanguageRequest;
 };
 
 export default function installLanguage({
   deviceId,
-  language,
-}: InstallLanguageRequest): Observable<InstallLanguageEvent> {
+  request,
+}: Input): Observable<InstallLanguageEvent> {
+  const { language } = request;
+
   const sub = withDevice(deviceId)(
     (transport) =>
       new Observable((subscriber) => {

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
@@ -8,7 +8,6 @@
  * app that fulfils the minimum version defined we are instead now throwing a fw update error.
  */
 import { DeviceInfo } from "@ledgerhq/types-live";
-import { identifyTargetId, DeviceModelId } from "@ledgerhq/devices";
 import semver from "semver";
 import { getProviderId } from "../manager/provider";
 import ManagerAPI from "../api/Manager";
@@ -20,8 +19,6 @@ const isUpdateAvailable = async (
   appAndVersion: AppAndVersion,
   checkMustUpdate = true
 ): Promise<boolean> => {
-  const deviceModel = identifyTargetId(deviceInfo.targetId as number);
-
   const deviceVersionP = ManagerAPI.getDeviceVersion(
     deviceInfo.targetId,
     getProviderId(deviceInfo)

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
@@ -58,11 +58,7 @@ const isUpdateAvailable = async (
 
   return (
     !!appAvailableInProvider &&
-    !mustUpgrade(
-      deviceModel?.id as DeviceModelId,
-      appAvailableInProvider.name,
-      appAvailableInProvider.version
-    )
+    !mustUpgrade(appAvailableInProvider.name, appAvailableInProvider.version)
   );
 };
 

--- a/libs/ledger-live-common/src/hw/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/renameDevice.ts
@@ -15,15 +15,18 @@ export type RenameDeviceEvent =
       name: string;
     };
 
-export type RenameDeviceRequest = {
+export type RenameDeviceRequest = { name: string };
+export type Input = {
   deviceId: string;
-  name: string; // New device name
+  request: RenameDeviceRequest;
 };
 
 export default function renameDevice({
   deviceId,
-  name,
-}: RenameDeviceRequest): Observable<RenameDeviceEvent> {
+  request,
+}: Input): Observable<RenameDeviceEvent> {
+  const { name } = request;
+
   const sub = withDevice(deviceId)(
     (transport) =>
       new Observable((o) => {

--- a/libs/ledger-live-common/src/hw/staxFetchImage.ts
+++ b/libs/ledger-live-common/src/hw/staxFetchImage.ts
@@ -38,14 +38,20 @@ export type FetchImageEvent =
     };
 
 export type FetchImageRequest = {
-  deviceId: string;
   backupHash?: string; // When provided, will skip the backup if it matches the hash.
+};
+
+export type Input = {
+  deviceId: string;
+  request: FetchImageRequest;
 };
 
 export default function fetchImage({
   deviceId,
-  backupHash,
-}: FetchImageRequest): Observable<FetchImageEvent> {
+  request,
+}: Input): Observable<FetchImageEvent> {
+  const { backupHash } = request;
+
   const sub = withDevice(deviceId)(
     (transport) =>
       new Observable((subscriber) => {

--- a/libs/ledger-live-common/src/hw/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/staxLoadImage.ts
@@ -42,17 +42,27 @@ export type LoadImageEvent =
       imageHash: string;
     };
 
+export type LoadimageResult = {
+  imageHash: string;
+  imageSize: number;
+};
+
 export type LoadImageRequest = {
-  deviceId: string;
-  hexImage: string;
+  hexImage: string; // When provided, will skip the backup if it matches the hash.
   padImage?: boolean;
+};
+
+export type Input = {
+  deviceId: string;
+  request: LoadImageRequest;
 };
 
 export default function loadImage({
   deviceId,
-  hexImage,
-  padImage = true,
-}: LoadImageRequest): Observable<LoadImageEvent> {
+  request,
+}: Input): Observable<LoadImageEvent> {
+  const { hexImage, padImage } = request;
+
   const sub = withDevice(deviceId)(
     (transport) =>
       new Observable((subscriber) => {
@@ -70,7 +80,7 @@ export default function loadImage({
               const imageData = await generateStaxImageFormat(
                 hexImage,
                 true,
-                padImage
+                !!padImage
               );
               const imageLength = imageData.length;
 

--- a/libs/ledger-live-common/src/load/speculos.ts
+++ b/libs/ledger-live-common/src/load/speculos.ts
@@ -290,8 +290,8 @@ export async function listAppCandidates(cwd: string): Promise<AppCandidate[]> {
             const appVersion = elf.slice(4, elf.length - 4);
             if (
               semver.valid(appVersion) &&
-              !shouldUpgrade(model, appName, appVersion) &&
-              !mustUpgrade(model, appName, appVersion)
+              !shouldUpgrade(appName, appVersion) &&
+              !mustUpgrade(appName, appVersion)
             ) {
               c.push({
                 path: p4,


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

A tangent that was prompted last week during the look into faster manager access was reworking device actions in general. I tackled every single device action in our code base for both LLD and LLM, we had a lot of duplicated or close to duplicated code resulting in inconsistencies in the way we handle the device state between flows. I rewrote this all into a beautiful, typed, single implementation for polling and one for events (BLE, USB).
This means we have 800 less lines of code to maintain going forward.

I eliminated all the debounces that caused delays between the action happening on the nano side and the UI changing on LLM. For example, actions like allowing manager or opening an app were previously over one second apart, but now they're instantly linked, providing a much better user experience. Although proper state reducers should be sufficient to prevent blinking, there is a possibility that I may have missed something.
### ❓ Context

- **Impacted projects**: `common, desktop, mobile, cli` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6930` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
I can't demo

### 🚀 Expectations to reach
It affects all device actions for both LLD and LLM, this means all flows. However, since they will all share the logic now an issue on one flow should also be present on others. In particular, testing the app switches that happen when you have to enter or quit an application in the middle of a flow are the most important ones. Disconnections and timeouts too.