### PR TITLE
fix(Firmware Update LLM): fix LLM stuck on preparing update step

### DIFF
--- a/.changeset/few-kangaroos-press.md
+++ b/.changeset/few-kangaroos-press.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix a bug on the firmware update making the app to be stuck in a single step of the update model while the device updated.

--- a/apps/ledger-live-mobile/services/BackgroundRunnerService.ts
+++ b/apps/ledger-live-mobile/services/BackgroundRunnerService.ts
@@ -28,8 +28,8 @@ const BackgroundRunnerService = async ({
   deviceId: string;
   firmwareSerializedJson: string;
 }) => {
-  const emitEvent = (e: FwUpdateBackgroundEvent) =>
-    store.dispatch(addBackgroundEvent(e));
+  const emitEvent = (event: FwUpdateBackgroundEvent) =>
+    store.dispatch(addBackgroundEvent({ event }));
   const latestFirmware = JSON.parse(firmwareSerializedJson) as
     | FirmwareUpdateContext
     | null

--- a/apps/ledger-live-mobile/tsconfig.json
+++ b/apps/ledger-live-mobile/tsconfig.json
@@ -16,7 +16,7 @@
     "target": "esnext",
     "incremental": true
   },
-  "include": ["src/**/*", "e2e/**/*", "**/*.d.ts"],
+  "include": ["src/**/*", "e2e/**/*", "**/*.d.ts", "services/**/*"],
   "exclude": [
     "node_modules",
     "babel.config.js",


### PR DESCRIPTION
### 📝 Description
There was a mismatch on the signature of the action the background runner service was sending and the handling by the Redux store on LLM. This was causing the firmware update over USB OTG to be stuck in the "preparing update" step  on LLM while the update did continue on the device. This wasn't caught by type checks because the `services/` folder wasn't included on the type checks, this PR also adds it to the checks so it doesn't happen again.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-6942]
### ✅ Checklist

- [N/A] **Test coverage** 
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
N/A

### 🚀 Expectations to reach
Test plan: perform any update via USB on LLM. The status displayed on the app should match what's happening on the device.

[LIVE-6942]: https://ledgerhq.atlassian.net/browse/LIVE-6942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ