### PR TITLE
fix: navigation.pop in DeviceConnect

### DIFF
--- a/.changeset/smart-ligers-own.md
+++ b/.changeset/smart-ligers-own.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+fix: navigation.pop in DeviceConnect
+
+As it can be used in the Onboarding base navigator now, if you pop by getting the parent, you will pop the BaseNavigator

--- a/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
@@ -15,12 +15,10 @@ import DeviceActionModal from "../../components/DeviceActionModal";
 import NavigationScrollView from "../../components/NavigationScrollView";
 import {
   RootComposite,
-  StackNavigatorNavigation,
   StackNavigatorProps,
 } from "../../components/RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "../../const";
-import { RootStackParamList } from "../../components/RootNavigator/types/RootNavigator";
 
 const action = createAction(connectApp);
 
@@ -46,12 +44,7 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
   const onHideMenu = useCallback(() => setShowMenu(false), []);
 
   const onDone = useCallback(() => {
-    const n =
-      navigation.getParent<StackNavigatorNavigation<RootStackParamList>>();
-
-    if (n) {
-      n.pop();
-    }
+    navigation.pop();
   }, [navigation]);
 
   const handleSuccess = useCallback(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

As the wallet-api DeviceConnect screen is used in the Onboarding base navigator now, if you pop by getting the parent, you will pop the BaseNavigator

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`PROTECT-1521`](https://ledgerhq.atlassian.net/browse/PROTECT-1521) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** Tested manually <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Before:

https://user-images.githubusercontent.com/3009753/229183293-3836d581-1449-463b-8472-3ddaf5e4ee70.mov

After:
The error in the end is expected, what we want is to stay on the live-app

https://user-images.githubusercontent.com/3009753/229181944-c7bfea1e-57b7-4a74-bb0d-01faf9ac9952.mov


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
