### PR TITLE
fix: "back to Buy/Sell" button should not be displayed because of an internal iframe navigation

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -118,7 +118,7 @@ export function useWebviewState(
     (event: Electron.DidNavigateInPageEvent) => {
       const webview = webviewRef.current;
 
-      if (!webview) {
+      if (!webview || !event.isMainFrame) {
         return;
       }
 


### PR DESCRIPTION
### 📝 Description

bugfix : "back to Buy/Sell" button should not be displayed because of an internal iframe navigation
Do not change webviewState when event.isMainFrame is false. See https://github.com/electron/electron/issues/6808 and https://www.electronjs.org/docs/latest/api/web-contents#event-did-navigate-in-page

### ❓ Context

- **Impacted projects**: `` LLD
- 
### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
