### PR TITLE
Fix sign message support for Bitcoin app 2.1.0+ (CLA_NOT_SUPPORTED)

### DIFF
--- a/.changeset/stupid-rules-sort.md
+++ b/.changeset/stupid-rules-sort.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-btc": patch
+---
+
+Fix sign message support for Bitcoin app 2.1.0+

--- a/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
@@ -12,7 +12,6 @@ import { splitTransaction } from "./splitTransaction";
 import type { Transaction } from "./types";
 export type { AddressFormat };
 import { signP2SHTransaction } from "./signP2SHTransaction";
-import { signMessage } from "./signMessage";
 import { checkIsBtcLegacy, getAppAndVersion } from "./getAppAndVersion";
 
 /**
@@ -139,9 +138,11 @@ export default class Btc {
     r: string;
     s: string;
   }> {
-    return signMessage(this._transport, {
-      path,
-      messageHex,
+    return this.changeImplIfNecessary().then((impl) => {
+      return impl.signMessage({
+        path,
+        messageHex,
+      });
     });
   }
 

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
@@ -298,6 +298,38 @@ export default class BtcNew {
   }
 
   /**
+   * Signs an arbitrary hex-formatted message with the private key at
+   * the provided derivation path according to the Bitcoin Signature format
+   * and returns v, r, s.
+   */
+  async signMessage({
+    path,
+    messageHex,
+  }: {
+    path: string;
+    messageHex: string;
+  }): Promise<{
+    v: number;
+    r: string;
+    s: string;
+  }> {
+    const pathElements: number[] = pathStringToArray(path);
+    const message = Buffer.from(messageHex, "hex");
+    const sig = await this.client.signMessage(message, pathElements);
+    const buf = Buffer.from(sig, "base64");
+
+    const v = buf.readUInt8() - 27 - 4;
+    const r = buf.slice(1, 33).toString("hex");
+    const s = buf.slice(33, 65).toString("hex");
+
+    return {
+      v,
+      r,
+      s,
+    };
+  }
+
+  /**
    * Calculates an output script along with public key and possible redeemScript
    * from a path and accountType. The accountPath must be a prefix of path.
    *

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcOld.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcOld.ts
@@ -7,6 +7,7 @@ import { createTransaction } from "./createTransaction";
 import type { AddressFormat } from "./getWalletPublicKey";
 import { getWalletPublicKey } from "./getWalletPublicKey";
 import { pathArrayToString, pathStringToArray } from "./bip32";
+import { signMessage } from "./signMessage";
 export type { AddressFormat };
 
 /**
@@ -135,6 +136,23 @@ export default class BtcOld {
       );
     }
     return createTransaction(this.transport, arg);
+  }
+
+  async signMessage({
+    path,
+    messageHex,
+  }: {
+    path: string;
+    messageHex: string;
+  }): Promise<{
+    v: number;
+    r: string;
+    s: string;
+  }> {
+    return signMessage(this.transport, {
+      path,
+      messageHex,
+    });
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The `signMessage` function in `@ledgerhq/hw-app-btc` still only supports the old protocol pre Bitcoin app `2.1.0`.

With Bitcoin app `2.1.0+` the protocol has changed. This PR:

* Adds `signMessage` based on new protocol in `src/newops/appClient.ts`, where all other new ops are also implemented
* Adds `signMessage` to `src/BtcOld.ts` and `src/BtcNew.ts`, where the new one normalizes the `base64` signature returned from firmware to `v`, `r`, `s`
* Makes it so that `src/Btc.ts` switches between new and old implementation depending on existing `changeImplIfNecessary()` method

There are no breaking changes for client code.

### ❓ Context

- **Impacted projects**: `@ledgerhq/hw-app-btc` users <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: #2937 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->
