### PR TITLE
feat(Custom Lockscreen): Make image padding optional on Stax CLS

### DIFF
--- a/.changeset/happy-bananas-collect.md
+++ b/.changeset/happy-bananas-collect.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Make stax image padding optional on Stax Load image device action

--- a/apps/cli/src/commands/staxFetchAndRestoreDemo.ts
+++ b/apps/cli/src/commands/staxFetchAndRestoreDemo.ts
@@ -24,7 +24,7 @@ type staxFetchAndRestoreJobOpts = ScanCommonOpts & {
 const exec = async (opts: staxFetchAndRestoreJobOpts) => {
   const { fileInput, device: deviceId = "" } = opts;
   const hexImageWithoutHeader = fs.readFileSync(fileInput, "utf-8");
-  const hexImage = await generateStaxImageFormat(hexImageWithoutHeader, true);
+  const hexImage = await generateStaxImageFormat(hexImageWithoutHeader, true, true);
 
   await new Promise<void>(async (resolve) => {
     let hash = crypto.createHash("sha256").update(hexImage).digest("hex");


### PR DESCRIPTION
### 📝 Description
On Stax image loading, we have a manual padding that removes two lines of the image in order to make it adapted to the Stax screen. This PR makes this padding optional so we can load an image without it (useful for the case of restoring images recovered from the device, since they'd already include the padding).

### ❓ Context

- **Impacted projects**: `ledger-live-common`
- **Linked resource(s)**: N/A

### ✅ Checklist

- [N/A] **Test coverage** 
- [x] **Atomic delivery** 
- [x] **No breaking changes**

### 📸 Demo
N/A