### PR TITLE
fix: correctly trigger software checks during sync onboarding

### DIFF
--- a/.changeset/rude-guests-drum.md
+++ b/.changeset/rude-guests-drum.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+fix: correctly trigger software checks during sync onboarding on new firmware versions

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -238,9 +238,14 @@ const SyncOnboardingManual = ({ deviceModelId: strDeviceModelId }: SyncOnboardin
   }, []);
 
   useEffect(() => {
+    // When the device is seeded, there are 2 cases before triggering the software check step:
+    // - the user came to the sync onboarding with an non-seeded device and did a full onboarding: onboarding flag `Ready`
+    // - the user came to the sync onboarding with an already seeded device: onboarding flag `WelcomeScreen1`
     if (
       deviceOnboardingState?.isOnboarded &&
-      deviceOnboardingState?.currentOnboardingStep === DeviceOnboardingStep.Ready
+      [DeviceOnboardingStep.Ready, DeviceOnboardingStep.WelcomeScreen1].includes(
+        deviceOnboardingState?.currentOnboardingStep,
+      )
     ) {
       setStepKey(StepKey.SoftwareCheck);
       return;

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -325,10 +325,15 @@ export const SyncOnboarding = ({
   }, [isDesyncDrawerOpen]);
 
   useEffect(() => {
+    // When the device is seeded, there are 2 cases before triggering the software check step:
+    // - the user came to the sync onboarding with an non-seeded device and did a full onboarding: onboarding flag `Ready`
+    // - the user came to the sync onboarding with an already seeded device: onboarding flag `WelcomeScreen1`
     if (
       deviceOnboardingState?.isOnboarded &&
-      deviceOnboardingState?.currentOnboardingStep ===
-        DeviceOnboardingStep.Ready
+      [
+        DeviceOnboardingStep.Ready,
+        DeviceOnboardingStep.WelcomeScreen1,
+      ].includes(deviceOnboardingState?.currentOnboardingStep)
     ) {
       setCompanionStepKey(CompanionStepKey.SoftwareCheck);
       return;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

`r12` firmware updated the flag value from `Ready` to `WelcomeScreen1` once the device is seeded and restarted. This change was made to be consistent with LNS+ and LNX.

### ❓ Context

- **Impacted projects**: `LLM` and `LLD`
- **Linked resource(s)**: [LIVE-6997](https://ledgerhq.atlassian.net/browse/LIVE-6997)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6997]: https://ledgerhq.atlassian.net/browse/LIVE-6997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ