### PR TITLE
bugfix/LIVE-5912 UI fix for the Retry CTA on locked device errors

### DIFF
--- a/.changeset/heavy-bananas-wash.md
+++ b/.changeset/heavy-bananas-wash.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Locked device retry button, uses v3 styles now

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -525,9 +525,9 @@ export const renderLockedDeviceError = ({
       </ErrorDescription>
       <ButtonContainer>
         {onRetry ? (
-          <Button primary onClick={onRetry}>
+          <ButtonV3 variant="main" onClick={onRetry}>
             {t("common.retry")}
-          </Button>
+          </ButtonV3>
         ) : null}
       </ButtonContainer>
     </Wrapper>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix the broken hover effect for the retry button on locked device error rendering, this should impact all cases of this error, so onboarding, rename, manager access, etc. And the rendering may differ depending on the context, but it should always be readable.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-5912` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="1136" alt="onboarding" src="https://user-images.githubusercontent.com/4631227/230145506-d4186501-ed57-4b1c-a8b2-16e28c446c93.png">
<img width="1136" alt="rename" src="https://user-images.githubusercontent.com/4631227/230145499-9a81287e-829a-472e-b7bb-1f874ca59c49.png">
<img width="1136" alt="manager" src="https://user-images.githubusercontent.com/4631227/230145505-49d1c71e-69dc-42e3-b031-e4f134ee71a8.png">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Make sure the button text is readable.