### PR TITLE
bugfix/LIVE-7007 Dynamic max device name length depending on model/fw

### DIFF
--- a/.changeset/new-dogs-visit.md
+++ b/.changeset/new-dogs-visit.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Allow for model and version dependent max name length

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/DeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/DeviceName.tsx
@@ -54,9 +54,10 @@ const DeviceName: React.FC<Props> = ({
       device,
       onSetName: onSuccess,
       deviceName: name,
+      deviceInfo,
     });
     track("Page Manager RenameDeviceEntered");
-  }, [device, name, onSuccess]);
+  }, [device, deviceInfo, name, onSuccess]);
 
   return (
     <Flex alignItems="center">

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { Button, Flex, Divider, Text, Input, Icons, BoxedIcon } from "@ledgerhq/react-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTranslation } from "react-i18next";
@@ -9,16 +9,18 @@ import Box from "~/renderer/components/Box";
 import { getDeviceModel } from "@ledgerhq/devices";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { createAction } from "@ledgerhq/live-common/hw/actions/renameDevice";
+import getDeviceNameMaxLength from "@ledgerhq/live-common/hw/getDeviceNameMaxLength";
 import renameDevice from "@ledgerhq/live-common/hw/renameDevice";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import styled from "styled-components";
+import { DeviceInfo } from "@ledgerhq/types-live";
 
 const action = createAction(renameDevice);
-const MAX_DEVICE_NAME = 20;
 
 type Props = {
   onClose: () => void;
   deviceName: string;
+  deviceInfo: DeviceInfo;
   onSetName: (name: string) => void;
   device: Device;
 };
@@ -29,10 +31,25 @@ const TextEllipsis = styled.div`
   text-overflow: ellipsis;
 `;
 
-const EditDeviceName: React.FC<Props> = ({ onClose, deviceName, onSetName, device }: Props) => {
+const EditDeviceName: React.FC<Props> = ({
+  onClose,
+  deviceName,
+  deviceInfo,
+  onSetName,
+  device,
+}: Props) => {
   const { t } = useTranslation();
+  const maxDeviceName = useMemo(
+    () =>
+      getDeviceNameMaxLength({
+        deviceModelId: device.modelId,
+        version: deviceInfo.version,
+      }),
+    [device.modelId, deviceInfo.version],
+  );
+
   const productName = device ? getDeviceModel(device.modelId).productName : null;
-  const [name, setName] = useState<string>(deviceName);
+  const [name, setName] = useState<string>(deviceName.slice(0, maxDeviceName));
   const [completed, setCompleted] = useState<boolean>(false);
   const [error, setError] = useState<Error | undefined | null>(null);
   const [running, setRunning] = useState(false);
@@ -43,16 +60,19 @@ const EditDeviceName: React.FC<Props> = ({ onClose, deviceName, onSetName, devic
     setRunning(false);
   }, [onClose]);
 
-  const onChangeText = useCallback((name: string) => {
-    // eslint-disable-next-line no-control-regex
-    const invalidCharacters = name.replace(/[\x00-\x7F]*/g, "");
-    const maybeError = invalidCharacters
-      ? new DeviceNameInvalid("", { invalidCharacters })
-      : undefined;
+  const onChangeText = useCallback(
+    (name: string) => {
+      // eslint-disable-next-line no-control-regex
+      const invalidCharacters = name.replace(/[\x00-\x7F]*/g, "");
+      const maybeError = invalidCharacters
+        ? new DeviceNameInvalid("", { invalidCharacters })
+        : undefined;
 
-    setError(maybeError);
-    setName(name.slice(0, MAX_DEVICE_NAME));
-  }, []);
+      setError(maybeError);
+      setName(name.slice(0, maxDeviceName));
+    },
+    [maxDeviceName],
+  );
 
   const onSubmit = useCallback(async () => {
     setRunning(true);
@@ -69,7 +89,7 @@ const EditDeviceName: React.FC<Props> = ({ onClose, deviceName, onSetName, devic
     onSetName(name);
   }, [onSetName, name]);
 
-  const remainingCharacters = MAX_DEVICE_NAME - name.length;
+  const remainingCharacters = maxDeviceName - name.length;
 
   return (
     <Flex

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -1,4 +1,9 @@
-import type { Operation, AccountLike, Account } from "@ledgerhq/types-live";
+import type {
+  Operation,
+  AccountLike,
+  Account,
+  DeviceInfo,
+} from "@ledgerhq/types-live";
 import type {
   NavigatorScreenParams,
   ParamListBase,
@@ -151,6 +156,7 @@ export type BaseNavigatorStackParamList = {
   [ScreenName.EditDeviceName]: {
     device: Device;
     deviceName: string;
+    deviceInfo: DeviceInfo;
   };
   [ScreenName.MarketCurrencySelect]: undefined;
   [ScreenName.PortfolioOperationHistory]: undefined;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseOnboardingNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseOnboardingNavigator.ts
@@ -1,5 +1,6 @@
 import { NavigatorScreenParams } from "@react-navigation/native";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceInfo } from "@ledgerhq/types-live";
 import { NavigatorName, ScreenName } from "../../../const";
 import { OnboardingNavigatorParamList } from "./OnboardingNavigator";
 import { BuyDeviceNavigatorParamList } from "./BuyDeviceNavigator";
@@ -22,6 +23,7 @@ export type BaseOnboardingNavigatorParamList = {
   [ScreenName.EditDeviceName]: {
     device: Device;
     deviceName: string;
+    deviceInfo: DeviceInfo;
   };
   [NavigatorName.PasswordAddFlow]: NavigatorScreenParams<PasswordAddFlowParamList>;
   [NavigatorName.PasswordModifyFlow]: NavigatorScreenParams<PasswordModifyFlowParamList>;

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useState } from "react";
+import React, { memo, useCallback, useMemo, useState } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "react-i18next";
 import { connect } from "react-redux";
@@ -7,6 +7,7 @@ import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/ind
 import { Button, Text, Icons, Flex } from "@ledgerhq/native-ui";
 import { createAction } from "@ledgerhq/live-common/hw/actions/renameDevice";
 import renameDevice from "@ledgerhq/live-common/hw/renameDevice";
+import getDeviceNameMaxLength from "@ledgerhq/live-common/hw/getDeviceNameMaxLength";
 import { TrackScreen } from "../analytics";
 import KeyboardBackgroundDismiss from "../components/KeyboardBackgroundDismiss";
 import TextInput from "../components/TextInput";
@@ -23,7 +24,6 @@ import { ScreenName } from "../const";
 import { BaseOnboardingNavigatorParamList } from "../components/RootNavigator/types/BaseOnboardingNavigator";
 import { BleSaveDeviceNamePayload } from "../actions/types";
 
-const MAX_DEVICE_NAME = 20;
 const action = createAction(renameDevice);
 
 const mapDispatchToProps = {
@@ -44,10 +44,23 @@ type Props = {
 function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
   const originalName = route.params?.deviceName;
   const device = route.params?.device;
+  const deviceInfo = route.params?.deviceInfo;
 
   const { t } = useTranslation();
   const { pushToast } = useToasts();
-  const [name, setName] = useState<string>(originalName);
+
+  const maxDeviceName = useMemo(
+    () =>
+      getDeviceNameMaxLength({
+        deviceModelId: device.modelId,
+        version: deviceInfo.version,
+      }),
+    [device.modelId, deviceInfo.version],
+  );
+
+  const [name, setName] = useState<string>(
+    originalName.slice(0, maxDeviceName),
+  );
   const [completed, setCompleted] = useState<boolean>(false);
   const [error, setError] = useState<Error | undefined | null>(null);
   const [running, setRunning] = useState(false);
@@ -98,7 +111,7 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
     }
   }, [completed, navigation]);
 
-  const remainingCount = MAX_DEVICE_NAME - name.length;
+  const remainingCount = maxDeviceName - name.length;
   const cleanName = name.trim();
   const disabled =
     !cleanName || !!error || running || cleanName === originalName;
@@ -112,7 +125,7 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
             <TextInput
               value={name}
               onChangeText={onChangeText}
-              maxLength={MAX_DEVICE_NAME}
+              maxLength={maxDeviceName}
               autoFocus
               selectTextOnFocus
               blurOnSubmit={true}

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceName.tsx
@@ -7,11 +7,13 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { TouchableOpacity } from "react-native";
+import { DeviceInfo } from "@ledgerhq/types-live";
 import { deviceNameByDeviceIdSelectorCreator } from "../../../reducers/ble";
 import { ScreenName } from "../../../const";
 
 type Props = {
   device: Device;
+  deviceInfo: DeviceInfo;
   initialDeviceName?: string | null;
   disabled: boolean;
 };
@@ -23,10 +25,11 @@ const hitSlop = {
   top: 8,
 };
 
-export default function DeviceNameRow({
+export default function DeviceName({
   device,
   initialDeviceName,
   disabled,
+  deviceInfo,
 }: Props) {
   const navigation = useNavigation();
   const savedName = useSelector(
@@ -41,8 +44,9 @@ export default function DeviceNameRow({
       navigation.navigate(ScreenName.EditDeviceName, {
         device,
         deviceName: savedName,
+        deviceInfo,
       }),
-    [device, savedName, navigation],
+    [navigation, device, savedName, deviceInfo],
   );
 
   const displayedName = savedName || initialDeviceName || productName;

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
@@ -139,6 +139,7 @@ const DeviceCard = ({
         >
           <DeviceName
             device={device}
+            deviceInfo={deviceInfo}
             initialDeviceName={initialDeviceName}
             disabled={pendingInstalls}
           />

--- a/libs/ledger-live-common/src/hw/editDeviceName.ts
+++ b/libs/ledger-live-common/src/hw/editDeviceName.ts
@@ -1,11 +1,19 @@
 import Transport from "@ledgerhq/hw-transport";
-import { UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { StatusCodes, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+
+/**
+ * Specify a new name for a device. This is technically supported on all models
+ * but only allowed on LNX and Stax currently. There are some FW version based
+ * limitations on the max length to account for but these are enforced at the
+ * command user level.
+ */
 export default async (transport: Transport, name: string): Promise<void> => {
   await transport.send(0xe0, 0xd4, 0x00, 0x00, Buffer.from(name)).catch((e) => {
-    if (e.statusCode === 0x6985 || e.statusCode === 0x5501) {
-      throw new UserRefusedDeviceNameChange(undefined, {
-        productName: "Device", //Nb When possible, this is caught and will be overriden by the correct name.
-      });
+    if (
+      e.statusCode === StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED ||
+      e.statusCode === StatusCodes.USER_REFUSED_ON_DEVICE
+    ) {
+      throw new UserRefusedDeviceNameChange();
     }
 
     throw e;

--- a/libs/ledger-live-common/src/hw/getDeviceNameMaxLength.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceNameMaxLength.test.ts
@@ -1,0 +1,85 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import getDeviceNameMaxLength from "./getDeviceNameMaxLength";
+
+describe("getDeviceNameMaxLength", () => {
+  test("LNX 2.1.0 and lower should max at 17", async () => {
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoX,
+        version: "2.1.0",
+      })
+    ).toBe(17);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoX,
+        version: "2.0.0",
+      })
+    ).toBe(17);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoX,
+        version: "1.5.5",
+      })
+    ).toBe(17);
+  });
+  test("LNX 2.2.0 and higher should max at 20", async () => {
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoX,
+        version: "2.2.0",
+      })
+    ).toBe(20);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoX,
+        version: "2.3.0",
+      })
+    ).toBe(20);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoX,
+        version: "4.2.0",
+      })
+    ).toBe(20);
+  });
+  test("Stax of any version should max at 20", async () => {
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.stax,
+        version: "0.0.1",
+      })
+    ).toBe(20);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.stax,
+        version: "1.2.3",
+      })
+    ).toBe(20);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.stax,
+        version: "3.4.5",
+      })
+    ).toBe(20);
+  });
+  test("Other models should just return 17 as a fallback", async () => {
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.blue,
+        version: "3.4.5",
+      })
+    ).toBe(17);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoSP,
+        version: "3.4.5",
+      })
+    ).toBe(17);
+    expect(
+      getDeviceNameMaxLength({
+        deviceModelId: DeviceModelId.nanoS,
+        version: "3.4.5",
+      })
+    ).toBe(17);
+  });
+});

--- a/libs/ledger-live-common/src/hw/getDeviceNameMaxLength.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceNameMaxLength.ts
@@ -1,0 +1,41 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import semver from "semver";
+
+type Props = {
+  deviceModelId: DeviceModelId;
+  version: string;
+};
+
+/**
+ * This code enforces a maximum device name length on the Live side due to a bug
+ * in LNX <2.2.0 that breaks the BLE stack if the name is longer than 17 characters.
+ * To ensure consistency with the maximum length that can be set on Stax (23), the
+ * visible characters (20), and the maximum APDU-driven rename length (30), this
+ * patch introduces a maximum length of 20 characters until all inconsistencies
+ * are aligned.
+ */
+const getDeviceNameMaxLength = (props: Props): number => {
+  const { deviceModelId, version } = props;
+
+  let maxLength = 17; // Default for other models and versions.
+
+  switch (deviceModelId) {
+    case DeviceModelId.nanoX: {
+      const coercedVersion = semver.coerce(version);
+      const validVersion = semver.valid(coercedVersion) || "";
+
+      if (semver.gte(validVersion, "2.2.0")) {
+        maxLength = 20;
+      }
+      break;
+    }
+
+    case DeviceModelId.stax:
+      maxLength = 20;
+      break;
+  }
+
+  return maxLength;
+};
+
+export default getDeviceNameMaxLength;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Addressing a bug originally reported here https://github.com/LedgerHQ/ledger-live/issues/2987 where the BLE stack actually breaks on the Nano X if we rename a device to anything longer than 17 characters. This is already patched on 2.2.0 so updating the firmware should fix the problem, however, we have thousands of users that can potentially fall in this case and if the only connection mode they have is BLE this can be quite disruptive. 

This PR introduces the limitation of characters based on model and firmware version, falling back to 17 for all cases except LNX >=2.2.0 and any version of Stax.

Fixes https://github.com/LedgerHQ/ledger-live/issues/2987

### ❓ Context

- **Impacted projects**: `ledger-live-common, ledger-live-desktop, ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7007` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo

### 🚀 Expectations to reach
Test that you can rename the device properly and still connect in the above scenarios, also if renaming on the Stax to anything longer than 20 characters the last ones will be truncated from Ledger Live apps because the editor will not allow anything longer than that.