### PR TITLE
Bugfix: LIVE-7067 allow proxy device to bypass BLE requirements

### DIFF
--- a/.changeset/seven-pears-poke.md
+++ b/.changeset/seven-pears-poke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: enable debug proxy device to bypass bluetooth requirement

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -109,14 +109,14 @@ export default function SelectDevice({
 
   const handleOnSelect = useCallback(
     (device: Device) => {
-      const { modelId, wired } = device;
+      const { modelId, wired, deviceId } = device;
       track("Device selection", {
         modelId,
         connectionType: wired ? "USB" : "BLE",
       });
 
-      // If not wired, bluetooth is required
-      if (!wired) {
+      // If neither wired nor proxy-debug device, bluetooth is required
+      if (!wired && !deviceId.includes("httpdebug")) {
         if (!isBleRequired) {
           setLastSelectedDeviceBeforeRequireBluetoothCheck(device);
           setIsBleRequired(true);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Debug proxy (http) device were blocked on the new device selection component as the bluetooth requirement has been enforced recently.

This little added check fix this issue.

### ❓ Context

- **Impacted projects**: `LLM`
- **Linked resource(s)**: [LIVE-7067](https://ledgerhq.atlassian.net/browse/LIVE-7067)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<details>
  <summary>Small demo</summary>

https://user-images.githubusercontent.com/15096913/231480518-ff0d7055-ef45-4d4f-ad1d-2640ce539a8f.mp4



</details>

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7067]: https://ledgerhq.atlassian.net/browse/LIVE-7067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ