### PR TITLE
LLM [LIVE-7091] fix LLM sync-onboarding close button behavior

### DIFF
--- a/.changeset/fifty-oranges-help.md
+++ b/.changeset/fifty-oranges-help.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the behavior of the close button in the sync onboarding

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -28,7 +28,7 @@ import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { StorylyInstanceID } from "@ledgerhq/types-live";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { addKnownDevice } from "../../actions/ble";
-import { NavigatorName, ScreenName } from "../../const";
+import { ScreenName } from "../../const";
 import HelpDrawer from "./HelpDrawer";
 import DesyncDrawer from "./DesyncDrawer";
 import ResyncOverlay from "./ResyncOverlay";
@@ -41,10 +41,7 @@ import {
   setReadOnlyMode,
 } from "../../actions/settings";
 import DeviceSetupView from "../../components/DeviceSetupView";
-import {
-  BaseNavigatorStackParamList,
-  NavigateInput,
-} from "../../components/RootNavigator/types/BaseNavigator";
+import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { RootStackParamList } from "../../components/RootNavigator/types/RootNavigator";
 import { SyncOnboardingStackParamList } from "../../components/RootNavigator/types/SyncOnboardingNavigator";
 import InstallSetOfApps from "../../components/DeviceAction/InstallSetOfApps";

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -191,42 +191,6 @@ export const SyncOnboarding = ({
   const [isHelpDrawerOpen, setHelpDrawerOpen] = useState<boolean>(false);
   const [shouldRestoreApps, setShouldRestoreApps] = useState<boolean>(false);
 
-  const goBackToPairingFlow = useCallback(() => {
-    const navigateInput: NavigateInput<
-      RootStackParamList,
-      NavigatorName.BaseOnboarding
-    > = {
-      name: NavigatorName.BaseOnboarding,
-      params: {
-        screen: NavigatorName.SyncOnboarding,
-        params: {
-          screen: ScreenName.SyncOnboardingCompanion,
-          params: {
-            // @ts-expect-error BleDevicePairingFlow will set this param
-            device: null,
-          },
-        },
-      },
-    };
-
-    // On pairing success, navigate to the Sync Onboarding Companion
-    // Replace to avoid going back to this screen on return from the pairing flow
-    navigation.navigate(NavigatorName.Base, {
-      screen: ScreenName.BleDevicePairingFlow,
-      params: {
-        // TODO: For now, don't do that because stax shows up as nanoX
-        // filterByDeviceModelId: device.modelId,
-        areKnownDevicesDisplayed: true,
-        onSuccessAddToKnownDevices: false,
-        onSuccessNavigateToConfig: {
-          navigationType: "navigate",
-          navigateInput,
-          pathToDeviceParam: "params.params.params.device",
-        },
-      },
-    });
-  }, [navigation]);
-
   const {
     onboardingState: deviceOnboardingState,
     allowedError,
@@ -261,8 +225,8 @@ export const SyncOnboarding = ({
 
   const handleDesyncClose = useCallback(() => {
     setDesyncDrawerOpen(false);
-    goBackToPairingFlow();
-  }, [goBackToPairingFlow]);
+    navigation.goBack();
+  }, [navigation]);
 
   const handleDeviceReady = useCallback(() => {
     // Adds the device to the list of known devices
@@ -282,8 +246,8 @@ export const SyncOnboarding = ({
   }, [device, dispatchRedux, navigation]);
 
   const handleClose = useCallback(() => {
-    readyRedirectTimerRef.current ? handleDeviceReady() : goBackToPairingFlow();
-  }, [goBackToPairingFlow, handleDeviceReady]);
+    readyRedirectTimerRef.current ? handleDeviceReady() : navigation.goBack();
+  }, [navigation, handleDeviceReady]);
 
   useEffect(() => {
     if (!fatalError) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Instead of a complicated logic of navigation to the pairing screen (which causes a navigation loop from which it's impossible to go out of, except with the OS back gestures/buttons), the close button should not assume anything on the general navigation context and just... navigate back?

### ❓ Context

- **Impacted projects**: `mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7091] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

#### Steps to Reproduce:

- Click “get started” then close LLM
- Scan sync-onboarding QR-code
- Select Stax device on scanning screen
- Close sync-onboarding (click on cross)
- Click back on scanning screen 

**Expected behavior:**

Go back to onboarding first page

**Actual behavior:**

Opens previous device sync-onboarding


https://user-images.githubusercontent.com/91890529/231806116-fc924e2b-2bf6-4e1a-a8e1-344e353cbecb.MP4




### ✅ Checklist

- [ ] **Test coverage** flow too complex to handle through e2e test for now, mocking possibilites regarding device interactions is not sufficient for a sync onboarding flow
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/91890529/231984984-a39b4b29-f89f-4f5f-bd42-c6c294de86d1.MP4




### 🚀 Expectations to reach

The expected behavior described in the Context section should be what happens.

How to test:

NB: you won’t be able to test with the QR code directly as it only works with the apps with the prod/nightly bundle id / package name, but you can test
- with the deeplink `ledgerlive://sync-onboarding`
- or with the staging universal link (which is the staging equivalent of what the link in the QR code redirects to) https://ledger-staging.go.link/sync-onboarding?adj_t=p72sbdr

You should test the behavior of the close button of the sync onboarding in the 4 scenarios in which it can be reached:
- non onboarded LL
  - through deeplink or universal link
  - through device selection in regular onboarding flow
- onboarded LL
  - through deeplink or universal link
  - through “my ledger” add new device flow

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7091]: https://ledgerhq.atlassian.net/browse/LIVE-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ