### PR TITLE
feat: LIVE-6654 check if we are in BOLOS before appOp in BLE

### DIFF
--- a/.changeset/late-toys-melt.md
+++ b/.changeset/late-toys-melt.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+automatically quit apps when installing/uninstalling on LLM BLE

--- a/apps/ledger-live-mobile/src/screens/Manager/shared.ts
+++ b/apps/ledger-live-mobile/src/screens/Manager/shared.ts
@@ -6,7 +6,7 @@ import { isDashboardName } from "@ledgerhq/live-common/hw/isDashboardName";
 
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import quitApp from "@ledgerhq/live-common/hw/quitApp";
-import { concatMap } from "rxjs/operators";
+import { concatMap, retry } from "rxjs/operators";
 import { from, of, timer } from "rxjs";
 import getAppAndVersion from "@ledgerhq/live-common/hw/getAppAndVersion";
 
@@ -17,6 +17,8 @@ export function useApps(
 ) {
   // Nb Two device jobs are chained due to the BLE stack getting reset when we enter/exit,
   // an application. A reconnectable transport paradigm could simplify this.
+  // The `retry` is present because some devices take longer to become available for BLE
+  // connection than others.
   const exec: Exec = useCallback(
     (...args) =>
       withDevice(deviceId)(transport =>
@@ -29,11 +31,11 @@ export function useApps(
         ),
       ).pipe(
         concatMap(alreadyInDashboard =>
-          timer(alreadyInDashboard ? 0 : 4000).pipe(
+          timer(alreadyInDashboard ? 0 : 2000).pipe(
             concatMap(_ =>
               withDevice(deviceId)(transport =>
                 execWithTransport(transport)(...args),
-              ),
+              ).pipe(retry(3)),
             ),
           ),
         ),

--- a/apps/ledger-live-mobile/src/screens/Manager/shared.ts
+++ b/apps/ledger-live-mobile/src/screens/Manager/shared.ts
@@ -2,16 +2,42 @@ import { useCallback } from "react";
 import type { Exec, ListAppsResult } from "@ledgerhq/live-common/apps/index";
 import { useAppsRunner } from "@ledgerhq/live-common/apps/react";
 import { execWithTransport } from "@ledgerhq/live-common/apps/hw";
+import { isDashboardName } from "@ledgerhq/live-common/hw/isDashboardName";
+
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import quitApp from "@ledgerhq/live-common/hw/quitApp";
+import { concatMap } from "rxjs/operators";
+import { from, of, timer } from "rxjs";
+import getAppAndVersion from "@ledgerhq/live-common/hw/getAppAndVersion";
 
 export function useApps(
   listAppsRes: ListAppsResult,
   deviceId: string,
   appsToRestore?: string[],
 ) {
+  // Nb Two device jobs are chained due to the BLE stack getting reset when we enter/exit,
+  // an application. A reconnectable transport paradigm could simplify this.
   const exec: Exec = useCallback(
     (...args) =>
-      withDevice(deviceId)(transport => execWithTransport(transport)(...args)),
+      withDevice(deviceId)(transport =>
+        from(getAppAndVersion(transport)).pipe(
+          concatMap(appAndVersion =>
+            isDashboardName(appAndVersion.name)
+              ? of(true)
+              : from(quitApp(transport)),
+          ),
+        ),
+      ).pipe(
+        concatMap(alreadyInDashboard =>
+          timer(alreadyInDashboard ? 0 : 4000).pipe(
+            concatMap(_ =>
+              withDevice(deviceId)(transport =>
+                execWithTransport(transport)(...args),
+              ),
+            ),
+          ),
+        ),
+      ),
     [deviceId],
   );
 

--- a/apps/ledger-live-mobile/src/screens/PairDevices/RenderError.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/RenderError.tsx
@@ -65,7 +65,7 @@ function RenderError({ error, status, onBypassGenuine, onRetry }: Props) {
 
   const isPairingStatus = status === "pairing";
   const isGenuineCheckStatus = status === "genuinecheck";
-  const url = (isPairingStatus && urls.errors.PairingFailed) || undefined;
+  const url = isPairingStatus ? urls.errors.PairingFailed : undefined;
 
   const outerError = isPairingStatus
     ? new PairingFailed()


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
In the LLD USB event based paradigm we detect that a device has left the dashboard and entered an application while we are in the My Ledger screen and react to it by exiting the screen and offering some meaningful UI. This was done in order to allow the user to interact with another application if they forgot that LLD was open. 

On LLM things are a bit different and we can't detect that application switch until we try to talk to the device the next time, this resulted in the `appOp` (installations and uninstallations) failing when we tried to relay the apdus from the HSM through the scriptrunner connection since it expects BOLOS and not some random app to be open.

This PR introduces a check that only impacts LLM that will query the device for its currently running application and quit it if needed. The difference here is that the installation is a deliberate action from the user so it makes sense that we want to respect the action even at the cost of quitting a running app, whereas on LLD we react to the app switch because the action was done on the device and not on LLD.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-6654

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/4631227/231822635-73f41890-17b5-476d-99d5-0b404a6e81da.mp4


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
I haven't tested how it behaves on USB OTG but I expect it to work as well, worth checking though if the app switch is impacting this. It is **only** used inside the manager, flows like inline app installs are not affected and there's no need to test them to validate the PR since they go through a device action which already ensures that we are in the right app.