### PR TITLE
feat: deeplink for stax restore with recover

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -88,6 +88,7 @@ import {
   NavigationHeaderCloseButton,
   NavigationHeaderCloseButtonAdvanced,
 } from "../NavigationHeaderCloseButton";
+import { RedirectToRecoverStaxFlowScreen } from "../../screens/Protect/RedirectToRecoverStaxFlow";
 
 const Stack = createStackNavigator<BaseNavigatorStackParamList>();
 
@@ -563,6 +564,11 @@ export default function BaseNavigator() {
         name={ScreenName.RedirectToOnboardingRecoverFlow}
         options={{ headerShown: false }}
         component={RedirectToOnboardingRecoverFlowScreen}
+      />
+      <Stack.Screen
+        name={ScreenName.RedirectToRecoverStaxFlow}
+        options={{ headerShown: false }}
+        component={RedirectToRecoverStaxFlowScreen}
       />
       <Stack.Screen
         name={NavigatorName.NoFundsFlow}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -178,6 +178,7 @@ export type BaseNavigatorStackParamList = {
     areKnownDevicesDisplayed?: boolean;
     areKnownDevicesPairable?: boolean;
     onSuccessAddToKnownDevices?: boolean;
+    isRecoverFlow?: boolean;
     onSuccessNavigateToConfig: {
       navigateInput: NavigateInput;
       pathToDeviceParam: PathToDeviceParam;
@@ -328,4 +329,5 @@ export type BaseNavigatorStackParamList = {
   [NavigatorName.StakeFlow]: NavigatorScreenParams<StakeNavigatorParamList>;
 
   [ScreenName.RedirectToOnboardingRecoverFlow]: undefined;
+  [ScreenName.RedirectToRecoverStaxFlow]: undefined;
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -178,7 +178,6 @@ export type BaseNavigatorStackParamList = {
     areKnownDevicesDisplayed?: boolean;
     areKnownDevicesPairable?: boolean;
     onSuccessAddToKnownDevices?: boolean;
-    isRecoverFlow?: boolean;
     onSuccessNavigateToConfig: {
       navigateInput: NavigateInput;
       pathToDeviceParam: PathToDeviceParam;
@@ -329,5 +328,5 @@ export type BaseNavigatorStackParamList = {
   [NavigatorName.StakeFlow]: NavigatorScreenParams<StakeNavigatorParamList>;
 
   [ScreenName.RedirectToOnboardingRecoverFlow]: undefined;
-  [ScreenName.RedirectToRecoverStaxFlow]: undefined;
+  [ScreenName.RedirectToRecoverStaxFlow]: Record<string, unknown>;
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -484,6 +484,7 @@ export enum ScreenName {
   Stake = "Stake",
 
   RedirectToOnboardingRecoverFlow = "RedirectToOnboardingRecoverFlow",
+  RedirectToRecoverStaxFlow = "RedirectToRecoverStaxFlow",
 }
 export enum NavigatorName {
   // Stack

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -161,6 +161,7 @@ const linkingOptions = {
           [ScreenName.BleDevicePairingFlow]: "sync-onboarding",
 
           [ScreenName.RedirectToOnboardingRecoverFlow]: "recover-restore-flow",
+          [ScreenName.RedirectToRecoverStaxFlow]: "recover-restore-stax-flow",
 
           [NavigatorName.PostOnboarding]: {
             screens: {

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -380,6 +380,8 @@ const getOnboardingLinkingOptions = (acceptedTermsOfUse: boolean) => ({
                */
               [ScreenName.PlatformApp]: "discover/:platform",
               [ScreenName.Recover]: "recover/:platform",
+              [ScreenName.RedirectToRecoverStaxFlow]:
+                "recover-restore-stax-flow",
             },
           },
         },

--- a/apps/ledger-live-mobile/src/screens/BleDevicePairingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/BleDevicePairingFlow/index.tsx
@@ -1,10 +1,8 @@
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import React, { useCallback } from "react";
 import { has as hasFromPath, set as setFromPath } from "lodash";
-import { Linking } from "react-native";
 import { Flex } from "@ledgerhq/native-ui";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { NavigatorName, ScreenName } from "../../const";
 import { useIncrementOnNavigationFocusState } from "../../helpers/useIncrementOnNavigationFocusState";
 import BleDevicePairingFlowComponent, {
@@ -17,8 +15,6 @@ import {
 } from "../../components/RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { NavigationHeaderBackButton } from "../../components/NavigationHeaderBackButton";
-import { ServicesConfig } from "../../components/ServicesWidget/types";
-import { usePostOnboardingURI } from "../../hooks/recoverFeatureFlag";
 
 export type Props = RootComposite<
   StackNavigatorProps<
@@ -41,7 +37,6 @@ const defaultNavigationParams = {
   filterByDeviceModelId: DeviceModelId.stax, // This needs to be removed when nanos are supported
   areKnownDevicesDisplayed: true,
   onSuccessAddToKnownDevices: false,
-  isRecoverFlow: false,
   successNavigateToConfig: {
     navigationType: "navigate",
     pathToDeviceParam: "params.params.params.device",
@@ -103,7 +98,6 @@ export const BleDevicePairingFlow = ({ navigation, route }: Props) => {
     areKnownDevicesDisplayed = true,
     areKnownDevicesPairable = false,
     onSuccessAddToKnownDevices = false,
-    isRecoverFlow = false,
     onSuccessNavigateToConfig = defaultNavigationParams.successNavigateToConfig,
   } = params;
 
@@ -113,25 +107,12 @@ export const BleDevicePairingFlow = ({ navigation, route }: Props) => {
     navigationType = "navigate",
   } = onSuccessNavigateToConfig;
 
-  const recoverConfig: ServicesConfig | null = useFeature(
-    "protectServicesMobile",
-  );
-
   // Makes sure the pairing components are reset when navigating back to this screen
   const keyToReset =
     useIncrementOnNavigationFocusState<Props["navigation"]>(navigation);
 
-  const recoverRestoreFlowURI = usePostOnboardingURI();
-
   const onPairingSuccess = useCallback(
     (device: Device) => {
-      if (recoverConfig?.enabled && recoverRestoreFlowURI && isRecoverFlow) {
-        Linking.canOpenURL(recoverRestoreFlowURI).then(() =>
-          Linking.openURL(recoverRestoreFlowURI),
-        );
-        return;
-      }
-
       const hasDeviceParam = hasFromPath(navigateInput, pathToDeviceParam);
       if (hasDeviceParam) {
         setFromPath(navigateInput, pathToDeviceParam, device);
@@ -162,15 +143,7 @@ export const BleDevicePairingFlow = ({ navigation, route }: Props) => {
         navigation.navigate(navigateInput.name, params);
       }
     },
-    [
-      isRecoverFlow,
-      navigateInput,
-      navigation,
-      navigationType,
-      pathToDeviceParam,
-      recoverConfig?.enabled,
-      recoverRestoreFlowURI,
-    ],
+    [navigateInput, navigation, navigationType, pathToDeviceParam],
   );
 
   const requestToSetHeaderOptions = useCallback(

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from "react";
+import { useNavigation } from "@react-navigation/native";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
+import {
+  RootComposite,
+  StackNavigatorProps,
+} from "../../components/RootNavigator/types/helpers";
+import { NavigatorName, ScreenName } from "../../const";
+import { useNavigationInterceptor } from "../Onboarding/onboardingContext";
+
+type NavigationProps = RootComposite<
+  StackNavigatorProps<
+    BaseNavigatorStackParamList,
+    ScreenName.RedirectToOnboardingRecoverFlow
+  >
+>;
+
+export function RedirectToRecoverStaxFlowScreen() {
+  const { replace } = useNavigation<NavigationProps["navigation"]>();
+  const { setShowWelcome, setFirstTimeOnboarding } = useNavigationInterceptor();
+
+  useEffect(() => {
+    setShowWelcome(false);
+    setFirstTimeOnboarding(false);
+    replace(NavigatorName.Base, {
+      screen: ScreenName.BleDevicePairingFlow,
+      params: {
+        filterByDeviceModelId: DeviceModelId.stax,
+        areKnownDevicesDisplayed: true,
+        onSuccessAddToKnownDevices: false,
+        isRecoverFlow: true,
+        // `onSuccessNavigateToConfig` will never be used when `isRecoverFlow: true`
+        onSuccessNavigateToConfig: {
+          navigationType: "push",
+          navigateInput: {
+            name: NavigatorName.BaseOnboarding,
+            params: {
+              screen: NavigatorName.SyncOnboarding,
+              params: {
+                screen: ScreenName.SyncOnboardingCompanion,
+                params: {
+                  device: null,
+                },
+              },
+            },
+          },
+          pathToDeviceParam: "params.params.params.device",
+        },
+      },
+    });
+  }, [replace, setFirstTimeOnboarding, setShowWelcome]);
+
+  return <></>;
+}

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
@@ -58,9 +58,9 @@ export function RedirectToRecoverStaxFlowScreen({
           key={keyToReset}
           filterByDeviceModelId={DeviceModelId.stax}
           areKnownDevicesDisplayed={true}
-          areKnownDevicesPairable={false}
+          areKnownDevicesPairable={true}
           onPairingSuccess={onPairingSuccess}
-          onPairingSuccessAddToKnownDevices={false}
+          onPairingSuccessAddToKnownDevices={true}
         />
       </Flex>
     </DeviceSetupView>

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect } from "react";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Flex } from "@ledgerhq/native-ui";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { Linking } from "react-native";
+import { Linking, StyleSheet, SafeAreaView } from "react-native";
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import {
   RootComposite,
@@ -11,7 +11,6 @@ import {
 import { ScreenName } from "../../const";
 import { useNavigationInterceptor } from "../Onboarding/onboardingContext";
 import BleDevicePairingFlow from "../../components/BleDevicePairingFlow";
-import DeviceSetupView from "../../components/DeviceSetupView";
 import { useIncrementOnNavigationFocusState } from "../../helpers/useIncrementOnNavigationFocusState";
 import { usePostOnboardingURI } from "../../hooks/recoverFeatureFlag";
 import { ServicesConfig } from "../../components/ServicesWidget/types";
@@ -51,8 +50,15 @@ export function RedirectToRecoverStaxFlowScreen({
     }
   }, [recoverConfig?.enabled, recoverRestoreFlowURI]);
 
+  const requestToSetHeaderOptions = useCallback(
+    () => ({
+      type: "clean",
+    }),
+    [],
+  );
+
   return (
-    <DeviceSetupView hasBackButton>
+    <SafeAreaView style={[styles.root]}>
       <Flex px={6} flex={1}>
         <BleDevicePairingFlow
           key={keyToReset}
@@ -61,8 +67,17 @@ export function RedirectToRecoverStaxFlowScreen({
           areKnownDevicesPairable={true}
           onPairingSuccess={onPairingSuccess}
           onPairingSuccessAddToKnownDevices={true}
+          requestToSetHeaderOptions={requestToSetHeaderOptions}
         />
       </Flex>
-    </DeviceSetupView>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    margin: 16,
+    alignSelf: "center",
+  },
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds the configuration for Stax's recovery with Recover.

NOTE: since I own no Stax, I changed the config to filter NanoX for the demo.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [PROTECT-1734](https://ledgerhq.atlassian.net/browse/PROTECT-1734)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/102669540/232054825-03f3251d-58f1-4966-ab3a-f5987c0fec4a.mp4

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-1734]: https://ledgerhq.atlassian.net/browse/PROTECT-1734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ