### PR TITLE
feat(News):LLM-Swap NewsFeed Tab with Learn Tab

### DIFF
--- a/.changeset/perfect-months-shop.md
+++ b/.changeset/perfect-months-shop.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Swap NewsFeed Tab with Learn Tab in Discover section

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExploreTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExploreTabNavigator.tsx
@@ -37,7 +37,7 @@ export default function ExploreTabNavigator() {
 
   return (
     <ExploreTab.Navigator
-      initialRouteName={ScreenName.Learn}
+      initialRouteName={ScreenName.Newsfeed}
       backBehavior={"history"}
       tabBar={
         isNewsfeedAvailable && isLearnAvailable
@@ -47,6 +47,15 @@ export default function ExploreTabNavigator() {
       style={{ backgroundColor: "transparent" }}
       sceneContainerStyle={{ backgroundColor: "transparent" }}
     >
+      {isNewsfeedAvailable && (
+        <ExploreTab.Screen
+          name={ScreenName.Newsfeed}
+          component={NewsfeedPage}
+          options={{
+            title: t("newsfeed.title"),
+          }}
+        />
+      )}
       {isLearnAvailable && (
         <ExploreTab.Screen
           name={ScreenName.Learn}
@@ -58,16 +67,6 @@ export default function ExploreTabNavigator() {
             headerLeft: () => <BackButton navigation={navigation} />,
             headerRight: () => null,
           })}
-        />
-      )}
-
-      {isNewsfeedAvailable && (
-        <ExploreTab.Screen
-          name={ScreenName.Newsfeed}
-          component={NewsfeedPage}
-          options={{
-            title: t("newsfeed.title"),
-          }}
         />
       )}
     </ExploreTab.Navigator>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

LLM - News Tab default redirection to NewsFeed and not Learn tab

When a user clicks on the News section in the Discover page he is expected to be redirected to the newsFeed tab by default and not the Learn Tab


### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-6963] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/112866305/232781831-ec405d38-dc04-47f2-b971-72066211993b.mp4

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
