### PR TITLE
feat: pass buy deeplink query params to the buy application (LIVE-6743)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
@@ -99,7 +99,7 @@ export function useDeepLinkHandler() {
           break;
         }
         case "buy":
-          navigate("/exchange");
+          navigate("/exchange", undefined, search);
           break;
         case "earn": {
           navigate("/earn", undefined, search);

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -51,7 +51,8 @@ const DEFAULT_MULTIBUY_APP_ID = "multibuy";
 
 // Exchange (Buy / Sell) as a live app screen
 const LiveAppExchange = ({ appId }: { appId: string }) => {
-  const { state: urlParams } = useLocation();
+  const { state: urlParams, search } = useLocation();
+  const searchParams = new URLSearchParams(search);
   const locale = useSelector(languageSelector);
 
   const mockManifest: LiveAppManifest | undefined =
@@ -76,6 +77,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
             theme: themeType,
             ...urlParams,
             lang: locale,
+            ...Object.fromEntries(searchParams.entries()),
           }}
         />
       ) : null}

--- a/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
@@ -24,6 +24,9 @@ const appManifestNotFoundError = new Error("App not found"); // FIXME move this 
 export function BuyAndSellScreen({ route }: Props) {
   const { theme } = useTheme();
   const { platform: appId, ...params } = route.params || {};
+  const searchParams = route.path
+    ? new URL("ledgerlive://" + route.path).searchParams
+    : new URLSearchParams();
   const localManifest = useLocalLiveAppManifest(appId);
   const remoteManifest = useRemoteLiveAppManifest(appId);
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
@@ -39,6 +42,7 @@ export function BuyAndSellScreen({ route }: Props) {
           theme,
           lang: locale,
           ...params,
+          ...Object.fromEntries(searchParams.entries()),
         }}
       />
     </>


### PR DESCRIPTION
### 📝 Description

In LLM / LLD, allow deeplink query params to go to the buy application. This feature will be used in the binance buy integration : the binance sso is made in the browser, then redirects back to binance page in buy section thanks to this deeplink - query params contain authentication state. See related PR in buy application.

### ❓ Context

- **Impacted projects**: `LLM, LLD` 
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6743`

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
