### PR TITLE
chore: remove instances of service account token

### DIFF
--- a/.github/workflow-templates/bot-coin-family.yml
+++ b/.github/workflow-templates/bot-coin-family.yml
@@ -45,13 +45,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflow-templates/bot-coin-family.yml
+++ b/.github/workflow-templates/bot-coin-family.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
-          ref: ledger-live-bot
+          ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
           token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps

--- a/.github/workflows/bot-carbon.yml
+++ b/.github/workflows/bot-carbon.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
-          ref: ledger-live-bot
+          ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
           token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps

--- a/.github/workflows/bot-carbon.yml
+++ b/.github/workflows/bot-carbon.yml
@@ -52,13 +52,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-mere-denis.yml
+++ b/.github/workflows/bot-mere-denis.yml
@@ -52,13 +52,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-mooncake.yml
+++ b/.github/workflows/bot-mooncake.yml
@@ -52,13 +52,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-nitrogen.yml
+++ b/.github/workflows/bot-nitrogen.yml
@@ -52,13 +52,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-nonreg-carbon.yml
+++ b/.github/workflows/bot-nonreg-carbon.yml
@@ -44,13 +44,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-nonreg-mooncake.yml
+++ b/.github/workflows/bot-nonreg-mooncake.yml
@@ -44,13 +44,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-nonreg-nitrogen.yml
+++ b/.github/workflows/bot-nonreg-nitrogen.yml
@@ -45,13 +45,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-nonreg-oxygen.yml
+++ b/.github/workflows/bot-nonreg-oxygen.yml
@@ -44,13 +44,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-nonreg-silicium.yml
+++ b/.github/workflows/bot-nonreg-silicium.yml
@@ -44,13 +44,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-oxygen.yml
+++ b/.github/workflows/bot-oxygen.yml
@@ -51,13 +51,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-phosphore.yml
+++ b/.github/workflows/bot-phosphore.yml
@@ -52,13 +52,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-portfolio-report.yml
+++ b/.github/workflows/bot-portfolio-report.yml
@@ -56,13 +56,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - name: Setup the toolchain
         uses: ./tools/actions/composites/setup-toolchain

--- a/.github/workflows/bot-silicium.yml
+++ b/.github/workflows/bot-silicium.yml
@@ -52,13 +52,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-staging-explorer-btc.yml
+++ b/.github/workflows/bot-staging-explorer-btc.yml
@@ -45,6 +45,12 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
         with:
           ref: main
@@ -53,7 +59,7 @@ jobs:
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -45,6 +45,12 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
         with:
           ref: main
@@ -53,7 +59,7 @@ jobs:
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - uses: ./tools/actions/composites/bot
         id: bot

--- a/.github/workflows/bot-transfer.yml
+++ b/.github/workflows/bot-transfer.yml
@@ -57,13 +57,19 @@ jobs:
     runs-on: ${{ needs.start-runner.outputs.label }}
     needs: [start-runner]
     steps:
+      - name: generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v3
       - name: Retrieving coin apps
         uses: actions/checkout@v3
         with:
           ref: generated/ledger-live-bot
           repository: LedgerHQ/coin-apps
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           path: coin-apps
       - name: Setup the toolchain
         uses: ./tools/actions/composites/setup-toolchain

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Git stuff
         run: |
           git config checkout.defaultRemote origin
-          git config user.email "team-live@ledger.fr"
+          git config user.email "105061298+live-github-bot[bot]@users.noreply.github.com"
           git config user.name "live-github-bot[bot]"
           git fetch -n origin
       - name: Execute shell script

--- a/tools/actions/turbo-affected/src/main.ts
+++ b/tools/actions/turbo-affected/src/main.ts
@@ -8,7 +8,7 @@ async function main() {
 
   try {
     const turboOutput = execSync(
-      `npx turbo@1.7 run ${command} --filter=...[${ref}] --dry=json`,
+      `npx turbo@1.8 run ${command} --filter=...[${ref}] --dry=json`,
       { encoding: "utf-8" }
     );
     const pnpmOutput = execSync(`npx pnpm list -r --depth=0 --json`, {

--- a/tools/github-bot/src/features/orchestrator/index.ts
+++ b/tools/github-bot/src/features/orchestrator/index.ts
@@ -29,53 +29,56 @@ export function orchestrator(app: Probot) {
    * When a workflow is requested for the first time:
    *  - Create the related check run
    */
-  app.on("workflow_run.requested", async (context) => {
-    const { payload, octokit } = context;
+  app.on(
+    "workflow_run.requested",
+    async (context): Promise<void> => {
+      const { payload, octokit } = context;
 
-    const { owner, repo } = context.repo();
-    const workflowFile = extractWorkflowFile(payload);
-    const matchedWorkflow = WORKFLOWS[workflowFile as keyof typeof WORKFLOWS];
+      const { owner, repo } = context.repo();
+      const workflowFile = extractWorkflowFile(payload);
+      const matchedWorkflow = WORKFLOWS[workflowFile as keyof typeof WORKFLOWS];
 
-    if (matchedWorkflow) {
-      context.log.info(
-        `[Orchestrator](workflow_run.requested) ${payload.workflow_run.name}`
-      );
-      const workflowUrl = payload.workflow_run.html_url;
-      const summaryPrefix = matchedWorkflow.description
-        ? `#### ${matchedWorkflow.description}\n\n`
-        : "";
+      if (matchedWorkflow) {
+        context.log.info(
+          `[Orchestrator](workflow_run.requested) ${payload.workflow_run.name}`
+        );
+        const workflowUrl = payload.workflow_run.html_url;
+        const summaryPrefix = matchedWorkflow.description
+          ? `#### ${matchedWorkflow.description}\n\n`
+          : "";
 
-      const { data: checkSuite } = await octokit.checks.getSuite({
-        owner,
-        repo,
-        check_suite_id: payload.workflow_run.check_suite_id,
-      });
+        const { data: checkSuite } = await octokit.checks.getSuite({
+          owner,
+          repo,
+          check_suite_id: payload.workflow_run.check_suite_id,
+        });
 
-      // Will trigger the check_run.created event (which will update the watcher)
-      context.log.info(
-        `[Orchestrator](workflow_run.requested) Creating check run ${matchedWorkflow.checkRunName} @sha ${checkSuite.head_sha}`
-      );
+        // Will trigger the check_run.created event (which will update the watcher)
+        context.log.info(
+          `[Orchestrator](workflow_run.requested) Creating check run ${matchedWorkflow.checkRunName} @sha ${checkSuite.head_sha}`
+        );
 
-      const response = await octokit.checks.create({
-        owner,
-        repo,
-        name: matchedWorkflow.checkRunName,
-        head_sha: checkSuite.head_sha,
-        status: "queued",
-        started_at: new Date().toISOString(),
-        output: {
-          title: "⏱️ Queued",
-          summary:
-            summaryPrefix +
-            `The **[workflow](${workflowUrl})** is currently queued.`,
-          details_url: workflowUrl,
-        },
-      });
-      context.log.info(
-        `[Orchestrator](workflow_run.requested) Check run created @id ${response.data.id}`
-      );
+        const response = await octokit.checks.create({
+          owner,
+          repo,
+          name: matchedWorkflow.checkRunName,
+          head_sha: checkSuite.head_sha,
+          status: "queued",
+          started_at: new Date().toISOString(),
+          output: {
+            title: "⏱️ Queued",
+            summary:
+              summaryPrefix +
+              `The **[workflow](${workflowUrl})** is currently queued.`,
+            details_url: workflowUrl,
+          },
+        });
+        context.log.info(
+          `[Orchestrator](workflow_run.requested) Check run created @id ${response.data.id}`
+        );
+      }
     }
-  });
+  );
 
   /**
    * When a workflow is re-run, or the first time it gets in progress:


### PR DESCRIPTION
### 📝 Description

As a way to strengthen our security, we want to sunset our old github ledgerlive service account in favor of the github app we now use.
This PR aims to remove any calls / references to the github user and any of it's access token.

### ❓ Context

- **Impacted projects**: `repository` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://github.com/LedgerHQ/ledger-live-issues/issues/92 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) 
-->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

no demo

### 🚀 Expectations to reach

Will run a bot test to see if the github app token can successfully checkout the needed repositories.

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
