### PR TITLE
[LIVE-7167] Bugfix - Change incremental sync order for Ethereum family explorers

### DIFF
--- a/.changeset/tender-items-watch.md
+++ b/.changeset/tender-items-watch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Fix incremental sync order for Ethereum family to prevent fetching operations before a block instead of after a block

--- a/libs/ledger-live-common/src/api/Ethereum.test.ts
+++ b/libs/ledger-live-common/src/api/Ethereum.test.ts
@@ -60,11 +60,12 @@ describe("apiForCurrency", () => {
     });
 
     describe("when blockHeight is defined", () => {
-      it("should use descending order", async () => {
+      // ↓ this is necessary in order to get transactions after the block height and not before. Order is still descending in the end
+      it("should use ascending order", async () => {
         await apiForCurrency(currencyMock).getTransactions(addressMock, 9000);
         const formatUrlInput: URL.UrlObject = urlFormatSpy.mock.lastCall[0];
         expect((formatUrlInput.query as ParsedUrlQueryInput).order).toEqual(
-          "descending"
+          "ascending"
         );
       });
 
@@ -78,6 +79,10 @@ describe("apiForCurrency", () => {
         expect(
           (formatUrlInput.query as ParsedUrlQueryInput).from_height
         ).toEqual(blockHeightMock);
+        // ↓ this is necessary in order to get transactions after the block height and not before. Order is still descending in the end
+        expect((formatUrlInput.query as ParsedUrlQueryInput).order).toEqual(
+          "ascending"
+        );
       });
     });
 

--- a/libs/ledger-live-common/src/api/Ethereum.ts
+++ b/libs/ledger-live-common/src/api/Ethereum.ts
@@ -183,7 +183,7 @@ export const apiForCurrency = (currency: CryptoCurrency): API => {
       };
       if (blockHeight) {
         query.from_height = blockHeight;
-        query.order = "descending";
+        query.order = "ascending"; // Needed to make sure we get transactions after the block height and not before. Order is still descending in the end
       }
       if (token) {
         query.token = token;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixing incremental sync fetching previous transactions to a block instead of the subsequent ones.

See explorer swagger explaining it here: https://explorers.api.live.ledger.com/blockchain/v4/eth/docs/#/address/Transactions%20by%20address

### ❓ Context

- **Impacted projects**: `@ledgerhq/live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-7167 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://user-images.githubusercontent.com/44363395/233385678-9b003ae4-9ced-476c-9b9d-e2171f51ba23.mp4


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
