### PR TITLE
fix: LIVE-7184 stax load image pad regression

### DIFF
--- a/.changeset/brown-hairs-count.md
+++ b/.changeset/brown-hairs-count.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix regression in the stax load image introduced by device action rework

--- a/libs/ledger-live-common/src/hw/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/staxLoadImage.ts
@@ -61,7 +61,7 @@ export default function loadImage({
   deviceId,
   request,
 }: Input): Observable<LoadImageEvent> {
-  const { hexImage, padImage } = request;
+  const { hexImage, padImage = true } = request;
 
   const sub = withDevice(deviceId)(
     (transport) =>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The recent refactoring of device actions broke the optional padding parameter for loading stax custom lock screens resulting in skewed/distorted images when loading from LLD/LLM. This brings back the default parameter.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7184` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Change CLS on LLM/LLD see if it's not broken.