### PR TITLE
feat: LLD allow users to use Ledger Vault as a signer

### DIFF
--- a/.changeset/nasty-rats-raise.md
+++ b/.changeset/nasty-rats-raise.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/hw-transport-http": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: LDD allow user to use vault as a signer

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -5,6 +5,7 @@ import { Redirect, Route, Switch, useHistory } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
+import VaultSignerTransport from "~/renderer/components/VaultSignerTransport";
 import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
 import { SyncNewAccounts } from "~/renderer/bridge/SyncNewAccounts";
 import Dashboard from "~/renderer/screens/dashboard";
@@ -51,6 +52,7 @@ import { ToastOverlay } from "~/renderer/components/ToastOverlay";
 import Drawer from "~/renderer/drawers/Drawer";
 import UpdateBanner from "~/renderer/components/Updater/Banner";
 import FirmwareUpdateBanner from "~/renderer/components/FirmwareUpdateBanner";
+import VaultSignerBanner from "~/renderer/components/VaultSignerBanner";
 import Onboarding from "~/renderer/components/Onboarding";
 import PostOnboardingScreen from "~/renderer/components/PostOnboardingScreen";
 import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
@@ -146,6 +148,7 @@ export default function Default() {
       <TriggerAppReady />
       <ExportLogsButton hookToShortcut />
       <TrackAppStart />
+      <VaultSignerTransport />
       <Idler />
       {process.platform === "darwin" ? <AppRegionDrag /> : null}
 
@@ -205,6 +208,7 @@ export default function Default() {
                           <TopBannerContainer>
                             <UpdateBanner />
                             <FirmwareUpdateBanner />
+                            <VaultSignerBanner />
                           </TopBannerContainer>
                           <Switch>
                             <Route path="/" exact component={Dashboard} />

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -18,6 +18,7 @@ import {
   filterTokenOperationsZeroAmountSelector,
   selectedTimeRangeSelector,
   SettingsState,
+  VaultSigner,
 } from "~/renderer/reducers/settings";
 import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 export type SaveSettings = (
@@ -331,4 +332,9 @@ export const setFeatureFlagsButtonVisible = (featureFlagsButtonVisible: boolean)
   payload: {
     featureFlagsButtonVisible,
   },
+});
+
+export const setVaultSigner = (payload: VaultSigner) => ({
+  type: "SET_VAULT_SIGNER",
+  payload,
 });

--- a/apps/ledger-live-desktop/src/renderer/components/VaultSignerBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/VaultSignerBanner.tsx
@@ -1,0 +1,23 @@
+import React, { useContext } from "react";
+import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
+import { Trans } from "react-i18next";
+import { useSelector } from "react-redux";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+import TopBanner from "~/renderer/components/TopBanner";
+
+const VaultSignerBanner = () => {
+  const { enabled } = useSelector(vaultSignerSelector);
+  if (!enabled) return null;
+  return (
+    <TopBanner
+      id={"vault-signer-banner"}
+      content={{
+        Icon: ExclamationCircleThin,
+        message: <Trans i18nKey="banners.vaultSigner.title" />,
+      }}
+      status={"warning"}
+    />
+  );
+};
+
+export default VaultSignerBanner;

--- a/apps/ledger-live-desktop/src/renderer/components/VaultSignerTransport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/VaultSignerTransport.tsx
@@ -1,0 +1,52 @@
+// @flow
+
+import React, { useEffect } from "react";
+import { registerTransportModule } from "@ledgerhq/live-common/hw/index";
+import { retry } from "@ledgerhq/live-common/promise";
+import { VaultTransport } from "@ledgerhq/hw-transport-http";
+import { useSelector } from "react-redux";
+import { setDeviceMode, currentMode } from "@ledgerhq/live-common/hw/actions/app";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+
+const originalDeviceMode = currentMode;
+
+/*
+This component "listens" (with useEffect()) for changes in settings.vaultSigner and update
+the vault-transport in the global modules object.
+As this transport needs to be in sync with settings we couldn't register it
+on the internal process.
+
+To avoid cluttering the transport modules global object, we have updated it
+to not blindly push in the array but to update it if it's already in the array
+
+I'ts also important to check for the id of the transport in the open() method because
+there is also IPC transport registered.
+*/
+
+const VaultSignerTransport = () => {
+  const { token, enabled, host, workspace } = useSelector(vaultSignerSelector);
+  useEffect(() => {
+    if (enabled && currentMode !== "polling") {
+      setDeviceMode("polling");
+    } else if (!enabled) {
+      setDeviceMode(originalDeviceMode);
+    }
+    registerTransportModule({
+      id: "vault-transport",
+      open: (id: string) => {
+        if (id !== "vault-transport") return;
+        return retry(() =>
+          VaultTransport.open(host).then(transport => {
+            transport.setData({ token, workspace });
+            return Promise.resolve(transport);
+          }),
+        );
+      },
+      disconnect: () => Promise.resolve(),
+    });
+  }, [host, token, workspace, enabled]);
+
+  return null;
+};
+
+export default VaultSignerTransport;

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -17,6 +17,9 @@ setEnvOnAllThreads("USER_ID", getUserId());
 // This defines our IPC Transport that will proxy to an internal process (we shouldn't use node-hid on renderer)
 registerTransportModule({
   id: "ipc",
-  open: id => retry(() => IPCTransport.open(id)),
+  open: (id: string) => {
+    if (id !== "ipc") return;
+    return retry(() => IPCTransport.open(id));
+  },
   disconnect: () => Promise.resolve(),
 });

--- a/apps/ledger-live-desktop/src/renderer/modals/VaultSigner/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/VaultSigner/index.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { Flex } from "@ledgerhq/react-ui";
+import Label from "~/renderer/components/Label";
+import { setEnvOnAllThreads } from "~/helpers/env";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+import { setVaultSigner } from "~/renderer/actions/settings";
+import Modal, { ModalBody } from "~/renderer/components/Modal";
+import Button from "~/renderer/components/Button";
+import Input from "~/renderer/components/Input";
+import InputPassword from "~/renderer/components/InputPassword";
+
+const VaultSigner = ({ name }: { name: string }) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { host, token, workspace, ...rest } = useSelector(vaultSignerSelector);
+  const [localHost, setLocalHost] = useState<string>(host);
+  const [localWorkspace, setLocalWorkspace] = useState<string>(workspace);
+  const [localToken, setLocalToken] = useState<string>(token);
+
+  const onSubmit = onClose => {
+    setEnvOnAllThreads("VAULT_SIGNER_HOST", localHost);
+    setEnvOnAllThreads("VAULT_SIGNER_TOKEN", localToken);
+
+    dispatch(
+      setVaultSigner({ ...rest, token: localToken, host: localHost, workspace: localWorkspace }),
+    );
+    onClose();
+  };
+
+  const isValid = localHost !== "" && localWorkspace !== "" && localToken !== "";
+
+  return (
+    <Modal
+      name={name}
+      centered
+      render={({ onClose }: { onClose: void }) => (
+        <ModalBody
+          onClose={onClose}
+          onBack={undefined}
+          title={<Trans i18nKey="vaultSigner.modal.title" />}
+          noScroll
+          render={() => (
+            <Flex flexDirection="column" rowGap={4}>
+              <Flex flexDirection="column" rowGap={1}>
+                <Label>
+                  <Trans i18nKey="vaultSigner.modal.host.title" />
+                </Label>
+                <Input
+                  onChange={setLocalHost}
+                  value={localHost}
+                  placeholder={t("vaultSigner.modal.host.placeholder")}
+                />
+              </Flex>
+              <Flex flexDirection="column" rowGap={1}>
+                <Label>
+                  <Trans i18nKey="vaultSigner.modal.workspace.title" />
+                </Label>
+                <Input
+                  onChange={setLocalWorkspace}
+                  value={localWorkspace}
+                  placeholder={t("vaultSigner.modal.workspace.placeholder")}
+                />
+              </Flex>
+              <Flex flexDirection="column" rowGap={1}>
+                <Label>
+                  <Trans i18nKey="vaultSigner.modal.token.title" />
+                </Label>
+                <InputPassword
+                  onChange={setLocalToken}
+                  value={localToken}
+                  placeholder={t("vaultSigner.modal.token.placeholder")}
+                />
+              </Flex>
+              <Flex alignSelf="flex-end">
+                <Button primary onClick={() => onSubmit(onClose)} disabled={!isValid}>
+                  <Trans i18nKey="vaultSigner.modal.submit" />
+                </Button>
+              </Flex>
+            </Flex>
+          )}
+        />
+      )}
+    />
+  );
+};
+
+export default VaultSigner;

--- a/apps/ledger-live-desktop/src/renderer/modals/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.ts
@@ -26,6 +26,7 @@ import MODAL_STORYLY_DEBUGGER from "./StorylyDebugger";
 import MODAL_BLACKLIST_TOKEN from "./BlacklistToken";
 import MODAL_HIDE_NFT_COLLECTION from "./HideNftCollection";
 import MODAL_PROTECT_DISCOVER from "./ProtectDiscover";
+import MODAL_VAULT_SIGNER from "./VaultSigner";
 
 type ModalComponent = React.ComponentType<any>; // FIXME determine the common ground to modals
 type Modals = Record<string, ModalComponent>;
@@ -60,6 +61,9 @@ const modals: Modals = {
   MODAL_PLATFORM_EXCHANGE_START,
   MODAL_PLATFORM_EXCHANGE_COMPLETE,
   MODAL_CONNECT_DEVICE,
+
+  // Vault,
+  MODAL_VAULT_SIGNER,
 
   // NB We have dettached modals such as the repair modal,
   // in the meantime, we can rely on this to add the backdrop

--- a/apps/ledger-live-desktop/src/renderer/reducers/devices.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/devices.ts
@@ -3,6 +3,8 @@ import { getEnv } from "@ledgerhq/live-common/env";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { Handlers } from "./types";
+import { SettingsState } from "./settings";
+
 export type DevicesState = {
   currentDevice: Device | undefined | null;
   devices: Device[];
@@ -50,8 +52,13 @@ function setCurrentDevice(state: DevicesState) {
     currentDevice,
   };
 }
+export function getCurrentDevice(state: { devices: DevicesState; settings: SettingsState }) {
+  const isVaultSigner = state.settings.vaultSigner.enabled;
 
-export function getCurrentDevice(state: { devices: DevicesState }) {
+  if (isVaultSigner) {
+    return { deviceId: "vault-transport", wired: true, modelId: DeviceModelId.nanoS };
+  }
+
   if (getEnv("DEVICE_PROXY_URL") || getEnv("MOCK")) {
     // bypass the listen devices (we should remove modelId here by instead get it at open time if needed)
     return {

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -18,6 +18,12 @@ import { Handlers } from "./types";
 
 /* Initial state */
 
+export type VaultSigner = {
+  enabled: boolean;
+  host: string;
+  workspace: string;
+  token: string;
+};
 export type SettingsState = {
   loaded: boolean;
   // is the settings loaded from db (it not we don't save them)
@@ -89,6 +95,7 @@ export type SettingsState = {
     [key in FeatureId]: Feature;
   };
   featureFlagsButtonVisible: boolean;
+  vaultSigner: VaultSigner;
 };
 
 const DEFAULT_LANGUAGE_LOCALE = "en";
@@ -162,6 +169,9 @@ const INITIAL_STATE: SettingsState = {
   starredMarketCoins: [],
   overriddenFeatureFlags: {} as Record<FeatureId, Feature>,
   featureFlagsButtonVisible: false,
+
+  // Vault
+  vaultSigner: { enabled: false, host: "", token: "" },
 };
 
 /* Handlers */
@@ -392,6 +402,10 @@ const handlers: SettingsHandlers = {
   SET_FEATURE_FLAGS_BUTTON_VISIBLE: (state: SettingsState, { payload }) => ({
     ...state,
     featureFlagsButtonVisible: payload.featureFlagsButtonVisible,
+  }),
+  SET_VAULT_SIGNER: (state: SettingsState, { payload }) => ({
+    ...state,
+    vaultSigner: payload,
   }),
 };
 export default handleActions<SettingsState, HandlersPayloads[keyof HandlersPayloads]>(
@@ -688,3 +702,4 @@ export const overriddenFeatureFlagsSelector = (state: State) =>
   state.settings.overriddenFeatureFlags;
 export const featureFlagsButtonVisibleSelector = (state: State) =>
   state.settings.featureFlagsButtonVisible;
+export const vaultSignerSelector = (state: State) => state.settings.vaultSigner;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/VaultSigner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/VaultSigner.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from "react";
+import { useTranslation, Trans } from "react-i18next";
+
+import { useDispatch, useSelector } from "react-redux";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+import { setVaultSigner } from "~/renderer/actions/settings";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+import { openModal } from "~/renderer/actions/modals";
+import Switch from "~/renderer/components/Switch";
+
+const VaultSigner = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const onOpenModal = useCallback(() => dispatch(openModal("MODAL_VAULT_SIGNER")), [dispatch]);
+  const { enabled, ...rest } = useSelector(vaultSignerSelector);
+
+  const handleChange = (val: boolean) => {
+    dispatch(setVaultSigner({ ...rest, enabled: val }));
+    if (val) {
+      onOpenModal();
+    }
+  };
+
+  return (
+    <SettingsSectionRow
+      title={t("settings.experimental.features.vaultSigner.title")}
+      desc={t("settings.experimental.features.vaultSigner.description")}
+    >
+      <Switch isChecked={enabled} onChange={handleChange} data-test-id={`enable-vault-signer`} />
+    </SettingsSectionRow>
+  );
+};
+
+export default VaultSigner;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
@@ -17,6 +17,8 @@ import FullNode from "~/renderer/screens/settings/sections/Accounts/FullNode";
 import LottieTester from "./LottieTester";
 import StorylyTester from "./StorylyTester";
 import PostOnboardingHubTester from "./PostOnboardingHubTester";
+import VaultSigner from "./VaultSigner";
+
 const experimentalTypesMap = {
   toggle: ExperimentalSwitch,
   integer: ExperimentalInteger,
@@ -103,6 +105,7 @@ const SectionExperimental = () => {
         {process.env.DEBUG_LOTTIE ? <LottieTester /> : null}
         {process.env.DEBUG_STORYLY ? <StorylyTester /> : null}
         {process.env.DEBUG_POSTONBOARDINGHUB ? <PostOnboardingHubTester /> : null}
+        <VaultSigner />
 
         <FullNode />
       </Body>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -632,6 +632,24 @@
   "postOnboardingDebugger": {
     "buttonTitle": "Test"
   },
+  "vaultSigner": {
+    "modal": {
+      "title": "Connect Vault",
+      "host": {
+        "title": "URL",
+        "placeholder": "ws://localhost:3030"
+      },
+      "workspace": {
+        "title": "Workspace name",
+        "placeholder": "workspace"
+      },
+      "token": {
+        "title": "API Operator Token",
+        "placeholder": "Token"
+      },
+      "submit": "Connect"
+    }
+  },
   "fullNode": {
     "status": "Status",
     "connect": "Connect",
@@ -1366,6 +1384,9 @@
     "referralProgram": {
       "title": "Refer and earn $10",
       "description": "Successfully refer a friend and you both earn $10 worth of Bitcoin."
+    },
+    "vaultSigner": {
+      "title": "Vault signer mode"
     }
   },
   "signmessage": {
@@ -3904,6 +3925,10 @@
         "1559DeactivateGate": {
           "title": "Deactivate EIP1559 minimum priority fee gate",
           "description": "This will allow a transaction to be sent without any minimum priority fee expected. This may result in a transaction getting stuck in the mempool forever."
+        },
+        "vaultSigner": {
+          "title": "Vault Signer",
+          "description": "Use Ledger Vault as a signer with your operator API token"
         },
         "1559CustomPriorityLowerGate": {
           "title": "Custom priority fee gate",

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -42,7 +42,12 @@ export type TransportModule = {
 };
 const modules: TransportModule[] = [];
 export const registerTransportModule = (module: TransportModule): void => {
-  modules.push(module);
+  const index = modules.findIndex((m) => m.id === module.id);
+  if (index > -1) {
+    modules[index] = module;
+  } else {
+    modules.push(module);
+  }
 };
 export const discoverDevices = (
   accept: (module: TransportModule) => boolean = () => true

--- a/libs/ledgerjs/packages/hw-transport-http/src/VaultTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/VaultTransport.ts
@@ -1,0 +1,39 @@
+import { log } from "@ledgerhq/logs";
+import WebSocketTransport from "./WebSocketTransport";
+
+type VaultData = {
+  token: string;
+  workspace: string;
+};
+
+export default class VaultTransport extends WebSocketTransport {
+  protected data: VaultData | null;
+
+  constructor(hook: any) {
+    super(hook);
+    this.data = null;
+  }
+
+  setData(data: VaultData): void {
+    this.data = data;
+  }
+
+  async exchange(apdu: Buffer): Promise<Buffer> {
+    const hex = apdu.toString("hex");
+    log("apdu", "=> " + hex);
+    const res: Buffer = await new Promise((resolve, reject) => {
+      this.hook.rejectExchange = (e: any) => reject(e);
+
+      this.hook.resolveExchange = (b: Buffer) => resolve(b);
+      const data = {
+        workspace: this.data?.workspace,
+        token: this.data?.token,
+        apdu: hex,
+      };
+
+      this.hook.send(JSON.stringify(data));
+    });
+    log("apdu", "<= " + res.toString("hex"));
+    return res;
+  }
+}

--- a/libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
@@ -109,7 +109,7 @@ export default class WebSocketTransport extends Transport {
         reject(e);
       }
     });
-    return new WebSocketTransport(exchangeMethods);
+    return new this(exchangeMethods);
   }
 
   hook: any;

--- a/libs/ledgerjs/packages/hw-transport-http/src/withStaticURLs.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/withStaticURLs.ts
@@ -1,6 +1,9 @@
 import HttpTransport from "./HttpTransport";
 import WebSocketTransport from "./WebSocketTransport";
 import Transport from "@ledgerhq/hw-transport";
+
+export { default as VaultTransport } from "./VaultTransport";
+
 import type {
   Observer,
   DescriptorEvent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5154,14 +5154,14 @@ packages:
     resolution: {integrity: sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==}
     dev: true
 
-  /@abandonware/bluetooth-hci-socket@0.5.3-10:
-    resolution: {integrity: sha512-wXHiGmHaHz1pUR6Ix6uut24uTYCWZJL68aP9F056jnnl+U3KrjLT77g9dZHWDAId+9yQN54lLO4MEOIV0z9fUg==}
+  /@abandonware/bluetooth-hci-socket@0.5.3-8:
+    resolution: {integrity: sha512-JIUkTZpAo6vKyXd94OasynjnmAxgCvn3VRrQJM/KXBKbm/yW59BMK6ni1wLy/JLM4eFhsLkd2S907HJnXBSWKw==}
     os: [linux, android, freebsd, win32]
     requiresBuild: true
     dependencies:
-      '@mapbox/node-pre-gyp': 1.0.10
+      '@mapbox/node-pre-gyp': 1.0.9
       debug: 4.3.4
-      nan: 2.17.0
+      nan: 2.15.0
     optionalDependencies:
       usb: 1.9.2
     transitivePeerDependencies:
@@ -5179,7 +5179,7 @@ packages:
       debug: 4.3.4
       node-addon-api: 3.2.1
     optionalDependencies:
-      '@abandonware/bluetooth-hci-socket': 0.5.3-10
+      '@abandonware/bluetooth-hci-socket': 0.5.3-8
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5529,7 +5529,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser@7.18.9(@babel/core@7.21.0)(eslint@8.38.0):
+  /@babel/eslint-parser@7.18.9(@babel/core@7.21.0)(eslint@8.15.0):
     resolution: {integrity: sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -5537,7 +5537,7 @@ packages:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
       '@babel/core': 7.21.0
-      eslint: 8.38.0
+      eslint: 8.15.0
       eslint-scope: 5.1.1
       eslint-visitor-keys: 2.1.0
       semver: 6.3.0
@@ -5925,7 +5925,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
-    dev: false
 
   /@babel/helper-module-imports@7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -9108,7 +9107,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/traverse@7.18.11:
     resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
@@ -9145,23 +9143,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@babel/traverse@7.20.13(supports-color@5.5.0):
-    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.21.4
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.4
-      '@babel/types': 7.21.4
-      debug: 4.3.4(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/traverse@7.21.4:
     resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
@@ -11515,19 +11496,10 @@ packages:
       eslint-visitor-keys: 3.4.0
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.38.0):
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.38.0
-      eslint-visitor-keys: 3.4.0
-    dev: false
-
   /@eslint-community/regexpp@4.5.0:
     resolution: {integrity: sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
 
   /@eslint/eslintrc@0.1.3:
     resolution: {integrity: sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==}
@@ -11569,38 +11541,15 @@ packages:
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.5.1
+      espree: 9.4.1
       globals: 13.20.0
-      ignore: 5.2.4
+      ignore: 5.2.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@eslint/eslintrc@2.0.2:
-    resolution: {integrity: sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 9.5.1
-      globals: 13.20.0
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@eslint/js@8.38.0:
-    resolution: {integrity: sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
 
   /@ethereumjs/common@2.6.4:
     resolution: {integrity: sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==}
@@ -12261,7 +12210,7 @@ packages:
       getenv: 1.0.0
       glob: 7.1.6
       resolve-from: 5.0.0
-      semver: 7.5.0
+      semver: 7.3.8
       slash: 3.0.0
       xcode: 3.0.1
       xml2js: 0.4.23
@@ -13326,17 +13275,6 @@ packages:
       path: 0.12.7
     dev: false
 
-  /@humanwhocodes/config-array@0.11.8:
-    resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@humanwhocodes/config-array@0.5.0:
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
     engines: {node: '>=10.10.0'}
@@ -13367,12 +13305,6 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@humanwhocodes/module-importer@1.0.1:
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
-    dev: false
 
   /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
@@ -13480,7 +13412,7 @@ packages:
       ansi-escapes: 3.2.0
       chalk: 2.4.2
       exit: 0.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-changed-files: 24.9.0
       jest-config: 24.9.0
       jest-haste-map: 24.9.0
@@ -13525,7 +13457,7 @@ packages:
       chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-changed-files: 27.5.1
       jest-config: 27.5.1
       jest-haste-map: 27.5.1
@@ -13571,7 +13503,7 @@ packages:
       chalk: 4.1.2
       ci-info: 3.3.2
       exit: 0.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
       jest-config: 28.1.3(@types/node@18.15.11)
       jest-haste-map: 28.1.3
@@ -13983,7 +13915,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.2.0
       istanbul-lib-report: 3.0.0
@@ -14023,7 +13955,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.2.0
       istanbul-lib-report: 3.0.0
@@ -14062,7 +13994,7 @@ packages:
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.2.0
       istanbul-lib-report: 3.0.0
@@ -14136,7 +14068,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       source-map: 0.6.1
 
   /@jest/source-map@27.5.1:
@@ -14144,7 +14076,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       callsites: 3.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       source-map: 0.6.1
     dev: false
 
@@ -14154,7 +14086,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       callsites: 3.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
     dev: true
 
   /@jest/test-result@24.9.0:
@@ -14213,7 +14145,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/test-result': 27.5.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-runtime: 27.5.1
     transitivePeerDependencies:
@@ -14226,7 +14158,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/test-result': 28.1.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 28.1.3
       slash: 3.0.0
     transitivePeerDependencies:
@@ -14238,7 +14170,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/test-result': 28.1.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 28.1.3(metro@0.76.0)
       slash: 3.0.0
     transitivePeerDependencies:
@@ -14255,7 +14187,7 @@ packages:
       chalk: 2.4.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 24.9.0
       jest-regex-util: 24.9.0
       jest-util: 24.9.0
@@ -14279,7 +14211,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2
       jest-regex-util: 26.0.0
       jest-util: 26.6.2
@@ -14303,7 +14235,7 @@ packages:
       chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 26.6.2(metro@0.76.0)
       jest-regex-util: 26.0.0
       jest-util: 26.6.2
@@ -14593,13 +14525,13 @@ packages:
       semver: 7.3.8
     dev: false
 
-  /@ledgerhq/devices@8.0.1:
-    resolution: {integrity: sha512-8uuyR8DGowYBLatur+MyJtRJ8RYDWSFFqGnNmgBBdlRG6VPf9vjhrFZlmYqukWesPwkZNZstP475W4TS+j6EFw==}
+  /@ledgerhq/devices@8.0.0:
+    resolution: {integrity: sha512-gSnRT0KPca+LIpaC6D/WZQjOAlSI5uCvK1dmxXtKhODLAj735rX5Z3SnGnLUavRCHNbUi44FzgvloF5BKTkh7A==}
     dependencies:
-      '@ledgerhq/errors': 6.12.4
+      '@ledgerhq/errors': 6.12.3
       '@ledgerhq/logs': 6.10.1
       rxjs: 6.6.7
-      semver: 7.5.0
+      semver: 7.3.8
     dev: false
 
   /@ledgerhq/electron-updater@4.2.2:
@@ -14621,15 +14553,15 @@ packages:
     resolution: {integrity: sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==}
     dev: false
 
-  /@ledgerhq/errors@6.12.4:
-    resolution: {integrity: sha512-qi5poMrcIuFuivdzRjjQsNp7rRwUA5v3eo6D4yEy+l+w8wT4d4JtQ5u1TbrlGfFHfgLq7Lv6dsvh2ooLyWTyfg==}
+  /@ledgerhq/errors@6.12.3:
+    resolution: {integrity: sha512-djiMSgB/7hnK3aLR/c5ZMMivxjcI7o2+y3VKcsZZpydPoVf9+FXqeJPRfOwmJ0JxbQ//LinUfWpIfHew8LkaVw==}
     dev: false
 
   /@ledgerhq/hw-app-eth@5.11.0:
     resolution: {integrity: sha512-qgpPwZzM8UMHYMC5+9xYV2O+8kgkDAl9+38w9JiBksaGmUFqcS4najsB1nj6AWf2rGEuXdKMb2WEYRskVypJrA==}
     dependencies:
       '@ledgerhq/errors': 5.50.0
-      '@ledgerhq/hw-transport': 5.11.0
+      '@ledgerhq/hw-transport': 5.51.1
     dev: false
 
   /@ledgerhq/hw-transport-u2f@5.36.0-deprecated:
@@ -14667,11 +14599,11 @@ packages:
       events: 3.3.0
     dev: false
 
-  /@ledgerhq/hw-transport@6.28.2:
-    resolution: {integrity: sha512-2LxQdZnhSzu394brKuUZIWfuT2YAyNI3glRMf8+yHx3wUFqi10v8NzII99SHDyT8tN3Ovzmq+hbGHvrR2PqYRA==}
+  /@ledgerhq/hw-transport@6.28.1:
+    resolution: {integrity: sha512-RaZe+abn0zBIz82cE9tp7Y7aZkHWWbEaE2yJpfxT8AhFz3fx+BU0kLYzuRN9fmA7vKueNJ1MTVUCY+Ex9/CHSQ==}
     dependencies:
-      '@ledgerhq/devices': 8.0.1
-      '@ledgerhq/errors': 6.12.4
+      '@ledgerhq/devices': 8.0.0
+      '@ledgerhq/errors': 6.12.3
       events: 3.3.0
     dev: false
 
@@ -14704,7 +14636,7 @@ packages:
   /@ledgerhq/wallet-api-client@0.15.2:
     resolution: {integrity: sha512-mjTOP7k0dETDPZuRKbaIJH6yHNZsDkwE6bwdZDFGyI2TlCly5HKmVUjHzePOF4VA+JgOmvL03YAh2NunrVICsA==}
     dependencies:
-      '@ledgerhq/hw-transport': 6.28.2
+      '@ledgerhq/hw-transport': 6.28.1
       '@ledgerhq/wallet-api-core': 0.16.0
       bignumber.js: 9.1.0
     dev: false
@@ -14712,7 +14644,7 @@ packages:
   /@ledgerhq/wallet-api-core@0.16.0:
     resolution: {integrity: sha512-UKlLE+46z4EQ3UcTcrkMvIkSYC9H9gwtpKxdTwbnI+tBnOusO6TvOg+qu5E0HZXG39f0xZF6OV7pdor8qmFryg==}
     dependencies:
-      '@ledgerhq/errors': 6.12.4
+      '@ledgerhq/errors': 6.12.3
       bignumber.js: 9.1.0
       uuid: 9.0.0
       zod: 3.19.1
@@ -14776,26 +14708,6 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@mapbox/node-pre-gyp@1.0.10:
-    resolution: {integrity: sha512-4ySo4CjzStuprMwk35H5pPbkymjv1SF3jGLj6rAHp/xT/RF7TL7bd9CTm1xDY49K2qF7jmR/g7k+SkLETP6opA==}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      detect-libc: 2.0.1
-      https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
-      node-fetch: 2.6.9
-      nopt: 5.0.0
-      npmlog: 5.0.1
-      rimraf: 3.0.2
-      semver: 7.5.0
-      tar: 6.1.13
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-    optional: true
-
   /@mapbox/node-pre-gyp@1.0.9:
     resolution: {integrity: sha512-aDF3S3rK9Q2gey/WAttUlISduDItz5BU3306M9Eyv6/oS40aMprnopshtlKTykxRNIBEZuRMaZAnbrQ4QtKGyw==}
     hasBin: true
@@ -14812,7 +14724,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: true
 
   /@material-ui/core@4.12.4(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==}
@@ -15012,7 +14923,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.5.0
+      semver: 7.3.8
 
   /@npmcli/move-file@1.1.2:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
@@ -15266,12 +15177,6 @@ packages:
     resolution: {integrity: sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==}
     engines: {node: '>=8.0.0'}
     dev: true
-
-  /@pkgjs/parseargs@0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-    requiresBuild: true
-    optional: true
 
   /@pkgr/utils@2.3.1:
     resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
@@ -15912,7 +15817,7 @@ packages:
       '@react-native-community/cli-tools': 10.1.1
       chalk: 4.1.2
       execa: 1.0.0
-      glob: 7.2.0
+      glob: 7.2.3
       logkitty: 0.7.1
     transitivePeerDependencies:
       - encoding
@@ -15958,7 +15863,7 @@ packages:
       chalk: 4.1.2
       execa: 1.0.0
       fast-xml-parser: 4.1.3
-      glob: 7.2.0
+      glob: 7.2.3
       ora: 5.4.1
     transitivePeerDependencies:
       - encoding
@@ -21590,7 +21495,7 @@ packages:
     resolution: {integrity: sha512-gyBO8FarBrItPGAfrnm4J7vrIWMsr9xqgfzgN4PAqY7eEmL8MDuZtdpk6B6DBuJ3hYbqxvOEa0QPhNzBxnGPeA==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@ledgerhq/hw-transport': 6.28.2
+      '@ledgerhq/hw-transport': 6.28.1
       '@stablelib/blake2b': 1.0.1
       '@taquito/taquito': 13.0.1
       '@taquito/utils': 13.0.1
@@ -23225,7 +23130,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.38.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.15.0)(typescript@4.9.5):
     resolution: {integrity: sha512-vwksQWSFZiUhgq3Kv7o1Jcj0DUNylwnIlGvKvLLYsq8pAWha6/WCnXUeaSoNNha/K7QSf2+jvmkxggC1u3pIwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -23236,12 +23141,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.50.0
-      '@typescript-eslint/type-utils': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
       debug: 4.3.4
-      eslint: 8.38.0
+      eslint: 8.15.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
@@ -23349,6 +23254,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils@5.3.1(eslint@8.15.0)(typescript@4.9.5):
+    resolution: {integrity: sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.3.1
+      '@typescript-eslint/types': 5.3.1
+      '@typescript-eslint/typescript-estree': 5.3.1(typescript@4.9.5)
+      eslint: 8.15.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0(eslint@8.15.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/experimental-utils@5.3.1(eslint@8.2.0)(typescript@4.9.5):
     resolution: {integrity: sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -23366,24 +23289,6 @@ packages:
       - supports-color
       - typescript
     dev: true
-
-  /@typescript-eslint/experimental-utils@5.3.1(eslint@8.38.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.11
-      '@typescript-eslint/scope-manager': 5.3.1
-      '@typescript-eslint/types': 5.3.1
-      '@typescript-eslint/typescript-estree': 5.3.1(typescript@4.9.5)
-      eslint: 8.38.0
-      eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.38.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
 
   /@typescript-eslint/parser@2.34.0(eslint@6.8.0)(typescript@4.9.5):
     resolution: {integrity: sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==}
@@ -23545,7 +23450,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.50.0(eslint@8.38.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.50.0(eslint@8.15.0)(typescript@4.9.5):
     resolution: {integrity: sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -23559,7 +23464,7 @@ packages:
       '@typescript-eslint/types': 5.50.0
       '@typescript-eslint/typescript-estree': 5.50.0(typescript@4.9.5)
       debug: 4.3.4
-      eslint: 8.38.0
+      eslint: 8.15.0
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
@@ -23690,7 +23595,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@5.50.0(eslint@8.38.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.50.0(eslint@8.15.0)(typescript@4.9.5):
     resolution: {integrity: sha512-dcnXfZ6OGrNCO7E5UY/i0ktHb7Yx1fV6fnQGGrlnfDhilcs6n19eIRcvLBqx6OQkrPaFlDPk3OJ0WlzQfrV0bQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -23701,9 +23606,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.50.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
+      '@typescript-eslint/utils': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
       debug: 4.3.4
-      eslint: 8.38.0
+      eslint: 8.15.0
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -23777,7 +23682,7 @@ packages:
       glob: 7.2.3
       is-glob: 4.0.3
       lodash: 4.17.21
-      semver: 7.5.0
+      semver: 7.3.8
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -23798,7 +23703,7 @@ packages:
       glob: 7.2.3
       is-glob: 4.0.3
       lodash: 4.17.21
-      semver: 7.5.0
+      semver: 7.3.8
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -23861,7 +23766,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.0
+      semver: 7.3.8
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -23987,7 +23892,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.50.0(eslint@8.38.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.50.0(eslint@8.15.0)(typescript@4.9.5):
     resolution: {integrity: sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -23998,9 +23903,9 @@ packages:
       '@typescript-eslint/scope-manager': 5.50.0
       '@typescript-eslint/types': 5.50.0
       '@typescript-eslint/typescript-estree': 5.50.0(typescript@4.9.5)
-      eslint: 8.38.0
+      eslint: 8.15.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.38.0)
+      eslint-utils: 3.0.0(eslint@8.15.0)
       semver: 7.3.8
     transitivePeerDependencies:
       - supports-color
@@ -24114,34 +24019,34 @@ packages:
       - supports-color
     dev: true
 
-  /@vue/compiler-core@3.2.47:
-    resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
+  /@vue/compiler-core@3.2.33:
+    resolution: {integrity: sha512-AAmr52ji3Zhk7IKIuigX2osWWsb2nQE5xsdFYjdnmtQ4gymmqXbjLvkSE174+fF3A3kstYrTgGkqgOEbsdLDpw==}
     dependencies:
       '@babel/parser': 7.21.4
-      '@vue/shared': 3.2.47
+      '@vue/shared': 3.2.33
       estree-walker: 2.0.2
       source-map: 0.6.1
     dev: true
     optional: true
 
-  /@vue/compiler-dom@3.2.47:
-    resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
+  /@vue/compiler-dom@3.2.33:
+    resolution: {integrity: sha512-GhiG1C8X98Xz9QUX/RlA6/kgPBWJkjq0Rq6//5XTAGSYrTMBgcLpP9+CnlUg1TFxnnCVughAG+KZl28XJqw8uQ==}
     dependencies:
-      '@vue/compiler-core': 3.2.47
-      '@vue/shared': 3.2.47
+      '@vue/compiler-core': 3.2.33
+      '@vue/shared': 3.2.33
     dev: true
     optional: true
 
-  /@vue/compiler-sfc@3.2.47:
-    resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
+  /@vue/compiler-sfc@3.2.33:
+    resolution: {integrity: sha512-H8D0WqagCr295pQjUYyO8P3IejM3vEzeCO1apzByAEaAR/WimhMYczHfZVvlCE/9yBaEu/eu9RdiWr0kF8b71Q==}
     requiresBuild: true
     dependencies:
       '@babel/parser': 7.21.4
-      '@vue/compiler-core': 3.2.47
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-ssr': 3.2.47
-      '@vue/reactivity-transform': 3.2.47
-      '@vue/shared': 3.2.47
+      '@vue/compiler-core': 3.2.33
+      '@vue/compiler-dom': 3.2.33
+      '@vue/compiler-ssr': 3.2.33
+      '@vue/reactivity-transform': 3.2.33
+      '@vue/shared': 3.2.33
       estree-walker: 2.0.2
       magic-string: 0.25.9
       postcss: 8.4.21
@@ -24149,27 +24054,27 @@ packages:
     dev: true
     optional: true
 
-  /@vue/compiler-ssr@3.2.47:
-    resolution: {integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==}
+  /@vue/compiler-ssr@3.2.33:
+    resolution: {integrity: sha512-XQh1Xdk3VquDpXsnoCd7JnMoWec9CfAzQDQsaMcSU79OrrO2PNR0ErlIjm/mGq3GmBfkQjzZACV+7GhfRB8xMQ==}
     dependencies:
-      '@vue/compiler-dom': 3.2.47
-      '@vue/shared': 3.2.47
+      '@vue/compiler-dom': 3.2.33
+      '@vue/shared': 3.2.33
     dev: true
     optional: true
 
-  /@vue/reactivity-transform@3.2.47:
-    resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
+  /@vue/reactivity-transform@3.2.33:
+    resolution: {integrity: sha512-4UL5KOIvSQb254aqenW4q34qMXbfZcmEsV/yVidLUgvwYQQ/D21bGX3DlgPUGI3c4C+iOnNmDCkIxkILoX/Pyw==}
     dependencies:
       '@babel/parser': 7.21.4
-      '@vue/compiler-core': 3.2.47
-      '@vue/shared': 3.2.47
+      '@vue/compiler-core': 3.2.33
+      '@vue/shared': 3.2.33
       estree-walker: 2.0.2
       magic-string: 0.25.9
     dev: true
     optional: true
 
-  /@vue/shared@3.2.47:
-    resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
+  /@vue/shared@3.2.33:
+    resolution: {integrity: sha512-UBc1Pg1T3yZ97vsA2ueER0F6GbJebLHYlEi4ou1H5YL4KWvMOOWwpYo9/QpWq93wxKG6Wo13IY74Hcn/f7c7Bg==}
     dev: true
     optional: true
 
@@ -26921,7 +26826,7 @@ packages:
     engines: {node: '>= 8.0.0'}
     requiresBuild: true
     dependencies:
-      nan: 2.17.0
+      nan: 2.15.0
     dev: false
 
   /blake2b-wasm@1.1.7:
@@ -27469,8 +27374,8 @@ packages:
     engines: {node: '>=0.2.0'}
     dev: true
 
-  /bufferutil@4.0.7:
-    resolution: {integrity: sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==}
+  /bufferutil@4.0.6:
+    resolution: {integrity: sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==}
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
@@ -27631,7 +27536,7 @@ packages:
       chownr: 1.1.4
       figgy-pudding: 3.5.2
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
@@ -27651,10 +27556,10 @@ packages:
       figgy-pudding: 3.5.2
       fs-minipass: 2.1.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       infer-owner: 1.0.4
       lru-cache: 5.1.1
-      minipass: 3.3.6
+      minipass: 3.1.6
       minipass-collect: 1.0.2
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -28689,7 +28594,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       dot-prop: 5.3.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       make-dir: 3.1.0
       unique-string: 2.0.0
       write-file-atomic: 3.0.3
@@ -29124,7 +29029,7 @@ packages:
     resolution: {integrity: sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==}
     engines: {node: '>=8'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       make-dir: 3.1.0
       nested-error-stacks: 2.1.1
       p-event: 4.2.0
@@ -29454,7 +29359,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
-      semver: 7.5.0
+      semver: 7.3.8
       webpack: 5.76.1(metro@0.76.0)
     dev: true
 
@@ -30372,7 +30277,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       globby: 11.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       is-glob: 4.0.3
       is-path-cwd: 2.2.0
       is-path-inside: 3.0.3
@@ -30787,8 +30692,8 @@ packages:
       vinyl-fs: 3.0.3
       yargs: 15.4.1
     optionalDependencies:
-      '@vue/compiler-sfc': 3.2.47
-      vue-template-compiler: 2.7.14
+      '@vue/compiler-sfc': 3.2.33
+      vue-template-compiler: 2.6.14
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -31254,7 +31159,7 @@ packages:
     resolution: {integrity: sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       memory-fs: 0.5.0
       tapable: 1.1.3
 
@@ -31269,7 +31174,7 @@ packages:
     resolution: {integrity: sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       tapable: 2.2.1
 
   /enquirer@2.3.6:
@@ -32199,7 +32104,7 @@ packages:
       eslint-plugin-react-hooks: 1.7.0(eslint@6.8.0)
       typescript: 4.9.5
 
-  /eslint-config-react-app@7.0.1(eslint@8.38.0)(jest@27.5.1)(typescript@4.9.5):
+  /eslint-config-react-app@7.0.1(eslint@8.15.0)(jest@27.5.1)(typescript@4.9.5):
     resolution: {integrity: sha512-K6rNzvkIeHaTd8m/QEh1Zko0KI7BACWkkneSs6s9cKZC/J27X3eZR6Upt1jkmZ/4FK+XUOPPxMEN7+lbUXfSlA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -32210,20 +32115,20 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/eslint-parser': 7.18.9(@babel/core@7.21.0)(eslint@8.38.0)
+      '@babel/eslint-parser': 7.18.9(@babel/core@7.21.0)(eslint@8.15.0)
       '@rushstack/eslint-patch': 1.1.4
-      '@typescript-eslint/eslint-plugin': 5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.38.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.15.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
       babel-preset-react-app: 10.0.1
       confusing-browser-globals: 1.0.11
-      eslint: 8.38.0
-      eslint-plugin-flowtype: 8.0.3(eslint@8.38.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.50.0)(eslint@8.38.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.50.0)(eslint@8.38.0)(jest@27.5.1)(typescript@4.9.5)
-      eslint-plugin-jsx-a11y: 6.6.1(eslint@8.38.0)
-      eslint-plugin-react: 7.31.10(eslint@8.38.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.38.0)
-      eslint-plugin-testing-library: 5.6.0(eslint@8.38.0)(typescript@4.9.5)
+      eslint: 8.15.0
+      eslint-plugin-flowtype: 8.0.3(eslint@8.15.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.50.0)(eslint@8.15.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.50.0)(eslint@8.15.0)(jest@27.5.1)(typescript@4.9.5)
+      eslint-plugin-jsx-a11y: 6.6.1(eslint@8.15.0)
+      eslint-plugin-react: 7.31.10(eslint@8.15.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.15.0)
+      eslint-plugin-testing-library: 5.6.0(eslint@8.15.0)(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - '@babel/plugin-syntax-flow'
@@ -32466,7 +32371,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -32569,7 +32474,7 @@ packages:
       eslint: 6.8.0
       lodash: 4.17.21
 
-  /eslint-plugin-flowtype@8.0.3(eslint@8.38.0):
+  /eslint-plugin-flowtype@8.0.3(eslint@8.15.0):
     resolution: {integrity: sha512-dX8l6qUL6O+fYPtpNRideCFSpmWOUVx5QcaGLVqe/vlDiBSe4vYljDWDETwnyFzpl7By/WVIu6rcrniCgH9BqQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -32577,7 +32482,7 @@ packages:
       '@babel/plugin-transform-react-jsx': ^7.14.9
       eslint: ^8.1.0
     dependencies:
-      eslint: 8.38.0
+      eslint: 8.15.0
       lodash: 4.17.21
       string-natural-compare: 3.0.1
     dev: false
@@ -32681,7 +32586,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.50.0)(eslint@8.38.0):
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.50.0)(eslint@8.15.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -32691,12 +32596,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
-      eslint: 8.38.0
+      eslint: 8.15.0
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.3(@typescript-eslint/parser@5.50.0)(eslint-import-resolver-node@0.3.6)
       has: 1.0.3
@@ -32792,7 +32697,7 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.50.0)(eslint@8.38.0)(jest@27.5.1)(typescript@4.9.5):
+  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.50.0)(eslint@8.15.0)(jest@27.5.1)(typescript@4.9.5):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -32805,9 +32710,9 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.38.0)(typescript@4.9.5)
-      '@typescript-eslint/experimental-utils': 5.3.1(eslint@8.38.0)(typescript@4.9.5)
-      eslint: 8.38.0
+      '@typescript-eslint/eslint-plugin': 5.50.0(@typescript-eslint/parser@5.50.0)(eslint@8.15.0)(typescript@4.9.5)
+      '@typescript-eslint/experimental-utils': 5.3.1(eslint@8.15.0)(typescript@4.9.5)
+      eslint: 8.15.0
       jest: 27.5.1
     transitivePeerDependencies:
       - supports-color
@@ -32882,7 +32787,7 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.6.1(eslint@8.38.0):
+  /eslint-plugin-jsx-a11y@6.6.1(eslint@8.15.0):
     resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -32896,7 +32801,7 @@ packages:
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.38.0
+      eslint: 8.15.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.5
@@ -33115,13 +33020,13 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.38.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.15.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.38.0
+      eslint: 8.15.0
     dev: false
 
   /eslint-plugin-react-native-globals@0.1.2:
@@ -33264,7 +33169,7 @@ packages:
       string.prototype.matchall: 4.0.7
     dev: true
 
-  /eslint-plugin-react@7.31.10(eslint@8.38.0):
+  /eslint-plugin-react@7.31.10(eslint@8.15.0):
     resolution: {integrity: sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -33273,7 +33178,7 @@ packages:
       array-includes: 3.1.5
       array.prototype.flatmap: 1.3.0
       doctrine: 2.1.0
-      eslint: 8.38.0
+      eslint: 8.15.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.0
       minimatch: 3.1.2
@@ -33296,14 +33201,14 @@ packages:
       eslint: 7.32.0
     dev: true
 
-  /eslint-plugin-testing-library@5.6.0(eslint@8.38.0)(typescript@4.9.5):
+  /eslint-plugin-testing-library@5.6.0(eslint@8.15.0)(typescript@4.9.5):
     resolution: {integrity: sha512-y63TRzPhGCMNsnUwMGJU1MFWc/3GvYw+nzobp9QiyNTTKsgAt5RKAOT1I34+XqVBpX1lC8bScoOjCkP7iRv0Mw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.50.0(eslint@8.38.0)(typescript@4.9.5)
-      eslint: 8.38.0
+      '@typescript-eslint/utils': 5.50.0(eslint@8.15.0)(typescript@4.9.5)
+      eslint: 8.15.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -33354,15 +33259,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-    dev: true
-
-  /eslint-scope@7.2.0:
-    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
-    dev: false
 
   /eslint-utils@1.4.3:
     resolution: {integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==}
@@ -33394,7 +33290,6 @@ packages:
     dependencies:
       eslint: 8.15.0
       eslint-visitor-keys: 2.1.0
-    dev: true
 
   /eslint-utils@3.0.0(eslint@8.2.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
@@ -33405,16 +33300,6 @@ packages:
       eslint: 8.2.0
       eslint-visitor-keys: 2.1.0
     dev: true
-
-  /eslint-utils@3.0.0(eslint@8.38.0):
-    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
-    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
-    peerDependencies:
-      eslint: '>=5'
-    dependencies:
-      eslint: 8.38.0
-      eslint-visitor-keys: 2.1.0
-    dev: false
 
   /eslint-visitor-keys@1.3.0:
     resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
@@ -33427,13 +33312,12 @@ packages:
   /eslint-visitor-keys@3.3.0:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
   /eslint-visitor-keys@3.4.0:
     resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  /eslint-webpack-plugin@3.2.0(eslint@8.38.0)(webpack@5.72.1):
+  /eslint-webpack-plugin@3.2.0(eslint@8.15.0)(webpack@5.72.1):
     resolution: {integrity: sha512-avrKcGncpPbPSUHX6B3stNGzkKFto3eL+DKM4+VyMrVnhPc3vRczVlCq3uhuFOdRvDHTVXuzwk1ZKUrqDQHQ9w==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -33441,7 +33325,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.4.2
-      eslint: 8.38.0
+      eslint: 8.15.0
       jest-worker: 28.1.3
       micromatch: 4.0.5
       normalize-path: 3.0.0
@@ -33466,7 +33350,7 @@ packages:
       eslint-utils: 1.4.3
       eslint-visitor-keys: 1.3.0
       espree: 6.2.1
-      esquery: 1.5.0
+      esquery: 1.4.0
       esutils: 2.0.3
       file-entry-cache: 5.0.1
       functional-red-black-tree: 1.0.1
@@ -33586,7 +33470,6 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /eslint@8.2.0:
     resolution: {integrity: sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==}
@@ -33635,55 +33518,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint@8.38.0:
-    resolution: {integrity: sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.38.0)
-      '@eslint-community/regexpp': 4.5.0
-      '@eslint/eslintrc': 2.0.2
-      '@eslint/js': 8.38.0
-      '@humanwhocodes/config-array': 0.11.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@nodelib/fs.walk': 1.2.8
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.0
-      espree: 9.5.1
-      esquery: 1.5.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      globals: 13.20.0
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      is-path-inside: 3.0.3
-      js-sdsl: 4.4.0
-      js-yaml: 4.1.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /espree@6.2.1:
     resolution: {integrity: sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==}
     engines: {node: '>=6.0.0'}
@@ -33706,11 +33540,10 @@ packages:
     dependencies:
       acorn: 8.8.2
       acorn-jsx: 5.3.2(acorn@8.8.2)
-      eslint-visitor-keys: 3.4.0
-    dev: true
+      eslint-visitor-keys: 3.3.0
 
-  /espree@9.5.1:
-    resolution: {integrity: sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==}
+  /espree@9.4.1:
+    resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.2
@@ -33724,12 +33557,6 @@ packages:
 
   /esquery@1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      estraverse: 5.3.0
-
-  /esquery@1.5.0:
-    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -34894,8 +34721,8 @@ packages:
     resolution: {integrity: sha512-XEujWSZpsdptky62Qt0Yj8jVGVT6yVXS6fOteL/b8wLdB122ykrxVlcQbNWVxFSEgusju3f6/0uqDC7R9qfwDw==}
     engines: {node: '>=v12.22.9'}
     dependencies:
-      glob: 8.1.0
-      graceful-fs: 4.2.11
+      glob: 8.0.3
+      graceful-fs: 4.2.10
       handlebars: 4.7.7
     dev: false
 
@@ -35363,7 +35190,7 @@ packages:
   /filelist@1.0.3:
     resolution: {integrity: sha512-LwjCsruLWQULGYKy7TX0OPtrL9kLpojOFKc5VCTxdFTV7w5zbsgqVKfnkKG7Qgjtq50gKfO56hJv88OfcGb70Q==}
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.0
 
   /filename-regex@2.0.1:
     resolution: {integrity: sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=}
@@ -35707,13 +35534,6 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
-  /foreground-child@3.1.1:
-    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
-    engines: {node: '>=14'}
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 4.0.1
-
   /forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -35855,7 +35675,7 @@ packages:
       memfs: 3.4.6
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.0
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 4.42.1
@@ -35887,11 +35707,43 @@ packages:
       memfs: 3.4.6
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.0
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 4.42.1
     dev: true
+
+  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.15.0)(typescript@4.9.5)(webpack@5.72.1):
+    resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
+    engines: {node: '>=10', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.21.4
+      '@types/json-schema': 7.0.11
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 6.0.0
+      deepmerge: 4.3.0
+      eslint: 8.15.0
+      fs-extra: 9.1.0
+      glob: 7.2.3
+      memfs: 3.4.6
+      minimatch: 3.1.2
+      schema-utils: 2.7.0
+      semver: 7.3.8
+      tapable: 1.1.3
+      typescript: 4.9.5
+      webpack: 5.72.1
+    dev: false
 
   /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.15.0)(typescript@4.9.5)(webpack@5.76.1):
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
@@ -35919,7 +35771,7 @@ packages:
       memfs: 3.4.6
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.0
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 5.76.1(metro@0.76.0)
@@ -35951,43 +35803,11 @@ packages:
       memfs: 3.4.6
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.5.0
+      semver: 7.3.8
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 4.42.1
     dev: true
-
-  /fork-ts-checker-webpack-plugin@6.5.2(eslint@8.38.0)(typescript@4.9.5)(webpack@5.72.1):
-    resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
-    engines: {node: '>=10', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@types/json-schema': 7.0.11
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 6.0.0
-      deepmerge: 4.3.0
-      eslint: 8.38.0
-      fs-extra: 9.1.0
-      glob: 7.2.3
-      memfs: 3.4.6
-      minimatch: 3.1.2
-      schema-utils: 2.7.0
-      semver: 7.5.0
-      tapable: 1.1.3
-      typescript: 4.9.5
-      webpack: 5.72.1
-    dev: false
 
   /form-data@2.3.3:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
@@ -36099,7 +35919,7 @@ packages:
   /fs-extra@0.30.0:
     resolution: {integrity: sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jsonfile: 2.4.0
       klaw: 1.3.1
       path-is-absolute: 1.0.1
@@ -36109,7 +35929,7 @@ packages:
   /fs-extra@1.0.0:
     resolution: {integrity: sha512-VerQV6vEKuhDWD2HGOybV6v5I73syoc/cXAbKlgTC7M/oFVEtklWlp9QH2Ijw3IaWDOQcMkldSPa7zXy79Z/UQ==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jsonfile: 2.4.0
       klaw: 1.3.1
     dev: true
@@ -36126,7 +35946,7 @@ packages:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
     engines: {node: '>=14.14'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
@@ -36150,7 +35970,7 @@ packages:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jsonfile: 4.0.0
       universalify: 0.1.2
 
@@ -36167,7 +35987,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jsonfile: 6.1.0
       universalify: 1.0.0
 
@@ -36190,13 +36010,13 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
     dependencies:
-      minipass: 3.3.6
+      minipass: 3.1.6
 
   /fs-mkdirp-stream@1.0.0:
     resolution: {integrity: sha512-+vSd9frUnapVC2RZYfL3FCB2p3g4TBhaUmrsWlSudsGdnxIuUvBB2QM1VZeBtc49QFwrp+wQLrDs3+xxDgI5gQ==}
     engines: {node: '>= 0.10'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       through2: 2.0.5
     dev: true
 
@@ -36210,7 +36030,7 @@ packages:
   /fs-write-stream-atomic@1.0.10:
     resolution: {integrity: sha512-gehEzmPn2nAwr39eay+x3X34Ra+M2QlVUTLhkXPjWdeO8RF9kszk116avgBJM3ZyNHgHXBNx+VmPaFC36k0PzA==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       iferr: 0.1.5
       imurmurhash: 0.1.4
       readable-stream: 2.3.8
@@ -36230,7 +36050,7 @@ packages:
     requiresBuild: true
     dependencies:
       bindings: 1.5.0
-      nan: 2.17.0
+      nan: 2.15.0
     optional: true
 
   /fsevents@2.1.2:
@@ -36252,7 +36072,7 @@ packages:
     resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
     engines: {node: '>=0.6'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       inherits: 2.0.4
       mkdirp: 0.5.6
       rimraf: 2.7.1
@@ -36569,18 +36389,6 @@ packages:
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
-  /glob@10.2.1:
-    resolution: {integrity: sha512-ngom3wq2UhjdbmRE/krgkD8BQyi1KZ5l+D2dVm4+Yj+jJIBp74/ZGunL6gNGc/CYuQmvUBiavWEXIotRiv5R6A==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-    dependencies:
-      foreground-child: 3.1.1
-      fs.realpath: 1.0.0
-      jackspeak: 2.0.3
-      minimatch: 9.0.0
-      minipass: 5.0.0
-      path-scurry: 1.7.0
-
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
     dependencies:
@@ -36639,20 +36447,8 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.6
+      minimatch: 5.1.0
       once: 1.4.0
-    dev: true
-
-  /glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.6
-      once: 1.4.0
-    dev: false
 
   /glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -36728,7 +36524,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
-    dev: true
 
   /globals@13.20.0:
     resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
@@ -36911,9 +36706,6 @@ packages:
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-
-  /graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   /graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
@@ -38836,14 +38628,6 @@ packages:
       es-get-iterator: 1.1.2
       iterate-iterator: 1.0.2
 
-  /jackspeak@2.0.3:
-    resolution: {integrity: sha512-0Jud3OMUdMbrlr3PyUMKESq51LXVAB+a239Ywdvd+Kgxj3MaBRml/nVRxf8tQFyfthMjuRkxkv7Vg58pmIMfuQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      cliui: 7.0.4
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   /jake@10.8.5:
     resolution: {integrity: sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==}
     engines: {node: '>=10'}
@@ -39035,7 +38819,7 @@ packages:
       '@jest/types': 27.5.1
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 27.5.1
       jest-util: 27.5.1
@@ -39066,7 +38850,7 @@ packages:
       '@jest/types': 28.1.3
       chalk: 4.1.2
       exit: 0.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 28.1.3(@types/node@14.18.17)
       jest-util: 28.1.3
@@ -39298,7 +39082,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 27.5.1
       jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
@@ -39342,7 +39126,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39382,7 +39166,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39422,7 +39206,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39462,7 +39246,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3(metro@0.76.0)
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39502,7 +39286,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39543,7 +39327,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39584,7 +39368,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39625,7 +39409,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39666,7 +39450,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39705,7 +39489,7 @@ packages:
       ci-info: 3.3.2
       deepmerge: 4.3.0
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-circus: 28.1.3(metro@0.76.0)
       jest-environment-node: 28.1.3
       jest-get-type: 28.0.2
@@ -39980,7 +39764,7 @@ packages:
       '@jest/types': 24.9.0
       anymatch: 2.0.0
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       invariant: 2.2.4
       jest-serializer: 24.9.0
       jest-util: 24.9.0
@@ -40003,7 +39787,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 26.0.0
       jest-serializer: 26.6.2
       jest-util: 26.6.2
@@ -40027,7 +39811,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 26.0.0
       jest-serializer: 26.6.2
       jest-util: 26.6.2
@@ -40051,7 +39835,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 27.5.1
       jest-serializer: 27.5.1
       jest-util: 27.5.1
@@ -40072,7 +39856,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 27.5.1
       jest-serializer: 27.5.1
       jest-util: 27.5.1
@@ -40094,7 +39878,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 28.0.2
       jest-util: 28.1.3
       jest-worker: 28.1.3
@@ -40115,7 +39899,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 28.0.2
       jest-util: 28.1.3
       jest-worker: 28.1.3(metro@0.76.0)
@@ -40136,7 +39920,7 @@ packages:
       '@types/node': 18.15.11
       anymatch: 3.1.2
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-regex-util: 29.2.0
       jest-util: 29.5.0
       jest-worker: 29.3.1(metro@0.76.0)
@@ -40335,7 +40119,7 @@ packages:
       '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       micromatch: 4.0.5
       pretty-format: 29.5.0
       slash: 3.0.0
@@ -40505,7 +40289,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       chalk: 4.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 28.1.3
       jest-pnp-resolver: 1.2.2(jest-resolve@28.1.3)
       jest-util: 28.1.3
@@ -40522,7 +40306,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       chalk: 4.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 28.1.3(metro@0.76.0)
       jest-pnp-resolver: 1.2.2(jest-resolve@28.1.3)
       jest-util: 28.1.3
@@ -40544,7 +40328,7 @@ packages:
       '@jest/types': 24.9.0
       chalk: 2.4.2
       exit: 0.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-config: 24.9.0
       jest-docblock: 24.9.0
       jest-haste-map: 24.9.0
@@ -40575,7 +40359,7 @@ packages:
       '@types/node': 18.15.11
       chalk: 4.1.2
       emittery: 0.8.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-docblock: 27.5.1
       jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
@@ -40608,7 +40392,7 @@ packages:
       '@types/node': 18.15.11
       chalk: 4.1.2
       emittery: 0.10.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-docblock: 28.1.1
       jest-environment-node: 28.1.3
       jest-haste-map: 28.1.3
@@ -40638,7 +40422,7 @@ packages:
       '@types/node': 18.15.11
       chalk: 4.1.2
       emittery: 0.10.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-docblock: 28.1.1
       jest-environment-node: 28.1.3
       jest-haste-map: 28.1.3(metro@0.76.0)
@@ -40670,7 +40454,7 @@ packages:
       chalk: 2.4.2
       exit: 0.1.2
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-config: 24.9.0
       jest-haste-map: 24.9.0
       jest-message-util: 24.9.0
@@ -40706,7 +40490,7 @@ packages:
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
       glob: 7.2.3
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
@@ -40792,7 +40576,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@types/node': 18.15.11
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
     dev: true
 
   /jest-serializer@27.5.1:
@@ -40800,7 +40584,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@types/node': 18.15.11
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
 
   /jest-snapshot@24.9.0:
     resolution: {integrity: sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==}
@@ -40838,7 +40622,7 @@ packages:
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.0)
       chalk: 4.1.2
       expect: 27.5.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       jest-haste-map: 27.5.1
@@ -40847,7 +40631,7 @@ packages:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
-      semver: 7.5.0
+      semver: 7.3.8
     transitivePeerDependencies:
       - metro
       - supports-color
@@ -40928,7 +40712,7 @@ packages:
       '@jest/types': 24.9.0
       callsites: 3.1.0
       chalk: 2.4.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       is-ci: 2.0.0
       mkdirp: 0.5.6
       slash: 2.0.0
@@ -40943,7 +40727,7 @@ packages:
       '@jest/types': 26.6.2
       '@types/node': 18.15.11
       chalk: 4.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       is-ci: 2.0.0
       micromatch: 4.0.5
     dev: true
@@ -40956,7 +40740,7 @@ packages:
       '@types/node': 18.15.11
       chalk: 4.1.2
       ci-info: 3.3.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       picomatch: 2.3.1
 
   /jest-util@28.1.3:
@@ -40989,7 +40773,7 @@ packages:
       '@types/node': 18.15.11
       chalk: 4.1.2
       ci-info: 3.3.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       picomatch: 2.3.1
 
   /jest-validate@24.9.0:
@@ -41565,10 +41349,6 @@ packages:
       easy-stack: 1.0.1
     dev: true
 
-  /js-sdsl@4.4.0:
-    resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
-    dev: false
-
   /js-sha256@0.9.0:
     resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
     dev: false
@@ -41645,7 +41425,7 @@ packages:
       babel-core: 7.0.0-bridge.0(@babel/core@7.21.0)
       chalk: 4.1.2
       flow-parser: 0.185.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       micromatch: 3.1.10
       neo-async: 2.6.2
       node-dir: 0.1.17
@@ -41674,7 +41454,7 @@ packages:
       babel-core: 7.0.0-bridge.0(@babel/core@7.21.0)
       chalk: 4.1.2
       flow-parser: 0.185.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       micromatch: 3.1.10
       neo-async: 2.6.2
       node-dir: 0.1.17
@@ -42006,20 +41786,20 @@ packages:
   /jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
     dev: true
 
   /jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
 
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
 
   /jsonify@0.0.0:
     resolution: {integrity: sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=}
@@ -42187,7 +41967,7 @@ packages:
     dependencies:
       bindings: 1.5.0
       inherits: 2.0.4
-      nan: 2.17.0
+      nan: 2.15.0
       safe-buffer: 5.2.1
     dev: false
 
@@ -42258,7 +42038,7 @@ packages:
   /klaw@1.3.1:
     resolution: {integrity: sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==}
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
     dev: true
 
   /kleur@3.0.3:
@@ -42749,7 +42529,7 @@ packages:
     resolution: {integrity: sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       parse-json: 2.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -42761,7 +42541,7 @@ packages:
     resolution: {integrity: sha512-3p6ZOGNbiX4CdvEd1VcE6yi78UrGNpjHO33noGwHCnT/o2fyllJDepsm8+mFFv/DvtwFHht5HIHSyOy5a+ChVQ==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       parse-json: 2.2.0
       pify: 2.3.0
       strip-bom: 3.0.0
@@ -42770,7 +42550,7 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -42779,7 +42559,7 @@ packages:
     resolution: {integrity: sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       parse-json: 4.0.0
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -42802,7 +42582,7 @@ packages:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -44043,7 +43823,7 @@ packages:
       anymatch: 3.1.2
       debug: 2.6.9
       fb-watchman: 2.0.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       invariant: 2.2.4
       jest-regex-util: 27.5.1
       jest-serializer: 27.5.1
@@ -44748,7 +44528,7 @@ packages:
       denodeify: 1.2.1
       error-stack-parser: 2.0.7
       fs-extra: 1.0.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       hermes-parser: 0.5.0
       image-size: 0.6.3
       invariant: 2.2.4
@@ -44810,7 +44590,7 @@ packages:
       debug: 2.6.9
       denodeify: 1.2.1
       error-stack-parser: 2.0.7
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       hermes-parser: 0.8.0
       image-size: 0.6.3
       invariant: 2.2.4
@@ -45124,20 +44904,8 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
 
-  /minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-
   /minimatch@8.0.4:
     resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-
-  /minimatch@9.0.0:
-    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -45189,12 +44957,6 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-
   /minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
@@ -45213,7 +44975,7 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
     dependencies:
-      minipass: 3.3.6
+      minipass: 3.1.6
       yallist: 4.0.0
 
   /miscreant@0.3.2:
@@ -45472,9 +45234,6 @@ packages:
   /nan@2.15.0:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
     requiresBuild: true
-
-  /nan@2.17.0:
-    resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
 
   /nano-json-stream-parser@0.1.2:
     resolution: {integrity: sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==}
@@ -45871,7 +45630,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.11.0
-      semver: 7.5.0
+      semver: 7.3.8
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -46563,7 +46322,7 @@ packages:
     resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
     engines: {node: '>=8'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       hasha: 5.2.2
       lodash.flattendeep: 4.4.0
       release-zalgo: 1.0.0
@@ -46822,7 +46581,7 @@ packages:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       pify: 2.3.0
       pinkie-promise: 2.0.1
     dev: true
@@ -47866,7 +47625,7 @@ packages:
       postcss-normalize: 10.0.1(postcss@7.0.39)
       postcss-preset-env: 7.7.2(postcss@7.0.39)
       schema-utils: 3.1.1
-      semver: 7.5.0
+      semver: 7.3.8
       webpack: 4.42.1
     transitivePeerDependencies:
       - browserslist
@@ -49188,7 +48947,7 @@ packages:
   /proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       retry: 0.12.0
       signal-exit: 3.0.7
     dev: true
@@ -49679,7 +49438,7 @@ packages:
       - supports-color
       - vue-template-compiler
 
-  /react-dev-utils@12.0.1(eslint@8.38.0)(typescript@4.9.5)(webpack@5.72.1):
+  /react-dev-utils@12.0.1(eslint@8.15.0)(typescript@4.9.5)(webpack@5.72.1):
     resolution: {integrity: sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -49698,7 +49457,7 @@ packages:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.38.0)(typescript@4.9.5)(webpack@5.72.1)
+      fork-ts-checker-webpack-plugin: 6.5.2(eslint@8.15.0)(typescript@4.9.5)(webpack@5.72.1)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -50094,7 +49853,7 @@ packages:
     dependencies:
       '@babel/parser': 7.21.4
       flow-parser: 0.185.2
-      glob: 10.2.1
+      glob: 7.2.3
       invariant: 2.2.4
       jscodeshift: 0.13.1
       nullthrows: 1.1.1
@@ -50107,7 +49866,7 @@ packages:
     dependencies:
       '@babel/parser': 7.21.4
       flow-parser: 0.185.2
-      glob: 10.2.1
+      glob: 7.2.3
       invariant: 2.2.4
       jscodeshift: 0.13.1(@babel/preset-env@7.17.10)
       nullthrows: 1.1.1
@@ -51024,9 +50783,9 @@ packages:
       css-minimizer-webpack-plugin: 3.4.1(webpack@5.72.1)
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
-      eslint: 8.38.0
-      eslint-config-react-app: 7.0.1(eslint@8.38.0)(jest@27.5.1)(typescript@4.9.5)
-      eslint-webpack-plugin: 3.2.0(eslint@8.38.0)(webpack@5.72.1)
+      eslint: 8.15.0
+      eslint-config-react-app: 7.0.1(eslint@8.15.0)(jest@27.5.1)(typescript@4.9.5)
+      eslint-webpack-plugin: 3.2.0(eslint@8.15.0)(webpack@5.72.1)
       file-loader: 6.2.0(webpack@5.72.1)
       fs-extra: 10.1.0
       html-webpack-plugin: 5.5.0(webpack@5.72.1)
@@ -51043,7 +50802,7 @@ packages:
       prompts: 2.4.2
       react: 17.0.2
       react-app-polyfill: 3.0.0
-      react-dev-utils: 12.0.1(eslint@8.38.0)(typescript@4.9.5)(webpack@5.72.1)
+      react-dev-utils: 12.0.1(eslint@8.15.0)(typescript@4.9.5)(webpack@5.72.1)
       react-refresh: 0.11.0
       resolve: 1.22.0
       resolve-url-loader: 4.0.0
@@ -51418,7 +51177,7 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
@@ -51507,7 +51266,7 @@ packages:
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
     engines: {node: '>=0.10'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       micromatch: 3.1.10
       readable-stream: 2.3.8
     transitivePeerDependencies:
@@ -51518,7 +51277,7 @@ packages:
     resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
     engines: {node: '>=0.10'}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       micromatch: 3.1.10(supports-color@6.1.0)
       readable-stream: 2.3.8
     transitivePeerDependencies:
@@ -52450,10 +52209,10 @@ packages:
       '@babel/runtime': 7.20.13
       eventemitter3: 4.0.7
       uuid: 8.3.2
-      ws: 8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)
+      ws: 8.13.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
     optionalDependencies:
-      bufferutil: 4.0.7
-      utf-8-validate: 5.0.10
+      bufferutil: 4.0.6
+      utf-8-validate: 5.0.9
     dev: false
 
   /rsvp@4.8.5:
@@ -52834,13 +52593,6 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
-  /semver@7.5.0:
-    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -53152,10 +52904,6 @@ packages:
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  /signal-exit@4.0.1:
-    resolution: {integrity: sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==}
-    engines: {node: '>=14'}
-
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -53403,8 +53151,8 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
-  /sodium-native@3.4.1:
-    resolution: {integrity: sha512-PaNN/roiFWzVVTL6OqjzYct38NSXewdl2wz8SRB51Br/MLIJPrbM3XexhVWkq7D3UWMysfrhKVf1v1phZq6MeQ==}
+  /sodium-native@3.3.0:
+    resolution: {integrity: sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==}
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.4.0
@@ -53701,7 +53449,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       figgy-pudding: 3.5.2
-      minipass: 3.3.6
+      minipass: 3.1.6
 
   /ssri@8.0.1:
     resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
@@ -53760,7 +53508,7 @@ packages:
       find-up: 5.0.0
       fs-access: 1.0.1
       git-semver-tags: 4.1.1
-      semver: 7.5.0
+      semver: 7.3.8
       stringify-package: 1.0.1
       yargs: 16.2.0
     dev: true
@@ -53819,7 +53567,7 @@ packages:
       sha.js: 2.4.11
       tweetnacl: 1.0.3
     optionalDependencies:
-      sodium-native: 3.4.1
+      sodium-native: 3.3.0
     dev: false
 
   /stellar-sdk@10.1.2:
@@ -54359,8 +54107,8 @@ packages:
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
     dependencies:
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/traverse': 7.20.13(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/traverse': 7.17.10(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.1.2
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
@@ -54382,8 +54130,8 @@ packages:
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
     dependencies:
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/traverse': 7.20.13(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/traverse': 7.17.10(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.1.2
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
@@ -54406,8 +54154,8 @@ packages:
       react-dom: '>= 16.8.0'
       react-is: '>= 16.8.0'
     dependencies:
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/traverse': 7.20.13(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.16.7
+      '@babel/traverse': 7.17.10(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.1.2
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
@@ -54890,24 +54638,10 @@ packages:
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
-      minipass: 3.3.6
+      minipass: 3.1.6
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
-
-  /tar@6.1.13:
-    resolution: {integrity: sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==}
-    engines: {node: '>=10'}
-    requiresBuild: true
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 4.2.8
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    dev: false
-    optional: true
 
   /telejson@5.3.3:
     resolution: {integrity: sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==}
@@ -55260,7 +54994,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 7.2.0
+      glob: 7.2.3
       minimatch: 3.1.2
 
   /text-encoding-polyfill@0.6.7:
@@ -57009,8 +56743,8 @@ packages:
     hasBin: true
     dev: true
 
-  /utf-8-validate@5.0.10:
-    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+  /utf-8-validate@5.0.9:
+    resolution: {integrity: sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==}
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
@@ -57662,7 +57396,7 @@ packages:
     dependencies:
       append-buffer: 1.0.2
       convert-source-map: 1.8.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       normalize-path: 2.1.1
       now-and-later: 2.0.1
       remove-bom-buffer: 3.0.0
@@ -57765,8 +57499,8 @@ packages:
     resolution: {integrity: sha512-EcswR2S8bpR7fD0YPeS7r2xXExrScVMxg4MedACaWHEtx9ftCF/qHG1xGkolzTPcEmjTavCQgbVzHUIdTMzFGA==}
     dev: true
 
-  /vue-template-compiler@2.7.14:
-    resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
+  /vue-template-compiler@2.6.14:
+    resolution: {integrity: sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==}
     requiresBuild: true
     dependencies:
       de-indent: 1.0.2
@@ -57844,7 +57578,7 @@ packages:
   /watchpack@1.7.5:
     resolution: {integrity: sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       neo-async: 2.6.2
     optionalDependencies:
       chokidar: 3.5.3
@@ -57857,14 +57591,14 @@ packages:
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
 
   /watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
     dev: true
 
   /wbuf@1.7.3:
@@ -59006,11 +58740,11 @@ packages:
     resolution: {integrity: sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==}
     engines: {node: '>=4.0.0'}
     dependencies:
-      bufferutil: 4.0.7
+      bufferutil: 4.0.6
       debug: 2.6.9
       es5-ext: 0.10.61
       typedarray-to-buffer: 3.1.5
-      utf-8-validate: 5.0.10
+      utf-8-validate: 5.0.9
       yaeti: 0.0.6
     transitivePeerDependencies:
       - supports-color
@@ -59573,14 +59307,14 @@ packages:
   /write-file-atomic@2.4.1:
     resolution: {integrity: sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
   /write-file-atomic@2.4.3:
     resolution: {integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==}
     dependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
 
@@ -59705,7 +59439,7 @@ packages:
       utf-8-validate:
         optional: true
 
-  /ws@8.13.0(bufferutil@4.0.7)(utf-8-validate@5.0.10):
+  /ws@8.13.0(bufferutil@4.0.6)(utf-8-validate@5.0.9):
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -59717,8 +59451,8 @@ packages:
       utf-8-validate:
         optional: true
     dependencies:
-      bufferutil: 4.0.7
-      utf-8-validate: 5.0.10
+      bufferutil: 4.0.6
+      utf-8-validate: 5.0.9
     dev: false
 
   /ws@8.6.0:


### PR DESCRIPTION
### 📝 Description
Context
-------

In ledger Vault team, we want to speed up the process of integrating new coins. That's why we are working on allowing users to create "raw" transaction and sign them with the HSM, leaving the user the responsibility to craft the transaction somewhow, outside of the vault. It's a small first step but it's not really user friendly. That's why we want to start integrating with external wallets. Obviously, Ledger-Live was our first choice :)

How?
----

The idea is simple. To minimize the number of changes on the Live and to allow us to move forward independently we decided to plug ourselves at the APDU level. Our solution is to create a VaultTransport that extends WebSocketTransport, overriding just the `exchange()` method in order to pass some additionnal data (ledger workspace/token..etc..). This transports calls a WSS service that parses APDU and returns appropriate responses, see [@ledgerhq/vault-apdu-connector](https://github.com/LedgerHQ/vault-apdu-connector).

Then we introduced a settings in experimental features that allows the user to swicth from the normal "device mode" to a mode where the VaultTransport would be used.

Some explanation of some changes
--------------------------------

Since the `open()` is a static method that return the instance of the class and given WebSocketTransport can be extended (in our case by VaultTransport.ts) we want to return an instance of the good class and not always the parent one:

```diff
modified   libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
@@ -109,7 +109,7 @@ export default class WebSocketTransport extends Transport {
         reject(e);
       }
     });
-    return new WebSocketTransport(exchangeMethods);
+    return new this(exchangeMethods);
   }

   hook: any;
```

We have to register VaultTransport to the global `modules` that holds the transports. We have to do it on the `renderer` side because this transport needs to be in sync with the settings (settings.vaultSigner):

```diff
modified   apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -5,6 +5,7 @@ import { Redirect, Route, Switch, useLocation, useHistory } from "react-router-d
 import { useSelector } from "react-redux";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
+import VaultSignerTransport from "~/renderer/components/VaultSignerTransport";
@@ -146,6 +148,7 @@ export default function Default() {
       <TriggerAppReady />
       <ExportLogsButton hookToShortcut />
       <TrackAppStart />
+      <VaultSignerTransport />
       <Idler />
       {process.platform === "darwin" ? <AppRegionDrag /> : null}
modified   apps/ledger-live-desktop/src/renderer/actions/settings.ts
```

It's done in a useEffect() because we want to update the transport everytime the settings change. In the open function we have to make sure the id is vault-transport, because there is also IPC transport. That's why I also updated the `registerTransportModule` of `IPC`:

```js
+  const { token, enabled, host, workspace } = useSelector(vaultSignerSelector);
+  useEffect(() => {
+    if (enabled && currentMode !== "polling") {
+      setDeviceMode("polling");
+    } else if (!enabled) {
+      setDeviceMode(originalDeviceMode);
+    }
+    registerTransportModule({
+      id: "vault-transport",
+      open: (id: string) => {
+        if (id !== "vault-transport") return;
+        return retry(() =>
+          VaultTransport.open(host).then(transport => {
+            transport.setData({ token, workspace });
+            return Promise.resolve(transport);
+          }),
+        );
+      },
+      disconnect: () => Promise.resolve(),
+    });
+  }, [host, token, workspace, enabled]);
```

```diff
modified   apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -17,6 +17,9 @@ setEnvOnAllThreads("USER_ID", getUserId());
 // This defines our IPC Transport that will proxy to an internal process (we shouldn't use node-hid on renderer)
 registerTransportModule({
   id: "ipc",
-  open: id => retry(() => IPCTransport.open(id)),
+  open: (id: string) => {
+    if (id !== "ipc") return;
+    return retry(() => IPCTransport.open(id));
+  },
   disconnect: () => Promise.resolve(),
 });
```

Because the `useEffect()` is run everytime the `settings.vaultSigner` change, I updated the `registerTransportModules` to not always `push()` inside the array but only update the transport if it's already there.

```diff
modified   libs/ledger-live-common/src/hw/index.ts
@@ -42,7 +42,12 @@ export type TransportModule = {
 };
 const modules: TransportModule[] = [];
 export const registerTransportModule = (module: TransportModule): void => {
-  modules.push(module);
+  const index = modules.findIndex((m) => m.id === module.id);
+  if (index > -1) {
+    modules[index] = module;
+  } else {
+    modules.push(module);
+  }
 };
 export const discoverDevices = (
   accept: (module: TransportModule) => boolean = () => true
```

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

_Replace this text by a clear and concise description of what this pull request is about and why it is needed._

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` `ledger-live-common` `ledgerjs/hw-transport-http`
- **Linked resource(s)**: [VG-14376](https://ledgerhq.atlassian.net/browse/VG-14376)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery**
- [x] **No breaking changes** 

### 📸 Demo
![cosmoslive](https://user-images.githubusercontent.com/944835/233651842-637ba15b-55ed-469d-beb0-e12fc3b20c49.gif)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[VG-14376]: https://ledgerhq.atlassian.net/browse/VG-14376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ