### PR TITLE
feat: LLD allow users to use Ledger Vault as a signer

### DIFF
--- a/.changeset/nasty-rats-raise.md
+++ b/.changeset/nasty-rats-raise.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/hw-transport-http": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: LDD allow user to use vault as a signer

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -5,6 +5,7 @@ import { Redirect, Route, Switch, useHistory } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
+import VaultSignerTransport from "~/renderer/components/VaultSignerTransport";
 import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
 import { SyncNewAccounts } from "~/renderer/bridge/SyncNewAccounts";
 import Dashboard from "~/renderer/screens/dashboard";
@@ -51,6 +52,7 @@ import { ToastOverlay } from "~/renderer/components/ToastOverlay";
 import Drawer from "~/renderer/drawers/Drawer";
 import UpdateBanner from "~/renderer/components/Updater/Banner";
 import FirmwareUpdateBanner from "~/renderer/components/FirmwareUpdateBanner";
+import VaultSignerBanner from "~/renderer/components/VaultSignerBanner";
 import Onboarding from "~/renderer/components/Onboarding";
 import PostOnboardingScreen from "~/renderer/components/PostOnboardingScreen";
 import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
@@ -146,6 +148,7 @@ export default function Default() {
       <TriggerAppReady />
       <ExportLogsButton hookToShortcut />
       <TrackAppStart />
+      <VaultSignerTransport />
       <Idler />
       {process.platform === "darwin" ? <AppRegionDrag /> : null}
 
@@ -205,6 +208,7 @@ export default function Default() {
                           <TopBannerContainer>
                             <UpdateBanner />
                             <FirmwareUpdateBanner />
+                            <VaultSignerBanner />
                           </TopBannerContainer>
                           <Switch>
                             <Route path="/" exact component={Dashboard} />

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -18,6 +18,7 @@ import {
   filterTokenOperationsZeroAmountSelector,
   selectedTimeRangeSelector,
   SettingsState,
+  VaultSigner,
 } from "~/renderer/reducers/settings";
 import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 export type SaveSettings = (
@@ -331,4 +332,9 @@ export const setFeatureFlagsButtonVisible = (featureFlagsButtonVisible: boolean)
   payload: {
     featureFlagsButtonVisible,
   },
+});
+
+export const setVaultSigner = (payload: VaultSigner) => ({
+  type: "SET_VAULT_SIGNER",
+  payload,
 });

--- a/apps/ledger-live-desktop/src/renderer/components/VaultSignerBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/VaultSignerBanner.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { Trans, useTranslation } from "react-i18next";
+
+import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+import TopBanner from "~/renderer/components/TopBanner";
+import { openURL } from "~/renderer/linking";
+import ExternalLink from "./ExternalLink";
+
+const VaultSignerBanner = () => {
+  const { t } = useTranslation();
+  const { enabled } = useSelector(vaultSignerSelector);
+  if (!enabled) return null;
+  return (
+    <TopBanner
+      id={"vault-signer-banner"}
+      content={{
+        Icon: ExclamationCircleThin,
+        message: <Trans i18nKey="banners.vaultSigner.title" />,
+        right: (
+          <ExternalLink
+            isInternal={false}
+            onClick={() => openURL("https://help.vault.ledger.com")}
+            label={t("banners.vaultSigner.link")}
+          />
+        ),
+      }}
+      status={"warning"}
+    />
+  );
+};
+
+export default VaultSignerBanner;

--- a/apps/ledger-live-desktop/src/renderer/components/VaultSignerTransport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/VaultSignerTransport.tsx
@@ -1,0 +1,52 @@
+// @flow
+
+import React, { useEffect } from "react";
+import { registerTransportModule } from "@ledgerhq/live-common/hw/index";
+import { retry } from "@ledgerhq/live-common/promise";
+import { VaultTransport } from "@ledgerhq/hw-transport-http";
+import { useSelector } from "react-redux";
+import { setDeviceMode, currentMode } from "@ledgerhq/live-common/hw/actions/app";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+
+const originalDeviceMode = currentMode;
+
+/*
+This component "listens" (with useEffect()) for changes in settings.vaultSigner and update
+the vault-transport in the global modules object.
+As this transport needs to be in sync with settings we couldn't register it
+on the internal process.
+
+To avoid cluttering the transport modules global object, we have updated it
+to not blindly push in the array but to update it if it's already in the array
+
+I'ts also important to check for the id of the transport in the open() method because
+there is also IPC transport registered.
+*/
+
+const VaultSignerTransport = () => {
+  const { token, enabled, host, workspace } = useSelector(vaultSignerSelector);
+  useEffect(() => {
+    if (enabled && currentMode !== "polling") {
+      setDeviceMode("polling");
+    } else if (!enabled) {
+      setDeviceMode(originalDeviceMode);
+    }
+    registerTransportModule({
+      id: "vault-transport",
+      open: (id: string) => {
+        if (id !== "vault-transport") return;
+        return retry(() =>
+          VaultTransport.open(host).then(transport => {
+            transport.setData({ token, workspace });
+            return Promise.resolve(transport);
+          }),
+        );
+      },
+      disconnect: () => Promise.resolve(),
+    });
+  }, [host, token, workspace, enabled]);
+
+  return null;
+};
+
+export default VaultSignerTransport;

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -17,6 +17,11 @@ setEnvOnAllThreads("USER_ID", getUserId());
 // This defines our IPC Transport that will proxy to an internal process (we shouldn't use node-hid on renderer)
 registerTransportModule({
   id: "ipc",
-  open: id => retry(() => IPCTransport.open(id)),
+  open: (id: string) => {
+    // id could be another type of transport such as vault-transport
+    // that is registered in src/renderer/components/VaultSignerTransport.tsx
+    if (id !== "ipc") return;
+    return retry(() => IPCTransport.open(id));
+  },
   disconnect: () => Promise.resolve(),
 });

--- a/apps/ledger-live-desktop/src/renderer/modals/VaultSigner/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/VaultSigner/index.tsx
@@ -1,0 +1,101 @@
+import React, { useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { Flex } from "@ledgerhq/react-ui";
+
+import Label from "~/renderer/components/Label";
+import Alert from "~/renderer/components/Alert";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+import { setVaultSigner } from "~/renderer/actions/settings";
+import Modal, { ModalBody, RenderProps } from "~/renderer/components/Modal";
+import Button from "~/renderer/components/Button";
+import Input from "~/renderer/components/Input";
+import InputPassword from "~/renderer/components/InputPassword";
+import ExternalLink from "~/renderer/components/ExternalLink";
+import { openURL } from "~/renderer/linking";
+
+const VaultSigner = ({ name }: { name: string }) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { host, token, workspace, ...rest } = useSelector(vaultSignerSelector);
+  const [localHost, setLocalHost] = useState<string>(host);
+  const [localWorkspace, setLocalWorkspace] = useState<string>(workspace);
+  const [localToken, setLocalToken] = useState<string>(token);
+
+  const onSubmit = (onClose: (a: void) => void) => {
+    dispatch(
+      setVaultSigner({ ...rest, token: localToken, host: localHost, workspace: localWorkspace }),
+    );
+    onClose();
+  };
+
+  const isValid = localHost !== "" && localWorkspace !== "" && localToken !== "";
+
+  return (
+    <Modal
+      name={name}
+      centered
+      render={({ onClose }: RenderProps) => (
+        <ModalBody
+          onClose={onClose}
+          onBack={undefined}
+          title={<Trans i18nKey="vaultSigner.modal.title" />}
+          noScroll
+          render={() => (
+            <Flex flexDirection="column" rowGap={4}>
+              <Alert type="primary">
+                <Flex flexDirection="column" rowGap={2}>
+                  <Trans i18nKey="vaultSigner.modal.info" />
+                  <ExternalLink
+                    label={t("vaultSigner.modal.info_link")}
+                    isInternal={false}
+                    onClick={() => openURL("https://help.vault.ledger.com")}
+                  />
+                </Flex>
+              </Alert>
+              <Flex flexDirection="column" rowGap={1}>
+                <Label>
+                  <Trans i18nKey="vaultSigner.modal.workspace.title" />
+                </Label>
+                <Input
+                  onFocus={() => undefined}
+                  onBlur={() => undefined}
+                  onChange={setLocalWorkspace}
+                  value={localWorkspace}
+                  placeholder={t("vaultSigner.modal.workspace.placeholder")}
+                />
+              </Flex>
+              <Flex flexDirection="column" rowGap={1}>
+                <Label>
+                  <Trans i18nKey="vaultSigner.modal.host.title" />
+                </Label>
+                <Input
+                  onFocus={() => undefined}
+                  onBlur={() => undefined}
+                  onChange={setLocalHost}
+                  value={localHost}
+                  placeholder={t("vaultSigner.modal.host.placeholder")}
+                />
+              </Flex>
+              <Flex flexDirection="column" rowGap={1}>
+                <Label>
+                  <Trans i18nKey="vaultSigner.modal.token.title" />
+                </Label>
+                <InputPassword onChange={setLocalToken} value={localToken} />
+              </Flex>
+              {onClose && (
+                <Flex alignSelf="flex-end">
+                  <Button primary onClick={() => onSubmit(onClose)} disabled={!isValid}>
+                    <Trans i18nKey="vaultSigner.modal.submit" />
+                  </Button>
+                </Flex>
+              )}
+            </Flex>
+          )}
+        />
+      )}
+    />
+  );
+};
+
+export default VaultSigner;

--- a/apps/ledger-live-desktop/src/renderer/modals/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.ts
@@ -26,6 +26,7 @@ import MODAL_STORYLY_DEBUGGER from "./StorylyDebugger";
 import MODAL_BLACKLIST_TOKEN from "./BlacklistToken";
 import MODAL_HIDE_NFT_COLLECTION from "./HideNftCollection";
 import MODAL_PROTECT_DISCOVER from "./ProtectDiscover";
+import MODAL_VAULT_SIGNER from "./VaultSigner";
 
 type ModalComponent = React.ComponentType<any>; // FIXME determine the common ground to modals
 type Modals = Record<string, ModalComponent>;
@@ -60,6 +61,9 @@ const modals: Modals = {
   MODAL_PLATFORM_EXCHANGE_START,
   MODAL_PLATFORM_EXCHANGE_COMPLETE,
   MODAL_CONNECT_DEVICE,
+
+  // Vault,
+  MODAL_VAULT_SIGNER,
 
   // NB We have dettached modals such as the repair modal,
   // in the meantime, we can rely on this to add the backdrop

--- a/apps/ledger-live-desktop/src/renderer/reducers/devices.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/devices.ts
@@ -3,6 +3,8 @@ import { getEnv } from "@ledgerhq/live-common/env";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { Handlers } from "./types";
+import { SettingsState } from "./settings";
+
 export type DevicesState = {
   currentDevice: Device | undefined | null;
   devices: Device[];
@@ -50,8 +52,13 @@ function setCurrentDevice(state: DevicesState) {
     currentDevice,
   };
 }
+export function getCurrentDevice(state: { devices: DevicesState; settings: SettingsState }) {
+  const isVaultSigner = state.settings.vaultSigner.enabled;
 
-export function getCurrentDevice(state: { devices: DevicesState }) {
+  if (isVaultSigner) {
+    return { deviceId: "vault-transport", wired: true, modelId: DeviceModelId.nanoS };
+  }
+
   if (getEnv("DEVICE_PROXY_URL") || getEnv("MOCK")) {
     // bypass the listen devices (we should remove modelId here by instead get it at open time if needed)
     return {

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -18,6 +18,13 @@ import { Handlers } from "./types";
 
 /* Initial state */
 
+export type VaultSigner = {
+  enabled: boolean;
+  host: string;
+  workspace: string;
+  token: string;
+};
+
 export type SettingsState = {
   loaded: boolean;
   // is the settings loaded from db (it not we don't save them)
@@ -89,6 +96,7 @@ export type SettingsState = {
     [key in FeatureId]: Feature;
   };
   featureFlagsButtonVisible: boolean;
+  vaultSigner: VaultSigner;
 };
 
 const DEFAULT_LANGUAGE_LOCALE = "en";
@@ -162,6 +170,9 @@ const INITIAL_STATE: SettingsState = {
   starredMarketCoins: [],
   overriddenFeatureFlags: {} as Record<FeatureId, Feature>,
   featureFlagsButtonVisible: false,
+
+  // Vault
+  vaultSigner: { enabled: false, host: "", token: "", workspace: "" },
 };
 
 /* Handlers */
@@ -214,6 +225,7 @@ type HandlersPayloads = {
   SET_FEATURE_FLAGS_BUTTON_VISIBLE: {
     featureFlagsButtonVisible: boolean;
   };
+  SET_VAULT_SIGNER: VaultSigner;
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
@@ -392,6 +404,10 @@ const handlers: SettingsHandlers = {
   SET_FEATURE_FLAGS_BUTTON_VISIBLE: (state: SettingsState, { payload }) => ({
     ...state,
     featureFlagsButtonVisible: payload.featureFlagsButtonVisible,
+  }),
+  SET_VAULT_SIGNER: (state: SettingsState, { payload }) => ({
+    ...state,
+    vaultSigner: payload,
   }),
 };
 export default handleActions<SettingsState, HandlersPayloads[keyof HandlersPayloads]>(
@@ -688,3 +704,4 @@ export const overriddenFeatureFlagsSelector = (state: State) =>
   state.settings.overriddenFeatureFlags;
 export const featureFlagsButtonVisibleSelector = (state: State) =>
   state.settings.featureFlagsButtonVisible;
+export const vaultSignerSelector = (state: State) => state.settings.vaultSigner;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/VaultSigner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/VaultSigner.tsx
@@ -1,0 +1,34 @@
+import React, { useCallback } from "react";
+import { useTranslation, Trans } from "react-i18next";
+
+import { useDispatch, useSelector } from "react-redux";
+import { vaultSignerSelector } from "~/renderer/reducers/settings";
+import { setVaultSigner } from "~/renderer/actions/settings";
+import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
+import { openModal } from "~/renderer/actions/modals";
+import Switch from "~/renderer/components/Switch";
+
+const VaultSigner = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const onOpenModal = useCallback(() => dispatch(openModal("MODAL_VAULT_SIGNER")), [dispatch]);
+  const { enabled, ...rest } = useSelector(vaultSignerSelector);
+
+  const handleChange = (val: boolean) => {
+    dispatch(setVaultSigner({ ...rest, enabled: val }));
+    if (val) {
+      onOpenModal();
+    }
+  };
+
+  return (
+    <SettingsSectionRow
+      title={t("settings.experimental.features.vaultSigner.title")}
+      desc={t("settings.experimental.features.vaultSigner.description")}
+    >
+      <Switch isChecked={enabled} onChange={handleChange} data-test-id={`enable-vault-signer`} />
+    </SettingsSectionRow>
+  );
+};
+
+export default VaultSigner;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
@@ -17,6 +17,8 @@ import FullNode from "~/renderer/screens/settings/sections/Accounts/FullNode";
 import LottieTester from "./LottieTester";
 import StorylyTester from "./StorylyTester";
 import PostOnboardingHubTester from "./PostOnboardingHubTester";
+import VaultSigner from "./VaultSigner";
+
 const experimentalTypesMap = {
   toggle: ExperimentalSwitch,
   integer: ExperimentalInteger,
@@ -103,6 +105,7 @@ const SectionExperimental = () => {
         {process.env.DEBUG_LOTTIE ? <LottieTester /> : null}
         {process.env.DEBUG_STORYLY ? <StorylyTester /> : null}
         {process.env.DEBUG_POSTONBOARDINGHUB ? <PostOnboardingHubTester /> : null}
+        <VaultSigner />
 
         <FullNode />
       </Body>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -634,6 +634,26 @@
   "postOnboardingDebugger": {
     "buttonTitle": "Test"
   },
+  "vaultSigner": {
+    "modal": {
+      "title": "Connect Vault",
+      "info": "Link your Ledger Vault workspace accounts and create transactions from Ledger Live by completing fields below. Locate info at Settings > External wallet signer.",
+      "info_link": "Learn more",
+      "host": {
+        "title": "URL Endpoint",
+        "placeholder": "ws://localhost:3030"
+      },
+      "workspace": {
+        "title": "Workspace name",
+        "placeholder": "workspace"
+      },
+      "token": {
+        "title": "Operator API Token",
+        "placeholder": "Token"
+      },
+      "submit": "Connect"
+    }
+  },
   "fullNode": {
     "status": "Status",
     "connect": "Connect",
@@ -1368,6 +1388,10 @@
     "referralProgram": {
       "title": "Refer and earn $10",
       "description": "Successfully refer a friend and you both earn $10 worth of Bitcoin."
+    },
+    "vaultSigner": {
+      "title": "Vault signer mode",
+      "link": "Vault Help Center"
     }
   },
   "signmessage": {
@@ -3907,6 +3931,10 @@
         "1559DeactivateGate": {
           "title": "Deactivate EIP1559 minimum priority fee gate",
           "description": "This will allow a transaction to be sent without any minimum priority fee expected. This may result in a transaction getting stuck in the mempool forever."
+        },
+        "vaultSigner": {
+          "title": "Vault Signer",
+          "description": "Use Ledger Vault as a signer with your operator API token"
         },
         "1559CustomPriorityLowerGate": {
           "title": "Custom priority fee gate",

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -42,7 +42,12 @@ export type TransportModule = {
 };
 const modules: TransportModule[] = [];
 export const registerTransportModule = (module: TransportModule): void => {
-  modules.push(module);
+  const index = modules.findIndex((m) => m.id === module.id);
+  if (index > -1) {
+    modules[index] = module;
+  } else {
+    modules.push(module);
+  }
 };
 export const discoverDevices = (
   accept: (module: TransportModule) => boolean = () => true

--- a/libs/ledgerjs/packages/hw-transport-http/src/VaultTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/VaultTransport.ts
@@ -1,0 +1,39 @@
+import { log } from "@ledgerhq/logs";
+import WebSocketTransport from "./WebSocketTransport";
+
+type VaultData = {
+  token: string;
+  workspace: string;
+};
+
+export default class VaultTransport extends WebSocketTransport {
+  protected data: VaultData | null;
+
+  constructor(hook: any) {
+    super(hook);
+    this.data = null;
+  }
+
+  setData(data: VaultData): void {
+    this.data = data;
+  }
+
+  async exchange(apdu: Buffer): Promise<Buffer> {
+    const hex = apdu.toString("hex");
+    log("apdu", "=> " + hex);
+    const res: Buffer = await new Promise((resolve, reject) => {
+      this.hook.rejectExchange = (e: any) => reject(e);
+
+      this.hook.resolveExchange = (b: Buffer) => resolve(b);
+      const data = {
+        workspace: this.data?.workspace,
+        token: this.data?.token,
+        apdu: hex,
+      };
+
+      this.hook.send(JSON.stringify(data));
+    });
+    log("apdu", "<= " + res.toString("hex"));
+    return res;
+  }
+}

--- a/libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
@@ -109,7 +109,9 @@ export default class WebSocketTransport extends Transport {
         reject(e);
       }
     });
-    return new WebSocketTransport(exchangeMethods);
+    // import to return new this(..) and not WebSocketTransport because
+    // WebSocketTransport can be extended, and is extended by VaultTransport
+    return new this(exchangeMethods);
   }
 
   hook: any;

--- a/libs/ledgerjs/packages/hw-transport-http/src/withStaticURLs.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/withStaticURLs.ts
@@ -1,6 +1,9 @@
 import HttpTransport from "./HttpTransport";
 import WebSocketTransport from "./WebSocketTransport";
 import Transport from "@ledgerhq/hw-transport";
+
+export { default as VaultTransport } from "./VaultTransport";
+
 import type {
   Observer,
   DescriptorEvent,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In ledger Vault team, we want to speed up the process of integrating new coins. That's why we are working on allowing users to create "raw" transaction and sign them with the HSM, leaving the user the responsibility to craft the transaction somewhow, outside of the vault. It's a small first step but it's not really user friendly. That's why we want to start integrating with external wallets. Obviously, Ledger-Live was our first choice :)


The idea is simple. To minimize the number of changes on the Live and to allow us to move forward independently we decided to plug ourselves at the APDU level. Our solution is to create a VaultTransport that extends WebSocketTransport, overriding just the `exchange()` method in order to pass some additionnal data (ledger workspace/token..etc..). This transports calls a WSS service that parses APDU and returns appropriate responses, see [@ledgerhq/vault-apdu-connector](https://github.com/LedgerHQ/vault-apdu-connector).

Then we introduced a settings in experimental features that allows the user to swicth from the normal "device mode" to a mode where the VaultTransport would be used.

Since the `open()` is a static method that return the instance of the class and given WebSocketTransport can be extended (in our case by VaultTransport.ts) we want to return an instance of the good class and not always the parent one:

```diff
modified   libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
@@ -109,7 +109,7 @@ export default class WebSocketTransport extends Transport {
         reject(e);
       }
     });
-    return new WebSocketTransport(exchangeMethods);
+    return new this(exchangeMethods);
   }

   hook: any;
```

We have to register VaultTransport to the global `modules` that holds the transports. We have to do it on the `renderer` side because this transport needs to be in sync with the settings (settings.vaultSigner):

```diff
modified   apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -5,6 +5,7 @@ import { Redirect, Route, Switch, useLocation, useHistory } from "react-router-d
 import { useSelector } from "react-redux";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
+import VaultSignerTransport from "~/renderer/components/VaultSignerTransport";
@@ -146,6 +148,7 @@ export default function Default() {
       <TriggerAppReady />
       <ExportLogsButton hookToShortcut />
       <TrackAppStart />
+      <VaultSignerTransport />
       <Idler />
       {process.platform === "darwin" ? <AppRegionDrag /> : null}
modified   apps/ledger-live-desktop/src/renderer/actions/settings.ts
```

It's done in a useEffect() because we want to update the transport everytime the settings change. In the open function we have to make sure the id is vault-transport, because there is also IPC transport. That's why I also updated the `registerTransportModule` of `IPC`:

```js
+  const { token, enabled, host, workspace } = useSelector(vaultSignerSelector);
+  useEffect(() => {
+    if (enabled && currentMode !== "polling") {
+      setDeviceMode("polling");
+    } else if (!enabled) {
+      setDeviceMode(originalDeviceMode);
+    }
+    registerTransportModule({
+      id: "vault-transport",
+      open: (id: string) => {
+        if (id !== "vault-transport") return;
+        return retry(() =>
+          VaultTransport.open(host).then(transport => {
+            transport.setData({ token, workspace });
+            return Promise.resolve(transport);
+          }),
+        );
+      },
+      disconnect: () => Promise.resolve(),
+    });
+  }, [host, token, workspace, enabled]);
```

```diff
modified   apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -17,6 +17,9 @@ setEnvOnAllThreads("USER_ID", getUserId());
 // This defines our IPC Transport that will proxy to an internal process (we shouldn't use node-hid on renderer)
 registerTransportModule({
   id: "ipc",
-  open: id => retry(() => IPCTransport.open(id)),
+  open: (id: string) => {
+    if (id !== "ipc") return;
+    return retry(() => IPCTransport.open(id));
+  },
   disconnect: () => Promise.resolve(),
 });
```

Because the `useEffect()` is run everytime the `settings.vaultSigner` change, I updated the `registerTransportModules` to not always `push()` inside the array but only update the transport if it's already there.

```diff
modified   libs/ledger-live-common/src/hw/index.ts
@@ -42,7 +42,12 @@ export type TransportModule = {
 };
 const modules: TransportModule[] = [];
 export const registerTransportModule = (module: TransportModule): void => {
-  modules.push(module);
+  const index = modules.findIndex((m) => m.id === module.id);
+  if (index > -1) {
+    modules[index] = module;
+  } else {
+    modules.push(module);
+  }
 };
 export const discoverDevices = (
   accept: (module: TransportModule) => boolean = () => true
```

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` `ledger-live-common` `ledgerjs/hw-transport-http` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [VG-14376](https://ledgerhq.atlassian.net/browse/VG-14376) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->
![cosmoslive](https://user-images.githubusercontent.com/944835/234013291-4ac28664-d01e-48d5-b1d9-5ec009d286d6.gif)

Between the record of this GIF, I updated some wording and added some Alerts:

![1682342399](https://user-images.githubusercontent.com/944835/234013646-2108ae6e-a8e2-49f9-ba8d-a1242a17d77c.png)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[VG-14376]: https://ledgerhq.atlassian.net/browse/VG-14376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ