### PR TITLE
feat: recover login cta in llm welcome screen

### DIFF
--- a/.changeset/swift-apples-hope.md
+++ b/.changeset/swift-apples-hope.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Sign-in to Recover from LLM Welcome screen

--- a/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
@@ -1,6 +1,7 @@
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet, SafeAreaView, BackHandler, Platform } from "react-native";
+import { useDispatch } from "react-redux";
 
 import { useNavigation } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
@@ -18,6 +19,12 @@ import { InfoPanel } from "../WebPlatformPlayer/InfoPanel";
 import { RightHeader } from "../WebPlatformPlayer/RightHeader";
 import extraStatusBarPadding from "../../logic/extraStatusBarPadding";
 
+import {
+  completeOnboarding,
+  setHasOrderedNano,
+  setReadOnlyMode,
+} from "../../actions/settings";
+
 type Props = {
   manifest: LiveAppManifest;
   inputs?: Record<string, string>;
@@ -30,6 +37,7 @@ const WebRecoverPlayer = ({ manifest, inputs }: Props) => {
   const [webviewState, setWebviewState] =
     useState<WebviewState>(initialWebviewState);
   const [isInfoPanelOpened, setIsInfoPanelOpened] = useState(false);
+  const dispatch = useDispatch();
 
   const navigation =
     useNavigation<
@@ -89,6 +97,21 @@ const WebRecoverPlayer = ({ manifest, inputs }: Props) => {
           },
     );
   }, [headerShown, manifest, navigation, webviewState]);
+
+  const handleBypassOnboarding = useCallback(() => {
+    dispatch(completeOnboarding());
+    dispatch(setReadOnlyMode(false));
+    dispatch(setHasOrderedNano(false));
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!webviewState?.url) return;
+
+    const url = new URL(webviewState.url);
+    const paramBypassOnboarding = url.searchParams.get("bypassLLOnboarding");
+
+    if (paramBypassOnboarding === "true") handleBypassOnboarding();
+  }, [handleBypassOnboarding, webviewState]);
 
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1197,7 +1197,8 @@
       "terms": "By tapping “Get Started” you consent and agree to our",
       "termsLink": "Terms of Service",
       "privacyLink": "Privacy Policy",
-      "and": "and"
+      "and": "and",
+      "recoverLogIn": "Log in for Ledger Recover"
     },
     "stepDoYouHaveALedgerDevice": {
       "title": "Do you own a Ledger?",
@@ -6168,20 +6169,6 @@
             "alreadySubscribed": "Already logged in? <LinkAccount>View my subscription</LinkAccount>"
           }
         }
-      }
-    }
-  },
-  "protect": {
-    "login": {
-      "title": "Log In",
-      "desc": "Log in with your Ledger account to manage your Protect subscription.",
-      "email": "Email",
-      "password": "Password",
-      "cta": "Login",
-      "forgotPassword": "Forgot password?",
-      "errors": {
-        "emptyEmail": "Email cannot be empty",
-        "emptyPassword": "Password cannot be empty"
       }
     }
   },

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/welcome.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/welcome.tsx
@@ -116,6 +116,19 @@ function OnboardingStepWelcome({ navigation }: NavigationProps) {
     ? videoSources.welcomeScreenStax
     : videoSources.welcomeScreen;
 
+  const recoverFeature = useFeature("protectServicesMobile");
+
+  const recoverLogIn = useCallback(() => {
+    acceptTerms();
+    dispatch(setAnalytics(true));
+
+    const url = `${recoverFeature?.params?.account?.loginURI}&shouldBypassLLOnboarding=true`;
+
+    Linking.canOpenURL(url).then(canOpen => {
+      if (canOpen) Linking.openURL(url);
+    });
+  }, [acceptTerms, dispatch, recoverFeature?.params?.account?.loginURI]);
+
   return (
     <ForceTheme selectedPalette={"dark"}>
       <Flex flex={1} position="relative" bg="constant.purple">
@@ -207,6 +220,19 @@ function OnboardingStepWelcome({ navigation }: NavigationProps) {
           >
             {t("onboarding.stepWelcome.start")}
           </Button>
+          {recoverFeature?.enabled &&
+          recoverFeature?.params?.onboardingLogin ? (
+            <Button
+              outline
+              type="main"
+              size="large"
+              onPress={recoverLogIn}
+              mt={0}
+              mb={7}
+            >
+              {t("onboarding.stepWelcome.recoverLogIn")}
+            </Button>
+          ) : null}
           <Text variant="small" textAlign="center" color="neutral.c100">
             {t("onboarding.stepWelcome.terms")}
           </Text>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds a CTA in LLM Welcome screen to sign-in to Recover. This button will open Recover and pass a query param `shouldBypassLLOnboarding=true`. After a successful sign-in, Recover will add a query param `bypassOnboarding=true` to its URL. A watcher will intercept this param and will set the onboarding to completed.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [PROTECT-1726](https://ledgerhq.atlassian.net/browse/PROTECT-1726)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/102669540/fe756ee2-07c7-4c95-a9d6-ac5e486ac29e

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-1726]: https://ledgerhq.atlassian.net/browse/PROTECT-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ