### PR TITLE
Bugfix/LIVE-7226: fix possible duplicated BLEerror messages on the Manager

### DIFF
--- a/.changeset/shiny-mice-try.md
+++ b/.changeset/shiny-mice-try.md
@@ -1,0 +1,16 @@
+---
+"live-mobile": patch
+---
+
+fix: manager possible duplicated ble requirements error messages
+
+In the Manager: both the old (SelectDevice) and new (SelectDevice2)
+device selection components handle the bluetooth requirements with a hook
+
+- bottom drawer.
+
+The fix gives back the responsibilities to those select components to check for
+the bluetooth requirements and avoids a duplicated error drawers/messages.
+
+The only drawback: the user has to select again their device once the bluetooth
+requirements are respected.

--- a/apps/ledger-live-mobile/src/screens/Manager/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@react-navigation/native";
 import { Trans } from "react-i18next";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { BluetoothRequired } from "@ledgerhq/errors";
 
 import connectManager from "@ledgerhq/live-common/hw/connectManager";
 import { createAction, Result } from "@ledgerhq/live-common/hw/actions/manager";
@@ -100,6 +101,16 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
     setDevice(undefined);
   };
 
+  const onError = (error: Error) => {
+    // Both the old (SelectDevice) and new (SelectDevice2) device selection components handle the bluetooth requirements with a hook + bottom drawer.
+    // By setting back the device to `undefined` it gives back the responsibilities to those select components to check for the bluetooth requirements
+    // and avoids a duplicated error drawers/messages.
+    // The only drawback: the user has to select again their device once the bluetooth requirements are respected.
+    if (error instanceof BluetoothRequired) {
+      setDevice(undefined);
+    }
+  };
+
   useEffect(() => {
     setDevice(params?.device);
   }, [params]);
@@ -191,6 +202,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
         onModalHide={onModalHide}
         action={action}
         request={null}
+        onError={onError}
       />
     </Flex>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the Manager: both the old (SelectDevice) and new (SelectDevice2)
device selection components handle the bluetooth requirements with a hook + bottom drawer.

The fix gives back the responsibilities to those select components to check for
the bluetooth requirements and avoids a duplicated error drawers/messages.

The only drawback: the user has to select again their device once the bluetooth
requirements are respected.

### ❓ Context

- **Impacted projects**: `LLM`
- **Linked resource(s)**:  [LIVE-7226](https://ledgerhq.atlassian.net/browse/LIVE-7226)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<details>
  <summary>Quick demo</summary>
You can see that the BLE requirements issue is handled by a "new" drawer and not directly in the drawer that was displaying the device action


https://user-images.githubusercontent.com/15096913/234520406-45b28ce4-015f-47e8-b0d9-7c298124ef4d.mp4



</details>

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7226]: https://ledgerhq.atlassian.net/browse/LIVE-7226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ