### PR TITLE
feat: lld recover only on lnx modal

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectUseCase/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectUseCase/index.tsx
@@ -2,6 +2,8 @@ import React, { useContext } from "react";
 import { useHistory } from "react-router-dom";
 import { useTranslation, Trans } from "react-i18next";
 import { Flex, Text } from "@ledgerhq/react-ui";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { UseCaseOption } from "./UseCaseOption";
 import { ScrollArea } from "~/renderer/components/Onboarding/ScrollArea";
@@ -21,6 +23,7 @@ import restoreUsingRecoverDark from "./assets/restoreUsingRecoverDark.png";
 
 import Illustration from "~/renderer/components/Illustration";
 import { FeatureToggle } from "@ledgerhq/live-common/featureFlags/index";
+import { openModal } from "~/renderer/actions/modals";
 
 registerAssets([
   connectNanoLight,
@@ -84,6 +87,7 @@ export function SelectUseCase({ setUseCase, setOpenedPedagogyModal }: Props) {
   const { t } = useTranslation();
   const { deviceModelId } = useContext(OnboardingContext);
   const history = useHistory();
+  const dispatch = useDispatch();
 
   return (
     <ScrollArea withHint>
@@ -199,9 +203,15 @@ export function SelectUseCase({ setUseCase, setOpenedPedagogyModal }: Props) {
                   />
                 }
                 onClick={() => {
-                  track("Onboarding - Restore");
-                  setUseCase(UseCase.recover);
-                  history.push(`/onboarding/${UseCase.recover}/${ScreenId.pairMyNano}`);
+                  track("Onboarding - Restore With Recover");
+
+                  // An array is used here because we'll have to allow Stax later
+                  if (deviceModelId && [DeviceModelId.nanoX].includes(deviceModelId)) {
+                    setUseCase(UseCase.recover);
+                    history.push(`/onboarding/${UseCase.recover}/${ScreenId.pairMyNano}`);
+                  } else {
+                    dispatch(openModal("MODAL_PROTECT_DISCOVER", null));
+                  }
                 }}
               />
             </FeatureToggle>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Opens Recover's modal previously added to the main sidebar when selecting `Restore using Ledger Recover` in the onboarding with a device other than NanoX.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` 
- **Linked resource(s)**: [PROTECT-1716](https://ledgerhq.atlassian.net/browse/PROTECT-1716)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://user-images.githubusercontent.com/102669540/234521310-db306c5a-db0d-4bdd-acd7-17d52a3fc6d9.mov

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-1716]: https://ledgerhq.atlassian.net/browse/PROTECT-1716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ