### PR TITLE
Feat/live 6884/currency settings earn

### DIFF
--- a/.changeset/violet-cameras-wonder.md
+++ b/.changeset/violet-cameras-wonder.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add currency settings to EARN dashboard to display values in settings currency

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import Card from "~/renderer/components/Box/Card";
-import { languageSelector } from "~/renderer/reducers/settings";
+import { counterValueCurrencySelector, languageSelector } from "~/renderer/reducers/settings";
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import WebPlatformPlayer from "~/renderer/components/WebPlatformPlayer";
 import useTheme from "~/renderer/hooks/useTheme";
@@ -12,6 +12,7 @@ const DEFAULT_EARN_APP_ID = "earn";
 
 const Earn = () => {
   const locale = useSelector(languageSelector);
+  const fiatCurrency = useSelector(counterValueCurrencySelector);
   const localManifest = useLocalLiveAppManifest(DEFAULT_EARN_APP_ID);
   const remoteManifest = useRemoteLiveAppManifest(DEFAULT_EARN_APP_ID);
   const manifest = localManifest || remoteManifest;
@@ -38,6 +39,7 @@ const Earn = () => {
           inputs={{
             theme: themeType,
             lang: locale,
+            currencyTicker: fiatCurrency.ticker,
           }}
         />
       ) : null}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add currencyTicker to query params passed to EARN dashboard webview component in order for EARN to display values in the same currency as that set in ledger live desktop.

### ❓ Context

- **Impacted projects**: ledger-live-desktop
- **Linked resource(s)**: LIVE-6884

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->
<img width="661" alt="Screenshot 2023-04-26 at 16 12 49" src="https://user-images.githubusercontent.com/105203468/234620970-b6ff2cb7-1fc5-43ce-ba4e-66f1b4bb1eec.png">

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
