### PR TITLE
feat/LIVE-6570 Custom lockscreen removal feature for Stax

### DIFF
--- a/.changeset/empty-tigers-whisper.md
+++ b/.changeset/empty-tigers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+implementation of cls removal on llc

--- a/.changeset/long-falcons-film.md
+++ b/.changeset/long-falcons-film.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+implementation of cls removal on lld

--- a/.changeset/moody-hats-lick.md
+++ b/.changeset/moody-hats-lick.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-cli": patch
+"@ledgerhq/live-common": patch
+---
+
+Implemented remove custom image command for stax and exposed it on CLI.

--- a/.changeset/swift-camels-exist.md
+++ b/.changeset/swift-camels-exist.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+implementation of cls removal on lld

--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -48,6 +48,7 @@ import staxFetchAndRestoreDemo from "./commands/staxFetchAndRestoreDemo";
 import staxFetchImage from "./commands/staxFetchImage";
 import staxFetchImageHash from "./commands/staxFetchImageHash";
 import staxLoadImage from "./commands/staxLoadImage";
+import staxRemoveImage from "./commands/staxRemoveImage";
 import swap from "./commands/swap";
 import sync from "./commands/sync";
 import synchronousOnboarding from "./commands/synchronousOnboarding";
@@ -108,6 +109,7 @@ export default {
   staxFetchImage,
   staxFetchImageHash,
   staxLoadImage,
+  staxRemoveImage,
   swap,
   sync,
   synchronousOnboarding,

--- a/apps/cli/src/commands/staxRemoveImage.ts
+++ b/apps/cli/src/commands/staxRemoveImage.ts
@@ -1,0 +1,13 @@
+import { from } from "rxjs";
+import type { ScanCommonOpts } from "../scan";
+import { command as staxRemoveImage } from "@ledgerhq/live-common/hw/staxRemoveImage";
+import { deviceOpt } from "../scan";
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+
+export default {
+  description: "Remove custom lock screen",
+  arg: [
+    deviceOpt,
+  ],
+  job: (arg: ScanCommonOpts): any => withDevice(arg?.device || "")((t) => from(staxRemoveImage(t)))
+};

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -18,7 +18,12 @@ import AutoRepair from "~/renderer/components/AutoRepair";
 import TransactionConfirm from "~/renderer/components/TransactionConfirm";
 import SignMessageConfirm from "~/renderer/components/SignMessageConfirm";
 import useTheme from "~/renderer/hooks/useTheme";
-import { ManagerNotEnoughSpaceError, UpdateYourApp, TransportStatusError } from "@ledgerhq/errors";
+import {
+  ManagerNotEnoughSpaceError,
+  UpdateYourApp,
+  TransportStatusError,
+  UserRefusedOnDevice,
+} from "@ledgerhq/errors";
 import {
   InstallingApp,
   renderAllowManager,
@@ -36,6 +41,7 @@ import {
   renderSecureTransferDeviceConfirmation,
   renderAllowLanguageInstallation,
   renderInstallingLanguage,
+  renderAllowRemoveCustomLockscreen,
   renderLockedDeviceError,
   RenderDeviceNotOnboardedError,
 } from "./rendering";
@@ -162,6 +168,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     error,
     isLoading,
     allowManagerRequestedWording,
+    imageRemoveRequested,
     requestQuitApp,
     deviceInfo,
     latestFirmware,
@@ -272,6 +279,21 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
 
   if (languageInstallationRequested) {
     return renderAllowLanguageInstallation({ modelId, type, t });
+  }
+
+  if (imageRemoveRequested) {
+    if (error) {
+      if (error instanceof UserRefusedOnDevice) {
+        return renderError({
+          t,
+          error,
+          onRetry,
+          info: true,
+        });
+      }
+    } else {
+      return renderAllowRemoveCustomLockscreen({ modelId, type });
+    }
   }
 
   if (listingApps) {

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -108,6 +108,7 @@ type States = PartialNullable<{
   completeExchangeStarted: boolean;
   completeExchangeResult: Transaction;
   completeExchangeError: Error;
+  imageRemoveRequested: boolean;
   initSellRequested: boolean;
   initSellResult: InitSellResult;
   initSellError: Error;

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -431,6 +431,27 @@ export const renderAllowLanguageInstallation = ({
   </Flex>
 );
 
+export const renderAllowRemoveCustomLockscreen = ({
+  modelId,
+  type,
+}: {
+  modelId: DeviceModelId;
+  type: Theme["theme"];
+}) => (
+  <Wrapper>
+    <DeviceBlocker />
+    <Header />
+    <AnimationWrapper modelId={modelId}>
+      <Animation animation={getDeviceAnimation(modelId, type, "verify")} />
+    </AnimationWrapper>
+    <Footer>
+      <Title>
+        <Trans i18nKey="removeCustomLockscreen.confirmation" />
+      </Title>
+    </Footer>
+  </Wrapper>
+);
+
 export const renderAllowOpeningApp = ({
   modelId,
   type,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -441,7 +441,7 @@ export const renderAllowRemoveCustomLockscreen = ({
   <Wrapper>
     <DeviceBlocker />
     <Header />
-    <AnimationWrapper modelId={modelId}>
+    <AnimationWrapper>
       <Animation animation={getDeviceAnimation(modelId, type, "verify")} />
     </AnimationWrapper>
     <Footer>

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useRef, useState, useCallback, useMemo, useEffect } from "react";
 import styled from "styled-components";
+import { log } from "@ledgerhq/logs";
 import { withTranslation } from "react-i18next";
 import { App, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { Exec, InstalledItem, ListAppsResult } from "@ledgerhq/live-common/apps/types";
@@ -18,7 +19,11 @@ import DeviceStorage from "../DeviceStorage/index";
 import AppDepsInstallModal from "./AppDepsInstallModal";
 import AppDepsUnInstallModal from "./AppDepsUnInstallModal";
 import ErrorModal from "~/renderer/modals/ErrorModal/index";
-import { setHasInstalledApps, setLastSeenDeviceInfo } from "~/renderer/actions/settings";
+import {
+  clearLastSeenCustomImage,
+  setHasInstalledApps,
+  setLastSeenDeviceInfo,
+} from "~/renderer/actions/settings";
 import { useDispatch, useSelector } from "react-redux";
 import {
   hasInstalledAppsSelector,
@@ -142,6 +147,14 @@ const AppsList = ({
       }),
     );
   }, [device, state.installed, deviceInfo, reduxDispatch, firmware]);
+
+  useEffect(() => {
+    // Not ideal but we have no concept of device ids so we can consider
+    // an empty custom image size an indicator of not having an image set.
+    // If this is troublesome we'd have to react by asking the device directly.
+    if (state.customImageBlocks === 0) reduxDispatch(clearLastSeenCustomImage());
+  }, [reduxDispatch, state.customImageBlocks]);
+
   const disableFirmwareUpdate = state.installQueue.length > 0 || state.uninstallQueue.length > 0;
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/CustomImageManagerButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/CustomImageManagerButton.tsx
@@ -4,13 +4,23 @@ import { useTranslation } from "react-i18next";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import CustomImage from "~/renderer/screens/customImage";
+import RemoveCustomImage from "./RemoveCustomImage";
 import UFO from "~/renderer/icons/UFO";
+import { useSelector } from "react-redux";
+import { lastSeenCustomImageSelector } from "~/renderer/reducers/settings";
 
-const CustomImageManagerButton: React.FC<Record<string, never>> = () => {
+const CustomImageManagerButton = () => {
   const { t } = useTranslation();
-  const handleClick = useCallback(() => {
+  const lastSeenCustomImage = useSelector(lastSeenCustomImageSelector);
+
+  const onAdd = useCallback(() => {
     setDrawer(CustomImage);
   }, []);
+
+  const onRemove = useCallback(() => {
+    setDrawer(RemoveCustomImage);
+  }, []);
+
   return (
     <Flex flexDirection="row" columnGap={3} alignItems="center">
       <UFO />
@@ -18,12 +28,21 @@ const CustomImageManagerButton: React.FC<Record<string, never>> = () => {
         {t("customImage.managerCTA")}
       </Text>
       <Link
-        onClick={handleClick}
+        onClick={onAdd}
         Icon={Icons.ChevronRightMedium}
         data-test-id="manager-custom-image-button"
       >
         {t("common.add")}
       </Link>
+      {lastSeenCustomImage.size ? (
+        <Link
+          onClick={onRemove}
+          Icon={Icons.ChevronRightMedium}
+          data-test-id="manager-custom-image-button"
+        >
+          {t("removeCustomLockscreen.cta")}
+        </Link>
+      ) : null}
     </Flex>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
@@ -110,7 +110,7 @@ const EditDeviceName: React.FC<Props> = ({
             flexDirection="column"
             alignItems="center"
             justifyContent="center"
-            data-test-id="language-installed"
+            data-test-id="device-renamed"
           >
             <BoxedIcon
               Icon={Icons.CheckAloneMedium}

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/RemoveCustomImage.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { BoxedIcon, Flex, Icons, Text } from "@ledgerhq/react-ui";
+import { useDispatch } from "react-redux";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import DeviceAction from "~/renderer/components/DeviceAction";
+import { createAction } from "@ledgerhq/live-common/hw/actions/staxRemoveImage";
+import removeImage from "@ledgerhq/live-common/hw/staxRemoveImage";
+import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
+import styled from "styled-components";
+import { useTranslation } from "react-i18next";
+import { clearLastSeenCustomImage } from "~/renderer/actions/settings";
+
+const action = createAction(removeImage);
+
+type Props = {
+  onClose: () => void;
+  setDeviceHasImage: (arg0: boolean) => void;
+  device: Device;
+};
+
+const TextEllipsis = styled.div`
+  flex-shrink: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const RemoveCustomImage: React.FC<Props> = ({ onClose, setDeviceHasImage, device }: Props) => {
+  const request = useMemo(() => ({}), []);
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  const [completed, setCompleted] = useState(false);
+  const [running, setRunning] = useState(true);
+
+  const onSuccess = useCallback(() => {
+    setCompleted(true);
+    setRunning(false);
+    dispatch(clearLastSeenCustomImage());
+  }, [dispatch]);
+
+  return (
+    <Flex
+      flexDirection="column"
+      rowGap={5}
+      height="100%"
+      overflowY="hidden"
+      width="100%"
+      flex={1}
+      data-test-id="device-rename-container"
+    >
+      <Flex flex={1} flexDirection="column" justifyContent="space-between" overflowY="hidden">
+        {completed ? (
+          <Flex
+            flex={1}
+            flexDirection="column"
+            alignItems="center"
+            justifyContent="center"
+            data-test-id="custom-image-removed"
+          >
+            <BoxedIcon
+              Icon={Icons.CheckAloneMedium}
+              iconColor="success.c100"
+              size={64}
+              iconSize={24}
+            />
+            <Text
+              variant="large"
+              alignSelf="stretch"
+              mx={16}
+              mt={10}
+              textAlign="center"
+              fontSize={22}
+            >
+              <TextEllipsis>{t("removeCustomLockscreen.success")}</TextEllipsis>
+            </Text>
+          </Flex>
+        ) : running ? (
+          <Flex flex={1} alignItems="center" justifyContent="center" p={2}>
+            <DeviceAction
+              device={device}
+              request={request}
+              action={action}
+              onClose={onClose}
+              onResult={onSuccess}
+            />
+          </Flex>
+        ) : null}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default withV3StyleProvider(RemoveCustomImage);

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/RemoveCustomImage.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { BoxedIcon, Flex, Icons, Text } from "@ledgerhq/react-ui";
 import { useDispatch } from "react-redux";
-import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { createAction } from "@ledgerhq/live-common/hw/actions/staxRemoveImage";
 import removeImage from "@ledgerhq/live-common/hw/staxRemoveImage";
@@ -12,19 +11,13 @@ import { clearLastSeenCustomImage } from "~/renderer/actions/settings";
 
 const action = createAction(removeImage);
 
-type Props = {
-  onClose: () => void;
-  setDeviceHasImage: (arg0: boolean) => void;
-  device: Device;
-};
-
 const TextEllipsis = styled.div`
   flex-shrink: 1;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
-const RemoveCustomImage: React.FC<Props> = ({ onClose, setDeviceHasImage, device }: Props) => {
+const RemoveCustomImage: React.FC<{}> = () => {
   const request = useMemo(() => ({}), []);
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -76,13 +69,7 @@ const RemoveCustomImage: React.FC<Props> = ({ onClose, setDeviceHasImage, device
           </Flex>
         ) : running ? (
           <Flex flex={1} alignItems="center" justifyContent="center" p={2}>
-            <DeviceAction
-              device={device}
-              request={request}
-              action={action}
-              onClose={onClose}
-              onResult={onSuccess}
-            />
+            <DeviceAction request={request} action={action} onResult={onSuccess} />
           </Flex>
         ) : null}
       </Flex>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2269,6 +2269,11 @@
     "remainingCharacters": "{{ remainingCharacters }} characters remaining",
     "renamed": "{{ productName }} name changed to \n“{{ name }}” "
   },
+  "removeCustomLockscreen": {
+    "cta": "Remove",
+    "confirmation": "Confirm removal of image on your Ledger Stax",
+    "success": "Lock screen picture removed"
+  },
   "deviceLocalization": {
     "language": "Language",
     "deviceLanguage": "Language",
@@ -5728,6 +5733,7 @@
   "customImage": {
     "title": "Custom lock screen",
     "managerCTA": "Lock screen picture",
+    "managerCTARemove": "Remove",
     "steps": {
       "choose": {
         "stepLabel": "Choose an image",
@@ -5736,6 +5742,7 @@
         "myNfts": "My NFTs",
         "upload": "Upload from my computer",
         "chooseNft": "Choose an NFT",
+        "remove": "Remove current picture",
         "selectNft": "Choose NFT",
         "previousSelectNft": "back",
         "nftEmptyStateTitle": "No NFT's to show yet",

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -8,6 +8,7 @@ import {
 import {
   TransportStatusError,
   UserRefusedDeviceNameChange,
+  UserRefusedOnDevice,
 } from "@ledgerhq/errors";
 import { useTranslation } from "react-i18next";
 import {
@@ -53,6 +54,7 @@ import {
   LoadingAppInstall,
   AutoRepair,
   renderAllowLanguageInstallation,
+  renderAllowRemoveCustomLockscreen,
   renderImageLoadRequested,
   renderLoadingImage,
   renderImageCommitRequested,
@@ -105,6 +107,7 @@ type Status = PartialNullable<{
   initSwapResult: InitSwapResult | null;
   installingLanguage: boolean;
   languageInstallationRequested: boolean;
+  imageRemoveRequested: boolean;
   signMessageRequested: TypedMessageData | MessageData;
   allowOpeningGranted: boolean;
   completeExchangeStarted: boolean;
@@ -207,6 +210,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
     initSwapResult,
     installingLanguage,
     languageInstallationRequested,
+    imageRemoveRequested,
     signMessageRequested,
     allowOpeningGranted,
     completeExchangeStarted,
@@ -328,6 +332,31 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
 
   if (languageInstallationRequested) {
     return renderAllowLanguageInstallation({
+      t,
+      theme,
+      device: selectedDevice,
+    });
+  }
+
+  // FIXME when we rework the error rendering, this should be handled at that
+  // level instead of being an exception here.
+  if (imageRemoveRequested) {
+    if (error && (error as Status["error"]) instanceof UserRefusedOnDevice) {
+      return renderError({
+        t,
+        navigation,
+        error,
+        onRetry,
+        colors,
+        theme,
+        iconColor: palette.neutral.c100a01,
+        Icon: () => (
+          <Icons.InfoAltFillMedium size={28} color={palette.primary.c80} />
+        ),
+        device: device ?? undefined,
+      });
+    }
+    return renderAllowRemoveCustomLockscreen({
       t,
       theme,
       device: selectedDevice,

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -341,26 +341,29 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   // FIXME when we rework the error rendering, this should be handled at that
   // level instead of being an exception here.
   if (imageRemoveRequested) {
-    if (error && (error as Status["error"]) instanceof UserRefusedOnDevice) {
-      return renderError({
+    if (error) {
+      if ((error as Status["error"]) instanceof UserRefusedOnDevice) {
+        return renderError({
+          t,
+          navigation,
+          error,
+          onRetry,
+          colors,
+          theme,
+          iconColor: palette.neutral.c20,
+          Icon: () => (
+            <Icons.InfoAltFillMedium size={28} color={palette.primary.c80} />
+          ),
+          device: device ?? undefined,
+        });
+      }
+    } else {
+      return renderAllowRemoveCustomLockscreen({
         t,
-        navigation,
-        error,
-        onRetry,
-        colors,
         theme,
-        iconColor: palette.neutral.c20,
-        Icon: () => (
-          <Icons.InfoAltFillMedium size={28} color={palette.primary.c80} />
-        ),
-        device: device ?? undefined,
+        device: selectedDevice,
       });
     }
-    return renderAllowRemoveCustomLockscreen({
-      t,
-      theme,
-      device: selectedDevice,
-    });
   }
 
   if (listingApps) {

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -349,7 +349,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
         onRetry,
         colors,
         theme,
-        iconColor: palette.neutral.c100a01,
+        iconColor: palette.neutral.c20,
         Icon: () => (
           <Icons.InfoAltFillMedium size={28} color={palette.primary.c80} />
         ),

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -469,6 +469,29 @@ export function renderAllowLanguageInstallation({
   );
 }
 
+export const renderAllowRemoveCustomLockscreen = ({
+  t,
+  device,
+  theme,
+}: RawProps & {
+  device: Device;
+}) => {
+  const productName = getDeviceModel(device.modelId).productName;
+  const key = device.modelId === "stax" ? "allowManager" : "sign";
+
+  return (
+    <Wrapper>
+      <TrackScreen category={`Allow CLS removal on ${productName}`} />
+      <Text variant="h4" textAlign="center">
+        {t("DeviceAction.allowRemoveCustomLockscreen", { productName })}
+      </Text>
+      <AnimationContainer>
+        <Animation source={getDeviceAnimation({ device, key, theme })} />
+      </AnimationContainer>
+    </Wrapper>
+  );
+};
+
 const AllowOpeningApp = ({
   t,
   navigation,

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3674,6 +3674,7 @@
     "allowAppPermission": "Open the {{wording}} app on your device",
     "allowAppPermissionSubtitleToken": "to manage your {{token}} tokens",
     "allowManagerPermission": "Allow {{wording}} on your {{productName}}",
+    "allowRemoveCustomLockscreen": "Confirm removal of image on your Ledger Stax",
     "loading": "Loading...",
     "turnOnAndUnlockDevice": "Turn on and unlock your device",
     "connectAndUnlockDevice": "Connect and unlock your device",
@@ -5974,9 +5975,11 @@
     "drawer": {
       "options": {
         "uploadFromPhone": "Choose from my picture gallery",
-        "selectFromNFTGallery": "Choose from NFT gallery"
+        "selectFromNFTGallery": "Choose from NFT gallery",
+        "remove": "Remove current picture"
       }
     },
+    "toastRemove": "Lock screen picture removed",
     "cropImage": "Crop picture",
     "chooseConstrast": "Choose contrast",
     "uploadAnotherImage": "Upload another image",

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
@@ -10,7 +10,10 @@ import { from } from "rxjs";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import { hasCompletedCustomImageFlowSelector } from "../../../reducers/settings";
+import {
+  hasCompletedCustomImageFlowSelector,
+  lastSeenCustomImageSelector,
+} from "../../../reducers/settings";
 import { NavigatorName, ScreenName } from "../../../const";
 import CustomImageBottomModal from "../../../components/CustomImage/CustomImageBottomModal";
 import DeviceOptionRow from "./DeviceOptionRow";
@@ -19,11 +22,17 @@ const CustomLockScreen: React.FC<{ device: Device }> = ({ device }) => {
   const navigation = useNavigation();
   const [isCustomImageOpen, setIsCustomImageOpen] = useState(false);
   const [deviceHasImage, setDeviceHasImage] = useState(false);
+  const lastSeenCustomImage = useSelector(lastSeenCustomImageSelector);
+
   const hasCompletedCustomImageFlow = useSelector(
     hasCompletedCustomImageFlowSelector,
   );
 
   const { t } = useTranslation();
+
+  useEffect(() => {
+    setDeviceHasImage(!!lastSeenCustomImage);
+  }, [lastSeenCustomImage]);
 
   useEffect(() => {
     withDevice(device.deviceId)(transport =>
@@ -59,7 +68,9 @@ const CustomLockScreen: React.FC<{ device: Device }> = ({ device }) => {
       />
       <CustomImageBottomModal
         device={device}
+        deviceHasImage={deviceHasImage}
         isOpened={isCustomImageOpen}
+        setDeviceHasImage={setDeviceHasImage}
         onClose={() => setIsCustomImageOpen(false)}
       />
     </>

--- a/libs/ledger-live-common/src/hw/actions/staxRemoveImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxRemoveImage.ts
@@ -1,0 +1,131 @@
+import { Observable } from "rxjs";
+import { scan, tap } from "rxjs/operators";
+import { useCallback, useEffect, useState } from "react";
+import { log } from "@ledgerhq/logs";
+import type { DeviceInfo } from "@ledgerhq/types-live";
+import { useReplaySubject } from "../../observable";
+import type {
+  RemoveImageEvent,
+  Input as RemoveImageInput,
+} from "../staxRemoveImage";
+import type { Action, Device } from "./types";
+import { currentMode } from "./app";
+import { getImplementation } from "./implementations";
+
+type State = {
+  isLoading: boolean;
+  requestQuitApp: boolean;
+  unresponsive: boolean;
+  imageRemoveRequested?: boolean;
+  imageRemoved: boolean;
+  device: Device | null | undefined;
+  deviceInfo: DeviceInfo | null | undefined;
+  error: Error | null | undefined;
+};
+type StateWithRetry = State & { onRetry: () => void };
+
+type RemoveImageAction = Action<RemoveImageInput, StateWithRetry, boolean>;
+
+const mapResult = ({ imageRemoved }: State) => imageRemoved;
+
+type Event =
+  | RemoveImageEvent
+  | {
+      type: "error";
+      error: Error;
+    }
+  | {
+      type: "deviceChange";
+      device: Device | null | undefined;
+    };
+
+const getInitialState = (device?: Device | null | undefined): State => ({
+  isLoading: !!device,
+  requestQuitApp: false,
+  unresponsive: false,
+  device,
+  deviceInfo: null,
+  error: null,
+  imageRemoveRequested: false,
+  imageRemoved: false,
+});
+
+const reducer = (state: State, e: Event): State => {
+  switch (e.type) {
+    case "unresponsiveDevice":
+      return { ...state, unresponsive: true, isLoading: false };
+
+    case "deviceChange":
+      return getInitialState(e.device);
+
+    case "error":
+      return {
+        ...state,
+        error: e.error,
+        isLoading: false,
+      };
+    case "removeImagePermissionRequested":
+      return {
+        ...state,
+        unresponsive: false,
+        imageRemoveRequested: true,
+        isLoading: false,
+      };
+    case "imageRemoved":
+      return {
+        ...state,
+        unresponsive: false,
+        imageRemoveRequested: false,
+        isLoading: false,
+        imageRemoved: true,
+      };
+  }
+};
+
+export const createAction = (
+  task: (arg0: RemoveImageInput) => Observable<RemoveImageEvent>
+): RemoveImageAction => {
+  const useHook = (
+    device: Device | null | undefined,
+    _: {}
+  ): StateWithRetry => {
+    const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
+    const deviceSubject = useReplaySubject(device);
+
+    const onRetry = useCallback(() => {
+      setResetIndex((currIndex) => currIndex + 1);
+      setState((s) => getInitialState(s.device));
+    }, []);
+
+    useEffect(() => {
+      if (state.imageRemoved) return;
+
+      const impl = getImplementation(currentMode)<RemoveImageEvent, {}>({
+        deviceSubject,
+        task,
+        request: {},
+      });
+
+      const sub = impl
+        .pipe(
+          tap((e: any) => log("actions-remove-stax-image-event", e.type, e)),
+          scan(reducer, getInitialState())
+        )
+        .subscribe(setState);
+      return () => {
+        sub.unsubscribe();
+      };
+    }, [deviceSubject, resetIndex, state.imageRemoved]);
+
+    return {
+      ...state,
+      onRetry,
+    };
+  };
+
+  return {
+    useHook,
+    mapResult,
+  };
+};

--- a/libs/ledger-live-common/src/hw/actions/staxRemoveImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxRemoveImage.ts
@@ -24,7 +24,7 @@ type State = {
 };
 type StateWithRetry = State & { onRetry: () => void };
 
-type RemoveImageAction = Action<RemoveImageInput, StateWithRetry, boolean>;
+type RemoveImageAction = Action<{}, StateWithRetry, boolean>;
 
 const mapResult = ({ imageRemoved }: State) => imageRemoved;
 

--- a/libs/ledger-live-common/src/hw/staxRemoveImage.test.ts
+++ b/libs/ledger-live-common/src/hw/staxRemoveImage.test.ts
@@ -1,5 +1,9 @@
-import { StatusCodes } from "@ledgerhq/errors";
-import staxRemoveImage from "./staxRemoveImage";
+import {
+  StatusCodes,
+  UnexpectedBootloader,
+  UserRefusedOnDevice,
+} from "@ledgerhq/errors";
+import { command as staxRemoveImage } from "./staxRemoveImage";
 import Transport from "@ledgerhq/hw-transport";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -14,6 +18,15 @@ describe("staxRemoveImage", () => {
     await expect(staxRemoveImage(mockedTransport)).resolves.toBeUndefined();
   });
 
+  test("should fail with correct error if user refuses", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex")
+    );
+    await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(
+      UserRefusedOnDevice
+    );
+  });
+
   test("should throw if user refuses", async () => {
     const mockedTransport: Transport = mockTransportGenerator(
       Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex")
@@ -25,6 +38,8 @@ describe("staxRemoveImage", () => {
     const mockedTransport = mockTransportGenerator(
       Buffer.from(StatusCodes.CUSTOM_IMAGE_BOOTLOADER.toString(16), "hex")
     );
-    await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(Error);
+    await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(
+      UnexpectedBootloader
+    );
   });
 });

--- a/libs/ledger-live-common/src/hw/staxRemoveImage.test.ts
+++ b/libs/ledger-live-common/src/hw/staxRemoveImage.test.ts
@@ -1,0 +1,30 @@
+import { StatusCodes } from "@ledgerhq/errors";
+import staxRemoveImage from "./staxRemoveImage";
+import Transport from "@ledgerhq/hw-transport";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore next-line
+const mockTransportGenerator = (out) => ({ send: () => out } as Transport);
+
+describe("staxRemoveImage", () => {
+  test("should succeed if user approves", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.OK.toString(16), "hex")
+    );
+    await expect(staxRemoveImage(mockedTransport)).resolves.toBeUndefined();
+  });
+
+  test("should throw if user refuses", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex")
+    );
+    await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(Error);
+  });
+
+  test("unexpected bootloader or any other code, should throw", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from(StatusCodes.CUSTOM_IMAGE_BOOTLOADER.toString(16), "hex")
+    );
+    await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(Error);
+  });
+});

--- a/libs/ledger-live-common/src/hw/staxRemoveImage.ts
+++ b/libs/ledger-live-common/src/hw/staxRemoveImage.ts
@@ -1,0 +1,27 @@
+import {
+  TransportStatusError,
+  UnexpectedBootloader,
+  StatusCodes,
+} from "@ledgerhq/errors";
+import Transport from "@ledgerhq/hw-transport";
+
+/**
+ * Clear an existing custom image from the device.
+ */
+export default async (transport: Transport): Promise<void> => {
+  const res = await transport.send(0xe0, 0x63, 0x00, 0x00, Buffer.from([]), [
+    StatusCodes.OK,
+    StatusCodes.CUSTOM_IMAGE_BOOTLOADER,
+    StatusCodes.UNKNOWN_APDU,
+  ]);
+
+  const status = res.readUInt16BE(res.length - 2);
+
+  switch (status) {
+    case StatusCodes.OK:
+      return;
+    case StatusCodes.CUSTOM_IMAGE_BOOTLOADER:
+      throw new UnexpectedBootloader();
+  }
+  throw new TransportStatusError(status);
+};

--- a/libs/ledger-live-common/src/hw/staxRemoveImage.ts
+++ b/libs/ledger-live-common/src/hw/staxRemoveImage.ts
@@ -2,16 +2,40 @@ import {
   TransportStatusError,
   UnexpectedBootloader,
   StatusCodes,
+  UserRefusedOnDevice,
 } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
+import { Observable, from, of } from "rxjs";
+import { withDevice } from "./deviceAccess";
+import { delay, mergeMap } from "rxjs/operators";
+import getDeviceInfo from "./getDeviceInfo";
+
+export type RemoveImageEvent =
+  | {
+      type: "unresponsiveDevice";
+    }
+  | {
+      type: "removeImagePermissionRequested";
+    }
+  | {
+      type: "imageRemoved";
+    };
+
+export type Input = {
+  deviceId: string;
+  request: {};
+};
 
 /**
- * Clear an existing custom image from the device.
+ * Clear an existing custom image from the device, we could argue this would need to be
+ * a task and a command, separated, but we are not quite there yet so I'm leaving them in
+ * the same file. Not totally convinced but here we are.
  */
-export default async (transport: Transport): Promise<void> => {
+export const command = async (transport: Transport): Promise<void> => {
   const res = await transport.send(0xe0, 0x63, 0x00, 0x00, Buffer.from([]), [
     StatusCodes.OK,
     StatusCodes.CUSTOM_IMAGE_BOOTLOADER,
+    StatusCodes.USER_REFUSED_ON_DEVICE,
     StatusCodes.UNKNOWN_APDU,
   ]);
 
@@ -22,6 +46,41 @@ export default async (transport: Transport): Promise<void> => {
       return;
     case StatusCodes.CUSTOM_IMAGE_BOOTLOADER:
       throw new UnexpectedBootloader();
+    case StatusCodes.USER_REFUSED_ON_DEVICE:
+      throw new UserRefusedOnDevice();
   }
   throw new TransportStatusError(status);
 };
+
+export default function removeImage({
+  deviceId,
+}: Input): Observable<RemoveImageEvent> {
+  const sub = withDevice(deviceId)(
+    (transport) =>
+      new Observable((subscriber) => {
+        const timeoutSub = of<RemoveImageEvent>({
+          type: "unresponsiveDevice",
+        })
+          .pipe(delay(1000))
+          .subscribe((e) => subscriber.next(e));
+
+        const sub = from(getDeviceInfo(transport))
+          .pipe(
+            mergeMap(async () => {
+              timeoutSub.unsubscribe();
+              subscriber.next({ type: "removeImagePermissionRequested" });
+              await command(transport);
+              subscriber.next({ type: "imageRemoved" });
+            })
+          )
+          .subscribe(subscriber);
+
+        return () => {
+          timeoutSub.unsubscribe();
+          sub.unsubscribe();
+        };
+      })
+  );
+
+  return sub as Observable<RemoveImageEvent>;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Introduces the functionality of removing a custom lock screen from a device for both LLM and LLD.
The UI will be aligned with the rework from https://github.com/LedgerHQ/ledger-live/pull/3314 once it's merged.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile, ledger-live-desktop, live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6570` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Be able to remove a CLS that's been set on both LLM and LLD.