### PR TITLE
[LIVE-6970] Restore full network logs under env var + exp setting

### DIFF
--- a/.changeset/lovely-baboons-bathe.md
+++ b/.changeset/lovely-baboons-bathe.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-env": minor
+---
+
+Restore full network logs under env var and with experimental setting

--- a/apps/ledger-live-desktop/src/renderer/experimental.tsx
+++ b/apps/ledger-live-desktop/src/renderer/experimental.tsx
@@ -129,6 +129,12 @@ export const experimentalFeatures: Feature[] = [
     minValue: 0,
     maxValue: 10,
   },
+  {
+    type: "toggle",
+    name: "ENABLE_NETWORK_LOGS",
+    title: <Trans i18nKey="settings.experimental.features.enableNetworkLogs.title" />,
+    description: <Trans i18nKey="settings.experimental.features.enableNetworkLogs.description" />,
+  },
 ];
 const lsKey = "experimentalFlags";
 const lsKeyVersion = `${lsKey}_llversion`;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3937,6 +3937,10 @@
         "1559CustomBaseFeeMultiplier": {
           "title": "Custom multiplier for the base fee",
           "description": "Customize the multiplier used for the base fee composing the maxFeePerGas of the EIP1559 transaction"
+        },
+        "enableNetworkLogs": {
+          "title": "Enable network logs",
+          "description": "Enable network logs in the console (error logs are always enabled)"
         }
       }
     },

--- a/apps/ledger-live-mobile/src/experimental.ts
+++ b/apps/ledger-live-mobile/src/experimental.ts
@@ -124,6 +124,14 @@ export const experimentalFeatures: Feature[] = [
     minValue: 0,
     maxValue: 10,
   },
+  {
+    type: "toggle",
+    name: "ENABLE_NETWORK_LOGS",
+    title: i18n.t(i18nKey("experimentalEnableNetworkLogs", "title")),
+    description: i18n.t(
+      i18nKey("experimentalEnableNetworkLogs", "description"),
+    ),
+  },
   ...(__DEV__
     ? [
         {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2698,6 +2698,10 @@
         "experimentalSwap": {
           "title": "New SWAP interface",
           "description": "Use the new experimental swap interface"
+        },
+        "experimentalEnableNetworkLogs": {
+          "title": "Enable network logs",
+          "description": "Enable network logs in the console (error logs are always enabled)"
         }
       },
       "developerFeatures": {
@@ -6095,7 +6099,7 @@
         "tag": "{{count}} NFTs"
       }
     },
-    "referralProgram":"$10"
+    "referralProgram": "$10"
   },
   "servicesWidget": {
     "title": "Services",

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -740,6 +740,11 @@ const envDefinitions: Record<
     parser: intParser,
     desc: "Time after which an optimisc operation is considered stuck",
   },
+  ENABLE_NETWORK_LOGS: {
+    def: false,
+    parser: boolParser,
+    desc: "Enable network request and responses logs. Errors are always logged",
+  },
 };
 
 export const getDefinition = (name: string): EnvDef<any> | null | undefined =>

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/explorer/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/explorer/index.ts
@@ -1,12 +1,16 @@
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AxiosRequestConfig } from "axios";
 import axios, { AxiosInstance } from "axios";
 import axiosRetry, { isNetworkOrIdempotentRequestError } from "axios-retry";
 import genericPool, { Pool } from "generic-pool";
+import { blockchainBaseURL } from "../../../../explorer";
+import {
+  errorInterceptor,
+  requestInterceptor,
+  responseInterceptor,
+} from "../../../../network";
 import { Address, Block, TX } from "../storage/types";
 import { IExplorer } from "./types";
-import { errorInterceptor } from "../../../../network";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { blockchainBaseURL } from "../../../../explorer";
 
 type ExplorerParams = {
   batch_size?: number;
@@ -74,7 +78,8 @@ class BitcoinLikeExplorer implements IExplorer {
     }
 
     // Logging
-    client.interceptors.response.use(undefined, errorInterceptor);
+    client.interceptors.request.use(requestInterceptor);
+    client.interceptors.response.use(responseInterceptor, errorInterceptor);
   }
 
   async broadcast(tx: string): Promise<{ data: { result: string } }> {

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -45,7 +45,7 @@ export const responseInterceptor = (response: Response): Response => {
     `${response.status} ${method} ${baseURL || ""}${url} (${(
       Date.now() - startTime
     ).toFixed(0)}ms)`,
-    getEnv("DEBUG_HTTP_RESPONSE") ? { data: response.data } : undefined
+    { data: response.data }
   );
 
   return response;

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -28,11 +28,13 @@ export const requestInterceptor = (
   return req;
 };
 
-type Response = {
+type InterceptedResponse = {
   config: ExtendedXHRConfig;
 } & AxiosResponse<any>;
 
-export const responseInterceptor = (response: Response): Response => {
+export const responseInterceptor = (
+  response: InterceptedResponse
+): InterceptedResponse => {
   if (!getEnv("ENABLE_NETWORK_LOGS")) {
     return response;
   }
@@ -51,8 +53,12 @@ export const responseInterceptor = (response: Response): Response => {
   return response;
 };
 
-export const errorInterceptor = (error: AxiosError<any>): AxiosError<any> => {
-  const config = error?.response?.config as ExtendedXHRConfig | null;
+type InterceptedError = {
+  response?: InterceptedResponse;
+} & AxiosError<any>;
+
+export const errorInterceptor = (error: InterceptedError): InterceptedError => {
+  const config = error?.response?.config;
   if (!config) throw error;
   const { baseURL, url, method = "", metadata } = config;
   const { startTime = 0 } = metadata || {};

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -1,15 +1,54 @@
-import invariant from "invariant";
-import axios, { AxiosPromise } from "axios";
-import type { AxiosError, AxiosRequestConfig, Method } from "axios";
+import { LedgerAPI4xx, LedgerAPI5xx, NetworkDown } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
-import { NetworkDown, LedgerAPI5xx, LedgerAPI4xx } from "@ledgerhq/errors";
+import type { AxiosError, AxiosRequestConfig, Method } from "axios";
+import axios, { AxiosPromise, AxiosResponse } from "axios";
+import invariant from "invariant";
+import { changes, getEnv } from "./env";
 import { retry } from "./promise";
-import { getEnv, changes } from "./env";
+
+type Metadata = { startTime: number };
+type ExtendedXHRConfig = AxiosRequestConfig & { metadata?: Metadata };
+
+export const requestInterceptor = (
+  request: AxiosRequestConfig
+): ExtendedXHRConfig => {
+  const { baseURL, url, method = "", data } = request;
+  log("network", `${method} ${baseURL || ""}${url}`, { data });
+
+  // $FlowFixMe (LLD side)
+  const req: ExtendedXHRConfig = request;
+
+  req.metadata = {
+    startTime: Date.now(),
+  };
+
+  return req;
+};
+
+export const responseInterceptor = (
+  response: {
+    config: ExtendedXHRConfig;
+  } & AxiosResponse<any>
+) => {
+  const { baseURL, url, method = "", metadata } = response.config;
+  const { startTime = 0 } = metadata || {};
+
+  log(
+    "network-success",
+    `${response.status} ${method} ${baseURL || ""}${url} (${(
+      Date.now() - startTime
+    ).toFixed(0)}ms)`,
+    getEnv("DEBUG_HTTP_RESPONSE") ? { data: response.data } : undefined
+  );
+
+  return response;
+};
 
 export const errorInterceptor = (error: AxiosError<any>): AxiosError<any> => {
-  const config = error?.response?.config || null;
+  const config = error?.response?.config as ExtendedXHRConfig | null;
   if (!config) throw error;
-  const { baseURL, url, method = "" } = config;
+  const { baseURL, url, method = "", metadata } = config;
+  const { startTime = 0 } = metadata || {};
 
   let errorToThrow;
   if (error.response) {
@@ -34,18 +73,28 @@ export const errorInterceptor = (error: AxiosError<any>): AxiosError<any> => {
     }
     log(
       "network-error",
-      `${status} ${method} ${baseURL || ""}${url}: ${errorToThrow.message}`,
+      `${status} ${method} ${baseURL || ""}${url} (${(
+        Date.now() - startTime
+      ).toFixed(0)}ms): ${errorToThrow.message}`,
       getEnv("DEBUG_HTTP_RESPONSE") ? { data: data } : {}
     );
     throw errorToThrow;
   } else if (error.request) {
-    log("network-down", `DOWN ${method} ${baseURL || ""}${url}`);
+    log(
+      "network-down",
+      `DOWN ${method} ${baseURL || ""}${url} (${(
+        Date.now() - startTime
+      ).toFixed(0)}ms)`
+    );
     throw new NetworkDown();
   }
   throw error;
 };
 
-axios.interceptors.response.use(undefined, errorInterceptor);
+axios.interceptors.request.use(requestInterceptor);
+
+// $FlowFixMe LLD raise issues here
+axios.interceptors.response.use(responseInterceptor, errorInterceptor);
 
 const makeError = (
   msg: string,

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -12,6 +12,10 @@ type ExtendedXHRConfig = AxiosRequestConfig & { metadata?: Metadata };
 export const requestInterceptor = (
   request: AxiosRequestConfig
 ): ExtendedXHRConfig => {
+  if (!getEnv("ENABLE_NETWORK_LOGS")) {
+    return request;
+  }
+
   const { baseURL, url, method = "", data } = request;
   log("network", `${method} ${baseURL || ""}${url}`, { data });
 
@@ -30,6 +34,10 @@ export const responseInterceptor = (
     config: ExtendedXHRConfig;
   } & AxiosResponse<any>
 ) => {
+  if (!getEnv("ENABLE_NETWORK_LOGS")) {
+    return response;
+  }
+
   const { baseURL, url, method = "", metadata } = response.config;
   const { startTime = 0 } = metadata || {};
 

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -19,7 +19,6 @@ export const requestInterceptor = (
   const { baseURL, url, method = "", data } = request;
   log("network", `${method} ${baseURL || ""}${url}`, { data });
 
-  // $FlowFixMe (LLD side)
   const req: ExtendedXHRConfig = request;
 
   req.metadata = {
@@ -100,8 +99,6 @@ export const errorInterceptor = (error: AxiosError<any>): AxiosError<any> => {
 };
 
 axios.interceptors.request.use(requestInterceptor);
-
-// $FlowFixMe LLD raise issues here
 axios.interceptors.response.use(responseInterceptor, errorInterceptor);
 
 const makeError = (

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -28,11 +28,11 @@ export const requestInterceptor = (
   return req;
 };
 
-export const responseInterceptor = (
-  response: {
-    config: ExtendedXHRConfig;
-  } & AxiosResponse<any>
-) => {
+type Response = {
+  config: ExtendedXHRConfig;
+} & AxiosResponse<any>;
+
+export const responseInterceptor = (response: Response): Response => {
   if (!getEnv("ENABLE_NETWORK_LOGS")) {
     return response;
   }

--- a/libs/ledger-live-common/src/network.ts
+++ b/libs/ledger-live-common/src/network.ts
@@ -57,7 +57,9 @@ export const errorInterceptor = (error: AxiosError<any>): AxiosError<any> => {
   const { baseURL, url, method = "", metadata } = config;
   const { startTime = 0 } = metadata || {};
 
-  let errorToThrow;
+  const duration = `${(Date.now() - startTime).toFixed(0)}ms`;
+
+  let errorToThrow: Error;
   if (error.response) {
     // The request was made and the server responded with a status code
     // that falls out of the range of 2xx
@@ -78,21 +80,17 @@ export const errorInterceptor = (error: AxiosError<any>): AxiosError<any> => {
     } else {
       errorToThrow = makeError(`API HTTP ${status}`, status, url, method);
     }
+
     log(
       "network-error",
-      `${status} ${method} ${baseURL || ""}${url} (${(
-        Date.now() - startTime
-      ).toFixed(0)}ms): ${errorToThrow.message}`,
+      `${status} ${method} ${baseURL || ""}${url} (${duration}): ${
+        errorToThrow.message
+      }`,
       getEnv("DEBUG_HTTP_RESPONSE") ? { data: data } : {}
     );
     throw errorToThrow;
   } else if (error.request) {
-    log(
-      "network-down",
-      `DOWN ${method} ${baseURL || ""}${url} (${(
-        Date.now() - startTime
-      ).toFixed(0)}ms)`
-    );
+    log("network-down", `DOWN ${method} ${baseURL || ""}${url} (${duration})`);
     throw new NetworkDown();
   }
   throw error;


### PR DESCRIPTION
### 📝 Description

Restore full network logs under env var + exp setting to help debugging and investigation issues, including in production.

Most of it is a revert of [this PR](https://github.com/LedgerHQ/ledger-live/pull/2419)

### ❓ Context

- **Impacted projects**: `LLC LLM LLD`
- **Linked resource(s)**: [LIVE-6970](https://ledgerhq.atlassian.net/browse/LIVE-6970)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6970]: https://ledgerhq.atlassian.net/browse/LIVE-6970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ