### PR TITLE
Bugfix - Fix prerelease tags w/ `shouldUpgrade` & `mustUpgrade`

### DIFF
--- a/libs/ledger-live-common/src/apps/support.test.ts
+++ b/libs/ledger-live-common/src/apps/support.test.ts
@@ -1,0 +1,31 @@
+import { mustUpgrade, shouldUpgrade } from "./support";
+
+describe("Support.ts", () => {
+  describe("shouldUpgrade", () => {
+    it("should ask for an ugprade for an outdated Bitcoin nano app", () => {
+      expect(shouldUpgrade("Bitcoin", "0.1.0")).toBe(true);
+    });
+
+    it("should not ask for any ugprade for a valid Bitcoin nano app", () => {
+      expect(shouldUpgrade("Bitcoin", "1.4.0")).toBe(false);
+    });
+
+    it("should not ask for any ugprade for a valid Bitcoin nano app with a pre-release tag", () => {
+      expect(shouldUpgrade("Bitcoin", "1.4.0-dev")).toBe(false);
+    });
+  });
+
+  describe("mustUpgrade", () => {
+    it("should ask an upgrade for an outdated nano app", () => {
+      expect(mustUpgrade("Ethereum", "0.1.0")).toBe(true);
+    });
+
+    it("should not ask any upgrade for the latest Ethereum nano app", () => {
+      expect(mustUpgrade("Ethereum", "1.10.2")).toBe(false);
+    });
+
+    it("should not ask any upgrade for the latest Ethereum nano app with a pre-release tag", () => {
+      expect(mustUpgrade("Ethereum", "1.10.2-dev")).toBe(false);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -16,9 +16,7 @@ export function shouldUpgrade(appName: string, appVersion: string): boolean {
     appName === "Bitcoin"
   ) {
     // https://donjon.ledger.com/lsb/010/
-    return !semver.satisfies(appVersion || "", ">= 1.4.0", {
-      includePrerelease: true, // this will allow pre-release tags that would otherwise return false. E.g. 1.0.0-dev
-    });
+    return !semver.satisfies(appVersion || "", ">= 1.4.0-0"); // the `-0` is here to allow for pre-release tags
   }
 
   return false;
@@ -28,7 +26,7 @@ const appVersionsRequired = {
   Algorand: ">= 1.2.9",
   MultiversX: ">= 1.0.18",
   Polkadot: ">= 20.9370.0",
-  Ethereum: ">= 1.10.2",
+  Ethereum: ">= 1.10.2-0", // the `-0` is here to allow for pre-release tags
   Solana: ">= 1.2.0",
   Celo: ">= 1.1.8",
   "Cardano ADA": ">= 4.1.0",
@@ -40,9 +38,7 @@ export function mustUpgrade(appName: string, appVersion: string): boolean {
   const range = appVersionsRequired[appName];
 
   if (range) {
-    return !semver.satisfies(appVersion || "", range, {
-      includePrerelease: true, // this will allow pre-release tags that would otherwise return false. E.g. 1.0.0-dev
-    });
+    return !semver.satisfies(appVersion || "", range);
   }
 
   return false;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixing the pre-release tags being allowed for the 2 helpers `shouldUpgrade` & `mustUpgrade` (only for the Ethereum nano app for the latest)

### ❓ Context

- **Impacted projects**: `@ledgerhq/live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
