### PR TITLE
feat(Firmware Update LLM): add restore of apps after firmware update

### DIFF
--- a/.changeset/fuzzy-experts-kneel.md
+++ b/.changeset/fuzzy-experts-kneel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add restoration of apps step on the new firmware update UX

--- a/.changeset/gentle-spiders-promise.md
+++ b/.changeset/gentle-spiders-promise.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Minor changes on several device actions to allow for retries and to better manage the state in memory

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -877,14 +877,22 @@ export function renderConnectYourDevice({
   device,
   theme,
   onSelectDeviceLink,
+  fullScreen = true,
 }: RawProps & {
   unresponsive?: boolean | null;
   isLocked?: boolean;
   device: Device;
+  fullScreen?: boolean;
   onSelectDeviceLink?: () => void;
 }) {
   return (
-    <Wrapper>
+    <Flex
+      flexDirection="column"
+      justifyContent="center"
+      alignItems="center"
+      alignSelf="stretch"
+      flex={fullScreen ? 1 : undefined}
+    >
       <AnimationContainer
         withConnectDeviceHeight={
           ![DeviceModelId.blue, DeviceModelId.stax].includes(device.modelId)
@@ -919,7 +927,7 @@ export function renderConnectYourDevice({
           />
         </ConnectDeviceExtraContentWrapper>
       ) : null}
-    </Wrapper>
+    </Flex>
   );
 }
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4098,7 +4098,8 @@
         "titleInactive": "Restore apps and settings",
         "description": "Your settings and blockchain apps will be restored.",
         "restoreLockScreenPicture": "Restoring lock screen picture",
-        "restoreLanguage": "Restoring language"
+        "restoreLanguage": "Restoring language",
+        "installingApps": "Installing apps"
       }
     },
     "newVersion": "Update {{version}} available for your {{deviceName}}",

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -17,7 +17,11 @@ import {
 } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import { Item } from "@ledgerhq/native-ui/components/Layout/List/types";
-import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import {
+  DeviceInfo,
+  FirmwareUpdateContext,
+  languageIds,
+} from "@ledgerhq/types-live";
 
 import { useNavigation, useRoute } from "@react-navigation/native";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -41,6 +45,7 @@ import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/t
 import { ScreenName } from "../../const";
 import {
   renderAllowLanguageInstallation,
+  renderConnectYourDevice,
   renderImageCommitRequested,
   renderImageLoadRequested,
 } from "../../components/DeviceAction/rendering";
@@ -143,9 +148,14 @@ export const FirmwareUpdate = ({
   const {
     updateActionState,
     updateStep,
-    retryUpdate,
+    retryCurrentStep,
+    staxFetchImageState,
     staxLoadImageState,
     installLanguageState,
+    restoreAppsState,
+    noOfAppsToReinstall,
+    deviceLockedOrUnresponsive,
+    hasReconnectErrors,
   } = useUpdateFirmwareAndRestoreSettings({
     updateFirmwareAction,
     device,
@@ -165,11 +175,14 @@ export const FirmwareUpdate = ({
     return undefined;
   });
 
-  const restoreSteps = useMemo(
-    () => [
-      {
+  const restoreSteps = useMemo(() => {
+    const steps = [];
+
+    if (deviceInfo.languageId !== languageIds["english"]) {
+      steps.push({
         status: {
           start: ItemStatus.inactive,
+          appsBackup: ItemStatus.inactive,
           imageBackup: ItemStatus.inactive,
           firmwareUpdate: ItemStatus.inactive,
           languageRestore: ItemStatus.active,
@@ -179,10 +192,14 @@ export const FirmwareUpdate = ({
         }[updateStep],
         progress: installLanguageState.progress,
         title: t("FirmwareUpdate.steps.restoreSettings.restoreLanguage"),
-      },
-      {
+      });
+    }
+
+    if (staxFetchImageState.hexImage) {
+      steps.push({
         status: {
           start: ItemStatus.inactive,
+          appsBackup: ItemStatus.inactive,
           imageBackup: ItemStatus.inactive,
           firmwareUpdate: ItemStatus.inactive,
           languageRestore: ItemStatus.inactive,
@@ -194,10 +211,48 @@ export const FirmwareUpdate = ({
         title: t(
           "FirmwareUpdate.steps.restoreSettings.restoreLockScreenPicture",
         ),
-      },
-    ],
-    [updateStep, installLanguageState.progress, t, staxLoadImageState.progress],
-  );
+      });
+    }
+
+    if (noOfAppsToReinstall > 0) {
+      steps.push({
+        status: {
+          start: ItemStatus.inactive,
+          appsBackup: ItemStatus.inactive,
+          imageBackup: ItemStatus.inactive,
+          firmwareUpdate: ItemStatus.inactive,
+          languageRestore: ItemStatus.inactive,
+          imageRestore: ItemStatus.inactive,
+          appsRestore: ItemStatus.active,
+          completed: ItemStatus.completed,
+        }[updateStep],
+        progress: restoreAppsState.itemProgress,
+        title:
+          t("FirmwareUpdate.steps.restoreSettings.installingApps") +
+          ` ${
+            !restoreAppsState.listedApps
+              ? 0
+              : restoreAppsState.installQueue !== undefined &&
+                restoreAppsState.installQueue.length > 0
+              ? noOfAppsToReinstall - (restoreAppsState.installQueue.length - 1)
+              : noOfAppsToReinstall
+          }/${noOfAppsToReinstall}`,
+      });
+    }
+
+    return steps;
+  }, [
+    updateStep,
+    installLanguageState.progress,
+    t,
+    staxFetchImageState.hexImage,
+    staxLoadImageState.progress,
+    restoreAppsState.listedApps,
+    restoreAppsState.itemProgress,
+    restoreAppsState.installQueue,
+    noOfAppsToReinstall,
+    deviceInfo.languageId,
+  ]);
 
   const defaultSteps: UpdateSteps = useMemo(
     () => ({
@@ -231,8 +286,9 @@ export const FirmwareUpdate = ({
             <Text color="neutral.c80">
               {t("FirmwareUpdate.steps.restoreSettings.description")}
             </Text>
-            {/* TODO: create custom component here with its own state for the restoring */}
-            <VerticalStepper nested steps={restoreSteps} />
+            {restoreSteps.length > 0 && (
+              <VerticalStepper nested steps={restoreSteps} />
+            )}
           </Flex>
         ),
       },
@@ -375,7 +431,12 @@ export const FirmwareUpdate = ({
 
   const deviceInteractionDisplay = useMemo(() => {
     const error = updateActionState.error;
-    if (error) {
+
+    // a TransportRaceCondition error is to be expected since we chain multiple
+    // device actions that use different transport acquisition paradigms
+    // the action should, however, retry to execute and resolve the error by itself
+    // no need to present the error to the user
+    if (error && error.name !== "TransportRaceCondition") {
       return (
         <DeviceActionError
           device={device}
@@ -418,7 +479,7 @@ export const FirmwareUpdate = ({
           <FirmwareUpdateDenied
             device={device}
             newFirmwareVersion={firmwareUpdateContext.final.name}
-            onPressRestart={retryUpdate}
+            onPressRestart={retryCurrentStep}
             onPressQuit={quitUpdate}
             t={t}
           />
@@ -437,12 +498,46 @@ export const FirmwareUpdate = ({
         break;
     }
 
+    if (deviceLockedOrUnresponsive || hasReconnectErrors) {
+      return (
+        <Flex>
+          {renderConnectYourDevice({
+            t,
+            device,
+            theme,
+            fullScreen: false,
+          })}
+          <Button
+            type="main"
+            outline={false}
+            onPress={retryCurrentStep}
+            mt={6}
+            alignSelf="stretch"
+          >
+            {t("common.retry")}
+          </Button>
+          <Button type="default" outline={false} onPress={quitUpdate} mt={6}>
+            {t("FirmwareUpdate.quitUpdate")}
+          </Button>
+        </Flex>
+      );
+    }
+
     if (staxLoadImageState.imageLoadRequested) {
       return renderImageLoadRequested({ t, device, fullScreen: false });
     }
 
     if (staxLoadImageState.imageCommitRequested) {
       return renderImageCommitRequested({ t, device, fullScreen: false });
+    }
+
+    if (restoreAppsState.allowManagerRequestedWording) {
+      return (
+        <AllowManager
+          device={device}
+          wording={t("DeviceAction.allowSecureConnection")}
+        />
+      );
     }
 
     if (installLanguageState.languageInstallationRequested) {
@@ -462,13 +557,17 @@ export const FirmwareUpdate = ({
     staxLoadImageState.imageLoadRequested,
     staxLoadImageState.imageCommitRequested,
     installLanguageState.languageInstallationRequested,
+    restoreAppsState.allowManagerRequestedWording,
     device,
     t,
+    theme,
     quitUpdate,
     deviceInfo.seVersion,
     firmwareUpdateContext.final.name,
     firmwareUpdateContext.shouldFlashMCU,
-    retryUpdate,
+    retryCurrentStep,
+    hasReconnectErrors,
+    deviceLockedOrUnresponsive,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -175,6 +175,14 @@ const Manager = ({ navigation, route }: NavigationProps) => {
     [device, installedApps, navigation, refreshDeviceInfo],
   );
 
+  const onBackFromNewUpdateUx = useCallback(
+    () => {
+      navigation.replace(ScreenName.Manager, {
+        device
+      });
+    }, [device, navigation]
+  )
+
   return (
     <>
       <TrackScreen
@@ -203,7 +211,7 @@ const Manager = ({ navigation, route }: NavigationProps) => {
         tab={tab}
         result={result}
         onLanguageChange={refreshDeviceInfo}
-        onBackFromUpdate={refreshDeviceInfo}
+        onBackFromUpdate={onBackFromNewUpdateUx}
       />
       <GenericErrorBottomModal error={error} onClose={closeErrorModal} />
       <QuitManagerModal

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -112,6 +112,8 @@ const findDependents = (
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
+    case "reset":
+      return action.initialState;
     case "onRunnerEvent": {
       // an app operation was correctly prefered. update state accordingly
       const { event } = action;

--- a/libs/ledger-live-common/src/apps/react.ts
+++ b/libs/ledger-live-common/src/apps/react.ts
@@ -25,6 +25,14 @@ export const useAppsRunner = (
   );
   const nextAppOp = useMemo(() => getNextAppOp(state), [state]);
   const appOp = state.currentAppOp || nextAppOp;
+
+  useEffect(() => {
+    dispatch({
+      type: "reset",
+      initialState: initState(listResult, appsToRestore),
+    });
+  }, [listResult, appsToRestore]);
+
   useEffect(() => {
     if (appOp) {
       const sub = runAppOp(state, appOp, exec).subscribe((event) => {

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -130,6 +130,10 @@ export type SkippedAppOp = {
 
 export type Action =  // recover from an error
   | {
+      type: "reset";
+      initialState: State;
+    }
+  | {
       type: "recover";
     } // wipe will remove all apps of the device
   | {

--- a/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
@@ -88,7 +88,7 @@ export function updateFirmwareAction({
         | GetLatestFirmwareTaskErrorEvent
         | GetDeviceInfoTaskErrorEvent,
         UpdateFirmwareActionState
-      >((currentState, event) => {
+      >((_, event) => {
         switch (event.type) {
           case "taskError":
             return {
@@ -102,7 +102,7 @@ export function updateFirmwareAction({
           case "flashingMcu":
           case "flashingBootloader":
             return {
-              ...currentState,
+              ...initialState,
               step: event.type,
               progress: event.progress,
             };
@@ -110,16 +110,16 @@ export function updateFirmwareAction({
           case "installOsuDevicePermissionRequested":
           case "installOsuDevicePermissionGranted":
           case "installOsuDevicePermissionDenied":
-            return { ...currentState, step: event.type };
+            return { ...initialState, step: event.type };
           case "firmwareUpdateCompleted":
             return {
-              ...currentState,
+              ...initialState,
               step: event.type,
               updatedDeviceInfo: event.updatedDeviceInfo,
             };
           default:
             return {
-              ...currentState,
+              ...initialState,
               ...sharedReducer({
                 event,
               }),

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -2,6 +2,7 @@ import {
   CantOpenDevice,
   DisconnectedDevice,
   LockedDeviceError,
+  TransportRaceCondition,
   createCustomErrorClass,
 } from "@ledgerhq/errors";
 import { Observable, from, of, throwError, timer } from "rxjs";
@@ -50,7 +51,8 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
                 if (
                   error instanceof LockedDeviceError ||
                   error instanceof CantOpenDevice ||
-                  error instanceof DisconnectedDevice
+                  error instanceof DisconnectedDevice ||
+                  error instanceof TransportRaceCondition
                 ) {
                   // Emits to the action a locked device error event so it is aware of it before retrying
                   subscriber.next({ type: "error", error });

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -508,6 +508,7 @@ export const createAction = (
         appRequest.appName, // eslint-disable-next-line react-hooks/exhaustive-deps
         appRequest.account && appRequest.account.id, // eslint-disable-next-line react-hooks/exhaustive-deps
         appRequest.currency && appRequest.currency.id,
+        appRequest.dependencies,
       ]
     );
 

--- a/libs/ledger-live-common/src/hw/actions/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/actions/installLanguage.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 import { scan, tap } from "rxjs/operators";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { useReplaySubject } from "../../observable";
@@ -26,9 +26,13 @@ type State = {
   progress?: number;
 };
 
+type ActionState = State & {
+  onRetry: () => void;
+}
+
 type InstallLanguageAction = Action<
   InstallLanguageRequest,
-  State,
+  ActionState,
   boolean | undefined
 >;
 
@@ -111,8 +115,9 @@ export const createAction = (
   const useHook = (
     device: Device | null | undefined,
     request: InstallLanguageRequest
-  ): State => {
+  ): ActionState => {
     const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
     const deviceSubject = useReplaySubject(device);
 
     useEffect(() => {
@@ -136,10 +141,16 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, request, state.languageInstalled]);
+    }, [deviceSubject, request, state.languageInstalled, resetIndex]);
+
+    const onRetry = useCallback(() => {
+      setResetIndex((currIndex) => currIndex + 1);
+      setState((s) => getInitialState(s.device));
+    }, []);
 
     return {
       ...state,
+      onRetry
     };
   };
 

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -43,6 +43,7 @@ type ManagerState = State & {
 export type ManagerRequest =
   | {
       autoQuitAppDisabled?: boolean;
+      cancelExecution?: boolean;
     }
   | null
   | undefined;
@@ -183,6 +184,8 @@ export const createAction = (
     } | null>(null);
 
     useEffect(() => {
+      if(request?.cancelExecution) return;
+
       const impl = getImplementation(currentMode)<
         ConnectManagerEvent,
         ManagerRequest

--- a/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
+++ b/libs/ledger-live-common/src/hw/actions/staxLoadImage.ts
@@ -1,6 +1,6 @@
 import { Observable } from "rxjs";
 import { scan, tap } from "rxjs/operators";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 import { useReplaySubject } from "../../observable";
@@ -30,7 +30,11 @@ type State = {
   progress?: number;
 };
 
-type LoadImageAction = Action<LoadImageRequest, State, LoadimageResult>;
+type ActionState = State & {
+  onRetry: () => void;
+};
+
+type LoadImageAction = Action<LoadImageRequest, ActionState, LoadimageResult>;
 
 const mapResult = ({ imageHash, imageSize }: State) => ({
   imageHash,
@@ -127,8 +131,9 @@ export const createAction = (
   const useHook = (
     device: Device | null | undefined,
     request: LoadImageRequest
-  ): State => {
+  ): ActionState => {
     const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
     const deviceSubject = useReplaySubject(device);
 
     useEffect(() => {
@@ -152,10 +157,16 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [deviceSubject, request, state.imageLoaded]);
+    }, [deviceSubject, request, state.imageLoaded, resetIndex]);
+
+    const onRetry = useCallback(() => {
+      setResetIndex((currIndex) => currIndex + 1);
+      setState((s) => getInitialState(s.device));
+    }, []);
 
     return {
       ...state,
+      onRetry,
     };
   };
 


### PR DESCRIPTION
### 📝 Description
This PR adds the last step of the new firmware update UX: the restoration of the previously installed apps. Besides that it makes a few improvements on the entirety of the flow such as properly detecting when a device is locked and allowing the users to retry a specific step.

### ❓ Context
- **Impacted projects**: `ledger-live-mobile`, `ledger-live-common`
- **Linked resource(s)**: [LIVE-6306]

### ✅ Checklist

- [N/A] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
tbd

### 🚀 Expectations to reach


[LIVE-6306]: https://ledgerhq.atlassian.net/browse/LIVE-6306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ