### PR TITLE
chore: establishes LLD coin families typing

### DIFF
--- a/apps/ledger-live-desktop/.eslintignore
+++ b/apps/ledger-live-desktop/.eslintignore
@@ -1,3 +1,3 @@
 *.min.js
-src/renderer/generated
+src/renderer/families/generated.ts
 !.github

--- a/apps/ledger-live-desktop/.eslintrc.js
+++ b/apps/ledger-live-desktop/.eslintrc.js
@@ -1,19 +1,15 @@
 const currencyFamiliesRules = {
   files: ["src/**"],
-  excludedFiles: [
-    "src/generated/**",
-    "src/renderer/families/**",
-    "src/renderer/screens/lend/**", // FIXME lend screen should be migrated to ethereum family (if we don't sunset it)
-  ],
+  excludedFiles: ["**/families/generated.ts", "**/families/*/**"],
   rules: {
     "no-restricted-imports": [
       "error",
       {
         patterns: [
           {
-            group: ["**/families/**"],
+            group: ["**/families/*/**"],
             message:
-              "families files must not be imported directly. use the bridge or export through 'generated/' folder instead.",
+              "families files must not be imported directly. use the bridge or export them through the LLDCoinFamily interface instead.",
           },
         ],
       },

--- a/apps/ledger-live-desktop/.gitignore
+++ b/apps/ledger-live-desktop/.gitignore
@@ -116,7 +116,7 @@ dist
 !jsconfig.json
 !tools/dist
 
-src/renderer/generated/
+src/renderer/families/generated.ts
 tests/coverage/
 tests/artifacts/*
 !tests/artifacts/.gitkeep

--- a/apps/ledger-live-desktop/.prettierignore
+++ b/apps/ledger-live-desktop/.prettierignore
@@ -1,5 +1,5 @@
 test-e2e/**/*.json
-src/renderer/generated
+src/renderer/families/generated.ts
 analytics.min.js
 src/renderer/animations/**/*.json
 src/renderer/components/Onboarding/Screens/Tutorial/assets/animations/**/*.json

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/AmountCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/AmountCell.tsx
@@ -7,7 +7,8 @@ import Box from "~/renderer/components/Box";
 import CounterValue from "~/renderer/components/CounterValue";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import { colors } from "~/renderer/styles/theme";
-import perFamilyOperationDetails from "~/renderer/generated/operationDetails";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 const Cell = styled(Box).attrs(() => ({
   px: 4,
   horizontal: false,
@@ -31,35 +32,28 @@ class AmountCell extends PureComponent<Props> {
     const { currency, unit, operation, isConfirmed } = this.props;
     const amount = getOperationAmountNumber(operation);
 
-    const specific =
-      "family" in currency && currency.family
-        ? perFamilyOperationDetails[currency.family as keyof typeof perFamilyOperationDetails]
-        : null;
-    const Element =
-      specific && "amountCellExtra" in specific && specific.amountCellExtra
-        ? specific.amountCellExtra[operation.type as keyof typeof specific.amountCellExtra]
-        : null;
-    const AmountElement =
-      specific && "amountCell" in specific && specific.amountCell
-        ? specific.amountCell[operation.type as keyof typeof specific.amountCell]
-        : null;
+    const cryptoCurrency = "family" in currency && currency.family ? currency : null;
+    const specific = cryptoCurrency ? getLLDCoinFamily(cryptoCurrency.family) : null;
+    const amountCellExtra = specific?.operationDetails?.amountCellExtra;
+    const Element = amountCellExtra ? amountCellExtra[operation.type] : null;
+    const amountCell = specific?.operationDetails?.amountCell;
+    const AmountElement = amountCell ? amountCell[operation.type] : null;
+
     return (
       <>
-        {Element && (
+        {Element && cryptoCurrency && (
           <Cell>
-            {/* @ts-expect-error TODO: check why TS is unable to reconciliate Element as a react component */}
-            <Element operation={operation} unit={unit} currency={currency} />
+            <Element operation={operation} unit={unit} currency={cryptoCurrency} />
           </Cell>
         )}
         {(!amount.isZero() || AmountElement) && (
           <Cell>
-            {AmountElement ? (
+            {AmountElement && cryptoCurrency ? (
               <AmountElement
-                // @ts-expect-error TODO: double check if any of the families have a component accepting an amount prop
                 amount={amount}
                 operation={operation}
                 unit={unit}
-                currency={currency}
+                currency={cryptoCurrency}
               />
             ) : (
               <>

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/ConfirmationCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/ConfirmationCell.tsx
@@ -7,7 +7,8 @@ import { getOperationAmountNumber } from "@ledgerhq/live-common/operation";
 import { getMarketColor } from "~/renderer/styles/helpers";
 import Box from "~/renderer/components/Box";
 import ConfirmationCheck from "./ConfirmationCheck";
-import perFamilyOperationDetails from "~/renderer/generated/operationDetails";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 const Cell = styled(Box).attrs(() => ({
   pl: 4,
   horizontal: true,
@@ -34,16 +35,12 @@ class ConfirmationCell extends PureComponent<Props> {
       isNegative,
     });
 
-    const specific =
-      "family" in currency && currency.family
-        ? perFamilyOperationDetails[currency.family as keyof typeof perFamilyOperationDetails]
-        : null;
-    const SpecificConfirmationCell =
-      specific && "confirmationCell" in specific && specific.confirmationCell
-        ? specific.confirmationCell[operation.type as keyof typeof specific.confirmationCell]
-        : null;
+    const cryptoCurrency = "family" in currency && currency.family ? currency : null;
+    const specific = cryptoCurrency ? getLLDCoinFamily(cryptoCurrency.family) : null;
+
+    const confirmationCell = specific?.operationDetails?.confirmationCell;
+    const SpecificConfirmationCell = confirmationCell ? confirmationCell[operation.type] : null;
     return SpecificConfirmationCell ? (
-      // @ts-expect-error TODO: check why TS is unable to infer the type of SpecificConfirmationCell
       <SpecificConfirmationCell
         operation={operation}
         type={operation.type}

--- a/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.tsx
@@ -3,14 +3,10 @@ import React from "react";
 import { Trans, withTranslation, TFunction } from "react-i18next";
 import styled from "styled-components";
 import { getAccountUnit, getMainAccount } from "@ledgerhq/live-common/account/index";
-import { Account, AccountLike } from "@ledgerhq/types-live";
+import { Account, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import {
-  getDeviceTransactionConfig,
-  DeviceTransactionField,
-} from "@ledgerhq/live-common/transaction/index";
+import { getDeviceTransactionConfig } from "@ledgerhq/live-common/transaction/index";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import transactionConfirmFieldsPerFamily from "~/renderer/generated/TransactionConfirmFields";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import WarnBox from "~/renderer/components/WarnBox";
@@ -18,6 +14,9 @@ import useTheme from "~/renderer/hooks/useTheme";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import { renderVerifyUnwrapped } from "~/renderer/components/DeviceAction/rendering";
 import TransactionConfirmField from "./TransactionConfirmField";
+import { getLLDCoinFamily } from "~/renderer/families";
+import { FieldComponentProps as FCPGeneric } from "~/renderer/families/types";
+
 const FieldText = styled(Text).attrs(() => ({
   ml: 1,
   ff: "Inter|Medium",
@@ -28,14 +27,10 @@ const FieldText = styled(Text).attrs(() => ({
   text-align: right;
   max-width: 50%;
 `;
-export type FieldComponentProps = {
-  account: AccountLike;
-  parentAccount: Account | undefined | null;
-  transaction: Transaction;
-  status: TransactionStatus;
-  field: DeviceTransactionField;
-};
+
+export type FieldComponentProps = FCPGeneric<Account, TransactionCommon, TransactionStatus>;
 export type FieldComponent = React.ComponentType<FieldComponentProps>;
+
 const AmountField = ({ account, status: { amount }, field }: FieldComponentProps) => (
   <TransactionConfirmField label={field.label}>
     <FormattedVal
@@ -123,17 +118,15 @@ const TransactionConfirm = ({ t, device, account, parentAccount, transaction, st
   const mainAccount = getMainAccount(account, parentAccount);
   const type = useTheme("colors.palette.type");
   if (!device) return null;
-  const r =
-    transactionConfirmFieldsPerFamily[
-      mainAccount.currency.family as keyof typeof transactionConfirmFieldsPerFamily
-    ];
+  const specific = getLLDCoinFamily(mainAccount.currency.family);
+  const r = specific?.transactionConfirmFields;
   const fieldComponents: Record<string, FieldComponent> = {
     ...commonFieldComponents,
-    ...(r && "fieldComponents" in r && r.fieldComponents),
+    ...r?.fieldComponents,
   };
-  const Warning = r && "warning" in r && r.warning;
-  const Title = r && "title" in r && r.title;
-  const Footer = r && "footer" in r && r.footer;
+  const Warning = r?.warning;
+  const Title = r?.title;
+  const Footer = r?.footer;
   const fields = getDeviceTransactionConfig({
     account,
     parentAccount,
@@ -146,7 +139,6 @@ const TransactionConfirm = ({ t, device, account, parentAccount, transaction, st
     <Container>
       {Warning ? (
         <Warning
-          // @ts-expect-error it seems like "account" is a non-existing prop?
           account={account}
           parentAccount={parentAccount}
           transaction={transaction}
@@ -165,7 +157,6 @@ const TransactionConfirm = ({ t, device, account, parentAccount, transaction, st
       )}
       {Title ? (
         <Title
-          // @ts-expect-error it seems like "account" is a non-existing prop?
           account={account}
           parentAccount={parentAccount}
           transaction={transaction}

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/index.ts
@@ -1,0 +1,21 @@
+import {
+  AlgorandAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/algorand/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import AccountBodyHeader from "./AccountBodyHeader";
+import tokenList from "./TokenList";
+
+const family: LLDCoinFamily<AlgorandAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  modals,
+  tokenList,
+  accountHeaderManageActions,
+  AccountBodyHeader,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/index.ts
@@ -1,0 +1,17 @@
+import "./live-common-setup";
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/celo/types";
+import { LLDCoinFamily } from "../types";
+import modals from "./modals";
+import sendAmountFields from "./SendAmountFields";
+import sendRecipientFields from "./SendRecipientFields";
+import StepReceiveFundsPostAlert from "./StepReceiveFundsPostAlert";
+import { Account } from "@ledgerhq/types-live";
+
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus> = {
+  modals,
+  sendAmountFields,
+  sendRecipientFields,
+  StepReceiveFundsPostAlert,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/index.ts
@@ -1,0 +1,19 @@
+import {
+  CardanoAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/cardano/types";
+import { LLDCoinFamily } from "../types";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountSubHeader from "./AccountSubHeader";
+import sendAmountFields from "./SendAmountFields";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+
+const family: LLDCoinFamily<CardanoAccount, Transaction, TransactionStatus> = {
+  AccountBodyHeader,
+  AccountSubHeader,
+  sendAmountFields,
+  AccountBalanceSummaryFooter,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/celo/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/index.ts
@@ -1,0 +1,25 @@
+import {
+  CeloAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/celo/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountSubHeader from "./AccountSubHeader";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+
+const family: LLDCoinFamily<CeloAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  modals,
+  transactionConfirmFields,
+  AccountBodyHeader,
+  AccountSubHeader,
+  AccountBalanceSummaryFooter,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/index.ts
@@ -1,0 +1,27 @@
+import {
+  CosmosAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/cosmos/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountBodyHeader from "./AccountBodyHeader";
+import sendRecipientFields from "./SendRecipientFields";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import StakeBanner from "./StakeBanner";
+
+const family: LLDCoinFamily<CosmosAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  modals,
+  transactionConfirmFields,
+  AccountBodyHeader,
+  sendRecipientFields,
+  AccountBalanceSummaryFooter,
+  StakeBanner,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/crypto_org/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/crypto_org/index.ts
@@ -1,0 +1,15 @@
+import {
+  CryptoOrgAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/crypto_org/types";
+import { LLDCoinFamily } from "../types";
+import AccountSubHeader from "./AccountSubHeader";
+import sendRecipientFields from "./SendRecipientFields";
+
+const family: LLDCoinFamily<CryptoOrgAccount, Transaction, TransactionStatus> = {
+  AccountSubHeader,
+  sendRecipientFields,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/index.ts
@@ -1,0 +1,25 @@
+import {
+  ElrondAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/elrond/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountSubHeader from "./AccountSubHeader";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import StakeBanner from "./StakeBanner";
+
+const family: LLDCoinFamily<ElrondAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  modals,
+  AccountBodyHeader,
+  AccountSubHeader,
+  AccountBalanceSummaryFooter,
+  StakeBanner,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/ethereum/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/ethereum/index.ts
@@ -1,0 +1,20 @@
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ethereum/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import sendAmountFields from "./SendAmountFields";
+import StakeBanner from "./StakeBanner";
+import { Account } from "@ledgerhq/types-live";
+
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  modals,
+  transactionConfirmFields,
+  sendAmountFields,
+  StakeBanner,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/filecoin/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/filecoin/index.ts
@@ -1,0 +1,12 @@
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/filecoin/types";
+import { LLDCoinFamily } from "../types";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountSubHeader from "./AccountSubHeader";
+import { Account } from "@ledgerhq/types-live";
+
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus> = {
+  transactionConfirmFields,
+  AccountSubHeader,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/index.ts
@@ -1,0 +1,16 @@
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/hedera/types";
+import { Account } from "@ledgerhq/types-live";
+import { LLDCoinFamily } from "../types";
+import AccountSubHeader from "./AccountSubHeader";
+import sendAmountFields from "./SendAmountFields";
+import StepReceiveFunds from "./StepReceiveFunds";
+import NoAssociatedAccounts from "./NoAssociatedAccounts";
+
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus> = {
+  AccountSubHeader,
+  sendAmountFields,
+  StepReceiveFunds,
+  NoAssociatedAccounts,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/index.ts
@@ -1,0 +1,34 @@
+import { Account, TransactionCommon, TransactionStatusCommon } from "@ledgerhq/types-live";
+import generated from "./generated";
+import { Modals, LLDCoinFamily } from "./types";
+
+export function getLLDCoinFamily<
+  A extends Account,
+  T extends TransactionCommon,
+  TS extends TransactionStatusCommon
+>(name: string): LLDCoinFamily<A, T, TS> {
+  const f = generated[name];
+  if (!f) {
+    throw new Error(`family ${name} not found`);
+  }
+  return f;
+}
+
+// families export their own modals
+
+export const modals: Modals = {};
+
+for (const fam in generated) {
+  const family = generated[fam];
+  const m = family.modals;
+  if (!m) continue;
+  const components = m;
+  for (const name in components) {
+    if (name in modals) {
+      throw new Error(
+        `modal ${name} already exists. Make sure there is no name collision between families.`,
+      );
+    }
+    modals[name] = components[name];
+  }
+}

--- a/apps/ledger-live-desktop/src/renderer/families/near/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/near/index.ts
@@ -1,0 +1,25 @@
+import {
+  NearAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/near/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountSubHeader from "./AccountSubHeader";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import StakeBanner from "./StakeBanner";
+
+const family: LLDCoinFamily<NearAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  modals,
+  AccountBodyHeader,
+  AccountSubHeader,
+  AccountBalanceSummaryFooter,
+  StakeBanner,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/near/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/operationDetails.tsx
@@ -38,11 +38,10 @@ const AmountCellExtra = ({ operation, currency, unit }: AmountCellExtraProps) =>
     )
   );
 };
-const amountCellExtra: {
-  [key: string]: ComponentType<any>;
-} = {
+const amountCellExtra = {
   STAKE: AmountCellExtra,
 };
+
 type OperationDetailsExtraProps = {
   operation: Operation;
   type: string;

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/index.ts
@@ -1,0 +1,23 @@
+import {
+  PolkadotAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/polkadot/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+
+const family: LLDCoinFamily<PolkadotAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  modals,
+  transactionConfirmFields,
+  AccountBodyHeader,
+  AccountBalanceSummaryFooter,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/ripple/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/ripple/SendAmountFields.tsx
@@ -9,6 +9,7 @@ import InputCurrency from "~/renderer/components/InputCurrency";
 import Box from "~/renderer/components/Box";
 import GenericContainer from "~/renderer/components/FeesContainer";
 import { track } from "~/renderer/analytics/segment";
+
 type Props = {
   account: Account;
   transaction: Transaction;

--- a/apps/ledger-live-desktop/src/renderer/families/ripple/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/ripple/index.ts
@@ -1,0 +1,12 @@
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ripple/types";
+import { LLDCoinFamily } from "../types";
+import sendAmountFields from "./SendAmountFields";
+import sendRecipientFields from "./SendRecipientFields";
+import { Account } from "@ledgerhq/types-live";
+
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus> = {
+  sendAmountFields,
+  sendRecipientFields,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/solana/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/index.ts
@@ -1,0 +1,25 @@
+import {
+  SolanaAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/solana/types";
+import { LLDCoinFamily } from "../types";
+import modals from "./modals";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountSubHeader from "./AccountSubHeader";
+import sendRecipientFields from "./SendRecipientFields";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import StakeBanner from "./StakeBanner";
+
+const family: LLDCoinFamily<SolanaAccount, Transaction, TransactionStatus> = {
+  accountHeaderManageActions,
+  modals,
+  AccountBodyHeader,
+  AccountSubHeader,
+  sendRecipientFields,
+  AccountBalanceSummaryFooter,
+  StakeBanner,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/index.ts
@@ -1,0 +1,23 @@
+import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/stellar/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountSubHeader from "./AccountSubHeader";
+import sendAmountFields from "./SendAmountFields";
+import sendRecipientFields from "./SendRecipientFields";
+import tokenList from "./TokenList";
+
+import { Account } from "@ledgerhq/types-live";
+
+const family: LLDCoinFamily<Account, Transaction, TransactionStatus> = {
+  operationDetails,
+  modals,
+  transactionConfirmFields,
+  AccountSubHeader,
+  sendAmountFields,
+  sendRecipientFields,
+  tokenList,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/index.ts
@@ -1,0 +1,27 @@
+import {
+  TezosAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/tezos/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import modals from "./modals";
+import accountActions from "./accountActions";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountBodyHeader from "./AccountBodyHeader";
+import sendWarning from "./SendWarning";
+import receiveWarning from "./ReceiveWarning";
+
+const family: LLDCoinFamily<TezosAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountActions,
+  accountHeaderManageActions,
+  modals,
+  transactionConfirmFields,
+  sendWarning,
+  receiveWarning,
+  AccountBodyHeader,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/tron/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/tron/index.ts
@@ -1,0 +1,25 @@
+import {
+  TronAccount,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/families/tron/types";
+import { LLDCoinFamily } from "../types";
+import operationDetails from "./operationDetails";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
+import transactionConfirmFields from "./TransactionConfirmFields";
+import AccountBodyHeader from "./AccountBodyHeader";
+import AccountSubHeader from "./AccountSubHeader";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import StepReceiveFundsPostAlert from "./StepReceiveFundsPostAlert";
+
+const family: LLDCoinFamily<TronAccount, Transaction, TransactionStatus> = {
+  operationDetails,
+  accountHeaderManageActions,
+  transactionConfirmFields,
+  AccountBodyHeader,
+  AccountSubHeader,
+  AccountBalanceSummaryFooter,
+  StepReceiveFundsPostAlert,
+};
+
+export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/types.ts
@@ -1,0 +1,315 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { TFunction } from "react-i18next";
+import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
+import { Unit, CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import {
+  Account,
+  ChildAccount,
+  FeeStrategy,
+  Operation,
+  OperationType,
+  TokenAccount,
+  TransactionCommon,
+} from "@ledgerhq/types-live";
+// FIXME: ideally we need to have <A,T,TS> parametric version of StepProps
+import { StepProps as SendStepProps } from "../modals/Send/types";
+import { StepProps as ReceiveStepProps } from "../modals/Receive/Body";
+import { StepProps as AddAccountsStepProps } from "../modals/AddAccounts";
+import { Modals } from "../modals";
+
+/**
+ * LLD family specific that a coin family can implement
+ */
+export type LLDCoinFamily<
+  A extends Account,
+  T extends TransactionCommon,
+  TS extends TransactionStatus
+> = {
+  operationDetails?: {
+    /**
+     * TODO document me
+     */
+    amountCellExtra?: Partial<
+      Record<
+        OperationType,
+        React.ComponentType<{
+          operation: Operation;
+          unit: Unit;
+          currency: CryptoCurrency;
+        }>
+      >
+    >;
+
+    /**
+     * TODO document me
+     */
+    amountCell?: Partial<
+      Record<
+        OperationType,
+        React.ComponentType<{
+          amount: BigNumber;
+          operation: Operation;
+          unit: Unit;
+          currency: CryptoCurrency;
+        }>
+      >
+    >;
+
+    /**
+     * TODO document me
+     */
+    confirmationCell?: Partial<
+      Record<
+        OperationType,
+        React.ComponentType<{
+          operation: Operation;
+          type?: OperationType;
+          isConfirmed: boolean;
+          marketColor: string;
+          hasFailed?: boolean;
+          t: TFunction;
+          withTooltip?: boolean;
+          style?: React.CSSProperties;
+        }>
+      >
+    >;
+
+    /**
+     * TODO document me
+     */
+    amountTooltip?: Partial<
+      Record<
+        OperationType,
+        React.ComponentType<{
+          operation: Operation;
+          unit: Unit;
+          amount: BigNumber;
+        }>
+      >
+    >;
+
+    /**
+     * TODO document me
+     */
+    getURLWhatIsThis?: (_: { op: Operation; currencyId: string }) => string | undefined;
+
+    /**
+     * TODO document me
+     */
+    getURLFeesInfo?: (_: { op: Operation; currencyId: string }) => string | undefined;
+  };
+
+  /**
+   * TODO document me
+   */
+  OperationDetailsExtra?: React.ComponentType<{
+    operation: Operation;
+    account: A;
+    type: OperationType;
+    extra: {
+      [key: string]: string;
+    };
+  }>;
+
+  accountActions?: {
+    /**
+     * TODO document me
+     */
+    SendAction?: React.ComponentType<{
+      account: A | TokenAccount | ChildAccount;
+      parentAccount: A | null | undefined;
+      onClick: () => void;
+    }>;
+
+    /**
+     * TODO document me
+     */
+    ReceiveAction?: React.ComponentType<{
+      account: TokenAccount | A | ChildAccount;
+      parentAccount: A | null | undefined;
+      onClick: () => void;
+    }>;
+  };
+
+  /**
+   * TODO document me
+   */
+  accountHeaderManageActions?: (_: {
+    account: A | TokenAccount | ChildAccount;
+    parentAccount: A | null | undefined;
+    source?: string;
+  }) => ManageAction[] | null | undefined;
+
+  /**
+   * TODO document me
+   */
+  transactionConfirmFields?: {
+    fieldComponents?: Record<string, React.ComponentType<FieldComponentProps<A, T, TS>>>;
+
+    warning?: React.ComponentType<{
+      account: A | TokenAccount | ChildAccount;
+      parentAccount: A | null | undefined;
+      transaction: T;
+      status: TS;
+      recipientWording: string;
+    }>;
+
+    title?: React.ComponentType<{
+      account: A | TokenAccount | ChildAccount;
+      parentAccount: A | null | undefined;
+      transaction: T;
+      status: TS;
+    }>;
+
+    footer?: React.ComponentType<{
+      transaction: T;
+    }>;
+  };
+
+  /**
+   * TODO document me
+   */
+  AccountBodyHeader?: React.ComponentType<{
+    account: A | TokenAccount | ChildAccount;
+    parentAccount: A | null | undefined;
+  }>;
+
+  /**
+   * TODO document me
+   */
+  AccountSubHeader?: React.ComponentType<{
+    account: A | TokenAccount | ChildAccount;
+    parentAccount: A | null | undefined;
+  }>;
+
+  /**
+   * TODO document me
+   */
+  sendAmountFields?: {
+    component: React.ComponentType<{
+      account: A;
+      transaction: T;
+      status: TS;
+      onChange: (t: T) => void;
+      updateTransaction: (updater: (t: T) => T) => void;
+      mapStrategies?: (a: FeeStrategy) => FeeStrategy;
+      bridgePending?: boolean;
+      trackProperties?: Record<string, unknown>;
+    }>;
+    fields?: string[];
+  };
+
+  /**
+   * TODO document me
+   */
+  sendRecipientFields?: {
+    component: React.ComponentType<{
+      account: A;
+      transaction: T;
+      status: TS;
+      onChange: (t: T) => void;
+    }>;
+    fields?: string[];
+  };
+
+  /**
+   * TODO document me
+   */
+  sendWarning?: {
+    // FIXME: StepProps is not the right type here: we could precide the type with A,T,TS
+    component: React.ComponentType<SendStepProps>;
+    footer: React.ComponentType<SendStepProps>;
+  };
+
+  /**
+   * TODO document me
+   */
+  receiveWarning?: {
+    // FIXME: StepProps is not the right type here: we could precide the type with A,T,TS
+    component: React.ComponentType<ReceiveStepProps>;
+    footer: React.ComponentType<ReceiveStepProps>;
+  };
+
+  /**
+   * TODO document me
+   */
+  AccountBalanceSummaryFooter?: React.ComponentType<{
+    account: A | TokenAccount | ChildAccount;
+    counterValue: Currency;
+    discreetMode: boolean;
+  }>;
+
+  /**
+   * TODO document me
+   */
+  tokenList?: {
+    hasSpecificTokenWording?: boolean;
+    ReceiveButton?: React.ComponentType<{
+      account: A;
+      onClick: () => void;
+    }>;
+  };
+
+  /**
+   * TODO document me
+   */
+  StepReceiveFunds?: React.ComponentType<ReceiveStepProps>;
+
+  /**
+   * TODO document me
+   */
+  StepReceiveFundsPostAlert?: React.ComponentType<ReceiveStepProps>;
+
+  /**
+   * TODO document me
+   */
+  NoAssociatedAccounts?: React.ComponentType<AddAccountsStepProps>;
+
+  /**
+   * TODO document me
+   */
+  StakeBanner?: React.ComponentType<{
+    account: A;
+  }>;
+
+  /**
+   * all modals that are specific to this family
+   */
+  modals?: Modals;
+};
+
+export type FieldComponentProps<
+  A extends Account,
+  T extends TransactionCommon,
+  TS extends TransactionStatus
+> = {
+  account: A | TokenAccount | ChildAccount;
+  parentAccount: A | undefined | null;
+  transaction: T;
+  status: TS;
+  field: DeviceTransactionField;
+};
+
+export type ManageAction = {
+  key: string;
+  label: React.ReactElement;
+  onClick: () => void;
+  event?: string;
+  eventProperties?: Record<string, unknown>;
+  icon:
+    | React.ComponentType<{
+        size: number;
+        overrideColor: string;
+        currency: TokenCurrency | CryptoCurrency;
+      }>
+    | ((a: { size: number }) => React.ReactElement);
+  disabled?: boolean;
+  tooltip?: string;
+  accountActionsTestId?: string;
+};
+
+// the AllCoinFamilies type is the only time we accept to go "any" because it's the generated entry point where the bridge is rooted.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AllCoinFamilies = Record<string, LLDCoinFamily<any, any, any>>;

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -1,6 +1,7 @@
 import "~/live-common-setup-base";
 import "~/live-common-set-supported-currencies";
-import "./generated/live-common-setup";
+import "./families"; // families may set up their own things
+
 import { registerTransportModule } from "@ledgerhq/live-common/hw/index";
 import { retry } from "@ledgerhq/live-common/promise";
 import { listen as listenLogs } from "@ledgerhq/logs";

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -26,8 +26,8 @@ import Switch from "~/renderer/components/Switch";
 import { StepProps } from "..";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
-import byFamily from "~/renderer/generated/NoAssociatedAccounts";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 type Props = AccountListProps & {
   defaultSelected: boolean;
@@ -286,7 +286,10 @@ class StepImport extends PureComponent<
         : [preferredNewAccountScheme!],
     });
     let creatable;
-    const NoAssociatedAccounts = byFamily[mainCurrency.family as keyof typeof byFamily];
+    const NoAssociatedAccounts = mainCurrency
+      ? getLLDCoinFamily(mainCurrency.family).NoAssociatedAccounts
+      : null;
+
     if (alreadyEmptyAccount) {
       creatable = (
         <Trans i18nKey="addAccounts.createNewAccount.noOperationOnLastAccount" parent="div">

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -29,13 +29,12 @@ import ModalBody from "~/renderer/components/Modal/ModalBody";
 import QRCode from "~/renderer/components/QRCode";
 import { getEnv } from "@ledgerhq/live-common/env";
 import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
-import byFamily from "~/renderer/generated/StepReceiveFunds";
-import byFamilyPostAlert from "~/renderer/generated/StepReceiveFundsPostAlert";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { LOCAL_STORAGE_KEY_PREFIX } from "./StepReceiveStakingFlow";
 import { useDispatch } from "react-redux";
 import { openModal } from "~/renderer/actions/modals";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 const Separator = styled.div`
   border-top: 1px solid #99999933;
@@ -248,13 +247,13 @@ const StepReceiveFunds = (props: StepProps) => {
   }, [isAddressVerified, confirmAddress]);
 
   // custom family UI for StepReceiveFunds
-  const CustomStepReceiveFunds = byFamily[mainAccount.currency.family as keyof typeof byFamily];
+  const specific = getLLDCoinFamily(mainAccount.currency.family);
+  const CustomStepReceiveFunds = specific?.StepReceiveFunds;
   if (CustomStepReceiveFunds) {
     return <CustomStepReceiveFunds {...props} />;
   }
 
-  const CustomPostAlertReceiveFunds =
-    byFamilyPostAlert[mainAccount.currency.family as keyof typeof byFamilyPostAlert];
+  const CustomPostAlertReceiveFunds = specific?.StepReceiveFundsPostAlert;
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepWarning.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepWarning.tsx
@@ -1,23 +1,26 @@
 import React from "react";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import byFamily from "~/renderer/generated/ReceiveWarning";
 import { StepProps } from "../Body";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 const StepWarning = (props: StepProps) => {
   const { account, parentAccount } = props;
   const mainAccount = account && getMainAccount(account, parentAccount);
   if (!mainAccount) return null;
-  const module = byFamily[mainAccount.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily(mainAccount.currency.family)?.receiveWarning;
   if (!module) return null;
-  const Comp = module.component as React.ComponentType<StepProps>;
+  const Comp = module.component;
   return <Comp {...props} />;
 };
+
 export const StepWarningFooter = (props: StepProps) => {
   const { account, parentAccount } = props;
   const mainAccount = account && getMainAccount(account, parentAccount);
   if (!mainAccount) return null;
-  const module = byFamily[mainAccount.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily(mainAccount.currency.family)?.receiveWarning;
   if (!module) return null;
   const Comp = module.footer;
   return <Comp {...props} />;
 };
+
 export default StepWarning;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/SendAmountFields.tsx
@@ -1,24 +1,25 @@
 import React from "react";
 import { Account, FeeStrategy } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import byFamily from "~/renderer/generated/SendAmountFields";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 type Props = {
   account: Account;
   transaction: Transaction;
   status: TransactionStatus;
   onChange: (a: Transaction) => void;
-  updateTransaction: (updater: any) => void;
-  mapStrategies?: (
-    a: FeeStrategy,
-  ) => FeeStrategy & {
-    [x: string]: unknown;
-  };
-  [key: string]: unknown;
+  updateTransaction: (updater: (_: Transaction) => Transaction) => void;
+  mapStrategies?: (a: FeeStrategy) => FeeStrategy;
+  bridgePending?: boolean;
+  trackProperties?: Record<string, unknown>;
 };
+
 const AmountRelatedField = (props: Props) => {
-  const module = byFamily[props.account.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily<Account, Transaction, TransactionStatus>(
+    props.account.currency.family,
+  )?.sendAmountFields;
   if (!module) return null;
-  const Cmp = module.component as React.ComponentType<Props>;
+  const Cmp = module.component;
   return <Cmp {...props} />;
 };
 export default AmountRelatedField;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/SendRecipientFields.tsx
@@ -1,22 +1,27 @@
 import React from "react";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import byFamily from "~/renderer/generated/SendRecipientFields";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 type Props = {
   account: Account;
   transaction: Transaction;
   status: TransactionStatus;
   onChange: (a: Transaction) => void;
 };
+
 export const getFields = (account: Account): string[] => {
-  const module = byFamily[account.currency.family as keyof typeof byFamily];
-  if (!module) return [];
-  return "fields" in module ? module.fields : [];
+  const module = getLLDCoinFamily(account.currency.family)?.sendRecipientFields;
+  return module?.fields || [];
 };
+
 const RecipientRelatedField = (props: Props) => {
-  const module = byFamily[props.account.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily<Account, Transaction, TransactionStatus>(
+    props.account.currency.family,
+  )?.sendRecipientFields;
   if (!module) return null;
   const Cmp = module.component;
   return <Cmp {...props} />;
 };
+
 export default RecipientRelatedField;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepWarning.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepWarning.tsx
@@ -1,23 +1,26 @@
 import React from "react";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import byFamily from "~/renderer/generated/SendWarning";
 import { StepProps } from "../types";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 const StepWarning = (props: StepProps) => {
   const { account, parentAccount } = props;
   const mainAccount = account && getMainAccount(account, parentAccount);
   if (!mainAccount) return null;
-  const module = byFamily[mainAccount.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily(mainAccount.currency.family)?.sendWarning;
   if (!module) return null;
   const Comp = module.component as React.ComponentType<StepProps>;
   return <Comp {...props} />;
 };
+
 export const StepWarningFooter = (props: StepProps) => {
   const { account, parentAccount } = props;
   const mainAccount = account && getMainAccount(account, parentAccount);
   if (!mainAccount) return null;
-  const module = byFamily[mainAccount.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily(mainAccount.currency.family)?.sendWarning;
   if (!module) return null;
   const Comp = module.footer;
   return <Comp {...props} />;
 };
+
 export default StepWarning;

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/SendAmountFields.tsx
@@ -1,19 +1,24 @@
 import React from "react";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import byFamily from "~/renderer/generated/SendAmountFields";
+import { getLLDCoinFamily } from "~/renderer/families";
+
 type Props = {
   account: Account;
   transaction: Transaction;
   status: TransactionStatus;
   onChange: (a: Transaction) => void;
   updateTransaction: (updater: any) => void;
-  [key: string]: unknown;
+  bridgePending?: boolean;
 };
+
 const AmountRelatedField = (props: Props) => {
-  const module = byFamily[props.account.currency.family as keyof typeof byFamily];
+  const module = getLLDCoinFamily<Account, Transaction, TransactionStatus>(
+    props.account.currency.family,
+  )?.sendAmountFields;
   if (!module) return null;
-  const Cmp = module.component as React.ComponentType<Props>;
+  const Cmp = module.component;
   return <Cmp {...props} />;
 };
+
 export default AmountRelatedField;

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/types.ts
@@ -29,6 +29,6 @@ export type StepProps = {
   onResetMaybeRecipient: () => void;
   maybeAmount?: BigNumber;
   onResetMaybeAmount: () => void;
-  updateTransaction: (updater: any) => void;
+  updateTransaction: (updater: (_: Transaction) => Transaction) => void;
 };
 export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/modals/StartStake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/StartStake/index.tsx
@@ -1,15 +1,13 @@
-import perFamilyManageActions from "~/renderer/generated/AccountHeaderManageActions";
 import { FC, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { closeModal } from "~/renderer/actions/modals";
 import { Account } from "@ledgerhq/types-live";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 type Action = {
   key: string;
   onClick?: () => void;
 };
-
-type CurrencyFamily = keyof typeof perFamilyManageActions;
 
 interface ModalStartStakeProps {
   account: Account;
@@ -19,8 +17,8 @@ interface ModalStartStakeProps {
 }
 
 const ModalStartStake: FC<ModalStartStakeProps> = ({ account, parentAccount, source }) => {
-  const currencyFamily: CurrencyFamily = account.currency.family as CurrencyFamily;
-  const manage = perFamilyManageActions[currencyFamily];
+  const currencyFamily = account.currency.family;
+  const manage = getLLDCoinFamily(currencyFamily).accountHeaderManageActions;
   const dispatch = useDispatch();
   let manageList: Action[] = [];
   if (manage) {

--- a/apps/ledger-live-desktop/src/renderer/modals/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.ts
@@ -1,4 +1,4 @@
-import generated from "../generated/modals";
+import { modals as familiesModals } from "../families";
 import MODAL_WEBSOCKET_BRIDGE from "./WebSocketBridge";
 import MODAL_EXPORT_OPERATIONS from "./ExportOperations";
 import MODAL_PASSWORD from "./PasswordModal";
@@ -27,8 +27,8 @@ import MODAL_BLACKLIST_TOKEN from "./BlacklistToken";
 import MODAL_HIDE_NFT_COLLECTION from "./HideNftCollection";
 import MODAL_PROTECT_DISCOVER from "./ProtectDiscover";
 
-type ModalComponent = React.ComponentType<any>; // FIXME determine the common ground to modals
-type Modals = Record<string, ModalComponent>;
+export type ModalComponent = React.ComponentType<any>; // FIXME determine the common ground to modals
+export type Modals = Record<string, ModalComponent>;
 
 const modals: Modals = {
   MODAL_WEBSOCKET_BRIDGE,
@@ -64,18 +64,8 @@ const modals: Modals = {
   // NB We have dettached modals such as the repair modal,
   // in the meantime, we can rely on this to add the backdrop
   MODAL_STUB: () => null,
-};
 
-for (const family in generated) {
-  const components = (generated as Record<string, Modals>)[family] as Modals;
-  for (const name in components) {
-    if (name in modals) {
-      throw new Error(
-        `modal ${name} already exists. Make sure there is no name collision between families.`,
-      );
-    }
-    modals[name] = components[name];
-  }
-}
+  ...familiesModals,
+};
 
 export default modals;

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -18,8 +18,6 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import Box, { Tabbable } from "~/renderer/components/Box";
 import Star from "~/renderer/components/Stars/Star";
 import Tooltip from "~/renderer/components/Tooltip";
-import perFamilyAccountActions from "~/renderer/generated/accountActions";
-import perFamilyManageActions from "~/renderer/generated/AccountHeaderManageActions";
 import useTheme from "~/renderer/hooks/useTheme";
 import IconAccountSettings from "~/renderer/icons/AccountSettings";
 import IconWalletConnect from "~/renderer/icons/WalletConnect";
@@ -37,6 +35,8 @@ import {
 import { useGetSwapTrackingProperties } from "~/renderer/screens/exchange/Swap2/utils/index";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getLLDCoinFamily } from "~/renderer/families";
+import { ManageAction } from "~/renderer/families/types";
 
 type RenderActionParams = {
   label: React.ReactElement;
@@ -153,20 +153,18 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
 
   // PTX smart routing feature flag - buy sell live app flag
   const ptxSmartRouting = useFeature("ptxSmartRouting");
-  const decorators =
-    perFamilyAccountActions[mainAccount.currency.family as keyof typeof perFamilyAccountActions];
-  const manage =
-    perFamilyManageActions[mainAccount.currency.family as keyof typeof perFamilyManageActions];
-  let manageList: any[] = [];
+
+  const specific = getLLDCoinFamily(mainAccount.currency.family);
+
+  const manage = specific?.accountHeaderManageActions;
+  let manageList: ManageAction[] = [];
   if (manage) {
-    const familyManageActions = manage({
-      account: account as Account,
-      parentAccount,
-    });
+    const familyManageActions = manage({ account, parentAccount });
     manageList = familyManageActions && familyManageActions.length > 0 ? familyManageActions : [];
   }
-  const SendAction = (decorators && decorators.SendAction) || SendActionDefault;
-  const ReceiveAction = (decorators && decorators.ReceiveAction) || ReceiveActionDefault;
+
+  const SendAction = specific?.accountActions?.SendAction || SendActionDefault;
+  const ReceiveAction = specific?.accountActions?.ReceiveAction || ReceiveActionDefault;
   const currency = getAccountCurrency(account);
 
   const rampCatalog = useRampCatalog();

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountStakeBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountStakeBanner.tsx
@@ -1,14 +1,11 @@
 import React from "react";
-import { Account, AccountLike } from "@ledgerhq/types-live";
+import { AccountLike } from "@ledgerhq/types-live";
 import { isAccount } from "@ledgerhq/live-common/account/index";
-import generated from "~/renderer/generated/StakeBanner";
-
-type Generated = Record<string, React.FC<{ account: Account }>>;
+import { getLLDCoinFamily } from "~/renderer/families";
 
 export const AccountStakeBanner = ({ account }: { account: AccountLike }) => {
   if (account && isAccount(account)) {
-    // @ts-expect-error  Need to update prop in families
-    const Comp = (generated as Generated)[account.currency.family];
+    const Comp = getLLDCoinFamily(account.currency.family).StakeBanner;
     if (Comp) return <Comp account={account} />;
   }
   return null;

--- a/apps/ledger-live-desktop/src/renderer/screens/account/BalanceSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/BalanceSummary.tsx
@@ -11,9 +11,9 @@ import Chart from "~/renderer/components/Chart";
 import Box, { Card } from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import AccountBalanceSummaryHeader from "./AccountBalanceSummaryHeader";
-import perFamilyAccountBalanceSummaryFooter from "~/renderer/generated/AccountBalanceSummaryFooter";
 import FormattedDate from "~/renderer/components/FormattedDate";
 import { Data, Item } from "~/renderer/components/Chart/types";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 type Props = {
   chartColor: string;
@@ -88,9 +88,7 @@ export default function AccountBalanceSummary({
   );
   const displayCountervalue = countervalueFirst && countervalueAvailable;
   const AccountBalanceSummaryFooter = mainAccount
-    ? perFamilyAccountBalanceSummaryFooter[
-        mainAccount.currency.family as keyof typeof perFamilyAccountBalanceSummaryFooter
-      ]
+    ? getLLDCoinFamily(mainAccount.currency.family).AccountBalanceSummaryFooter
     : null;
   const chartMagnitude = displayCountervalue
     ? counterValue.units[0].magnitude
@@ -132,7 +130,6 @@ export default function AccountBalanceSummary({
       {AccountBalanceSummaryFooter && (
         <AccountBalanceSummaryFooter
           account={account}
-          // @ts-expect-error Need to update prop in families
           counterValue={counterValue}
           discreetMode={discreetMode}
         />

--- a/apps/ledger-live-desktop/src/renderer/screens/account/TokensList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/TokensList.tsx
@@ -17,10 +17,10 @@ import LabelWithExternalIcon from "~/renderer/components/LabelWithExternalIcon";
 import { openURL } from "~/renderer/linking";
 import { track } from "~/renderer/analytics/segment";
 import AccountContextMenu from "~/renderer/components/ContextMenu/AccountContextMenu";
-import perFamilyTokenList from "~/renderer/generated/TokenList";
 import { useTimeRange } from "~/renderer/actions/settings";
 import TableContainer, { TableHeader } from "~/renderer/components/TableContainer";
 import AngleDown from "~/renderer/icons/AngleDown";
+import { getLLDCoinFamily } from "~/renderer/families";
 type Props = {
   account: Account;
 };
@@ -64,9 +64,9 @@ function TokensList({ account }: Props) {
     currency && currency.type && tokenTypes && tokenTypes.length > 0
       ? supportLinkByTokenType[tokenTypes[0] as keyof typeof supportLinkByTokenType]
       : null;
-  const specific = perFamilyTokenList[family as keyof typeof perFamilyTokenList];
+  const specific = getLLDCoinFamily(family)?.tokenList;
   const hasSpecificTokenWording = specific?.hasSpecificTokenWording;
-  const ReceiveButtonComponent = specific ? specific.ReceiveButton : ReceiveButton;
+  const ReceiveButtonComponent = specific?.ReceiveButton || ReceiveButton;
   const titleLabel = t(hasSpecificTokenWording ? `tokensList.${family}.title` : "tokensList.title");
   const placeholderLabel = t(
     hasSpecificTokenWording ? `tokensList.${family}.placeholder` : "tokensList.placeholder",
@@ -144,7 +144,7 @@ function TokensList({ account }: Props) {
 }
 
 // Fixme Temporarily hiding the receive token button
-function ReceiveButton(props: { onClick: (account: Account) => void }) {
+function ReceiveButton(props: { account: Account; onClick: () => void }) {
   const { t } = useTranslation();
   return (
     <Button small primary onClick={props.onClick}>

--- a/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/index.tsx
@@ -23,8 +23,6 @@ import {
   hiddenNftCollectionsSelector,
 } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";
-import perFamilyAccountBodyHeader from "~/renderer/generated/AccountBodyHeader";
-import perFamilyAccountSubHeader from "~/renderer/generated/AccountSubHeader";
 import Box from "~/renderer/components/Box";
 import OperationsList from "~/renderer/components/OperationsList";
 import useTheme from "~/renderer/hooks/useTheme";
@@ -37,6 +35,7 @@ import TokensList from "./TokensList";
 import { AccountStakeBanner } from "~/renderer/screens/account/AccountStakeBanner";
 import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
 import { State } from "~/renderer/reducers";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 type Params = {
   id: string;
@@ -89,16 +88,9 @@ const AccountPage = ({
   setCountervalueFirst,
 }: Props) => {
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
-  const AccountBodyHeader = mainAccount
-    ? perFamilyAccountBodyHeader[
-        mainAccount.currency.family as keyof typeof perFamilyAccountBodyHeader
-      ]
-    : null;
-  const AccountSubHeader = mainAccount
-    ? perFamilyAccountSubHeader[
-        mainAccount.currency.family as keyof typeof perFamilyAccountSubHeader
-      ]
-    : null;
+  const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family) : null;
+  const AccountBodyHeader = specific?.AccountBodyHeader;
+  const AccountSubHeader = specific?.AccountSubHeader;
   const bgColor = useTheme().colors.palette.background.paper;
   const [shouldFilterTokenOpsZeroAmount] = useFilterTokenOperationsZeroAmount();
   const hiddenNftCollections = useSelector(hiddenNftCollectionsSelector);
@@ -153,7 +145,6 @@ const AccountPage = ({
         <AccountHeaderActions account={account} parentAccount={parentAccount} />
       </Box>
       {AccountSubHeader ? (
-        // @ts-expect-error Need to update type in families
         <AccountSubHeader account={account} parentAccount={parentAccount} />
       ) : null}
       {!isAccountEmpty(account) ? (
@@ -170,7 +161,6 @@ const AccountPage = ({
           </Box>
           <AccountStakeBanner account={account} />
           {AccountBodyHeader ? (
-            // @ts-expect-error Need to update type in families
             <AccountBodyHeader account={account} parentAccount={parentAccount} />
           ) : null}
           {account.type === "Account" && isNFTActive(account.currency) ? (

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountRowItem/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountRowItem/index.tsx
@@ -20,7 +20,7 @@ import Header from "./Header";
 import Star from "~/renderer/components/Stars/Star";
 import { hideEmptyTokenAccountsSelector } from "~/renderer/reducers/settings";
 import Button from "~/renderer/components/Button";
-import perFamilyTokenList from "~/renderer/generated/TokenList";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 const Row = styled(Box)`
   background: ${p => p.theme.colors.palette.background.paper};
@@ -212,8 +212,7 @@ class AccountRowItem extends PureComponent<Props, State> {
       if (tokens) tokens = tokens.filter(t => matchesSearch(search, t));
     }
     const showTokensIndicator = Boolean(tokens && tokens.length > 0 && !hidden);
-    const specific =
-      perFamilyTokenList[mainAccount.currency.family as keyof typeof perFamilyTokenList];
+    const specific = mainAccount ? getLLDCoinFamily(mainAccount.currency.family).tokenList : null;
     const hasSpecificTokenWording = specific?.hasSpecificTokenWording;
     const translationMap = isToken
       ? {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
@@ -7,7 +7,6 @@ import SummaryLabel from "./SummaryLabel";
 import SummaryValue, { NoValuePlaceholder } from "./SummaryValue";
 import SummarySection from "./SummarySection";
 import FeesDrawer from "../FeesDrawer";
-import sendAmountByFamily from "~/renderer/generated/SendAmountFields";
 import {
   SwapTransactionType,
   SwapSelectorStateType,
@@ -22,6 +21,7 @@ import TachometerLow from "~/renderer/icons/TachometerLow";
 import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import styled from "styled-components";
 import { useGetSwapTrackingProperties } from "../../utils/index";
+import { getLLDCoinFamily } from "~/renderer/families";
 
 type Strategies = "slow" | "medium" | "fast" | "advanced";
 
@@ -76,6 +76,7 @@ const SectionFees = ({
   const estimatedFees = status?.estimatedFees;
   const showSummaryValue = mainFromAccount && estimatedFees && estimatedFees.gt(0);
   const family = mainFromAccount?.currency.family;
+  const sendAmountSpecific = account && family && getLLDCoinFamily(family)?.sendAmountFields;
   const canEdit =
     hasRates &&
     showSummaryValue &&
@@ -84,7 +85,7 @@ const SectionFees = ({
     transaction.networkInfo &&
     account &&
     family &&
-    sendAmountByFamily[family as keyof typeof sendAmountByFamily];
+    sendAmountSpecific;
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const StrategyIcon = useMemo(
     () =>

--- a/apps/ledger-live-desktop/src/renderer/screens/lend/modals/Enable/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/lend/modals/Enable/types.ts
@@ -2,6 +2,7 @@ import { TFunction } from "react-i18next";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Step } from "~/renderer/components/Stepper";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+// eslint-disable-next-line no-restricted-imports
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ethereum/types";
 export type StepId = "amount" | "connectDevice" | "confirmation";
 export type StepProps = {
@@ -24,6 +25,6 @@ export type StepProps = {
   onOperationBroadcasted: (a: Operation) => void;
   setSigned: (a: boolean) => void;
   bridgePending: boolean;
-  onUpdateTransaction: (updater: any) => void;
+  onUpdateTransaction: (updater: (_: Transaction) => void) => void;
 };
 export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-desktop/src/renderer/screens/lend/modals/Supply/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/lend/modals/Supply/types.ts
@@ -3,6 +3,7 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Step } from "~/renderer/components/Stepper";
 import { Account, AccountLike, TokenAccount, Operation } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+// eslint-disable-next-line no-restricted-imports
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ethereum/types";
 export type StepId = "amount" | "connectDevice" | "confirmation";
 export type StepProps = {

--- a/apps/ledger-live-desktop/src/renderer/screens/lend/modals/Withdraw/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/lend/modals/Withdraw/types.ts
@@ -2,6 +2,7 @@ import { TFunction } from "react-i18next";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Step } from "~/renderer/components/Stepper";
 import { Account, TokenAccount, Operation } from "@ledgerhq/types-live";
+// eslint-disable-next-line no-restricted-imports
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ethereum/types";
 export type StepId = "amount" | "connectDevice" | "confirmation";
 export type StepProps = {
@@ -24,6 +25,6 @@ export type StepProps = {
   onOperationBroadcasted: (a: Operation) => void;
   setSigned: (a: boolean) => void;
   bridgePending: boolean;
-  onUpdateTransaction: (updater: any) => void;
+  onUpdateTransaction: (updater: (_: Transaction) => void) => void;
 };
 export type St = Step<StepId, StepProps>;

--- a/libs/coin-framework/src/account/helpers.ts
+++ b/libs/coin-framework/src/account/helpers.ts
@@ -20,13 +20,13 @@ import {
 // By convention, a main account is the top level account
 // - in case of an Account is the account itself
 // - in case of a SubAccount it's the parentAccount
-export const getMainAccount = (
-  account: AccountLike,
-  parentAccount?: Account | null | undefined
-): Account => {
+export const getMainAccount = <A extends Account>(
+  account: A | SubAccount,
+  parentAccount?: A | null | undefined
+): A => {
   const mainAccount = account.type === "Account" ? account : parentAccount;
   invariant(mainAccount, "an account is expected");
-  return mainAccount as Account;
+  return mainAccount as A;
 };
 
 // Return the currency in which fees are paid for this account


### PR DESCRIPTION
- [ ] properly document each method/component of LLDCoinFamily

in light of incoming fixing the TypeScript of src/renderer/families of LLD, we are establishing the base type of what is a LLD Coin Family.

### 📝 Description

- **`generated/` is gone!** in the process of fixing typescript of coin families folder, we remove completely this complex folder. We only need one `generated.ts` which is the result of all the `families/*/index.ts`
- each family export one **`index.ts`** and only exports a module object of type `LLDCoinFamily`.
- this unified type will allow us to more easily maintain the "Coin Family interface" to implement in LLD, easily deprecate things if we have to, as well as detect typescript issues.
- this unified type is self documenting the API you have to implement with comments on each component that you can define (instead of the current status quo of copying things from another family!)

#### Better typing with parametric binding specifics' Account, Transaction and TransactionStatus

The type is reinforced in that you can define your own specific account/transaction/status and it's about the only place where you are allowed to do these (inside your family). This does not involve casting at all!

```typescript
import { CeloAccount, Transaction, TransactionStatus } from "@ledgerhq/live-common/families/celo/types";
const family: LLDCoinFamily<CeloAccount, Transaction, TransactionStatus> = {
```

this will allow you to drop any code like `invariant(account.family === "celo")` and `account as CeloAccount`, you have typesafety on this and all components will directly be able to define `({ account: CeloAccount })` as props.

let's hope this gives idea to eventually generalize the same on the bridge interface!

this essentially works by the fact the type is defined as:

```
type LLDCoinFamily<
  A extends Account,
  T extends TransactionCommon,
  TS extends TransactionStatus,
  CoinModalsData = {}
>
```

### GUIDE TO UPGRADE:

#### NO BREAKING CHANGES from a family perspective...

an important choice of this rework was to NOT break any signature and existing design choices.

#### ...BUT just one file to add, and types to fix to it:

The impact is very limited. You just need to add a index.ts file. you can start with this template and remove the files you don't have:

```typescript
import "./live-common-setup";
import {
  _FAMILY_Account,
  Transaction,
  TransactionStatus,
} from "@ledgerhq/live-common/families/_FAMILY_/types";
import { LLDCoinFamily } from "../types";
import operationDetails from "./operationDetails";
import modals, { ModalsData } from "./modals";
import accountActions from "./accountActions";
import accountHeaderManageActions from "./AccountHeaderManageActions";
import transactionConfirmFields from "./TransactionConfirmFields";
import AccountBodyHeader from "./AccountBodyHeader";
import AccountSubHeader from "./AccountSubHeader";
import sendAmountFields from "./SendAmountFields";
import sendRecipientFields from "./SendRecipientFields";
import sendWarning from "./SendWarning";
import receiveWarning from "./ReceiveWarning";
import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
import tokenList from "./TokenList";
import StepReceiveFunds from "./StepReceiveFunds";
import StepReceiveFundsPostAlert from "./StepReceiveFundsPostAlert";
import NoAssociatedAccounts from "./NoAssociatedAccounts";
import StakeBanner from "./StakeBanner";

const family: LLDCoinFamily<_FAMILY_Account, Transaction, TransactionStatus, ModalsData> = {
  operationDetails,
  accountActions,
  accountHeaderManageActions,
  modals,
  transactionConfirmFields,
  AccountBodyHeader,
  AccountSubHeader,
  sendAmountFields,
  sendRecipientFields,
  sendWarning,
  receiveWarning,
  AccountBalanceSummaryFooter,
  tokenList,
  StepReceiveFunds,
  StepReceiveFundsPostAlert,
  NoAssociatedAccounts,
  StakeBanner,
};

export default family;
```

#### Notes for future

the tradeoff of no breaking change is that, we should probably rework some parts. Here are a few ideas to consider in future:

- A bunch of components takes `{ account: A | TokenAccount | SubAccount, parentAccount: A | undefined | null }` props but it's possible they could just need `{ account: A }` where account would be the "parentAccount" in that case. For now, this code isn't touching this aspect.
  - in the meantime, `getMainAccount()` was improved to have a parametric `A` so we can preserve that A, where A extends Account.
- StepProps would be better if reworked with a parametric type from perspective of a coin.
- `export type AllCoinFamilies = Record<string, LLDCoinFamily<any, any, any>>;` is currently necessary due to the need to implement `getLLDCoinFamily<A extends Account, T extends TransactionCommon,  TS extends TransactionStatusCommon>(name: string): LLDCoinFamily<A, T, TS>`. In future, we could make this function return `LLDCoinFamily<Account,TransactionCommon,TransactionStatusCommon>` but it wouldn't work due to heavy usage of union type `Transaction`. **overall this is the only single place we allow the type to become loosely, but on both side we have typechecks working**


### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-7308 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
