### PR TITLE
fix(React Native BLE Transport): fix remapping of disconnected device ble errors

### DIFF
--- a/.changeset/popular-nails-laugh.md
+++ b/.changeset/popular-nails-laugh.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hw-transport-ble": patch
+---
+
+Fix the mapping of errors on the BLE transport. "Disconnect" and "device not found" errors were not correctly being mapped.

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/remapErrors.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/remapErrors.ts
@@ -22,7 +22,9 @@ export const remapError = (error: IOBleErrorRemap): IOBleErrorRemap => {
     } else if (error?.attErrorCode === 22) {
       return new PairingFailed();
     }
-  } else if (
+  } 
+  
+  if (
     error.message.includes("was disconnected") ||
     error.message.includes("not found")
   ) {


### PR DESCRIPTION
### 📝 Description
Fix the remapping of errors in the React Native BLE Transport. Due to a recent change in the remapping code, the "was disconnected" and "not found" type of errors were not being correctly remapped into the DisconnectedDevice error class. 
This PR fixes this issue.

### ❓ Context

- **Impacted projects**: `ledgerjs/react-native-hw-transport-ble`
- **Linked resource(s)**: None

### ✅ Checklist

- [ ] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes** -- there will only be breaking changes if a dependent package was relying on that wrong behavior. Which is most probably not the case as the problem was only introduced very recently.

### 📸 Demo
N/A