### PR TITLE
fix(Ledger Live Common): throttle events coming on inline app installs

### DIFF
--- a/.changeset/smooth-cooks-sort.md
+++ b/.changeset/smooth-cooks-sort.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Throttle the events coming from inline app installs. They were causing the UI to slow down as they weren't being properly throttled.

--- a/libs/ledger-live-common/src/apps/inlineAppInstall.ts
+++ b/libs/ledger-live-common/src/apps/inlineAppInstall.ts
@@ -11,7 +11,7 @@ import {
 } from "./logic";
 import { runAllWithProgress } from "./runner";
 import { InlineAppInstallEvent } from "./types";
-import { mergeMap, map } from "rxjs/operators";
+import { mergeMap, map, throttleTime } from "rxjs/operators";
 
 /**
  * Tries to install a list of apps
@@ -95,6 +95,7 @@ const inlineAppInstall = ({
             }),
             maybeSkippedEvent,
             runAllWithProgress(state, exec).pipe(
+              throttleTime(100),
               map(
                 ({
                   globalProgress,


### PR DESCRIPTION
### 📝 Description
Due to some refactorings done on the device actions the inline app install events stopped being throttled. This was a regression since it slowed down the UI during inline app installs. This PR adds back a throttle to those events.

### ❓ Context
- **Impacted projects**: `ledger-live-common` 
- **Linked resource(s)**: N/A

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
N/A

