### PR TITLE
Bugfix/live 7388 llm device name UI

### DIFF
--- a/.changeset/witty-plants-clap.md
+++ b/.changeset/witty-plants-clap.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+---
+
+Fix device name text wrapping issue in My Ledger
+Fix device renaming input focusing issue on iOS

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -1,7 +1,15 @@
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "react-i18next";
 import { connect } from "react-redux";
+import { TextInput as NativeTextInput } from "react-native";
 import { DeviceNameInvalid } from "@ledgerhq/errors";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import { Button, Text, Icons, Flex } from "@ledgerhq/native-ui";
@@ -45,6 +53,8 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
   const originalName = route.params?.deviceName;
   const device = route.params?.device;
   const deviceInfo = route.params?.deviceInfo;
+
+  const textInputRef = useRef<NativeTextInput | null>(null);
 
   const { t } = useTranslation();
   const { pushToast } = useToasts();
@@ -117,6 +127,17 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
   const disabled =
     !cleanName || !!error || running || cleanName === originalName;
 
+  useEffect(() => {
+    let handle: number;
+    if (running) textInputRef.current?.blur();
+    else {
+      handle = requestAnimationFrame(() => textInputRef.current?.focus());
+    }
+    return () => {
+      handle && cancelAnimationFrame(handle);
+    };
+  }, [running]);
+
   return (
     <KeyboardBackgroundDismiss>
       <SafeAreaView style={{ flex: 1 }}>
@@ -124,10 +145,10 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
           <TrackScreen category="EditDeviceName" />
           <Flex flex={1} p={6} bg="background.main">
             <TextInput
+              ref={textInputRef}
               value={name}
               onChangeText={onChangeText}
               maxLength={maxDeviceName}
-              autoFocus
               selectTextOnFocus
               blurOnSubmit={true}
               clearButtonMode="always"

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -127,6 +127,15 @@ function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
   const disabled =
     !cleanName || !!error || running || cleanName === originalName;
 
+  /**
+   * Blurring the input when "running" (when the device action modal is mounted)
+   * allows to avoid a glitch in case of success: on iOS, if the input was
+   * focused when the modal got initially mounted, on the unmount of the modal
+   * it would refocus the input, so the keyboard would reappear. In this
+   * specific case, on success of the renaming action, the input gets unmounted
+   * as well (because we navigate away from this screen), resulting in a glitch
+   * where the keyboard appears and then quickly disappears.
+   */
   useEffect(() => {
     let handle: number;
     if (running) textInputRef.current?.blur();

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceName.tsx
@@ -61,6 +61,7 @@ export default function DeviceName({
         uppercase={false}
         numberOfLines={2}
         ellipsizeMode="tail"
+        flexShrink={1}
       >
         {displayedName}
       </Text>


### PR DESCRIPTION

### 📝 Description

[LIVE-7388]: Fix device name text wrapping issue in My Ledger
[LIVE-7386]: Fix device renaming input focusing issue on iOS by implementing a custom auto focus/blur logic: the input now gets blurred automatically when the modal appears which avoids the glitch that was found.

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7388], [LIVE-7386] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

- For [LIVE-7388] (text wrapping issue):
  - Before (the edit button is pushed beyond the padding zone):
  ![photo_2023-05-11 13 20 58](https://github.com/LedgerHQ/ledger-live/assets/91890529/c0237b69-056a-4acc-9457-4225600a3a0f)
  - After (text is properly wrapped):
  ![photo_2023-05-11 13 20 56](https://github.com/LedgerHQ/ledger-live/assets/91890529/f4deb13b-2ac9-4286-8af1-4c560a44dfa4)
- For [LIVE-7386]: (input/keyboard glitch)

https://github.com/LedgerHQ/ledger-live/assets/91890529/1f6a2a6d-6477-40ff-85c7-75b835c43611






### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7388]: https://ledgerhq.atlassian.net/browse/LIVE-7388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-7386]: https://ledgerhq.atlassian.net/browse/LIVE-7386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-7388]: https://ledgerhq.atlassian.net/browse/LIVE-7388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-7386]: https://ledgerhq.atlassian.net/browse/LIVE-7386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-7388]: https://ledgerhq.atlassian.net/browse/LIVE-7388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-7386]: https://ledgerhq.atlassian.net/browse/LIVE-7386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ