### PR TITLE
feat: live-6476 bring the optimistic storage bar to LLM

### DIFF
--- a/.changeset/olive-planes-behave.md
+++ b/.changeset/olive-planes-behave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Bring the optimistic state to the LLM storage bar

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
@@ -5,7 +5,13 @@ import {
   listTokens,
   isCurrencySupported,
 } from "@ledgerhq/live-common/currencies/index";
-import { distribute, Action, State } from "@ledgerhq/live-common/apps/index";
+import {
+  distribute,
+  Action,
+  State,
+  predictOptimisticState,
+  reducer,
+} from "@ledgerhq/live-common/apps/index";
 import { App, DeviceInfo } from "@ledgerhq/types-live";
 import { useAppsSections } from "@ledgerhq/live-common/apps/react";
 
@@ -84,7 +90,17 @@ const AppsScreen = ({
   result,
   onLanguageChange,
 }: Props) => {
-  const distribution = distribute(state);
+  const distribution = useMemo(() => {
+    const newState = state.installQueue.length
+      ? predictOptimisticState(
+          reducer(state, {
+            type: "install",
+            name: state.installQueue[0],
+          }),
+        )
+      : state;
+    return distribute(newState);
+  }, [state]);
 
   const [appFilter, setFilter] = useState<AppType | null | undefined>("all");
   const [sort, setSort] = useState<SortOptions["type"] | null | undefined>(

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceAppStorage.tsx
@@ -10,11 +10,14 @@ import { WarningMedium } from "@ledgerhq/native-ui/assets/icons";
 
 import styled from "styled-components/native";
 import ByteSize from "../../../components/ByteSize";
+import StorageBarItem from "./StorageBarItem";
 
 type Props = {
   deviceModel: DeviceModel;
   deviceInfo: DeviceInfo;
   distribution: AppsDistribution;
+  installQueue: string[];
+  uninstallQueue: string[];
 };
 
 const StorageRepartition = styled(Box)`
@@ -38,6 +41,8 @@ const DeviceAppStorage = ({
     shouldWarnMemory,
     apps,
   },
+  installQueue,
+  uninstallQueue,
 }: Props) => {
   const appSizes = useMemo(
     () =>
@@ -141,7 +146,10 @@ const DeviceAppStorage = ({
       </Flex>
       <StorageRepartition bg="neutral.c40" style={{ flex: 1 }}>
         {appSizes.map(({ ratio, color, name }, i) => (
-          <Box
+          <StorageBarItem
+            installing={
+              installQueue.includes(name) || uninstallQueue.includes(name)
+            }
             key={`${i}${name}`}
             backgroundColor={color}
             flexBasis={`${ratio}%`}

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/StorageBarItem.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/StorageBarItem.tsx
@@ -1,0 +1,50 @@
+import { Box } from "@ledgerhq/native-ui";
+import React from "react";
+import { useTheme } from "styled-components/native";
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+import { FlexBoxProps } from "@ledgerhq/native-ui/components/Layout/Flex/index";
+
+const StorageBarItem = (props: FlexBoxProps & { installing: boolean }) => {
+  const { colors } = useTheme();
+  const { installing, backgroundColor, ...rest } = props;
+
+  const opacity = useSharedValue(0);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const opacityValue = interpolate(opacity.value, [0, 1], [0, 1]);
+    return {
+      opacity: withRepeat(
+        withTiming(opacityValue, { duration: 800 }),
+        -1,
+        true,
+      ),
+    };
+  });
+
+  opacity.value = withTiming(1, { duration: 800 });
+
+  return (
+    <Box backgroundColor={installing ? undefined : backgroundColor} {...rest}>
+      {props.installing ? (
+        <Animated.View
+          style={[
+            animatedStyle,
+            {
+              height: "100%",
+              width: "100%",
+              backgroundColor: colors.neutral.c30,
+            },
+          ]}
+        />
+      ) : null}
+    </Box>
+  );
+};
+
+export default StorageBarItem;

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
@@ -203,6 +203,8 @@ const DeviceCard = ({
       <DeviceAppStorage
         distribution={distribution}
         deviceModel={deviceModel}
+        installQueue={state.installQueue}
+        uninstallQueue={state.uninstallQueue}
         deviceInfo={deviceInfo}
       />
       {appList.length > 0 && (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
The storage bar inside My Ledger for LLM was not reflecting the optimistic state (result of queued installs/uninstalls) like it happens on LLD. This PR introduces that behaviour as well as the nifty animation used on LLD to convey something is happening. 

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6476` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/4631227/2cca972d-b47b-4745-ad82-67764fd1fa15


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
For a little bit more context, the _state_ of the data when we enter My Ledger is calculated by querying the device for what it has inside, getting what's available in the selected provider, and computing all of that to reflect it on a storage bar so we know how much space is available, what can fit and what can't, etc. 

On LLM this status bar is currently only showing the _real_ state, meaning the state that has been committed to the device. This means that if there's a queue of actions pending, it doesn't reflect the space that will be available once we complete that queue. It's mostly a UI thing, and this PR simply aligns it with LLD, following the same animation pattern for the "pending" installed apps and whatnot.
