### PR TITLE
fix(Device Pairing Screen): remove unnecessary manual sentry reporting

### DIFF
--- a/.changeset/afraid-seals-design.md
+++ b/.changeset/afraid-seals-design.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove unnecessary reporting of errors to Sentry

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -107,9 +107,9 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
       type: "scanning",
     });
   }, [dispatch, navigation]);
+
   const onError = useCallback(
     (error: Error) => {
-      logger.critical(error);
       navigation.setParams({
         hasError: true,
       });
@@ -120,6 +120,7 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
     },
     [dispatch, navigation],
   );
+
   const onSelect = useCallback(
     async (bleDevice: TransportBleDevice, deviceMeta?: Device) => {
       const device = {

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -11,7 +11,6 @@ import { delay } from "@ledgerhq/live-common/promise";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "@react-navigation/native";
 import { TransportBleDevice } from "@ledgerhq/live-common/ble/types";
-import logger from "../../logger";
 import TransportBLE from "../../react-native-hw-transport-ble";
 import { GENUINE_CHECK_TIMEOUT } from "../../constants";
 import { addKnownDevice } from "../../actions/ble";


### PR DESCRIPTION
### 📝 Description
Historically errors on the pairing screen were being manually reported to Sentry (since around when Sentry reporting was introduced 4 years ago). However, this pollutes our error monitoring and impacts our Sentry usage quota. Since these are errors for which we have no control over as they can stem from user behaviour (e.g. user denied the pairing on the device), it's better to remove this reporting and use Sentry mainly for uncaught errors and crashes.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: N/A

### ✅ Checklist

- [N/A] **Test coverage** 
- [x] **Atomic delivery** 
- [x] **No breaking changes**

### 📸 Demo
N/A

### 🚀 Expectations to reach
