### PR TITLE
fix(live-common): fix the calculation of spendable balance in Stellar accounts.

### DIFF
--- a/.changeset/olive-dragons-wink.md
+++ b/.changeset/olive-dragons-wink.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix the calculation of spendable balance in Stellar accounts.

--- a/libs/ledger-live-common/src/families/stellar/logic.ts
+++ b/libs/ledger-live-common/src/families/stellar/logic.ts
@@ -92,7 +92,7 @@ export const getReservedBalance = (
     (b) => b.asset_type === "native"
   ) as BalanceAsset;
 
-  const amountInOffers = new BigNumber(nativeAsset?.buying_liabilities || 0);
+  const amountInOffers = new BigNumber(nativeAsset?.selling_liabilities || 0);
   const numOfEntries = new BigNumber(account.subentry_count);
 
   return new BigNumber(BASE_RESERVE_MIN_COUNT)

--- a/libs/ledger-live-common/src/families/stellar/tokens.ts
+++ b/libs/ledger-live-common/src/families/stellar/tokens.ts
@@ -38,7 +38,7 @@ const buildStellarTokenAccount = ({
   );
 
   const reservedBalance = new BigNumber(stellarAsset.balance).minus(
-    stellarAsset.buying_liabilities || 0
+    stellarAsset.selling_liabilities || 0
   );
   const spendableBalance = parseCurrencyUnit(
     token.units[0],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

> Buying liabilities equal the total amount of the asset offered to buy aggregated over all offers owned by an account, and selling liabilities equal the total amount of the asset offered to sell aggregated over all offers owned by an account.

https://developers.stellar.org/docs/fundamentals-and-concepts/stellar-data-structures/accounts#trustlines

We need to subtract the selling liabilities from the balance when calculating the spendable balance, instead of the buying liabilities.


### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1024" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/2368403/c2f7c0a9-e5f7-4a75-8928-8f25b16fdf28">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
