### PR TITLE
fix(live-common): fix the calculation of spendable balance in Stellar accounts.

### DIFF
--- a/.changeset/olive-dragons-wink.md
+++ b/.changeset/olive-dragons-wink.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix the calculation of spendable balance in Stellar accounts.

--- a/libs/ledger-live-common/src/families/stellar/bridge.integration.test.ts
+++ b/libs/ledger-live-common/src/families/stellar/bridge.integration.test.ts
@@ -373,6 +373,54 @@ const dataset: DatasetTest<Transaction> = {
             unitMagnitude: 7,
           },
         },
+        {
+          FIXME_tests: ["balance is sum of ops"],
+          raw: {
+            id: "libcore:1:stellar:GAS5NQ2VU6LA3QPDSCVBH66IHP2RE52VFCLFQKSGRF7VKMZA2KTLGI3M:sep5",
+            seedIdentifier:
+              "25d6c355a7960dc1e390aa13fbc83bf51277552896582a46897f553320d2a6b3",
+            name: "Stellar 4",
+            xpub: "GAS5NQ2VU6LA3QPDSCVBH66IHP2RE52VFCLFQKSGRF7VKMZA2KTLGI3M",
+            derivationMode: "sep5",
+            index: 0,
+            freshAddress:
+              "GAS5NQ2VU6LA3QPDSCVBH66IHP2RE52VFCLFQKSGRF7VKMZA2KTLGI3M",
+            freshAddressPath: "44'/148'/0'",
+            freshAddresses: [
+              {
+                address:
+                  "GAS5NQ2VU6LA3QPDSCVBH66IHP2RE52VFCLFQKSGRF7VKMZA2KTLGI3M",
+                derivationPath: "44'/148'/0'",
+              },
+            ],
+            balance: "0",
+            blockHeight: 0,
+            currencyId: "stellar",
+            lastSyncDate: "",
+            operations: [],
+            pendingOperations: [],
+            unitMagnitude: 7,
+          },
+          transactions: [
+            {
+              name: "check spendable balance (selling_liabilities is not zero)",
+              transaction: (t) => ({
+                ...t,
+                useAllAmount: true,
+                fees: new BigNumber("0"),
+                recipient:
+                  "GAIXIJBMYPTSF2CDVQ35WOTULCLZIE4W2SDEK3RQGAA3A22BPWY7R53Z",
+              }),
+              expectedStatus: {
+                // You can get the spenaable balance here
+                // https://stellar.expert/explorer/public/account/GAS5NQ2VU6LA3QPDSCVBH66IHP2RE52VFCLFQKSGRF7VKMZA2KTLGI3M
+                amount: new BigNumber(12485498),
+                errors: {},
+                warnings: {},
+              },
+            },
+          ],
+        },
       ],
     },
   },

--- a/libs/ledger-live-common/src/families/stellar/logic.ts
+++ b/libs/ledger-live-common/src/families/stellar/logic.ts
@@ -92,7 +92,7 @@ export const getReservedBalance = (
     (b) => b.asset_type === "native"
   ) as BalanceAsset;
 
-  const amountInOffers = new BigNumber(nativeAsset?.buying_liabilities || 0);
+  const amountInOffers = new BigNumber(nativeAsset?.selling_liabilities || 0);
   const numOfEntries = new BigNumber(account.subentry_count);
 
   return new BigNumber(BASE_RESERVE_MIN_COUNT)

--- a/libs/ledger-live-common/src/families/stellar/tokens.ts
+++ b/libs/ledger-live-common/src/families/stellar/tokens.ts
@@ -38,7 +38,7 @@ const buildStellarTokenAccount = ({
   );
 
   const reservedBalance = new BigNumber(stellarAsset.balance).minus(
-    stellarAsset.buying_liabilities || 0
+    stellarAsset.selling_liabilities || 0
   );
   const spendableBalance = parseCurrencyUnit(
     token.units[0],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

> Buying liabilities equal the total amount of the asset offered to buy aggregated over all offers owned by an account, and selling liabilities equal the total amount of the asset offered to sell aggregated over all offers owned by an account.

https://developers.stellar.org/docs/fundamentals-and-concepts/stellar-data-structures/accounts#trustlines

We need to subtract the selling liabilities from the balance when calculating the spendable balance, instead of the buying liabilities.


### ❓ Context

- **Impacted projects**: `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-7352 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1024" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/2368403/c2f7c0a9-e5f7-4a75-8928-8f25b16fdf28">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
