### PR TITLE
fix: correct logic for showing the provider warning ui on LLM

### DIFF
--- a/.changeset/curly-bottles-pump.md
+++ b/.changeset/curly-bottles-pump.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix bad logic for ProviderWarning visibility

--- a/apps/ledger-live-mobile/src/screens/Manager/ProviderWarning.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/ProviderWarning.tsx
@@ -24,7 +24,7 @@ const ProviderWarning = () => {
     });
   }, [navigation]);
 
-  return forcedProvider !== 1 ? (
+  return oddProvider || devMode ? (
     <Flex mt={4}>
       <Alert
         type="warning"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When you have either an odd provider or developer mode enabled on LLM it should be showing the warning while inside My Ledger. In the first implementation which I hastily merged, I was only showing the banner if the provider was not 1. Meaning that in the specific case of the provider being 1, but the developer mode being ON, there would be no warning. This PR addresses that.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7301` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![Group 1](https://github.com/LedgerHQ/ledger-live/assets/4631227/81a3cb3a-3776-4ab3-bc72-c23e73cf2d32)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Testing with any combination of the settings should match the expected screenshots.