### PR TITLE
fix: allow closing device action modals when no blocking action

### DIFF
--- a/.changeset/two-flies-double.md
+++ b/.changeset/two-flies-double.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: allow closing modals if no blocking action is happening LLM

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -588,6 +588,7 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
           : t("send.verification.streaming.inaccurate"),
       colors,
       theme,
+      lockModal: true,
     });
   }
 

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -531,6 +531,7 @@ const AllowOpeningApp = ({
           })}
         </CenteredText>
       ) : null}
+      <ModalLock />
     </Wrapper>
   );
 };
@@ -922,8 +923,10 @@ export function renderConnectYourDevice({
 export function renderLoading({
   t,
   description,
+  lockModal = false,
 }: RawProps & {
   description?: string;
+  lockModal?: boolean;
 }) {
   return (
     <Wrapper>
@@ -931,7 +934,7 @@ export function renderLoading({
         <InfiniteLoader />
       </SpinnerContainer>
       <CenteredText>{description ?? t("DeviceAction.loading")}</CenteredText>
-      <ModalLock />
+      {lockModal ? <ModalLock /> : null}
     </Wrapper>
   );
 }
@@ -1004,7 +1007,7 @@ export function LoadingAppInstall({
     track(...trackingArgs);
   }, [appName, analyticsPropertyFlow]);
 
-  return renderLoading(props);
+  return renderLoading({ ...props, lockModal: true });
 }
 
 type WarningOutdatedProps = RawProps & {

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
@@ -210,7 +210,11 @@ export function Confirmation({
         footer={
           <View style={styles.footerContainer}>
             {signedOperation ? (
-              renderLoading({ t, description: t("transfer.swap.broadcasting") })
+              renderLoading({
+                t,
+                description: t("transfer.swap.broadcasting"),
+                lockModal: true,
+              })
             ) : !swapData ? (
               <DeviceAction
                 key={"initSwap"}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

For the sake of this task, the only thing that we need to check is that upon selecting a device from the device selection screen, during the Loading step or any other step that is not blocking, we should still see the X on the top right and be allowed to dismiss the modal. A regression introduced a few months ago meant that we had to wait until a timeout error in order to close the modal, leading to a sub-par user experience if they chose the wrong device.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7435` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/4631227/2f278717-7f45-4b64-8650-1aed319606dd




### 🚀 Expectations to reach

The easiest way to test this is to follow what the video does, select a device that is not available and see if you can close the modal while it _tries_ to connect to said device. A future task that covers all steps would be useful but for now, most blocking steps are already blocking and this should introduce no changes to them.