### PR TITLE
feat: add network error component and error fallback for webview

### DIFF
--- a/.changeset/eight-colts-double.md
+++ b/.changeset/eight-colts-double.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+add error handling in desktop webview component

--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -126,6 +126,8 @@ export const urls = {
     "https://support.ledger.com/hc/en-us/articles/4404382258961-Install-uninstall-and-update-apps?docs=true&utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=manager_hanging",
   contactSupport:
     "https://support.ledger.com/hc/en-us/requests/new?ticket_form_id=248165?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=support_contact",
+  contactSupportWebview:
+    "https://support.ledger.com/hc/en-us/articles/4423020306705-Contact-Us?support=true",
   whatIsARecoveryPhrase: "https://www.ledger.com/academy/crypto/what-is-a-recovery-phrase",
   feesMoreInfo:
     "https://support.ledger.com/hc/en-us/articles/360021039173-Choose-network-fees?docs=true",

--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -73,6 +73,26 @@ const terms = {
     "https://shop.ledger.com/ko/pages/ledger-live-terms-of-use?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=terms",
 };
 
+const contactSupportWebview = {
+  ar:
+    "https://support.ledger.com/hc/ar/articles/4423020306705-%D8%AA%D9%88%D8%A7%D8%B5%D9%84-%D9%85%D8%B9%D9%86%D8%A7?support=true",
+  de: "https://support.ledger.com/hc/de/articles/4423020306705-Kontakt?support=true",
+  en: "https://support.ledger.com/hc/en-us/articles/4423020306705-Contact-Us?support=true",
+  es: "https://support.ledger.com/hc/es/articles/4423020306705-Contacto?support=true",
+  fr: "https://support.ledger.com/hc/fr-fr/articles/4423020306705-Nous-contacter?support=true",
+  ja:
+    "https://support.ledger.com/hc/ja/articles/4423020306705-%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B?support=true",
+  ko:
+    "https://support.ledger.com/hc/ko/articles/4423020306705-%EA%B3%A0%EA%B0%9D-%EB%AC%B8%EC%9D%98?support=true",
+  pt:
+    "https://support.ledger.com/hc/pt-br/articles/4423020306705-Entre-em-contato-conosco?support=true",
+  ru:
+    "https://support.ledger.com/hc/ru/articles/4423020306705-%D0%A1%D0%B2%D1%8F%D0%B6%D0%B8%D1%82%D0%B5%D1%81%D1%8C-%D1%81-%D0%BD%D0%B0%D0%BC%D0%B8?support=true",
+  tr: "https://support.ledger.com/hc/tr/articles/4423020306705-Bize-Ula%C5%9F%C4%B1n?support=true",
+  zh:
+    "https://support.ledger.com/hc/zh-cn/articles/4423020306705-%E8%81%94%E7%B3%BB%E6%88%91%E4%BB%AC?support=true",
+};
+
 export const urls = {
   ledger: "https://www.ledger.com",
   liveHome:
@@ -126,8 +146,7 @@ export const urls = {
     "https://support.ledger.com/hc/en-us/articles/4404382258961-Install-uninstall-and-update-apps?docs=true&utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=manager_hanging",
   contactSupport:
     "https://support.ledger.com/hc/en-us/requests/new?ticket_form_id=248165?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=support_contact",
-  contactSupportWebview:
-    "https://support.ledger.com/hc/en-us/articles/4423020306705-Contact-Us?support=true",
+  contactSupportWebview,
   whatIsARecoveryPhrase: "https://www.ledger.com/academy/crypto/what-is-a-recovery-phrase",
   feesMoreInfo:
     "https://support.ledger.com/hc/en-us/articles/360021039173-Choose-network-fees?docs=true",

--- a/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.tsx
@@ -41,6 +41,7 @@ type Props = {
   title?: React.ReactNode;
   withoutAppData?: boolean;
   accounts?: Account[];
+  customComponent?: React.FC<() => Promise<void>>;
 } & RestProps;
 const ExportLogsBtnWrapper = (args: Props) => {
   if (args.withoutAppData) {
@@ -59,6 +60,7 @@ const ExportLogsBtn = ({
   small = true,
   title,
   accounts = [],
+  customComponent,
   ...rest
 }: Props) => {
   const { t } = useTranslation();
@@ -113,6 +115,9 @@ const ExportLogsBtn = ({
     [handleExportLogs],
   );
   const text = title || t("settings.exportLogs.btn");
+  if (customComponent) {
+    return customComponent(handleExportLogs);
+  }
   return hookToShortcut ? (
     <KeyHandler keyValue="e" onKeyHandle={onKeyHandle} />
   ) : (

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from "react";
+import { Button, Flex, Icon, Link, Text } from "@ledgerhq/react-ui";
+import { useTranslation } from "react-i18next";
+import ErrorNoBorder from "~/renderer/icons/ErrorNoBorder";
+import { urls } from "~/config/urls";
+import { openURL } from "~/renderer/linking";
+
+export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
+  const { t } = useTranslation();
+
+  const handleContactSupport = useCallback(() => openURL(urls.contactSupportWebview), []);
+
+  return (
+    <Flex alignItems="center" justifyContent="center" flexGrow={1} flexDirection="column">
+      <ErrorNoBorder size={64} />
+      <Text
+        variant="h4Inter"
+        marginTop="16px"
+        fontSize={24}
+        fontWeight="semiBold"
+        fontFamily="Inter"
+      >
+        {t("webview.networkError.title")}
+      </Text>
+      <Text variant="body" color="neutral.c70" marginTop="24px" fontSize={14} fontFamily="Inter">
+        {t("webview.networkError.subtitle")}
+      </Text>
+      <Text variant="body" color="neutral.c70" marginTop="0px" fontSize={14} fontFamily="Inter">
+        {t("webview.networkError.subtitleTwo")}
+      </Text>
+      <Button
+        variant="main"
+        width={143}
+        height={40}
+        marginTop="24px"
+        onClick={refresh}
+        borderRadius="44px"
+      >
+        {t("webview.networkError.tryAgain")}
+      </Button>
+      <Link
+        size="large"
+        Icon={() => <Icon name="ExternalLink" />}
+        marginTop="17px"
+        onClick={handleContactSupport}
+      >
+        <Text fontSize={14} fontWeight="bold" fontFamily="Inter">
+          {t("webview.networkError.contactSupport")}
+        </Text>
+      </Link>
+    </Flex>
+  );
+};

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
@@ -61,7 +61,7 @@ export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
         customComponent={(handleSaveLogPress: () => Promise<void>) => (
           <Link
             size="large"
-            Icon={() => <Icon name="Download" />}
+            Icon={() => <Icon name="Import" />}
             marginTop="17px"
             onClick={handleSaveLogPress}
           >

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
@@ -4,11 +4,22 @@ import { useTranslation } from "react-i18next";
 import ErrorNoBorder from "~/renderer/icons/ErrorNoBorder";
 import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
+import { languageSelector } from "~/renderer/reducers/settings";
+import { useSelector } from "react-redux";
 
 export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
   const { t } = useTranslation();
+  const locale = useSelector(languageSelector) || "en";
 
-  const handleContactSupport = useCallback(() => openURL(urls.contactSupportWebview), []);
+  const handleContactSupport = useCallback(
+    () =>
+      openURL(
+        urls.contactSupportWebview[
+          locale in urls.terms ? (locale as keyof typeof urls.terms) : "en"
+        ],
+      ),
+    [locale],
+  );
 
   return (
     <Flex alignItems="center" justifyContent="center" flexGrow={1} flexDirection="column">

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
@@ -15,7 +15,7 @@ export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
     () =>
       openURL(
         urls.contactSupportWebview[
-          locale in urls.terms ? (locale as keyof typeof urls.terms) : "en"
+          locale in urls.contactSupportWebview ? (locale as keyof typeof urls.contactSupportWebview) : "en"
         ],
       ),
     [locale],

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/NetworkError.tsx
@@ -6,6 +6,7 @@ import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
 import { languageSelector } from "~/renderer/reducers/settings";
 import { useSelector } from "react-redux";
+import ExportLogsButton from "~/renderer/components/ExportLogsButton";
 
 export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
   const { t } = useTranslation();
@@ -15,7 +16,9 @@ export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
     () =>
       openURL(
         urls.contactSupportWebview[
-          locale in urls.contactSupportWebview ? (locale as keyof typeof urls.contactSupportWebview) : "en"
+          locale in urls.contactSupportWebview
+            ? (locale as keyof typeof urls.contactSupportWebview)
+            : "en"
         ],
       ),
     [locale],
@@ -33,11 +36,16 @@ export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
       >
         {t("webview.networkError.title")}
       </Text>
-      <Text variant="body" color="neutral.c70" marginTop="24px" fontSize={14} fontFamily="Inter">
+      <Text
+        variant="body"
+        color="neutral.c70"
+        marginTop="24px"
+        width="343px"
+        fontSize={14}
+        fontFamily="Inter"
+        textAlign="center"
+      >
         {t("webview.networkError.subtitle")}
-      </Text>
-      <Text variant="body" color="neutral.c70" marginTop="0px" fontSize={14} fontFamily="Inter">
-        {t("webview.networkError.subtitleTwo")}
       </Text>
       <Button
         variant="main"
@@ -49,13 +57,28 @@ export const NetworkErrorScreen = ({ refresh }: { refresh: () => void }) => {
       >
         {t("webview.networkError.tryAgain")}
       </Button>
+      <ExportLogsButton
+        customComponent={(handleSaveLogPress: () => Promise<void>) => (
+          <Link
+            size="large"
+            Icon={() => <Icon name="Download" />}
+            marginTop="17px"
+            onClick={handleSaveLogPress}
+          >
+            <Text fontSize={14} fontWeight="semiBold" fontFamily="Inter">
+              {t("webview.networkError.saveLog")}
+            </Text>
+          </Link>
+        )}
+      />
+
       <Link
         size="large"
         Icon={() => <Icon name="ExternalLink" />}
         marginTop="17px"
         onClick={handleContactSupport}
       >
-        <Text fontSize={14} fontWeight="bold" fontFamily="Inter">
+        <Text fontSize={14} fontWeight="semiBold" fontFamily="Inter">
           {t("webview.networkError.contactSupport")}
         </Text>
       </Link>

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -29,6 +29,7 @@ import { Loader } from "./styled";
 import { WebviewAPI, WebviewProps, WebviewTag } from "./types";
 import { useWebviewState } from "./helpers";
 import { getStoreValue, setStoreValue } from "~/renderer/store";
+import { NetworkErrorScreen } from "./NetworkError";
 
 const wallet = { name: "ledger-live-desktop", version: __APP_VERSION__ };
 const tracking = trackingWrapper(track);
@@ -274,8 +275,10 @@ interface Props {
 
 export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   ({ manifest, inputs = {}, onStateChange }, ref) => {
-    const { webviewState, webviewRef, webviewProps } = useWebviewState({ manifest, inputs }, ref);
-
+    const { webviewState, webviewRef, webviewProps, handleRefresh } = useWebviewState(
+      { manifest, inputs },
+      ref,
+    );
     useEffect(() => {
       if (onStateChange) {
         onStateChange(webviewState);
@@ -291,6 +294,9 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     return (
       <>
+        {!webviewState.loading && webviewState.isAppUnavailable && (
+          <NetworkErrorScreen refresh={handleRefresh} />
+        )}
         <webview
           ref={webviewRef}
           /**

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -11,6 +11,7 @@ import { addParamsToURL } from "@ledgerhq/live-common/wallet-api/helpers";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { LiveAppManifest } from "~/../../../libs/ledger-live-common/lib/platform/types";
 import { WebviewAPI, WebviewState, WebviewTag } from "./types";
+import { track } from "~/renderer/analytics/segment";
 
 export const initialWebviewState: WebviewState = {
   url: "",
@@ -183,15 +184,13 @@ export function useWebviewState(
     }));
   }, [webviewRef]);
 
-  const handleFailLoad = useCallback(
+  const handleFailLoad = (useCallback(
     (errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
-      console.error(
-        "Web3AppView handleFailLoad",
-        errorCode,
-        errorDescription,
-        validatedURL,
-        isMainFrame,
-      );
+      const errorInfo = { errorCode, errorDescription, validatedURL, isMainFrame };
+      console.error("Web3AppView handleFailLoad", errorInfo);
+
+      track("useWebviewState", errorInfo);
+
       if (isMainFrame) {
         setState(oldState => ({
           ...oldState,
@@ -201,7 +200,7 @@ export function useWebviewState(
       }
     },
     [],
-  );
+  ) as unknown) as EventListenerOrEventListenerObject;
 
   const handleCrashed = useCallback(() => {
     setState(oldState => ({

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -219,6 +219,7 @@ export function useWebviewState(
       webview.removeEventListener("did-start-loading", handleDidStartLoading);
       webview.removeEventListener("did-stop-loading", handleDidStopLoading);
       webview.removeEventListener("dom-ready", handleDomReady);
+      webview.removeEventListener("did-fail-load", handleFail);
       webview.removeEventListener("crashed", handleFail);
     };
   }, [

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -185,10 +185,19 @@ export function useWebviewState(
   }, [webviewRef]);
 
   const handleFailLoad = (useCallback(
-    (errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
-      const errorInfo = { errorCode, errorDescription, validatedURL, isMainFrame };
-      console.error("Web3AppView handleFailLoad", errorInfo);
-
+    (errorEvent: {
+      errorCode: number;
+      errorDescription: string;
+      validatedURL: string;
+      isMainFrame: boolean;
+    }) => {
+      const { errorCode, validatedURL, isMainFrame } = errorEvent;
+      const fullURL = new URL(validatedURL);
+      const errorInfo = {
+        errorCode,
+        url: fullURL.hostname,
+      };
+      console.error("Web3AppView handleFailLoad", { errorInfo, isMainFrame });
       track("useWebviewState", errorInfo);
 
       if (isMainFrame) {

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/helpers.ts
@@ -183,7 +183,27 @@ export function useWebviewState(
     }));
   }, [webviewRef]);
 
-  const handleFail = useCallback(() => {
+  const handleFailLoad = useCallback(
+    (errorCode: number, errorDescription: string, validatedURL: string, isMainFrame: boolean) => {
+      console.error(
+        "Web3AppView handleFailLoad",
+        errorCode,
+        errorDescription,
+        validatedURL,
+        isMainFrame,
+      );
+      if (isMainFrame) {
+        setState(oldState => ({
+          ...oldState,
+          loading: false,
+          isAppUnavailable: true,
+        }));
+      }
+    },
+    [],
+  );
+
+  const handleCrashed = useCallback(() => {
     setState(oldState => ({
       ...oldState,
       loading: false,
@@ -209,8 +229,8 @@ export function useWebviewState(
     webview.addEventListener("did-start-loading", handleDidStartLoading);
     webview.addEventListener("did-stop-loading", handleDidStopLoading);
     webview.addEventListener("dom-ready", handleDomReady);
-    webview.addEventListener("did-fail-load", handleFail);
-    webview.addEventListener("crashed", handleFail);
+    webview.addEventListener("did-fail-load", handleFailLoad);
+    webview.addEventListener("crashed", handleCrashed);
 
     return () => {
       webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
@@ -219,8 +239,8 @@ export function useWebviewState(
       webview.removeEventListener("did-start-loading", handleDidStartLoading);
       webview.removeEventListener("did-stop-loading", handleDidStopLoading);
       webview.removeEventListener("dom-ready", handleDomReady);
-      webview.removeEventListener("did-fail-load", handleFail);
-      webview.removeEventListener("crashed", handleFail);
+      webview.removeEventListener("did-fail-load", handleFailLoad);
+      webview.removeEventListener("crashed", handleCrashed);
     };
   }, [
     handleDidNavigate,
@@ -229,7 +249,8 @@ export function useWebviewState(
     handleDidStopLoading,
     handlePageTitleUpdated,
     handleDomReady,
-    handleFail,
+    handleFailLoad,
+    handleCrashed,
     webviewRef,
     isMounted,
   ]);

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/types.ts
@@ -15,6 +15,7 @@ export type WebviewState = {
   canGoForward: boolean;
   title: string;
   loading: boolean;
+  isAppUnavailable: boolean;
 };
 
 export type WebviewAPI = {

--- a/apps/ledger-live-desktop/src/renderer/icons/ErrorNoBorder.tsx
+++ b/apps/ledger-live-desktop/src/renderer/icons/ErrorNoBorder.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const ErrorNoBorder = ({ size }: { size: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 64 64"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect width="64" height="64" rx="32" fill="white" fillOpacity="0.05" />
+    <path
+      d="M43.104 41.12L33.984 32L43.104 22.88L41.056 20.96L32 30.016L22.944 20.96L20.896 22.88L30.016 32L20.896 41.12L22.944 43.04L32 33.984L41.056 43.04L43.104 41.12Z"
+      fill="#E86164"
+    />
+  </svg>
+);
+export default ErrorNoBorder;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5852,10 +5852,10 @@
   "webview": {
     "networkError": {
       "title": "Network Error",
-      "subtitle": "Check your internet connection and try again.",
-      "subtitleTwo": "Contact Ledger Support if the problem continues.",
+      "subtitle": "Something went wrong. Please try again. If the problem persists, save your log and contact Ledger support.",
       "tryAgain": "Try again",
-      "contactSupport": "Contact Ledger support" 
+      "contactSupport": "Contact Ledger support",
+      "saveLog": "Save log"
     }
   }
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5848,5 +5848,14 @@
     "description": "Your Secret Recovery Phrase won't always be within reach.\nSoft launch exclusively for Ledger Nano X. Subscribe for free until June 30th 2023",
     "cta": "Why should I subscribe?",
     "downloadLLM": "Subscribe to <purple>Ledger Recover</purple> using the Ledger Live mobile app"
+  },
+  "webview": {
+    "networkError": {
+      "title": "Network Error",
+      "subtitle": "Check your internet connection and try again.",
+      "subtitleTwo": "Contact Ledger Support if the problem continues.",
+      "tryAgain": "Try again",
+      "contactSupport": "Contact Ledger support" 
+    }
   }
 }


### PR DESCRIPTION
### 📝 Description

Adds an error handler and error screen for webview when the external web application fails to load properly.  When try again is pressed it imperatively refreshes the webview via its ref.

### ❓ Context

- **Impacted projects**: `PTX`
- **Linked resource(s)**: `LIVE-7063` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1428" alt="Screenshot 2023-05-16 at 16 36 48" src="https://github.com/LedgerHQ/ledger-live/assets/105203468/48d949af-9660-4442-93de-bb58a434986c">

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
