### PR TITLE
chore: fix ledger cli README instructions

### DIFF
--- a/apps/ledger-live-mobile/README.md
+++ b/apps/ledger-live-mobile/README.md
@@ -139,9 +139,9 @@ React Native integration seems pretty bleeding edge right now, so don't expect e
 
 It is possible to run Ledger Live Mobile on an emulator and connect to a Nano that is plugged in via USB.
 
-- Install the [ledger-live cli](https://github.com/LedgerHQ/ledger-live/wiki/LLC:cli).
+- Install the [ledger-live cli](https://developers.ledger.com/docs/coin/ledger-live-cli/).
 - Plug in your Nano to your computer.
-- Run `ledger-live proxy`. A server starts and displays variable environments that can be used to build Ledger-Live Mobile. For example:
+- Run `ledger-live proxy` or `pnpm run:cli proxy`. A server starts and displays variable environments that can be used to build Ledger-Live Mobile. For example:
   ```
   DEVICE_PROXY_URL=ws://localhost:8435
   DEVICE_PROXY_URL=ws://192.168.1.14:8435


### PR DESCRIPTION

### 📝 Description

The current link to docs for ledger cli do not work. 
- Replace broken url with https://developers.ledger.com/docs/coin/ledger-live-cli/ 
- replace suggested cli command with `pnpm run:cli proxy`, which does work

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- internal developers
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->
- N/A

### ✅ Checklist


- [x] **Test coverage**  N/A
- [x] **Atomic delivery** Independent
- [x] **No breaking changes** just README affected

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
