### PR TITLE
fix(lld/EditDeviceName): remove superfluous footer

### DIFF
--- a/.changeset/purple-peaches-tell.md
+++ b/.changeset/purple-peaches-tell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix duplicate footer in "rename device" drawer

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/EditDeviceName.tsx
@@ -172,20 +172,6 @@ const EditDeviceName: React.FC<Props> = ({
             </Box>
           </Flex>
         )}
-        {(!running || completed) && (
-          <Flex flexDirection="column" rowGap={8}>
-            <Divider />
-            <Flex alignSelf="end" px={12} pb={8}>
-              <Button
-                variant="main"
-                onClick={completed ? onCloseDrawer : onSubmit}
-                disabled={!!disableButton}
-              >
-                {completed ? t(`common.close`) : t(`common.continue`)}
-              </Button>
-            </Flex>
-          </Flex>
-        )}
       </Flex>
       {!running || (running && actionError) || completed ? (
         <Flex flexDirection="column" alignSelf="stretch">


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Just removing a duplicate footer in the rename device drawer on LLD (which was the result of a mistake in a conflict resolution I guess?)

### ❓ Context

- **Impacted projects**: `lld` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7138] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1136" alt="Screenshot 2023-05-19 at 16 24 19" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/b8e78bc0-2c85-4ab4-b12a-e937bb5916e8">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7138]: https://ledgerhq.atlassian.net/browse/LIVE-7138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ