### PR TITLE
fix: bad rendering of hash verification on old fw update step

### DIFF
--- a/.changeset/clever-dolls-lie.md
+++ b/.changeset/clever-dolls-lie.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix bad rendering for old firmware update hash veritification

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/01-step-prepare.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/01-step-prepare.tsx
@@ -25,6 +25,7 @@ import { EMPTY, concat } from "rxjs";
 import { map, tap } from "rxjs/operators";
 import { DeviceBlocker } from "~/renderer/components/DeviceAction/DeviceBlocker";
 import { StepProps } from "..";
+import manager from "@ledgerhq/live-common/manager/index";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -42,7 +43,10 @@ const HighlightVersion = styled(Text).attrs(() => ({
   py: 1,
   mx: 3,
 }))`
+  display: inline-block;
+  word-break: break-word;
   border-radius: 4px;
+  text-align: center;
 `;
 
 const Body = ({
@@ -69,7 +73,6 @@ const Body = ({
   const from = deviceInfo.version;
   const to = firmware?.final.name;
   const normalProgress = (progress || 0) * 100;
-  const maybeHash = firmware?.osu?.hash;
 
   if (!displayedOnDevice) {
     return (
@@ -111,18 +114,22 @@ const Body = ({
             <Animation animation={getDeviceAnimation(deviceModelId, type, "verify")} />
           </Box>
         )}
-
-        <Flex flexDirection="row" alignItems="center" my={2}>
-          {hasHash ? (
-            <HighlightVersion>{maybeHash}</HighlightVersion>
-          ) : (
+        {hasHash ? (
+          <HighlightVersion>
+            {firmware.osu &&
+              manager
+                .formatHashName(firmware.osu.hash, deviceModelId, deviceInfo)
+                .map((hash, i) => <span key={`${i}-${hash}`}>{hash}</span>)}
+          </HighlightVersion>
+        ) : (
+          <Flex flexDirection="row" alignItems="center" my={2}>
             <>
               <HighlightVersion>{`V ${from}`}</HighlightVersion>
               <Icons.ArrowRightMedium size={14} />
               <HighlightVersion>{`V ${to}`}</HighlightVersion>
             </>
-          )}
-        </Flex>
+          </Flex>
+        )}
 
         <Text ff="Inter|Regular" textAlign="center" color="palette.text.shade100">
           {t("manager.modal.confirmIdentifierText", { productName: deviceModel.productName })}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix overflow of the fw update verification hash for old firmware update flows.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7523` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://github.com/LedgerHQ/ledger-live/assets/4631227/b947ab3e-32c8-40a7-a0a6-c8eda827fa3e)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Follow a firmware update of an old path (1.4.2 on lns for instance) check that the identifier doesn't overflow. Depending on the version there may be some ellipsis, some multi-line, etc. It should match what the device shows in any case.