### PR TITLE
feat: add network error screen

### DIFF
--- a/.changeset/fluffy-rockets-reply.md
+++ b/.changeset/fluffy-rockets-reply.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add network error view to WebPTXPlayer

--- a/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
+++ b/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
@@ -23,11 +23,12 @@ type Props = {
   Icon?: IconType;
   iconColor?: string;
   children?: React.ReactNode;
+  footerComponent?: React.ReactNode;
+  exportLogIcon?: typeof Icons.DownloadMedium | typeof Icons.ImportMedium;
+  exportLogIconPosition?: "left" | "right";
 };
 
-const StyledLink = styled(Link).attrs({
-  iconPosition: "left",
-})`
+const StyledLink = styled(Link)`
   margin-top: 32px;
   margin-bottom: 10px;
 `;
@@ -42,6 +43,9 @@ const GenericErrorView = ({
   children,
   Icon = CloseMedium,
   iconColor = "error.c60",
+  footerComponent,
+  exportLogIcon = Icons.DownloadMedium,
+  exportLogIconPosition = "left",
 }: Props) => {
   const { t } = useTranslation();
 
@@ -102,10 +106,15 @@ const GenericErrorView = ({
       ) : null}
       {children}
       {hasExportLogButton ? (
-        <StyledLink Icon={Icons.DownloadMedium} onPress={onExport}>
+        <StyledLink
+          Icon={exportLogIcon}
+          onPress={onExport}
+          iconPosition={exportLogIconPosition}
+        >
           {t("common.saveLogs")}
         </StyledLink>
       ) : null}
+      {footerComponent}
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Linking } from "react-native";
+import { createCustomErrorClass } from "@ledgerhq/errors";
+import { Trans } from "react-i18next";
+import GenericErrorView from "../GenericErrorView";
+import Button from "../Button";
+import ExternalLink from "../ExternalLink";
+
+const WebPTXPlayerNetworkFail = createCustomErrorClass(
+  "WebPTXPlayerNetworkFail",
+);
+
+export const NetworkError = ({
+  handleTryAgain,
+}: {
+  handleTryAgain: () => void;
+}) => (
+  <GenericErrorView error={new WebPTXPlayerNetworkFail()}>
+    <Button
+      mx={6}
+      my={6}
+      type="main"
+      outline={false}
+      event="button_clicked"
+      eventProperties={{
+        button: "Contact Ledger Support",
+      }}
+      onPress={handleTryAgain}
+      size="large"
+    >
+      <Trans i18nKey="errors.WebPTXPlayerNetworkFail.primaryCTA" />{" "}
+    </Button>
+    <ExternalLink
+      onPress={() => Linking.openURL("")}
+      text={<Trans i18nKey="errors.WebPTXPlayerNetworkFail.contactSupport" />}
+      type="main"
+    />
+  </GenericErrorView>
+);

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
@@ -2,38 +2,72 @@ import React from "react";
 import { Linking } from "react-native";
 import { createCustomErrorClass } from "@ledgerhq/errors";
 import { Trans } from "react-i18next";
+import styled from "styled-components/native";
+import { Flex, Icons } from "@ledgerhq/native-ui";
 import GenericErrorView from "../GenericErrorView";
 import Button from "../Button";
 import ExternalLink from "../ExternalLink";
+import { useLocale } from "../../context/Locale";
+import { urls } from "../../config/urls";
 
 const WebPTXPlayerNetworkFail = createCustomErrorClass(
   "WebPTXPlayerNetworkFail",
 );
 
+const ExternalLinkWrapper = styled.View`
+  margin-top: 19px;
+`;
+
 export const NetworkError = ({
   handleTryAgain,
 }: {
   handleTryAgain: () => void;
-}) => (
-  <GenericErrorView error={new WebPTXPlayerNetworkFail()}>
-    <Button
-      mx={6}
-      my={6}
-      type="main"
-      outline={false}
-      event="button_clicked"
-      eventProperties={{
-        button: "Contact Ledger Support",
-      }}
-      onPress={handleTryAgain}
-      size="large"
-    >
-      <Trans i18nKey="errors.WebPTXPlayerNetworkFail.primaryCTA" />{" "}
-    </Button>
-    <ExternalLink
-      onPress={() => Linking.openURL("")}
-      text={<Trans i18nKey="errors.WebPTXPlayerNetworkFail.contactSupport" />}
-      type="main"
-    />
-  </GenericErrorView>
-);
+}) => {
+  const { locale } = useLocale();
+
+  return (
+    <Flex flex={1} justifyContent="center">
+      <GenericErrorView
+        exportLogIcon={Icons.ImportMedium}
+        exportLogIconPosition="right"
+        error={new WebPTXPlayerNetworkFail()}
+        footerComponent={
+          <ExternalLinkWrapper>
+            <ExternalLink
+              onPress={() =>
+                Linking.openURL(
+                  urls.contactSupportWebview[
+                    locale as keyof typeof urls.contactSupportWebview
+                  ] ?? urls.contactSupportWebview.en,
+                )
+              }
+              text={
+                <Trans i18nKey="errors.WebPTXPlayerNetworkFail.contactSupport" />
+              }
+              type="main"
+            />
+          </ExternalLinkWrapper>
+        }
+      >
+        <Button
+          paddingX={40}
+          marginTop={24}
+          type="main"
+          outline={false}
+          event="button_clicked"
+          eventProperties={{
+            button: "Contact Ledger Support",
+          }}
+          onPress={handleTryAgain}
+          minWidth="143px"
+          height="40px"
+        >
+          <Trans
+            marginWidth={40}
+            i18nKey="errors.WebPTXPlayerNetworkFail.primaryCTA"
+          />
+        </Button>
+      </GenericErrorView>
+    </Flex>
+  );
+};

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -6,7 +6,6 @@ import React, {
   RefObject,
   forwardRef,
 } from "react";
-
 import { useSelector } from "react-redux";
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import VersionNumber from "react-native-version-number";
@@ -36,6 +35,7 @@ import getOrCreateUser from "../../user";
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebviewState } from "./helpers";
 import deviceStorage from "../../logic/storeWrapper";
+import { NetworkError } from "./NetworkError";
 
 const wallet = {
   name: "ledger-live-mobile",
@@ -365,6 +365,9 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         automaticallyAdjustContentInsets={false}
         scrollEnabled={true}
         style={styles.webview}
+        renderError={() => (
+          <NetworkError handleTryAgain={() => webviewRef.current?.reload()} />
+        )}
         {...webviewProps}
       />
     );

--- a/apps/ledger-live-mobile/src/config/urls.tsx
+++ b/apps/ledger-live-mobile/src/config/urls.tsx
@@ -26,6 +26,19 @@ export const urls = {
     ko: "https://www.ledger.com/ko/privacy-policy?utm_content=privacy&utm_medium=self_referral&utm_source=ledger_live_mobile",
     ru: "https://www.ledger.com/ru/privacy-policy?utm_content=privacy&utm_medium=self_referral&utm_source=ledger_live_mobile",
   },
+  contactSupportWebview: {
+    ar: "https://support.ledger.com/hc/ar/articles/4423020306705-%D8%AA%D9%88%D8%A7%D8%B5%D9%84-%D9%85%D8%B9%D9%86%D8%A7?support=true",
+    de: "https://support.ledger.com/hc/de/articles/4423020306705-Kontakt?support=true",
+    en: "https://support.ledger.com/hc/en-us/articles/4423020306705-Contact-Us?support=true",
+    es: "https://support.ledger.com/hc/es/articles/4423020306705-Contacto?support=true",
+    fr: "https://support.ledger.com/hc/fr-fr/articles/4423020306705-Nous-contacter?support=true",
+    ja: "https://support.ledger.com/hc/ja/articles/4423020306705-%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B?support=true",
+    ko: "https://support.ledger.com/hc/ko/articles/4423020306705-%EA%B3%A0%EA%B0%9D-%EB%AC%B8%EC%9D%98?support=true",
+    pt: "https://support.ledger.com/hc/pt-br/articles/4423020306705-Entre-em-contato-conosco?support=true",
+    ru: "https://support.ledger.com/hc/ru/articles/4423020306705-%D0%A1%D0%B2%D1%8F%D0%B6%D0%B8%D1%82%D0%B5%D1%81%D1%8C-%D1%81-%D0%BD%D0%B0%D0%BC%D0%B8?support=true",
+    tr: "https://support.ledger.com/hc/tr/articles/4423020306705-Bize-Ula%C5%9F%C4%B1n?support=true",
+    zh: "https://support.ledger.com/hc/zh-cn/articles/4423020306705-%E8%81%94%E7%B3%BB%E6%88%91%E4%BB%AC?support=true",
+  },
   pairingIssues:
     "https://support.ledger.com/hc/en-us/articles/360025864773-Fix-Bluetooth-pairing-issues?support=true",
   ratingsContact:

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -587,6 +587,12 @@
       "title": "Something went wrong",
       "description": "Please check that your hardware wallet is set up with the recovery phrase or passphrase associated to the selected account."
     },
+    "WebPTXPlayerNetworkFail": {
+      "title": "Network error",
+      "description": "Check your internet connection and try again. Contact Ledger Support if the problem continues.",
+      "contactSupport": "Contact Ledger support",
+      "primaryCTA": "Try again"
+    },
     "UnexpectedBootloader": {
       "title": "Sorry, your device must not be in Bootloader mode",
       "description": "Please restart your device without touching the buttons when the logo appears. Please try again. If the problem persists, please save your logs using the button below and provide them to Ledger Support."


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds a network error view to WebPTXPlayer on it's `renderError` prop that allows for a refresh if there are issues caused by network failure. 

### ❓ Context

- **Impacted projects**: `Ledger live mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7065` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="309" alt="Screenshot 2023-05-23 at 16 11 39" src="https://github.com/LedgerHQ/ledger-live/assets/105203468/ed0727c4-9037-4974-9302-39b3999dfff0">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
