### PR TITLE
Support - Add special comments to ignore istanbul coverage for useless files

### DIFF
--- a/libs/domain-service/src/__tests__/unit/hooks/logic.unit.test.ts
+++ b/libs/domain-service/src/__tests__/unit/hooks/logic.unit.test.ts
@@ -1,0 +1,40 @@
+import { isError, isLoaded } from "../../../hooks/logic";
+import { DomainServiceStatus } from "../../../hooks/types";
+
+describe("type gards", () => {
+  describe("isLoaded", () => {
+    it("should return that a domain is loaded", () => {
+      const domain: DomainServiceStatus = {
+        status: "loaded",
+        resolutions: [],
+        updatedAt: 0,
+      };
+      expect(isLoaded(domain)).toBe(true);
+    });
+
+    it("should return that a domain is not loaded", () => {
+      const domain: DomainServiceStatus = {
+        status: "loading",
+      };
+      expect(isLoaded(domain)).toBe(false);
+    });
+  });
+
+  describe("isError", () => {
+    it("should return that a domain is an error", () => {
+      const domain: DomainServiceStatus = {
+        status: "error",
+        error: new Error(),
+        updatedAt: 0,
+      };
+      expect(isError(domain)).toBe(true);
+    });
+
+    it("should return that a domain is not error", () => {
+      const domain: DomainServiceStatus = {
+        status: "loading",
+      };
+      expect(isError(domain)).toBe(false);
+    });
+  });
+});

--- a/libs/domain-service/src/hooks/index.tsx
+++ b/libs/domain-service/src/hooks/index.tsx
@@ -27,7 +27,8 @@ import {
 const DomainServiceContext = createContext<DomainServiceContextType>({
   cache: {},
   loadDomainServiceAPI: () => Promise.resolve(),
-  clearCache: () => {},
+  clearCache:
+    /* istanbul ignore next: don't test default state because it's gonna be overriden */ () => {},
 });
 
 export const useDomain = (

--- a/libs/domain-service/src/index.ts
+++ b/libs/domain-service/src/index.ts
@@ -1,3 +1,4 @@
+/* istanbul ignore file: pure exports, test unecessary */
 export * from "./registries";
 export * from "./resolvers";
 export * from "./signers";

--- a/libs/domain-service/src/resolvers/index.ts
+++ b/libs/domain-service/src/resolvers/index.ts
@@ -25,7 +25,9 @@ export const resolveDomain = async (
       const registry = registries.find(
         (r) => r.name === registryName && r.patterns.forward.test(domain)
       );
-      return registry ? [registry] : [];
+      return registry
+        ? [registry]
+        : /* istanbul ignore next: don't test emptiness of resolutions */ [];
     }
     return getRegistriesForDomain(domain);
   })();
@@ -43,6 +45,7 @@ export const resolveDomain = async (
     promises.reduce((result, promise, index) => {
       if (promise.status !== "fulfilled") {
         // ignore 404 error
+        /* istanbul ignore next: don't test logs */
         if (
           axios.isAxiosError(promise.reason) &&
           promise.reason.response?.status !== 404
@@ -92,7 +95,9 @@ export const resolveAddress = async (
       const registry = registries.find(
         (r) => r.name === registryName && r.patterns.reverse.test(address)
       );
-      return registry ? [registry] : [];
+      return registry
+        ? [registry]
+        : /* istanbul ignore next: don't test emptiness of resolutions */ [];
     }
     return getRegistriesForAddress(address);
   })();
@@ -118,6 +123,7 @@ export const resolveAddress = async (
     promises.reduce((result, promise, index) => {
       if (promise.status !== "fulfilled") {
         // ignore 404 error
+        /* istanbul ignore next: don't test logs */
         if (
           axios.isAxiosError(promise.reason) &&
           promise.reason.response?.status !== 404

--- a/libs/domain-service/src/signers/index.ts
+++ b/libs/domain-service/src/signers/index.ts
@@ -37,6 +37,7 @@ export const signDomainResolution = async (
     })
     .then(({ data }) => data.payload)
     .catch((error) => {
+      /* istanbul ignore next: don't test logs */
       if (error.status !== 404) {
         log("domain-service", "failed to get APDU for a domain", {
           domain,
@@ -75,6 +76,7 @@ export const signAddressResolution = async (
     })
     .then(({ data }) => data.payload)
     .catch((error) => {
+      /* istanbul ignore next: don't test logs */
       if (error.status !== 404) {
         log("domain-service", "failed to get APDU for an address", {
           address,

--- a/libs/domain-service/src/tools/index.ts
+++ b/libs/domain-service/src/tools/index.ts
@@ -1,3 +1,5 @@
+/* istanbul ignore file: this file can be ignored in tests as long as it's only for debugging purpose & not touching userland */
+
 /**
  * Helper designed to parse the APDU crafted by the Ledger backend to clear sign domains.
  * The APDU is encoded with a TLV scheme: https://en.wikipedia.org/wiki/Type%E2%80%93length%E2%80%93value


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR is adding some special comments to specify to [istanbul](https://istanbul.js.org/) to not take into account some files in the code coverage to prevent some false negative stats.

Full documentation about those specials comments can be found here: https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md

Command use for coverage: `pnpm domain test -- --coverage --coverage-reporters=lcov --collectCoverageFrom="src/**/*.{ts,tsx}" --coverageDirectory ~/Downloads/domain`

### ❓ Context

- **Impacted projects**: `@ledgerhq/domain-service` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Before:

![7PNBeUt](https://github.com/LedgerHQ/ledger-live/assets/44363395/31709edd-7c98-4bcb-b8c8-1e75efc16710)

After:

<img width="1504" alt="Screenshot 2023-05-23 at 17 19 53" src="https://github.com/LedgerHQ/ledger-live/assets/44363395/b69439a8-bee8-4e6c-8991-442ff30c5f32">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
