### PR TITLE
feat: LIVE-7480 smaller lottie option for transctional confirmation

### DIFF
--- a/.changeset/clean-tools-wave.md
+++ b/.changeset/clean-tools-wave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Added small lottie version option for transactional confirmations

--- a/apps/ledger-live-desktop/src/renderer/animations/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/animations/index.tsx
@@ -12,6 +12,7 @@ const Animation = ({
   },
   isPaused = false,
   isStopped = false,
+  small = false,
 }: {
   animation: any;
   width?: string;
@@ -21,12 +22,16 @@ const Animation = ({
   rendererSettings?: LottieProps["options"]["rendererSettings"];
   isPaused?: boolean;
   isStopped?: boolean;
+  small?: boolean;
 }) =>
   animation ? (
     <Flex
       style={{
-        maxHeight: `200px`,
+        maxHeight: small ? "120px" : "200px",
         maxWidth: `500px`,
+        marginTop: small ? 20 : undefined,
+        paddingLeft: 20,
+        paddingRight: 20,
       }}
     >
       <Lottie

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -215,7 +215,7 @@ export const renderVerifyUnwrapped = ({
 }) => (
   <AnimationWrapper>
     <DeviceBlocker />
-    <Animation animation={getDeviceAnimation(modelId, type, "verify")} />
+    <Animation small animation={getDeviceAnimation(modelId, type, "verify")} />
   </AnimationWrapper>
 );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Lotties for stax on transactional confirmations just didn't fit. This is a rough proposal to mitigate it.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7480` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://github.com/LedgerHQ/ledger-live/assets/4631227/f9d13148-6a08-4e79-ad70-de5c361289d0)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
The original ticket or figma implies that these flows are showing the Nano X lottie but my testing shows that it's showing the right device (stax). What I did is offer a smaller version for transactional confirmationals (receive, send, delegate, stake, swap, sell, you name it) in order to try to make them fit. It's probably not addressing all cases but it should be less terrible than the big size.

Size can be tweaked, feel free to do so.