### PR TITLE
test: NFT gallery hide and empty state Detox tests

### DIFF
--- a/.changeset/eight-garlics-reflect.md
+++ b/.changeset/eight-garlics-reflect.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LIVE-4142 added empty state and hide NFT Detox tests

--- a/apps/ledger-live-mobile/e2e/models/nft/nftViewerPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/nft/nftViewerPage.ts
@@ -1,7 +1,7 @@
 import { getElementById, tapByElement } from "../../helpers";
 
 export default class NftViewerPage {
-  mainScrollView = () => getElementById(`nft-viewer-page-scrollview`);
+  mainScrollView = () => getElementById("nft-viewer-page-scrollview");
   backButton = () => getElementById("navigation-header-back-button");
 
   async navigateToNftGallery() {

--- a/apps/ledger-live-mobile/e2e/models/wallet/nftGalleryPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/wallet/nftGalleryPage.ts
@@ -1,20 +1,34 @@
-import { getElementById, tapByElement, getElementByText } from "../../helpers";
+import { getElementById, openDeeplink, tapByElement } from "../../helpers";
+import { expect } from "detox";
+
+const baseLink = "nftgallery";
 
 export default class NftGalleryPage {
+  root = () => getElementById("wallet-nft-gallery-screen");
+  emptyScreen = () => getElementById("wallet-nft-gallery-empty");
   nftListComponent = () => getElementById(`wallet-nft-gallery-list`);
-  nftListItems = () => getElementById(`wallet-nft-gallery-list-item`);
   nftAddNewListItem = () =>
-    getElementById(`wallet-nft-gallery-add-new-list-item`);
+    getElementById("wallet-nft-gallery-add-new-list-item");
+  receiveNftButton = () =>
+    getElementById("wallet-nft-gallery-receive-nft-button");
   nftReceiveModalContinueButton = () =>
-    getElementById(`wallet-nft-gallery-receive-modal-continue-button`);
-  nftReceiveModal = () => getElementById(`wallet-nft-gallery-receive-modal`);
+    getElementById("wallet-nft-gallery-receive-modal-continue-button");
+  nftReceiveModal = () => getElementById("wallet-nft-gallery-receive-modal");
+  selectAndHide = () => getElementById("wallet-nft-gallery-select-and-hide");
+  confirmHide = () => getElementById("wallet-nft-gallery-confirm-hide");
+  nftListItem = (index: number) =>
+    getElementById(`wallet-nft-gallery-list-item-${index}`);
 
-  async navigateToNftViewer() {
-    await tapByElement(this.nftListItems());
+  async openViaDeeplink() {
+    await openDeeplink(baseLink);
   }
 
-  async openRecevieNFTsModal() {
-    await tapByElement(this.nftAddNewListItem());
+  async hideNft(index: number) {
+    await expect(this.nftListItem(index)).toBeVisible();
+    await tapByElement(this.selectAndHide());
+    await tapByElement(this.nftListItem(index));
+    await tapByElement(this.confirmHide());
+    await expect(this.nftListItem(index)).not.toBeVisible();
   }
 
   async continueFromReceiveNFTsModal() {

--- a/apps/ledger-live-mobile/e2e/models/wallet/walletTabNavigator.ts
+++ b/apps/ledger-live-mobile/e2e/models/wallet/walletTabNavigator.ts
@@ -4,8 +4,13 @@ import { ScreenName } from "../../../src/const";
 export default class WalletTabNavigatorPage {
   nftGalleryTab = () =>
     getElementById(`wallet-tab-${ScreenName.WalletNftGallery}`);
+  portfolioTab = () => getElementById(`wallet-tab-${ScreenName.Portfolio}`);
 
   async navigateToNftGallery() {
     await tapByElement(this.nftGalleryTab());
+  }
+
+  async navigateToPortfolio() {
+    await tapByElement(this.portfolioTab());
   }
 }

--- a/apps/ledger-live-mobile/e2e/specs/nftGallery.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/nftGallery.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from "detox";
 import PortfolioPage from "../models/wallet/portfolioPage";
-import { loadConfig } from "../bridge/server";
+
 import WalletTabNavigatorPage from "../models/wallet/walletTabNavigator";
 import NftViewerPage from "../models/nft/nftViewerPage";
 import NftGalleryPage from "../models/wallet/nftGalleryPage";
 import ManagerPage from "../models/manager/managerPage";
-import { tapByText } from "../helpers";
+import { tapByElement, tapByText } from "../helpers";
 import ReceivePage from "../models/trade/receivePage";
+import { loadConfig } from "../bridge/server";
 
 let portfolioPage: PortfolioPage;
 let walletTabNavigatorPage: WalletTabNavigatorPage;
@@ -15,40 +16,43 @@ let nftViewerPage: NftViewerPage;
 let managerPage: ManagerPage;
 let receivePage: ReceivePage;
 
-beforeAll(async () => {
-  portfolioPage = new PortfolioPage();
-  walletTabNavigatorPage = new WalletTabNavigatorPage();
-  nftGalleryPage = new NftGalleryPage();
-  nftViewerPage = new NftViewerPage();
-  managerPage = new ManagerPage();
-  receivePage = new ReceivePage();
-});
-
 describe("NFT Gallery screen", () => {
   beforeAll(async () => {
-    await loadConfig("1Account1NFT", true);
+    portfolioPage = new PortfolioPage();
+    walletTabNavigatorPage = new WalletTabNavigatorPage();
+    nftGalleryPage = new NftGalleryPage();
+    nftViewerPage = new NftViewerPage();
+    managerPage = new ManagerPage();
+    receivePage = new ReceivePage();
+    await loadConfig("1Account1NFT");
     await portfolioPage.waitForPortfolioPageToLoad();
     await managerPage.openViaDeeplink();
     await managerPage.expectManagerPage();
     await managerPage.addDevice("Nano X de David");
-    await portfolioPage.openViaDeeplink();
-  });
-
-  it("should open on Portofolio page", async () => {
-    await portfolioPage.waitForPortfolioPageToLoad();
+    await nftGalleryPage.openViaDeeplink();
   });
 
   it("should see NFT tab", async () => {
     await expect(walletTabNavigatorPage.nftGalleryTab()).toBeVisible();
   });
 
-  it("should navigate to NFT gallery on NFT tab press", async () => {
+  it("should navigate to portfolio page on tab press", async () => {
+    await walletTabNavigatorPage.navigateToPortfolio();
+    await expect(nftGalleryPage.root()).not.toBeVisible();
+  });
+
+  it("should navigate back to NFT gallery on tab press", async () => {
     await walletTabNavigatorPage.navigateToNftGallery();
+    await expect(nftGalleryPage.root()).toBeVisible();
+  });
+
+  it("should have a list of NFTs", async () => {
     await expect(nftGalleryPage.nftListComponent()).toBeVisible();
+    await expect(nftGalleryPage.nftListItem(0)).toBeVisible();
   });
 
   it("should navigate to NFT viewer page on NFT gallery item press", async () => {
-    await nftGalleryPage.navigateToNftViewer();
+    await tapByElement(nftGalleryPage.nftListItem(0));
     await expect(nftViewerPage.mainScrollView()).toBeVisible();
   });
 
@@ -58,9 +62,9 @@ describe("NFT Gallery screen", () => {
     await expect(nftGalleryPage.nftListComponent()).toBeVisible();
   });
 
-  it('should show receive NFT\'s modal when "Adding new item"', async () => {
+  it('should show receive NFT\'s modal when "Adding new item" from list', async () => {
     await expect(nftGalleryPage.nftReceiveModal()).not.toBeVisible();
-    await nftGalleryPage.openRecevieNFTsModal();
+    await tapByElement(nftGalleryPage.nftAddNewListItem());
     await expect(nftGalleryPage.nftReceiveModal()).toBeVisible();
   });
 
@@ -73,5 +77,20 @@ describe("NFT Gallery screen", () => {
     // NOTE: Use .toExist because the modal overlay with an opacity
     // means we cannot use .toBeVisible
     await expect(receivePage.getStep3HeaderTitle()).toExist();
+  });
+
+  it("should let users hide NFT's", async () => {
+    await nftGalleryPage.openViaDeeplink();
+    await nftGalleryPage.hideNft(0);
+  });
+
+  it("should render empty state", async () => {
+    await expect(nftGalleryPage.emptyScreen()).toBeVisible();
+  });
+
+  it('should show modal on "Receive NFT\'s" button tap', async () => {
+    await expect(nftGalleryPage.nftReceiveModal()).not.toBeVisible();
+    await tapByElement(nftGalleryPage.receiveNftButton());
+    await expect(nftGalleryPage.nftReceiveModal()).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/components/Nft/NftGallery/NftList.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftGallery/NftList.tsx
@@ -86,7 +86,7 @@ export function NftList({ data }: Props) {
             : 1
         }
         mr={(index + 1) % NB_COLUMNS > 0 ? 6 : 0}
-        testID={"wallet-nft-gallery-list-item"}
+        testID={`wallet-nft-gallery-list-item-${index}`}
       >
         {item.id === ADD_NEW.id ? (
           <>{!multiSelectModeEnabled && <AddNewItem />}</>
@@ -139,6 +139,7 @@ export function NftList({ data }: Props) {
                   justifyContent="flex-start"
                 >
                   <StyledButton
+                    testID="wallet-nft-gallery-select-and-hide"
                     onPress={onPressMultiselect}
                     type="default"
                     iconName="Tasks"
@@ -173,6 +174,7 @@ export function NftList({ data }: Props) {
 
             <ButtonsContainer width="100%" justifyContent={"space-between"}>
               <StyledButton
+                testID="wallet-nft-gallery-confirm-hide"
                 onPress={onPressHide}
                 type="main"
                 iconName="EyeNone"

--- a/apps/ledger-live-mobile/src/screens/Nft/NftGallery/NftGalleryEmptyState.tsx
+++ b/apps/ledger-live-mobile/src/screens/Nft/NftGallery/NftGalleryEmptyState.tsx
@@ -27,7 +27,12 @@ const NftGalleryEmptyState = () => {
   }, []);
 
   return (
-    <Flex flex={1} alignItems={"center"} justifyContent={"center"}>
+    <Flex
+      testID="wallet-nft-gallery-empty"
+      flex={1}
+      alignItems="center"
+      justifyContent="center"
+    >
       <TrackScreen
         category={
           readOnlyModeEnabled
@@ -51,7 +56,13 @@ const NftGalleryEmptyState = () => {
       >
         {t("wallet.nftGallery.empty.subtitle")}
       </Text>
-      <Button onPress={openModal} size={"large"} type={"main"} mb={8}>
+      <Button
+        testID="wallet-nft-gallery-receive-nft-button"
+        onPress={openModal}
+        size={"large"}
+        type={"main"}
+        mb={8}
+      >
         {t("wallet.nftGallery.empty.receive")}
       </Button>
       <Link

--- a/apps/ledger-live-mobile/src/screens/Nft/WalletNftGallery/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Nft/WalletNftGallery/index.tsx
@@ -16,7 +16,7 @@ const WalletNftGallery = () => {
   const hasNFTs = nftsOrdered.length > 0;
 
   return (
-    <Flex flex={1}>
+    <Flex flex={1} testID="wallet-nft-gallery-screen">
       {hasNFTs ? (
         <NftList data={nftsOrdered} />
       ) : (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Added some more Detox tests to validate the hide NFT flow in the NFT gallery and check the empty state renders.

### ❓ Context

- **Impacted projects**: `N/A` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-4142` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="831" alt="Screenshot 2023-05-25 at 18 44 05" src="https://github.com/LedgerHQ/ledger-live/assets/1044686/1cbf6afb-985d-431e-8411-07b4931f4124">

https://github.com/LedgerHQ/ledger-live/assets/1044686/0a24c82b-0640-4c2d-b18b-4272be534088

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
