### PR TITLE
Bugfix - Allow pre-pelease tags for higher versions of nano apps than the minimum one

### DIFF
--- a/.changeset/spicy-cats-rest.md
+++ b/.changeset/spicy-cats-rest.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix `mustUpgrade` & `shouldUpgrade` for pre-release tags with higher than exepected versions

--- a/libs/ledger-live-common/src/apps/support.test.ts
+++ b/libs/ledger-live-common/src/apps/support.test.ts
@@ -24,8 +24,12 @@ describe("Support.ts", () => {
       expect(mustUpgrade("Ethereum", "1.10.2")).toBe(false);
     });
 
-    it("should not ask any upgrade for the latest Ethereum nano app with a pre-release tag", () => {
+    it("should not ask any upgrade for the latest Ethereum nano app with a pre-release tag for a version equal to the minimum version", () => {
       expect(mustUpgrade("Ethereum", "1.10.2-dev")).toBe(false);
+    });
+
+    it("should not ask any upgrade for the latest Ethereum nano app with a pre-release tag for a version superior to the minimum version", () => {
+      expect(mustUpgrade("Ethereum", "1.10.3-dev")).toBe(false);
     });
   });
 });

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -16,7 +16,10 @@ export function shouldUpgrade(appName: string, appVersion: string): boolean {
     appName === "Bitcoin"
   ) {
     // https://donjon.ledger.com/lsb/010/
-    return !semver.satisfies(appVersion || "", ">= 1.4.0-0"); // the `-0` is here to allow for pre-release tags
+    // the `-0` is here to allow for pre-release tags of the 1.4.0
+    return !semver.satisfies(appVersion || "", ">= 1.4.0-0", {
+      includePrerelease: true, // this will allow pre-release tags for higher versions (> 1.4.0)
+    });
   }
 
   return false;
@@ -26,7 +29,7 @@ const appVersionsRequired = {
   Algorand: ">= 1.2.9",
   MultiversX: ">= 1.0.18",
   Polkadot: ">= 20.9370.0",
-  Ethereum: ">= 1.10.2-0", // the `-0` is here to allow for pre-release tags
+  Ethereum: ">= 1.10.2-0", // the `-0` is here to allow for pre-release tags of the same version (1.10.2)
   Solana: ">= 1.2.0",
   Celo: ">= 1.1.8",
   "Cardano ADA": ">= 4.1.0",
@@ -38,7 +41,9 @@ export function mustUpgrade(appName: string, appVersion: string): boolean {
   const range = appVersionsRequired[appName];
 
   if (range) {
-    return !semver.satisfies(appVersion || "", range);
+    return !semver.satisfies(appVersion || "", range, {
+      includePrerelease: true, // this will allow pre-release tags for higher versions than the minimum one
+    });
   }
 
   return false;


### PR DESCRIPTION
…versions pre-release tags

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR fixes my own mess where I removed the `includePrerelease` option (that I previously added...) thinking it wasn't used when we added the last `-0` to the minimum semver required, but that `-0` is only working for the minimum version, not higher versions.
TLDR: 
 - with ">= 1.10.2-0" only -> `1.10.2-dev` is ok but not `1.10.3-dev`
 - with  `includePrerelease` true only -> `1.10.3-dev` is ok but not `1.10.2-dev`

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
