### PR TITLE
feat/LIVE-7292 Improvements to the removal of CLS on Stax

### DIFF
--- a/.changeset/cold-badgers-live.md
+++ b/.changeset/cold-badgers-live.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Improve the image removal flow for Stax

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -9,6 +9,7 @@ import {
   NoSuchAppOnProvider,
   EConnResetError,
   LanguageInstallRefusedOnDevice,
+  ImageDoesNotExistOnDevice,
 } from "@ledgerhq/live-common/errors";
 import { InitSellResult } from "@ledgerhq/live-common/exchange/sell/types";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -290,12 +291,15 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   }
 
   if (imageRemoveRequested) {
+    const refused = error instanceof UserRefusedOnDevice;
+    const noImage = error instanceof ImageDoesNotExistOnDevice;
     if (error) {
-      if (error instanceof UserRefusedOnDevice) {
+      if (refused || noImage) {
         return renderError({
           t,
+          inlineRetry,
           error,
-          onRetry,
+          onRetry: refused ? onRetry : undefined,
           info: true,
         });
       }

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
@@ -16,6 +16,7 @@ import {
   DeviceNotOnboarded,
   NoSuchAppOnProvider,
   LanguageInstallRefusedOnDevice,
+  ImageDoesNotExistOnDevice,
 } from "@ledgerhq/live-common/errors";
 import { Icons } from "@ledgerhq/react-ui";
 
@@ -37,6 +38,7 @@ const ErrorIcon = ({ error, size = 44 }: ErrorIconProps) => {
     error instanceof UserRefusedOnDevice ||
     error instanceof UserRefusedAddress ||
     error instanceof LanguageInstallRefusedOnDevice ||
+    error instanceof ImageDoesNotExistOnDevice ||
     error instanceof UserRefusedDeviceNameChange
   ) {
     return <Icons.InfoMedium size={size} />;

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceStorage/RemoveCustomImage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { BoxedIcon, Flex, Icons, Text } from "@ledgerhq/react-ui";
+import { BoxedIcon, Button, Divider, Flex, Icons, Text } from "@ledgerhq/react-ui";
 import { useDispatch } from "react-redux";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { createAction } from "@ledgerhq/live-common/hw/actions/staxRemoveImage";
@@ -8,6 +8,7 @@ import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { clearLastSeenCustomImage } from "~/renderer/actions/settings";
+import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 
 const action = createAction(removeImage);
 
@@ -17,31 +18,60 @@ const TextEllipsis = styled.div`
   text-overflow: ellipsis;
 `;
 
-const RemoveCustomImage: React.FC<{}> = () => {
+const RemoveCustomImage: React.FC<{ onClose?: () => void }> = ({ onClose }) => {
   const request = useMemo(() => ({}), []);
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
   const [completed, setCompleted] = useState(false);
+  const [nonce, setNonce] = useState(0);
+  const [error, setError] = useState<Error | null>(null);
   const [running, setRunning] = useState(true);
 
+  const onRetry = useCallback(() => {
+    setError(null);
+    setNonce(currentNonce => currentNonce + 1);
+  }, []);
+
   const onSuccess = useCallback(() => {
+    setError(null);
     setCompleted(true);
     setRunning(false);
     dispatch(clearLastSeenCustomImage());
   }, [dispatch]);
 
+  const onError = useCallback(
+    error => {
+      setError(error);
+      if (error instanceof ImageDoesNotExistOnDevice) {
+        dispatch(clearLastSeenCustomImage());
+      }
+    },
+    [dispatch],
+  );
+
+  const showRetry = error && !(error instanceof ImageDoesNotExistOnDevice);
   return (
     <Flex
       flexDirection="column"
+      key={`${nonce}-removeDeviceImage`}
       rowGap={5}
       height="100%"
       overflowY="hidden"
       width="100%"
       flex={1}
-      data-test-id="device-rename-container"
+      data-test-id="device-remove-image-container"
     >
-      <Flex flex={1} flexDirection="column" justifyContent="space-between" overflowY="hidden">
+      <Text alignSelf="center" variant="h5Inter" mb={3}>
+        {t("removeCustomLockscreen.title")}
+      </Text>
+      <Flex
+        flex={1}
+        px={12}
+        flexDirection="column"
+        justifyContent="space-between"
+        overflowY="hidden"
+      >
         {completed ? (
           <Flex
             flex={1}
@@ -56,23 +86,57 @@ const RemoveCustomImage: React.FC<{}> = () => {
               size={64}
               iconSize={24}
             />
-            <Text
-              variant="large"
-              alignSelf="stretch"
-              mx={16}
-              mt={10}
-              textAlign="center"
-              fontSize={22}
-            >
+            <Text variant="large" alignSelf="stretch" mt={9} textAlign="center">
               <TextEllipsis>{t("removeCustomLockscreen.success")}</TextEllipsis>
             </Text>
           </Flex>
         ) : running ? (
           <Flex flex={1} alignItems="center" justifyContent="center" p={2}>
-            <DeviceAction request={request} action={action} onResult={onSuccess} />
+            <DeviceAction
+              inlineRetry={false}
+              request={request}
+              action={action}
+              onResult={onSuccess}
+              onError={onError}
+            />
           </Flex>
         ) : null}
       </Flex>
+      {!running || (running && error) || completed ? (
+        <Flex flexDirection="column" alignSelf="stretch">
+          <Divider />
+          <Flex
+            px={12}
+            alignSelf="stretch"
+            flexDirection="row"
+            justifyContent="space-between"
+            pt={4}
+            pb={1}
+          >
+            {showRetry ? (
+              <Button
+                data-test-id="retry-device-custom-image-removal-button"
+                variant="main"
+                outline
+                onClick={onRetry}
+                disabled={!running}
+              >
+                {t(`common.retry`)}
+              </Button>
+            ) : (
+              <Flex flex={1} />
+            )}
+            <Button
+              variant="main"
+              data-test-id="close-device-custom-image-removal-button"
+              onClick={onClose}
+              disabled={running && !error}
+            >
+              {t(`common.close`)}
+            </Button>
+          </Flex>
+        </Flex>
+      ) : null}
     </Flex>
   );
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2277,6 +2277,7 @@
     "renamed": "{{ productName }} name changed to \n“{{ name }}” "
   },
   "removeCustomLockscreen": {
+    "title": "Remove lock screen picture",
     "cta": "Remove",
     "confirmation": "Confirm removal of image on your Ledger Stax",
     "success": "Lock screen picture removed"
@@ -5681,6 +5682,10 @@
     "ImageLoadRefusedOnDevice": {
       "title": "Lock screen cancelled on Ledger Stax",
       "description": "If this image wasn't the right fit, you can try again with another image."
+    },
+    "ImageDoesNotExistOnDevice": {
+      "title": "Your Ledger Stax doesn’t have a lock screen picture to remove",
+      "description": "The customized lock screen picture was previously removed."
     },
     "RestoreImageCommitRefusedOnDevice": {
       "title": "Restoration of Lock screen picture was cancelled on Ledger Stax",

--- a/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
@@ -6,6 +6,7 @@ import { createAction } from "@ledgerhq/live-common/hw/actions/staxRemoveImage";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import removeImage from "@ledgerhq/live-common/hw/staxRemoveImage";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
+import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { NavigatorName, ScreenName } from "../../const";
 import QueuedDrawer, { Props as BottomModalProps } from "../QueuedDrawer";
 import ModalChoice from "./ModalChoice";
@@ -111,6 +112,17 @@ const CustomImageBottomModal: React.FC<Props> = props => {
     });
   }, [setDeviceHasImage, wrappedOnClose, pushToast, t]);
 
+  const onError = useCallback(
+    error => {
+      if (error instanceof ImageDoesNotExistOnDevice) {
+        if (setDeviceHasImage) {
+          setDeviceHasImage(false);
+        }
+      }
+    },
+    [setDeviceHasImage],
+  );
+
   return (
     <QueuedDrawer
       isRequestingToBeOpened={!!isOpened}
@@ -130,6 +142,7 @@ const CustomImageBottomModal: React.FC<Props> = props => {
               request={request}
               action={action}
               onResult={onSuccess}
+              onError={onError}
             />
           </Flex>
         </Flex>

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 import type { Action, Device } from "@ledgerhq/live-common/hw/actions/types";
 import {
   DeviceNotOnboarded,
+  ImageDoesNotExistOnDevice,
   LatestFirmwareVersionRequired,
 } from "@ledgerhq/live-common/errors";
 import {
@@ -342,14 +343,18 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   // level instead of being an exception here.
   if (imageRemoveRequested) {
     if (error) {
-      if ((error as Status["error"]) instanceof UserRefusedOnDevice) {
+      const refused = (error as Status["error"]) instanceof UserRefusedOnDevice;
+      const noImage =
+        (error as Status["error"]) instanceof ImageDoesNotExistOnDevice;
+      if (refused || noImage) {
         return renderError({
           t,
           navigation,
           error,
-          onRetry,
+          onRetry: refused ? onRetry : undefined,
           colors,
           theme,
+          hasExportLogButton: false,
           iconColor: palette.neutral.c20,
           Icon: () => (
             <Icons.InfoAltFillMedium size={28} color={palette.primary.c80} />

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -658,6 +658,7 @@ export function renderError({
   Icon,
   iconColor,
   device,
+  hasExportLogButton,
 }: RawProps & {
   navigation?: StackNavigationProp<ParamListBase>;
   error: Error;
@@ -666,6 +667,7 @@ export function renderError({
   Icon?: React.ComponentProps<typeof GenericErrorView>["Icon"];
   iconColor?: string;
   device?: Device;
+  hasExportLogButton?: boolean;
 }) {
   const onPress = () => {
     if (managerAppName && navigation) {
@@ -702,6 +704,7 @@ export function renderError({
         withIcon
         Icon={Icon}
         iconColor={iconColor}
+        hasExportLogButton={hasExportLogButton}
       >
         {showRetryIfAvailable && (onRetry || managerAppName) ? (
           <ActionContainer marginBottom={0} marginTop={32}>

--- a/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
+++ b/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
@@ -98,6 +98,7 @@ const GenericErrorView = ({
             color="neutral.c80"
             textAlign="center"
             numberOfLines={6}
+            mt={5}
           >
             <TranslatedError error={error} field="description" />
           </Text>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -325,6 +325,10 @@
       "description": "If this image wasn't the right fit, you can try again with another image.",
       "primaryCTA": "Upload another picture"
     },
+    "ImageDoesNotExistOnDevice": {
+      "title": "Your Ledger Stax doesn’t have a lock screen picture to remove",
+      "description": "The customized lock screen picture was previously removed."
+    },
     "InvalidAddress": {
       "title": "This is not a valid {{currencyName}} address"
     },

--- a/libs/ledger-live-common/src/hw/staxRemoveImage.test.ts
+++ b/libs/ledger-live-common/src/hw/staxRemoveImage.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@ledgerhq/errors";
 import { command as staxRemoveImage } from "./staxRemoveImage";
 import Transport from "@ledgerhq/hw-transport";
+import { ImageDoesNotExistOnDevice } from "../errors";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore next-line
@@ -32,6 +33,15 @@ describe("staxRemoveImage", () => {
       Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex")
     );
     await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(Error);
+  });
+
+  test("missing image, should throw", async () => {
+    const mockedTransport = mockTransportGenerator(
+      Buffer.from(StatusCodes.CUSTOM_IMAGE_EMPTY.toString(16), "hex")
+    );
+    await expect(staxRemoveImage(mockedTransport)).rejects.toThrow(
+      ImageDoesNotExistOnDevice
+    );
   });
 
   test("unexpected bootloader or any other code, should throw", async () => {

--- a/libs/ledger-live-common/src/hw/staxRemoveImage.ts
+++ b/libs/ledger-live-common/src/hw/staxRemoveImage.ts
@@ -9,6 +9,7 @@ import { Observable, from, of } from "rxjs";
 import { withDevice } from "./deviceAccess";
 import { delay, mergeMap } from "rxjs/operators";
 import getDeviceInfo from "./getDeviceInfo";
+import { ImageDoesNotExistOnDevice } from "../errors";
 
 export type RemoveImageEvent =
   | {
@@ -36,6 +37,7 @@ export const command = async (transport: Transport): Promise<void> => {
     StatusCodes.OK,
     StatusCodes.CUSTOM_IMAGE_BOOTLOADER,
     StatusCodes.USER_REFUSED_ON_DEVICE,
+    StatusCodes.CUSTOM_IMAGE_EMPTY,
     StatusCodes.UNKNOWN_APDU,
   ]);
 
@@ -44,6 +46,8 @@ export const command = async (transport: Transport): Promise<void> => {
   switch (status) {
     case StatusCodes.OK:
       return;
+    case StatusCodes.CUSTOM_IMAGE_EMPTY:
+      throw new ImageDoesNotExistOnDevice();
     case StatusCodes.CUSTOM_IMAGE_BOOTLOADER:
       throw new UnexpectedBootloader();
     case StatusCodes.USER_REFUSED_ON_DEVICE:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The initial implementation of the image removal for the Stax device had an edge case where the user may delete the image on the device and then attempt to remove it again on Live. While tackling it I aligned the UI/UX of the flow to match the other flows that were adapted recently (rename, languages and CLS) trying to follow the same spacing, sizes, and behaviour.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop, ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7292` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo

### 🚀 Expectations to reach
- Launch LLD/LLD
- Access My Ledger with a Stax device
- Set up a custom lock screen
- Remove the image on Stax device by following the `settings/lockscreen/customize/remove` route
- Attempt to remove the custom lockscreen (Already removed) from the option on My ledger

It is expected that the error is handled, has adequate wording, no retry offered, and no export logs option available.