### PR TITLE
fix: allow navigation to binance.com for login (LIVE-7646)

### DIFF
--- a/.changeset/strange-peaches-leave.md
+++ b/.changeset/strange-peaches-leave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix: Binance.com redirection to browser perform authentication on iOS was not triggered

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -532,6 +532,10 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       tracking.platformLoad(manifest);
     }, [manifest]);
 
+    // See https://ledgerhq.atlassian.net/browse/LIVE-7646 : (temporary ?) workaround for binance buy integration
+    const javaScriptCanOpenWindowsAutomatically =
+      manifest.id === "binancecnt" || manifest.id === "multibuy";
+
     return (
       <RNWebView
         ref={webviewRef}
@@ -550,6 +554,9 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         automaticallyAdjustContentInsets={false}
         scrollEnabled={true}
         style={styles.webview}
+        javaScriptCanOpenWindowsAutomatically={
+          javaScriptCanOpenWindowsAutomatically
+        }
         {...webviewProps}
       />
     );


### PR DESCRIPTION
### 📝 Description

Fixes binancecnt authentication through binance.com on iOS :
Selectively set javaScriptCanOpenWindowsAutomatically to true only for multibuy and binancecnt apps, and only on platform sdk webview. We may decide later to extend the solution or not.

### ❓ Context

- **Impacted projects**: `` LLM iOS : multibuy, binance live app
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-7646

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
