### PR TITLE
bump usb

### DIFF
--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
@@ -34,7 +34,7 @@
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
     "node-hid": "^2.1.2",
-    "usb": "2.5.1"
+    "usb": "^2.9.0"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/package.json
@@ -34,7 +34,7 @@
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
     "node-hid": "^2.1.2",
-    "usb": "^1.7.0"
+    "usb": "^2.9.0"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/src/listenDevices.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/src/listenDevices.ts
@@ -1,7 +1,7 @@
 import EventEmitter from "events";
 import { getDevices } from "@ledgerhq/hw-transport-node-hid-noevents";
 import { log } from "@ledgerhq/logs";
-import usb from "usb";
+import { usb } from "usb";
 import debounce from "lodash/debounce";
 export default (
   delay: number,


### PR DESCRIPTION
### 📝 Description

Attempts to address https://github.com/LedgerHQ/ledger-live/issues/3416 (failing builds with `hw-transport-node-hid` on macOS) by bumping `usb`. 

Note that `usb` has been bumped in `hw-transport-node-hid-singleton` to keep the versions used consistent.