### PR TITLE
fix: bump usb to version 2, fix macOS builds

### DIFF
--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/hw-transport-node-hid-singleton",
-  "version": "6.28.6",
+  "version": "6.28.7",
   "description": "Ledger Hardware Wallet Node implementation of the communication layer, using node-hid and node-usb",
   "keywords": [
     "Ledger",

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
@@ -34,7 +34,7 @@
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
     "node-hid": "2.1.1",
-    "usb": "2.5.1"
+    "usb": "^2.9.0"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/hw-transport-node-hid",
-  "version": "6.27.9",
+  "version": "6.27.10",
   "description": "Ledger Hardware Wallet Node implementation of the communication layer, using node-hid",
   "keywords": [
     "Ledger",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/package.json
@@ -34,7 +34,7 @@
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
     "node-hid": "^2.1.2",
-    "usb": "^1.7.0"
+    "usb": "^2.9.0"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/src/listenDevices.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/src/listenDevices.ts
@@ -1,7 +1,7 @@
 import EventEmitter from "events";
 import { getDevices } from "@ledgerhq/hw-transport-node-hid-noevents";
 import { log } from "@ledgerhq/logs";
-import usb from "usb";
+import { usb } from "usb";
 import debounce from "lodash/debounce";
 export default (
   delay: number,


### PR DESCRIPTION
### 📝 Description

Attempts to address https://github.com/LedgerHQ/ledger-live/issues/3416 (failing builds with `hw-transport-node-hid` on macOS) by bumping usb.

Note that usb has been bumped in `hw-transport-node-hid-singleton` to keep the versions used consistent.

### ❓ Context

- **Impacted projects**: `hw-transport-node-hid`, `hw-transport-node-hid-singleton`
- **Linked resource(s)**: ``

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
