### PR TITLE
feat: LIVE-7473 add 800ms delay before failures for better UX

### DIFF
--- a/.changeset/nasty-papayas-peel.md
+++ b/.changeset/nasty-papayas-peel.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add fake delay before device action failures for better UX


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The rapid transition between steps during error cases for device actions may result in a glitchy appearance. For example, when attempting to retry a failed device action on a locked device, the completion time is just a few milliseconds. However, this duration is sufficient for the device action to briefly display a flashing indication of the previously attempted step before the failure.

To address this issue we have implemented a compromise solution. We introduce an `800ms` delay for error notifications, allowing users to observe a visual indication before the error is thrown again and the user interface (UI) changes accordingly. It is important to note that this delay also affects user refusals, but the product team has agreed that this delay is acceptable.

If there are specific errors for which we do not want to introduce a delay, we can incorporate provisions to whitelist user refusals from the beginning. Implementing this provision should be relatively straightforward.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7473` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo

### 🚀 Expectations to reach
Failed cases for device actions should be delayed, an easy way of testing this is accessing the manager with a locked device and hitting retry but technically all device action flows should benefit from this improvement.