### PR TITLE
feat: LIVE-6329 add visual indicator of disabled CTA while app ops

### DIFF
--- a/.changeset/plenty-stingrays-trade.md
+++ b/.changeset/plenty-stingrays-trade.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add visual indicator of disabled state for flows while apps are being installed/uninstalled

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/CustomLockScreen.tsx
@@ -18,7 +18,10 @@ import { NavigatorName, ScreenName } from "../../../const";
 import CustomImageBottomModal from "../../../components/CustomImage/CustomImageBottomModal";
 import DeviceOptionRow from "./DeviceOptionRow";
 
-const CustomLockScreen: React.FC<{ device: Device }> = ({ device }) => {
+const CustomLockScreen: React.FC<{ device: Device; disabled: boolean }> = ({
+  device,
+  disabled,
+}) => {
   const navigation = useNavigation();
   const [isCustomImageOpen, setIsCustomImageOpen] = useState(false);
   const [deviceHasImage, setDeviceHasImage] = useState(false);
@@ -63,7 +66,7 @@ const CustomLockScreen: React.FC<{ device: Device }> = ({ device }) => {
         Icon={Icons.PhotographMedium}
         iconSize={20}
         label={t("customImage.title")}
-        onPress={handleStartCustomImage}
+        onPress={disabled ? undefined : handleStartCustomImage}
         linkLabel={t(deviceHasImage ? "customImage.replace" : "common.add")}
       />
       <CustomImageBottomModal

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceLanguage.tsx
@@ -11,7 +11,7 @@ import { track } from "../../../analytics";
 import DeviceOptionRow from "./DeviceOptionRow";
 
 type Props = {
-  pendingInstalls: boolean;
+  disabled: boolean;
   currentDeviceLanguage: Language;
   device: Device;
   deviceInfo: DeviceInfo;
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const DeviceLanguage: React.FC<Props> = ({
-  pendingInstalls,
+  disabled,
   currentDeviceLanguage,
   device,
   deviceInfo,
@@ -94,7 +94,7 @@ const DeviceLanguage: React.FC<Props> = ({
       <DeviceOptionRow
         Icon={Icons.LanguageMedium}
         label={t("deviceLocalization.language")}
-        onPress={pendingInstalls ? undefined : openChangeLanguageModal}
+        onPress={disabled ? undefined : openChangeLanguageModal}
         linkLabel={t(`deviceLocalization.languages.${currentDeviceLanguage}`)}
         right={
           availableLanguages.length ? undefined : (

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/DeviceName.tsx
@@ -73,14 +73,19 @@ export default function DeviceName({
         >
           <Flex
             ml={3}
-            backgroundColor={"palette.primary.c30"}
+            backgroundColor={
+              disabled ? "palette.neutral.c30" : "palette.primary.c30"
+            }
             borderRadius={14}
             width={28}
             height={28}
             alignItems="center"
             justifyContent="center"
           >
-            <PenMedium size={16} color={"palette.primary.c80"} />
+            <PenMedium
+              size={16}
+              color={disabled ? "palette.neutral.c80" : "palette.primary.c80"}
+            />
           </Flex>
         </TouchableOpacity>
       )}

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
@@ -122,6 +122,8 @@ const DeviceCard = ({
   const hasCustomImage =
     useFeature("customImage")?.enabled && deviceModel.id === DeviceModelId.stax;
 
+  const disableFlows = pendingInstalls;
+
   return (
     <BorderCard>
       <Flex flexDirection={"row"} mt={20} mx={4} mb={8} alignItems="center">
@@ -137,7 +139,7 @@ const DeviceCard = ({
             device={device}
             deviceInfo={deviceInfo}
             initialDeviceName={initialDeviceName}
-            disabled={pendingInstalls}
+            disabled={disableFlows}
           />
           <Flex
             backgroundColor={"neutral.c30"}
@@ -174,11 +176,13 @@ const DeviceCard = ({
       {hasCustomImage || showDeviceLanguage ? (
         <>
           <Flex px={6}>
-            {hasCustomImage && <CustomLockScreen device={device} />}
+            {hasCustomImage && (
+              <CustomLockScreen disabled={disableFlows} device={device} />
+            )}
             {showDeviceLanguage && (
               <Flex mt={hasCustomImage ? 6 : 0}>
                 <DeviceLanguage
-                  pendingInstalls={pendingInstalls}
+                  disabled={disableFlows}
                   currentDeviceLanguage={
                     idsToLanguage[
                       deviceInfo.languageId as keyof typeof idsToLanguage


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When there are ongoing app operations inside My Ledger, we should disable access to other flows (CLS, Language, Rename) and show it in the UI so that it's evident.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6329` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="487" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/4631227/5bfbd409-d253-4f04-a855-a16980c4ef7d">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- Access My Ledger with a device that can handle CLS/Lang/Rename
- Start an app operation (ie install Bitcoin)
- Make sure that the flows are disabled.