### PR TITLE
fixed hex encoding issue on sign flow

### DIFF
--- a/.changeset/silly-planes-develop.md
+++ b/.changeset/silly-planes-develop.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fixed a wallet-api message signature issue

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -448,7 +448,7 @@ export function useWalletAPIServer({
               message,
               onSuccess: (signature) => {
                 tracking.signMessageSuccess(manifest);
-                resolve(Buffer.from(signature));
+                resolve(Buffer.from(signature.replace("0x", ""), "hex"));
               },
               onCancel: () => {
                 tracking.signMessageFail(manifest);


### PR DESCRIPTION

### 📝 Description

Fix an encoding issue that would over hex encode anything signed trough the wallet api

### ❓ Context

- **Impacted projects**: `` eth-dapp-browser

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Message signature done in the wallet-api-tools should be correct

<!-- If any of the expectations are not met please explain the reason in detail. -->
