### PR TITLE
[fix/LIVE-7365]: add eth staking modal to tab navigation menu

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import { useTheme } from "styled-components/native";
 import { Icons } from "@ledgerhq/native-ui";
+import { RouteProp, useRoute } from "@react-navigation/core";
 
 import {
   BottomTabBarProps,
@@ -24,6 +25,8 @@ import DiscoverNavigator from "./DiscoverNavigator";
 import customTabBar from "../TabBar/CustomTabBar";
 import { MainNavigatorParamList } from "./types/MainNavigator";
 import { isMainNavigatorVisibleSelector } from "../../reducers/appstate";
+import { EthereumStakingDrawer } from "../../families/ethereum/EthereumStakingDrawer";
+import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
 
 const Tab = createBottomTabNavigator<MainNavigatorParamList>();
 
@@ -33,6 +36,8 @@ const Tab = createBottomTabNavigator<MainNavigatorParamList>();
 // https://github.com/react-navigation/react-navigation/issues/6674#issuecomment-562813152
 
 export default function MainNavigator() {
+  const route =
+    useRoute<RouteProp<BaseNavigatorStackParamList, NavigatorName.Main>>();
   const { colors } = useTheme();
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const hasOrderedNano = useSelector(hasOrderedNanoSelector);
@@ -64,135 +69,138 @@ export default function MainNavigator() {
   );
 
   return (
-    <Tab.Navigator
-      tabBar={tabBar}
-      screenOptions={{
-        tabBarStyle: [
-          {
-            height: 300,
-            borderTopColor: colors.neutral.c30,
-            borderTopWidth: 1,
-            elevation: 5,
-            shadowColor: colors.neutral.c30,
-            backgroundColor: colors.opacityDefault.c10,
-          },
-        ],
-        unmountOnBlur: true, // Nb prevents ghost device interactions
-        tabBarShowLabel: false,
-        tabBarActiveTintColor: colors.palette.primary.c80,
-        tabBarInactiveTintColor: colors.palette.neutral.c70,
-        headerShown: false,
-      }}
-      sceneContainerStyle={[{ backgroundColor: colors.background.main }]}
-    >
-      <Tab.Screen
-        name={NavigatorName.Portfolio}
-        component={PortfolioNavigator}
-        options={{
+    <>
+      <EthereumStakingDrawer drawer={route.params?.drawer} />
+      <Tab.Navigator
+        tabBar={tabBar}
+        screenOptions={{
+          tabBarStyle: [
+            {
+              height: 300,
+              borderTopColor: colors.neutral.c30,
+              borderTopWidth: 1,
+              elevation: 5,
+              shadowColor: colors.neutral.c30,
+              backgroundColor: colors.opacityDefault.c10,
+            },
+          ],
+          unmountOnBlur: true, // Nb prevents ghost device interactions
+          tabBarShowLabel: false,
+          tabBarActiveTintColor: colors.palette.primary.c80,
+          tabBarInactiveTintColor: colors.palette.neutral.c70,
           headerShown: false,
-          unmountOnBlur: true,
-          tabBarIcon: props => <PortfolioTabIcon {...props} />,
         }}
-        listeners={({ navigation }) => ({
-          tabPress: e => {
-            e.preventDefault();
-            managerLockAwareCallback(() => {
-              navigation.navigate(NavigatorName.Portfolio, {
-                screen: ScreenName.Portfolio,
-              });
-            });
-          },
-        })}
-      />
-      <Tab.Screen
-        name={NavigatorName.Market}
-        component={MarketNavigator}
-        options={{
-          headerShown: false,
-          unmountOnBlur: true,
-          tabBarIcon: props => (
-            <TabIcon
-              Icon={Icons.GraphGrowMedium}
-              i18nKey="tabs.market"
-              {...props}
-            />
-          ),
-        }}
-        listeners={({ navigation }) => ({
-          tabPress: e => {
-            e.preventDefault();
-            managerLockAwareCallback(() => {
-              navigation.navigate(NavigatorName.Market, {
-                screen: ScreenName.MarketList,
-              });
-            });
-          },
-        })}
-      />
-
-      <Tab.Screen
-        name={ScreenName.Transfer}
-        component={Transfer}
-        options={{
-          headerShown: false,
-          tabBarIcon: () => <TransferTabIcon />,
-        }}
-      />
-      <Tab.Screen
-        name={NavigatorName.Discover}
-        component={DiscoverNavigator}
-        options={{
-          headerShown: false,
-          tabBarIcon: props => (
-            <TabIcon
-              Icon={Icons.PlanetMedium}
-              i18nKey="tabs.discover"
-              {...props}
-            />
-          ),
-        }}
-        listeners={({ navigation }) => ({
-          tabPress: e => {
-            e.preventDefault();
-            managerLockAwareCallback(() => {
-              navigation.navigate(NavigatorName.Discover, {
-                screen: ScreenName.DiscoverScreen,
-              });
-            });
-          },
-        })}
-      />
-      <Tab.Screen
-        name={NavigatorName.Manager}
-        component={ManagerNavigator}
-        options={{
-          tabBarIcon: props => <ManagerTabIcon {...props} />,
-          tabBarTestID: "TabBarManager",
-        }}
-        listeners={({ navigation }) => ({
-          tabPress: e => {
-            e.preventDefault();
-            managerLockAwareCallback(() => {
-              if (readOnlyModeEnabled && hasOrderedNano) {
-                navigation.navigate(
-                  ScreenName.PostBuyDeviceSetupNanoWallScreen,
-                );
-              } else if (readOnlyModeEnabled) {
-                navigation.navigate(NavigatorName.BuyDevice);
-              } else {
-                navigation.navigate(NavigatorName.Manager, {
-                  screen: ScreenName.Manager,
-                  params: {
-                    tab: undefined,
-                    searchQuery: undefined,
-                    updateModalOpened: undefined,
-                  },
+        sceneContainerStyle={[{ backgroundColor: colors.background.main }]}
+      >
+        <Tab.Screen
+          name={NavigatorName.Portfolio}
+          component={PortfolioNavigator}
+          options={{
+            headerShown: false,
+            unmountOnBlur: true,
+            tabBarIcon: props => <PortfolioTabIcon {...props} />,
+          }}
+          listeners={({ navigation }) => ({
+            tabPress: e => {
+              e.preventDefault();
+              managerLockAwareCallback(() => {
+                navigation.navigate(NavigatorName.Portfolio, {
+                  screen: ScreenName.Portfolio,
                 });
-              }
-            });
-          },
-        })}
-      />
-    </Tab.Navigator>
+              });
+            },
+          })}
+        />
+        <Tab.Screen
+          name={NavigatorName.Market}
+          component={MarketNavigator}
+          options={{
+            headerShown: false,
+            unmountOnBlur: true,
+            tabBarIcon: props => (
+              <TabIcon
+                Icon={Icons.GraphGrowMedium}
+                i18nKey="tabs.market"
+                {...props}
+              />
+            ),
+          }}
+          listeners={({ navigation }) => ({
+            tabPress: e => {
+              e.preventDefault();
+              managerLockAwareCallback(() => {
+                navigation.navigate(NavigatorName.Market, {
+                  screen: ScreenName.MarketList,
+                });
+              });
+            },
+          })}
+        />
+
+        <Tab.Screen
+          name={ScreenName.Transfer}
+          component={Transfer}
+          options={{
+            headerShown: false,
+            tabBarIcon: () => <TransferTabIcon />,
+          }}
+        />
+        <Tab.Screen
+          name={NavigatorName.Discover}
+          component={DiscoverNavigator}
+          options={{
+            headerShown: false,
+            tabBarIcon: props => (
+              <TabIcon
+                Icon={Icons.PlanetMedium}
+                i18nKey="tabs.discover"
+                {...props}
+              />
+            ),
+          }}
+          listeners={({ navigation }) => ({
+            tabPress: e => {
+              e.preventDefault();
+              managerLockAwareCallback(() => {
+                navigation.navigate(NavigatorName.Discover, {
+                  screen: ScreenName.DiscoverScreen,
+                });
+              });
+            },
+          })}
+        />
+        <Tab.Screen
+          name={NavigatorName.Manager}
+          component={ManagerNavigator}
+          options={{
+            tabBarIcon: props => <ManagerTabIcon {...props} />,
+            tabBarTestID: "TabBarManager",
+          }}
+          listeners={({ navigation }) => ({
+            tabPress: e => {
+              e.preventDefault();
+              managerLockAwareCallback(() => {
+                if (readOnlyModeEnabled && hasOrderedNano) {
+                  navigation.navigate(
+                    ScreenName.PostBuyDeviceSetupNanoWallScreen,
+                  );
+                } else if (readOnlyModeEnabled) {
+                  navigation.navigate(NavigatorName.BuyDevice);
+                } else {
+                  navigation.navigate(NavigatorName.Manager, {
+                    screen: ScreenName.Manager,
+                    params: {
+                      tab: undefined,
+                      searchQuery: undefined,
+                      updateModalOpened: undefined,
+                    },
+                  });
+                }
+              });
+            },
+          })}
+        />
+      </Tab.Navigator>
+    </>
   );
 }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -98,6 +98,13 @@ export type BaseNavigatorStackParamList = {
   [NavigatorName.Main]:
     | (NavigatorScreenParams<MainNavigatorParamList> & {
         hideTabNavigation?: boolean;
+        drawer?: {
+          id: string;
+          props: {
+            singleProviderRedirectMode: boolean;
+            accountId: string;
+          };
+        };
       })
     | undefined;
   [NavigatorName.BuyDevice]:

--- a/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react";
-import { useNavigation } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { ScrollView } from "react-native-gesture-handler";
@@ -41,6 +41,7 @@ export default function TransferDrawer({
   onClose,
 }: Omit<ModalProps, "isRequestingToBeOpened">) {
   const navigation = useNavigation();
+  const route = useRoute();
   const { t } = useTranslation();
 
   const { page, track } = useAnalytics();
@@ -84,8 +85,11 @@ export default function TransferDrawer({
       page,
       flow: "stake",
     });
-    onNavigate(NavigatorName.StakeFlow);
-  }, [onNavigate, page, track]);
+    onNavigate(NavigatorName.StakeFlow, {
+      screen: ScreenName.Stake,
+      params: { parentRoute: route },
+    });
+  }, [onNavigate, page, track, route]);
 
   const onWalletConnect = useCallback(
     () =>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
A bug was spotted during testing where the app crashed when the user tried to navigate to ethereum staking from the tabbed menu in Main.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/132384348/66b0c8f4-6238-4496-bc35-925ebf49d8eb



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
