### PR TITLE
fix(Firmware Update LLM): fix bluetooth restriction bypass

### DIFF
--- a/.changeset/giant-wolves-add.md
+++ b/.changeset/giant-wolves-add.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix potential USB-only restriction bypass for firmware update on unsupported devices.

--- a/apps/ledger-live-mobile/src/actions/appstate.ts
+++ b/apps/ledger-live-mobile/src/actions/appstate.ts
@@ -32,6 +32,7 @@ export const setModalLock = createAction<AppStateSetModalLockPayload>(
 export const addBackgroundEvent = createAction<AppStateAddBackgroundEventPayload>(
   AppStateActionTypes.QUEUE_BACKGROUND_EVENT,
 );
+export const dequeueBackgroundEvent = createAction(AppStateActionTypes.DEQUEUE_BACKGROUND_EVENT);
 export const clearBackgroundEvents = createAction(AppStateActionTypes.CLEAR_BACKGROUND_EVENTS);
 export const updateMainNavigatorVisibility =
   createAction<AppStateUpdateMainNavigatorVisibilityPayload>(

--- a/apps/ledger-live-mobile/src/actions/appstate.ts
+++ b/apps/ledger-live-mobile/src/actions/appstate.ts
@@ -32,9 +32,7 @@ export const setModalLock = createAction<AppStateSetModalLockPayload>(
 export const addBackgroundEvent = createAction<AppStateAddBackgroundEventPayload>(
   AppStateActionTypes.QUEUE_BACKGROUND_EVENT,
 );
-export const clearBackgroundEvents = createAction(
-  AppStateActionTypes.CLEAR_BACKGROUND_EVENTS,
-);
+export const clearBackgroundEvents = createAction(AppStateActionTypes.CLEAR_BACKGROUND_EVENTS);
 export const updateMainNavigatorVisibility =
   createAction<AppStateUpdateMainNavigatorVisibilityPayload>(
     AppStateActionTypes.UPDATE_MAIN_NAVIGATOR_VISIBILITY,

--- a/apps/ledger-live-mobile/src/actions/appstate.ts
+++ b/apps/ledger-live-mobile/src/actions/appstate.ts
@@ -7,7 +7,6 @@ import type {
   AppStateIsConnectedPayload,
   AppStateSetHasConnectedDevicePayload,
   AppStateSetModalLockPayload,
-  AppStateSetWiredDevicePayload,
   AppStateUpdateMainNavigatorVisibilityPayload,
 } from "./types";
 import { AppStateActionTypes } from "./types";
@@ -33,11 +32,9 @@ export const setModalLock = createAction<AppStateSetModalLockPayload>(
 export const addBackgroundEvent = createAction<AppStateAddBackgroundEventPayload>(
   AppStateActionTypes.QUEUE_BACKGROUND_EVENT,
 );
-export const dequeueBackgroundEvent = createAction(AppStateActionTypes.DEQUEUE_BACKGROUND_EVENT);
-export const setWiredDevice = createAction<AppStateSetWiredDevicePayload>(
-  AppStateActionTypes.SET_WIRED_DEVICE,
+export const clearBackgroundEvents = createAction(
+  AppStateActionTypes.CLEAR_BACKGROUND_EVENTS,
 );
-export const clearBackgroundEvents = createAction(AppStateActionTypes.CLEAR_BACKGROUND_EVENTS);
 export const updateMainNavigatorVisibility =
   createAction<AppStateUpdateMainNavigatorVisibilityPayload>(
     AppStateActionTypes.UPDATE_MAIN_NAVIGATOR_VISIBILITY,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -83,12 +83,11 @@ export enum AppStateActionTypes {
   CLEAR_BACKGROUND_EVENTS = "CLEAR_BACKGROUND_EVENTS",
   DANGEROUSLY_OVERRIDE_STATE = "DANGEROUSLY_OVERRIDE_STATE",
   UPDATE_MAIN_NAVIGATOR_VISIBILITY = "UPDATE_MAIN_NAVIGATOR_VISIBILITY",
-  SET_WIRED_DEVICE = "SET_WIRED_DEVICE",
 }
 
 export type AppStateIsConnectedPayload = AppState["isConnected"];
-export type AppStateSetHasConnectedDevicePayload = AppState["hasConnectedDevice"];
-export type AppStateSetWiredDevicePayload = AppState["wiredDevice"];
+export type AppStateSetHasConnectedDevicePayload =
+  AppState["hasConnectedDevice"];
 export type AppStateSetModalLockPayload = AppState["modalLock"];
 export type AppStateAddBackgroundEventPayload = {
   event: FwUpdateBackgroundEvent;

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -86,8 +86,7 @@ export enum AppStateActionTypes {
 }
 
 export type AppStateIsConnectedPayload = AppState["isConnected"];
-export type AppStateSetHasConnectedDevicePayload =
-  AppState["hasConnectedDevice"];
+export type AppStateSetHasConnectedDevicePayload = AppState["hasConnectedDevice"];
 export type AppStateSetModalLockPayload = AppState["modalLock"];
 export type AppStateAddBackgroundEventPayload = {
   event: FwUpdateBackgroundEvent;

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -21,7 +21,7 @@ import {
   hasCompletedOnboardingSelector,
   lastConnectedDeviceSelector,
 } from "../reducers/settings";
-import { getWiredDeviceSelector, hasConnectedDeviceSelector } from "../reducers/appstate";
+import { hasConnectedDeviceSelector } from "../reducers/appstate";
 import Button from "./Button";
 import QueuedDrawer from "./QueuedDrawer";
 import InvertTheme from "./theme/InvertTheme";
@@ -31,9 +31,12 @@ type FirmwareUpdateBannerProps = {
   onBackFromUpdate?: () => void;
 };
 
-const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) => {
-  const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
-  const wiredDevice = useSelector(getWiredDeviceSelector);
+const FirmwareUpdateBanner = ({
+  onBackFromUpdate,
+}: FirmwareUpdateBannerProps) => {
+  const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(
+    lastSeenDeviceSelector,
+  );
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   const hasConnectedDevice = useSelector(hasConnectedDeviceSelector);
   const hasCompletedOnboarding: boolean = useSelector(hasCompletedOnboardingSelector);
@@ -133,7 +136,10 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     lastSeenDevice &&
     isFirmwareUpdateVersionSupported(lastSeenDevice.deviceInfo, lastSeenDevice.modelId);
 
-  const usbFwUpdateActivated = Platform.OS === "android" && isUsbFwVersionUpdateSupported;
+  const wiredDevice = lastConnectedDevice?.wired === true;
+
+  const usbFwUpdateActivated =
+    Platform.OS === "android" && isUsbFwVersionUpdateSupported;
 
   const fwUpdateActivatedButNotWired = usbFwUpdateActivated && !wiredDevice;
 

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -31,12 +31,8 @@ type FirmwareUpdateBannerProps = {
   onBackFromUpdate?: () => void;
 };
 
-const FirmwareUpdateBanner = ({
-  onBackFromUpdate,
-}: FirmwareUpdateBannerProps) => {
-  const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(
-    lastSeenDeviceSelector,
-  );
+const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) => {
+  const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   const hasConnectedDevice = useSelector(hasConnectedDeviceSelector);
   const hasCompletedOnboarding: boolean = useSelector(hasCompletedOnboardingSelector);
@@ -138,8 +134,7 @@ const FirmwareUpdateBanner = ({
 
   const wiredDevice = lastConnectedDevice?.wired === true;
 
-  const usbFwUpdateActivated =
-    Platform.OS === "android" && isUsbFwVersionUpdateSupported;
+  const usbFwUpdateActivated = Platform.OS === "android" && isUsbFwVersionUpdateSupported;
 
   const fwUpdateActivatedButNotWired = usbFwUpdateActivated && !wiredDevice;
 

--- a/apps/ledger-live-mobile/src/hooks/useListenToHidDevices.ts
+++ b/apps/ledger-live-mobile/src/hooks/useListenToHidDevices.ts
@@ -5,9 +5,8 @@ import { DescriptorEvent, DeviceModelId } from "@ledgerhq/types-devices";
 import HIDTransport from "@ledgerhq/react-native-hid";
 import { map } from "rxjs/operators";
 import useIsMounted from "@ledgerhq/live-common/hooks/useIsMounted";
-import { setWiredDevice } from "../actions/appstate";
 import { DeviceLike } from "../reducers/types";
-import { AppStateSetWiredDevicePayload } from "../actions/types";
+import { setLastConnectedDevice } from "../actions/settings";
 
 /**
  * Allows LLM to be aware of USB OTG connections on Android as they happen.
@@ -46,8 +45,17 @@ export const useListenToHidDevices = () => {
           ),
         )
         .subscribe({
-          next: (wiredDevice: AppStateSetWiredDevicePayload) => {
-            dispatch(setWiredDevice(wiredDevice));
+          next: (wiredDevice: DeviceLike | null) => {
+            if (wiredDevice) {
+              dispatch(
+                setLastConnectedDevice({
+                  deviceId: wiredDevice.id,
+                  modelId: wiredDevice.modelId,
+                  deviceName: wiredDevice.name,
+                  wired: true,
+                }),
+              );
+            }
           },
           error: () => {
             onScheduleNewListen();

--- a/apps/ledger-live-mobile/src/reducers/appstate.ts
+++ b/apps/ledger-live-mobile/src/reducers/appstate.ts
@@ -10,7 +10,6 @@ import type {
   AppStatePayload,
   AppStateSetHasConnectedDevicePayload,
   AppStateSetModalLockPayload,
-  AppStateSetWiredDevicePayload,
   AppStateUpdateMainNavigatorVisibilityPayload,
   DangerouslyOverrideStatePayload,
 } from "../actions/types";
@@ -27,7 +26,6 @@ export const INITIAL_STATE: AppState = {
   backgroundEvents: [],
   debugMenuVisible: false,
   isMainNavigatorVisible: true,
-  wiredDevice: null,
 };
 
 const handlers: ReducerMap<AppState, AppStatePayload> = {
@@ -49,11 +47,6 @@ const handlers: ReducerMap<AppState, AppStatePayload> = {
   [AppStateActionTypes.SET_MODAL_LOCK]: (state, action) => ({
     ...state,
     modalLock: (action as Action<AppStateSetModalLockPayload>).payload,
-  }),
-
-  [AppStateActionTypes.SET_WIRED_DEVICE]: (state, action) => ({
-    ...state,
-    wiredDevice: (action as Action<AppStateSetWiredDevicePayload>).payload,
   }),
 
   [AppStateActionTypes.QUEUE_BACKGROUND_EVENT]: (state, action) => ({
@@ -94,8 +87,8 @@ const handlers: ReducerMap<AppState, AppStatePayload> = {
 export const isDebugMenuVisible = (state: State) => state.appstate.debugMenuVisible;
 export const isConnectedSelector = (state: State) => state.appstate.isConnected;
 export const isModalLockedSelector = (state: State) => state.appstate.modalLock;
-export const getWiredDeviceSelector = (state: State) => state.appstate.wiredDevice;
-export const hasConnectedDeviceSelector = (state: State) => state.appstate.hasConnectedDevice;
+export const hasConnectedDeviceSelector = (state: State) =>
+  state.appstate.hasConnectedDevice;
 
 export const backgroundEventsSelector = (state: State) => state.appstate.backgroundEvents;
 

--- a/apps/ledger-live-mobile/src/reducers/appstate.ts
+++ b/apps/ledger-live-mobile/src/reducers/appstate.ts
@@ -87,8 +87,7 @@ const handlers: ReducerMap<AppState, AppStatePayload> = {
 export const isDebugMenuVisible = (state: State) => state.appstate.debugMenuVisible;
 export const isConnectedSelector = (state: State) => state.appstate.isConnected;
 export const isModalLockedSelector = (state: State) => state.appstate.modalLock;
-export const hasConnectedDeviceSelector = (state: State) =>
-  state.appstate.hasConnectedDevice;
+export const hasConnectedDeviceSelector = (state: State) => state.appstate.hasConnectedDevice;
 
 export const backgroundEventsSelector = (state: State) => state.appstate.backgroundEvents;
 

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -73,7 +73,6 @@ export type AppState = {
   modalLock: boolean;
   backgroundEvents: Array<FwUpdateBackgroundEvent>;
   isMainNavigatorVisible: boolean;
-  wiredDevice: DeviceLike | null;
 };
 
 // === BLE STATE ===

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -22,10 +22,7 @@ import { setLastSeenDeviceInfo } from "../../actions/settings";
 import { ScreenName } from "../../const";
 import FirmwareUpdateScreen from "../../components/FirmwareUpdate";
 import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/types/ManagerNavigator";
-import {
-  BaseComposite,
-  StackNavigatorProps,
-} from "../../components/RootNavigator/types/helpers";
+import { BaseComposite, StackNavigatorProps } from "../../components/RootNavigator/types/helpers";
 import { lastConnectedDeviceSelector } from "../../reducers/settings";
 
 type NavigationProps = BaseComposite<

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, memo, useMemo } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { from } from "rxjs";
 import type { App } from "@ledgerhq/types-live";
 import { predictOptimisticState } from "@ledgerhq/live-common/apps/index";
@@ -22,7 +22,11 @@ import { setLastSeenDeviceInfo } from "../../actions/settings";
 import { ScreenName } from "../../const";
 import FirmwareUpdateScreen from "../../components/FirmwareUpdate";
 import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/types/ManagerNavigator";
-import { BaseComposite, StackNavigatorProps } from "../../components/RootNavigator/types/helpers";
+import {
+  BaseComposite,
+  StackNavigatorProps,
+} from "../../components/RootNavigator/types/helpers";
+import { lastConnectedDeviceSelector } from "../../reducers/settings";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<ManagerNavigatorStackParamList, ScreenName.ManagerMain>
@@ -43,6 +47,17 @@ const Manager = ({ navigation, route }: NavigationProps) => {
   const { deviceId, deviceName, modelId } = device;
   const [state, dispatch] = useApps(result, deviceId, appsToRestore);
   const reduxDispatch = useDispatch();
+
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  useEffect(() => {
+    // refresh the manager if a new device gets connected
+    // (happes only when we plug a new device via USB)
+    if (lastConnectedDevice?.deviceId !== device.deviceId) {
+      navigation.replace(ScreenName.Manager, {
+        device: lastConnectedDevice,
+      });
+    }
+  }, [device.deviceId, lastConnectedDevice, navigation]);
 
   const refreshDeviceInfo = useCallback(() => {
     withDevice(deviceId)(transport => from(getDeviceInfo(transport)))


### PR DESCRIPTION
### 📝 Description
Since https://github.com/LedgerHQ/ledger-live/pull/2742 it has been possible to bypass the USB-only restriction on the firmware update for LNX and start the firmware update using a Bluetooth transport. However, Bluetooth firmware updates are not supported by LNX and can lead to unpredictable behaviour. This PR fixes this and keeps the fix that was made on https://github.com/LedgerHQ/ledger-live/pull/2742 for the firmware update banner. It does that by updating the transport to be considered for the firmware update when we plug a device via USB. If the user is on the manager, the manager gets reloaded and starts using the USB transport for all operations (Firmware update, app installations, etc).

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-7048]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
https://github.com/LedgerHQ/ledger-live/assets/6013294/61546a2e-0f73-4bf8-9672-502708cc8eff





[LIVE-7048]: https://ledgerhq.atlassian.net/browse/LIVE-7048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ