### PR TITLE
feat(Firmware Update LLM): make stax battery warning unskippable

### DIFF
--- a/.changeset/tidy-crabs-relax.md
+++ b/.changeset/tidy-crabs-relax.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Make the battery warning banner for firmware updates on Stax unskippable.

--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -16,6 +16,7 @@ import devDeviceAppsScenario from "./commands/devDeviceAppsScenario";
 import deviceAppVersion from "./commands/deviceAppVersion";
 import deviceInfo from "./commands/deviceInfo";
 import deviceSDKFirmwareUpdate from "./commands/deviceSDKFirmwareUpdate";
+import deviceSDKGetBatteryStatuses from "./commands/deviceSDKGetBatteryStatuses";
 import deviceSDKGetDeviceInfo from "./commands/deviceSDKGetDeviceInfo";
 import deviceSDKToggleOnboardingEarlyCheck from "./commands/deviceSDKToggleOnboardingEarlyCheck";
 import deviceVersion from "./commands/deviceVersion";
@@ -78,6 +79,7 @@ export default {
   deviceAppVersion,
   deviceInfo,
   deviceSDKFirmwareUpdate,
+  deviceSDKGetBatteryStatuses,
   deviceSDKGetDeviceInfo,
   deviceSDKToggleOnboardingEarlyCheck,
   deviceVersion,

--- a/apps/cli/src/commands/deviceSDKGetBatteryStatuses.ts
+++ b/apps/cli/src/commands/deviceSDKGetBatteryStatuses.ts
@@ -1,0 +1,27 @@
+import { Observable } from "rxjs";
+import { getBatteryStatusesAction } from "@ledgerhq/live-common/deviceSDK/actions/getBatteryStatuses";
+import { deviceOpt } from "../scan";
+import { BatteryStatusTypes } from "@ledgerhq/live-common/hw/getBatteryStatus";
+
+export default {
+  description: "Device SDK: get battery statuses",
+  args: [deviceOpt],
+  job: ({
+    device,
+  }: Partial<{
+    device: string;
+  }>) => {
+    return new Observable((o) => {
+      return getBatteryStatusesAction({
+        deviceId: device ?? "",
+        statuses: [
+          BatteryStatusTypes.BATTERY_CURRENT,
+          BatteryStatusTypes.BATTERY_FLAGS,
+          BatteryStatusTypes.BATTERY_PERCENTAGE,
+          BatteryStatusTypes.BATTERY_TEMPERATURE,
+          BatteryStatusTypes.BATTERY_VOLTAGE,
+        ],
+      }).subscribe(o);
+    });
+  },
+};

--- a/apps/cli/src/commands/deviceSDKGetBatteryStatuses.ts
+++ b/apps/cli/src/commands/deviceSDKGetBatteryStatuses.ts
@@ -11,7 +11,7 @@ export default {
   }: Partial<{
     device: string;
   }>) => {
-    return new Observable((o) => {
+    return new Observable(o => {
       return getBatteryStatusesAction({
         deviceId: device ?? "",
         statuses: [

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -40,7 +40,7 @@ const requiredBatteryStatuses = [
 
 const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) => {
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
-  const wiredDevice = useSelector(getWiredDeviceSelector);
+
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   const hasConnectedDevice = useSelector(hasConnectedDeviceSelector);
   const hasCompletedOnboarding: boolean = useSelector(hasCompletedOnboardingSelector);

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -160,15 +160,6 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     wiredDevice,
   ]);
 
-  const onContinueWithLowBattery = useCallback(() => {
-    if (newFwUpdateUxFeatureFlag?.enabled) {
-      onExperimentalFirmwareUpdate();
-    } else {
-      setShowBatteryWarningDrawer(false);
-      setShowUnsupportedUpdateDrawer(true);
-    }
-  }, [newFwUpdateUxFeatureFlag?.enabled, onExperimentalFirmwareUpdate]);
-
   const deviceName = lastConnectedDevice
     ? getDeviceModel(lastConnectedDevice.modelId).productName
     : "";
@@ -267,11 +258,11 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
           <Button
             type="main"
             outline={false}
-            onPress={onContinueWithLowBattery}
+            onPress={() => setShowBatteryWarningDrawer(false)}
             mt={8}
             alignSelf="stretch"
           >
-            {t("common.continue")}
+            {t("common.close")}
           </Button>
         </Flex>
       </QueuedDrawer>

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -14,6 +14,7 @@ import isFirmwareUpdateVersionSupported from "@ledgerhq/live-common/hw/isFirmwar
 import useLatestFirmware from "@ledgerhq/live-common/hooks/useLatestFirmware";
 import { useBatteryStatuses } from "@ledgerhq/live-common/deviceSDK/hooks/useBatteryStatuses";
 import { BatteryStatusFlags } from "@ledgerhq/types-devices";
+import { log } from "@ledgerhq/logs";
 
 import { ScreenName, NavigatorName } from "../const";
 import {
@@ -104,6 +105,14 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     deviceId: lastConnectedDevice?.deviceId,
     statuses: requiredBatteryStatuses,
   });
+
+  // TODO: to remove this, it is temporary for debugging
+  useEffect(() => {
+    if (batteryStatusesState.error) {
+      log("error", "error when retrieving the battery statuses", batteryStatusesState.error);
+    }
+  }, [batteryStatusesState.error]);
+
   // Effect that will check the battery of stax before triggering the update and display a warning preventing the update
   // in case the battery is too low and the device is not charging
   useEffect(() => {
@@ -278,8 +287,8 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
       </QueuedDrawer>
       <QueuedDrawer
         isRequestingToBeOpened={
-          (batteryStatusesState.error &&
-            batteryStatusesState.error.message === "DisconnectedDevice") ||
+          batteryStatusesState.error?.message === "DisconnectedDevice" ||
+          batteryStatusesState.error?.message === "ConnectManagerTimeout" ||
           batteryStatusesState.lockedDevice
         }
         onClose={() => {

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -1,20 +1,20 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { Platform, Linking } from "react-native";
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { useNavigation, useRoute, useTheme } from "@react-navigation/native";
 import { DeviceModelInfo } from "@ledgerhq/types-live";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Alert, Text, Flex, IconsLegacy, IconBadge } from "@ledgerhq/native-ui";
+import { Alert, Text, Flex, IconsLegacy, IconBadge, ProgressLoader } from "@ledgerhq/native-ui";
 import { DownloadMedium, UsbMedium } from "@ledgerhq/native-ui/assets/icons";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { StackNavigationProp } from "@react-navigation/stack";
-import getBatteryStatus, { BatteryStatusTypes } from "@ledgerhq/live-common/hw/getBatteryStatus";
-import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
-import { from } from "rxjs";
+import { BatteryStatusTypes } from "@ledgerhq/live-common/hw/getBatteryStatus";
 import isFirmwareUpdateVersionSupported from "@ledgerhq/live-common/hw/isFirmwareUpdateVersionSupported";
 import useLatestFirmware from "@ledgerhq/live-common/hooks/useLatestFirmware";
-import { log } from "@ledgerhq/logs";
+import { useBatteryStatuses } from "@ledgerhq/live-common/deviceSDK/hooks/useBatteryStatuses";
+import { BatteryStatusFlags } from "@ledgerhq/types-devices";
+
 import { ScreenName, NavigatorName } from "../const";
 import {
   lastSeenDeviceSelector,
@@ -26,20 +26,30 @@ import Button from "./Button";
 import QueuedDrawer from "./QueuedDrawer";
 import InvertTheme from "./theme/InvertTheme";
 import { urls } from "../config/urls";
+import { renderConnectYourDevice } from "./DeviceAction/rendering";
 
 type FirmwareUpdateBannerProps = {
   onBackFromUpdate?: () => void;
 };
 
+const requiredBatteryStatuses = [
+  BatteryStatusTypes.BATTERY_PERCENTAGE,
+  BatteryStatusTypes.BATTERY_FLAGS,
+];
+
 const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) => {
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
+
+  const wiredDevice = useSelector(getWiredDeviceSelector);
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   const hasConnectedDevice = useSelector(hasConnectedDeviceSelector);
   const hasCompletedOnboarding: boolean = useSelector(hasCompletedOnboardingSelector);
 
+  const { dark } = useTheme();
+  const theme: "dark" | "light" = dark ? "dark" : "light";
   const [disableUpdateButton, setDisableUpdateButton] = useState(false);
-  const [staxUpdateTriggerNonce, setStaxUpdateTriggerNonce] = useState(0);
-  const [showBatteryWarningDrawer, setShowBatteryWarningDrawer] = useState<boolean>(false);
+  const [showBatteryWarningDrawer, setShowBatteryWarningDrawer] =
+    useState<boolean>(false);
 
   const [showUnsupportedUpdateDrawer, setShowUnsupportedUpdateDrawer] = useState<boolean>(false);
 
@@ -87,40 +97,33 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     onBackFromUpdate,
   ]);
 
+  const {
+    requestCompleted: batteryRequestCompleted,
+    batteryStatusesState,
+    triggerRequest: triggerBatteryCheck,
+    cancelRequest: cancelBatteryCheck,
+  } = useBatteryStatuses({
+    deviceId: lastConnectedDevice?.deviceId,
+    statuses: requiredBatteryStatuses,
+  });
   // Effect that will check the battery of stax before triggering the update and display a warning preventing the update
   // in case the battery is too low and the device is not charging
   useEffect(() => {
-    if (staxUpdateTriggerNonce > 0 && lastConnectedDevice) {
-      setDisableUpdateButton(true);
-      const sub = withDevice(lastConnectedDevice.deviceId)(transport =>
-        from(
-          getBatteryStatus(transport, [
-            BatteryStatusTypes.BATTERY_PERCENTAGE,
-            BatteryStatusTypes.BATTERY_FLAGS,
-          ] as const),
-        ),
-      ).subscribe({
-        next: ([percentage, statusFlags]) => {
-          percentage < 20 && statusFlags.charging === 0
-            ? setShowBatteryWarningDrawer(true)
-            : onExperimentalFirmwareUpdate();
-          setDisableUpdateButton(false);
-        },
-        error: err => {
-          log("FirmwareUpdateBanner", "Unable to retrieve Stax's battery", err);
-          setShowBatteryWarningDrawer(true);
-          setDisableUpdateButton(false);
-        },
-      });
+    if (batteryRequestCompleted) {
+      const [percentage, statusFlags] =
+        batteryStatusesState.batteryStatuses as [number, BatteryStatusFlags];
 
-      return () => {
-        setDisableUpdateButton(false);
-        sub.unsubscribe();
-      };
+      percentage < 20 && statusFlags.charging === 0
+        ? setShowBatteryWarningDrawer(true)
+        : onExperimentalFirmwareUpdate();
+
+      setDisableUpdateButton(false);
     }
-
-    return undefined;
-  }, [lastConnectedDevice, onExperimentalFirmwareUpdate, staxUpdateTriggerNonce]);
+  }, [
+    batteryRequestCompleted,
+    batteryStatusesState.batteryStatuses,
+    onExperimentalFirmwareUpdate,
+  ]);
 
   const showBanner = Boolean(latestFirmware);
   const version = latestFirmware?.final?.name ?? "";
@@ -150,7 +153,8 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     if (lastConnectedDevice?.modelId === DeviceModelId.stax && newFwUpdateUxFeatureFlag?.enabled) {
       // This leads to a check on the battery before triggering update, it is only necessary for Stax and on the new UX
       // (because it's the only type of update that can happen via BLE)
-      setStaxUpdateTriggerNonce(staxUpdateTriggerNonce + 1);
+      setDisableUpdateButton(true);
+      triggerBatteryCheck();
     }
     // Path with any device model, wired and on android
     else if (isUsbFwVersionUpdateSupported && wiredDevice && Platform.OS === "android") {
@@ -159,12 +163,12 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
       setShowUnsupportedUpdateDrawer(true);
     }
   }, [
-    isUsbFwVersionUpdateSupported,
-    newFwUpdateUxFeatureFlag?.enabled,
     lastConnectedDevice?.modelId,
-    staxUpdateTriggerNonce,
-    onExperimentalFirmwareUpdate,
+    newFwUpdateUxFeatureFlag?.enabled,
+    isUsbFwVersionUpdateSupported,
     wiredDevice,
+    triggerBatteryCheck,
+    onExperimentalFirmwareUpdate,
   ]);
 
   const deviceName = lastConnectedDevice
@@ -202,10 +206,14 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
                 eventProperties={{ button: "Update" }}
                 disabled={disableUpdateButton}
                 type="main"
-                title={t("FirmwareUpdate.update")}
+                title={!disableUpdateButton ? t("FirmwareUpdate.update") : null}
                 onPress={onClickUpdate}
                 outline={false}
-              />
+              >
+                {disableUpdateButton && (
+                  <ProgressLoader infinite radius={10} strokeWidth={2} />
+                )}
+              </Button>
             </Flex>
           </InvertTheme>
         </Flex>
@@ -273,6 +281,24 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
             {t("common.close")}
           </Button>
         </Flex>
+      </QueuedDrawer>
+      <QueuedDrawer
+        isRequestingToBeOpened={batteryStatusesState.lockedDevice}
+        onClose={() => {
+          cancelBatteryCheck();
+          setDisableUpdateButton(false);
+        }}
+      >
+        {lastConnectedDevice && (
+          <Flex alignItems="center" justifyContent="center" px={1}>
+            {renderConnectYourDevice({
+              t,
+              device: lastConnectedDevice,
+              theme,
+              fullScreen: false,
+            })}
+          </Flex>
+        )}
       </QueuedDrawer>
     </>
   ) : null;

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -39,7 +39,6 @@ const requiredBatteryStatuses = [
 
 const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) => {
   const lastSeenDevice: DeviceModelInfo | null | undefined = useSelector(lastSeenDeviceSelector);
-
   const wiredDevice = useSelector(getWiredDeviceSelector);
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   const hasConnectedDevice = useSelector(hasConnectedDeviceSelector);
@@ -48,8 +47,7 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
   const { dark } = useTheme();
   const theme: "dark" | "light" = dark ? "dark" : "light";
   const [disableUpdateButton, setDisableUpdateButton] = useState(false);
-  const [showBatteryWarningDrawer, setShowBatteryWarningDrawer] =
-    useState<boolean>(false);
+  const [showBatteryWarningDrawer, setShowBatteryWarningDrawer] = useState<boolean>(false);
 
   const [showUnsupportedUpdateDrawer, setShowUnsupportedUpdateDrawer] = useState<boolean>(false);
 
@@ -110,8 +108,10 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
   // in case the battery is too low and the device is not charging
   useEffect(() => {
     if (batteryRequestCompleted) {
-      const [percentage, statusFlags] =
-        batteryStatusesState.batteryStatuses as [number, BatteryStatusFlags];
+      const [percentage, statusFlags] = batteryStatusesState.batteryStatuses as [
+        number,
+        BatteryStatusFlags,
+      ];
 
       percentage < 20 && statusFlags.charging === 0
         ? setShowBatteryWarningDrawer(true)
@@ -119,11 +119,7 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
 
       setDisableUpdateButton(false);
     }
-  }, [
-    batteryRequestCompleted,
-    batteryStatusesState.batteryStatuses,
-    onExperimentalFirmwareUpdate,
-  ]);
+  }, [batteryRequestCompleted, batteryStatusesState.batteryStatuses, onExperimentalFirmwareUpdate]);
 
   const showBanner = Boolean(latestFirmware);
   const version = latestFirmware?.final?.name ?? "";
@@ -210,9 +206,7 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
                 onPress={onClickUpdate}
                 outline={false}
               >
-                {disableUpdateButton && (
-                  <ProgressLoader infinite radius={10} strokeWidth={2} />
-                )}
+                {disableUpdateButton && <ProgressLoader infinite radius={10} strokeWidth={2} />}
               </Button>
             </Flex>
           </InvertTheme>

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -277,7 +277,11 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
         </Flex>
       </QueuedDrawer>
       <QueuedDrawer
-        isRequestingToBeOpened={batteryStatusesState.lockedDevice}
+        isRequestingToBeOpened={
+          (batteryStatusesState.error &&
+            batteryStatusesState.error.message === "DisconnectedDevice") ||
+          batteryStatusesState.lockedDevice
+        }
         onClose={() => {
           cancelBatteryCheck();
           setDisableUpdateButton(false);

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -288,7 +288,7 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
       <QueuedDrawer
         isRequestingToBeOpened={
           batteryStatusesState.error?.message === "DisconnectedDevice" ||
-          batteryStatusesState.error?.message === "ConnectManagerTimeout" ||
+          batteryStatusesState.error?.name === "TimeoutError" ||
           batteryStatusesState.lockedDevice
         }
         onClose={() => {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4224,6 +4224,18 @@
       "pleaseConnectUsbTitle": "USB cable needed",
       "pleaseConnectUsbDescription": "To start the firmware update, plug your {{deviceName}} to your mobile phone using a USB cable."
     },
+    "batteryStatusErrors": {
+      "errors": {
+        "TimeoutError": {
+          "title": "Device disconnected",
+          "description": "The update was unable to start because we lost connection to {{deviceName}}"
+        },
+        "BatteryStatusNotRetrieved": {
+          "title": "Unable to retrieve battery status",
+          "description": "The update was unable to start because we weren't able to retrieve the battery status for {{deviceName}}"
+        }
+      }
+    },
     "errors": {
       "TimeoutError": {
         "title": "Update timeout",

--- a/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
@@ -1,0 +1,63 @@
+import { BatteryStatusFlags } from "@ledgerhq/types-devices";
+import { DeviceId } from "@ledgerhq/types-live";
+import { Observable } from "rxjs";
+import { scan } from "rxjs/operators";
+import {
+  FullActionState,
+  initialSharedActionState,
+  sharedReducer,
+} from "./core";
+import {
+  getBatteryStatusTask,
+  GetBatteryStatusesTaskError,
+} from "../tasks/getBatteryStatuses";
+import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+
+export type GetBatteryStatusesActionArgs = {
+  deviceId: DeviceId;
+  statuses: BatteryStatusTypes[];
+};
+
+// Union of all the tasks specific errors
+export type GetBatteryStatusesActionErrorType = GetBatteryStatusesTaskError;
+
+export type GetBatteryStatusesActionState = FullActionState<{
+  batteryStatuses: (number | BatteryStatusFlags)[];
+  error: { type: GetBatteryStatusesActionErrorType; message?: string } | null;
+}>;
+
+export const initialState: GetBatteryStatusesActionState = {
+  batteryStatuses: [],
+  ...initialSharedActionState,
+};
+
+export function getBatteryStatusesAction({
+  deviceId,
+  statuses,
+}: GetBatteryStatusesActionArgs): Observable<GetBatteryStatusesActionState> {
+  return getBatteryStatusTask({ deviceId, statuses }).pipe(
+    scan((currentState, event) => {
+      switch (event.type) {
+        case "taskError":
+          return { ...initialState, error: { type: event.error } };
+        case "data":
+          return {
+            ...currentState,
+            error: null,
+            lockedDevice: false,
+            batteryStatuses: [
+              ...currentState.batteryStatuses,
+              event.batteryStatus,
+            ],
+          };
+        case "error":
+          return {
+            ...currentState,
+            ...sharedReducer({
+              event,
+            }),
+          };
+      }
+    }, initialState)
+  );
+}

--- a/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
@@ -16,7 +16,7 @@ export type GetBatteryStatusesActionErrorType = GetBatteryStatusesTaskError;
 
 export type GetBatteryStatusesActionState = FullActionState<{
   batteryStatuses: (number | BatteryStatusFlags)[];
-  error: { type: GetBatteryStatusesActionErrorType; message?: string } | null;
+  error: { type: GetBatteryStatusesActionErrorType; message?: string; name?: string } | null;
 }>;
 
 export const initialState: GetBatteryStatusesActionState = {

--- a/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
@@ -2,15 +2,8 @@ import { BatteryStatusFlags } from "@ledgerhq/types-devices";
 import { DeviceId } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
 import { scan } from "rxjs/operators";
-import {
-  FullActionState,
-  initialSharedActionState,
-  sharedReducer,
-} from "./core";
-import {
-  getBatteryStatusTask,
-  GetBatteryStatusesTaskError,
-} from "../tasks/getBatteryStatuses";
+import { FullActionState, initialSharedActionState, sharedReducer } from "./core";
+import { getBatteryStatusTask, GetBatteryStatusesTaskError } from "../tasks/getBatteryStatuses";
 import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
 
 export type GetBatteryStatusesActionArgs = {
@@ -45,10 +38,7 @@ export function getBatteryStatusesAction({
             ...currentState,
             error: null,
             lockedDevice: false,
-            batteryStatuses: [
-              ...currentState.batteryStatuses,
-              event.batteryStatus,
-            ],
+            batteryStatuses: [...currentState.batteryStatuses, event.batteryStatus],
           };
         case "error":
           return {
@@ -58,6 +48,6 @@ export function getBatteryStatusesAction({
             }),
           };
       }
-    }, initialState)
+    }, initialState),
   );
 }

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.test.ts
@@ -3,9 +3,9 @@ import { ChargingModes } from "@ledgerhq/types-devices";
 import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
 import { getBatteryStatus } from "./getBatteryStatus";
 
-const mockTransportGenerator = (out) =>
+const mockTransportGenerator = out =>
   ({
-    send: () => new Promise((res) => res(out)),
+    send: () => new Promise(res => res(out)),
     on: () => {},
     off: () => {},
     setExchangeUnresponsiveTimeout: () => {},
@@ -120,9 +120,7 @@ describe("getBatteryStatus", () => {
 
   test("battery flags for USB charging", async () => {
     const statusType = BatteryStatusTypes.BATTERY_FLAGS;
-    const transport = mockTransportGenerator(
-      Buffer.from("0000000F9000", "hex")
-    );
+    const transport = mockTransportGenerator(Buffer.from("0000000F9000", "hex"));
 
     const response = await getBatteryStatus({
       transport,
@@ -142,9 +140,7 @@ describe("getBatteryStatus", () => {
 
   test("battery flags for not charging", async () => {
     const statusType = BatteryStatusTypes.BATTERY_FLAGS;
-    const transport = mockTransportGenerator(
-      Buffer.from("000000069000", "hex")
-    );
+    const transport = mockTransportGenerator(Buffer.from("000000069000", "hex"));
 
     const response = await getBatteryStatus({
       transport,
@@ -164,9 +160,7 @@ describe("getBatteryStatus", () => {
 
   test("battery flags for Qi charging without USB", async () => {
     const statusType = BatteryStatusTypes.BATTERY_FLAGS;
-    const transport = mockTransportGenerator(
-      Buffer.from("000000079000", "hex")
-    );
+    const transport = mockTransportGenerator(Buffer.from("000000079000", "hex"));
 
     const response = await getBatteryStatus({
       transport,

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.test.ts
@@ -1,0 +1,186 @@
+import Transport from "@ledgerhq/hw-transport";
+import { ChargingModes } from "@ledgerhq/types-devices";
+import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+import { getBatteryStatus } from "./getBatteryStatus";
+
+const mockTransportGenerator = (out) =>
+  ({
+    send: () => new Promise((res) => res(out)),
+    on: () => {},
+    off: () => {},
+    setExchangeUnresponsiveTimeout: () => {},
+  } as unknown as Transport);
+
+describe("getBatteryStatus", () => {
+  test("battery percentage OK", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_PERCENTAGE;
+    const transport = mockTransportGenerator(Buffer.from("639000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(99);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery percentage KO returns -1", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_PERCENTAGE;
+    const transport = mockTransportGenerator(Buffer.from("FF9000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(-1);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery voltage resolves", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_VOLTAGE;
+    const transport = mockTransportGenerator(Buffer.from("0FFF9000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(4095);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery temperature with positive values", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_TEMPERATURE;
+    const transport = mockTransportGenerator(Buffer.from("109000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(16);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery temperature with negative values", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_TEMPERATURE;
+    const transport = mockTransportGenerator(Buffer.from("FD9000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(-3);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery current with positive values", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_CURRENT;
+    const transport = mockTransportGenerator(Buffer.from("109000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(16);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery current with negative values", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_CURRENT;
+    const transport = mockTransportGenerator(Buffer.from("FD9000", "hex"));
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual(-3);
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery flags for USB charging", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_FLAGS;
+    const transport = mockTransportGenerator(
+      Buffer.from("0000000F9000", "hex")
+    );
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual({
+        charging: ChargingModes.USB,
+        issueCharging: false,
+        issueTemperature: false,
+        issueBattery: false,
+      });
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery flags for not charging", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_FLAGS;
+    const transport = mockTransportGenerator(
+      Buffer.from("000000069000", "hex")
+    );
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual({
+        charging: ChargingModes.NONE,
+        issueCharging: false,
+        issueTemperature: false,
+        issueBattery: false,
+      });
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+
+  test("battery flags for Qi charging without USB", async () => {
+    const statusType = BatteryStatusTypes.BATTERY_FLAGS;
+    const transport = mockTransportGenerator(
+      Buffer.from("000000079000", "hex")
+    );
+
+    const response = await getBatteryStatus({
+      transport,
+      statusType,
+    }).toPromise();
+    if (response.type === "data") {
+      expect(response.batteryStatus).toEqual({
+        charging: ChargingModes.QI,
+        issueCharging: false,
+        issueTemperature: false,
+        issueBattery: false,
+      });
+    } else {
+      fail("Incorrect response event");
+    }
+  });
+});

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
@@ -19,7 +19,7 @@ export function getBatteryStatus({
   transport,
   statusType,
 }: GetBatteryStatusCmdArgs): Observable<GetBatteryStatusCmdEvent> {
-  return new Observable((subscriber) => {
+  return new Observable(subscriber => {
     const oldTimeout = transport.unresponsiveTimeout;
     transport.setExchangeUnresponsiveTimeout(1000);
 
@@ -87,7 +87,7 @@ export function getBatteryStatus({
             }
           }
         }),
-        finalize(() => transport.setExchangeUnresponsiveTimeout(oldTimeout))
+        finalize(() => transport.setExchangeUnresponsiveTimeout(oldTimeout)),
       )
       .subscribe(subscriber);
   });

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
@@ -1,0 +1,96 @@
+import Transport from "@ledgerhq/hw-transport";
+import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+import { UnresponsiveCmdEvent } from "./core";
+import { Observable, from, of } from "rxjs";
+import { finalize, switchMap } from "rxjs/operators";
+import { BatteryStatusTypes, FlagMasks } from "../../hw/getBatteryStatus";
+
+export type GetBatteryStatusCmdEvent =
+  | { type: "data"; batteryStatus: BatteryStatusFlags | number }
+  | UnresponsiveCmdEvent;
+
+export type GetBatteryStatusCmdArgs = {
+  transport: Transport;
+  statusType: BatteryStatusTypes;
+};
+
+export function getBatteryStatus({
+  transport,
+  statusType,
+}: GetBatteryStatusCmdArgs): Observable<GetBatteryStatusCmdEvent> {
+  return new Observable((subscriber) => {
+    const oldTimeout = transport.unresponsiveTimeout;
+    transport.setExchangeUnresponsiveTimeout(1000);
+
+    const unresponsiveCallback = () => {
+      // Needs to push a value and not an error to allow the command to continue once
+      // the device is not unresponsive anymore. Pushing an error would stop the command.
+      subscriber.next({ type: "unresponsive" });
+    };
+
+    transport.on("unresponsive", unresponsiveCallback);
+
+    return from(transport.send(0xe0, 0x10, 0x00, statusType))
+      .pipe(
+        switchMap((res): Observable<GetBatteryStatusCmdEvent> => {
+          transport.off("unresponsive", unresponsiveCallback);
+
+          const status = res.readUInt16BE(res.length - 2);
+
+          if (status !== StatusCodes.OK) {
+            throw new TransportStatusError(status);
+          }
+
+          switch (statusType) {
+            case BatteryStatusTypes.BATTERY_PERCENTAGE: {
+              // Nb values greater that 100 would mean a bad case
+              // to be assessed if we want to break the flow.
+              const temp = res.readUInt8(0);
+              return of({
+                type: "data",
+                batteryStatus: temp > 100 ? -1 : temp,
+              });
+            }
+            case BatteryStatusTypes.BATTERY_VOLTAGE:
+              return of({
+                type: "data",
+                batteryStatus: res.readUInt16BE(0),
+              });
+            case BatteryStatusTypes.BATTERY_TEMPERATURE:
+            case BatteryStatusTypes.BATTERY_CURRENT:
+              // Nb turn the usigned byte into a signed int to cover
+              // negative values. Two's compliment.
+              return of({
+                type: "data",
+                batteryStatus: (res.readUInt8() << 24) >> 24,
+              });
+            case BatteryStatusTypes.BATTERY_FLAGS: {
+              const flags = res.readUInt16BE(2); // Nb Ignoring the first two bytes
+
+              const chargingUSB = !!(flags & FlagMasks.USB_POWERED);
+              const chargingQi = !chargingUSB && !!(flags & FlagMasks.CHARGING);
+
+              return of({
+                type: "data",
+                batteryStatus: {
+                  charging: chargingQi
+                    ? ChargingModes.QI
+                    : chargingUSB
+                    ? ChargingModes.USB
+                    : ChargingModes.NONE,
+                  issueCharging: !!(flags & FlagMasks.ISSUE_CHARGING),
+                  issueTemperature: !!(flags & FlagMasks.ISSUE_TEMPERATURE),
+                  issueBattery: !!(flags & FlagMasks.ISSUE_BATTERY),
+                },
+              });
+            }
+          }
+        }),
+        finalize(() => transport.setExchangeUnresponsiveTimeout(oldTimeout))
+      )
+      .subscribe(subscriber);
+  });
+}
+
+export default getBatteryStatus;

--- a/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
@@ -39,7 +39,7 @@ export const useBatteryStatuses = ({
         deviceId,
         statuses,
       }).subscribe({
-        next: (state) => setBatteryStatusesState(state),
+        next: state => setBatteryStatusesState(state),
         complete: () => {
           setRequestCompleted(true);
         },
@@ -60,7 +60,7 @@ export const useBatteryStatuses = ({
   const triggerRequest = useCallback(() => {
     setRequestCompleted(false);
     setBatteryStatusesState(initialState);
-    setNonce((nonce) => nonce + 1);
+    setNonce(nonce => nonce + 1);
   }, []);
 
   return {

--- a/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  getBatteryStatusesAction,
+  GetBatteryStatusesActionState,
+  initialState,
+} from "../actions/getBatteryStatuses";
+import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+
+export type UseBateryStatusesArgs = {
+  deviceId: string;
+  statuses: BatteryStatusTypes[];
+};
+
+/**
+ * Hook used to query one or multiple battery statuses for Ledger Stax. The state will contain an array of with all the
+ * requested statuses in corresponding order.
+ * @param Args Object containing the arguments of the hook: a deviceId and a list of status types to query
+ * @returns An object containing the current state of the request, a boolean that informs if the request is complete,
+ * and a function to trigger an retrigger the device action
+ */
+export const useBatteryStatuses = ({
+  deviceId,
+  statuses,
+}: UseBateryStatusesArgs): {
+  batteryStatusesState: GetBatteryStatusesActionState;
+  requestCompleted: boolean;
+  triggerRequest: () => void;
+} => {
+  const [batteryStatusesState, setBatteryStatusesState] =
+    useState<GetBatteryStatusesActionState>(initialState);
+  const [requestCompleted, setRequestCompleted] = useState<boolean>(false);
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    if (nonce > 0) {
+      const sub = getBatteryStatusesAction({
+        deviceId,
+        statuses,
+      }).subscribe({
+        next: (state) => setBatteryStatusesState(state),
+      });
+
+      return () => {
+        sub.unsubscribe();
+      };
+    }
+  }, [deviceId, statuses, nonce]);
+
+  const triggerRequest = useCallback(() => {
+    setRequestCompleted(false);
+    setBatteryStatusesState(initialState);
+    setNonce((nonce) => nonce + 1);
+  }, []);
+
+  return {
+    batteryStatusesState,
+    triggerRequest,
+    requestCompleted,
+  };
+};

--- a/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
@@ -5,6 +5,7 @@ import {
   initialState,
 } from "../actions/getBatteryStatuses";
 import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+import { log } from "@ledgerhq/logs";
 
 export type UseBateryStatusesArgs = {
   deviceId?: string;
@@ -43,6 +44,7 @@ export const useBatteryStatuses = ({
         complete: () => {
           setRequestCompleted(true);
         },
+        error: err => log("error", "error while retrieving the battery statuses", err),
       });
 
       setCancelRequest(() => () => {

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -1,0 +1,70 @@
+import { DisconnectedDevice, LockedDeviceError } from "@ledgerhq/errors";
+import type { DeviceId } from "@ledgerhq/types-live";
+
+import { Observable, concat } from "rxjs";
+import { map, switchMap } from "rxjs/operators";
+import {
+  SharedTaskEvent,
+  retryOnErrorsCommandWrapper,
+  sharedLogicTaskWrapper,
+} from "./core";
+import { quitApp } from "../commands/quitApp";
+import { withTransport } from "../transports/core";
+import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+import { BatteryStatusFlags } from "@ledgerhq/types-devices";
+import getBatteryStatus from "../commands/getBatteryStatus";
+
+export type GetBatteryStatusesTaskArgs = {
+  deviceId: DeviceId;
+  statuses: BatteryStatusTypes[];
+};
+
+// No taskError for getDeviceInfoTask. Kept for consistency with other tasks.
+export type GetBatteryStatusesTaskError = "None";
+
+export type GetBatteryStatusesTaskErrorEvent = {
+  type: "taskError";
+  error: GetBatteryStatusesTaskError;
+};
+
+export type GetBatteryStatusesTaskEvent =
+  | { type: "data"; batteryStatus: number | BatteryStatusFlags }
+  | GetBatteryStatusesTaskErrorEvent
+  | SharedTaskEvent;
+
+function internalGetBatteryStatusesTask({
+  deviceId,
+  statuses,
+}: GetBatteryStatusesTaskArgs): Observable<GetBatteryStatusesTaskEvent> {
+  return new Observable((subscriber) => {
+    return withTransport(deviceId)(({ transportRef }) =>
+      quitApp(transportRef.current).pipe(
+        switchMap(() => {
+          const statusesObservable = statuses.map((statusType) =>
+            retryOnErrorsCommandWrapper({
+              command: ({ transport }) =>
+                getBatteryStatus({ transport, statusType }),
+              allowedErrors: [
+                { maxRetries: 3, errorClass: DisconnectedDevice },
+              ],
+            })(transportRef, {})
+          );
+          return concat(...statusesObservable);
+        }),
+        map((value) => {
+          if (value.type === "unresponsive") {
+            return { type: "error" as const, error: new LockedDeviceError() };
+          }
+
+          const { batteryStatus } = value;
+
+          return { type: "data" as const, batteryStatus };
+        })
+      )
+    ).subscribe(subscriber);
+  });
+}
+
+export const getBatteryStatusTask = sharedLogicTaskWrapper(
+  internalGetBatteryStatusesTask
+);

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.ts
@@ -12,7 +12,7 @@ export enum BatteryStatusTypes {
 
 // Nb USB and BLE masks not used by implementation since we have
 // them from the model.
-enum FlagMasks {
+export enum FlagMasks {
   CHARGING = 0x00000001,
   USB = 0x00000002,
   USB_POWERED = 0x00000008,


### PR DESCRIPTION
### 📝 Description
This PR makes two changes to the workings of the battery warning banner on firmware updates for Stax. The first one is that it checks the Stax battery status at the moment the user clicks to update, instead of when the component is rendered. This way we always have the latest status right before launching the firmware update.

The second change is making the warning banner unskippable, we do not allow the update to be launched on low, not charging, battery. 

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-7417]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
N/A

### 🚀 Expectations to reach


[LIVE-7417]: https://ledgerhq.atlassian.net/browse/LIVE-7417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ