### PR TITLE
optimize useTrackingPairForAccounts

### DIFF
--- a/libs/ledger-live-common/src/countervalues/logic.ts
+++ b/libs/ledger-live-common/src/countervalues/logic.ts
@@ -91,6 +91,7 @@ export function inferTrackingPairForAccounts(
 ): TrackingPair[] {
   const yearAgo = new Date();
   yearAgo.setFullYear(yearAgo.getFullYear() - 1);
+  yearAgo.setHours(0, 0, 0, 0);
   return resolveTrackingPairs(
     flattenAccounts(accounts).map((a) => {
       const currency = getAccountCurrency(a);

--- a/libs/ledger-live-common/src/countervalues/react.test.ts
+++ b/libs/ledger-live-common/src/countervalues/react.test.ts
@@ -1,0 +1,120 @@
+import { useTrackingPairForAccounts } from "./react";
+import { genAccount } from "../mock/account";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { getFiatCurrencyByTicker } from "../currencies";
+import { inferTrackingPairForAccounts } from "./logic";
+
+describe("useTrackingPairForAccounts", () => {
+  const accounts = Array(20)
+    .fill(null)
+    .map((_, i) => genAccount("test" + i));
+  const usd = getFiatCurrencyByTicker("USD");
+  const eur = getFiatCurrencyByTicker("EUR");
+  const trackingPairs = inferTrackingPairForAccounts(accounts, usd);
+
+  test("it returns same tracking pairs as when using inferTrackingPairForAccounts", async () => {
+    const { result } = renderHook(() =>
+      useTrackingPairForAccounts(accounts, usd)
+    );
+    await act(async () => {
+      expect(result.current).toEqual(trackingPairs);
+    });
+  });
+
+  test("a re-render preserve the reference", async () => {
+    const { result, rerender } = renderHook(() =>
+      useTrackingPairForAccounts(accounts, usd)
+    );
+    let initial;
+    await act(async () => {
+      initial = result.current;
+    });
+    rerender();
+    await act(async () => {
+      expect(result.current).toBe(initial);
+    });
+  });
+
+  test("a re-render preserve the reference even when accounts change", async () => {
+    const { result, rerender } = renderHook(() =>
+      useTrackingPairForAccounts(accounts.slice(0), usd)
+    );
+    let initial;
+    await act(async () => {
+      initial = result.current;
+    });
+    rerender();
+    await act(async () => {
+      expect(result.current).toBe(initial);
+    });
+  });
+
+  test("when accounts appears, it properly converge to the trackingPairs", async () => {
+    const { result, rerender } = renderHook((added) =>
+      useTrackingPairForAccounts(!added ? [] : accounts, usd)
+    );
+    await act(async () => {
+      expect(result.current).toEqual([]);
+    });
+    rerender(true);
+    await act(async () => {
+      expect(result.current).toEqual(trackingPairs);
+    });
+  });
+
+  test("when accounts changes fundamentally, pairs change", async () => {
+    const { result, rerender } = renderHook((empty) =>
+      useTrackingPairForAccounts(empty ? [] : accounts, usd)
+    );
+    await act(async () => {
+      expect(result.current).toEqual(trackingPairs);
+    });
+    rerender(true);
+    await act(async () => {
+      expect(result.current).toEqual([]);
+    });
+  });
+
+  test("when currency changes, pairs change", async () => {
+    const { result, rerender } = renderHook((usesEur) =>
+      useTrackingPairForAccounts(accounts, usesEur ? eur : usd)
+    );
+    await act(async () => {
+      expect(result.current).toEqual(trackingPairs);
+    });
+    rerender(true);
+    await act(async () => {
+      expect(result.current).not.toEqual(trackingPairs);
+    });
+  });
+
+  test("if accounts reorder, it doesn't change", async () => {
+    const reverse = accounts.slice(0).reverse();
+    const { result, rerender } = renderHook((rev) =>
+      useTrackingPairForAccounts(rev ? reverse : accounts, usd)
+    );
+    let initial;
+    await act(async () => {
+      initial = result.current;
+    });
+    rerender(true);
+    await act(async () => {
+      expect(result.current).toBe(initial);
+    });
+  });
+
+  test("if accounts doubles, it doesn't change", async () => {
+    const doubled = accounts.concat(accounts);
+    const { result, rerender } = renderHook((d) =>
+      useTrackingPairForAccounts(d ? doubled : accounts, usd)
+    );
+    let initial;
+    await act(async () => {
+      initial = result.current;
+    });
+    rerender(true);
+    await act(async () => {
+      expect(result.current).toBe(initial);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/countervalues/react.tsx
+++ b/libs/ledger-live-common/src/countervalues/react.tsx
@@ -1,7 +1,6 @@
 import { BigNumber } from "bignumber.js";
 import React, {
   createContext,
-  useRef,
   useMemo,
   useContext,
   useEffect,
@@ -85,19 +84,17 @@ export function useTrackingPairForAccounts(
   accounts: Account[],
   countervalue: Currency
 ): TrackingPair[] {
-  const memo = useMemo(
-    () => inferTrackingPairForAccounts(accounts, countervalue),
-    [accounts, countervalue]
-  );
-  const ref = useRef(memo);
-
-  if (trackingPairsHash(ref.current) === trackingPairsHash(memo)) {
-    return ref.current;
-  }
-
-  ref.current = memo;
-  return memo;
+  // first we cache the tracking pairs with its hash
+  const c = useMemo(() => {
+    const pairs = inferTrackingPairForAccounts(accounts, countervalue);
+    return { pairs, hash: trackingPairsHash(pairs) };
+  }, [accounts, countervalue]);
+  // we only want to return the pairs when the hash changes
+  // to not recalculate pairs as fast as accounts resynchronizes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => c.pairs, [c.hash]);
 }
+
 export function Countervalues({
   children,
   userSettings,


### PR DESCRIPTION
- [x] add a test that covers this.

### 📝 Description

provide a faster implementation of useTrackingPairForAccounts.

this logic runs to determine what are the pairs to use with countervalues api. 
in the hook, we have two level of memo optimisation: a first level only calculate `inferTrackingPairForAccounts` when accounts and countervalue changes. however, it wasn't enough because accounts can change a lot, like every resync, and we then did a second level of optimisation using a hash that determines where the countervalues are likely to really change (which is most of the time never: unless you add/remove new accounts, there are still same countervalues to fetch), however we were probably not very efficient of that optimisation which likely have the reverse effect of what we try to optimise here.

- AFTER: we can only calculate the "hash" do it once per time `[accounts,countervalue]` change as much as `inferTrackingPairForAccounts` runs
- BEFORE: we were doing too much re-computation of that hash (which isn't free to calculate as it uses date formatting): 2 times per re-render.

### ❓ Context

- **Impacted projects**: `LLD, LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
