### PR TITLE
feat/LIVE-7727: do not wrap tag on eth staking drawer provider

### DIFF
--- a/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerProvider.tsx
+++ b/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerProvider.tsx
@@ -58,37 +58,31 @@ export function EthereumStakingDrawerProvider({
     <TouchableOpacity onPress={providerPress}>
       <Flex flexDirection="row" columnGap={16}>
         <EthereumStakingDrawerProviderIcon icon={provider.icon} />
-        <Flex rowGap={12} alignItems="flex-start" flex={1}>
-          <Flex rowGap={2}>
-            <Flex
-              flexDirection="row"
-              columnGap={8}
-              rowGap={8}
-              mb={2}
-              flexWrap="nowrap"
-            >
-              <Text variant="body" fontWeight="semiBold">
-                {t(`stake.ethereum.providers.${provider.id}.title`)}
-              </Text>
-              {hasTag && (
-                <Tag type="color">
-                  {t(`stake.ethereum.providers.${provider.id}.tag`)}
-                </Tag>
-              )}
-            </Flex>
+        <Flex rowGap={2} alignItems="flex-start" flex={1}>
+          <Flex flexDirection="row" columnGap={8} rowGap={8} mb={2}>
+            <Text variant="body" fontWeight="semiBold">
+              {t(`stake.ethereum.providers.${provider.id}.title`)}
+            </Text>
+            {hasTag && (
+              <Tag type="color">
+                {t(`stake.ethereum.providers.${provider.id}.tag`)}
+              </Tag>
+            )}
+          </Flex>
+          <Flex rowGap={12}>
             <Text variant="paragraph" lineHeight="20px" color="neutral.c70">
               {t(`stake.ethereum.providers.${provider.id}.description`)}
             </Text>
+            <Link
+              size="medium"
+              type="color"
+              iconPosition="right"
+              onPress={supportLinkPress}
+              Icon={Icons.ExternalLinkMedium}
+            >
+              {t(`stake.ethereum.providers.${provider.id}.supportLink`)}
+            </Link>
           </Flex>
-          <Link
-            size="medium"
-            type="color"
-            iconPosition="right"
-            onPress={supportLinkPress}
-            Icon={Icons.ExternalLinkMedium}
-          >
-            {t(`stake.ethereum.providers.${provider.id}.supportLink`)}
-          </Link>
         </Flex>
         <Flex alignSelf="center">
           <Icon name="ChevronRight" size={32} color="neutral.c100" />

--- a/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerProvider.tsx
+++ b/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerProvider.tsx
@@ -65,7 +65,7 @@ export function EthereumStakingDrawerProvider({
               columnGap={8}
               rowGap={8}
               mb={2}
-              flexWrap="wrap"
+              flexWrap="nowrap"
             >
               <Text variant="body" fontWeight="semiBold">
                 {t(`stake.ethereum.providers.${provider.id}.title`)}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

* update the provider item in ethereum staking to not wrap the provider tag if it exists.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7727` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![Simulator Screenshot - iPhone SE (3rd generation) - 2023-06-05 at 17 07 49](https://github.com/LedgerHQ/ledger-live/assets/132384348/1b53bda8-a6e3-44c6-99f0-724e1fc3e77b)




### 🚀 Expectations to reach

