### PR TITLE
fix: prevent endless loop in swap flows  (to develop)

### DIFF
--- a/.changeset/young-tigers-bake.md
+++ b/.changeset/young-tigers-bake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Prevent endless loop in swap request

--- a/libs/ledger-live-common/src/hw/actions/initSwap.ts
+++ b/libs/ledger-live-common/src/hw/actions/initSwap.ts
@@ -1,5 +1,5 @@
 import { log } from "@ledgerhq/logs";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { concat, Observable, of } from "rxjs";
 import { catchError, scan, tap } from "rxjs/operators";
 import { getMainAccount } from "../../account";
@@ -12,7 +12,7 @@ import type {
   SwapTransaction,
 } from "../../exchange/swap/types";
 import type { ConnectAppEvent, Input as ConnectAppInput } from "../connectApp";
-import type { AppState } from "./app";
+import type { AppRequest, AppState } from "./app";
 import { createAction as createAppAction } from "./app";
 import type { Action, Device } from "./types";
 import { TransactionStatus } from "../../generated/types";
@@ -145,9 +145,9 @@ export const createAction = (
       exchange;
     const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
     const maintoAccount = getMainAccount(toAccount, toParentAccount);
-    const appState = createAppAction(connectAppExec).useHook(
-      reduxDeviceFrozen,
-      {
+
+    const request: AppRequest = useMemo(() => {
+      return {
         appName: "Exchange",
         dependencies: [
           {
@@ -158,7 +158,11 @@ export const createAction = (
           },
         ],
         requireLatestFirmware,
-      }
+      };
+    }, [mainFromAccount, maintoAccount, requireLatestFirmware]);
+    const appState = createAppAction(connectAppExec).useHook(
+      reduxDeviceFrozen,
+      request
     );
     const { device, opened, error } = appState;
     const hasError = error || state.error;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Addresses a regression that was introduced in the firmware update rework, the whole swap request dependency is very old code and it was bound to break eventually. This memoizes the request and should prevent the loop.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7722` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://github.com/LedgerHQ/ledger-live/assets/4631227/9ab6538c-5aa1-453e-8d9c-45be7d81bdc9)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- Assets **should be swappable**.
- That's basically it, if you can reach the swap confirmation step, the bug is solved.
- If you see a loading step and nothing happens, it's probably eating up your memory and won't do anything.