### PR TITLE
feat(Firmware Update LLM): add info drawer with 'skip' and 'retry' options on restore steps denial

### DIFF
--- a/.changeset/neat-mugs-bake.md
+++ b/.changeset/neat-mugs-bake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add info drawer when users deny a settings restore step during the firmware update allowing them to retry or skip the restore step.

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -398,7 +398,7 @@ export function renderAllowLanguageInstallation({
       alignSelf="stretch"
       flex={fullScreen ? 1 : undefined}
     >
-      <TrackScreen category="Allow language installation on Stax" />
+      <TrackScreen category="Allow language installation on Stax" refreshSource={false} />
       <Text variant="h4" textAlign="center">
         {t("deviceLocalization.allowLanguageInstallation", { deviceName })}
       </Text>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4106,7 +4106,14 @@
         "description": "Your settings and blockchain apps will be restored.",
         "restoreLockScreenPicture": "Restoring lock screen picture",
         "restoreLanguage": "Restoring language",
-        "installingApps": "Installing apps"
+        "installingApps": "Installing apps",
+        "errors": {
+          "description": "If this was a mistake you can retry the restoration, or you may skip this step",
+          "LanguageInstallRefusedOnDevice": "Language change was cancelled on {{deviceName}}",
+          "ImageLoadRefusedOnDevice": "Restoration of lock screen picture was cancelled on {{deviceName}}",
+          "ImageCommitRefusedOnDevice": "Restoration of lock screen picture was cancelled on {{deviceName}}",
+          "UserRefusedAllowManager": "Restoration of apps was cancelled on {{deviceName}}"
+        }
       }
     },
     "newVersion": "Update {{version}} available for your {{deviceName}}",

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Text, Flex, Icons, IconBadge } from "@ledgerhq/native-ui";
+import { Device } from "@ledgerhq/types-devices";
+import { TFunction } from "i18next";
+import { getDeviceModel } from "@ledgerhq/devices";
+import Button from "../../components/wrappedUi/Button";
+import Link from "../../components/wrappedUi/Link";
+import { TrackScreen } from "../../analytics";
+import { UserRefusedAllowManager } from "@ledgerhq/errors";
+import {
+  LanguageInstallRefusedOnDevice,
+  ImageLoadRefusedOnDevice,
+  ImageCommitRefusedOnDevice,
+} from "@ledgerhq/live-common/errors";
+
+export const RestoreStepDenied = ({
+  t,
+  device,
+  onPressRetry,
+  onPressSkip,
+  stepDeniedError,
+}: {
+  t: TFunction;
+  device: Device;
+  onPressRetry: () => void;
+  onPressSkip: () => void;
+  stepDeniedError: Error;
+}) => {
+  const deviceName = getDeviceModel(device.modelId).productName;
+  const analyticsDrawerName =
+    stepDeniedError instanceof LanguageInstallRefusedOnDevice
+      ? `Error: the language change was cancelled on ${deviceName}`
+      : (stepDeniedError as Error) instanceof ImageLoadRefusedOnDevice ||
+        (stepDeniedError as Error) instanceof ImageCommitRefusedOnDevice
+      ? `Error: the restoration of lock screen picture was cancelled on ${deviceName}`
+      : (stepDeniedError as Error) instanceof UserRefusedAllowManager
+      ? `Error: the restoration of apps was cancelled on ${deviceName}`
+      : `Error: ${(stepDeniedError as Error).name}`;
+  return (
+    <Flex alignItems="center" justifyContent="center" px={1}>
+      <TrackScreen category={analyticsDrawerName} refreshSource={false} />
+      <IconBadge iconColor="primary.c100" iconSize={32} Icon={Icons.InfoAltFillMedium} />
+      <Text fontSize={7} fontWeight="semiBold" textAlign="center" mt={6}>
+        {t(`FirmwareUpdate.steps.restoreSettings.errors.${stepDeniedError.name}`, {
+          deviceName: getDeviceModel(device.modelId).productName,
+        })}
+      </Text>
+      <Text fontSize={4} textAlign="center" color="neutral.c80" mt={6}>
+        {t("FirmwareUpdate.steps.restoreSettings.errors.description")}
+      </Text>
+      <Button
+        event="button_clicked"
+        eventProperties={{
+          button: "Retry",
+          screen: "Firmware update",
+          drawer: analyticsDrawerName,
+        }}
+        type="main"
+        outline={false}
+        onPress={onPressRetry}
+        mt={8}
+        alignSelf="stretch"
+      >
+        {t("common.retry")}
+      </Button>
+      <Flex mt={8} mb={6} alignSelf="stretch">
+        <Link
+          event="button_clicked"
+          eventProperties={{
+            button: "Skip",
+            screen: "Firmware update",
+            drawer: analyticsDrawerName,
+          }}
+          onPress={onPressSkip}
+        >
+          {t("common.skip")}
+        </Link>
+      </Flex>
+    </Flex>
+  );
+};

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -48,6 +48,7 @@ import { targetDataDimensions } from "../CustomImage/shared";
 import { ProcessorPreviewResult } from "../../components/CustomImage/ImageProcessor";
 import { ImageSourceContext } from "../../components/CustomImage/StaxFramedImage";
 import Button from "../../components/wrappedUi/Button";
+import { RestoreStepDenied } from "./RestoreStepDenied";
 
 type FirmwareUpdateProps = {
   device: Device;
@@ -160,6 +161,8 @@ export const FirmwareUpdate = ({
     noOfAppsToReinstall,
     deviceLockedOrUnresponsive,
     hasReconnectErrors,
+    restoreStepDeniedError,
+    skipCurrentRestoreStep,
   } = useUpdateFirmwareAndRestoreSettings({
     updateFirmwareAction,
     device,
@@ -558,6 +561,18 @@ export const FirmwareUpdate = ({
       });
     }
 
+    if (restoreStepDeniedError) {
+      return (
+        <RestoreStepDenied
+          device={device}
+          onPressRetry={retryCurrentStep}
+          onPressSkip={skipCurrentRestoreStep}
+          stepDeniedError={restoreStepDeniedError}
+          t={t}
+        />
+      );
+    }
+
     return undefined;
   }, [
     updateActionState.error,
@@ -577,6 +592,8 @@ export const FirmwareUpdate = ({
     retryCurrentStep,
     hasReconnectErrors,
     deviceLockedOrUnresponsive,
+    restoreStepDeniedError,
+    skipCurrentRestoreStep,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -24,8 +24,14 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   LockedDeviceError,
+  UserRefusedAllowManager,
 } from "@ledgerhq/errors";
-import { ConnectManagerTimeout } from "@ledgerhq/live-common/errors";
+import {
+  ConnectManagerTimeout,
+  ImageCommitRefusedOnDevice,
+  ImageLoadRefusedOnDevice,
+  LanguageInstallRefusedOnDevice,
+} from "@ledgerhq/live-common/errors";
 
 export const reconnectDeviceErrors: LedgerErrorConstructor<{
   [key: string]: unknown;
@@ -221,7 +227,8 @@ export const useUpdateFirmwareAndRestoreSettings = ({
       case "languageRestore":
         unrecoverableError =
           installLanguageState.error &&
-          !reconnectDeviceErrors.some(err => installLanguageState.error instanceof err);
+          !reconnectDeviceErrors.some(err => installLanguageState.error instanceof err) &&
+          !(installLanguageState.error instanceof LanguageInstallRefusedOnDevice);
         if (installLanguageState.languageInstalled || unrecoverableError) {
           if (installLanguageState.error)
             log("FirmwareUpdate", "error while restoring language", installLanguageState.error);
@@ -231,7 +238,11 @@ export const useUpdateFirmwareAndRestoreSettings = ({
       case "imageRestore":
         unrecoverableError =
           staxLoadImageState.error &&
-          !reconnectDeviceErrors.some(err => staxLoadImageState.error instanceof err);
+          !reconnectDeviceErrors.some(err => staxLoadImageState.error instanceof err) &&
+          !(staxLoadImageState.error instanceof ImageLoadRefusedOnDevice) &&
+          // TypeScript doesn't work well with our custom error classes. It seems to think that if the error is not an
+          // instance of ImageLoadRefusedOnDevice then it's of type "never", this is why we're casting it here to unkown
+          !((staxLoadImageState.error as unknown) instanceof ImageCommitRefusedOnDevice);
         if (staxLoadImageState.imageLoaded || unrecoverableError || !staxFetchImageState.hexImage) {
           if (staxLoadImageState.error) {
             log("FirmwareUpdate", "error while restoring stax image", staxLoadImageState.error);
@@ -242,7 +253,8 @@ export const useUpdateFirmwareAndRestoreSettings = ({
       case "appsRestore":
         unrecoverableError =
           restoreAppsState.error &&
-          !reconnectDeviceErrors.some(err => restoreAppsState.error instanceof err);
+          !reconnectDeviceErrors.some(err => restoreAppsState.error instanceof err) &&
+          !(restoreAppsState.error instanceof UserRefusedAllowManager);
         if (restoreAppsState.opened || unrecoverableError) {
           if (restoreAppsState.error) {
             log("FirmwareUpdate", "error while restoring apps", restoreAppsState.error);
@@ -298,6 +310,35 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     ],
   );
 
+  const restoreStepDeniedError = useMemo(() => {
+    if (
+      updateStep === "languageRestore" &&
+      installLanguageState.error &&
+      installLanguageState.error instanceof LanguageInstallRefusedOnDevice
+    ) {
+      return installLanguageState.error;
+    }
+
+    if (
+      updateStep === "imageRestore" &&
+      staxLoadImageState.error &&
+      (staxLoadImageState.error instanceof ImageLoadRefusedOnDevice ||
+        (staxLoadImageState.error as unknown) instanceof ImageCommitRefusedOnDevice)
+    ) {
+      return staxLoadImageState.error;
+    }
+
+    if (
+      updateStep === "appsRestore" &&
+      restoreAppsState.error &&
+      restoreAppsState.error instanceof UserRefusedAllowManager
+    ) {
+      return restoreAppsState.error;
+    }
+
+    return undefined;
+  }, [installLanguageState.error, staxLoadImageState.error, restoreAppsState.error, updateStep]);
+
   const deviceLockedOrUnresponsive = useMemo(
     () =>
       updateActionState.lockedDevice ||
@@ -349,6 +390,22 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     updateStep,
   ]);
 
+  const skipCurrentRestoreStep = useCallback(() => {
+    switch (updateStep) {
+      case "languageRestore":
+        proceedToImageRestore();
+        break;
+      case "imageRestore":
+        proceedToAppsRestore();
+        break;
+      case "appsRestore":
+        proceedToUpdateCompleted();
+        break;
+      default:
+        break;
+    }
+  }, [updateStep, proceedToImageRestore, proceedToAppsRestore, proceedToUpdateCompleted]);
+
   return {
     updateStep,
     connectManagerState,
@@ -358,8 +415,10 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     installLanguageState,
     restoreAppsState,
     retryCurrentStep,
+    skipCurrentRestoreStep,
     noOfAppsToReinstall: installedApps.length,
     deviceLockedOrUnresponsive,
     hasReconnectErrors,
+    restoreStepDeniedError,
   };
 };


### PR DESCRIPTION
### 📝 Description
Before this PR, we were just skipping the current restore step on the firmware update if the user denied authorization in the device. This PR adds an info banner when this denial happens, the banner explains what happened and gives the user to retry the step or skip it.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-7417]

### ✅ Checklist

- [N/A] **Test coverage** 
- [x] **Atomic delivery** 
- [x] **No breaking changes**

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/6013294/bceb0a5f-bd7e-4379-9c24-86c5c642918a



[LIVE-7417]: https://ledgerhq.atlassian.net/browse/LIVE-7417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ