### PR TITLE
[fix/LIVE-7772]: only navigation pop if navigation index is > 0.

### DIFF
--- a/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
@@ -114,8 +114,10 @@ function SelectAccount({ navigation, route }: Props) {
         navigation.getParent<
           StackNavigatorNavigation<BaseNavigatorStackParamList>
         >() || navigation;
-      n.pop();
       onSuccess && onSuccess(account, parentAccount);
+      if (navigation.getState().index > 0) {
+        n.pop();
+      }
     },
     [navigation, onSuccess],
   );


### PR DESCRIPTION
### 📝 Description
Fixes bug where user was returned to initial page of buy app after selecting account.

- Tested buy on ActionBar, Asset, Account, Market  ✅ 
- Testing eth liquid staking modal ActionBar, Asset, Account, Market ✅ 
- Testing native staking ActionBar, Asset, Account, Market ✅ 

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7772` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Original bug.

https://github.com/LedgerHQ/ledger-live/assets/132384348/7836ac4f-a6e5-4b9d-9d84-df0660686008



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
