### PR TITLE
fix(Firmware Update LLM): fix the MyLedger redirection after the update is finished

### DIFF
--- a/.changeset/friendly-goats-tickle.md
+++ b/.changeset/friendly-goats-tickle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the manager redirection after the new firmware update flow

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -104,7 +104,7 @@ export const FirmwareUpdate = ({
   const dispatch = useDispatch();
 
   const quitUpdate = useCallback(() => {
-    if (onBackFromUpdate){
+    if (onBackFromUpdate) {
       onBackFromUpdate();
     } else {
       navigation.goBack();

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -104,8 +104,11 @@ export const FirmwareUpdate = ({
   const dispatch = useDispatch();
 
   const quitUpdate = useCallback(() => {
-    if (onBackFromUpdate) onBackFromUpdate();
-    navigation.goBack();
+    if (onBackFromUpdate){
+      onBackFromUpdate();
+    } else {
+      navigation.goBack();
+    }
   }, [navigation, onBackFromUpdate]);
 
   const onOpenReleaseNotes = useCallback(() => {


### PR DESCRIPTION
### 📝 Description
After the update is completely finished and all the potential restores are done, the user should be redirected to the MyLedger screen with a reload in order for all the settings to be correctly updated in the MyLedger page (installed, apps, language, lockscreen, available updates, etc). This wasn't working due to a merge issue that broke the logic of an if statement. This PR fixes it.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-7661]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/6013294/13332c24-e0f9-4e7c-bba4-a0a950389190




[LIVE-7661]: https://ledgerhq.atlassian.net/browse/LIVE-7661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ