### PR TITLE
bugfix/LIVE-7728 Memoize device action requests to prevent loops

### DIFF
--- a/.changeset/eighty-zebras-build.md
+++ b/.changeset/eighty-zebras-build.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Memoize requests for device actions to prevent rendering loops

--- a/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { TFunction, useTranslation } from "react-i18next";
@@ -94,6 +94,13 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
     [navigation, t],
   );
 
+  const request = useMemo(
+    () => ({
+      appName,
+    }),
+    [appName],
+  );
+
   return (
     <SafeAreaView
       edges={["bottom"]}
@@ -137,9 +144,7 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
         device={device}
         onResult={handleSuccess}
         onClose={resetDevice}
-        request={{
-          appName,
-        }}
+        request={request}
         analyticsPropertyFlow={"device connect"}
       />
     </SafeAreaView>

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -2,9 +2,10 @@ import completeExchange from "@ledgerhq/live-common/exchange/platform/completeEx
 import { createAction } from "@ledgerhq/live-common/hw/actions/completeExchange";
 import { createAction as txCreateAction } from "@ledgerhq/live-common/hw/actions/transaction";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import DeviceActionModal from "../../../components/DeviceActionModal";
 import { useBroadcast } from "../../../components/useBroadcast";
 import { StackNavigatorProps } from "../../../components/RootNavigator/types/helpers";
@@ -24,7 +25,8 @@ const PlatformCompleteExchange: React.FC<Props> = ({
 }) => {
   const { fromAccount: account, fromParentAccount: parentAccount } =
     request.exchange;
-  let tokenCurrency;
+  let tokenCurrency: TokenCurrency | undefined;
+
   if (account.type === "TokenAccount") tokenCurrency = account.token;
 
   const broadcast = useBroadcast({ account, parentAccount });
@@ -69,6 +71,17 @@ const PlatformCompleteExchange: React.FC<Props> = ({
     }
   }, []);
 
+  const signRequest = useMemo(
+    () => ({
+      tokenCurrency,
+      parentAccount,
+      account,
+      transaction,
+      appName: "Exchange",
+    }),
+    [account, parentAccount, tokenCurrency, transaction],
+  );
+
   return (
     <SafeAreaView style={styles.root}>
       {!transaction ? (
@@ -88,13 +101,8 @@ const PlatformCompleteExchange: React.FC<Props> = ({
           action={sendAction}
           onClose={onClose}
           onResult={onSign}
-          request={{
-            tokenCurrency,
-            parentAccount,
-            account,
-            transaction,
-            appName: "Exchange",
-          }}
+          // @ts-expect-error Wrong types?
+          request={signRequest}
         />
       )}
     </SafeAreaView>

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -5,7 +5,7 @@ import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useIsFocused } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import DeviceActionModal from "../../../components/DeviceActionModal";
@@ -42,7 +42,7 @@ const PlatformStartExchange: React.FC<Props> = ({ navigation, route }) => {
 
   // Does not react to an header update request, the header stays the same.
   const requestToSetHeaderOptions = useCallback(() => undefined, []);
-
+  const request = useMemo(() => route.params.request, [route.params.request]);
   return (
     <SafeAreaView style={styles.root}>
       {newDeviceSelectionFeatureFlag?.enabled ? (
@@ -61,7 +61,7 @@ const PlatformStartExchange: React.FC<Props> = ({ navigation, route }) => {
         action={action}
         onClose={onClose}
         onResult={onResult}
-        request={route.params.request}
+        request={request}
       />
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import { StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -40,8 +40,28 @@ function ConnectDevice({
   const handleTx = useSignedTxHandlerWithoutBroadcast({
     onSuccess,
   });
-  // Nb setting the mainAccount as a dependency will ensure latest versions of plugins.
-  const dependencies = [mainAccount];
+
+  const request = useMemo(
+    () => ({
+      account,
+      parentAccount,
+      appName,
+      transaction,
+      status,
+      tokenCurrency,
+      dependencies: [mainAccount],
+      requireLatestFirmware: true,
+    }),
+    [
+      account,
+      appName,
+      mainAccount,
+      parentAccount,
+      status,
+      tokenCurrency,
+      transaction,
+    ],
+  );
   return transaction ? (
     <SafeAreaView
       style={[
@@ -57,16 +77,8 @@ function ConnectDevice({
       />
       <DeviceAction
         action={action}
-        request={{
-          account,
-          parentAccount,
-          appName,
-          transaction,
-          status,
-          tokenCurrency,
-          dependencies,
-          requireLatestFirmware: true,
-        }}
+        // @ts-expect-error Wrong types?
+        request={request}
         device={route.params.device}
         onResult={handleTx}
         onSelectDeviceLink={() => navigateToSelectDevice(navigation, route)}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The recent refactor in device action implementation meant that rerenders of the screen that renders the `DeviceAction` component would trigger a new execution of the action itself **if the request was set inline**, if we memoize the request this doesn't happen.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7728` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://github.com/LedgerHQ/ledger-live/assets/4631227/51a95fdf-5f2a-47b7-8785-afdcab89774d)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

In particular it should impact flows starting on the discover section, these were found out to be looping in the regression testing. This should address that.
