### PR TITLE
feat: LIVE-7784 memoize device action requests for LLD

### DIFF
--- a/.changeset/calm-glasses-design.md
+++ b/.changeset/calm-glasses-design.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Memoize all device action requests to prevent loops on LLD

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepConnectDevice.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { reduce } from "rxjs/operators";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import DeviceAction from "~/renderer/components/DeviceAction";
@@ -34,6 +34,7 @@ const StepConnectDevice = ({
   const currency = getCryptoCurrencyById("bitcoin");
   const [device, setDevice] = useState<Device>(null);
   const [scanStatus, setScanStatus] = useState<ConnectionStatus>(connectionStatus.IDLE);
+  const request = useMemo(() => ({ currency }), [currency]);
   useEffect(() => {
     if (device) {
       const sub = scanDescriptors(
@@ -67,9 +68,7 @@ const StepConnectDevice = ({
       {scanStatus === connectionStatus.IDLE ? (
         <DeviceAction
           action={action}
-          request={{
-            currency,
-          }}
+          request={request}
           onResult={({ device }) => {
             setDevice(device);
             setScanStatus(connectionStatus.PENDING);

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepConnectDevice.tsx
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { prepareCurrency } from "~/renderer/bridge/cache";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import DeviceAction from "~/renderer/components/DeviceAction";
@@ -23,14 +23,19 @@ const StepConnectDevice = ({ currency, transitionTo, flow }: StepProps) => {
       ? currency.parentCurrency.name
       : currency.name
     : undefined;
+
+  const request = useMemo(
+    () => ({
+      currency: currency.type === "TokenCurrency" ? currency.parentCurrency : currency,
+    }),
+    [currency],
+  );
   return (
     <>
       <TrackPage category="AddAccounts" name="Step2" currencyName={currencyName} />
       <DeviceAction
         action={action}
-        request={{
-          currency: currency.type === "TokenCurrency" ? currency.parentCurrency : currency,
-        }}
+        request={request}
         onResult={() => {
           transitionTo("import");
         }}

--- a/apps/ledger-live-desktop/src/renderer/modals/ConnectDevice/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ConnectDevice/index.tsx
@@ -25,9 +25,8 @@ export default function ConnectDevice() {
             <Box alignItems={"center"} px={32}>
               <DeviceAction
                 action={appAction}
-                request={{
-                  appName: data?.appName || "BOLOS",
-                }}
+                // @ts-expect-error This type is not compatible with the one expected by the action
+                request={request}
                 onResult={res => {
                   data?.onResult(res);
                   onClose && onClose();

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Exchange } from "@ledgerhq/live-common/exchange/platform/types";
 import { Operation, SignedOperation } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
@@ -54,6 +54,16 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
       onCancel(error);
     }
   }, [onCancel, error]);
+  const signRequest = useMemo(
+    () => ({
+      tokenCurrency,
+      parentAccount,
+      account,
+      transaction,
+      appName: "Exchange",
+    }),
+    [account, parentAccount, tokenCurrency, transaction],
+  );
   return (
     <ModalBody
       onClose={() => {
@@ -87,13 +97,8 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
                 key="sign"
                 action={sendAction}
                 // TODO: the proper team should investigate why the types mismatch
-                request={{
-                  tokenCurrency,
-                  parentAccount,
-                  account,
-                  transaction,
-                  appName: "Exchange",
-                }}
+                // @ts-expect-error This type is not compatible with the one expected by the action
+                request={signRequest}
                 onResult={result => {
                   if ("transactionSignError" in result) {
                     setError(result.transactionSignError);

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepConnectDevice.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -19,15 +19,19 @@ export default function StepConnectDevice({
 }: StepProps) {
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   const tokenCurrency = (account && account.type === "TokenAccount" && account.token) || token;
+  const request = useMemo(
+    () => ({
+      account: mainAccount || undefined,
+      tokenCurrency: tokenCurrency || undefined,
+    }),
+    [mainAccount, tokenCurrency],
+  );
   return (
     <>
       {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       <DeviceAction
         action={action}
-        request={{
-          account: mainAccount || undefined,
-          tokenCurrency: tokenCurrency || undefined,
-        }}
+        request={request}
         onResult={() => transitionTo("receive")}
         analyticsPropertyFlow="receive"
       />

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -61,17 +61,23 @@ export default function StepConnectDevice({
     parentAccount,
   });
   const tokenCurrency = (account && account.type === "TokenAccount" && account.token) || undefined;
+  const request = useMemo(
+    () => ({
+      tokenCurrency,
+      parentAccount,
+      account,
+      transaction,
+      status,
+    }),
+    [account, parentAccount, status, tokenCurrency, transaction],
+  );
   if (!transaction || !account) return null;
+
   return (
     <DeviceAction
       action={action}
-      request={{
-        tokenCurrency,
-        parentAccount,
-        account,
-        transaction,
-        status,
-      }}
+      // @ts-expect-error This type is not compatible with the one expected by the action
+      request={request}
       Result={Result}
       onResult={result => {
         if ("signedOperation" in result) {

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSign.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSign.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useDispatch } from "react-redux";
 import { getEnv } from "@ledgerhq/live-common/env";
 import { StepProps } from "../types";
@@ -20,13 +20,17 @@ export default function StepSign({
   onFailHandler,
 }: StepProps) {
   const dispatch = useDispatch();
+  const request = useMemo(
+    () => ({
+      account,
+      message,
+    }),
+    [account, message],
+  );
   return (
     <DeviceAction
       action={action}
-      request={{
-        account,
-        message,
-      }}
+      request={request}
       onResult={r => {
         const result = r as {
           error: Error | null | undefined;

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Trans } from "react-i18next";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import DeviceAction from "~/renderer/components/DeviceAction";
@@ -54,20 +54,34 @@ export default function StepConnectDevice({
   requireLatestFirmware?: boolean;
 }) {
   const tokenCurrency = account && account.type === "TokenAccount" ? account.token : undefined;
+  const request = useMemo(
+    () => ({
+      tokenCurrency,
+      parentAccount,
+      account,
+      appName: useApp,
+      transaction,
+      status,
+      dependencies,
+      requireLatestFirmware,
+    }),
+    [
+      account,
+      dependencies,
+      parentAccount,
+      requireLatestFirmware,
+      status,
+      tokenCurrency,
+      transaction,
+      useApp,
+    ],
+  );
   if (!transaction || !account) return null;
   return (
     <DeviceAction
       action={action}
-      request={{
-        tokenCurrency,
-        parentAccount,
-        account,
-        appName: useApp,
-        transaction,
-        status,
-        dependencies,
-        requireLatestFirmware,
-      }}
+      // @ts-expect-error This type is not compatible with the one expected by the action
+      request={request}
       Result={Result}
       onResult={result => {
         if ("signedOperation" in result) {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/SwapAction.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/SwapAction.tsx
@@ -106,18 +106,32 @@ export default function SwapAction({
       );
     }
   }, [broadcast, onCompletion, onError, initData, signedOperation]);
+  const request = useMemo(
+    () => ({
+      exchange: exchange as Exchange,
+      exchangeRate,
+      transaction: transaction as SwapTransaction,
+      status,
+      device: deviceRef,
+      userId: providerKYC?.id,
+    }),
+    [exchange, exchangeRate, providerKYC?.id, status, transaction],
+  );
+  const signRequest = useMemo(
+    () => ({
+      tokenCurrency,
+      parentAccount: fromParentAccount,
+      account: fromAccount!,
+      transaction: initData?.transaction,
+      appName: "Exchange",
+    }),
+    [fromAccount, fromParentAccount, initData?.transaction, tokenCurrency],
+  );
   return !initData || !transaction ? (
     <DeviceAction
       key={"initSwap"}
       action={initAction}
-      request={{
-        exchange: exchange as Exchange,
-        exchangeRate,
-        transaction: transaction as SwapTransaction,
-        status,
-        device: deviceRef,
-        userId: providerKYC?.id,
-      }}
+      request={request}
       onResult={result => {
         if ("initSwapError" in result && result.initSwapError) {
           onError({
@@ -134,13 +148,8 @@ export default function SwapAction({
     <DeviceAction
       key={"send"}
       action={transactionAction}
-      request={{
-        tokenCurrency,
-        parentAccount: fromParentAccount,
-        account: fromAccount!,
-        transaction: initData.transaction,
-        appName: "Exchange",
-      }}
+      // @ts-expect-error This type is not compatible with the one expected by the action
+      request={signRequest}
       Result={TransactionResult}
       onResult={result => {
         if ("transactionSignError" in result) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The recent refactor in device action implementation meant that rerenders of the screen that renders the DeviceAction component would trigger a new execution of the action itself if the request was set inline, if we memoize the request this doesn't happen. This is the LLD equivalent of the others.

Introducing a bunch of errors that would need to be addressed @alexandremgo 


### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7784` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Nothing to demo