### PR TITLE
fix: regression on select account on success

### DIFF
--- a/.changeset/fast-hornets-flash.md
+++ b/.changeset/fast-hornets-flash.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix regression on Select Account onSuccess LLM

--- a/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
@@ -110,12 +110,12 @@ function SelectAccount({ navigation, route }: Props) {
   ) as { account: AccountLike; subAccount: SubAccount | null }[];
   const onSelect = useCallback(
     (account: AccountLike, parentAccount?: Account) => {
+      onSuccess && onSuccess(account, parentAccount);
       const n =
         navigation.getParent<
           StackNavigatorNavigation<BaseNavigatorStackParamList>
         >() || navigation;
       n.pop();
-      onSuccess && onSuccess(account, parentAccount);
     },
     [navigation, onSuccess],
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR is to revert regression found in https://github.com/LedgerHQ/ledger-live/pull/3526/files#r1221273156, which resulted in the error message `'JSON-RPC method account.request responded an error', [Error: Request account interrupted by user]`.

I have QA'ed that stake and buy both work post reverting.

### ❓ Context

- **Impacted projects**: Closes https://ledgerhq.atlassian.net/browse/LIVE-7772
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
