### PR TITLE
fix: NEAR validator commission denomination

### DIFF
--- a/.changeset/tall-hairs-suffer.md
+++ b/.changeset/tall-hairs-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Adjusting the commission calculation for NEAR validators as the value from the API has changed.

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakeBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakeBanner.tsx
@@ -24,7 +24,9 @@ const StakeBanner: React.FC<{ account: NearAccount }> = ({ account }) => {
 
   const commission = ledgerValidator?.commission ? ledgerValidator?.commission * 100 : 1;
 
-  const title = redelegate ? t("account.near.title") : t("account.banner.delegation.title");
+  const title = redelegate
+    ? t("account.banner.redelegation.near.title")
+    : t("account.banner.delegation.title");
   const description = redelegate
     ? t("account.banner.redelegation.near.description")
     : t("account.banner.delegation.near.description", {

--- a/libs/ledger-live-common/src/families/near/api/archive-node-sdk.ts
+++ b/libs/ledger-live-common/src/families/near/api/archive-node-sdk.ts
@@ -294,9 +294,8 @@ export const getCommission = async (
   if (Array.isArray(result) && result.length) {
     const parsedResult = JSON.parse(Buffer.from(result).toString());
 
-    return (
-      Math.round((parsedResult.numerator / parsedResult.denominator) * 100) /
-      100
+    return Math.round(
+      (parsedResult.numerator / parsedResult.denominator) * 100
     );
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adjusting the commission calculation for NEAR validators as the value from the API has changed.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop`, `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:
  - https://ledgerhq.atlassian.net/browse/LIVE-7693
  - [`Discord thread`](https://discord.com/channels/885256081289379850/973221693638193152/1115284843346001930) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] ~~**Test coverage**~~ no impact <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

BEFORE:

<img width="570" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/8867651/9aa55ca4-3249-4d7e-8983-a2a4115411d1">


AFTER:

<img width="578" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/8867651/c80e1f14-f2a4-4029-a9e0-9ef6cc890f05">

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
