### PR TITLE
bugfix/LIVE-7816 Regression in recovery mode firmware update for LLD

### DIFF
--- a/.changeset/sour-phones-sing.md
+++ b/.changeset/sour-phones-sing.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix fw update regression for unseeded devices LLD

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/01-step-prepare.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/01-step-prepare.tsx
@@ -9,7 +9,7 @@ import { hasFinalFirmware } from "@ledgerhq/live-common/hw/hasFinalFirmware";
 import staxFetchImage, { FetchImageEvent } from "@ledgerhq/live-common/hw/staxFetchImage";
 import firmwareUpdatePrepare from "@ledgerhq/live-common/hw/firmwareUpdate-prepare";
 import { getEnv } from "@ledgerhq/live-common/env";
-
+import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Track from "~/renderer/analytics/Track";
@@ -22,7 +22,7 @@ import { getDeviceAnimation } from "~/renderer/components/DeviceAction/animation
 import { AnimationWrapper, Title } from "~/renderer/components/DeviceAction/rendering";
 import useTheme from "~/renderer/hooks/useTheme";
 import { EMPTY, concat } from "rxjs";
-import { map, tap } from "rxjs/operators";
+import { catchError, map, tap } from "rxjs/operators";
 import { DeviceBlocker } from "~/renderer/components/DeviceAction/DeviceBlocker";
 import { StepProps } from "..";
 import manager from "@ledgerhq/live-common/manager/index";
@@ -196,6 +196,14 @@ const StepPrepare = ({
     // Allow for multiple preparation flows in this paradigm.
     const task = concat(
       maybeCLSBackup.pipe(
+        catchError(e => {
+          if (e instanceof UnexpectedBootloader) {
+            // CLS checks fail when in recovery mode, preventing an update of an
+            // unseeded device. This bypasses that check.
+            return EMPTY;
+          }
+          throw e;
+        }),
         tap((e: FetchImageEvent) => {
           // bubble up this image to the main component and keep it in memory
           if (e.type === "imageFetched") {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

During the recent rework for backup and restore of device configuration, we introduced a bug that prevents firmware update for unseeded devices, a feature that is used internally by our colleagues and that we can't simply remove. This PR should address that regression bringing the expected behavior back.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7816` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
An unseeded device in recovery mode should be able to complete a firmware update on LLD.
Steps on the ticket.