### PR TITLE
chore: bumping usb to 2.9.0 on hw-transport-node-hid and  hw-transport-node-hid-singleton

### DIFF
--- a/.changeset/little-seahorses-relax.md
+++ b/.changeset/little-seahorses-relax.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/hw-transport-node-hid-singleton": patch
+"@ledgerhq/hw-transport-node-hid": patch
+---
+
+chore: bumping `usb` to 2.9.0
+
+For both `hw-transport-node-hid` and `hw-transport-node-hid-singleton`

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
@@ -34,7 +34,7 @@
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
     "node-hid": "^2.1.2",
-    "usb": "2.5.1"
+    "usb": "^2.9.0"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/package.json
@@ -34,7 +34,7 @@
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
     "node-hid": "^2.1.2",
-    "usb": "^1.7.0"
+    "usb": "^2.9.0"
   },
   "scripts": {
     "clean": "rimraf lib lib-es",

--- a/libs/ledgerjs/packages/hw-transport-node-hid/src/listenDevices.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/src/listenDevices.ts
@@ -1,8 +1,9 @@
 import EventEmitter from "events";
+import { usb } from "usb";
+import debounce from "lodash/debounce";
 import { getDevices } from "@ledgerhq/hw-transport-node-hid-noevents";
 import { log } from "@ledgerhq/logs";
-import usb from "usb";
-import debounce from "lodash/debounce";
+
 export default (
   delay: number,
   listenDevicesPollingSkip: () => boolean,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3363,8 +3363,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       usb:
-        specifier: ^1.7.0
-        version: 1.9.2
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.0
@@ -3461,8 +3461,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       usb:
-        specifier: 2.5.1
-        version: 2.5.1
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@types/jest':
         specifier: ^29.5.0
@@ -26087,7 +26087,7 @@ packages:
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
-      node-gyp-build: 4.4.0
+      node-gyp-build: 4.6.0
     dev: false
 
   /builder-util-runtime@8.6.0:
@@ -39778,7 +39778,7 @@ packages:
     requiresBuild: true
     dependencies:
       node-addon-api: 2.0.2
-      node-gyp-build: 4.4.0
+      node-gyp-build: 4.6.0
       readable-stream: 3.6.2
     dev: false
 
@@ -43161,6 +43161,12 @@ packages:
 
   /node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
     dev: false
 
   /node-dir@0.1.17:
@@ -43215,6 +43221,11 @@ packages:
 
   /node-gyp-build@4.4.0:
     resolution: {integrity: sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==}
+    hasBin: true
+    dev: false
+
+  /node-gyp-build@4.6.0:
+    resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
     hasBin: true
     dev: false
 
@@ -50138,7 +50149,7 @@ packages:
     dependencies:
       elliptic: 6.5.4
       node-addon-api: 2.0.2
-      node-gyp-build: 4.4.0
+      node-gyp-build: 4.6.0
     dev: false
 
   /secp256k1@4.0.3:
@@ -50807,7 +50818,7 @@ packages:
     resolution: {integrity: sha512-rg6lCDM/qa3p07YGqaVD+ciAbUqm6SoO4xmlcfkbU5r1zIGrguXztLiEtaLYTV5U6k8KSIUFmnU3yQUSKmf6DA==}
     requiresBuild: true
     dependencies:
-      node-gyp-build: 4.4.0
+      node-gyp-build: 4.6.0
     dev: false
     optional: true
 
@@ -54282,17 +54293,18 @@ packages:
     requiresBuild: true
     dependencies:
       node-addon-api: 4.3.0
-      node-gyp-build: 4.4.0
+      node-gyp-build: 4.6.0
     dev: false
+    optional: true
 
-  /usb@2.5.1:
-    resolution: {integrity: sha512-/VNr4wUL32KVqyrVJ1HGBhDEvklhouVh+8ehIGKv6FsOKz6MWlkYLLAEyXbRo72HXhhiFNj6bwz6L+bIk8F0Yw==}
+  /usb@2.9.0:
+    resolution: {integrity: sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==}
     engines: {node: '>=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0'}
     requiresBuild: true
     dependencies:
       '@types/w3c-web-usb': 1.0.6
-      node-addon-api: 4.3.0
-      node-gyp-build: 4.4.0
+      node-addon-api: 6.1.0
+      node-gyp-build: 4.6.0
     dev: false
 
   /use-composed-ref@1.3.0(react@17.0.2):
@@ -54378,7 +54390,7 @@ packages:
     engines: {node: '>=6.14.2'}
     requiresBuild: true
     dependencies:
-      node-gyp-build: 4.4.0
+      node-gyp-build: 4.6.0
     dev: false
 
   /utf8-byte-length@1.0.4:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

From: https://github.com/LedgerHQ/ledger-live/pull/3531, an attempt to fix the following issue: https://github.com/LedgerHQ/ledger-live/issues/3416.

- `@ledgerhq/hw-transport-node-hid`:
  	- is used by our CLI: `libs/ledgerjs/packages/hw-transport-node-hid/src/TransportNodeHid.ts`
	- the `usb` package is bumped from to `1.7.0` to `2.9.0`

- `@ledgerhq/hw-transport-node-hid-singleton`:
	- is used by LLD -> `libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/TransportNodeHid.ts`
	- the `usb` package is bumped from `2.5.1` to `2.9.0`

The migration from v1 to v2: we simply need to update the import statement (already done for `hw-transport-node-hid-singleton`)

The `usb` package is used to detect/listen to device connections/disconnections. 
The actual communication is done thanks to the [node-hid](https://www.npmjs.com/package/node-hid) package, already up-to-date (`2.1.2`).

### ❓ Context

- **Impacted projects**: `hw-transport-node-hid` and `hw-transport-node-hid-singleton`
- **Linked resource(s)**:  [LIVE-7819](https://ledgerhq.atlassian.net/browse/LIVE-7819)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

Test plan:
- LLD: test device connection/disconnection via USB on
	- [x] : macOS
	- [ ] : Linux 
	- [ ] : Windows
- CLI: test device connection/disconnection via USB on (the easiest is the command: `pnpm run:cli synchronousOnboarding`)
	- [x] : macOS
	- [ ] : Linux 
	- [ ] : Windows

[LIVE-7819]: https://ledgerhq.atlassian.net/browse/LIVE-7819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ