### PR TITLE
fix(MyLedger): fix flickering of the connect manager action when device is locked

### DIFF
--- a/.changeset/sweet-pens-repair.md
+++ b/.changeset/sweet-pens-repair.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Debounce device change events for longer than polling frequency on connect manager device action

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -48,7 +48,7 @@ type PollingImplementationParams<Request, EmittedEvents> = {
   config?: PollingImplementationConfig;
 };
 
-const defaultConfig: PollingImplementationConfig = {
+export const defaultConfig: PollingImplementationConfig = {
   pollingFrequency: 2000,
   initialWaitTime: 5000,
   reconnectWaitTime: 5000,

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -9,7 +9,7 @@ import manager from "../../manager";
 import type { Input as ConnectManagerInput, ConnectManagerEvent } from "../connectManager";
 import type { Action, Device } from "./types";
 import { currentMode } from "./app";
-import { getImplementation } from "./implementations";
+import { defaultConfig, getImplementation } from "./implementations";
 
 type State = {
   isLoading: boolean;
@@ -193,8 +193,14 @@ export const createAction = (
       const sub = impl
         .pipe(
           tap((e: any) => log("actions-manager-event", e.type, e)),
-          debounce((e: Event) => ("replaceable" in e && e.replaceable ? interval(100) : EMPTY)),
-          scan(reducer, getInitialState()),
+          debounce((e: Event) =>
+            "replaceable" in e && e.replaceable
+              ? e.type === "deviceChange" && currentMode === "polling"
+                ? interval(defaultConfig.pollingFrequency + 50)
+                : interval(100)
+              : EMPTY
+          ),
+          scan(reducer, getInitialState())
         )
         .subscribe(setState);
       return () => {

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -198,9 +198,9 @@ export const createAction = (
               ? e.type === "deviceChange" && currentMode === "polling"
                 ? interval(defaultConfig.pollingFrequency + 50)
                 : interval(100)
-              : EMPTY
+              : EMPTY,
           ),
-          scan(reducer, getInitialState())
+          scan(reducer, getInitialState()),
         )
         .subscribe(setState);
       return () => {


### PR DESCRIPTION
### 📝 Description
Since https://github.com/LedgerHQ/ledger-live/pull/3105 we've been sending a "deviceChange" event at each loop of the polling mode of device actions. This caused a flickering on the device action "locked" state when the device was locked on the connect manager action. This PR increases the debounce time of replaceable "deviceChange" events to be greater than the polling frequency, this way we don't have a flickering on the device action state.

### ❓ Context

- **Impacted projects**: `ledger-live-common`
- **Linked resource(s)**: [LIVE-7821]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
Before the PR:
https://github.com/LedgerHQ/ledger-live/assets/6013294/bd9a28f3-c4bb-4db1-96c1-e902ab531c43

After the PR:
https://github.com/LedgerHQ/ledger-live/assets/6013294/e379b08d-b778-4051-915c-29df22eed6f5


[LIVE-7821]: https://ledgerhq.atlassian.net/browse/LIVE-7821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ