### PR TITLE
fix: Fixes TransportStatusError message on node.js

### DIFF
--- a/.changeset/lemon-mangos-wash.md
+++ b/.changeset/lemon-mangos-wash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/errors": patch
+---
+
+Adds message to TransportStatusErrors displayed in node.js

--- a/libs/ledgerjs/packages/errors/src/index.test.ts
+++ b/libs/ledgerjs/packages/errors/src/index.test.ts
@@ -1,4 +1,9 @@
-import { AmountRequired, CurrencyNotSupported } from "./index";
+import {
+  AmountRequired,
+  CurrencyNotSupported,
+  TransportStatusError,
+  StatusCodes,
+} from "./index";
 
 function functionA() {
   throw new AmountRequired();
@@ -73,5 +78,10 @@ describe("custom errors", () => {
   test("error is instance of Error", () => {
     const error: Error = new AmountRequired();
     expect(error instanceof Error).toBeTruthy();
+  });
+
+  test("transport status error contains message", () => {
+    const error: Error = new TransportStatusError(StatusCodes.UNKNOWN_APDU);
+    expect(error.stack).toContain("Ledger device: UNKNOWN_APDU (0x6d02)");
   });
 });

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -286,7 +286,7 @@ export class TransportError extends Error {
     super(message || name);
     this.name = name;
     this.message = message;
-    this.stack = new Error().stack;
+    this.stack = new Error(message).stack;
     this.id = id;
   }
 }
@@ -380,7 +380,7 @@ export function TransportStatusError(statusCode: number): void {
 
   this.name = "TransportStatusError";
   this.message = message;
-  this.stack = new Error().stack;
+  this.stack = new Error(message).stack;
   this.statusCode = statusCode;
   this.statusText = statusText;
 }


### PR DESCRIPTION
### 📝 Description

Node.js prints the `stack` property when displaying an error. Thus, the error message is lost unless it is set on the error instance that generates the stack trace too.

### ✅ Checklist

- [x] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**