### PR TITLE
feat: recover on LLD

### DIFF
--- a/.changeset/thick-walls-rule.md
+++ b/.changeset/thick-walls-rule.md
@@ -1,0 +1,11 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: recover on LLD
+
+Handle the recover deeplink
+Add a screen to redirect to the correct device onboarding automatically
+Rework of the recover feature flags
+Add upsell screen for recover after onboarding

--- a/.changeset/thick-walls-rule.md
+++ b/.changeset/thick-walls-rule.md
@@ -1,6 +1,7 @@
 ---
 "ledger-live-desktop": minor
 "@ledgerhq/live-common": minor
+"@ledgerhq/live-env": minor
 ---
 
 feat: recover on LLD

--- a/apps/ledger-live-desktop/src/index-types.d.ts
+++ b/apps/ledger-live-desktop/src/index-types.d.ts
@@ -11,6 +11,8 @@ declare module "*.png";
 declare module "*.jpg";
 declare module "*.webm";
 
+type Store = import("redux").Store;
+type Device = import("@ledgerhq/live-common/hw/actions/types").Device;
 type ReplaySubject = import("rxjs").ReplaySubject;
 type ListAppResult = import("@ledgerhq/live-common/apps/types").ListAppsResult;
 type TransactionRaw = import("@ledgerhq/live-common/generated/types").TransactionRaw;
@@ -42,8 +44,12 @@ interface Window {
   };
 
   // for debugging purposes
-  // eslint-disable-next-line
-  ledger: any;
+  ledger: {
+    store: Store;
+    addDevice: (device: Device) => void;
+    removeDevice: (device: Device) => void;
+    resetDevices: () => void;
+  };
 
   // used for the analytics, initialized in the index.html
   // eslint-disable-next-line

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -52,6 +52,7 @@ import Drawer from "~/renderer/drawers/Drawer";
 import UpdateBanner from "~/renderer/components/Updater/Banner";
 import FirmwareUpdateBanner from "~/renderer/components/FirmwareUpdateBanner";
 import VaultSignerBanner from "~/renderer/components/VaultSignerBanner";
+import RecoverRestore from "~/renderer/components/RecoverRestore";
 import Onboarding from "~/renderer/components/Onboarding";
 import PostOnboardingScreen from "~/renderer/components/PostOnboardingScreen";
 import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
@@ -195,6 +196,7 @@ export default function Default() {
                   </>
                 )}
               />
+              <Route path="/recover-restore" component={RecoverRestore} />
 
               <Route path="/USBTroubleshooting">
                 <USBTroubleshooting onboarding={!hasCompletedOnboarding} />

--- a/apps/ledger-live-desktop/src/renderer/actions/devices.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/devices.ts
@@ -25,4 +25,5 @@ export const removeDevice: RemoveDevice = payload => ({
 });
 export const resetDevices = () => ({
   type: "RESET_DEVICES",
+  payload: undefined,
 });

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToSentry.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToSentry.tsx
@@ -36,10 +36,11 @@ export const ConnectEnvsToSentry = () => {
       });
       // if there are features on, we will add them in tags
       const features: { [key in FeatureId]?: boolean } = {};
-      Object.keys(defaultFeatures).forEach(key => {
-        const value = featureFlags.getFeature(key as keyof typeof defaultFeatures);
-        if (key && value && value.enabled !== defaultFeatures[key as FeatureId]!.enabled) {
-          features[key as FeatureId] = value.enabled;
+      Object.keys(defaultFeatures).forEach(k => {
+        const key = k as keyof typeof defaultFeatures;
+        const value = featureFlags.getFeature(key);
+        if (key && value && value.enabled !== defaultFeatures[key]!.enabled) {
+          features[key] = value.enabled;
         }
       });
 

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -227,6 +227,7 @@ const MainSideBar = () => {
   const displayBlueDot = useManagerBlueDot(lastSeenDevice);
 
   const referralProgramConfig = useFeature("referralProgramDesktopSidebar");
+  const recoverFeature = useFeature("protectServicesDesktop");
   const handleCollapse = useCallback(() => {
     dispatch(setSidebarCollapsed(!collapsed));
   }, [dispatch, collapsed]);
@@ -310,11 +311,25 @@ const MainSideBar = () => {
   }, [dispatch, maybeRedirectToAccounts]);
 
   const handleClickRecover = useCallback(() => {
+    const enabled = recoverFeature?.enabled;
+    const openRecoverFromSidebar = recoverFeature?.params?.openRecoverFromSidebar;
+    const liveAppId = recoverFeature?.params?.protectId;
+
+    if (enabled && openRecoverFromSidebar && liveAppId) {
+      push(`/recover/${liveAppId}`);
+    } else if (enabled) {
+      dispatch(openModal("MODAL_PROTECT_DISCOVER", undefined));
+    }
     track("button_clicked", {
       button: "Protect",
     });
-    dispatch(openModal("MODAL_PROTECT_DISCOVER", undefined));
-  }, [dispatch]);
+  }, [
+    recoverFeature?.enabled,
+    recoverFeature?.params?.openRecoverFromSidebar,
+    recoverFeature?.params?.protectId,
+    push,
+    dispatch,
+  ]);
 
   return (
     <Transition

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
@@ -46,6 +46,8 @@ import { UseCase } from "../../index";
 import { track } from "~/renderer/analytics/segment";
 import { RecoverHowTo } from "~/renderer/components/Onboarding/Screens/Tutorial/screens/RecoverHowTo";
 import { RecoverPinCodeHowTo } from "~/renderer/components/Onboarding/Screens/Tutorial/screens/RecoverPinCodeHowTo";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatueFlag";
 
 const FlowStepperContainer = styled(Flex)`
   width: 100%;
@@ -228,6 +230,8 @@ export default function Tutorial({ useCase }: Props) {
   const [quizzOpen, setQuizOpen] = useState(false);
   const { t } = useTranslation();
   const { pathname } = useLocation();
+  const servicesConfig = useFeature("protectServicesDesktop");
+  const upsellPath = useUpsellPath(servicesConfig);
 
   const [userUnderstandConsequences, setUserUnderstandConsequences] = useState(false);
   const [userChosePinCodeHimself, setUserChosePinCodeHimself] = useState(false);
@@ -497,6 +501,9 @@ export default function Tutorial({ useCase }: Props) {
           if (useCase === UseCase.recover) {
             history.push(`${path}/${ScreenId.recoverHowTo}`);
           } else {
+            if (upsellPath) {
+              history.push(upsellPath);
+            }
             dispatch(saveSettings({ hasCompletedOnboarding: true }));
             track("Onboarding - End");
             setOnboardingDone(true);
@@ -516,13 +523,13 @@ export default function Tutorial({ useCase }: Props) {
       },
     ],
     [
+      userChosePinCodeHimself,
+      useCase,
+      userUnderstandConsequences,
       connectedDevice,
       history,
       path,
-      useCase,
-      userChosePinCodeHimself,
-      userUnderstandConsequences,
-      setOnboardingDone,
+      upsellPath,
       dispatch,
     ],
   );

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/index.tsx
@@ -47,7 +47,10 @@ import { track } from "~/renderer/analytics/segment";
 import { RecoverHowTo } from "~/renderer/components/Onboarding/Screens/Tutorial/screens/RecoverHowTo";
 import { RecoverPinCodeHowTo } from "~/renderer/components/Onboarding/Screens/Tutorial/screens/RecoverPinCodeHowTo";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatueFlag";
+import {
+  usePostOnboardingPath,
+  useUpsellPath,
+} from "@ledgerhq/live-common/hooks/recoverFeatueFlag";
 
 const FlowStepperContainer = styled(Flex)`
   width: 100%;
@@ -208,8 +211,7 @@ type ScreenComponent =
   | typeof QuizFailure
   | typeof PairMyNano
   | typeof GenuineCheck
-  | typeof RecoverHowTo
-  | typeof Screen;
+  | typeof RecoverHowTo;
 
 interface IScreen {
   id: ScreenId;
@@ -232,6 +234,7 @@ export default function Tutorial({ useCase }: Props) {
   const { pathname } = useLocation();
   const servicesConfig = useFeature("protectServicesDesktop");
   const upsellPath = useUpsellPath(servicesConfig);
+  const postOnboardingPath = usePostOnboardingPath(servicesConfig);
 
   const [userUnderstandConsequences, setUserUnderstandConsequences] = useState(false);
   const [userChosePinCodeHimself, setUserChosePinCodeHimself] = useState(false);
@@ -649,18 +652,28 @@ export default function Tutorial({ useCase }: Props) {
     history.push(`${path}/quiz-failure`);
   }, [history, path]);
 
-  function handleNextInDrawer(closeCurrentDrawer: (bool: boolean) => void, targetPath: string) {
-    closeCurrentDrawer(false);
-    history.push(targetPath);
-  }
+  const handleNextInDrawer = useCallback(
+    (closeCurrentDrawer: (bool: boolean) => void, targetPath: string) => {
+      closeCurrentDrawer(false);
+      history.push(targetPath);
+    },
+    [history],
+  );
 
-  function handleNextInDrawerDeeplink(
-    closeCurrentDrawer: (bool: boolean) => void,
-    targetPath: string,
-  ) {
-    closeCurrentDrawer(false);
-    openURL(targetPath);
-  }
+  const handleNextPin = useCallback(() => {
+    let targetPath = `${path}/${ScreenId.existingRecoveryPhrase}`;
+
+    if (useCase === UseCase.recover && postOnboardingPath) {
+      targetPath = postOnboardingPath;
+      dispatch(saveSettings({ hasCompletedOnboarding: true }));
+    }
+
+    if (useCase === UseCase.setupDevice) {
+      targetPath = `${path}/${ScreenId.newRecoveryPhrase}`;
+    }
+
+    handleNextInDrawer(setHelpPinCode, targetPath);
+  }, [dispatch, handleNextInDrawer, path, postOnboardingPath, useCase]);
 
   return (
     <>
@@ -668,21 +681,7 @@ export default function Tutorial({ useCase }: Props) {
       <Drawer isOpen={helpPinCode} onClose={() => setHelpPinCode(false)} direction={Direction.Left}>
         <Flex px={40} height="100%">
           `
-          <PinHelp
-            handleNextInDrawer={() =>
-              useCase === UseCase.recover
-                ? handleNextInDrawerDeeplink(
-                    setHelpPinCode,
-                    "ledgerlive://recover/protect-simu?redirectTo=restore",
-                  )
-                : handleNextInDrawer(
-                    setHelpPinCode,
-                    useCase === UseCase.setupDevice
-                      ? `${path}/${ScreenId.newRecoveryPhrase}`
-                      : `${path}/${ScreenId.existingRecoveryPhrase}`,
-                  )
-            }
-          />
+          <PinHelp handleNextInDrawer={handleNextPin} />
         </Flex>
       </Drawer>
       <Drawer
@@ -747,14 +746,15 @@ export default function Tutorial({ useCase }: Props) {
         handleBack={previous}
       >
         <Switch>
-          {useCaseScreens.map(({ component: Screen, id, props: screenProps = {} }) => {
+          {useCaseScreens.map(({ component, id, props: screenProps = {} }) => {
             return (
               <Route
                 key={id}
                 path={`${path}/${id}`}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                render={props => <Screen {...{ ...props, ...screenProps }} />}
+                render={props => {
+                  const Screen: React.ElementType = component;
+                  return <Screen {...props} {...screenProps} />;
+                }}
               />
             );
           })}

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
@@ -11,6 +11,8 @@ import { Text, Button, Logos, Icons, InvertThemeV3, Flex } from "@ledgerhq/react
 import { saveSettings } from "~/renderer/actions/settings";
 import BuyNanoX from "./assets/buyNanoX.webm";
 import { hasCompletedOnboardingSelector, languageSelector } from "~/renderer/reducers/settings";
+import { FeatureToggle, useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useLoginPath } from "@ledgerhq/live-common/hooks/recoverFeatueFlag";
 
 const StyledLink = styled(Text)`
   text-decoration: underline;
@@ -87,9 +89,22 @@ export function Welcome() {
   const { colors } = useTheme();
   const locale = useSelector(languageSelector) || "en";
 
-  if (hasCompletedOnboarding) {
-    history.push("/onboarding/select-device");
-  }
+  useEffect(() => {
+    if (hasCompletedOnboarding) {
+      history.push("/onboarding/select-device");
+    }
+  }, [hasCompletedOnboarding, history]);
+
+  const recoverFeature = useFeature("protectServicesDesktop");
+  const loginPath = useLoginPath(recoverFeature);
+
+  const recoverLogIn = useCallback(() => {
+    if (!loginPath) return;
+
+    acceptTerms();
+    dispatch(saveSettings({ hasCompletedOnboarding: true }));
+    history.push(loginPath);
+  }, [dispatch, history, loginPath]);
 
   const buyNanoX = useCallback(() => {
     openURL(
@@ -173,10 +188,23 @@ export function Welcome() {
             Icon={Icons.ArrowRightMedium}
             variant="main"
             onClick={handleAcceptTermsAndGetStarted}
-            mb="24px"
+            mb="5"
           >
             {t("onboarding.screens.welcome.nextButton")}
           </Button>
+          <FeatureToggle feature="protectServicesDesktop">
+            <Button
+              iconPosition="right"
+              variant="main"
+              onClick={recoverLogIn}
+              outline={true}
+              flexDirection="column"
+              whiteSpace="normal"
+              mb="5"
+            >
+              {t("onboarding.screens.welcome.recoverSignIn")}
+            </Button>
+          </FeatureToggle>
           <Button
             iconPosition="right"
             variant="main"

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/index.tsx
@@ -62,12 +62,13 @@ export const OnboardingContext = createContext<OnboardingContextTypes>({
 });
 
 export function Onboarding() {
+  const { path } = useRouteMatch();
+  const matchRecover = useRouteMatch(`${path}/${UseCase.recover}`);
   const [imgsLoaded, setImgsLoaded] = useState(false);
-  const [useCase, setUseCase] = useState<UseCase | null>(null);
+  const [useCase, setUseCase] = useState<UseCase | null>(matchRecover ? UseCase.recover : null);
   const [deviceModelId, setDeviceModelId] = useState<NullableDeviceModelId>(null);
   const [openedPedagogyModal, setOpenedPedagogyModal] = useState(false);
   const [openedRecoveryPhraseWarningHelp, setOpenedRecoveryPhraseWarningHelp] = useState(false);
-  const { path } = useRouteMatch();
 
   useEffect(() => {
     preloadAssets().then(() => setImgsLoaded(true));

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -1,0 +1,47 @@
+import React, { useContext, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { useHistory } from "react-router-dom";
+import { Flex, Text } from "@ledgerhq/react-ui";
+import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import OnboardingNavHeader from "../Onboarding/OnboardingNavHeader";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { OnboardingContext, UseCase } from "../Onboarding";
+import { ScreenId } from "../Onboarding/Screens/Tutorial";
+
+const RecoverRestore = () => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const currentDevice = useSelector(getCurrentDevice);
+  const { setDeviceModelId } = useContext(OnboardingContext);
+
+  useEffect(() => {
+    switch (currentDevice?.modelId) {
+      case DeviceModelId.nanoX:
+        setDeviceModelId(currentDevice.modelId);
+        history.push(`/onboarding/${UseCase.recover}/${ScreenId.pairMyNano}`);
+        break;
+      case DeviceModelId.stax:
+        history.push(`/onboarding/sync/${currentDevice.modelId}`);
+        break;
+      default:
+        break;
+    }
+  }, [currentDevice?.modelId, history, setDeviceModelId]);
+
+  return (
+    <Flex width="100%" height="100%" position="relative">
+      <Flex position="relative" height="100%" width="100%" flexDirection="column">
+        <OnboardingNavHeader onClickPrevious={() => history.push("/onboarding/select-device")} />
+        <Flex flex={1} alignItems="center" justifyContent="center" flexDirection="column">
+          <Text variant="h3Inter" color="neutral.c100" mt={16}>
+            {t("recoverRestore.title")}
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default withV3StyleProvider(RecoverRestore);

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -35,7 +35,12 @@ const RecoverRestore = () => {
       <Flex position="relative" height="100%" width="100%" flexDirection="column">
         <OnboardingNavHeader onClickPrevious={() => history.push("/onboarding/select-device")} />
         <Flex flex={1} alignItems="center" justifyContent="center" flexDirection="column">
-          <Text variant="h3Inter" color="neutral.c100" mt={16}>
+          <Text
+            variant="h3Inter"
+            color="neutral.c100"
+            mt={16}
+            data-test-id="recover-restore-connect-text"
+          >
             {t("recoverRestore.title")}
           </Text>
         </Flex>

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
@@ -276,6 +276,9 @@ export function useDeepLinkHandler() {
         case "recover":
           navigate(`/recover/${path}`, undefined, search);
           break;
+        case "recover-restore-flow":
+          navigate("/recover-restore");
+          break;
         case "portfolio":
         default:
           navigate("/");

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -43,6 +43,8 @@ import {
 import ReactRoot from "~/renderer/ReactRoot";
 import AppError from "~/renderer/AppError";
 import { expectOperatingSystemSupportStatus } from "~/support/os";
+import { addDevice, removeDevice, resetDevices } from "~/renderer/actions/devices";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { listCachedCurrencyIds } from "./bridge/cache";
 if (process.env.VERBOSE) {
   enableDebugLogger();
@@ -205,6 +207,15 @@ async function init() {
   // expose stuff in Windows for DEBUG purpose
   window.ledger = {
     store,
+    addDevice: (device: Device) => {
+      store.dispatch(addDevice(device));
+    },
+    removeDevice: (device: Device) => {
+      store.dispatch(removeDevice(device));
+    },
+    resetDevices: () => {
+      store.dispatch(resetDevices());
+    },
   };
 }
 function r(Comp: JSX.Element) {

--- a/apps/ledger-live-desktop/src/renderer/modals/ProtectDiscover/ProtectDiscoverBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ProtectDiscover/ProtectDiscoverBody.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Flex, Button as BaseButton, Text } from "@ledgerhq/react-ui";
 import styled, { BaseStyledProps } from "@ledgerhq/react-ui/components/styled";
@@ -21,18 +21,19 @@ const StyledImgLink = styled("a")<BaseStyledProps>`
   cursor: pointer;
 `;
 
+const onAppStoreClick = () => openURL(urls.ledgerLiveMobile.appStore);
+const onPlayStoreClick = () => openURL(urls.ledgerLiveMobile.playStore);
+
 const ProtectDiscoverBody = ({ onClose }: Props) => {
   const { t } = useTranslation();
-  const protectServicesDiscoverDesktopFeature = useFeature("protectServicesDiscoverDesktop");
+  const protectServicesDesktopFeature = useFeature("protectServicesDesktop");
 
-  const onAppStoreClick = () => openURL(urls.ledgerLiveMobile.appStore);
-  const onPlayStoreClick = () => openURL(urls.ledgerLiveMobile.playStore);
-  const onDiscoverClick = () => {
+  const onDiscoverClick = useCallback(() => {
     track("button_clicked", {
       button: "Discover the benefits",
     });
-    openURL(protectServicesDiscoverDesktopFeature?.params?.discoverTheBenefitsLink);
-  };
+    openURL(protectServicesDesktopFeature?.params?.discoverTheBenefitsLink);
+  }, [protectServicesDesktopFeature?.params?.discoverTheBenefitsLink]);
 
   return (
     <ModalBody

--- a/apps/ledger-live-desktop/src/renderer/reducers/devices.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/devices.ts
@@ -70,7 +70,7 @@ export function getCurrentDevice(state: { devices: DevicesState; settings: Setti
     };
   }
 
-  if (getEnv("DEVICE_PROXY_URL") || getEnv("MOCK")) {
+  if (getEnv("DEVICE_PROXY_URL") || (getEnv("MOCK") && !getEnv("MOCK_NO_BYPASS"))) {
     // bypass the listen devices (we should remove modelId here by instead get it at open time if needed)
     return {
       deviceId: "",

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -32,6 +32,7 @@ const FullscreenWrapper = styled.div`
   width: 100vw;
   height: 100vh;
   z-index: 20;
+  background-color: ${p => p.theme.colors.palette.background.default};
 `;
 
 export default function RecoverPlayer({

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4360,7 +4360,7 @@
           },
           "4": {
             "title": "Restore using Ledger Recover",
-            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do"
+            "description": "Log into Ledger Trust Services on the Ledger Live app to restore the backup for your Secret Recovery Phrase."
           }
         }
       },

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5953,5 +5953,8 @@
       "contactSupport": "Contact Ledger support",
       "saveLog": "Save log"
     }
+  },
+  "recoverRestore": {
+    "title": "Connect and unlock your Ledger"
   }
 }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4310,6 +4310,7 @@
         "nextButton": "Get started",
         "noDevice": "No device?",
         "buyLink": "No device? Buy a Ledger Nano X",
+        "recoverSignIn": "Log in for Ledger Recover",
         "byTapping": "By tapping \"Get Started\" you consent and agree to our",
         "termsAndConditions": "Terms and conditions",
         "and": "and",

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -2,7 +2,7 @@ import { test as base, Page, ElectronApplication, _electron as electron } from "
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
-import { Feature, FeatureId } from "@ledgerhq/types-live";
+import { DefaultFeatures } from "@ledgerhq/types-live";
 import { responseLogfilePath } from "../utils/networkResponseLogger";
 
 export function generateUUID(): string {
@@ -15,10 +15,11 @@ type TestFixtures = {
   userdata: string;
   userdataDestinationPath: string;
   userdataOriginalFile: string;
-  userdataFile: any;
-  env: Record<string, any>;
+  userdataFile: unknown;
+  env: Record<string, string>;
+  electronApp: ElectronApplication;
   page: Page;
-  featureFlags: { [key in FeatureId]?: Feature };
+  featureFlags: DefaultFeatures;
   recordTestNamesForApiResponseLogging: void;
 };
 
@@ -40,17 +41,9 @@ const test = base.extend<TestFixtures>({
     const fullFilePath = path.join(userdataDestinationPath, "app.json");
     use(fullFilePath);
   },
-  page: async (
-    {
-      lang,
-      theme,
-      userdata,
-      userdataDestinationPath,
-      userdataOriginalFile,
-      env,
-      featureFlags,
-    }: TestFixtures,
-    use: (page: Page) => void,
+  electronApp: async (
+    { lang, theme, userdata, userdataDestinationPath, userdataOriginalFile, env, featureFlags },
+    use,
   ) => {
     // create userdata path
     fs.mkdirSync(userdataDestinationPath, { recursive: true });
@@ -101,6 +94,12 @@ const test = base.extend<TestFixtures>({
       timeout: 120000,
     });
 
+    await use(electronApp);
+
+    // close app
+    await electronApp.close();
+  },
+  page: async ({ electronApp }, use) => {
     // app is ready
     const page = await electronApp.firstWindow();
 
@@ -135,9 +134,6 @@ const test = base.extend<TestFixtures>({
 
     // use page in the test
     await use(page);
-
-    // close app
-    await electronApp.close();
   },
   // below is used for the logging file at `artifacts/networkResponses.log`
   recordTestNamesForApiResponseLogging: [

--- a/apps/ledger-live-desktop/tests/models/RecoverRestorePage.ts
+++ b/apps/ledger-live-desktop/tests/models/RecoverRestorePage.ts
@@ -1,0 +1,17 @@
+import { Page, Locator } from "@playwright/test";
+import { sendDeepLink } from "../utils/deeplink";
+
+export class RecoverRestorePage {
+  readonly page: Page;
+  readonly connectText: Locator;
+  readonly deepLink = "ledgerlive://recover-restore-flow";
+
+  constructor(page: Page) {
+    this.page = page;
+    this.connectText = page.locator("data-test-id=recover-restore-connect-text");
+  }
+
+  useDeepLink() {
+    return sendDeepLink(this.page, this.deepLink);
+  }
+}

--- a/apps/ledger-live-desktop/tests/specs/recover/recover.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/recover/recover.spec.ts
@@ -1,9 +1,14 @@
 import test from "../../fixtures/common";
 import { expect } from "@playwright/test";
 import { RecoverRestorePage } from "../../models/RecoverRestorePage";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+// importing manually until we correctly include the test directory
+// in the default tsconfig for the IDE
+import "../../../src/index-types.d.ts";
 
 test.use({
   userdata: "skip-onboarding",
+  env: { MOCK_NO_BYPASS: "1" },
 });
 
 test.describe.parallel("Recover", () => {
@@ -13,6 +18,52 @@ test.describe.parallel("Recover", () => {
 
     await test.step("Text is visible", async () => {
       await expect(recoverPage.connectText).toBeVisible();
+    });
+  });
+
+  test("Restore page with nanoX", async ({ page }) => {
+    const recoverPage = new RecoverRestorePage(page);
+    recoverPage.useDeepLink();
+
+    await test.step("Text is visible", async () => {
+      await expect(recoverPage.connectText).toBeVisible();
+    });
+
+    const modelId = DeviceModelId.nanoX;
+    await page.evaluate(modelId => {
+      window.ledger.addDevice({
+        deviceId: "",
+        deviceName: "My nanoX",
+        modelId,
+        wired: true,
+      });
+    }, modelId);
+
+    await test.step("Text is no longer visible", async () => {
+      await expect(recoverPage.connectText).not.toBeVisible();
+    });
+  });
+
+  test("Restore page with stax", async ({ page }) => {
+    const recoverPage = new RecoverRestorePage(page);
+    recoverPage.useDeepLink();
+
+    await test.step("Text is visible", async () => {
+      await expect(recoverPage.connectText).toBeVisible();
+    });
+
+    const modelId = DeviceModelId.stax;
+    await page.evaluate(modelId => {
+      window.ledger.addDevice({
+        deviceId: "",
+        deviceName: "My stax",
+        modelId,
+        wired: true,
+      });
+    }, modelId);
+
+    await test.step("Text is no longer visible", async () => {
+      await expect(recoverPage.connectText).not.toBeVisible();
     });
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/recover/recover.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/recover/recover.spec.ts
@@ -1,0 +1,18 @@
+import test from "../../fixtures/common";
+import { expect } from "@playwright/test";
+import { RecoverRestorePage } from "../../models/RecoverRestorePage";
+
+test.use({
+  userdata: "skip-onboarding",
+});
+
+test.describe.parallel("Recover", () => {
+  test("Restore page with no device", async ({ page }) => {
+    const recoverPage = new RecoverRestorePage(page);
+    recoverPage.useDeepLink();
+
+    await test.step("Text is visible", async () => {
+      await expect(recoverPage.connectText).toBeVisible();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/tests/utils/deeplink.ts
+++ b/apps/ledger-live-desktop/tests/utils/deeplink.ts
@@ -1,0 +1,9 @@
+import { Page } from "@playwright/test";
+
+export function sendDeepLink(page: Page, link: string) {
+  return page.evaluate(l => {
+    const app = require("@electron/remote");
+    const win = app.getCurrentWindow();
+    win.send("deep-linking", l);
+  }, link);
+}

--- a/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseFeatureFlags.tsx
@@ -106,10 +106,11 @@ export const getAllDivergedFlags = (
   appLanguage: string,
 ): Partial<{ [key in FeatureId]: boolean }> => {
   const res: Partial<{ [key in FeatureId]: boolean }> = {};
-  Object.keys(defaultFeatures).forEach(key => {
-    const value = getFeature({ key: key as FeatureId, appLanguage });
-    if (value && value.enabled !== defaultFeatures[key as FeatureId]?.enabled) {
-      res[key as FeatureId] = value.enabled;
+  Object.keys(defaultFeatures).forEach(k => {
+    const key = k as keyof typeof defaultFeatures;
+    const value = getFeature({ key, appLanguage });
+    if (value && value.enabled !== defaultFeatures[key]?.enabled) {
+      res[key] = value.enabled;
     }
   });
   return res;

--- a/apps/ledger-live-mobile/src/components/ServicesWidget/index.tsx
+++ b/apps/ledger-live-mobile/src/components/ServicesWidget/index.tsx
@@ -9,7 +9,6 @@ import {
   useLearnMoreURI,
 } from "@ledgerhq/live-common/hooks/recoverFeatueFlag";
 import NewProtectState from "./Protect/NewProtectState";
-import { ServicesConfigParams } from "./types";
 import Touchable from "../Touchable";
 
 import LedgerRecoverLogoLight from "../../images/ledger_recover_light.png";
@@ -19,7 +18,7 @@ import LedgerRecoverCardTopImage from "../../images/ledger_recover_card_top.png"
 
 function ServicesWidget() {
   const { t } = useTranslation();
-  const servicesConfig = useFeature<ServicesConfigParams>("protectServicesMobile");
+  const servicesConfig = useFeature("protectServicesMobile");
   const theme = useTheme();
 
   const learnMoreURI = useLearnMoreURI(servicesConfig);

--- a/apps/ledger-live-mobile/src/components/ServicesWidget/types.ts
+++ b/apps/ledger-live-mobile/src/components/ServicesWidget/types.ts
@@ -1,8 +1,3 @@
 export enum ProtectStateNumberEnum {
   NEW = "NEW",
 }
-
-export type ServicesConfigParams = {
-  login: Record<string, string>;
-  managerStatesData: Record<ProtectStateNumberEnum, Record<string, string>>;
-};

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToRecoverStaxFlow.tsx
@@ -10,7 +10,6 @@ import { ScreenName } from "../../const";
 import { useNavigationInterceptor } from "../Onboarding/onboardingContext";
 import BleDevicePairingFlow from "../../components/BleDevicePairingFlow";
 import { useIncrementOnNavigationFocusState } from "../../helpers/useIncrementOnNavigationFocusState";
-import { ServicesConfigParams } from "../../components/ServicesWidget/types";
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.RedirectToRecoverStaxFlow>
@@ -18,7 +17,7 @@ type NavigationProps = RootComposite<
 
 export function RedirectToRecoverStaxFlowScreen({ navigation }: NavigationProps) {
   const { setShowWelcome, setFirstTimeOnboarding } = useNavigationInterceptor();
-  const recoverConfig = useFeature<ServicesConfigParams>("protectServicesMobile");
+  const recoverConfig = useFeature("protectServicesMobile");
   const recoverRestoreFlowURI = usePostOnboardingURI(recoverConfig);
 
   useEffect(() => {

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -501,6 +501,11 @@ const envDefinitions: Record<string, EnvDef<boolean | string | number | string[]
     parser: stringParser,
     desc: "if defined, overrides the os and version. format: os@version. Example: Windows_NT@6.1.7601",
   },
+  MOCK_NO_BYPASS: {
+    def: false,
+    parser: boolParser,
+    desc: "if defined, avoids bypass of the currentDevice in the store.",
+  },
   NFT_CURRENCIES: {
     def: "ethereum,polygon",
     parser: stringParser,

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -239,7 +239,7 @@ export const defaultFeatures: DefaultFeatures = {
           alreadySubscribedURI: `ledgerlive://recover/protect-simu?redirectTo=login`,
         },
       },
-      login: {
+      account: {
         loginURI: "ledgerlive://recover/protect-simu?redirectTo=login",
       },
       protectId: "protect-simu",
@@ -254,12 +254,11 @@ export const defaultFeatures: DefaultFeatures = {
       version: "1",
     },
   },
-  protectServicesDiscoverDesktop: {
-    enabled: false,
-  },
   protectServicesDesktop: {
     enabled: false,
     params: {
+      openRecoverFromSidebar: true,
+      discoverTheBenefitsLink: "https://www.ledger.com/recover",
       onboardingRestore: {
         restoreInfoDrawer: {
           enabled: true,

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -1,6 +1,6 @@
 import type { DefaultFeatures } from "@ledgerhq/types-live";
 
-export const defaultFeatures: DefaultFeatures = {
+export const defaultFeatures = {
   learn: {
     enabled: false,
   },
@@ -272,7 +272,7 @@ export const defaultFeatures: DefaultFeatures = {
         upsellURI: "ledgerlive://recover/protect-simu?redirectTo=upsell",
         alreadySubscribedURI: "ledgerlive://recover/protect-simu?redirectTo=login",
       },
-      login: {
+      account: {
         loginURI: "ledgerlive://recover/protect-simu?redirectTo=login",
       },
       protectId: "protect-simu",
@@ -294,4 +294,4 @@ export const defaultFeatures: DefaultFeatures = {
   listAppsV2: {
     enabled: false,
   },
-};
+} as const satisfies DefaultFeatures;

--- a/libs/ledger-live-common/src/hooks/recoverFeatueFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatueFlag.ts
@@ -1,5 +1,9 @@
 import { useMemo } from "react";
 import { Feature } from "@ledgerhq/types-live";
+import { defaultFeatures } from "../featureFlags";
+
+type DesktopFeature = (typeof defaultFeatures)["protectServicesDesktop"]["params"];
+type MobileFeature = (typeof defaultFeatures)["protectServicesMobile"]["params"];
 
 export function useReplacedURI(uri?: string, id?: string): string | undefined {
   return useMemo(() => {
@@ -7,48 +11,69 @@ export function useReplacedURI(uri?: string, id?: string): string | undefined {
   }, [id, uri]);
 }
 
-function usePath(servicesConfig: Feature<any> | null, uri?: string) {
+function usePath(servicesConfig: Feature<unknown> | null, uri?: string) {
   return useMemo(() => {
     return servicesConfig?.enabled ? uri?.replace("ledgerlive://", "/") : undefined;
   }, [servicesConfig?.enabled, uri]);
 }
 
-export function usePostOnboardingURI(servicesConfig: Feature<any> | null): string | undefined {
+export function usePostOnboardingURI(
+  servicesConfig: Feature<MobileFeature | DesktopFeature> | null,
+): string | undefined {
   const uri = servicesConfig?.params?.onboardingRestore?.postOnboardingURI;
   const id = servicesConfig?.params?.protectId;
 
   return useReplacedURI(uri, id);
 }
 
-export function usePostOnboardingPath(servicesConfig: Feature<any> | null): string | undefined {
+export function usePostOnboardingPath(
+  servicesConfig: Feature<DesktopFeature> | null,
+): string | undefined {
   const uri = usePostOnboardingURI(servicesConfig);
 
   return usePath(servicesConfig, uri);
 }
 
-export function useLearnMoreURI(servicesConfig: Feature<any> | null): string | undefined {
+export function useLearnMoreURI(servicesConfig: Feature<MobileFeature> | null): string | undefined {
   const uri = servicesConfig?.params?.managerStatesData?.NEW?.learnMoreURI;
   const id = servicesConfig?.params?.protectId;
 
   return useReplacedURI(uri, id);
 }
 
-export function useAlreadySubscribedURI(servicesConfig: Feature<any> | null): string | undefined {
+export function useAlreadySubscribedURI(
+  servicesConfig: Feature<MobileFeature> | null,
+): string | undefined {
   const uri = servicesConfig?.params?.managerStatesData?.NEW?.alreadySubscribedURI;
   const id = servicesConfig?.params?.protectId;
 
   return useReplacedURI(uri, id);
 }
 
-export function useUpsellURI(servicesConfig: Feature<any> | null): string | undefined {
+export function useUpsellURI(servicesConfig: Feature<DesktopFeature> | null): string | undefined {
   const uri = servicesConfig?.params?.onboardingCompleted?.upsellURI;
   const id = servicesConfig?.params?.protectId;
 
   return useReplacedURI(uri, id);
 }
 
-export function useUpsellPath(servicesConfig: Feature<any> | null): string | undefined {
+export function useUpsellPath(servicesConfig: Feature<DesktopFeature> | null): string | undefined {
   const uri = useUpsellURI(servicesConfig);
+
+  return usePath(servicesConfig, uri);
+}
+
+export function useLoginURI(
+  servicesConfig: Feature<MobileFeature | DesktopFeature> | null,
+): string | undefined {
+  const uri = servicesConfig?.params?.account?.loginURI;
+  const id = servicesConfig?.params?.protectId;
+
+  return useReplacedURI(uri, id);
+}
+
+export function useLoginPath(servicesConfig: Feature<DesktopFeature> | null): string | undefined {
+  const uri = useLoginURI(servicesConfig);
 
   return usePath(servicesConfig, uri);
 }

--- a/libs/ledger-live-common/src/hooks/recoverFeatueFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatueFlag.ts
@@ -7,6 +7,12 @@ export function useReplacedURI(uri?: string, id?: string): string | undefined {
   }, [id, uri]);
 }
 
+function usePath(servicesConfig: Feature<any> | null, uri?: string) {
+  return useMemo(() => {
+    return servicesConfig?.enabled ? uri?.replace("ledgerlive://", "/") : undefined;
+  }, [servicesConfig?.enabled, uri]);
+}
+
 export function usePostOnboardingURI(servicesConfig: Feature<any> | null): string | undefined {
   const uri = servicesConfig?.params?.onboardingRestore?.postOnboardingURI;
   const id = servicesConfig?.params?.protectId;
@@ -17,9 +23,7 @@ export function usePostOnboardingURI(servicesConfig: Feature<any> | null): strin
 export function usePostOnboardingPath(servicesConfig: Feature<any> | null): string | undefined {
   const uri = usePostOnboardingURI(servicesConfig);
 
-  return useMemo(() => {
-    return servicesConfig?.enabled ? uri?.replace("ledgerlive://", "/") : undefined;
-  }, [servicesConfig?.enabled, uri]);
+  return usePath(servicesConfig, uri);
 }
 
 export function useLearnMoreURI(servicesConfig: Feature<any> | null): string | undefined {
@@ -34,4 +38,17 @@ export function useAlreadySubscribedURI(servicesConfig: Feature<any> | null): st
   const id = servicesConfig?.params?.protectId;
 
   return useReplacedURI(uri, id);
+}
+
+export function useUpsellURI(servicesConfig: Feature<any> | null): string | undefined {
+  const uri = servicesConfig?.params?.onboardingCompleted?.upsellURI;
+  const id = servicesConfig?.params?.protectId;
+
+  return useReplacedURI(uri, id);
+}
+
+export function useUpsellPath(servicesConfig: Feature<any> | null): string | undefined {
+  const uri = useUpsellURI(servicesConfig);
+
+  return usePath(servicesConfig, uri);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Handle the recover deeplink
Add a screen to redirect to the correct device onboarding automatically
Handle the stax recover selection on device
Rework of the recover feature flags
Add upsell screen for recover after onboarding

Incorporate #3430, #3507 and #3550 

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`PROTECT-1720`](https://ledgerhq.atlassian.net/browse/PROTECT-1720) [`PROTECT-1712`](https://ledgerhq.atlassian.net/browse/PROTECT-1712) [`PROTECT-1713`](https://ledgerhq.atlassian.net/browse/PROTECT-1713) [`PROTECT-1719`](https://ledgerhq.atlassian.net/browse/PROTECT-1719) [`PROTECT-2106`](https://ledgerhq.atlassian.net/browse/PROTECT-2106) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
