### PR TITLE
fix: blind fix for disconnects during fw update due to bad HSM data

### DIFF
--- a/.changeset/tiny-dancers-smell.md
+++ b/.changeset/tiny-dancers-smell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Sanitize the bulk exchange payload from HSM before exchanging it with the device


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We noticed something strange during a firmware update process between versions 1.1.0 and 1.2.0-rc1. Unfortunately, we couldn't get all the details because we send the data together in bulk and don't have access to the logs. However, after doing some debugging, I have a theory. 

It seems that the data we're receiving from the HSM is incorrect. I noticed a bunch of empty strings at the end of the APDU array. Since we don't check for empty strings, we end up sending HID/BLE frames without any data, which I believe is causing the disconnect. To address this issue, this pull request includes a sanity check or cleanup procedure where we remove empty APDUs before proceeding with the exchange.

### ❓ Context

- **Impacted projects**: `https://ledgerhq.atlassian.net/browse/LIVE-7868` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `ledger-live-common` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo

### 🚀 Expectations to reach
We should be able to complete the 1.1.0 to 1.2.0-rc1 update path without a disconnect.