### PR TITLE
feat/LIVE-7872 Uninstall all feature + CLI implementation

### DIFF
--- a/.changeset/slow-seals-boil.md
+++ b/.changeset/slow-seals-boil.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Logic implementation of the bulk uninstall apdu with test

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -191,7 +191,12 @@ export const reducer = (state: State, action: Action): State => {
 
     case "recover":
       return { ...state, currentError: null };
-
+    case "wiped":
+      // Reconciliate an already achieved wipe via single uninstall apdu
+      return {
+        ...state,
+        installed: [],
+      };
     case "wipe":
       return {
         ...state,

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -163,6 +163,9 @@ export type Action = // recover from an error
     | {
         type: "onRunnerEvent";
         event: RunnerEvent;
+      }
+    | {
+        type: "wiped";
       };
 export type RunnerEvent =
   | {

--- a/libs/ledger-live-common/src/hw/actions/uninstallAllApps.ts
+++ b/libs/ledger-live-common/src/hw/actions/uninstallAllApps.ts
@@ -1,0 +1,125 @@
+import { Observable } from "rxjs";
+import { scan, tap } from "rxjs/operators";
+import { useCallback, useEffect, useState } from "react";
+import { log } from "@ledgerhq/logs";
+import type { DeviceInfo } from "@ledgerhq/types-live";
+import { useReplaySubject } from "../../observable";
+import type { UninstallAllAppsEvent, Input as UninstallAllAppsInput } from "../uninstallAllApps";
+import type { Action, Device } from "./types";
+import { currentMode } from "./app";
+import { getImplementation } from "./implementations";
+
+type State = {
+  isLoading: boolean;
+  unresponsive: boolean;
+  requestQuitApp?: boolean;
+  uninstallAppsRequested?: boolean;
+  appsUninstalled: boolean;
+  device: Device | null | undefined;
+  deviceInfo: DeviceInfo | null | undefined;
+  error: Error | null | undefined;
+};
+type StateWithRetry = State & { onRetry: () => void };
+
+type RemoveImageAction = Action<unknown, StateWithRetry, boolean>;
+
+const mapResult = ({ appsUninstalled }: State) => appsUninstalled;
+
+type Event =
+  | UninstallAllAppsEvent
+  | {
+      type: "error";
+      error: Error;
+    }
+  | {
+      type: "deviceChange";
+      device: Device | null | undefined;
+    };
+
+const getInitialState = (device?: Device | null | undefined): State => ({
+  isLoading: !!device,
+  requestQuitApp: false,
+  unresponsive: false,
+  device,
+  deviceInfo: null,
+  error: null,
+  uninstallAppsRequested: false,
+  appsUninstalled: false,
+});
+
+const reducer = (state: State, e: Event): State => {
+  switch (e.type) {
+    case "unresponsiveDevice":
+      return { ...state, unresponsive: true, isLoading: false };
+
+    case "deviceChange":
+      return getInitialState(e.device);
+
+    case "error":
+      return {
+        ...state,
+        error: e.error,
+        isLoading: false,
+      };
+    case "uninstallAppsPermissionRequested":
+      return {
+        ...state,
+        unresponsive: false,
+        uninstallAppsRequested: true,
+        isLoading: false,
+      };
+    case "appsUninstalled":
+      return {
+        ...state,
+        unresponsive: false,
+        uninstallAppsRequested: false,
+        isLoading: false,
+        appsUninstalled: true,
+      };
+  }
+};
+
+export const createAction = (
+  task: (arg0: UninstallAllAppsInput) => Observable<UninstallAllAppsEvent>,
+): RemoveImageAction => {
+  const useHook = (device: Device | null | undefined, _: unknown): StateWithRetry => {
+    const [state, setState] = useState(() => getInitialState(device));
+    const [resetIndex, setResetIndex] = useState(0);
+    const deviceSubject = useReplaySubject(device);
+
+    const onRetry = useCallback(() => {
+      setResetIndex(currIndex => currIndex + 1);
+      setState(s => getInitialState(s.device));
+    }, []);
+
+    useEffect(() => {
+      if (state.appsUninstalled) return;
+
+      const impl = getImplementation(currentMode)<UninstallAllAppsEvent, Record<string, unknown>>({
+        deviceSubject,
+        task,
+        request: {},
+      });
+
+      const sub = impl
+        .pipe(
+          tap((e: any) => log("actions-remove-stax-image-event", e.type, e)),
+          scan(reducer, getInitialState()),
+        )
+        .subscribe(setState);
+      return () => {
+        sub.unsubscribe();
+      };
+    }, [deviceSubject, resetIndex, state.appsUninstalled]);
+
+    return {
+      ...state,
+      onRetry,
+    };
+  };
+
+  return {
+    useHook,
+    mapResult,
+  };
+};

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
@@ -1,0 +1,37 @@
+import { StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { command as uninstallAllApps } from "./uninstallAllApps";
+import Transport from "@ledgerhq/hw-transport";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore next-line
+const mockTransportGenerator = out => ({ send: () => out } as Transport);
+
+describe("uninstallAllApps", () => {
+  test("should complete with TRUE if user approves", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.OK.toString(16), "hex"),
+    );
+    await expect(uninstallAllApps(mockedTransport)).resolves.toBeTruthy();
+  });
+
+  test("should complete with FALSE if the APDU is unavailable", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.UNKNOWN_APDU.toString(16), "hex"),
+    );
+    await expect(uninstallAllApps(mockedTransport)).resolves.toBeFalsy();
+  });
+
+  test("should fail with correct error if user refuses", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex"),
+    );
+    await expect(uninstallAllApps(mockedTransport)).rejects.toThrow(UserRefusedOnDevice);
+  });
+
+  test("should throw if any other status", async () => {
+    const mockedTransport: Transport = mockTransportGenerator(
+      Buffer.from(StatusCodes.INS_NOT_SUPPORTED.toString(16), "hex"),
+    );
+    await expect(uninstallAllApps(mockedTransport)).rejects.toThrow(Error);
+  });
+});

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.ts
@@ -31,7 +31,6 @@ export const command = async (transport: Transport): Promise<boolean> => {
     StatusCodes.OK,
     StatusCodes.UNKNOWN_APDU,
     StatusCodes.USER_REFUSED_ON_DEVICE,
-    StatusCodes.CUSTOM_IMAGE_EMPTY,
     StatusCodes.UNKNOWN_APDU,
   ]);
 

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.ts
@@ -1,0 +1,83 @@
+import { TransportStatusError, StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import Transport from "@ledgerhq/hw-transport";
+import { Observable, from, of } from "rxjs";
+import { withDevice } from "./deviceAccess";
+import { delay, mergeMap } from "rxjs/operators";
+import getDeviceInfo from "./getDeviceInfo";
+
+export type UninstallAllAppsEvent =
+  | {
+      type: "unresponsiveDevice";
+    }
+  | {
+      type: "uninstallAppsPermissionRequested";
+    }
+  | {
+      type: "appsUninstalled";
+    };
+
+export type Input = {
+  deviceId: string;
+  request: Record<string, unknown>;
+};
+
+/**
+ * Prompt the user to uninstall all applications at once in order to avoid
+ * having to iterate over the installed applications one by one. This avoid
+ * unnnecesary HSM connections, speeds up the flow and improves the UX.
+ */
+export const command = async (transport: Transport): Promise<boolean> => {
+  const res = await transport.send(0xe0, 0x6dd, 0x00, 0x00, Buffer.from([]), [
+    StatusCodes.OK,
+    StatusCodes.UNKNOWN_APDU,
+    StatusCodes.USER_REFUSED_ON_DEVICE,
+    StatusCodes.CUSTOM_IMAGE_EMPTY,
+    StatusCodes.UNKNOWN_APDU,
+  ]);
+
+  const status = res.readUInt16BE(res.length - 2);
+
+  // We can complete with OK/KO, if the APDU is not available we can continue
+  // with the legacy queue based HSM uninstall, if we succeed, we can clear
+  // the queue.
+  switch (status) {
+    case StatusCodes.OK:
+      return true;
+    case StatusCodes.USER_REFUSED_ON_DEVICE:
+      throw new UserRefusedOnDevice();
+    case StatusCodes.UNKNOWN_APDU:
+      return false;
+  }
+  throw new TransportStatusError(status);
+};
+
+export default function uninstallAllApps({ deviceId }: Input): Observable<UninstallAllAppsEvent> {
+  const sub = withDevice(deviceId)(
+    transport =>
+      new Observable(subscriber => {
+        const timeoutSub = of<UninstallAllAppsEvent>({
+          type: "unresponsiveDevice",
+        })
+          .pipe(delay(1000))
+          .subscribe(e => subscriber.next(e));
+
+        const sub = from(getDeviceInfo(transport))
+          .pipe(
+            mergeMap(async () => {
+              timeoutSub.unsubscribe();
+              subscriber.next({ type: "uninstallAllAppsPermissionRequested" });
+              await command(transport);
+              subscriber.next({ type: "appsUninstalled" });
+            }),
+          )
+          .subscribe(subscriber);
+
+        return () => {
+          timeoutSub.unsubscribe();
+          sub.unsubscribe();
+        };
+      }),
+  );
+
+  return sub as Observable<UninstallAllAppsEvent>;
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

With the 1.2.0 version of Stax we receive for the first time a firmware that allows us to bulk uninstall with user consent, allowing us to skip the uninstall queue completely, prevent HSM connections, speeding up the flow, improving the UX. We should use that when available, falling back to the normal uninstall flow when it’s not. Luckily, when the APDU is not available we get a unified `6d02` response, so leverage that in the implementation so that we always try that first.

This pr introduces the device action, the command and logic used, test coverage and a CLI implementation of the command, testable with `FORCE_PROVIDER=3 pnpm run:cli appUninstallAll` on a 1.2.0 Stax. Running the command (without the forced provider) on any other device should still uninstall the applications, but slowly, one, by, one.

### ❓ Context

- **Impacted projects**: `ledger-live-common, cli` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7872` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
1.2.0 Stax should uninstall apps very quickly, other devices should uninstall apps very slowly in comparison.
Always in the scenario where we are uninstalling everything, of course.