### PR TITLE
Fix/LIVE-7801: add optional shouldNotPopNavigationOnSuccess param to account selection

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/RequestAccountNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/RequestAccountNavigator.ts
@@ -20,6 +20,7 @@ export type RequestAccountNavigatorParamList = {
     currency: CryptoOrTokenCurrency;
     allowAddAccount?: boolean;
     onSuccess?: (account: AccountLike, parentAccount?: Account) => void;
+    shouldNotPopNavigationOnSuccess?: boolean;
     onError?: (_: Error) => void;
   };
   [NavigatorName.RequestAccountsAddAccounts]: NavigatorScreenParams<AddAccountsNavigatorParamList> &

--- a/apps/ledger-live-mobile/src/components/Stake/index.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/index.tsx
@@ -65,6 +65,7 @@ const StakeFlow = ({ route }: Props) => {
         screen: ScreenName.RequestAccountsSelectAccount,
         params: {
           currency: cryptoCurrencies[0],
+          shouldNotPopNavigationOnSuccess: true,
           onSuccess,
         },
         onError,
@@ -75,6 +76,7 @@ const StakeFlow = ({ route }: Props) => {
         params: {
           currencies: cryptoCurrencies,
           allowAddAccount: true,
+          shouldNotPopNavigationOnSuccess: true,
           onSuccess,
         },
         onError,

--- a/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
@@ -88,7 +88,7 @@ const List = ({
 
 function SelectAccount({ navigation, route }: Props) {
   const { colors } = useTheme();
-  const { accounts$, currency, allowAddAccount, onSuccess, onError } = route.params;
+  const { accounts$, currency, allowAddAccount, onSuccess, onError, shouldNotPopNavigationOnSuccess } = route.params;
   const accountIds = useGetAccountIds(accounts$);
   const accounts = useSelector(accountsByCryptoCurrencyScreenSelector(currency, accountIds)) as {
     account: AccountLike;
@@ -97,11 +97,13 @@ function SelectAccount({ navigation, route }: Props) {
   const onSelect = useCallback(
     (account: AccountLike, parentAccount?: Account) => {
       onSuccess && onSuccess(account, parentAccount);
-      const n =
-        navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>() || navigation;
-      n.pop();
+      if (!shouldNotPopNavigationOnSuccess) {
+        const n =
+          navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>() || navigation;
+        n.pop();
+      }
     },
-    [navigation, onSuccess],
+    [navigation, onSuccess, shouldNotPopNavigationOnSuccess],
   );
   const renderItem = useCallback(
     ({ item }) => <Item item={item} onSelect={onSelect} />,


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
Add optional `shouldNotPopNavigationOnSuccess` parameter that can be passed to the account selection. In cases where this is undefined or false then the account screen will work as it has previously.
In cases where the value is true then we will not pop the navigation on the account page. At the moment this is only useful for the staking flows as most handle their own navigation and poping from the account selection page has caused issues where the user is unable to access the staking flows.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7801` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
