### PR TITLE
fix: LIVE-7878 inline [] causing manager state rerender

### DIFF
--- a/.changeset/red-falcons-train.md
+++ b/.changeset/red-falcons-train.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Prevent render loop that dismisses app state in my ledger

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/index.tsx
@@ -16,7 +16,7 @@ import { context } from "~/renderer/drawers/Provider";
 
 const action = createAction(getEnv("MOCK") ? mockedEventEmitter : connectManager);
 const Manager = () => {
-  const [appsToRestore, setRestoreApps] = useState();
+  const [appsToRestore, setRestoreApps] = useState([]);
   const { setDrawer } = useContext(context);
   const [result, setResult] = useState<Result | null>(null);
   const [hasReset, setHasReset] = useState(false);
@@ -57,7 +57,7 @@ const Manager = () => {
         <Dashboard
           {...result}
           onReset={onReset}
-          appsToRestore={appsToRestore || []}
+          appsToRestore={appsToRestore}
           onRefreshDeviceInfo={refreshDeviceInfo}
         />
       ) : !hasReset ? (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

During the typescript migration of LLD we changed the way we passed the `appsToRestore` parameter around turning `appsToRestore={appsToRestore}` to `appsToRestore={appsToRestore || []}`. A seemingly harmless change to make typescript happy but with the added consequence of making anything that depends on that variable having to be recalculated **every time there's a render.** This had the side effect of resetting the app state every time we opened or closed a drawer.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7878` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- Enter the manager
- Install some apps
- Start some flow (rename, cls, language)
- It is expected that the state is respected and not reset.