### PR TITLE
LIVE-7874 fix(llm/customlockscreen): preview from an NFT not loading

### DIFF
--- a/.changeset/four-cheetahs-lie.md
+++ b/.changeset/four-cheetahs-lie.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+---
+
+Custom lock screen: fix uncaught error in useCenteredImage
+Custom lock screen: fix NFT picture preview not loading

--- a/apps/ledger-live-mobile/src/components/CustomImage/useCenteredImage.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/useCenteredImage.tsx
@@ -5,12 +5,18 @@ import {
   ImageMetadataLoadingError,
   ImageResizeError,
 } from "@ledgerhq/live-common/customImage/errors";
-import { ImageBase64Data, ImageDimensions, ImageFileUri } from "./types";
+import { ImageBase64Data, ImageDimensions } from "./types";
 import { loadImageSizeAsync } from "./imageUtils";
 
 export type CenteredResult = ImageBase64Data & ImageDimensions;
 
-export type Params = Partial<ImageFileUri> & {
+export type Params = {
+  /**
+   * URI of the image to crop and center. Can be a file URI or a URL
+   * Careful if using a URL as the image will be downloaded everytime
+   * one of the props changes.
+   * */
+  imageUri?: string;
   targetDimensions: ImageDimensions;
   onError: (_: Error) => void;
   onResult: (_: CenteredResult) => void;
@@ -26,10 +32,10 @@ export type Params = Partial<ImageFileUri> & {
  * */
 
 function useCenteredImage(params: Params) {
-  const { imageFileUri, targetDimensions, onError, onResult } = params;
+  const { imageUri, targetDimensions, onError, onResult } = params;
   useEffect(() => {
     let dead = false;
-    if (!imageFileUri)
+    if (!imageUri)
       return () => {
         dead = true;
       };
@@ -37,7 +43,7 @@ function useCenteredImage(params: Params) {
     const load = async () => {
       let realImageDimensions;
       try {
-        realImageDimensions = await loadImageSizeAsync(imageFileUri);
+        realImageDimensions = await loadImageSizeAsync(imageUri);
       } catch (e) {
         console.error(e);
         throw new ImageMetadataLoadingError();
@@ -74,7 +80,7 @@ function useCenteredImage(params: Params) {
       };
 
       if (dead) return;
-      manipulateAsync(imageFileUri, [{ resize: resizedImageDimensions }], {
+      return manipulateAsync(imageUri, [{ resize: resizedImageDimensions }], {
         compress: 1,
         base64: false,
         format: SaveFormat.PNG,
@@ -114,7 +120,7 @@ function useCenteredImage(params: Params) {
       dead = true;
     };
   }, [
-    imageFileUri,
+    imageUri,
     targetDimensions?.height,
     targetDimensions?.width,
     onError,

--- a/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/PreviewPreEdit.tsx
@@ -163,7 +163,7 @@ const PreviewPreEdit = ({ navigation, route }: NavigationProps) => {
 
   useCenteredImage({
     targetDimensions: targetDisplayDimensions,
-    imageFileUri: loadedImage?.imageFileUri,
+    imageUri: imageUrl || loadedImage?.imageFileUri,
     onError: handleResizeError,
     onResult: handleResizeResult,
   });
@@ -341,7 +341,7 @@ const PreviewPreEdit = ({ navigation, route }: NavigationProps) => {
             <Link
               size="large"
               onPress={handleEditPicture}
-              disabled={previewLoading || isStaxEnabledImage}
+              disabled={!loadedImage || previewLoading || isStaxEnabledImage}
               event="button_clicked"
               eventProperties={analyticsEditEventProps}
             >


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixed two issues with Custom Lock Screen:
- fix uncaught error in `useCenteredImage`
- fix NFT picture preview not loading in some cases

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7874] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7874]: https://ledgerhq.atlassian.net/browse/LIVE-7874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ