### PR TITLE
fix: LLD fixes all cases where url(" was used instead of url('

### DIFF
--- a/.changeset/old-wombats-remember.md
+++ b/.changeset/old-wombats-remember.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fixes all cases where url(" was used instead of url('

--- a/apps/ledger-live-desktop/src/renderer/components/Carousel/Slide.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Carousel/Slide.tsx
@@ -15,7 +15,8 @@ const Layer = styled(animated.div)<{
   width: number;
   height: number;
 }>`
-  background-image: url("${p => p.image}");
+  // prettier-ignore
+  background-image: url('${p => p.image}');
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;

--- a/apps/ledger-live-desktop/src/renderer/components/LinkWithExternalIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LinkWithExternalIcon.tsx
@@ -21,7 +21,8 @@ const Wrapper = styled(Label).attrs<{
   }
 
   &:after {
-    -webkit-mask: url("${externalLink}");
+    // prettier-ignore
+    -webkit-mask: url('${externalLink}');
     -webkit-mask-size: cover;
     width: 12px;
     height: 12px;

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/OnboardingNavHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/OnboardingNavHeader.tsx
@@ -22,8 +22,10 @@ const Logo = styled(Box).attrs({
   height: "25px",
   width: "75px",
 })`
-  -webkit-mask-image: url("${ledgerLogo}");
-  mask-image: url("${ledgerLogo}");
+  // prettier-ignore
+  -webkit-mask-image: url('${ledgerLogo}');
+  // prettier-ignore
+  mask-image: url('${ledgerLogo}');
 `;
 
 interface Props {

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/shared.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/shared.tsx
@@ -30,7 +30,8 @@ export const IllustrationContainer: StyledComponent<
   DefaultTheme,
   BoxProps & { src: string }
 > = styled(Flex)<{ src: string }>`
-  background: url("${({ src }) => src}") no-repeat center;
+  // prettier-ignore
+  background: url('${({ src }) => src}') no-repeat center;
   background-size: contain;
 `;
 

--- a/apps/ledger-live-desktop/src/renderer/components/Stars/Star.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Stars/Star.tsx
@@ -100,7 +100,8 @@ const StarIcon = styled.div<{
 
   height: 50px;
   width: 50px;
-  background-image: url("${p => (p.yellow ? starAnim2 : starAnim)}");
+  // prettier-ignore
+  background-image: url('${p => (p.yellow ? starAnim2 : starAnim)}');
   background-repeat: no-repeat;
   background-size: 3000%;
   filter: brightness(1);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepDisconnect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepDisconnect.tsx
@@ -12,7 +12,8 @@ const Illustration = styled.div`
   margin-bottom: 24px;
   width: 236px;
   height: 64px;
-  background: url("${fullnodeIllustration}");
+  // prettier-ignore
+  background: url('${fullnodeIllustration}');
   background-size: contain;
   align-self: center;
 `;

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepLanding.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepLanding.tsx
@@ -13,7 +13,8 @@ const Illustration = styled.div`
   margin-bottom: 24px;
   width: 193px;
   height: 130px;
-  background: url("${fullnodeIllustration}");
+  // prettier-ignore
+  background: url('${fullnodeIllustration}');
   background-size: contain;
   align-self: center;
 `;

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/Intro.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/Intro.tsx
@@ -6,7 +6,8 @@ import Button from "~/renderer/components/Button";
 import styled from "styled-components";
 import illustration from "~/renderer/images/USBTroubleshooting/device.png";
 export const Illustration = styled.div<{ image: string }>`
-  background-image: url("${p => p.image}");
+  // prettier-ignore
+  background-image: url('${p => p.image}');
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/shared.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/solutions/shared.tsx
@@ -49,7 +49,8 @@ export const Content = styled(Box).attrs({
   width: 100%;
 `;
 export const Illustration = styled.div<{ image: string; height?: string | number }>`
-  background-image: url("${p => p.image}");
+  // prettier-ignore
+  background-image: url('${p => p.image}');
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/Disconnected.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/Disconnected.tsx
@@ -55,10 +55,11 @@ const illustrations = {
 const Illustration = styled.div<{
   modelId: string;
 }>`
-  background: url("${p =>
-      illustrations[p.modelId as keyof typeof illustrations][
-        p.theme.colors.palette.type || "light"
-      ]}")
+  // prettier-ignore
+  background: url('${p =>
+    illustrations[p.modelId as keyof typeof illustrations][
+      p.theme.colors.palette.type || "light"
+    ]}')
     no-repeat top right;
   width: ${p => illustrations[p.modelId as keyof typeof illustrations].width}px;
   height: 50px;


### PR DESCRIPTION

### 📝 Description

on LLD, fixes all cases where `url("` was used instead of `url('`. unfortunately, prettier seems to want to use `url("` but styled-component only support `url('` syntax for the image to appear.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7877` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
