### PR TITLE
fix: LIVE-7910 remove double retry button on locked device lang install

### DIFF
--- a/.changeset/late-meals-greet.md
+++ b/.changeset/late-meals-greet.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix double retry button on locked device for lang install from my ledger

--- a/apps/ledger-live-desktop/src/renderer/components/ChangeDeviceLanguageAction.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ChangeDeviceLanguageAction.tsx
@@ -46,6 +46,7 @@ const ChangeDeviceLanguageAction: React.FC<Props> = ({ language, onError, onSucc
     <DeviceAction
       action={action}
       request={request}
+      inlineRetry={false}
       onResult={onSuccess}
       Result={() => <DeviceLanguageInstalled language={language} />}
       onError={onError}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There are two retry buttons in the locked device error screen for the language pack installation on my ledger.
We introduced the concept of `inlineRetry` for device actions that handled the retry mechanism in a footer such as this one, it's just a matter of using that prop.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7904` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![image](https://github.com/LedgerHQ/ledger-live/assets/4631227/ef7f4914-e141-4f27-b53a-f2f04dc3284a)

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Trying to change the language on a locked device should throw an error but only offer one retry button, like civilised people.