### PR TITLE
feat(Firmware Update LLM): add possibility to retry firmware update when an error happens

### DIFF
--- a/.changeset/eleven-kids-dance.md
+++ b/.changeset/eleven-kids-dance.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Small fix on the state handling of the firmware update device action

--- a/.changeset/three-coats-teach.md
+++ b/.changeset/three-coats-teach.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add retry possibility when an error happens during the firmware update

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4159,6 +4159,10 @@
       "TimeoutError": {
         "title": "Update timeout",
         "description": "The update was unable to complete because we lost connection to {{deviceName}}"
+      },
+      "CantOpenDevice": {
+        "title": "Sorry, connection failed",
+        "description": "The update was unable to complete because we lost connection to {{deviceName}}."
       }
     }
   },

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -48,6 +48,7 @@ import { targetDataDimensions } from "../CustomImage/shared";
 import { ProcessorPreviewResult } from "../../components/CustomImage/ImageProcessor";
 import { ImageSourceContext } from "../../components/CustomImage/StaxFramedImage";
 import Button from "../../components/wrappedUi/Button";
+import Link from "../../components/wrappedUi/Link";
 import { RestoreStepDenied } from "./RestoreStepDenied";
 
 type FirmwareUpdateProps = {
@@ -469,18 +470,32 @@ export const FirmwareUpdate = ({
           <Button
             event="button_clicked"
             eventProperties={{
-              button: "Quit flow",
+              button: "Retry flow",
               screen: "Firmware update",
               drawer: `Error: ${error.name}`,
             }}
             type="main"
             outline={false}
-            onPress={quitUpdate}
+            onPress={retryCurrentStep}
             mt={6}
             alignSelf="stretch"
           >
-            {t("FirmwareUpdate.quitUpdate")}
+            {t("common.retry")}
           </Button>
+          <Flex mt={6} alignSelf="stretch">
+            <Link
+              event="button_clicked"
+              eventProperties={{
+                button: "Quit flow",
+                screen: "Firmware update",
+                drawer: `Error: ${error.name}`,
+              }}
+              type="main"
+              onPress={quitUpdate}
+            >
+              {t("FirmwareUpdate.quitUpdate")}
+            </Link>
+          </Flex>
         </DeviceActionError>
       );
     }

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -482,7 +482,7 @@ export const FirmwareUpdate = ({
           >
             {t("common.retry")}
           </Button>
-          <Flex mt={6} alignSelf="stretch">
+          <Flex mt={7} alignSelf="stretch">
             <Link
               event="button_clicked"
               eventProperties={{

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -218,7 +218,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
         }
         break;
       case "firmwareUpdate":
-        if (updateActionState.step === "preparingUpdate") {
+        if (updateActionState.step === "preparingUpdate" && !updateActionState.lockedDevice) {
           triggerUpdate();
         } else if (updateActionState.step === "firmwareUpdateCompleted") {
           proceedToLanguageRestore();
@@ -284,6 +284,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     staxLoadImageState.imageLoaded,
     triggerUpdate,
     updateActionState.step,
+    updateActionState.lockedDevice,
     updateStep,
     restoreAppsState.error,
     restoreAppsState.opened,

--- a/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/updateFirmware.ts
@@ -73,11 +73,11 @@ export function updateFirmwareAction({
       scan<
         UpdateFirmwareTaskEvent | GetLatestFirmwareTaskErrorEvent | GetDeviceInfoTaskErrorEvent,
         UpdateFirmwareActionState
-      >((_, event) => {
+      >((currentState, event) => {
         switch (event.type) {
           case "taskError":
             return {
-              ...initialState,
+              ...currentState,
               error: {
                 type: "UpdateFirmwareError",
                 name: event.error,
@@ -104,7 +104,7 @@ export function updateFirmwareAction({
             };
           default:
             return {
-              ...initialState,
+              ...currentState,
               ...sharedReducer({
                 event,
               }),

--- a/libs/ledger-live-common/src/deviceSDK/hooks/useUpdateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/hooks/useUpdateFirmware.ts
@@ -52,7 +52,10 @@ export const useUpdateFirmware = ({
     }
   }, [deviceId, updateFirmwareAction, nonce]);
 
-  const triggerUpdate = useCallback(() => setNonce(nonce => nonce + 1), []);
+  const triggerUpdate = useCallback(() => {
+    setUpdateState(initialState);
+    setNonce(nonce => nonce + 1);
+  }, []);
 
   return { updateState, triggerUpdate };
 };


### PR DESCRIPTION
### 📝 Description
Before this PR we would only allow the user to quit the firmware update in case an error happened during the actual firmware update phase (not back up or restore phase). This PR adds a button to the error drawer allowing the user to retry the firmware update step.
_It also fixes an issue with the firmware update device action that would reset the state in case an error happened_
### ❓ Context

- **Impacted projects**: `ledger-live-mobile`, `ledger-live-common`
- **Linked resource(s)**: [LIVE-7417]

### ✅ Checklist

- [N/A] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://github.com/LedgerHQ/ledger-live/assets/6013294/b86268d2-25fe-4b4f-be20-a4054d8e14b5




[LIVE-7417]: https://ledgerhq.atlassian.net/browse/LIVE-7417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ