### PR TITLE
fix: unable to close root drawer without navigation

### DIFF
--- a/apps/ledger-live-mobile/src/components/RootDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/RootDrawer.tsx
@@ -3,20 +3,28 @@ import React from "react";
 import { StakingDrawerNavigationProps } from "./Stake/types";
 import { EthereumStakingDrawer } from "../families/ethereum/EthereumStakingDrawer";
 
+import { RootDrawerProvider, useRootDrawerContext } from "../context/RootDrawerContext";
+
 export type RootDrawerProps = StakingDrawerNavigationProps;
 
 type Props = {
   drawer?: RootDrawerProps;
 };
 
-export function RootDrawer({ drawer }: Props) {
-  if (!drawer) {
-    return null;
-  }
+export function RootDrawerSelector() {
+  const { drawer } = useRootDrawerContext();
   switch (drawer.id) {
     case "EthStakingDrawer":
-      return <EthereumStakingDrawer drawer={drawer} />;
+      return <EthereumStakingDrawer />;
     default:
       return null;
   }
+}
+
+export function RootDrawer({ drawer }: Props) {
+  return (
+    <RootDrawerProvider drawer={drawer}>
+      <RootDrawerSelector />
+    </RootDrawerProvider>
+  );
 }

--- a/apps/ledger-live-mobile/src/context/RootDrawerContext.tsx
+++ b/apps/ledger-live-mobile/src/context/RootDrawerContext.tsx
@@ -1,0 +1,81 @@
+import EventEmitter from "events";
+import React, { PropsWithChildren, createContext, useCallback, useContext, useState } from "react";
+import { RootDrawerProps } from "../components/RootDrawer";
+import { ParamListBase, useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { NavigatorName } from "../const";
+
+const rootDrawerEmitter = new EventEmitter();
+
+type Props = {
+  drawer?: RootDrawerProps;
+};
+
+type RootDrawerContext = {
+  drawer: RootDrawerProps;
+  isOpen: boolean;
+  onModalHide(): void;
+  onClose(cb?: () => void): void;
+  openDrawer(): void;
+};
+
+export const RootDrawerContext = createContext<RootDrawerContext>({
+  drawer: {} as RootDrawerProps,
+  isOpen: false,
+  onModalHide: () => undefined,
+  onClose: cb => {
+    if (cb) cb();
+  },
+  openDrawer: () => undefined,
+});
+
+export function useRootDrawerContext() {
+  const ctx = useContext(RootDrawerContext);
+  return ctx;
+}
+
+export function RootDrawerProvider({ drawer, children }: PropsWithChildren<Props>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const navigation = useNavigation<StackNavigationProp<ParamListBase, string, NavigatorName>>();
+
+  const onModalHide = () => {
+    const parent = navigation.getParent(NavigatorName.RootNavigator);
+    if (parent) {
+      parent.setParams({ drawer: undefined });
+    }
+
+    /*
+     * The timeout is there to allow the params to be set to undefined
+     * before emitting the event which will then trigger the close callback.
+     * Without this the callback will be called before the setParams effect takes
+     * hold and the user will be unable to go to whatever navigation is called in
+     * the onClose callback.
+     * If Params are not set to undefined then we will run into an issue on the
+     * account stake button where the user could only trigger it once.
+     */
+    setTimeout(() => {
+      rootDrawerEmitter.emit("ll-root-drawer-on-modal-hide");
+    }, 0);
+  };
+
+  const onClose = useCallback(
+    (callback?: () => void) => {
+      setIsOpen(false);
+
+      if (callback) {
+        rootDrawerEmitter.once("ll-root-drawer-on-modal-hide", callback);
+      }
+    },
+    [setIsOpen],
+  );
+
+  const openDrawer = useCallback(() => setIsOpen(true), [setIsOpen]);
+
+  if (!drawer) return null;
+
+  return (
+    <RootDrawerContext.Provider value={{ isOpen, onClose, openDrawer, onModalHide, drawer }}>
+      {children}
+    </RootDrawerContext.Provider>
+  );
+}

--- a/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerBody.tsx
@@ -2,28 +2,31 @@ import { Flex, Text } from "@ledgerhq/native-ui";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Linking } from "react-native";
-import { useNavigation } from "@react-navigation/native";
+import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { appendQueryParamsToDappURL } from "@ledgerhq/live-common/platform/utils/appendQueryParamsToDappURL";
 
 import { ListProvider } from "./types";
 import { EthereumStakingDrawerProvider } from "./EthereumStakingDrawerProvider";
 import { useAnalytics } from "../../../analytics";
-import { ScreenName } from "../../../const";
+import { NavigatorName, ScreenName } from "../../../const";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 type Props = {
   providers: ListProvider[];
   singleProviderRedirectMode: boolean;
   accountId: string;
+  onClose(callback: () => void): void;
 };
 
 export function EthereumStakingDrawerBody({
   providers,
   singleProviderRedirectMode,
   accountId,
+  onClose,
 }: Props) {
   const { t } = useTranslation();
-  const { navigate } = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<ParamListBase, string, NavigatorName>>();
 
   const { track, page } = useAnalytics();
 
@@ -37,15 +40,17 @@ export function EthereumStakingDrawerBody({
           button: provider.id,
           page,
         });
-        navigate(ScreenName.PlatformApp, {
-          platform: manifest.id,
-          name: manifest.name,
-          accountId,
-          ...(customDappURL ? { customDappURL } : {}),
+        onClose(() => {
+          navigation.navigate(ScreenName.PlatformApp, {
+            platform: manifest.id,
+            name: manifest.name,
+            accountId,
+            ...(customDappURL ? { customDappURL } : {}),
+          });
         });
       }
     },
-    [track, page, navigate, accountId],
+    [track, page, navigation, accountId, onClose],
   );
 
   const onSupportLinkPress = useCallback(

--- a/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerProvider.tsx
+++ b/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/EthereumStakingDrawerProvider.tsx
@@ -69,16 +69,16 @@ export function EthereumStakingDrawerProvider({
             <Text variant="paragraph" lineHeight="20px" color="neutral.c70">
               {t(`stake.ethereum.providers.${provider.id}.description`)}
             </Text>
-            <Link
-              size="medium"
-              type="color"
-              iconPosition="right"
-              onPress={supportLinkPress}
-              Icon={Icons.ExternalLinkMedium}
-            >
-              {t(`stake.ethereum.providers.${provider.id}.supportLink`)}
-            </Link>
           </Flex>
+          <Link
+            size="medium"
+            type="color"
+            iconPosition="right"
+            onPress={supportLinkPress}
+            Icon={Icons.ExternalLinkMedium}
+          >
+            {t(`stake.ethereum.providers.${provider.id}.supportLink`)}
+          </Link>
         </Flex>
         <Flex alignSelf="center">
           <Icon name="ChevronRight" size={32} color="neutral.c100" />

--- a/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/ethereum/EthereumStakingDrawer/index.tsx
@@ -1,61 +1,41 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { Button, Flex } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 
-import QueuedDrawer from "../../../components/QueuedDrawer";
 import { EthStakingProviders } from "./types";
 import { EthereumStakingDrawerBody } from "./EthereumStakingDrawerBody";
 import { Track } from "../../../analytics";
-import { StakingDrawerNavigationProps } from "../../../components/Stake/types";
-import { ParamListBase, useNavigation } from "@react-navigation/native";
-import { StackNavigationProp } from "@react-navigation/stack";
-import { NavigatorName } from "../../../const";
+import QueuedDrawer from "../../../components/QueuedDrawer";
+import { useRootDrawerContext } from "../../../context/RootDrawerContext";
 
-type Props = {
-  drawer?: StakingDrawerNavigationProps;
-};
-
-export function EthereumStakingDrawer({ drawer }: Props) {
+export function EthereumStakingDrawer() {
   const { t } = useTranslation();
-  const [isOpen, setIsOpen] = useState(false);
-  const navigation = useNavigation<StackNavigationProp<ParamListBase, string, NavigatorName>>();
+  const { isOpen, onModalHide, openDrawer, onClose, drawer } = useRootDrawerContext();
   const ethStakingProviders = useFeature<EthStakingProviders>("ethStakingProviders");
 
-  const onModalHide = useCallback(() => {
-    // once the modal is hidden remove from params
-    const parent = navigation.getParent(NavigatorName.RootNavigator);
-    if (parent) {
-      parent.setParams({ drawer: undefined });
-    }
-  }, [navigation]);
-
-  const onClose = useCallback(() => {
-    setIsOpen(false);
-  }, [setIsOpen]);
-
   useEffect(() => {
-    setIsOpen(drawer?.id === "EthStakingDrawer");
-  }, [drawer]);
+    if (
+      ethStakingProviders?.enabled ||
+      (ethStakingProviders?.params?.listProvider ?? []).length > 0
+    ) {
+      openDrawer();
+    }
+  }, [ethStakingProviders, openDrawer]);
 
-  if (
-    !drawer ||
-    !ethStakingProviders?.enabled ||
-    (ethStakingProviders.params?.listProvider ?? []).length < 1
-  ) {
-    return null;
-  }
+  if (!ethStakingProviders) return null;
 
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose} onModalHide={onModalHide}>
       <Flex rowGap={52}>
         <Track onMount event="ETH Stake Modal" />
         <EthereumStakingDrawerBody
+          onClose={onClose}
           singleProviderRedirectMode={drawer.props.singleProviderRedirectMode ?? true}
           accountId={drawer.props.accountId}
           providers={ethStakingProviders.params!.listProvider}
         />
-        <Button onPress={onClose} type="main">
+        <Button onPress={() => onClose()} type="main">
           {t("stake.ethereum.close")}
         </Button>
       </Flex>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description


Unable to close root drawer without navigation.

* Created `RootDrawerProvider` to handle the logic of showing or hiding the drawer.
* In the onClose function create a one time listener that when triggered will call the onClose callback.
* Emit an event when the onModalHide component finishes. This is to allow the animation to complete fully.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach


_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
