### PR TITLE
[support] Restore ability to run LLM unit tests

### DIFF
--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -18,10 +18,7 @@ module.exports = {
   ...tsjPreset,
   verbose: true,
   preset: "react-native",
-  setupFilesAfterEnv: [
-    "@testing-library/jest-native/extend-expect",
-    "./jest-setup.js",
-  ],
+  setupFilesAfterEnv: ["@testing-library/jest-native/extend-expect", "./jest-setup.js"],
   testMatch: ["**/src/**/*.test.(ts|tsx)"],
   transform: {
     "^.+\\.js?$": "babel-jest",
@@ -35,14 +32,11 @@ module.exports = {
   coverageReporters: ["json"],
   coverageDirectory: "<rootDir>/coverage",
   moduleNameMapper: {
-    "^@ledgerhq/coin-framework(.*)$":
-      "<rootDir>/../../libs/coin-framework/lib$1.js",
-    "^@ledgerhq/icons-ui/native(.*)$":
-      "<rootDir>/../../libs/ui/packages/icons/native/$1",
+    "^@ledgerhq/coin-framework(.*)$": "<rootDir>/../../libs/coin-framework/lib$1.js",
+    "^@ledgerhq/icons-ui/native(.*)$": "<rootDir>/../../libs/ui/packages/icons/native/$1",
     "^@ledgerhq/crypto-icons-ui/native(.*)$":
       "<rootDir>/../../libs/ui/packages/crypto-icons/native/$1",
-    "^@ledgerhq/native-ui(.*)$":
-      "<rootDir>/../../libs/ui/packages/native/lib/$1",
+    "^@ledgerhq/native-ui(.*)$": "<rootDir>/../../libs/ui/packages/native/lib/$1",
     "^react-native/(.*)$": "<rootDir>/node_modules/react-native/$1",
     "^react-native$": "<rootDir>/node_modules/react-native",
     "^victory-native$": "victory",

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -10,6 +10,7 @@ const transformIncludePatterns = [
   "react-native-animatable",
   "@sentry/react-native",
   "react-native-startup-time",
+  "uuid",
 ];
 
 /** @type {import('ts-jest').JestConfigWithTsJest} */
@@ -24,8 +25,7 @@ module.exports = {
   testMatch: ["**/src/**/*.test.(ts|tsx)"],
   transform: {
     "^.+\\.js?$": "babel-jest",
-    "^.+\\.tsx?$": ["ts-jest", { babelConfig: true,}]
-    },
+    "^.+\\.tsx?$": ["ts-jest", { babelConfig: true }],
   },
   transformIgnorePatterns: [
     `node_modules/(?!(.pnpm|${transformIncludePatterns.join("|")})/)`,

--- a/apps/ledger-live-mobile/src/StyleProvider.tsx
+++ b/apps/ledger-live-mobile/src/StyleProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { ThemeProvider } from "styled-components/native";
 import theme from "@ledgerhq/native-ui/styles/theme";
-import { palettes } from "@ledgerhq/native-ui/lib/styles";
+import { palettes } from "@ledgerhq/native-ui/styles";
 import { lightTheme as light, darkTheme as dark } from "./colors";
 
 const themes = { light, dark };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Unit tests on LLM currently couldn't run because the `jest.config.js` file has a syntax issue.
Also needed to add `uuid` package to the `transformIncludePatterns`.

### ❓ Context

- **Impacted projects**: LLM <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-7900 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

Tests are able to run again, but 1 remaining error to fix:
```
 FAIL  src/components/LText/LText.test.tsx
  ● Test suite failed to run

    Configuration error:
    
    Could not locate module @ledgerhq/native-ui/lib/styles mapped as:
    /home/haammar/WORK/ledger-live/develop_clean/libs/ui/packages/native/lib/$1.
    
    Please check your configuration for these entries:
    {
      "moduleNameMapper": {
        "/^@ledgerhq\/native-ui(.*)$/": "/home/haammar/WORK/ledger-live/develop_clean/libs/ui/packages/native/lib/$1"
      },
      "resolver": undefined
    }

      2 | import { ThemeProvider } from "styled-components/native";
      3 | import theme from "@ledgerhq/native-ui/styles/theme";
    > 4 | import { palettes } from "@ledgerhq/native-ui/lib/styles";
        | ^
      5 | import { lightTheme as light, darkTheme as dark } from "./colors";
      6 |
      7 | const themes = { light, dark };

      at createNoMappedModuleFoundError (../../node_modules/.pnpm/jest-resolve@29.5.0_metro@0.76.0/node_modules/jest-resolve/build/resolver.js:759:17)
      at Object.require (src/StyleProvider.tsx:4:1)
      at Object.require (src/__test__/test-renderer.tsx:10:1)
      at Object.require (src/components/LText/LText.test.tsx:5:1)
```
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

- Non-reg: Live still builds. 100% covered by CI.
- `pnpm mobile test:jest` able to run (but returns errors to fix)
