### PR TITLE
chore: explicit dep to tslib for vercel to compile live-common-tools

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5019,6 +5019,9 @@ importers:
       styled-components:
         specifier: ^4.4.0
         version: 4.4.1(react-dom@17.0.2)(react@17.0.2)
+      tslib:
+        specifier: ^2.5.0
+        version: 2.5.0
       webpack:
         specifier: '4.42'
         version: 4.42.1

--- a/tools/common-tools/package.json
+++ b/tools/common-tools/package.json
@@ -39,6 +39,7 @@
     "rxjs": "*",
     "semver": "^7.3.7",
     "styled-components": "^4.4.0",
+    "tslib": "^2.5.0",
     "webpack": "4.42"
   },
   "scripts": {


### PR DESCRIPTION


### 📝 Description

apparently, vercel started to have this issue

```
live-common-tools:build: Cannot find module: 'tslib'. Make sure this package is installed.
```

so we try to add an explicit dependency to it on the live-common-tools project.

### ❓ Context

- **Impacted projects**: `live-common-tools` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
