### PR TITLE
chore: upgrade to Electron 25

### DIFF
--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -190,7 +190,7 @@
     "chalk": "^4.1.2",
     "cross-env": "^7.0.3",
     "debug": "^4.3.4",
-    "electron": "^23.1.3",
+    "electron": "^25.1.1",
     "electron-builder": "^23.6.0",
     "electron-devtools-installer": "^3.2.0",
     "esbuild-utils": "workspace:*",

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -133,7 +133,7 @@ app.on("ready", async () => {
   // cf. https://gist.github.com/codebytere/409738fcb7b774387b5287db2ead2ccb
   ipcMain.on("webview-dom-ready", (_, id) => {
     const wc = webContents.fromId(id);
-    wc.setWindowOpenHandler(({ url }) => {
+    wc?.setWindowOpenHandler(({ url }) => {
       const protocol = new URL(url).protocol;
       if (["https:", "http:"].includes(protocol)) {
         shell.openExternal(url);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,7 +219,7 @@ importers:
         version: 4.6.3
       '@electron/remote':
         specifier: ^2
-        version: 2.0.8(electron@23.1.3)
+        version: 2.0.8(electron@25.1.1)
       '@ledgerhq/coin-framework':
         specifier: workspace:^
         version: link:../../libs/coin-framework
@@ -648,8 +648,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4
       electron:
-        specifier: ^23.1.3
-        version: 23.1.3
+        specifier: ^25.1.1
+        version: 25.1.1
       electron-builder:
         specifier: ^23.6.0
         version: 23.6.0(lodash@4.17.21)
@@ -10589,12 +10589,12 @@ packages:
       - supports-color
     dev: true
 
-  /@electron/remote@2.0.8(electron@23.1.3):
+  /@electron/remote@2.0.8(electron@25.1.1):
     resolution: {integrity: sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==}
     peerDependencies:
       electron: '>= 13.0.0'
     dependencies:
-      electron: 23.1.3
+      electron: 25.1.1
     dev: false
 
   /@electron/universal@1.2.1:
@@ -21354,6 +21354,7 @@ packages:
 
   /@types/node@16.18.16:
     resolution: {integrity: sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA==}
+    dev: true
 
   /@types/node@17.0.32:
     resolution: {integrity: sha512-eAIcfAvhf/BkHcf4pkLJ7ECpBAhh9kcxRBpip9cTiO+hf+aJrsxYxBeS6OXvOd9WqNAJmavXVpZvY1rBjNsXmw==}
@@ -29440,14 +29441,14 @@ packages:
   /electron-to-chromium@1.4.355:
     resolution: {integrity: sha512-056hxzEE4l667YeOccgjhRr5fTiwZ6EIJ4FpzGps4k3YcS8iAhiaBYUBrv5E2LDQJsussscv9EEUwAYKnv+ZKg==}
 
-  /electron@23.1.3:
-    resolution: {integrity: sha512-MNjuUS2K6/OxlJ0zTC77djo1R3xM038v1kUunvNFgDMZHYKpSOzOMNsPiwM2BGp+uZbkUb0nTnYafxXrM8H16w==}
+  /electron@25.1.1:
+    resolution: {integrity: sha512-WvFUfVsJn6YiP35UxdibYVjU2LceastyMm4SVp2bmb4XvKEvItAIiwxgm7tPC5Syl1243aRCvQLqr84sZ71pyQ==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
     requiresBuild: true
     dependencies:
       '@electron/get': 2.0.2
-      '@types/node': 16.18.16
+      '@types/node': 18.15.11
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

everything appears to be smooth on upgrading from Electron 23 to Electron 25. this means we upgrade chromium from 110 to 114 with all the benefits these have. check https://www.electronjs.org/blog for more informations, there are no documented breaking changes that concerns us. if this PR pass the CI tests we will have a first level of confidence.

quick smoke test: I was able to run the app in dev mode on mac and make the USB works.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7943` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
