### PR TITLE
fix: update to latest eip55

### DIFF
--- a/.changeset/few-dogs-march.md
+++ b/.changeset/few-dogs-march.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/domain-service": patch
+"@ledgerhq/coin-evm": patch
+---
+
+Update eip55 dependency

--- a/libs/coin-evm/package.json
+++ b/libs/coin-evm/package.json
@@ -59,7 +59,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "axios": "0.26.1",
     "bignumber.js": "^9.1.0",
-    "eip55": "^2.1.0",
+    "eip55": "^2.1.1",
     "ethers": "^5.6.9",
     "expect": "^27.4.6",
     "invariant": "^2.2.2",

--- a/libs/domain-service/package.json
+++ b/libs/domain-service/package.json
@@ -68,7 +68,7 @@
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "axios": "^1.3.4",
-    "eip55": "^2.1.0",
+    "eip55": "^2.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -196,7 +196,7 @@
     "create-hmac": "^1.1.7",
     "crypto-js": "^4.1.1",
     "date-fns": "^2.23.0",
-    "eip55": "^2.1.0",
+    "eip55": "^2.1.1",
     "eth-sig-util": "3.0.1",
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^7.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1582,8 +1582,8 @@ importers:
         specifier: ^9.1.0
         version: 9.1.0
       eip55:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.1
+        version: 2.1.1
       ethers:
         specifier: ^5.6.9
         version: 5.7.0
@@ -1786,8 +1786,8 @@ importers:
         specifier: ^1.3.4
         version: 1.3.4
       eip55:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -2130,8 +2130,8 @@ importers:
         specifier: ^2.23.0
         version: 2.28.0
       eip55:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.1.1
+        version: 2.1.1
       eth-sig-util:
         specifier: 3.0.1
         version: 3.0.1
@@ -29560,10 +29560,10 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /eip55@2.1.0:
-    resolution: {integrity: sha512-jtOfFne69XvSYz58oBXqfKHk1cJwwHcAzKm9jbzOKsedKEaulMPCA4fq2UXS9NaxkdVOdbSG0kg7fM09+K4gjw==}
+  /eip55@2.1.1:
+    resolution: {integrity: sha512-WcagVAmNu2Ww2cDUfzuWVntYwFxbvZ5MvIyLZpMjTTkjD6sCvkGOiS86jTppzu9/gWsc8isLHAeMBWK02OnZmA==}
     dependencies:
-      keccak: 1.4.0
+      keccak: 3.0.3
     dev: false
 
   /ejs@3.1.7:
@@ -31589,7 +31589,7 @@ packages:
       create-hash: 1.2.0
       create-hmac: 1.1.7
       hash.js: 1.1.7
-      keccak: 3.0.2
+      keccak: 3.0.3
       pbkdf2: 3.1.2
       randombytes: 2.1.0
       safe-buffer: 5.2.1
@@ -39740,19 +39740,18 @@ packages:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
     dev: false
 
-  /keccak@1.4.0:
-    resolution: {integrity: sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==}
-    engines: {node: '>=4.0.0'}
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      inherits: 2.0.4
-      nan: 2.15.0
-      safe-buffer: 5.2.1
-    dev: false
-
   /keccak@3.0.2:
     resolution: {integrity: sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==}
+    engines: {node: '>=10.0.0'}
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 2.0.2
+      node-gyp-build: 4.6.0
+      readable-stream: 3.6.2
+    dev: false
+
+  /keccak@3.0.3:
+    resolution: {integrity: sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==}
     engines: {node: '>=10.0.0'}
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
### 📝 Description

At the moment ledger apps depend on eip55 v2.1.0. This results in build errors in browser contexts, such as electron. 
(https://github.com/iotaledger/firefly/actions/runs/5284776862/jobs/9562554148)

The root cause of this error is that eip55 relies on an old version of the keccak package. This has been fixed in v2.1.1.

This PR aims to update the eip55 dependency.

### ❓ Context

- **Impacted projects**: `` live-common, domain-service, coin-evm
- **Linked resource(s)**: ``https://github.com/cryptocoinjs/eip55/pull/8
### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
