### PR TITLE
fix: llm - loading between webviews & flickering header text

### DIFF
--- a/.changeset/grumpy-cameras-bake.md
+++ b/.changeset/grumpy-cameras-bake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix flickering in header by removing buggy onLoadProgress hook

--- a/.changeset/stupid-sloths-explain.md
+++ b/.changeset/stupid-sloths-explain.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add loading spinner when navigating between web pages in WebPTXPLayer

--- a/apps/ledger-live-mobile/src/components/Loading.tsx
+++ b/apps/ledger-live-mobile/src/components/Loading.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import { Box, InfiniteLoader } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
+
+type Props = {
+  size?: number;
+  color?: string;
+};
+
+export const Loading = ({ size = 40, color }: Props) => (
+  <Flex
+    flex={1}
+    position="absolute"
+    top="0"
+    right="0"
+    bottom="0"
+    left="0"
+    backgroundColor="background.main"
+  >
+    <Box flex={1} justifyContent="center">
+      <InfiniteLoader size={size} color={color} />
+    </Box>
+  </Flex>
+);

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -113,19 +113,6 @@ export function useWebviewState(
     });
   }, []);
 
-  const onLoadProgress: Required<WebViewProps>["onLoadProgress"] = useCallback(
-    ({ nativeEvent }) => {
-      setState({
-        title: nativeEvent.title,
-        url: nativeEvent.url,
-        canGoBack: nativeEvent.canGoBack,
-        canGoForward: nativeEvent.canGoForward,
-        loading: nativeEvent.loading,
-      });
-    },
-    [],
-  );
-
   const onNavigationStateChange: Required<WebViewProps>["onNavigationStateChange"] = useCallback(
     event => {
       setState({
@@ -144,11 +131,10 @@ export function useWebviewState(
       onLoad,
       onLoadStart,
       onLoadEnd,
-      onLoadProgress,
       onNavigationStateChange,
       source,
     }),
-    [onLoad, onLoadEnd, onLoadProgress, onLoadStart, onNavigationStateChange, source],
+    [onLoad, onLoadEnd, onLoadStart, onNavigationStateChange, source],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -24,6 +24,7 @@ import { initialWebviewState } from "../Web3AppWebview/helpers";
 import { track } from "../../analytics";
 import { NavigationHeaderCloseButtonAdvanced } from "../NavigationHeaderCloseButton";
 import { NavigatorName } from "../../const";
+import { Loading } from "../Loading";
 
 type BackToWhitelistedDomainProps = {
   manifest: AppManifest;
@@ -185,6 +186,7 @@ export const WebPTXPlayer = ({ manifest, inputs }: Props) => {
         inputs={inputs}
         onStateChange={setWebviewState}
       />
+      {webviewState.loading ? <Loading /> : null}
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

PR to:

1. Fix flickering in the header by removing the buggy onLoadProgress hook. `isWhitelistedDomain` was being updated by multiple WebView state hooks, including `onLoadProgress` which has the previous `nativeEvent.url` rather than current ... meaning header text flickered due to `isWhitelistedDomain` transitioning from `false` to `true` to `false`.

2. Add a loading spinner when navigating between WebViews in WebPTXPLayer

### ❓ Context

- **Impacted projects**: Closes https://ledgerhq.atlassian.net/browse/LIVE-7930 & https://ledgerhq.atlassian.net/browse/LIVE-7927
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
