### PR TITLE
feat: LIVE-7960 Support for dynamic hash + keep order on listapps v2

### DIFF
--- a/.changeset/hungry-phones-judge.md
+++ b/.changeset/hungry-phones-judge.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add support for "Fido U2F", "Security Key" on v2 listApps as well as maintaining the order of installation in the storage bar

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -138,6 +138,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
           return;
         }
 
+        // If the hash is not static (ex: Fido app) we need to find the app by its name using the catalog
         const matchFromCatalog = catalogForDevice.find(({ name }) => name === localName);
         log("list-apps", `falling back to catalog for ${localName}`);
         if (matchFromCatalog) {

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -2,7 +2,7 @@ import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId, getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { Observable, throwError, Subscription } from "rxjs";
-import { DeviceInfo } from "@ledgerhq/types-live";
+import { App, DeviceInfo } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
 import type { ListAppsEvent, ListAppsResult, ListAppResponse } from "../types";
 import manager, { getProviderId } from "../../manager";
@@ -45,18 +45,18 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
       const deviceModel = getDeviceModel(deviceModelId);
       const bytesPerBlock = deviceModel.getBlockSize(deviceInfo.version);
 
-      let installedAppHashesPromise: Promise<ListAppResponse>;
+      let listAppsResponsePromise: Promise<ListAppResponse>;
 
       if (deviceInfo.managerAllowed) {
         // If the user has already allowed a secure channel during this session we can directly
         // ask the device for the installed applications instead of going through a scriptrunner,
         // this is a performance optimization, part of a larger rework with Manager API v2.
-        log("hw", "using direct apdu listapps");
-        installedAppHashesPromise = hwListApps(transport);
+        log("list-apps", "using direct apdu listapps");
+        listAppsResponsePromise = hwListApps(transport);
       } else {
         // Fallback to original web-socket list apps
-        log("hw", "using scriptrunner listapps");
-        installedAppHashesPromise = new Promise<ListAppResponse>((resolve, reject) => {
+        log("list-apps", "using scriptrunner listapps");
+        listAppsResponsePromise = new Promise<ListAppResponse>((resolve, reject) => {
           sub = ManagerAPI.listInstalledApps(transport, {
             targetId: deviceInfo.targetId,
             perso: "perso_11",
@@ -104,24 +104,46 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
         listCryptoCurrencies(isDevMode, true),
       );
 
-      const installedAppsPromise = installedAppHashesPromise.then(hashes => {
+      const filteredListAppsPromise = listAppsResponsePromise.then(result => {
         // Empty HashData can come from apps that are not real apps (such as langauge packs)
         // or custom applications that have been sideloaded.
-        const filteredHashes = hashes
+        return result
           .filter(({ hash_code_data }) => hash_code_data !== emptyHashData)
-          .map(({ hash }) => hash);
-
-        return filteredHashes.length ? ManagerAPI.getAppsByHash(filteredHashes) : [];
+          .map(({ hash, name }) => ({ hash, name }));
       });
 
-      const [installedList, catalogForDevice, firmware, sortedCryptoCurrencies] = await Promise.all(
-        [
-          installedAppsPromise,
+      const listAppsAndMatchesPromise = filteredListAppsPromise.then(result => {
+        const hashes = result.map(({ hash }) => hash);
+        const matches = result.length ? ManagerAPI.getAppsByHash(hashes) : [];
+        return Promise.all([result, matches]);
+      });
+
+      const [[listApps, matches], catalogForDevice, firmware, sortedCryptoCurrencies] =
+        await Promise.all([
+          listAppsAndMatchesPromise,
           catalogForDevicesPromise,
           latestFirmwarePromise,
           sortedCryptoCurrenciesPromise,
-        ],
-      );
+        ]);
+
+      const installedList: App[] = [];
+
+      // Nb We can't reliably get the ordered result from the backend because of apps with
+      // inconsistent hashes. An iteration of the backend would be to return a key-value result
+      // instead of an unordered array but I think that's a needless optimization.
+      listApps.forEach(({ name: localName, hash: localHash }) => {
+        const matchFromHash = matches.find(({ hash }) => hash === localHash);
+        if (matchFromHash) {
+          installedList.push(matchFromHash);
+          return;
+        }
+
+        const matchFromCatalog = catalogForDevice.find(({ name }) => name === localName);
+        log("list-apps", `falling back to catalog for ${localName}`);
+        if (matchFromCatalog) {
+          installedList.push(matchFromCatalog);
+        }
+      });
 
       catalogForDevice.forEach(app => {
         const crypto = app.currencyId && findCryptoCurrencyById(app.currencyId);

--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -1,7 +1,11 @@
 // polyfill the unfinished support of apps logic
 import uniq from "lodash/uniq";
 import semver from "semver";
-import { listCryptoCurrencies, findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import {
+  listCryptoCurrencies,
+  findCryptoCurrencyById,
+  findCryptoCurrency,
+} from "@ledgerhq/cryptoassets";
 import { App, AppType, Application, ApplicationV2 } from "@ledgerhq/types-live";
 import type { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 const directDep = {};
@@ -110,16 +114,13 @@ export const polyfillApplication = (app: Application): Application => {
 };
 
 export const getCurrencyIdFromAppName = (
-  appName: string,
+  name: string,
 ): CryptoCurrencyId | "LBRY" | "groestcoin" | "osmo" | undefined => {
-  const crypto = listCryptoCurrencies(true, true).find(
-    crypto =>
-      appName.toLowerCase() === crypto.managerAppName.toLowerCase() &&
-      (crypto.managerAppName !== "Ethereum" ||
-        // if it's ethereum, we have a specific case that we must only allow the Ethereum app
-        appName === "Ethereum"),
-  );
-
+  const crypto =
+    // try to find the "official" currency when possible (2 currencies can have the same manager app and ticker)
+    findCryptoCurrency(c => c.name === name) ||
+    // Else take the first one with that manager app
+    findCryptoCurrency(c => c.managerAppName === name);
   return crypto?.id;
 };
 


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The current version of the list apps v2 (recently made available via feature flags) does not support dynamic hash applications, meaning that if you had `"Fido U2F" or "Security Key"`  installed they would not show in the catalog in the first place. At the same time, we were getting the response from the backend in an unordered manner meaning the storage bar from inside the My Ledger screen would not match that of v1 and, more importantly, would not match the order the user installed the apps in.

This little PR addresses both issues. Note that there's a willingness from backend to change the signature of the endpoint that does the apps by hash and return them as a dictionary instead of an array, this may be an improvement to tackle by someone someday when I'm gone. In the meantime this should work.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-7960` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
<img width="1169" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/4631227/89cf9658-6904-4073-ae99-a63d5dabbaff">

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
Testing versus a build from Develop, the result from the v2 enabled build from this branch should essentially match v1. Any discrepancy should be reported in case it's a bug either on my logic or on the data. Focus perhaps on installing some applications, those listed above with dynamic hashes too and playing a bit with the manager and inline app install. Anything major should be caught already.