### PR TITLE
bugfix(LLD): Remove modelListId in analytics

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -283,11 +283,6 @@ export const setLastSeenDevice = ({ deviceInfo }: { deviceInfo: DeviceInfo }) =>
     deviceInfo,
   },
 });
-
-export const addNewDevice = ({ seenDevice }: { seenDevice: DeviceModelInfo }) => ({
-  type: "ADD_SEEN_DEVICE",
-  payload: seenDevice,
-});
 export const setDeepLinkUrl = (url?: string | null) => ({
   type: "SET_DEEPLINK_URL",
   payload: url,

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -11,7 +11,6 @@ import {
   lastSeenDeviceSelector,
   localeSelector,
   languageSelector,
-  seenDevicesSelector,
 } from "~/renderer/reducers/settings";
 import { State } from "~/renderer/reducers";
 import { AccountLike, idsToLanguage } from "@ledgerhq/types-live";
@@ -51,7 +50,6 @@ const extraProperties = (store: ReduxStore) => {
   const region = (localeSelector(state).split("-")[1] || "").toUpperCase() || null;
   const systemLocale = getParsedSystemLocale();
   const device = lastSeenDeviceSelector(state);
-  const devices = seenDevicesSelector(state);
   const accounts = accountsSelector(state);
   const deviceInfo = device
     ? {
@@ -100,7 +98,6 @@ const extraProperties = (store: ReduxStore) => {
     blockchainsWithNftsOwned,
     hasGenesisPass,
     hasInfinityPass,
-    modelIdList: devices.map(d => d.modelId),
     ...deviceInfo,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -13,11 +13,7 @@ import {
 } from "@ledgerhq/live-common/errors";
 import { InitSellResult } from "@ledgerhq/live-common/exchange/sell/types";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
-import {
-  setPreferredDeviceModel,
-  setLastSeenDeviceInfo,
-  addNewDevice,
-} from "~/renderer/actions/settings";
+import { setPreferredDeviceModel, setLastSeenDeviceInfo } from "~/renderer/actions/settings";
 import { preferredDeviceModelSelector } from "~/renderer/reducers/settings";
 import { DeviceModelId } from "@ledgerhq/devices";
 import AutoRepair from "~/renderer/components/AutoRepair";
@@ -245,7 +241,6 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
         apps: [],
       };
       dispatch(setLastSeenDeviceInfo({ lastSeenDevice, latestFirmware }));
-      dispatch(addNewDevice({ seenDevice: lastSeenDevice }));
     }
   }, [dispatch, device, deviceInfo, latestFirmware]);
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -39,7 +39,6 @@ export type SettingsState = {
   preferredDeviceModel: DeviceModelId;
   hasInstalledApps: boolean;
   lastSeenDevice: DeviceModelInfo | undefined | null;
-  seenDevices: DeviceModelInfo[];
   latestFirmware: FirmwareUpdateContext | null;
   language: string | undefined | null;
   theme: string | undefined | null;
@@ -150,7 +149,6 @@ const INITIAL_STATE: SettingsState = {
   hasInstalledApps: true,
   carouselVisibility: 0,
   lastSeenDevice: null,
-  seenDevices: [],
   lastSeenCustomImage: {
     size: 0,
     hash: "",
@@ -203,7 +201,6 @@ type HandlersPayloads = {
     latestFirmware: FirmwareUpdateContext;
   };
   LAST_SEEN_DEVICE: DeviceModelInfo;
-  ADD_SEEN_DEVICE: DeviceModelInfo;
   SET_DEEPLINK_URL: string | null | undefined;
   SET_FIRST_TIME_LEND: never;
   SET_SWAP_SELECTABLE_CURRENCIES: string[];
@@ -320,11 +317,6 @@ const handlers: SettingsHandlers = {
           deviceInfo: payload.deviceInfo,
         }
       : undefined,
-  }),
-
-  ADD_SEEN_DEVICE: (state, { payload }) => ({
-    ...state,
-    seenDevices: Array.from(new Set(state.seenDevices.concat(payload))),
   }),
   SET_DEEPLINK_URL: (state, { payload: deepLinkUrl }) => ({
     ...state,

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -676,7 +676,7 @@ export const lastSeenDeviceSelector = (state: State): DeviceModelInfo | null | u
   }
   return state.settings.lastSeenDevice;
 };
-export const seenDevicesSelector = (state: State): DeviceModelInfo[] => state.settings.seenDevices;
+
 export const latestFirmwareSelector = (state: State) => state.settings.latestFirmware;
 export const swapHasAcceptedIPSharingSelector = (state: State) =>
   state.settings.swap.hasAcceptedIPSharing;

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.tsx
@@ -20,7 +20,6 @@ import AppDepsInstallModal from "./AppDepsInstallModal";
 import AppDepsUnInstallModal from "./AppDepsUnInstallModal";
 import ErrorModal from "~/renderer/modals/ErrorModal/index";
 import {
-  addNewDevice,
   clearLastSeenCustomImage,
   setHasInstalledApps,
   setLastSeenDeviceInfo,
@@ -149,7 +148,6 @@ const AppsList = ({
         latestFirmware: firmware,
       }),
     );
-    reduxDispatch(addNewDevice({ seenDevice: lastSeenDevice }));
   }, [device, state.installed, deviceInfo, reduxDispatch, firmware]);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

 Remove modelListId in analytics
 
 
 This property must be removed for the time being, as it is not possible to uniquely identify the connection of a new or old device.

Each time a Nano is connected, the list is expanded. So you could end up with 45 NanoXs when in fact it's potentially the same device 45 times over. The result is erroneous and potentially very misleading analytics.

To resolve this problem, we need to find a way, like LLM, to have a unique identifier for the Nano. So there's a dependency on the Device team on this subject.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7114] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7114]: https://ledgerhq.atlassian.net/browse/LIVE-7114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ