### PR TITLE
feat(LLD): Update modelListId with unique device type

### DIFF
--- a/.changeset/chilled-timers-remember.md
+++ b/.changeset/chilled-timers-remember.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": patch
 ---
 
-LLD - Add modelIdList user property and event property
+LLD - Add modelIdList user property and event property. The list will be: [ "nanoX", "stax", "nanoS"]

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -284,9 +284,9 @@ export const setLastSeenDevice = ({ deviceInfo }: { deviceInfo: DeviceInfo }) =>
   },
 });
 
-export const addNewDevice = ({ seenDevice }: { seenDevice: DeviceModelInfo }) => ({
-  type: "ADD_SEEN_DEVICE",
-  payload: seenDevice,
+export const addNewDeviceModel = ({ deviceModelId }: { deviceModelId: DeviceModelId }) => ({
+  type: "ADD_NEW_DEVICE_MODEL",
+  payload: deviceModelId,
 });
 export const setDeepLinkUrl = (url?: string | null) => ({
   type: "SET_DEEPLINK_URL",

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -11,7 +11,7 @@ import {
   lastSeenDeviceSelector,
   localeSelector,
   languageSelector,
-  seenDevicesSelector,
+  devicesModelListSelector,
 } from "~/renderer/reducers/settings";
 import { State } from "~/renderer/reducers";
 import { AccountLike, idsToLanguage } from "@ledgerhq/types-live";
@@ -51,7 +51,7 @@ const extraProperties = (store: ReduxStore) => {
   const region = (localeSelector(state).split("-")[1] || "").toUpperCase() || null;
   const systemLocale = getParsedSystemLocale();
   const device = lastSeenDeviceSelector(state);
-  const devices = seenDevicesSelector(state);
+  const devices = devicesModelListSelector(state);
   const accounts = accountsSelector(state);
   const deviceInfo = device
     ? {
@@ -100,7 +100,7 @@ const extraProperties = (store: ReduxStore) => {
     blockchainsWithNftsOwned,
     hasGenesisPass,
     hasInfinityPass,
-    modelIdList: devices.map(d => d.modelId),
+    modelIdList: devices,
     ...deviceInfo,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -16,7 +16,7 @@ import { getCurrentDevice } from "~/renderer/reducers/devices";
 import {
   setPreferredDeviceModel,
   setLastSeenDeviceInfo,
-  addNewDevice,
+  addNewDeviceModel,
 } from "~/renderer/actions/settings";
 import { preferredDeviceModelSelector } from "~/renderer/reducers/settings";
 import { DeviceModelId } from "@ledgerhq/devices";
@@ -245,7 +245,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
         apps: [],
       };
       dispatch(setLastSeenDeviceInfo({ lastSeenDevice, latestFirmware }));
-      dispatch(addNewDevice({ seenDevice: lastSeenDevice }));
+      dispatch(addNewDeviceModel({ deviceModelId: lastSeenDevice.modelId }));
     }
   }, [dispatch, device, deviceInfo, latestFirmware]);
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -39,7 +39,7 @@ export type SettingsState = {
   preferredDeviceModel: DeviceModelId;
   hasInstalledApps: boolean;
   lastSeenDevice: DeviceModelInfo | undefined | null;
-  seenDevices: DeviceModelInfo[];
+  devicesModelList: DeviceModelId[];
   latestFirmware: FirmwareUpdateContext | null;
   language: string | undefined | null;
   theme: string | undefined | null;
@@ -150,7 +150,7 @@ const INITIAL_STATE: SettingsState = {
   hasInstalledApps: true,
   carouselVisibility: 0,
   lastSeenDevice: null,
-  seenDevices: [],
+  devicesModelList: [],
   lastSeenCustomImage: {
     size: 0,
     hash: "",
@@ -203,7 +203,7 @@ type HandlersPayloads = {
     latestFirmware: FirmwareUpdateContext;
   };
   LAST_SEEN_DEVICE: DeviceModelInfo;
-  ADD_SEEN_DEVICE: DeviceModelInfo;
+  ADD_NEW_DEVICE_MODEL: DeviceModelId;
   SET_DEEPLINK_URL: string | null | undefined;
   SET_FIRST_TIME_LEND: never;
   SET_SWAP_SELECTABLE_CURRENCIES: string[];
@@ -322,10 +322,11 @@ const handlers: SettingsHandlers = {
       : undefined,
   }),
 
-  ADD_SEEN_DEVICE: (state, { payload }) => ({
+  ADD_NEW_DEVICE_MODEL: (state, { payload }) => ({
     ...state,
-    seenDevices: Array.from(new Set(state.seenDevices.concat(payload))),
+    devicesModelList: [...new Set(state.devicesModelList.concat(payload))],
   }),
+
   SET_DEEPLINK_URL: (state, { payload: deepLinkUrl }) => ({
     ...state,
     deepLinkUrl,
@@ -684,7 +685,8 @@ export const lastSeenDeviceSelector = (state: State): DeviceModelInfo | null | u
   }
   return state.settings.lastSeenDevice;
 };
-export const seenDevicesSelector = (state: State): DeviceModelInfo[] => state.settings.seenDevices;
+export const devicesModelListSelector = (state: State): DeviceModelId[] =>
+  state.settings.devicesModelList;
 export const latestFirmwareSelector = (state: State) => state.settings.latestFirmware;
 export const swapHasAcceptedIPSharingSelector = (state: State) =>
   state.settings.swap.hasAcceptedIPSharing;

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/AppsList/index.tsx
@@ -20,7 +20,7 @@ import AppDepsInstallModal from "./AppDepsInstallModal";
 import AppDepsUnInstallModal from "./AppDepsUnInstallModal";
 import ErrorModal from "~/renderer/modals/ErrorModal/index";
 import {
-  addNewDevice,
+  addNewDeviceModel,
   clearLastSeenCustomImage,
   setHasInstalledApps,
   setLastSeenDeviceInfo,
@@ -149,7 +149,7 @@ const AppsList = ({
         latestFirmware: firmware,
       }),
     );
-    reduxDispatch(addNewDevice({ seenDevice: lastSeenDevice }));
+    reduxDispatch(addNewDeviceModel({ deviceModelId: lastSeenDevice.modelId }));
   }, [device, state.installed, deviceInfo, reduxDispatch, firmware]);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This property must be updated for the time being, as it is not possible to uniquely identify the connection of a new or old device.

Each time a Nano is connected, the list is expanded. So you could end up with 45 NanoXs when in fact it's potentially the same device 45 times over. The result is erroneous and potentially very misleading analytics.

To resolve this problem, we need to find a way, like LLM, to have a unique identifier for the Nano. So there's a dependency on the Device team on this subject.


Now if my user has 3 nanoX, 1 Stax and 2 NanoS
the list will be: [ "nanoX", "stax", "nanoS"]

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7114] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7114]: https://ledgerhq.atlassian.net/browse/LIVE-7114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ