### PR TITLE
fix: back btn in pairing screen when restoring with recover

### DIFF
--- a/.changeset/bright-rules-draw.md
+++ b/.changeset/bright-rules-draw.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Fixes the back button in paring screen when restoring with Recover

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
@@ -111,6 +111,7 @@ export type Step = {
 
 export function BaseStepperView({
   onNext,
+  onBackOverride,
   steps,
   metadata,
   deviceModelId,
@@ -120,6 +121,7 @@ export function BaseStepperView({
   steps: Step[];
   metadata: Metadata[];
   deviceModelId?: DeviceModelId;
+  onBackOverride?: () => void;
   params?: object;
 }) {
   const [index, setIndex] = React.useState(0);
@@ -146,7 +148,7 @@ export function BaseStepperView({
         renderTransition={renderTransitionSlide}
         transitionDuration={transitionDuration}
         progressBarProps={{ opacity: 0 }}
-        extraProps={{ onBack: handleBack, metadata }}
+        extraProps={{ onBack: onBackOverride || handleBack, metadata }}
       >
         {steps.map((Children, i) => (
           <Scene key={Children.id + i}>

--- a/libs/ledger-live-common/src/hooks/recoverFeatueFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatueFlag.ts
@@ -35,3 +35,10 @@ export function useAlreadySubscribedURI(servicesConfig: Feature<any> | null): st
 
   return useReplacedURI(uri, id);
 }
+
+export function useAccountURI(servicesConfig: Feature<any> | null): string | undefined {
+  const uri = servicesConfig?.params?.account?.homeURI;
+  const id = servicesConfig?.params?.protectId;
+
+  return useReplacedURI(uri, id);
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes the back button in paring screen when restoring with Recover

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`, `ledger-live-common`
- **Linked resource(s)**: [PROTECT-1604](https://ledgerhq.atlassian.net/browse/PROTECT-1604)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Onboarding not completed | Onboarding completed
---------------------------|---------------------------
<video src="https://github.com/LedgerHQ/ledger-live/assets/102669540/af4b75e3-5c5b-4dd2-8016-7e191548b992" /> | <video src="https://github.com/LedgerHQ/ledger-live/assets/102669540/7b0f075c-7f9a-41cd-8532-95df5d39a2b1" />




### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-1604]: https://ledgerhq.atlassian.net/browse/PROTECT-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ