### PR TITLE
feat: LIVE-6280 allow device pairing with open app on LLM (new selector)

### DIFF
--- a/.changeset/tender-hairs-sip.md
+++ b/.changeset/tender-hairs-sip.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Allow device pairing with an open app (new selector)

--- a/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.test.ts
+++ b/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.test.ts
@@ -3,25 +3,23 @@ import { from } from "rxjs";
 import { DeviceModelId } from "@ledgerhq/devices";
 import Transport from "@ledgerhq/hw-transport";
 import { withDevice } from "../../hw/deviceAccess";
-import getVersion from "../../hw/getVersion";
+import getAppAndVersion from "../../hw/getAppAndVersion";
 import { useBleDevicePairing } from "./useBleDevicePairing";
 
 jest.mock("../../hw/deviceAccess");
-jest.mock("../../hw/getVersion");
+jest.mock("../../hw/getAppAndVersion");
 jest.mock("@ledgerhq/hw-transport");
 jest.useFakeTimers();
 
-const mockedGetVersion = jest.mocked(getVersion);
+const mockedGetAppAndVersion = jest.mocked(getAppAndVersion);
 const mockedWithDevice = jest.mocked(withDevice);
 
 mockedWithDevice.mockReturnValue(job => from(job(new Transport())));
 
-const aFirmwareInfo = {
-  isBootloader: false,
-  rawVersion: "",
-  targetId: 0,
-  mcuVersion: "",
-  flags: Buffer.from([]),
+const anAppAndVersion = {
+  name: "Bitcoin",
+  version: "1.0.0",
+  flags: 1,
 };
 
 const aDevice = {
@@ -42,13 +40,13 @@ class BleError extends Error {
 
 describe("useBleDevicePairing", () => {
   afterEach(() => {
-    mockedGetVersion.mockClear();
+    mockedGetAppAndVersion.mockClear();
     jest.clearAllTimers();
   });
 
   describe("When the request sent with the BLE transport to the device gets a success response", () => {
     beforeEach(() => {
-      mockedGetVersion.mockResolvedValue(aFirmwareInfo);
+      mockedGetAppAndVersion.mockResolvedValue(anAppAndVersion);
     });
 
     it("should inform the hook consumer that the device is paired", async () => {
@@ -70,7 +68,7 @@ describe("useBleDevicePairing", () => {
   describe("When the request sent with the BLE transport is rejected with an error", () => {
     beforeEach(() => {
       const bleError = new BleError("An error during pairing", 201);
-      mockedGetVersion.mockRejectedValue(bleError);
+      mockedGetAppAndVersion.mockRejectedValue(bleError);
     });
 
     it("should inform the hook consumer an error occurred", async () => {

--- a/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.ts
+++ b/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.ts
@@ -1,9 +1,8 @@
 import { useState, useEffect } from "react";
 import { from } from "rxjs";
 import { first } from "rxjs/operators";
-import type { FirmwareInfo } from "@ledgerhq/types-live";
 import { withDevice } from "../../hw/deviceAccess";
-import getVersion from "../../hw/getVersion";
+import getAppAndVersion from "../../hw/getAppAndVersion";
 import { BleError } from "../types";
 
 export type useBleDevicePairingArgs = {
@@ -31,10 +30,10 @@ export const useBleDevicePairing = ({
   const [pairingError, setPairingError] = useState<PairingError>(null);
 
   useEffect(() => {
-    const requestObservable = withDevice(deviceId)(t => from(getVersion(t))).pipe(first());
+    const requestObservable = withDevice(deviceId)(t => from(getAppAndVersion(t))).pipe(first());
 
     const sub = requestObservable.subscribe({
-      next: (_value: FirmwareInfo) => {
+      next: (_value: unknown) => {
         setIsPaired(true);
         setPairingError(null);
       },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The new device selector (the old one also fails) fails to complete a pairing flow when there's an open application on the device. The reason for this is the use of the `getVersion` apdu instead of the `getAppAndVersion` apdu since one is available only on the dashboard and the other is available virtually everywhere.

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6280` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo
<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach
- With the new device selector feature flag enabled
- Make sure your device is not paired with your phone, delete if from Live if necessary
- Enter BTC/ETH or some other application on your nano
- Attempt to pair the device on LLM

It is expected that the pairing will succeed (if you agree to the code of course). Entering the manager afterwards should automatically quit the app and access the screen.  Doing the same without the feature flag enabled should fail since the logic is relying on `getVersion` which fails if not on the dashboard.