### PR TITLE
Feature - Add `setLoadConfig` method to signerContext & support for env var backend URIs

### DIFF
--- a/.changeset/olive-items-yawn.md
+++ b/.changeset/olive-items-yawn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Adds support for the `setLoadConfig` during the SignOperation step and adds the usage of environment variables to set the backends URIs

--- a/libs/coin-evm/src/__tests__/hw-getAddress.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/hw-getAddress.unit.test.ts
@@ -18,6 +18,7 @@ const mockSignerFactory = (
   fn: (signer: EvmSigner) => Promise<EvmAddress | EvmSignature>,
 ) =>
   fn({
+    setLoadConfig: jest.fn(),
     getAddress: async () => ({
       publicKey: "",
       address: address.toLowerCase(),

--- a/libs/coin-evm/src/__tests__/signOperation.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/signOperation.unit.test.ts
@@ -44,6 +44,7 @@ const mockSignerContext: SignerContext<EvmSigner, EvmAddress | EvmSignature> = (
   fn: (signer: EvmSigner) => Promise<EvmAddress | EvmSignature>,
 ) => {
   return fn({
+    setLoadConfig: jest.fn(),
     getAddress: jest.fn(),
     signTransaction: () =>
       Promise.resolve({

--- a/libs/coin-evm/src/signer.ts
+++ b/libs/coin-evm/src/signer.ts
@@ -25,7 +25,22 @@ type LedgerEthTransactionResolution = {
   domains: DomainServiceResolution[];
 };
 
+// Duplicate type definition from hw-app-eth.
+type LoadConfig = {
+  // Backend service responsible for signed NFT APDUS
+  nftExplorerBaseURL?: string | null;
+  // example of payload https://cdn.live.ledger.com/plugins/ethereum/1.json
+  // fetch against an api (base url is an api that hosts /plugins/ethereum/${chainId}.json )
+  // set to null will disable it
+  pluginBaseURL?: string | null;
+  // provide manually some extra plugins to add for the resolution (e.g. for dev purpose)
+  // object will be merged with the returned value of the Ledger cdn payload
+  extraPlugins?: any | null;
+  cryptoassetsBaseURL?: string | null;
+};
+
 export interface EvmSigner {
+  setLoadConfig(loadConfig: LoadConfig): void;
   getAddress(path: string, boolDisplay?: boolean, boolChaincode?: boolean): Promise<EvmAddress>;
   signTransaction(
     path: string,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR adds support for the `setLoadConfig` method of `hw-app-eth` in the `signerContext` and adds the usage of the environment variables `DYNAMIC_CAL_BASE_URL` & `NFT_ETH_METADATA_SERVICE`.

### ❓ Context

- **Impacted projects**: `@ledgerhq/coin-evm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
