### PR TITLE
fix: fix vault center help url and extract it in url helper

### DIFF
--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -283,3 +283,8 @@ export const urls = {
   },
   howToUpdateNewLedger: "https://support.ledger.com/hc/en-us/articles/9305992683165?docs=true",
 };
+
+
+export const vaultSigner = {
+  help: "https://help.vault.ledger.com/developer-portal/content/signer/overview"
+}

--- a/apps/ledger-live-desktop/src/renderer/components/VaultSignerBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/VaultSignerBanner.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
+import { vaultSigner } from "~/config/urls";
 
 import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import { vaultSignerSelector } from "~/renderer/reducers/settings";
@@ -21,7 +22,7 @@ const VaultSignerBanner = () => {
         right: (
           <ExternalLink
             isInternal={false}
-            onClick={() => openURL("https://help.vault.ledger.com")}
+            onClick={() => openURL(vaultSigner.help)}
             label={t("banners.vaultSigner.link")}
           />
         ),

--- a/apps/ledger-live-desktop/src/renderer/modals/VaultSigner/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/VaultSigner/index.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Flex } from "@ledgerhq/react-ui";
 
+import { vaultSigner } from "~/config/urls";
 import Label from "~/renderer/components/Label";
 import Alert from "~/renderer/components/Alert";
 import { vaultSignerSelector } from "~/renderer/reducers/settings";
@@ -54,7 +55,7 @@ const VaultSigner = () => {
                   <ExternalLink
                     label={t("vaultSigner.modal.info_link")}
                     isInternal={false}
-                    onClick={() => openURL("https://help.vault.ledger.com")}
+                    onClick={() => openURL(vaultSigner.help)}
                   />
                 </Flex>
               </Alert>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This fixes the url of the vault center display in 
- the banner that warns the user it's using the vault a a signer
- the settings modal where the user can enter the vault settings

I took this opportunity to extract it on the urls helpers file.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
