### PR TITLE
chore(llc): coverage including untested files

### DIFF
--- a/.changeset/pretty-buckets-try.md
+++ b/.changeset/pretty-buckets-try.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix jest config to generate coverage report and include untested files

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -28,11 +28,8 @@ const defaultConfig = {
     },
   },
   testEnvironment: "node",
-  coverageDirectory: "./coverage/",
-  coverageReporters: ["json", "lcov", "clover"],
   reporters,
-  collectCoverage: true,
-  coveragePathIgnorePatterns: ["src/__tests__"],
+  coveragePathIgnorePatterns: ["src/__tests__/test-helpers"],
   modulePathIgnorePatterns: [
     "<rootDir>/benchmark/.*",
     "<rootDir>/cli/.yalc/.*",
@@ -44,6 +41,9 @@ const defaultConfig = {
 };
 
 export default {
+  collectCoverage: true,
+  collectCoverageFrom: ["src/**/*.{ts,tsx}"],
+  coverageReporters: ["json", "lcov", "clover", "json-summary"],
   projects: [
     {
       ...defaultConfig,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Currently when running `pnpm --filter="@ledgerhq/live-common" test` no coverage folder is created at the root of libs/ledger-live-common. This is fixed by moving the collectCoverage parameter outside the projects, at the root of the config object.

With the updated jest config, the coverage will include all untested files by including all ts and tsx files in the src/ folder.

### ❓ Context

- **Impacted projects**: `llc` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8184 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** : No tests, only modifying jest configuration<!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

<img width="239" alt="coverage folder under ledger-live-common" src="https://github.com/LedgerHQ/ledger-live/assets/108733454/d417e57f-6eb6-48a9-9860-ed765564f8af">

![llc lcov report](https://github.com/LedgerHQ/ledger-live/assets/108733454/403e3801-0e9a-4032-9f67-f73aa1cf9fc5)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
