### PR TITLE
bugfix/LIVE-8196 Firmware update regression in LLD for old devices

### DIFF
--- a/.changeset/real-adults-double.md
+++ b/.changeset/real-adults-double.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fixed regression in firmware update for old devices on LLD


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Longer explanation in the linked ticket.
We broke the automatic firmware update process for users on old versions, but we have found a solution. Instead of asking them to download an old version which was the temporary solution, we have this PR. The proposed fix, which opens a drawer instead of a modal, solves the original issue.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-8196` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
No demo

### 🚀 Expectations to reach
A nano S on 1.4.2 should be able to update its firmware on LLD without complications.