### PR TITLE
fix(Firmware Update LLM): fix manager reload during update

### DIFF
--- a/.changeset/new-maps-worry.md
+++ b/.changeset/new-maps-worry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Make reloading of manager upon new connection specific to Bluetooth to USB transitions

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -47,9 +47,8 @@ const Manager = ({ navigation, route }: NavigationProps) => {
 
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
   useEffect(() => {
-    // refresh the manager if a new device gets connected
-    // (happes only when we plug a new device via USB)
-    if (lastConnectedDevice?.deviceId !== device.deviceId) {
+    // refresh the manager if an USB device gets plugged while we're on a bluetooth connection
+    if (lastConnectedDevice?.deviceId.startsWith("usb|") && !device.deviceId.startsWith("usb|")) {
       navigation.replace(ScreenName.Manager, {
         device: lastConnectedDevice,
       });


### PR DESCRIPTION
### 📝 Description
A bug was introduced on https://github.com/LedgerHQ/ledger-live/pull/3570 that was causing the manager tab to reload during a firmware update. https://github.com/LedgerHQ/ledger-live/pull/3570 's fix relied on reloading the manager tab wen a new USB device was plugged in, however the multiple restarts during the firmware update were being recognized as new USB device being plugged in.

This PR fixes this issue by making the manager reload specific to BLE to USB transitions.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-8191]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
N/A (just a normal firmware update with no issues)

[LIVE-8191]: https://ledgerhq.atlassian.net/browse/LIVE-8191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ