### PR TITLE
feat(llm/debug): debug setting to simulate that LLM has seen Stax once

### DIFF
--- a/.changeset/perfect-chefs-know.md
+++ b/.changeset/perfect-chefs-know.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add debug setting to simulate LL having connected once to a Ledger Stax

--- a/.changeset/popular-cooks-switch.md
+++ b/.changeset/popular-cooks-switch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": patch
+---
+
+NFT fixtures: replace NFT with Stax metadata (previous one didn't have Stax metadata)

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -63,6 +63,7 @@ import {
   SettingsSetCustomImageTypePayload,
   SettingsSetGeneralTermsVersionAccepted,
   SettingsSetOnboardingTypePayload,
+  SettingsSetKnownDeviceModelIdsPayload,
 } from "./types";
 import { ImageType } from "../components/CustomImage/types";
 
@@ -179,6 +180,9 @@ export const setLastSeenDeviceInfo = createAction<SettingsLastSeenDeviceInfoPayl
 );
 export const setLastSeenDeviceLanguageId = createAction<SettingsLastSeenDeviceLanguagePayload>(
   SettingsActionTypes.LAST_SEEN_DEVICE_LANGUAGE_ID,
+);
+export const setKnownDeviceModelIds = createAction<SettingsSetKnownDeviceModelIdsPayload>(
+  SettingsActionTypes.SET_KNOWN_DEVICE_MODEL_IDS,
 );
 const setHasSeenStaxEnabledNftsPopupAction =
   createAction<SettingsSetHasSeenStaxEnabledNftsPopupPayload>(

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -181,6 +181,11 @@ export const setLastSeenDeviceInfo = createAction<SettingsLastSeenDeviceInfoPayl
 export const setLastSeenDeviceLanguageId = createAction<SettingsLastSeenDeviceLanguagePayload>(
   SettingsActionTypes.LAST_SEEN_DEVICE_LANGUAGE_ID,
 );
+/**
+ * Do not use this for purposes other than debugging. The reducers for other
+ * actions like setLastSeenDevice, setLastSeenDeviceInfo,
+ * setLastSeenDeviceLanguageId already update that part of the state.
+ * */
 export const setKnownDeviceModelIds = createAction<SettingsSetKnownDeviceModelIdsPayload>(
   SettingsActionTypes.SET_KNOWN_DEVICE_MODEL_IDS,
 );

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -186,7 +186,7 @@ export const setLastSeenDeviceLanguageId = createAction<SettingsLastSeenDeviceLa
  * actions like setLastSeenDevice, setLastSeenDeviceInfo,
  * setLastSeenDeviceLanguageId already update that part of the state.
  * */
-export const setKnownDeviceModelIds = createAction<SettingsSetKnownDeviceModelIdsPayload>(
+export const unsafe_setKnownDeviceModelIds = createAction<SettingsSetKnownDeviceModelIdsPayload>(
   SettingsActionTypes.SET_KNOWN_DEVICE_MODEL_IDS,
 );
 const setHasSeenStaxEnabledNftsPopupAction =

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -33,6 +33,7 @@ import type {
   ProtectState,
 } from "../reducers/types";
 import type { Unpacked } from "../types/helpers";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 
 //  === ACCOUNTS ACTIONS ===
 
@@ -246,6 +247,7 @@ export enum SettingsActionTypes {
   LAST_SEEN_DEVICE = "LAST_SEEN_DEVICE",
   LAST_SEEN_DEVICE_INFO = "LAST_SEEN_DEVICE_INFO",
   LAST_SEEN_DEVICE_LANGUAGE_ID = "LAST_SEEN_DEVICE_LANGUAGE_ID",
+  SET_KNOWN_DEVICE_MODEL_IDS = "SET_KNOWN_DEVICE_MODEL_IDS",
   SET_HAS_SEEN_STAX_ENABLED_NFTS_POPUP = "SET_HAS_SEEN_STAX_ENABLED_NFTS_POPUP",
   SET_LAST_SEEN_CUSTOM_IMAGE = "SET_LAST_SEEN_CUSTOM_IMAGE",
   ADD_STARRED_MARKET_COINS = "ADD_STARRED_MARKET_COINS",
@@ -325,6 +327,7 @@ export type SettingsLastSeenDevicePayload = NonNullable<
 >["deviceInfo"];
 export type SettingsLastSeenDeviceInfoPayload = DeviceModelInfo;
 export type SettingsLastSeenDeviceLanguagePayload = DeviceInfo["languageId"];
+export type SettingsSetKnownDeviceModelIdsPayload = { [key in DeviceModelId]?: boolean };
 export type SettingsAddStarredMarketcoinsPayload = Unpacked<SettingsState["starredMarketCoins"]>;
 export type SettingsRemoveStarredMarketcoinsPayload = Unpacked<SettingsState["starredMarketCoins"]>;
 export type SettingsSetLastConnectedDevicePayload = Device;

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -75,6 +75,7 @@ import type {
   SettingsSetGeneralTermsVersionAccepted,
   SettingsSetOnboardingHasDevicePayload,
   SettingsSetOnboardingTypePayload,
+  SettingsSetKnownDeviceModelIdsPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -456,6 +457,14 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     knownDeviceModelIds: {
       ...state.knownDeviceModelIds,
       [(action as Action<SettingsLastSeenDeviceInfoPayload>).payload.modelId]: true,
+    },
+  }),
+
+  [SettingsActionTypes.SET_KNOWN_DEVICE_MODEL_IDS]: (state, action) => ({
+    ...state,
+    knownDeviceModelIds: {
+      ...state.knownDeviceModelIds,
+      ...(action as Action<SettingsSetKnownDeviceModelIdsPayload>).payload,
     },
   }),
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/HasStaxRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/HasStaxRow.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Switch } from "@ledgerhq/native-ui";
+import SettingsRow from "../../../../components/SettingsRow";
+import { setKnownDeviceModelIds } from "../../../../actions/settings";
+import { knownDeviceModelIdsSelector } from "../../../../reducers/settings";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+const HasStaxRow = () => {
+  const dispatch = useDispatch();
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const hasStax = knownDeviceModelIds.stax;
+
+  const onChange = useCallback(
+    (enabled: boolean) => {
+      dispatch(setKnownDeviceModelIds({ [DeviceModelId.stax]: enabled }));
+    },
+    [dispatch],
+  );
+
+  return (
+    <>
+      <SettingsRow
+        title="Has connected once to a Ledger Stax"
+        desc="Some features (such as Stax NFT metadata) are only available if LL has been connected once to a Ledger Stax. Activate this to simulate that state."
+      >
+        <Switch checked={hasStax} onChange={onChange} />
+      </SettingsRow>
+    </>
+  );
+};
+
+export default HasStaxRow;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/HasStaxRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/HasStaxRow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { Switch } from "@ledgerhq/native-ui";
 import SettingsRow from "../../../../components/SettingsRow";
-import { setKnownDeviceModelIds } from "../../../../actions/settings";
+import { unsafe_setKnownDeviceModelIds } from "../../../../actions/settings";
 import { knownDeviceModelIdsSelector } from "../../../../reducers/settings";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
@@ -13,7 +13,7 @@ const HasStaxRow = () => {
 
   const onChange = useCallback(
     (enabled: boolean) => {
-      dispatch(setKnownDeviceModelIds({ [DeviceModelId.stax]: enabled }));
+      dispatch(unsafe_setKnownDeviceModelIds({ [DeviceModelId.stax]: enabled }));
     },
     [dispatch],
   );

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
@@ -15,6 +15,7 @@ import { StackNavigatorNavigation } from "../../../../components/RootNavigator/t
 import { SettingsNavigatorStackParamList } from "../../../../components/RootNavigator/types/SettingsNavigator";
 import ResetOnboardingStateRow from "./ResetOnboardingStateRow";
 import NftMetadataServiceRow from "./NftMetadataServiceRow";
+import HasStaxRow from "./HasStaxRow";
 
 export default function Configuration() {
   const navigation = useNavigation<StackNavigatorNavigation<SettingsNavigatorStackParamList>>();
@@ -39,6 +40,7 @@ export default function Configuration() {
       <ResetOnboardingStateRow />
       <ReadOnlyModeRow />
       <HasOrderedNanoRow />
+      <HasStaxRow />
       <MockModeRow />
       <AnalyticsConsoleRow />
       <NftMetadataServiceRow />

--- a/libs/coin-framework/src/mocks/fixtures/nfts.ts
+++ b/libs/coin-framework/src/mocks/fixtures/nfts.ts
@@ -303,12 +303,12 @@ export const NFTs = [
 // Ethereum NFTs with the special "staxImage" metadata designed to fit the Ledger Stax screen
 export const NFTs_ETHEREUM_STAX_METADATA = [
   {
-    id: "js:2:ethereum:0xB98d10d9f6d07bA283bFD21B2dFEc050f9Ae282A:+0xf4ac11a8967bc88c9ce5acf886bce605c9db9d6e+8482",
-    tokenId: "8482",
+    id: "js:2:ethereum:0xB98d10d9f6d07bA283bFD21B2dFEc050f9Ae282A:+0x0b51eb9d0e54c562fedc07ceba453f05b70c4b79+1",
+    tokenId: "1",
     amount: "1",
     collection: {
-      contract: "0xf4ac11a8967bc88c9ce5acf886bce605c9db9d6e",
-      standard: "ERC721",
+      contract: "0x0b51eb9d0e54c562fedc07ceba453f05b70c4b79",
+      standard: "ERC1155",
     },
   },
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add debug setting to simulate LL having connected once to a Ledger Stax. Useful to test some features without a Stax device (for instance Stax NFT metadata).

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8204] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/91890529/018ff61d-9a0b-40ce-b566-c0ad695d8575



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8204]: https://ledgerhq.atlassian.net/browse/LIVE-8204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ