### PR TITLE
feat: LIVE-6344 aligned UI of pairing flow + wording change

### DIFF
--- a/.changeset/lazy-clocks-repeat.md
+++ b/.changeset/lazy-clocks-repeat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Aligned UI of pairing flow + wording change

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
@@ -176,8 +176,7 @@ const BleDevicePairing = ({ deviceToPair, onPaired, onRetry }: BleDevicePairingP
           <Text mb={4} mt={16} textAlign="center" variant="h4" fontWeight="semiBold">
             {t("blePairingFlow.pairing.loading.title", { deviceName })}
           </Text>
-          {/* Transparent text in order to have a smooth transition between loading and success */}
-          <Text variant="body" textAlign="center" color="transparent">
+          <Text variant="body" textAlign="center">
             {t("blePairingFlow.pairing.loading.subtitle", { productName })}
           </Text>
         </Flex>

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -310,166 +310,159 @@ export default function SelectDevice({
         retryRequestOnIssue={retryRequestOnIssue}
         cannotRetryRequest={cannotRetryRequest}
       />
-      <Flex flex={1}>
-        {isPairingDevices ? (
-          <BleDevicePairingFlow
-            onPairingSuccess={handleOnSelect}
-            onGoBackFromScanning={closeBlePairingFlow}
-            onPairingSuccessAddToKnownDevices
-            requestToSetHeaderOptions={requestToSetHeaderOptions}
-          />
-        ) : (
-          <>
-            {postOnboardingVisible && (
-              <Box mb={8}>
-                <PostOnboardingEntryPointCard />
-              </Box>
-            )}
-            <Flex flexDirection="row" justifyContent="space-between" alignItems="center" mb={1}>
-              <Text variant="h5" fontWeight="semiBold">
-                <Trans i18nKey="manager.selectDevice.title" />
-              </Text>
-              {deviceList.length > 0 && (
-                <Touchable onPress={onAddNewPress} {...addNewButtonEventProps}>
-                  <Flex flexDirection="row" alignItems="center">
-                    <Text color="primary.c90" mr={3} fontWeight="semiBold">
-                      <Trans
-                        i18nKey={`manager.selectDevice.${
-                          Platform.OS === "android" ? "addWithBluetooth" : "addNewCTA"
-                        }`}
-                      />
-                    </Text>
-                    <Icons.PlusMedium color="primary.c90" size={15} />
-                  </Flex>
-                </Touchable>
-              )}
-            </Flex>
-            <ScrollContainer my={4}>
-              {deviceList.length > 0 ? (
-                deviceList.map(device => (
-                  <Item key={device.deviceId} device={device as Device} onPress={handleOnSelect} />
-                ))
-              ) : (
-                <Touchable
-                  onPress={isChoiceDrawerDisplayedOnAddDevice ? onAddNewPress : openBlePairingFlow}
-                  {...addNewButtonEventProps}
-                >
-                  <Flex
-                    p={5}
-                    mb={4}
-                    borderRadius={5}
-                    flexDirection="row"
-                    alignItems="center"
-                    borderColor="neutral.c40"
-                    borderStyle="dashed"
-                    borderWidth="1px"
-                  >
-                    <Icons.PlusMedium color="neutral.c90" size={20} />
-                    <Text variant="large" fontWeight="semiBold" ml={5}>
-                      {t(
-                        `manager.selectDevice.${
-                          Platform.OS === "android" ? "addWithBluetooth" : "addALedger"
-                        }`,
-                      )}
-                    </Text>
-                  </Flex>
-                </Touchable>
-              )}
-              {Platform.OS === "android" &&
-                USBDevice === undefined &&
-                ProxyDevice === undefined && (
-                  <Text
-                    color="neutral.c100"
-                    variant="large"
-                    fontWeight="semiBold"
-                    fontSize={4}
-                    lineHeight="21px"
-                  >
-                    <Trans i18nKey="manager.selectDevice.otgBanner" />
+
+      {isPairingDevices ? (
+        <BleDevicePairingFlow
+          onPairingSuccess={handleOnSelect}
+          onGoBackFromScanning={closeBlePairingFlow}
+          onPairingSuccessAddToKnownDevices
+          requestToSetHeaderOptions={requestToSetHeaderOptions}
+        />
+      ) : (
+        <Flex flex={1}>
+          {postOnboardingVisible && (
+            <Box mb={8}>
+              <PostOnboardingEntryPointCard />
+            </Box>
+          )}
+          <Flex flexDirection="row" justifyContent="space-between" alignItems="center" mb={1}>
+            <Text variant="h5" fontWeight="semiBold">
+              <Trans i18nKey="manager.selectDevice.title" />
+            </Text>
+            {deviceList.length > 0 && (
+              <Touchable onPress={onAddNewPress} {...addNewButtonEventProps}>
+                <Flex flexDirection="row" alignItems="center">
+                  <Text color="primary.c90" mr={3} fontWeight="semiBold">
+                    <Trans
+                      i18nKey={`manager.selectDevice.${
+                        Platform.OS === "android" ? "addWithBluetooth" : "addNewCTA"
+                      }`}
+                    />
                   </Text>
-                )}
-              {displayServicesWidget && <ServicesWidget />}
-            </ScrollContainer>
-            <Flex alignItems="center" mt={5}>
-              <BuyDeviceCTA />
+                  <Icons.PlusMedium color="primary.c90" size={15} />
+                </Flex>
+              </Touchable>
+            )}
+          </Flex>
+          <ScrollContainer my={4}>
+            {deviceList.length > 0 ? (
+              deviceList.map(device => (
+                <Item key={device.deviceId} device={device as Device} onPress={handleOnSelect} />
+              ))
+            ) : (
+              <Touchable
+                onPress={isChoiceDrawerDisplayedOnAddDevice ? onAddNewPress : openBlePairingFlow}
+                {...addNewButtonEventProps}
+              >
+                <Flex
+                  p={5}
+                  mb={4}
+                  borderRadius={5}
+                  flexDirection="row"
+                  alignItems="center"
+                  borderColor="neutral.c40"
+                  borderStyle="dashed"
+                  borderWidth="1px"
+                >
+                  <Icons.PlusMedium color="neutral.c90" size={20} />
+                  <Text variant="large" fontWeight="semiBold" ml={5}>
+                    {t(
+                      `manager.selectDevice.${
+                        Platform.OS === "android" ? "addWithBluetooth" : "addALedger"
+                      }`,
+                    )}
+                  </Text>
+                </Flex>
+              </Touchable>
+            )}
+            {Platform.OS === "android" && USBDevice === undefined && ProxyDevice === undefined && (
+              <Text
+                color="neutral.c100"
+                variant="large"
+                fontWeight="semiBold"
+                fontSize={4}
+                lineHeight="21px"
+              >
+                <Trans i18nKey="manager.selectDevice.otgBanner" />
+              </Text>
+            )}
+            {displayServicesWidget && <ServicesWidget />}
+          </ScrollContainer>
+          <Flex alignItems="center" mt={5}>
+            <BuyDeviceCTA />
+          </Flex>
+          <QueuedDrawer
+            isRequestingToBeOpened={isAddNewDrawerOpen}
+            onClose={() => setIsAddNewDrawerOpen(false)}
+          >
+            <Flex>
+              {withMyLedgerTracking ? (
+                <TrackScreen category={"Add a Ledger device"} type="drawer" refreshSource={false} />
+              ) : null}
+              <Touchable
+                onPress={onSetUpNewDevice}
+                {...(withMyLedgerTracking
+                  ? {
+                      event: "button_clicked",
+                      eventProperties: {
+                        button: "Set up a new Ledger",
+                        drawer: "Add a Ledger device",
+                      },
+                    }
+                  : {})}
+              >
+                <Flex backgroundColor="neutral.c30" mb={4} px={6} py={7} borderRadius={8}>
+                  <Flex flexDirection="row" justifyContent="space-between">
+                    <Flex flexShrink={1}>
+                      <Text variant="large" fontWeight="semiBold" mb={3}>
+                        {t("manager.selectDevice.setUpNewLedger")}
+                      </Text>
+                      <Text variant="paragraph" color="neutral.c80">
+                        {t("manager.selectDevice.setUpNewLedgerDescription")}
+                      </Text>
+                    </Flex>
+                    <Flex justifyContent="center" alignItems="center" ml={5} mr={2}>
+                      <Flex borderRadius="9999px" backgroundColor="neutral.c40" p={4}>
+                        <Icons.PlusMedium color="primary.c80" size={24} />
+                      </Flex>
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Touchable>
+              <Touchable
+                onPress={openBlePairingFlow}
+                {...(withMyLedgerTracking
+                  ? {
+                      event: "button_clicked",
+                      eventProperties: {
+                        button: "Connect with Bluetooth",
+                        drawer: "Add a Ledger device",
+                      },
+                    }
+                  : {})}
+              >
+                <Flex backgroundColor="neutral.c30" px={6} py={7} borderRadius={8}>
+                  <Flex flexDirection="row" justifyContent="space-between">
+                    <Flex flexShrink={1}>
+                      <Text variant="large" fontWeight="semiBold" mb={3}>
+                        {t("manager.selectDevice.connectExistingLedger")}
+                      </Text>
+                      <Text variant="paragraph" color="neutral.c80">
+                        {t("manager.selectDevice.connectExistingLedgerDescription")}
+                      </Text>
+                    </Flex>
+                    <Flex justifyContent="center" alignItems="center" ml={5} mr={2}>
+                      <Flex borderRadius="9999px" backgroundColor="neutral.c40" p={4}>
+                        <Icons.BluetoothMedium color="primary.c80" size={24} />
+                      </Flex>
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Touchable>
             </Flex>
-            <QueuedDrawer
-              isRequestingToBeOpened={isAddNewDrawerOpen}
-              onClose={() => setIsAddNewDrawerOpen(false)}
-            >
-              <Flex>
-                {withMyLedgerTracking ? (
-                  <TrackScreen
-                    category={"Add a Ledger device"}
-                    type="drawer"
-                    refreshSource={false}
-                  />
-                ) : null}
-                <Touchable
-                  onPress={onSetUpNewDevice}
-                  {...(withMyLedgerTracking
-                    ? {
-                        event: "button_clicked",
-                        eventProperties: {
-                          button: "Set up a new Ledger",
-                          drawer: "Add a Ledger device",
-                        },
-                      }
-                    : {})}
-                >
-                  <Flex backgroundColor="neutral.c30" mb={4} px={6} py={7} borderRadius={8}>
-                    <Flex flexDirection="row" justifyContent="space-between">
-                      <Flex flexShrink={1}>
-                        <Text variant="large" fontWeight="semiBold" mb={3}>
-                          {t("manager.selectDevice.setUpNewLedger")}
-                        </Text>
-                        <Text variant="paragraph" color="neutral.c80">
-                          {t("manager.selectDevice.setUpNewLedgerDescription")}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="center" alignItems="center" ml={5} mr={2}>
-                        <Flex borderRadius="9999px" backgroundColor="neutral.c40" p={4}>
-                          <Icons.PlusMedium color="primary.c80" size={24} />
-                        </Flex>
-                      </Flex>
-                    </Flex>
-                  </Flex>
-                </Touchable>
-                <Touchable
-                  onPress={openBlePairingFlow}
-                  {...(withMyLedgerTracking
-                    ? {
-                        event: "button_clicked",
-                        eventProperties: {
-                          button: "Connect with Bluetooth",
-                          drawer: "Add a Ledger device",
-                        },
-                      }
-                    : {})}
-                >
-                  <Flex backgroundColor="neutral.c30" px={6} py={7} borderRadius={8}>
-                    <Flex flexDirection="row" justifyContent="space-between">
-                      <Flex flexShrink={1}>
-                        <Text variant="large" fontWeight="semiBold" mb={3}>
-                          {t("manager.selectDevice.connectExistingLedger")}
-                        </Text>
-                        <Text variant="paragraph" color="neutral.c80">
-                          {t("manager.selectDevice.connectExistingLedgerDescription")}
-                        </Text>
-                      </Flex>
-                      <Flex justifyContent="center" alignItems="center" ml={5} mr={2}>
-                        <Flex borderRadius="9999px" backgroundColor="neutral.c40" p={4}>
-                          <Icons.BluetoothMedium color="primary.c80" size={24} />
-                        </Flex>
-                      </Flex>
-                    </Flex>
-                  </Flex>
-                </Touchable>
-              </Flex>
-            </QueuedDrawer>
-          </>
-        )}
-      </Flex>
+          </QueuedDrawer>
+        </Flex>
+      )}
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1860,7 +1860,7 @@
       },
       "loading": {
         "title": "Pairing with {{deviceName}}...",
-        "subtitle": "Confirm the code on your {{productName}}"
+        "subtitle": "If prompted, confirm the code on your {{productName}}"
       },
       "error": {
         "generic": {
@@ -1899,7 +1899,7 @@
       },
       "loading": {
         "title": "Pairing with {{deviceName}}",
-        "subtitle": "Confirm the code on your {{productName}}"
+        "subtitle": "If prompted, confirm the code on your {{productName}}"
       },
       "error": {
         "title": "Pairing unsuccessful",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Align the layout of the pairing flow (of the new selector) and change the wording to match the ticket.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/browse/LIVE-6344` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
Changes look like a lot but it's merely an indentation change from removing a wrapping Flex.
![image](https://github.com/LedgerHQ/ledger-live/assets/4631227/9905c6c7-5045-4621-94d1-97f09efa9cbc)

### 🚀 Expectations to reach
With the stax feature flag enabled (or the new device selection at least). Make sure the UI matches the screenshots and the wording too. Not much to check other than that since it's purely cosmetic. 