### PR TITLE
fix(DeviceActionImplementations): fix flickering on device actions

### DIFF
--- a/.changeset/hip-socks-refuse.md
+++ b/.changeset/hip-socks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix a device action implementation issue that was causing the UI to flicker during device actions

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -48,7 +48,7 @@ type PollingImplementationParams<Request, EmittedEvents> = {
   config?: PollingImplementationConfig;
 };
 
-export const defaultConfig: PollingImplementationConfig = {
+const defaultConfig: PollingImplementationConfig = {
   pollingFrequency: 2000,
   initialWaitTime: 5000,
   reconnectWaitTime: 5000,
@@ -162,13 +162,6 @@ const pollingImplementation: Implementation = <SpecificType, GenericRequestType>
               // All other events pass through.
               return EMPTY;
             }),
-            // NB An error is a dead-end as far as the task is concerned, and by delaying
-            // the emission of the event we prevent instant failures from showing flashing
-            // UI that looks like a glitch. For instance, if the device is locked and we retry
-            // this would allow a better UX, 800ms before a failure is totally acceptable.
-            delayWhen((e: any) =>
-              e.type === "error" || e.type === "lockedDevice" ? interval(800) : interval(0),
-            ),
           )
           .subscribe({
             next: (event: any) => {

--- a/libs/ledger-live-common/src/hw/actions/manager.ts
+++ b/libs/ledger-live-common/src/hw/actions/manager.ts
@@ -9,7 +9,7 @@ import manager from "../../manager";
 import type { Input as ConnectManagerInput, ConnectManagerEvent } from "../connectManager";
 import type { Action, Device } from "./types";
 import { currentMode } from "./app";
-import { defaultConfig, getImplementation } from "./implementations";
+import { getImplementation } from "./implementations";
 
 type State = {
   isLoading: boolean;
@@ -193,13 +193,7 @@ export const createAction = (
       const sub = impl
         .pipe(
           tap((e: any) => log("actions-manager-event", e.type, e)),
-          debounce((e: Event) =>
-            "replaceable" in e && e.replaceable
-              ? e.type === "deviceChange" && currentMode === "polling"
-                ? interval(defaultConfig.pollingFrequency + 50)
-                : interval(100)
-              : EMPTY,
-          ),
+          debounce((e: Event) => ("replaceable" in e && e.replaceable ? interval(100) : EMPTY)),
           scan(reducer, getInitialState()),
         )
         .subscribe(setState);


### PR DESCRIPTION
### 📝 Description
https://github.com/LedgerHQ/ledger-live/pull/3542 fixed an issue where the UI was refreshing way too fast when there was an error and it seemed to the user that nothing was happening, this happened only on event-based implementation of device actions (used by LLD), but the fix was also introduced on the polling based implementation (LLM). However, this fix introduced an issue for polling based implementations where the device action UI would flicker when the device was locked (see the video on [LIVE-8228]). 

This PR fixes the polling based flickering by removing the fix that was done on https://github.com/LedgerHQ/ledger-live/pull/3542, but only for the polling based implemenation of the device actions (since it wasn't initially needed there anyway).
This PR also reverts what was done on https://github.com/LedgerHQ/ledger-live/pull/3628 since it was a specific fix for this issue in one single device action and now it's fixed for all of them.

### ❓ Context

- **Impacted projects**: `ledger-live-common`
- **Linked resource(s)**: [LIVE-8228]

### ✅ Checklist

- [N/A] **Test coverage** 
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
N/A (device actions behave normally, without flickering)

### 🚀 Expectations to reach


[LIVE-8228]: https://ledgerhq.atlassian.net/browse/LIVE-8228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-8228]: https://ledgerhq.atlassian.net/browse/LIVE-8228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ