### PR TITLE
fix: LIVE-8236 Missing pending transaction

### DIFF
--- a/.changeset/violet-kids-arrive.md
+++ b/.changeset/violet-kids-arrive.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix missing pending transaction bug

--- a/libs/ledger-live-common/src/families/ethereum/postSyncPatch.ts
+++ b/libs/ledger-live-common/src/families/ethereum/postSyncPatch.ts
@@ -19,7 +19,7 @@ const postSyncPatchGen = <T extends AccountLike>(
     op =>
       (!parentPendingOperation || // a child pending parent need to disappear if parent eth op disappear
         parentPendingOperation.some(o => o.hash === op.hash)) &&
-      op.transactionSequenceNumber &&
+      op.transactionSequenceNumber !== undefined &&
       op.transactionSequenceNumber > latestNonce && // retain logic
       (shouldRetainPendingOperation(mainAccount, op) || // after retain logic, we need operation to appear
         !operations.some(o => o.hash === op.hash)),
@@ -29,7 +29,7 @@ const postSyncPatchGen = <T extends AccountLike>(
 
 const postSyncPatch = (initial: Account, synced: Account): Account => {
   const last = synced.operations.find(op => ["OUT", "FEES"].includes(op.type));
-  const latestNonce = last?.transactionSequenceNumber || 0;
+  const latestNonce = last?.transactionSequenceNumber || -1;
   const acc = postSyncPatchGen(initial, synced, latestNonce, synced);
   const { subAccounts, pendingOperations } = acc;
   const initialSubAccounts = initial.subAccounts;


### PR DESCRIPTION
### 📝 Description

When nonce = 0, pending transaction is filtered out by mistake because of (op.transactionSequenceNumber is false when transactionSequenceNumber = 0)


### ❓ Context

- **Impacted projects**: `` LLC
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** (I didn't add unit test for this PR as it is a bug in prod and the fix is obvious. We are going to migrate the eth family to evm family and this piece of code will not be used any more in the near future. We have a different logic to filter pending transactions )

- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
