### PR TITLE
'Stax for Recover' Feature Flag

### DIFF
--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -301,4 +301,7 @@ export const defaultFeatures = {
   listAppsV2: {
     enabled: false,
   },
+  staxRecover: {
+    enabled: false,
+  },
 } as const satisfies DefaultFeatures;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -67,7 +67,8 @@ export type FeatureId =
   | "protectServicesDiscoverDesktop"
   | "protectServicesDesktop"
   | "transactionsAlerts"
-  | "listAppsV2";
+  | "listAppsV2"
+  | "staxRecover";
 
 /**  We use objects instead of direct booleans for potential future improvements
 like feature versioning etc */


### PR DESCRIPTION
### 📝 Description

Have a feature flag to determine if Stax is compatible with Recover or not.
Will then be used by the [useFeature](https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3549298959/Feature+Flagging#useFeature) in [protect-frontend](https://github.com/LedgerHQ/protect-frontend/)

### ❓ Context

- **Linked resource(s)**: 
Ticket : https://ledgerhq.atlassian.net/browse/PROTECT-2111
Guidelines followed : https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3549298959/Feature+Flagging#Creating-a-new-flag-for-a-feature
