### PR TITLE
style(LLM/Device Actions): Style modifications for device actions lotties

### DIFF
--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -62,16 +62,12 @@ export const Wrapper = styled(Flex).attrs({
   minHeight: "160px",
 })``;
 
-type AnimationContainerExtraProps = {
-  withConnectDeviceHeight?: boolean;
-  withVerifyAddressHeight?: boolean;
-};
-const AnimationContainer = styled(Flex).attrs((p: AnimationContainerExtraProps) => ({
+const AnimationContainer = styled(Flex).attrs({
   alignSelf: "stretch",
   alignItems: "center",
   justifyContent: "center",
-  height: p.withConnectDeviceHeight ? "100px" : p.withVerifyAddressHeight ? "72px" : undefined,
-}))<AnimationContainerExtraProps>``;
+  height: "150px",
+})``;
 
 const ActionContainer = styled(Flex).attrs({
   alignSelf: "stretch",
@@ -120,6 +116,9 @@ const ConnectDeviceExtraContentWrapper = styled(Flex).attrs({
   mb: 8,
 })``;
 
+const animationStyles = (modelId: DeviceModelId) =>
+  modelId === DeviceModelId.stax ? { height: 210 } : {};
+
 type RawProps = {
   t: (key: string, options?: { [key: string]: string | number }) => string;
   colors?: Theme["colors"];
@@ -136,7 +135,10 @@ export function renderRequestQuitApp({
   return (
     <Wrapper>
       <AnimationContainer>
-        <Animation source={getDeviceAnimation({ device, key: "quitApp", theme })} />
+        <Animation
+          source={getDeviceAnimation({ device, key: "quitApp", theme })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
       <CenteredText>{t("DeviceAction.quitApp")}</CenteredText>
     </Wrapper>
@@ -193,8 +195,11 @@ export function renderVerifyAddress({
 }) {
   return (
     <Wrapper>
-      <AnimationContainer withVerifyAddressHeight={device.modelId !== "blue"}>
-        <Animation source={getDeviceAnimation({ device, key: "verify", theme })} />
+      <AnimationContainer>
+        <Animation
+          source={getDeviceAnimation({ device, key: "verify", theme })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
       <TitleText>{t("DeviceAction.verifyAddress.title")}</TitleText>
       <DescriptionText>
@@ -248,8 +253,11 @@ export function renderConfirmSwap({
             providerName,
           })}
         </Alert>
-        <AnimationContainer marginTop="16px" withVerifyAddressHeight={device.modelId !== "blue"}>
-          <Animation source={getDeviceAnimation({ device, key: "sign", theme })} />
+        <AnimationContainer marginTop="16px">
+          <Animation
+            source={getDeviceAnimation({ device, key: "sign", theme })}
+            style={animationStyles(device.modelId)}
+          />
         </AnimationContainer>
         <TitleText>{t("DeviceAction.confirmSwap.title")}</TitleText>
 
@@ -343,8 +351,11 @@ export function renderConfirmSell({
       <Alert type="primary" learnMoreUrl={urls.swap.learnMore}>
         {t("DeviceAction.confirmSell.alert")}
       </Alert>
-      <AnimationContainer marginTop="16px" withVerifyAddressHeight={device.modelId !== "blue"}>
-        <Animation source={getDeviceAnimation({ device, key: "sign" })} />
+      <AnimationContainer marginTop="16px">
+        <Animation
+          source={getDeviceAnimation({ device, key: "sign" })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
       <TitleText>{t("DeviceAction.confirmSell.title")}</TitleText>
     </Wrapper>
@@ -372,7 +383,10 @@ export function renderAllowManager({
         </Text>
       </Flex>
       <AnimationContainer>
-        <Animation source={getDeviceAnimation({ device, key: "allowManager", theme })} />
+        <Animation
+          source={getDeviceAnimation({ device, key: "allowManager", theme })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
     </Wrapper>
   );
@@ -403,7 +417,10 @@ export function renderAllowLanguageInstallation({
         {t("deviceLocalization.allowLanguageInstallation", { deviceName })}
       </Text>
       <AnimationContainer>
-        <Animation source={getDeviceAnimation({ device, key, theme })} />
+        <Animation
+          source={getDeviceAnimation({ device, key, theme })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
     </Flex>
   );
@@ -426,7 +443,10 @@ export const renderAllowRemoveCustomLockscreen = ({
         {t("DeviceAction.allowRemoveCustomLockscreen", { productName })}
       </Text>
       <AnimationContainer>
-        <Animation source={getDeviceAnimation({ device, key, theme })} />
+        <Animation
+          source={getDeviceAnimation({ device, key, theme })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
     </Wrapper>
   );
@@ -459,7 +479,14 @@ const AllowOpeningApp = ({
   return (
     <Wrapper>
       <AnimationContainer>
-        <Animation source={getDeviceAnimation({ device, key: "openApp", theme })} />
+        <Animation
+          source={getDeviceAnimation({
+            device,
+            key: "openApp",
+            theme,
+          })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
       <TitleText>{t("DeviceAction.allowAppPermission", { wording })}</TitleText>
       {tokenContext ? (
@@ -787,15 +814,14 @@ export function renderConnectYourDevice({
       alignSelf="stretch"
       flex={fullScreen ? 1 : undefined}
     >
-      <AnimationContainer
-        withConnectDeviceHeight={![DeviceModelId.blue, DeviceModelId.stax].includes(device.modelId)}
-      >
+      <AnimationContainer>
         <Animation
           source={getDeviceAnimation({
             device,
             key: isLocked || unresponsive ? "enterPinCode" : "plugAndPinCode",
             theme,
           })}
+          style={animationStyles(device.modelId)}
         />
       </AnimationContainer>
       {device.deviceName && <ConnectDeviceNameText>{device.deviceName}</ConnectDeviceNameText>}
@@ -877,7 +903,10 @@ export function renderSecureTransferDeviceConfirmation({
   return (
     <Wrapper>
       <AnimationContainer>
-        <Animation source={getDeviceAnimation({ device, key: "sign", theme })} />
+        <Animation
+          source={getDeviceAnimation({ device, key: "sign", theme })}
+          style={animationStyles(device.modelId)}
+        />
       </AnimationContainer>
       <TitleText>{t(`DeviceAction.${exchangeTypeName}.title`)}</TitleText>
       <Alert type="primary" learnMoreUrl={urls.swap.learnMore}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Modified the lotties on device actions (PTX flows...)
No more blue/stax height rule
The container is now 150px height,
If the device is a stax, the lottie is rendered with a height of 210px (allowing it to match the 150px container size, this is due to stax lotties being square with a big space all around)

### ❓ Context

- **Impacted projects**: LLM
- **Linked resource(s)**: [LIVE-7537]

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

N/A

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7537]: https://ledgerhq.atlassian.net/browse/LIVE-7537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ