### PR TITLE
chore: only display error in turbo output

### DIFF
--- a/.github/workflows/build-desktop-external.yml
+++ b/.github/workflows/build-desktop-external.yml
@@ -75,7 +75,7 @@ jobs:
           os: ${{ steps.os.outputs.result }}
       - name: Build the app
         id: build-app
-        run: pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       - name: Save result
         id: save-result
         shell: bash

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           os: linux
       - name: Build the app
-        run: pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       - name: Upload linux app
         uses: actions/upload-artifact@v3
         with:
@@ -82,7 +82,7 @@ jobs:
           os: win
       - name: Build the app
         run: |
-          pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
+          pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
         shell: bash
       - name: Upload windows
         uses: actions/upload-artifact@v3
@@ -115,7 +115,7 @@ jobs:
           os: mac
       - name: Build the app
         run: |
-          pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
+          pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       - name: Upload macOS app
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-mobile-external.yml
+++ b/.github/workflows/build-mobile-external.yml
@@ -60,7 +60,6 @@ jobs:
       - name: Get short SHA
         id: slug
         run: echo "sha8=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
       - name: make local version
         env:
           VERSION: ${{ steps.version.outputs.clean }}-sha.${{ steps.slug.outputs.sha8 }}
@@ -78,7 +77,7 @@ jobs:
           ANDROID_KEY_PASS: staging
           NODE_OPTIONS: "--max-old-space-size=7168"
           ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/apps/ledger-live-mobile/android/app/staging.kstr
-        run: pnpm build:llm:android --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm build:llm:android --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       - uses: ./tools/actions/get-package-infos
         id: post-version
         with:

--- a/.github/workflows/build-mobile.yml
+++ b/.github/workflows/build-mobile.yml
@@ -83,7 +83,7 @@ jobs:
           ANDROID_KEY_PASS: staging
           NODE_OPTIONS: "--max-old-space-size=7168"
           ANDROID_KEYSTORE_FILE: ${{ github.workspace }}/apps/ledger-live-mobile/android/app/staging.kstr
-        run: pnpm build-ci:llm:android --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm build-ci:llm:android --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       - uses: ./tools/actions/get-package-infos
         id: post-version
         with:

--- a/.github/workflows/test-mobile.yml
+++ b/.github/workflows/test-mobile.yml
@@ -52,13 +52,13 @@ jobs:
         run: pnpm i --filter="live-mobile..." --filter="ledger-live" --no-frozen-lockfile --unsafe-perm
       - name: Run linter
         run: |
-          pnpm lint --filter="live-mobile" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" -- --format="json" -o="lint.json"
+          pnpm lint --filter="live-mobile" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only" -- --format="json" -o="lint.json"
           node -p "require('./node_modules/eslint/lib/cli-engine/formatters/stylish.js')(require('./apps/ledger-live-mobile/lint.json'))"
       - name: check for dead code
         run: cd apps/ledger-live-mobile && npx unimported
         shell: bash
       - name: Run code checkers
-        run: pnpm typecheck --filter="live-mobile" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm typecheck --filter="live-mobile" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       - name: Run unit tests
         run: pnpm mobile test
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,7 @@ jobs:
         run: pnpm i --filter="!./apps/**"
       - name: Build and Test affected libraries
         id: test-libs
-        run: pnpm run test --continue --filter="!./apps/**" --filter="!./tools/**" --filter="!live-common-tools" --filter="!ledger-live...[${{ inputs.since_branch && format('origin/{0}', inputs.since_branch) || 'HEAD^1' }}]" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm run test --continue --filter="!./apps/**" --filter="!./tools/**" --filter="!live-common-tools" --filter="!ledger-live...[${{ inputs.since_branch && format('origin/{0}', inputs.since_branch) || 'HEAD^1' }}]" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
         shell: bash
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@v3

--- a/tools/actions/composites/setup-test-desktop/action.yml
+++ b/tools/actions/composites/setup-test-desktop/action.yml
@@ -65,7 +65,7 @@ runs:
         cleanup-cache-folder: "true"
     - name: Build dependencies
       run: |
-        pnpm build:lld:deps --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        pnpm build:lld:deps --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo" --output-logs="errors-only"
       shell: bash
     - name: Build LLD app for testing
       env:

--- a/tools/github-bot/src/features/lintCommits/index.ts
+++ b/tools/github-bot/src/features/lintCommits/index.ts
@@ -49,5 +49,9 @@ export function lintCommits(app: Probot) {
       from: payload.check_run.pull_requests[0]?.base.ref,
       login: payload.sender.login,
     }),
+    getConclusion: conclusion => {
+      if (conclusion == "failure") return "neutral";
+      return conclusion;
+    },
   });
 }

--- a/tools/github-bot/src/tools/monitorWorkflow.ts
+++ b/tools/github-bot/src/tools/monitorWorkflow.ts
@@ -19,6 +19,7 @@ type WorkflowDescriptor = {
   description?: string;
   summaryFile?: string;
   getInputs: (payload: GetInputsPayload) => Record<string, any>;
+  getConclusion?: (conclusion: string) => string;
 };
 export function monitorWorkflow(app: Probot, workflow: WorkflowDescriptor) {
   /**
@@ -142,12 +143,19 @@ export function monitorWorkflow(app: Probot, workflow: WorkflowDescriptor) {
       // ignore error, file is not found
     }
 
+    let conclusion: string;
+    if (workflow.getConclusion) {
+      conclusion = workflow.getConclusion(payload.workflow_run.conclusion);
+    } else {
+      conclusion = payload.workflow_run.conclusion;
+    }
+
     await octokit.checks.update({
       owner,
       repo,
       check_run_id: checkRun.id,
       status: "completed",
-      conclusion: payload.workflow_run.conclusion,
+      conclusion,
       output: {
         ...output,
         text: tips,


### PR DESCRIPTION
### 📝 Description

Only display errors in `turbo` tasks.

### ❓ Context

- **Impacted projects**: `CI` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

no demo, but less output in CI

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
