### PR TITLE
Feat/LIVE-8302: return device info from hook to get latest available firmware update

### DIFF
--- a/.changeset/angry-nails-camp.md
+++ b/.changeset/angry-nails-camp.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+feat: return device info from hook to get latest available firmware update
+
+- return device info from getLatestAvailableFirmwareFromDeviceId
+- return device info from hook useGetLatestAvailableFirmware

--- a/libs/ledger-live-common/src/hw/getLatestAvailableFirmwareFromDeviceId.ts
+++ b/libs/ledger-live-common/src/hw/getLatestAvailableFirmwareFromDeviceId.ts
@@ -1,6 +1,6 @@
-import { from, Observable } from "rxjs";
+import { forkJoin, from, Observable, of } from "rxjs";
 import { mergeMap, retryWhen } from "rxjs/operators";
-import type { FirmwareUpdateContext, DeviceId } from "@ledgerhq/types-live";
+import type { FirmwareUpdateContext, DeviceId, DeviceInfo } from "@ledgerhq/types-live";
 import manager from "../manager";
 import { retryWhileErrors, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
@@ -14,6 +14,7 @@ export type GetLatestAvailableFirmwareFromDeviceIdStatus = "started" | "done";
 
 export type GetLatestAvailableFirmwareFromDeviceIdResult = {
   firmwareUpdateContext: FirmwareUpdateContext | null;
+  deviceInfo: DeviceInfo | null;
   status: GetLatestAvailableFirmwareFromDeviceIdStatus;
   lockedDevice: boolean;
 };
@@ -26,6 +27,7 @@ export type GetLatestAvailableFirmwareFromDeviceIdOutput =
  * @param deviceId A device id, or an empty string if device is usb plugged
  * @returns An Observable pushing objects containing:
  * - firmwareUpdateContext: a FirmwareUpdateContext if found, or null or undefined otherwise
+ * - deviceInfo: a DeviceInfo if found, or null otherwise (if device locked for ex)
  * - lockedDevice: a boolean set to true if the device is currently locked, false otherwise
  * - status: to notify the consumer on the state of the request
  */
@@ -39,10 +41,12 @@ export const getLatestAvailableFirmwareFromDeviceId = ({
         mergeMap(deviceInfo => {
           subscriber.next({
             firmwareUpdateContext: null,
+            deviceInfo,
             lockedDevice: false,
             status: "started",
           });
-          return from(manager.getLatestFirmwareForDevice(deviceInfo));
+
+          return forkJoin([of(deviceInfo), from(manager.getLatestFirmwareForDevice(deviceInfo))]);
         }),
       ),
     ) // Needs to retry with withDevice
@@ -52,6 +56,7 @@ export const getLatestAvailableFirmwareFromDeviceId = ({
             if (e instanceof LockedDeviceError) {
               subscriber.next({
                 firmwareUpdateContext: null,
+                deviceInfo: null,
                 lockedDevice: true,
                 status: "started",
               });
@@ -63,12 +68,14 @@ export const getLatestAvailableFirmwareFromDeviceId = ({
         ),
       )
       .subscribe({
-        next: (firmwareUpdateContext: FirmwareUpdateContext | null) =>
+        next: ([deviceInfo, firmwareUpdateContext]: [DeviceInfo, FirmwareUpdateContext | null]) => {
           subscriber.next({
             firmwareUpdateContext,
+            deviceInfo,
             status: "done",
             lockedDevice: false,
-          }),
+          });
+        },
         error: e => subscriber.error(e),
         complete: () => subscriber.complete(),
       });

--- a/libs/ledger-live-common/src/hw/hooks/useGetLatestAvailableFirmware.test.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGetLatestAvailableFirmware.test.ts
@@ -1,7 +1,8 @@
 import { of } from "rxjs";
-import { FirmwareUpdateContext } from "@ledgerhq/types-live";
+import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { renderHook, act } from "@testing-library/react-hooks";
 import { aLatestFirmwareContextBuilder } from "../../mock/fixtures/aLatestFirmwareContext";
+import { aDeviceInfoBuilder } from "../../mock/fixtures/aDeviceInfo";
 import { getLatestAvailableFirmwareFromDeviceId } from "../getLatestAvailableFirmwareFromDeviceId";
 import { useGetLatestAvailableFirmware } from "./useGetLatestAvailableFirmware";
 
@@ -14,9 +15,11 @@ const mockedGetLatestAvailableFirmwareFromDeviceId = jest.mocked(
 
 describe("useGetLatestAvailableFirmware", () => {
   let aLatestFirmwareContext: FirmwareUpdateContext;
+  let aDeviceInfo: DeviceInfo;
 
   beforeEach(() => {
     aLatestFirmwareContext = aLatestFirmwareContextBuilder();
+    aDeviceInfo = aDeviceInfoBuilder();
   });
 
   afterEach(() => {
@@ -25,10 +28,11 @@ describe("useGetLatestAvailableFirmware", () => {
   });
 
   describe("When no new firmware update is available for a device", () => {
-    it("should notify the hook consumer that there is no latest available firmware", async () => {
+    it("should notify the hook consumer that there is no latest available firmware, and returns the device info", async () => {
       mockedGetLatestAvailableFirmwareFromDeviceId.mockReturnValue(
         of({
           firmwareUpdateContext: null,
+          deviceInfo: aDeviceInfo,
           lockedDevice: false,
           status: "done",
         }),
@@ -47,14 +51,16 @@ describe("useGetLatestAvailableFirmware", () => {
       expect(result.current.status).toEqual("no-available-firmware");
       expect(result.current.error).toBeNull();
       expect(result.current.latestFirmware).toBeNull();
+      expect(result.current.deviceInfo).toEqual(aDeviceInfo);
     });
   });
 
   describe("When a new firmware update is available for a device", () => {
-    it("should notify the hook consumer that there is a new latest available firmware", async () => {
+    it("should notify the hook consumer that there is a new latest available firmware, and return the device info", async () => {
       mockedGetLatestAvailableFirmwareFromDeviceId.mockReturnValue(
         of({
           firmwareUpdateContext: aLatestFirmwareContext,
+          deviceInfo: aDeviceInfo,
           lockedDevice: false,
           status: "done",
         }),
@@ -73,6 +79,7 @@ describe("useGetLatestAvailableFirmware", () => {
       expect(result.current.status).toEqual("available-firmware");
       expect(result.current.error).toBeNull();
       expect(result.current.latestFirmware).toEqual(aLatestFirmwareContext);
+      expect(result.current.deviceInfo).toEqual(aDeviceInfo);
     });
   });
 
@@ -81,6 +88,7 @@ describe("useGetLatestAvailableFirmware", () => {
       mockedGetLatestAvailableFirmwareFromDeviceId.mockReturnValue(
         of({
           firmwareUpdateContext: null,
+          deviceInfo: null,
           lockedDevice: true,
           status: "started",
         }),
@@ -101,6 +109,7 @@ describe("useGetLatestAvailableFirmware", () => {
       expect(result.current.status).toEqual("checking");
       expect(result.current.error).toBeNull();
       expect(result.current.latestFirmware).toBeNull();
+      expect(result.current.deviceInfo).toBeNull();
     });
   });
 });

--- a/libs/ledger-live-common/src/hw/hooks/useGetLatestAvailableFirmware.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGetLatestAvailableFirmware.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { FirmwareUpdateContext, DeviceId } from "@ledgerhq/types-live";
+import type { FirmwareUpdateContext, DeviceId, DeviceInfo } from "@ledgerhq/types-live";
 import type {
   GetLatestAvailableFirmwareFromDeviceIdArgs,
   GetLatestAvailableFirmwareFromDeviceIdResult,
@@ -26,6 +26,7 @@ export type useGetLatestAvailableFirmwareArgs = {
 
 export type useGetLatestAvailableFirmwareResult = {
   latestFirmware: FirmwareUpdateContext | null;
+  deviceInfo: DeviceInfo | null;
   status: FirmwareUpdateGettingStatus;
   lockedDevice: boolean;
   error: Error | null;
@@ -39,8 +40,9 @@ export type useGetLatestAvailableFirmwareResult = {
  * @param isHookEnabled A boolean to enable (true, default value) or disable (false) the hook
  * @param deviceId A device id, or an empty string if device is usb plugged
  * @returns An object containing:
- * - latestFirmware A FirmwareUpdateContext if found, or null if still processing or no available firmware update
- * - status A FirmwareUpdateGettingStatus to notify consumer on the hook state
+ * - latestFirmware: A FirmwareUpdateContext if found, or null if still processing or no available firmware update
+ * - deviceInfo: a DeviceInfo if found, or null otherwise (if device locked for ex)
+ * - status: A FirmwareUpdateGettingStatus to notify consumer on the hook state
  * - lockedDevice: a boolean set to true if the device is currently locked, false otherwise
  * - error: any error that occurred during the process, or null
  */
@@ -51,6 +53,7 @@ export const useGetLatestAvailableFirmware = ({
 }: useGetLatestAvailableFirmwareArgs &
   useGetLatestAvailableFirmwareDependencies): useGetLatestAvailableFirmwareResult => {
   const [latestFirmware, setLatestFirmware] = useState<FirmwareUpdateContext | null>(null);
+  const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [status, setStatus] = useState<FirmwareUpdateGettingStatus>("unchecked");
   const [lockedDevice, setLockedDevice] = useState<boolean>(false);
@@ -64,11 +67,13 @@ export const useGetLatestAvailableFirmware = ({
     const sub = getLatestAvailableFirmwareFromDeviceId({ deviceId }).subscribe({
       next: ({
         firmwareUpdateContext,
+        deviceInfo,
         lockedDevice,
         status: getStatus,
       }: GetLatestAvailableFirmwareFromDeviceIdResult) => {
         // A boolean, this will not trigger a rendering if the value is the same
         setLockedDevice(lockedDevice);
+        setDeviceInfo(deviceInfo);
 
         if (getStatus === "done") {
           if (!firmwareUpdateContext) {
@@ -80,7 +85,7 @@ export const useGetLatestAvailableFirmware = ({
           }
         }
       },
-      error: (e: any) => {
+      error: (e: unknown) => {
         if (e instanceof Error) {
           setError(e);
         } else {
@@ -94,5 +99,5 @@ export const useGetLatestAvailableFirmware = ({
     };
   }, [deviceId, getLatestAvailableFirmwareFromDeviceId, isHookEnabled]);
 
-  return { latestFirmware, error, status, lockedDevice };
+  return { latestFirmware, deviceInfo, error, status, lockedDevice };
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

2 changes (necessary for https://github.com/LedgerHQ/ledger-live/pull/3887 and the same work on LLD by Olivier):
- return device info from `getLatestAvailableFirmwareFromDeviceId` (with unit tests)
- return device info from hook `useGetLatestAvailableFirmware` (with unit tests)

No breaking changes as we only added an additional property to what the hook returns, and the logic is kept the same (unit tests are making sure no logic change was made).

Also the hook is currently only used in `apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SoftwareCheckStep.tsx` which is in the sync onboarding. You can see a small demo below showing it still works correctly.

### ❓ Context

- **Impacted projects**: `live-common`
- **Linked resource(s)**: [LIVE-8302](https://ledgerhq.atlassian.net/browse/LIVE-8302)

### ✅ Checklist

- [x] **Test coverage**: unit tested
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<details>
  <summary>Demo on Android to show that nothing was broken</summary>

https://github.com/LedgerHQ/ledger-live/assets/15096913/f1adba69-18bb-4a2a-9da1-4bfc319a219b



</details>

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8302]: https://ledgerhq.atlassian.net/browse/LIVE-8302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ