### PR TITLE
ci: add renovate action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,26 @@
+name: Renovate
+
+on:
+  schedule:
+    # The "*" (#42, asterisk) character has special semantics in YAML, so this
+    # string has to be quoted.
+    - cron: "0/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_BOT_APP_ID }}
+          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v38.1.6
+        with:
+          configurationFile: renovate-config.js
+          token: "${{ steps.get_token.outputs.token }}"

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  username: "live-github-bot[bot]",
+  gitAuthor: "live-github-bot[bot] <105061298+live-github-bot[bot]@users.noreply.github.com>",
+  platform: "github",
+  allowScripts: true,
+  repositories: ["LedgerHQ/ledger-live"],
+};

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,6 @@
   "labels": ["dependencies"],
   "automerge": false,
   "detectGlobalManagerConfig": true,
-  "allowScripts": true,
   "ignoreScripts": false,
   "packageRules": [
     {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The Renovate Github App forces the configuration option `allowScripts` to false and it is not possible to change it from out side.

Because of this flag the `pnpmfile.cjs` config is ignored by Renovate when bumping dependencies which results in massive and wrong updates to the lockfile. And ultimately the build crashes because of package resolution issues 💥.

Self-hosting Renovate using the official github action should fix the problem hopefully.

### ❓ Context

- **Impacted projects**: `n/a` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `n/a` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
