### PR TITLE
[Bugfix/LIVE-8380] add 10s timeout to swap quotes on LLD & LLM

### DIFF
--- a/.changeset/tall-dots-rule.md
+++ b/.changeset/tall-dots-rule.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Add timeout and timeoutErrorMessage params to useSwapTransaction

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.tsx
@@ -63,6 +63,7 @@ import {
 import BigNumber from "bignumber.js";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { SwapSelectorStateType } from "@ledgerhq/live-common/exchange/swap/types";
+import { SWAP_RATES_TIMEOUT } from "../../config";
 
 const Wrapper = styled(Box).attrs({
   p: 20,
@@ -137,7 +138,7 @@ const SwapForm = () => {
     onNoRates,
     ...(locationState as object),
     providers: storedProviders || undefined,
-    timeout: 10000,
+    timeout: SWAP_RATES_TIMEOUT,
     timeoutErrorMessage: t("swap2.form.timeout.message"),
   });
   const exchangeRatesState = swapTransaction.swap?.rates;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.tsx
@@ -137,6 +137,8 @@ const SwapForm = () => {
     onNoRates,
     ...(locationState as object),
     providers: storedProviders || undefined,
+    timeout: 10000,
+    timeoutErrorMessage: t("swap2.form.timeout.message"),
   });
   const exchangeRatesState = swapTransaction.swap?.rates;
   const swapError = swapTransaction.fromAmountError || exchangeRatesState?.error;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/config.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/config.ts
@@ -43,3 +43,4 @@ const config = {
 };
 export const getConfig = (): Config =>
   process.env.COINIFY_SANDBOX ? config.sandbox : config.production;
+export const SWAP_RATES_TIMEOUT = 10000; // 10s

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -381,6 +381,9 @@
         "withdrawalsBlockedError": {
           "message": "Your withdrawal has been blocked by {{providerName}}.\n\n Please contact their support for more information."
         }
+      },
+      "timeout": {
+        "message": "Quotes could not be generated because of technical issues. Try swapping again in a few moments."
       }
     },
     "history": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -649,6 +649,9 @@
       "title": "Something went wrong",
       "description": "The exchange transaction did not go through. Please try again or contact support."
     },
+    "SwapTimeoutError": {
+      "title": "Quotes could not be generated because of technical issues. Try swapping again in a few moments."
+    },
     "PolkadotElectionClosed": {
       "title": "Validators election must be closed"
     },

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -143,6 +143,8 @@ export function SwapForm({
     onBeforeTransaction,
     excludeFixedRates: true,
     providers,
+    timeout: 10000,
+    timeoutErrorMessage: t("errors.SwapTimeoutError.title"),
   });
 
   const exchangeRatesState = swapTransaction.swap?.rates;

--- a/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getExchangeRates.ts
@@ -20,6 +20,8 @@ const getExchangeRates: GetExchangeRates = async (
   userId?: string, // TODO remove when wyre doesn't require this for rates
   currencyTo?: TokenCurrency | CryptoCurrency | undefined | null,
   providers: AvailableProviderV3[] = [],
+  timeout = undefined,
+  timeoutErrorMessage = undefined,
 ) => {
   if (getEnv("MOCK") && !getEnv("PLAYWRIGHT_RUN"))
     return mockGetExchangeRates(exchange, transaction, currencyTo);
@@ -48,6 +50,8 @@ const getExchangeRates: GetExchangeRates = async (
     headers: {
       ...(userId ? { userId } : {}),
     },
+    ...(timeout ? { timeout } : {}),
+    ...(timeoutErrorMessage ? { timeoutErrorMessage } : {}),
     data: request,
   });
 

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useProviderRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useProviderRates.ts
@@ -36,6 +36,8 @@ type UseProviderRates = (args: {
   onBeforeTransaction?: OnBeforeTransaction;
   setExchangeRate?: SetExchangeRateCallback | null | undefined;
   providers?: AvailableProviderV3[];
+  timeout?: number;
+  timeoutErrorMessage?: string;
 }) => {
   rates: RatesReducerState;
   refetchRates: () => void;
@@ -55,6 +57,8 @@ export const useProviderRates: UseProviderRates = ({
   onBeforeTransaction,
   setExchangeRate,
   providers,
+  timeout,
+  timeoutErrorMessage,
 }) => {
   const { account: fromAccount, parentAccount: fromParentAccount } = fromState;
   const { currency: toCurrency, parentAccount: toParentAccount, account: toAccount } = toState;
@@ -97,6 +101,8 @@ export const useProviderRates: UseProviderRates = ({
             undefined,
             toCurrency,
             providers,
+            timeout,
+            timeoutErrorMessage,
           );
 
           if (abort) return;

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -49,6 +49,8 @@ export const useSwapTransaction = ({
   onBeforeTransaction,
   excludeFixedRates,
   providers,
+  timeout,
+  timeoutErrorMessage,
 }: {
   accounts?: Account[];
   setExchangeRate?: SetExchangeRateCallback;
@@ -59,6 +61,8 @@ export const useSwapTransaction = ({
   onBeforeTransaction?: OnBeforeTransaction;
   excludeFixedRates?: boolean;
   providers?: AvailableProviderV3[];
+  timeout?: number;
+  timeoutErrorMessage?: string;
 } = {}): SwapTransactionType => {
   const bridgeTransaction = useBridgeTransaction(() => ({
     account: defaultAccount,
@@ -110,6 +114,8 @@ export const useSwapTransaction = ({
     onNoRates,
     setExchangeRate,
     providers,
+    timeout,
+    timeoutErrorMessage,
   });
 
   return {

--- a/libs/ledger-live-common/src/exchange/swap/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/types.ts
@@ -138,6 +138,8 @@ export type GetExchangeRates = (
   wyreUserId?: string,
   currencyTo?: TokenCurrency | CryptoCurrency | undefined | null,
   providers?: AvailableProviderV3[],
+  timeout?: number,
+  timeoutErrorMessage?: string,
 ) => Promise<ExchangeRate[]>;
 export type GetProviders = () => Promise<AvailableProvider[]>;
 export type InitSwapResult = {


### PR DESCRIPTION
### 📝 Description

swap service is not available
When any other error or after 10s
Then Error message: Quotes could not be generated because of technical issues. Try swapping again in a few moments. is displayed

### ❓ Context

- **Impacted projects**: `LLC, LLM, LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8380](https://ledgerhq.atlassian.net/browse/LIVE-8380) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
![Simulator Screenshot - iPhone 14 Pro - 2023-07-06 at 18 09 20](https://github.com/LedgerHQ/ledger-live/assets/132384348/2e51b85a-3f33-4272-8367-fb280bebb4a5)


https://github.com/LedgerHQ/ledger-live/assets/132384348/8c842373-f52e-4690-8844-8ec0443d62b2

28-021f-4250-a4b8-1db92342e6f0)



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-5953]: https://ledgerhq.atlassian.net/browse/LIVE-5953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-8380]: https://ledgerhq.atlassian.net/browse/LIVE-8380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ