### PR TITLE
fix: respect the sdk version from root project

### DIFF
--- a/.changeset/rare-ladybugs-worry.md
+++ b/.changeset/rare-ladybugs-worry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-native-hid": minor
+---
+
+Android use compile sdk version from root project

--- a/libs/ledgerjs/packages/react-native-hid/android/build.gradle
+++ b/libs/ledgerjs/packages/react-native-hid/android/build.gradle
@@ -20,12 +20,16 @@ allprojects {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-  compileSdkVersion 29
+  compileSdkVersion safeExtGet("compileSdkVersion", 29)
 
   defaultConfig {
-    minSdkVersion 24
-    targetSdkVersion 29
+    minSdkVersion safeExtGet("minSdkVersion", 24)
+    targetSdkVersion safeExtGet("targetSdkVersion", 29)
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
### 📝 Description

Make `@ledgerhq/react-native-hid` package agnostic of compile SDK. This allows other projects with a higher SDK to use the package. The change is implemented in a backward-compatible version, and thus should not introduce any breaking changes.

### ❓ Context

- **Impacted projects**:  `@ledgerhq/react-native-hid`

### ✅ Checklist

- [x] **Test coverage** 
- [x] **Atomic delivery** 
- [x] **No breaking changes** 