### PR TITLE
ci(llm): use proper release env for android prod builds

### DIFF
--- a/apps/ledger-live-mobile/fastlane/.env.android.release
+++ b/apps/ledger-live-mobile/fastlane/.env.android.release
@@ -1,4 +1,4 @@
-ENVFILE=.env.android.prerelease
+ENVFILE=.env.android.release
 APP_IDENTIFIER="com.ledger.live"
 MY_APP_BUNDLE_ID="com.ledger.live"
 SHORT_BUNDLE_ID="com.ledger.live"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

**Fixes prod android builds reading the `react-native-config` environment from prerelease instead of release.**

```
Reading env from: .env.android.prerelease
```

Results in sentry logs get sent to the prerelease project. 💥 

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-5386`](https://ledgerhq.atlassian.net/browse/LIVE-5386) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
