### PR TITLE
[LIVE-7445] Filter device selection to only stax when using NFT as CLS

### DIFF
--- a/.changeset/angry-poets-end.md
+++ b/.changeset/angry-poets-end.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Filter for Stax devices during the "set NFT as custom lockscreen" flow

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -29,6 +29,7 @@ import { useDebouncedRequireBluetooth } from "../RequiresBLE/hooks/useRequireBlu
 import RequiresBluetoothDrawer from "../RequiresBLE/RequiresBluetoothDrawer";
 import QueuedDrawer from "../QueuedDrawer";
 import ServicesWidget from "../ServicesWidget";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 
 export type { SetHeaderOptionsRequest };
 
@@ -56,6 +57,7 @@ type Props = {
 
   isChoiceDrawerDisplayedOnAddDevice?: boolean;
   withMyLedgerTracking?: boolean;
+  deviceModelIds?: DeviceModelId[];
 };
 
 export default function SelectDevice({
@@ -65,6 +67,7 @@ export default function SelectDevice({
   requestToSetHeaderOptions,
   isChoiceDrawerDisplayedOnAddDevice = true,
   withMyLedgerTracking,
+  deviceModelIds,
 }: Props) {
   const [USBDevice, setUSBDevice] = useState<Device | undefined>();
   const [ProxyDevice, setProxyDevice] = useState<Device | undefined>();
@@ -210,8 +213,8 @@ export default function SelectDevice({
       devices.push(ProxyDevice);
     }
 
-    return devices;
-  }, [knownDevices, scannedDevices, USBDevice, ProxyDevice]);
+    return deviceModelIds ? devices.filter(d => deviceModelIds.includes(d.modelId)) : devices;
+  }, [knownDevices, scannedDevices, USBDevice, ProxyDevice, deviceModelIds]);
 
   // update device name on store when needed
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -8,6 +8,7 @@ import { Text, Flex, Icons, Box, ScrollContainer } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useBleDevicesScanning } from "@ledgerhq/live-common/ble/hooks/useBleDevicesScanning";
 import { usePostOnboardingEntryPointVisibleOnWallet } from "@ledgerhq/live-common/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 
 import TransportBLE from "../../react-native-hw-transport-ble";
 import { TrackScreen, track } from "../../analytics";
@@ -29,7 +30,6 @@ import { useDebouncedRequireBluetooth } from "../RequiresBLE/hooks/useRequireBlu
 import RequiresBluetoothDrawer from "../RequiresBLE/RequiresBluetoothDrawer";
 import QueuedDrawer from "../QueuedDrawer";
 import ServicesWidget from "../ServicesWidget";
-import { DeviceModelId } from "@ledgerhq/types-devices";
 
 export type { SetHeaderOptionsRequest };
 

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -57,7 +57,7 @@ type Props = {
 
   isChoiceDrawerDisplayedOnAddDevice?: boolean;
   withMyLedgerTracking?: boolean;
-  deviceModelIds?: DeviceModelId[];
+  filterByDeviceModelId?: DeviceModelId;
 };
 
 export default function SelectDevice({
@@ -67,7 +67,7 @@ export default function SelectDevice({
   requestToSetHeaderOptions,
   isChoiceDrawerDisplayedOnAddDevice = true,
   withMyLedgerTracking,
-  deviceModelIds,
+  filterByDeviceModelId,
 }: Props) {
   const [USBDevice, setUSBDevice] = useState<Device | undefined>();
   const [ProxyDevice, setProxyDevice] = useState<Device | undefined>();
@@ -213,8 +213,10 @@ export default function SelectDevice({
       devices.push(ProxyDevice);
     }
 
-    return deviceModelIds ? devices.filter(d => deviceModelIds.includes(d.modelId)) : devices;
-  }, [knownDevices, scannedDevices, USBDevice, ProxyDevice, deviceModelIds]);
+    return filterByDeviceModelId
+      ? devices.filter(d => d.modelId === filterByDeviceModelId)
+      : devices;
+  }, [knownDevices, scannedDevices, USBDevice, ProxyDevice, filterByDeviceModelId]);
 
   // update device name on store when needed
   useEffect(() => {
@@ -320,6 +322,7 @@ export default function SelectDevice({
           onGoBackFromScanning={closeBlePairingFlow}
           onPairingSuccessAddToKnownDevices
           requestToSetHeaderOptions={requestToSetHeaderOptions}
+          filterByDeviceModelId={filterByDeviceModelId}
         />
       ) : (
         <Flex flex={1}>

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -150,6 +150,7 @@ const Step3Transfer = ({ route, navigation }: NavigationProps) => {
           <Flex flex={1} alignSelf="stretch">
             <SelectDevice2
               onSelect={setDevice}
+              deviceModelIds={deviceModelIds}
               stopBleScanning={!!device}
               requestToSetHeaderOptions={requestToSetHeaderOptions}
             />

--- a/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/Step3Transfer.tsx
@@ -150,7 +150,7 @@ const Step3Transfer = ({ route, navigation }: NavigationProps) => {
           <Flex flex={1} alignSelf="stretch">
             <SelectDevice2
               onSelect={setDevice}
-              deviceModelIds={deviceModelIds}
+              filterByDeviceModelId={DeviceModelId.stax}
               stopBleScanning={!!device}
               requestToSetHeaderOptions={requestToSetHeaderOptions}
             />


### PR DESCRIPTION
### 📝 Description
This PR adds a filter on the type of device to be selectable on the device selections screen. It also makes use of this filter during the NFT -> custom lock screen flow in order to restrict the selection to Stax devices. This had already been done in the old device selection screen but not yet in the new one. 

### ❓ Context
- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-7445]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/6013294/ceca7ead-6830-4192-b650-2b543d55681e




[LIVE-7445]: https://ledgerhq.atlassian.net/browse/LIVE-7445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ