### PR TITLE
[bugfix] Disable default derivation scheme for ICP, only use custom one

### DIFF
--- a/.changeset/smart-eggs-allow.md
+++ b/.changeset/smart-eggs-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Disable default derivation scheme for ICP, to use only the custom one

--- a/libs/coin-framework/src/derivation.ts
+++ b/libs/coin-framework/src/derivation.ts
@@ -360,6 +360,7 @@ const disableBIP44: Record<string, boolean> = {
   cardano: true,
   cardano_testnet: true,
   near: true,
+  internet_computer: true,
 };
 type SeedInfo = {
   purpose: number;

--- a/libs/ledger-live-common/src/families/internet_computer/bridge.integration.test.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/bridge.integration.test.ts
@@ -24,6 +24,11 @@ const internet_computer: CurrenciesData<Transaction> = {
       => 11010000142c000080df000080010000800000000000000000
       <= 04fc89df2bb2677347117b550c9a66b9a54c384dfee78a83a1e3010fd2f5ce7418f6706102bc5611094702f64773fd5569ca5e24c44b77383e58e034f521f96bafe7b69dcf5141bfb119194185a296a11aa33c986f48369fac7ec6571b0202c1bf9b7b539ad8e39cf4df4881742be4fa2c4a6b1b97c1b735972665556742706e756a7566786877326f3436756b627836797273676b627177726a6e696932756d366a7133326967327032793777676b346e71659000
       `,
+      test: (expect, accounts) => {
+        for (const account of accounts) {
+          expect(account.derivationMode).toEqual("internet_computer");
+        }
+      },
     },
   ],
   accounts: [
@@ -31,7 +36,7 @@ const internet_computer: CurrenciesData<Transaction> = {
       raw: {
         balance: "1000000",
         currencyId: "internet_computer",
-        derivationMode: "",
+        derivationMode: "internet_computer",
         freshAddress: "e8a1474afbed438be8b019c4293b9e01b33075d72757ac715183ae7c7ba77e37",
         freshAddressPath: "44'/223'/0'/0/0",
         freshAddresses: [


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

ICP, like many other chains we support, don't use the standard BIP44 derivation scheme, but a custom one
The custom scheme was defined and used however using the standard BIP44 wasn't disabled, so both were used while scanning for accounts, resulting in the bug of having two versions of each account (one being incorrect).

### ❓ Context

- **Impacted projects**: `ledger-live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8498 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/59644786/67124dfc-08f4-4406-89b3-e7a65cbf50d6


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach


<!-- If any of the expectations are not met please explain the reason in detail. -->
