### PR TITLE
[SUPPORT] remove unnecessary check on tx networkInfo

### DIFF
--- a/.changeset/thirty-pumas-sleep.md
+++ b/.changeset/thirty-pumas-sleep.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+remove unnecessary check on tx networkInfo

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.tsx
@@ -52,7 +52,7 @@ export default function FeesDrawer({
       />
       <DrawerTitle i18nKey="swap2.form.details.label.fees" />
       <Box mt={3} flow={4} mx={3}>
-        {transaction && "networkInfo" in transaction && transaction.networkInfo && mainAccount && (
+        {transaction && mainAccount && (
           <SendAmountFields
             account={mainAccount as Account}
             parentAccount={parentAccount}

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
@@ -78,14 +78,7 @@ const SectionFees = ({
   const family = mainFromAccount?.currency.family;
   const sendAmountSpecific = account && family && getLLDCoinFamily(family)?.sendAmountFields;
   const canEdit =
-    hasRates &&
-    showSummaryValue &&
-    transaction &&
-    "networkInfo" in transaction &&
-    transaction.networkInfo &&
-    account &&
-    family &&
-    sendAmountSpecific;
+    hasRates && showSummaryValue && transaction && account && family && sendAmountSpecific;
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const StrategyIcon = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/components/SendRowsFee.tsx
+++ b/apps/ledger-live-mobile/src/components/SendRowsFee.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import type { Transaction as BitcoinTransaction } from "@ledgerhq/live-common/families/bitcoin/types";
 import { CompositeScreenProps } from "@react-navigation/native";
 
 import perFamily from "../generated/SendRowsFee";
@@ -40,8 +39,7 @@ export default ({
   // eslint-disable-next-line no-prototype-builtins
   if (perFamily.hasOwnProperty(mainAccount.currency.family)) {
     const C = perFamily[mainAccount.currency.family as keyof typeof perFamily];
-    // FIXME: looks like a hack, need to find how to handle networkInfo properly
-    return (transaction as BitcoinTransaction)?.networkInfo ? (
+    return (
       <C
         {...props}
         setTransaction={setTransaction}
@@ -51,7 +49,7 @@ export default ({
         navigation={navigation}
         route={route}
       />
-    ) : null;
+    );
   }
 
   return null;

--- a/libs/ledger-live-common/src/families/solana/js-prepareTransaction.ts
+++ b/libs/ledger-live-common/src/families/solana/js-prepareTransaction.ts
@@ -110,9 +110,6 @@ const prepareTransaction = async (
     model,
   };
 
-  // LLM requires this field to be truthy to show fees
-  (patch as any).networkInfo = true;
-
   return defaultUpdateTransaction(tx, patch);
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Following this comment https://github.com/LedgerHQ/ledger-live/pull/3945#discussion_r1259334119 and the related discussion, proposal to remove what seem to be an unnecessary condition on the existence of a `networkInfo` property on the `transaction` object to render (or not) a family custom `SendRowsFee` component.

Not all crypto transaction types have a `networkInfo` property and some of them have some custom `SendRowsFee` component.
If a family `SendRowsFee` component display is dependent on the presence of a `networkInfo` property in the `transaction` object, these families own `SendRowsFee` component will never be displayed.

This condition seems odd because not all families have a `networkInfo` property in their `transaction`. For example `algorand`, but also the new `evm`. But these families have their own `SendRowsFee` component defined in their family folder. Same thing for `celo`, `polkadot`, `solana` (here we even have some hardcoded patch, cf. [this](https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledger-live-common/src/families/solana/js-prepareTransaction.ts#L113-L114)).
So, based on this logic, as of today the `SendRowsFee` for `algorand`, `celo` and `polkadot` would not be displayed.

Furthermore, we don't seem to have similar logic on LLD (cf. [here](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/renderer/modals/Send/SendAmountFields.tsx) and [here](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/SendAmountFields.tsx)) where we don't have an condition on `networkInfo`. 

The only place where I found such condition on LLD are these 2 files ([here](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.tsx#L55) and [here](https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx#L84-L85)) related to swap, which might probably be some legacy logic from original swap implementation since these 2 conditions control the display of the `SendAmountFields` file listed just above, and it would not make sense to always display this component on a normal send flow but not on a swap flow (if I can edit fees on a normal send, why could I not do it in a Swap flow?)

### ❓ Context

- **Impacted projects**: `LLM` `LLD`
- **Linked resource(s)**: https://github.com/LedgerHQ/ledger-live/pull/3945#discussion_r1259334119

### ✅ Checklist

- [ ] **Test coverage** No component testing availble on send flows 😞 Video of non regression in the demo part ⬇️
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<table>
<tr>
<th> develop </th>
<th> support/remove-unnecessary-networkInfo-check </th>
</tr>
<tr>
<td>




https://github.com/LedgerHQ/ledger-live/assets/9203826/fb30bb48-1566-4508-8e8f-30112b668b62




</td>
<td>


https://github.com/LedgerHQ/ledger-live/assets/9203826/4e646724-cdca-44e5-ab92-73afbff992b8



</td>
</tr>
</table>

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
