### PR TITLE
[LIVE-8490] Bugfix - Fix wrong `shouldSkipAmount` in LLM send flow

### DIFF
--- a/.changeset/calm-nails-report.md
+++ b/.changeset/calm-nails-report.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix wrong `shouldSkipAmount` in general send flow

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -72,7 +72,7 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
       return transaction.mode === "erc721.transfer";
     }
 
-    return true;
+    return false;
   }, [transaction]);
   const isNftSend = isNftTransaction(transaction);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Correcting typo making all chains (except EVM/Ethereum ones) skip the amount screen during send flow.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8490 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** No component testing availble on send flows 😞 Video of non regression in the demo part ⬇️ 
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/44363395/25204498-cd66-4d8e-8139-5cdf069083f8


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
