### PR TITLE
[B2CQA-1883] Update detox and fix issues

### DIFF
--- a/apps/ledger-live-mobile/e2e/models/manager/managerPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/manager/managerPage.ts
@@ -2,10 +2,11 @@ import { expect } from "detox";
 import {
   getElementById,
   openDeeplink,
+  tapByElement,
   tapByText,
   waitForElementById,
-  waitForElementByText,
 } from "../../helpers";
+import { device } from "detox";
 import * as bridge from "../../bridge/server";
 
 const baseLink = "myledger";
@@ -27,9 +28,10 @@ export default class ManagerPage {
 
   async addDevice(deviceName: string) {
     await this.expectManagerPage();
-    await this.getPairDeviceButton().tap();
+    await device.disableSynchronization(); // Scanning animation prevents launching mocks
+    await tapByElement(this.getPairDeviceButton());
     bridge.addDevices();
-    await waitForElementByText(deviceName, 3000);
+    await device.enableSynchronization();
     await tapByText(deviceName);
     bridge.setInstalledApps(); // tell LLM what apps the mock device has
     bridge.open();

--- a/apps/ledger-live-mobile/e2e/specs/onboarding.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/onboarding.spec.ts
@@ -27,10 +27,6 @@ describe("Onboarding", () => {
     await onboardingSteps.chooseToPairMyNano();
   });
 
-  it("selects Pair with Bluetooth", async () => {
-    await onboardingSteps.selectPairWithBluetooth();
-  });
-
   it("adds device via Bluetooth", async () => {
     await onboardingSteps.addDeviceViaBluetooth("David");
   });

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -239,7 +239,7 @@
     "allure-js-commons": "1.3.2",
     "babel-jest": "^28.0.0",
     "babel-plugin-module-resolver": "^4.1.0",
-    "detox": "20.7.1",
+    "detox": "^20.11.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-detox": "^1.0.0",
     "eslint-plugin-i18next": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1265,8 +1265,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       detox:
-        specifier: 20.7.1
-        version: 20.7.1(jest@28.1.3)(metro@0.76.0)
+        specifier: ^20.11.0
+        version: 20.11.0(jest@28.1.3)(metro@0.76.0)
       eslint-import-resolver-typescript:
         specifier: ^3.5.5
         version: 3.5.5(@typescript-eslint/parser@5.60.0)(eslint-plugin-import@2.27.5)(eslint@8.41.0)
@@ -30899,8 +30899,8 @@ packages:
       defined: 1.0.0
       minimist: 1.2.8
 
-  /detox@20.7.1(jest@28.1.3)(metro@0.76.0):
-    resolution: {integrity: sha512-a8y+M40g4goqWnyHZnestmVL/EII8Hq4utCK4kuSpvRHWkBA5KuQFlXErfNrrOcqXuXhPqdBnxqO9VsMAlLHFA==}
+  /detox@20.11.0(jest@28.1.3)(metro@0.76.0):
+    resolution: {integrity: sha512-01LpETlZwfo2V7Awo+5ccUbee7E1lvH3ldLlmXxsx3mQ0pEA65f9CaO+FWhtUGYh7vQRMOQ9SnzYdej/ydQ7iQ==}
     engines: {node: '>=14.5.0'}
     hasBin: true
     requiresBuild: true
@@ -31348,7 +31348,7 @@ packages:
     engines: {node: '>=0.10'}
     requiresBuild: true
     dependencies:
-      nan: 2.15.0
+      nan: 2.17.0
     dev: true
     optional: true
 
@@ -44865,7 +44865,6 @@ packages:
   /nan@2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /nano-json-stream-parser@0.1.2:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Updating Detox to latest version [2.11.0](https://github.com/wix/Detox/releases/tag/20.11.0)_
On this version, synchronisation with reanimated animation is [fixed](https://github.com/wix-incubator/DetoxSync/pull/59), causing test to [halt](https://wix.github.io/Detox/docs/troubleshooting/synchronization/#endless-looping-animations) on scanning page animation, preventing mock devices to be added. Disabling [synchronisation](https://wix.github.io/Detox/docs/troubleshooting/synchronization/#controlling-the-entire-synchronization-mechanism) temporarily during these tests to fix this issue.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
