### PR TITLE
fix(LIVE-8530): quotes are not readable in light mode

### DIFF
--- a/.changeset/new-planets-raise.md
+++ b/.changeset/new-planets-raise.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+quotes are not readable in light mode

--- a/apps/ledger-live-desktop/src/renderer/components/Price.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Price.tsx
@@ -67,7 +67,10 @@ export default function Price({
     ? BigNumber(rawCounterValue)
     : rawCounterValue;
   const theme = useTheme();
-  const textColor = useMemo(() => color ?? theme.colors.palette.text.shade100, [color, theme]);
+  const textColor = useMemo(
+    () => (color ? colors[color] : theme.colors.palette.text.shade100),
+    [color, theme],
+  );
   const bgColor = theme.colors.palette.background.paper;
   const activityColor = useMemo(
     () =>

--- a/apps/ledger-live-desktop/src/renderer/components/Price.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Price.tsx
@@ -66,23 +66,25 @@ export default function Price({
     : typeof rawCounterValue === "number"
     ? BigNumber(rawCounterValue)
     : rawCounterValue;
-  const bgColor = useTheme().colors.palette.background.paper;
+  const theme = useTheme();
+  const textColor = useMemo(() => color ?? theme.colors.palette.text.shade100, [color, theme]);
+  const bgColor = theme.colors.palette.background.paper;
   const activityColor = useMemo(
     () =>
       withActivityColor
         ? colors[withActivityColor]
         : !withActivityCurrencyColor
-        ? color
-          ? colors[color]
+        ? textColor
+          ? textColor
           : undefined
         : getCurrencyColor(from, bgColor),
-    [bgColor, color, from, withActivityColor, withActivityCurrencyColor],
+    [bgColor, textColor, from, withActivityColor, withActivityCurrencyColor],
   );
   if (!counterValue || counterValue.isZero())
     return <NoCountervaluePlaceholder placeholder={placeholder} />;
   const subMagnitude = counterValue.lt(1) || showAllDigits ? 1 : 0;
   return (
-    <PriceWrapper color={color} fontSize={fontSize} fontWeight={fontWeight}>
+    <PriceWrapper color={textColor} fontSize={fontSize} fontWeight={fontWeight}>
       {withIcon ? (
         <IconActivity
           size={iconSize || 12}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Swap quotes are not readable in light mode. `Price` component has an optional `color` prop which determines the text color. If value is not provided text color seemed to be defaulted to white. 

Code changes to use `theme.colors.palette.text.shade100` as default value the `color` is not provided.

### ❓ Context

- **Impacted projects**: `LLD` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8530 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

<img width="1303" alt="Screenshot 2023-07-14 at 09 28 03" src="https://github.com/LedgerHQ/ledger-live/assets/138497251/ea963e49-1a3d-445f-a374-36f8d9076eac">
<img width="1303" alt="Screenshot 2023-07-14 at 09 28 17" src="https://github.com/LedgerHQ/ledger-live/assets/138497251/f0f61897-1f76-40bd-954b-f841712ae60e">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
