### PR TITLE
chore: fix windows git crashing on generate screenshots

### DIFF
--- a/tools/actions/composites/update-snapshots-desktop/action.yml
+++ b/tools/actions/composites/update-snapshots-desktop/action.yml
@@ -35,32 +35,16 @@ runs:
         echo ${{ steps.status.outputs.status }}
         echo "changes=$(git status -s)"
       shell: bash
-    - name: Commit snapshots (Linux | macOS)
-      if: steps.status.outputs.status != 0
+    - name: Commit snapshots
+      if: steps.status.outputs.status != 0 || steps.status-windows.outputs.status != 0
       run: |
         git add ./apps/ledger-live-desktop/tests/specs &&
-        git commit -m "test(lld): update screenshots (${{ inputs.os }})
-
-        ${{ steps.changes.outputs.changes }}
-        lld, test, screenshot" &&
+        git commit -m "test(lld): update screenshots (${{ inputs.os }}) ${{ steps.changes.outputs.changes }} lld, test, screenshot" &&
         git restore . &&
         git pull --rebase &&
         git push ||
         echo ""
       shell: bash
-    - name: Commit snapshots (Windows)
-      if: steps.status-windows.outputs.status != 0
-      run: |
-        git add ./apps/ledger-live-desktop/tests/specs &&
-        git commit -m "test(lld): update screenshots (${{ inputs.os }})
-
-        ${{ steps.changes.outputs.changes }}
-        lld, test, screenshot" &&
-        git restore . &&
-        git pull --rebase &&
-        git push ||
-        echo ""
-      shell: pwsh
     - name: Upload playwright results [On Failure]
       uses: actions/upload-artifact@v3
       if: failure() && !cancelled()


### PR DESCRIPTION
### 📝 Description

Windows was crashing when generating screenshots yet having no new screenshots to add (powershell specifities yay)
This hopefully will fix it.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
