### PR TITLE
feat: use transparent background on nft viewer screen

### DIFF
--- a/.changeset/modern-pandas-run.md
+++ b/.changeset/modern-pandas-run.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+use transparent background on nft viewer screen

--- a/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
@@ -6,6 +6,7 @@ import { Theme, withTheme } from "../../colors";
 import Skeleton from "../Skeleton";
 import NftImage from "./NftImage";
 import { TouchableOpacity } from "react-native-gesture-handler";
+import { Text } from "@ledgerhq/native-ui";
 
 const isAndroid = Platform.OS === "android";
 
@@ -22,6 +23,7 @@ type Props = {
 class NftVideo extends React.PureComponent<Props> {
   state = {
     isPosterMode: false,
+    loaded: false,
   };
 
   opacityAnim = new Animated.Value(0);
@@ -37,23 +39,25 @@ class NftVideo extends React.PureComponent<Props> {
   };
 
   onError = () => {
-    this.setState({ isPosterMode: true });
+    this.setState({ ...this.state, isPosterMode: true });
     this.startAnimation();
   };
 
   onLoad = (onLoadEvent: OnLoadData) => {
     if (!onLoadEvent?.duration) {
       this.onError();
+    } else {
+      this.setState({ ...this.state, loaded: true });
     }
   };
 
   render() {
-    const { style, src, colors, resizeMode = "cover", srcFallback, children } = this.props;
+    const { style, src, resizeMode = "cover", srcFallback, children } = this.props;
     const { isPosterMode } = this.state;
 
     return (
       <View style={[style, styles.root]}>
-        <Skeleton style={styles.skeleton} loading={true} />
+        <Skeleton style={styles.skeleton} loading={!this.state.loaded} />
         <Animated.View
           style={[
             styles.imageContainer,
@@ -63,7 +67,12 @@ class NftVideo extends React.PureComponent<Props> {
           ]}
         >
           {isPosterMode ? (
-            <NftImage {...this.props} status="loaded" src={srcFallback} />
+            <NftImage
+              {...this.props}
+              status="loaded"
+              style={styles.videoContainer}
+              src={srcFallback}
+            />
           ) : (
             <TouchableOpacity
               // Android video doesn't seem to support fullscreen without a custom
@@ -80,12 +89,7 @@ class NftVideo extends React.PureComponent<Props> {
                 ref={ref => {
                   this.videoRef = ref;
                 }}
-                style={[
-                  styles.video,
-                  {
-                    backgroundColor: colors.white,
-                  },
-                ]}
+                style={styles.video}
                 resizeMode={resizeMode}
                 source={{
                   uri: src,

--- a/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
@@ -18,6 +18,7 @@ type Props = {
   resizeMode?: VideoProperties["resizeMode"] & ResizeMode;
   colors: Theme["colors"];
   children?: React.ReactNode | null;
+  transparency?: boolean;
 };
 
 class NftVideo extends React.PureComponent<Props> {
@@ -39,7 +40,7 @@ class NftVideo extends React.PureComponent<Props> {
   };
 
   onError = () => {
-    this.setState({ ...this.state, isPosterMode: true });
+    this.setState({ ...this.state, loaded: true, isPosterMode: true });
     this.startAnimation();
   };
 
@@ -52,7 +53,15 @@ class NftVideo extends React.PureComponent<Props> {
   };
 
   render() {
-    const { style, src, resizeMode = "cover", srcFallback, children } = this.props;
+    const {
+      style,
+      src,
+      colors,
+      transparency,
+      resizeMode = "cover",
+      srcFallback,
+      children,
+    } = this.props;
     const { isPosterMode } = this.state;
 
     return (
@@ -84,7 +93,14 @@ class NftVideo extends React.PureComponent<Props> {
                 ref={ref => {
                   this.videoRef = ref;
                 }}
-                style={styles.video}
+                style={[
+                  styles.video,
+                  !transparency
+                    ? {
+                        backgroundColor: colors.white,
+                      }
+                    : {},
+                ]}
                 resizeMode={resizeMode}
                 source={{
                   uri: src,

--- a/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
@@ -6,7 +6,6 @@ import { Theme, withTheme } from "../../colors";
 import Skeleton from "../Skeleton";
 import NftImage from "./NftImage";
 import { TouchableOpacity } from "react-native-gesture-handler";
-import { Text } from "@ledgerhq/native-ui";
 
 const isAndroid = Platform.OS === "android";
 

--- a/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftVideo.tsx
@@ -67,12 +67,7 @@ class NftVideo extends React.PureComponent<Props> {
           ]}
         >
           {isPosterMode ? (
-            <NftImage
-              {...this.props}
-              status="loaded"
-              style={styles.videoContainer}
-              src={srcFallback}
-            />
+            <NftImage {...this.props} status="loaded" src={srcFallback} />
           ) : (
             <TouchableOpacity
               // Android video doesn't seem to support fullscreen without a custom

--- a/apps/ledger-live-mobile/src/components/Nft/NftViewer.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftViewer.tsx
@@ -512,9 +512,6 @@ const styles = StyleSheet.create({
   },
   imageContainer: {
     ...Platform.select({
-      android: {
-        elevation: 1,
-      },
       ios: {
         shadowOpacity: 0.2,
         shadowRadius: 14,

--- a/apps/ledger-live-mobile/src/components/Nft/NftViewer.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftViewer.tsx
@@ -281,6 +281,7 @@ const NftViewer = ({ route }: Props) => {
     () => (
       <>
         <NftMedia
+          transparency={true}
           resizeMode="contain"
           style={styles.image}
           metadata={nftMetadata}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Use a transparent background on the NFT image on the NFT Viewer screen to remove the "letter boxing"

### ❓ Context

- **Impacted projects**: `live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-8549` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/1044686/45a7c409-0412-41f2-9cd0-1d2c0c182287


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
