### PR TITLE
BACK-5411: disable dynamic CAL pipelines

### DIFF
--- a/.changeset/young-pumas-train.md
+++ b/.changeset/young-pumas-train.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+Disable dynamic CAL CDN workflows, now handled in CAL repository

--- a/.github/workflows/cal-importer-stg.yml
+++ b/.github/workflows/cal-importer-stg.yml
@@ -1,11 +1,6 @@
 name: "Dynamic cal importer ERC20 - [Staging]"
 on:
-  schedule:
-    - cron: 0 7 * * *
   workflow_dispatch:
-  push:
-    branches:
-      - feat/LIVE-2174-dynamic-cal
 
 concurrency:
   group: bot-dyn-cal

--- a/.github/workflows/cal-importer.yml
+++ b/.github/workflows/cal-importer.yml
@@ -1,11 +1,6 @@
 name: "Dynamic cal importer ERC20"
 on:
-  schedule:
-    - cron: 0 7 * * *
   workflow_dispatch:
-  push:
-    branches:
-      - feat/LIVE-2174-dynamic-cal
 
 concurrency:
   group: bot-dyn-cal


### PR DESCRIPTION
### 📝 Description

This disables the dynamic CAL CDN workflows, which are handled in the LedgerHQ/crypto-assets repository: LedgerHQ/crypto-assets#805

The workflows are temporarily kept so we can trigger them in case anything is wrong with the transition.

### ❓ Context

- **Impacted projects**: `@ledgerhq/cryptoassets`
- **Linked resource(s)**: [BACK-5411](https://ledgerhq.atlassian.net/browse/BACK-5411)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

CDN contents should not change, eg https://cdn.live.ledger.com/cryptoassets/evm/1/erc20.json

[BACK-5411]: https://ledgerhq.atlassian.net/browse/BACK-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ