### PR TITLE
[LIVE-8528] Add retry mechanism for app restoration errors during FW update

### DIFF
--- a/.changeset/chatty-horses-compare.md
+++ b/.changeset/chatty-horses-compare.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add automatic retry mechanism for app installation operations

--- a/.changeset/giant-pumpkins-study.md
+++ b/.changeset/giant-pumpkins-study.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add retry policy to app install operation.

--- a/.changeset/giant-pumpkins-study.md
+++ b/.changeset/giant-pumpkins-study.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/live-common": patch
----
-
-Add retry policy to app install operation.

--- a/.changeset/shiny-days-worry.md
+++ b/.changeset/shiny-days-worry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add manual retry mechanism for app restoration errors during the firmware update

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -457,7 +457,92 @@ export const FirmwareUpdate = ({
   ]);
 
   const deviceInteractionDisplay = useMemo(() => {
-    const error = updateActionState.error;
+    if (deviceLockedOrUnresponsive || hasReconnectErrors) {
+      return (
+        <Flex>
+          {renderConnectYourDevice({
+            t,
+            device,
+            theme,
+            fullScreen: false,
+          })}
+          <Button type="main" outline={false} onPress={retryCurrentStep} mt={6} alignSelf="stretch">
+            {t("common.retry")}
+          </Button>
+          <Button type="default" outline={false} onPress={quitUpdate} mt={6}>
+            {t("FirmwareUpdate.quitUpdate")}
+          </Button>
+        </Flex>
+      );
+    }
+
+    if (staxLoadImageState.imageLoadRequested) {
+      return renderImageLoadRequested({
+        t,
+        device,
+        fullScreen: false,
+        wording: t("FirmwareUpdate.steps.restoreSettings.imageLoadRequested", {
+          deviceName: productName,
+        }),
+      });
+    }
+
+    if (staxLoadImageState.imageCommitRequested) {
+      return renderImageCommitRequested({
+        t,
+        device,
+        fullScreen: false,
+        wording: t("FirmwareUpdate.steps.restoreSettings.imageCommitRequested", {
+          deviceName: productName,
+        }),
+      });
+    }
+
+    if (restoreAppsState.allowManagerRequestedWording) {
+      return (
+        <AllowManager
+          device={device}
+          wording={t("FirmwareUpdate.steps.restoreSettings.allowAppsRestoration", {
+            deviceName: productName,
+          })}
+        />
+      );
+    }
+
+    if (connectManagerState.allowManagerRequestedWording) {
+      return <AllowManager device={device} wording={t("DeviceAction.allowSecureConnection")} />;
+    }
+
+    if (installLanguageState.languageInstallationRequested) {
+      return renderAllowLanguageInstallation({
+        t,
+        device,
+        theme,
+        fullScreen: false,
+        wording: t("FirmwareUpdate.steps.restoreSettings.allowLanguageInstallation", {
+          deviceName: productName,
+        }),
+      });
+    }
+
+    if (restoreStepDeniedError) {
+      return (
+        <RestoreStepDenied
+          device={device}
+          onPressRetry={retryCurrentStep}
+          onPressSkip={skipCurrentRestoreStep}
+          stepDeniedError={restoreStepDeniedError}
+          t={t}
+        />
+      );
+    }
+
+    const error =
+      updateActionState.error ??
+      restoreAppsState.error ??
+      installLanguageState.error ??
+      staxLoadImageState.error ??
+      staxFetchImageState.error;
 
     // a TransportRaceCondition error is to be expected since we chain multiple
     // device actions that use different transport acquisition paradigms
@@ -545,108 +630,32 @@ export const FirmwareUpdate = ({
         break;
     }
 
-    if (deviceLockedOrUnresponsive || hasReconnectErrors) {
-      return (
-        <Flex>
-          {renderConnectYourDevice({
-            t,
-            device,
-            theme,
-            fullScreen: false,
-          })}
-          <Button type="main" outline={false} onPress={retryCurrentStep} mt={6} alignSelf="stretch">
-            {t("common.retry")}
-          </Button>
-          <Button type="default" outline={false} onPress={quitUpdate} mt={6}>
-            {t("FirmwareUpdate.quitUpdate")}
-          </Button>
-        </Flex>
-      );
-    }
-
-    if (staxLoadImageState.imageLoadRequested) {
-      return renderImageLoadRequested({
-        t,
-        device,
-        fullScreen: false,
-        wording: t("FirmwareUpdate.steps.restoreSettings.imageLoadRequested", {
-          deviceName: productName,
-        }),
-      });
-    }
-
-    if (staxLoadImageState.imageCommitRequested) {
-      return renderImageCommitRequested({
-        t,
-        device,
-        fullScreen: false,
-        wording: t("FirmwareUpdate.steps.restoreSettings.imageCommitRequested", {
-          deviceName: productName,
-        }),
-      });
-    }
-
-    if (restoreAppsState.allowManagerRequestedWording) {
-      return (
-        <AllowManager
-          device={device}
-          wording={t("FirmwareUpdate.steps.restoreSettings.allowAppsRestoration", {
-            deviceName: productName,
-          })}
-        />
-      );
-    }
-
-    if (connectManagerState.allowManagerRequestedWording) {
-      return <AllowManager device={device} wording={t("DeviceAction.allowSecureConnection")} />;
-    }
-
-    if (installLanguageState.languageInstallationRequested) {
-      return renderAllowLanguageInstallation({
-        t,
-        device,
-        theme,
-        fullScreen: false,
-        wording: t("FirmwareUpdate.steps.restoreSettings.allowLanguageInstallation", {
-          deviceName: productName,
-        }),
-      });
-    }
-
-    if (restoreStepDeniedError) {
-      return (
-        <RestoreStepDenied
-          device={device}
-          onPressRetry={retryCurrentStep}
-          onPressSkip={skipCurrentRestoreStep}
-          stepDeniedError={restoreStepDeniedError}
-          t={t}
-        />
-      );
-    }
-
     return undefined;
   }, [
-    updateActionState.error,
-    updateActionState.step,
-    updateActionState.progress,
     deviceLockedOrUnresponsive,
     hasReconnectErrors,
     staxLoadImageState.imageLoadRequested,
     staxLoadImageState.imageCommitRequested,
+    staxLoadImageState.error,
     restoreAppsState.allowManagerRequestedWording,
     connectManagerState.allowManagerRequestedWording,
+    restoreAppsState.error,
     installLanguageState.languageInstallationRequested,
+    installLanguageState.error,
     restoreStepDeniedError,
-    device,
+    updateActionState.error,
+    updateActionState.step,
+    updateActionState.progress,
+    staxFetchImageState.error,
     t,
+    device,
+    theme,
     retryCurrentStep,
     quitUpdate,
-    firmwareUpdateContext.final.name,
-    firmwareUpdateContext.shouldFlashMCU,
-    theme,
     productName,
     skipCurrentRestoreStep,
+    firmwareUpdateContext.final.name,
+    firmwareUpdateContext.shouldFlashMCU,
   ]);
 
   return (

--- a/libs/ledger-live-common/src/hw/installApp.ts
+++ b/libs/ledger-live-common/src/hw/installApp.ts
@@ -5,6 +5,11 @@ import Transport from "@ledgerhq/hw-transport";
 import type { ApplicationVersion, App } from "@ledgerhq/types-live";
 import ManagerAPI from "../manager/api";
 import { getDependencies } from "../apps/polyfill";
+import { retryWithDelay } from "../rxjs/operators/retryWithDelay";
+
+const APP_INSTALL_RETRY_DELAY = 500;
+const APP_INSTALL_RETRY_LIMIT = 5;
+
 export default function installApp(
   transport: Transport,
   targetId: string | number,
@@ -20,6 +25,7 @@ export default function installApp(
     firmwareKey: app.firmware_key,
     hash: app.hash,
   }).pipe(
+    retryWithDelay(APP_INSTALL_RETRY_DELAY, APP_INSTALL_RETRY_LIMIT),
     filter((e: any) => e.type === "bulk-progress"), // only bulk progress interests the UI
     throttleTime(100), // throttle to only emit 10 event/s max, to not spam the UI
     map((e: any) => ({


### PR DESCRIPTION
### 📝 Description
This PR adds two improvements to improve User Experience in case an error happens during the app restoration phase of a firmware update. 

The first is an automatic retry mechanism in the app installation operation in order to recover from quick transient errors (e.g. errors that might happen due to an unstable network).

The second one is a manual retry mechanism in case the app restoration fails to recover automatically. It works using the same manual retry mechanism as the other restoration phases of the firmware update. 

### ❓ Context
- **Impacted projects**: `ledger-live-common`,`ledger-live-mobile`
- **Linked resource(s)**: [LIVE-8528]

### ✅ Checklist

- [ ] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/6013294/f4afbc16-dfdc-414e-a796-aef76b87d0b2



### 🚀 Expectations to reach
Test plan:
The part concerning the automatic recovery might be hard to test. But in theory, one could disable and re-enabe their network so the first try fails but a subsequent one succeeds. In this case, no drawer will appear indicating any error and the installation will continue seamlessly.

The part concerning the manual retry is easier to test. First you need to disable the network data until an error drawer appears during the app installation, then you can re-enable the network and click on the retry button. Live will take some time to realize which apps have already been installed, but it should continue where it stopped and not reinstall already installed apps. Note that if you disable the network in the middle of an app installation, the installation will still work, since by the time the installation begins we have already downloaded all the data needed from the network, so you'll need to wait until the next app starts being installed to see any errors (see the demo video).

[LIVE-8528]: https://ledgerhq.atlassian.net/browse/LIVE-8528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ