### PR TITLE
fix: update color of close icon on base modal

### DIFF
--- a/.changeset/yellow-bananas-impress.md
+++ b/.changeset/yellow-bananas-impress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Update color passed to close icon in base modal

--- a/libs/ui/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
+++ b/libs/ui/packages/native/src/components/Layout/Modals/BaseModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import ReactNativeModal, { ModalProps } from "react-native-modal";
-import styled from "styled-components/native";
+import styled, { useTheme } from "styled-components/native";
 import { StyleProp, ViewStyle } from "react-native";
 
 import sizes from "../../../../helpers/getDeviceSize";
@@ -115,10 +115,11 @@ export function ModalHeader({
 export function ModalHeaderCloseButton({
   onClose,
 }: Pick<BaseModalProps, "onClose">): React.ReactElement {
+  const { colors } = useTheme();
   return (
     <CloseContainer>
       <ClosePressableExtendedBounds onPress={onClose}>
-        <Close color="neutral.c100" size="S" />
+        <Close color={colors.neutral.c100} size="S" />
       </ClosePressableExtendedBounds>
     </CloseContainer>
   );


### PR DESCRIPTION
### 📝 Description

* With a [change in Icons on native and react ui libraries](https://github.com/LedgerHQ/ledger-live/pull/4091) there was a small bug introduced where the string `neutral.c100` was no longer recognised. This PR will get the color from the `useTheme` hooks and pass it into the Icon component.

### ❓ Context

- **Impacted projects**: `UI` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
