### PR TITLE
fix(UI/IconsUI): Fixed new icon pack unable to use theme colors

### DIFF
--- a/.changeset/red-humans-appear.md
+++ b/.changeset/red-humans-appear.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/icons-ui": patch
+---
+
+Fixed color issue on new icon pack (Theme colors not working)

--- a/libs/ui/packages/icons/scripts/build.js
+++ b/libs/ui/packages/icons/scripts/build.js
@@ -1,5 +1,3 @@
-//used to build legacy icons - to be deprecated
-
 const fs = require("fs");
 const path = require("path");
 const glob = require("glob");
@@ -62,8 +60,8 @@ import { system } from "styled-system";
 
 export default styled.svg\`
   \${system({
-    fill: {
-      property: "fill",
+    color: {
+      property: "color",
       scale: "colors",
     }
   })}
@@ -76,8 +74,8 @@ import { system } from "styled-system";
 import Svg, { SvgProps } from "react-native-svg";
 
 const fillSystem = system({
-  fill: {
-    property: "fill",
+  color: {
+    property: "color",
     scale: "colors",
   },
 });
@@ -136,7 +134,7 @@ function reactNativeTemplate(
     ${sizeInterface}
 
     const availableSizes: AvailableSizes = ${JSON.stringify(availableSizes)}
-    
+
     function ${componentName} ({ size = "M", color = "neutral.c100", style }: Props): JSX.Element {
         const strokeWidth = availableSizes[size]?.stroke
         const appliedSize = availableSizes[size]?.size
@@ -184,8 +182,8 @@ const convert = (svg, options, componentName, outputFile) => {
     .then(result => {
       let component = result.replace("xlinkHref=", "href=").replace("import Svg,", "import ");
 
-      component = component.replace(/fill="white"/g, "fill={color}");
-      component = component.replace(/stroke="white"/g, "stroke={color}");
+      component = component.replace(/fill="white"/g, 'fill="currentColor"');
+      component = component.replace(/stroke="white"/g, 'stroke="currentColor"');
       component = component.replace(/<path/g, '<path vector-effect="non-scaling-stroke"');
       component = component.replace(/<Path/g, '<Path vector-effect="non-scaling-stroke"');
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixed design system icons, inability to set theme colors to design system

### ❓ Context

- **Impacted projects**: IconsUI
- **Linked resource(s)**: none

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/39890664/1540023c-dbc9-4e89-af86-6ffc2b7d6e9c


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
