### PR TITLE
[LIVE-8640] in app changelog for firmware updates

### DIFF
--- a/.changeset/big-ads-boil.md
+++ b/.changeset/big-ads-boil.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add in-app changelog for Firmware Updates

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4137,7 +4137,9 @@
   },
   "FirmwareUpdate": {
     "title": "Update firmware",
+    "beginUpdate": "Begin update",
     "updateDevice": "{{deviceName}} OS Update",
+    "releaseNotesTitle": "What's in this OS update?",
     "updateDone": "All done! Your {{deviceName}} is up to date",
     "updateDoneDescription": "New OS Version: {{firmwareVersion}}",
     "preparing": "Preparing the firmware update, please keep your device awake and connected. We will notify you of the progress",

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, Text } from "@ledgerhq/native-ui";
+import { Flex, Text } from "@ledgerhq/native-ui";
 import React from "react";
 import Button from "../../components/wrappedUi/Button";
 import SafeMarkdown from "../../components/SafeMarkdown";

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
@@ -1,0 +1,33 @@
+import { Divider, Flex, Text } from "@ledgerhq/native-ui";
+import React from "react";
+import Button from "../../components/wrappedUi/Button";
+import SafeMarkdown from "../../components/SafeMarkdown";
+import { useTranslation } from "react-i18next";
+import { ScrollView } from "react-native";
+
+type UpdateReleaseNotesProps = {
+  firmwareNotes?: string | null;
+  onContinue: () => void;
+};
+const UpdateReleaseNotes: React.FC<UpdateReleaseNotesProps> = ({ onContinue, firmwareNotes }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Flex flex={1} px={7} pb={7}>
+      <ScrollView persistentScrollbar>
+        <Flex px={3}>
+          <Text variant="h4" fontWeight="semiBold" mb={4}>
+            {t("FirmwareUpdate.releaseNotesTitle")}
+          </Text>
+          {firmwareNotes ? <SafeMarkdown markdown={firmwareNotes} /> : null}
+        </Flex>
+      </ScrollView>
+      <Divider />
+      <Button onPress={onContinue} type="main">
+        {t("FirmwareUpdate.beginUpdate")}
+      </Button>
+    </Flex>
+  );
+};
+
+export default UpdateReleaseNotes;

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
@@ -22,7 +22,6 @@ const UpdateReleaseNotes: React.FC<UpdateReleaseNotesProps> = ({ onContinue, fir
           {firmwareNotes ? <SafeMarkdown markdown={firmwareNotes} /> : null}
         </Flex>
       </ScrollView>
-      <Divider />
       <Button onPress={onContinue} type="main">
         {t("FirmwareUpdate.beginUpdate")}
       </Button>

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -50,6 +50,7 @@ import { ImageSourceContext } from "../../components/CustomImage/StaxFramedImage
 import Button from "../../components/wrappedUi/Button";
 import Link from "../../components/wrappedUi/Link";
 import { RestoreStepDenied } from "./RestoreStepDenied";
+import UpdateReleaseNotes from "./UpdateReleaseNotes";
 
 type FirmwareUpdateProps = {
   device: Device;
@@ -152,6 +153,7 @@ export const FirmwareUpdate = ({
   const [fullUpdateComplete, setFullUpdateComplete] = useState(false);
 
   const {
+    startUpdate,
     connectManagerState,
     updateActionState,
     updateStep,
@@ -660,7 +662,12 @@ export const FirmwareUpdate = ({
 
   return (
     <>
-      {fullUpdateComplete ? (
+      {updateStep === "start" ? (
+        <UpdateReleaseNotes
+          onContinue={startUpdate}
+          firmwareNotes={firmwareUpdateContext.osu?.notes}
+        />
+      ) : fullUpdateComplete ? (
         <Flex flex={1} px={7} pb={7}>
           <TrackScreen category={`${productName} OS successfully updated`} />
           <Flex flex={1} justifyContent="center" alignItems="center">

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -203,9 +203,6 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     let unrecoverableError;
 
     switch (updateStep) {
-      case "start":
-        proceedToAppsBackup();
-        break;
       case "appsBackup":
         unrecoverableError =
           connectManagerState.error &&
@@ -416,6 +413,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
   }, [updateStep, proceedToImageRestore, proceedToAppsRestore, proceedToUpdateCompleted]);
 
   return {
+    startUpdate: proceedToAppsBackup,
     updateStep,
     connectManagerState,
     staxFetchImageState,


### PR DESCRIPTION
### 📝 Description
This PR adds the changelog of the firmware update as an intermediary screen before the firmware update. Now the update only starts once the user clicks in the "Begin Update" button.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-8640]

### ✅ Checklist

- [N/A] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/6013294/95010980-944f-4d40-9655-9da6c37a0577


[LIVE-8640]: https://ledgerhq.atlassian.net/browse/LIVE-8640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ