### PR TITLE
bugfix(protect-2273): recover wording error device seeded

### DIFF
--- a/.changeset/healthy-suns-refuse.md
+++ b/.changeset/healthy-suns-refuse.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+add generic error and add error screen recover device already seeded

--- a/.changeset/metal-brooms-deny.md
+++ b/.changeset/metal-brooms-deny.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+change wording error device already seeded on recover onboarding

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -57,6 +57,8 @@ import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import DeviceIllustration from "~/renderer/components/DeviceIllustration";
 import FramedImage from "../CustomImage/FramedImage";
 import { Account } from "@ledgerhq/types-live";
+import LinkWithExternalIcon from "../LinkWithExternalIcon";
+import { openURL } from "~/renderer/linking";
 
 export const AnimationWrapper = styled.div`
   width: 600px;
@@ -625,6 +627,7 @@ export const renderError = ({
   withExportLogs,
   list,
   supportLink,
+  buyLedger,
   warning,
   info,
   managerAppName,
@@ -640,6 +643,7 @@ export const renderError = ({
   withExportLogs?: boolean;
   list?: boolean;
   supportLink?: string;
+  buyLedger?: string;
   warning?: boolean;
   info?: boolean;
   managerAppName?: string;
@@ -708,6 +712,12 @@ export const renderError = ({
               </Button>
             ) : null}
             {withOnboardingCTA ? <OpenOnboardingBtn /> : null}
+            {buyLedger ? (
+              <LinkWithExternalIcon
+                label={t("common.buyLedger")}
+                onClick={() => openURL(buyLedger)}
+              />
+            ) : null}
           </>
         )}
       </ButtonContainer>

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { Flex, Text } from "@ledgerhq/react-ui";
-import { DeviceOnboarded } from "@ledgerhq/live-common/errors";
+import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import OnboardingNavHeader from "../Onboarding/OnboardingNavHeader";
@@ -20,6 +20,8 @@ import {
 } from "@ledgerhq/live-common/hw/extractOnboardingState";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { renderError } from "../DeviceAction/rendering";
+import { urls } from "~/config/urls";
+import { languageSelector } from "~/renderer/reducers/settings";
 
 const RecoverRestore = () => {
   const { t } = useTranslation();
@@ -28,6 +30,7 @@ const RecoverRestore = () => {
   const [state, setState] = useState<OnboardingState>();
   const [error, setError] = useState<Error>();
   const { setDeviceModelId } = useContext(OnboardingContext);
+  const locale = useSelector(languageSelector) || "en";
 
   // check if device is seeded when selected
   useEffect(() => {
@@ -88,8 +91,11 @@ const RecoverRestore = () => {
           <OnboardingNavHeader onClickPrevious={() => history.push("/onboarding/select-device")} />
           {renderError({
             t,
-            error: new DeviceOnboarded(t("errors.DeviceAlreadySetup.title")),
-            device: currentDevice,
+            error: new DeviceAlreadySetup("", { device: currentDevice?.modelId ?? "device" }),
+            buyLedger:
+              urls.noDevice.buyNew[
+                locale in urls.terms ? (locale as keyof typeof urls.noDevice.buyNew) : "en"
+              ],
           })}
         </Flex>
       </Flex>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -142,7 +142,8 @@
     "connectDevice": "Connect your device",
     "add": "Add",
     "or": "OR",
-    "clearAll": "Clear all"
+    "clearAll": "Clear all",
+    "buyLedger": "Buy a Ledger"
   },
   "devices": {
     "nanoS": "Nano S",
@@ -5145,8 +5146,8 @@
       "description": "This crypto asset is not yet supported. Please contact Ledger Support."
     },
     "DeviceAlreadySetup": {
-      "title": "Your device is already setup with a Secret Recovery Phrase",
-      "description": null
+      "title": "Your {{device}} is already setup with a Secret Recovery Phrase",
+      "description": "Connect a Ledger that's not set up."
     },
     "DeviceNotGenuine": {
       "title": "Possibly not genuine",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5145,7 +5145,8 @@
       "description": "This crypto asset is not yet supported. Please contact Ledger Support."
     },
     "DeviceAlreadySetup": {
-      "title": "Your device is already setup with a Secret Recover Phrase"
+      "title": "Your device is already set up with a Secret Recovery Phrase",
+      "description": null
     },
     "DeviceNotGenuine": {
       "title": "Possibly not genuine",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5145,7 +5145,7 @@
       "description": "This crypto asset is not yet supported. Please contact Ledger Support."
     },
     "DeviceAlreadySetup": {
-      "title": "Your device is already set up with a Secret Recovery Phrase",
+      "title": "Your device is already setup with a Secret Recovery Phrase",
       "description": null
     },
     "DeviceNotGenuine": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -240,6 +240,10 @@
       "title": "Please restart your Ledger device and retry",
       "description": "An unexpected error occurred. Please try again."
     },
+    "DeviceAlreadySetup": {
+      "title": "Your device is already set up with a Secret Recovery Phrase",
+      "description": null
+    },
     "DeviceNotGenuine": {
       "title": "Device possibly not genuine",
       "description": "Please save your logs using the button below and provide them to Ledger Support."

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -241,7 +241,7 @@
       "description": "An unexpected error occurred. Please try again."
     },
     "DeviceAlreadySetup": {
-      "title": "Your device is already set up with a Secret Recovery Phrase",
+      "title": "Your device is already setup with a Secret Recovery Phrase",
       "description": null
     },
     "DeviceNotGenuine": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -241,8 +241,8 @@
       "description": "An unexpected error occurred. Please try again."
     },
     "DeviceAlreadySetup": {
-      "title": "Your device is already setup with a Secret Recovery Phrase",
-      "description": null
+      "title": "Your {{device}} is already setup with a Secret Recovery Phrase",
+      "description": "Connect a Ledger that's not set up."
     },
     "DeviceNotGenuine": {
       "title": "Device possibly not genuine",
@@ -1587,7 +1587,8 @@
         "title": "The OS on your Ledger Nano X needs to be updated",
         "desc": "You can try updating the OS or contact Ledger support for assistance.",
         "cta": "Learn how to update",
-        "supportLink": "Contact Ledger Support"
+        "supportLink": "Contact Ledger Support",
+        "buyLedger": "Buy a Ledger"
       }
     },
     "stepRecoveryPhrase": {
@@ -3792,6 +3793,7 @@
     "loading": "Loading...",
     "turnOnAndUnlockDevice": "Turn on and unlock your device",
     "connectAndUnlockDevice": "Connect and unlock your device",
+    "connectAnotherDevice": "Connect another Ledger",
     "unlockDevice": "Unlock your device",
     "outdated": "App version outdated",
     "outdatedDesc": "An important update is available for the {{appName}} application on your device. Please go to the Manager to update it.",

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Linking } from "react-native";
-import { Trans, useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
@@ -9,7 +9,7 @@ import type { FirmwareInfo } from "@ledgerhq/types-live";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getVersion from "@ledgerhq/live-common/hw/getVersion";
 import { BleError } from "@ledgerhq/live-common/ble/types";
-import { Flex, Button, IconsLegacy, Text } from "@ledgerhq/native-ui";
+import { Flex, Button, IconsLegacy } from "@ledgerhq/native-ui";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { DeviceModelId } from "@ledgerhq/devices";
 import {
@@ -34,7 +34,6 @@ type NavigationProps = RootComposite<
 >;
 
 export function RedirectToOnboardingRecoverFlowScreen({ navigation }: NavigationProps) {
-  const { t } = useTranslation();
   const { setShowWelcome, setFirstTimeOnboarding } = useNavigationInterceptor();
 
   // Not sure we need this,

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
@@ -198,15 +198,10 @@ export function RedirectToOnboardingRecoverFlowScreen({ navigation }: Navigation
           <Flex flex={1} justifyContent="center">
             <GenericErrorView
               error={new DeviceAlreadySetup("", { device: device?.modelId ?? "device" })}
-              withDescription={false}
               hasExportLogButton={false}
               withIcon
               withHelp={false}
-            >
-              <Text textAlign="center" variant="large" color="palette.neutral.c80">
-                {t("errors.DeviceAlreadySetup.description")}
-              </Text>
-            </GenericErrorView>
+            />
           </Flex>
 
           <Flex mt={30} flexDirection="column" width="100%">

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Linking } from "react-native";
-import { Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import { DeviceOnboarded } from "@ledgerhq/live-common/errors";
@@ -34,6 +34,7 @@ type NavigationProps = RootComposite<
 >;
 
 export function RedirectToOnboardingRecoverFlowScreen({ navigation }: NavigationProps) {
+  const { t } = useTranslation();
   const { setShowWelcome, setFirstTimeOnboarding } = useNavigationInterceptor();
 
   // Not sure we need this,
@@ -196,9 +197,7 @@ export function RedirectToOnboardingRecoverFlowScreen({ navigation }: Navigation
         <Flex px={16} py={5} flex={1} justifyContent="space-between">
           <Flex flex={1} justifyContent="center">
             <GenericErrorView
-              error={
-                new DeviceOnboarded("Your device is already setup with a Secret Recover Phrase")
-              }
+              error={new DeviceOnboarded(t("errors.DeviceAlreadySetup.title"))}
               withDescription
               hasExportLogButton={false}
               withIcon

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
@@ -3,7 +3,7 @@ import { Linking } from "react-native";
 import { Trans, useTranslation } from "react-i18next";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
-import { DeviceOnboarded } from "@ledgerhq/live-common/errors";
+import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { FirmwareInfo } from "@ledgerhq/types-live";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
@@ -197,11 +197,7 @@ export function RedirectToOnboardingRecoverFlowScreen({ navigation }: Navigation
         <Flex px={16} py={5} flex={1} justifyContent="space-between">
           <Flex flex={1} justifyContent="center">
             <GenericErrorView
-              error={
-                new DeviceOnboarded(
-                  t("errors.DeviceAlreadySetup.title", { device: device?.modelId ?? "device" }),
-                )
-              }
+              error={new DeviceAlreadySetup("", { device: device?.modelId ?? "device" })}
               withDescription={false}
               hasExportLogButton={false}
               withIcon

--- a/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/RedirectToOnboardingRecoverFlow.tsx
@@ -9,7 +9,7 @@ import type { FirmwareInfo } from "@ledgerhq/types-live";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getVersion from "@ledgerhq/live-common/hw/getVersion";
 import { BleError } from "@ledgerhq/live-common/ble/types";
-import { Flex, Button, IconsLegacy } from "@ledgerhq/native-ui";
+import { Flex, Button, IconsLegacy, Text } from "@ledgerhq/native-ui";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { DeviceModelId } from "@ledgerhq/devices";
 import {
@@ -129,8 +129,8 @@ export function RedirectToOnboardingRecoverFlowScreen({ navigation }: Navigation
     [goBack, navigation],
   );
 
-  const onOpenHelp = useCallback(() => {
-    Linking.openURL(urls.errors.PairingFailed);
+  const onClickBuyLedger = useCallback(() => {
+    Linking.openURL(urls.buyNanoX);
   }, []);
 
   const onRetry = useCallback(() => {
@@ -178,7 +178,7 @@ export function RedirectToOnboardingRecoverFlowScreen({ navigation }: Navigation
             <Button
               iconPosition="right"
               Icon={IconsLegacy.ExternalLinkMedium}
-              onPress={onOpenHelp}
+              onPress={onClickBuyLedger}
               mb={0}
             >
               <Trans i18nKey="help.helpCenter.desc" />
@@ -197,25 +197,33 @@ export function RedirectToOnboardingRecoverFlowScreen({ navigation }: Navigation
         <Flex px={16} py={5} flex={1} justifyContent="space-between">
           <Flex flex={1} justifyContent="center">
             <GenericErrorView
-              error={new DeviceOnboarded(t("errors.DeviceAlreadySetup.title"))}
-              withDescription
+              error={
+                new DeviceOnboarded(
+                  t("errors.DeviceAlreadySetup.title", { device: device?.modelId ?? "device" }),
+                )
+              }
+              withDescription={false}
               hasExportLogButton={false}
               withIcon
               withHelp={false}
-            />
+            >
+              <Text textAlign="center" variant="large" color="palette.neutral.c80">
+                {t("errors.DeviceAlreadySetup.description")}
+              </Text>
+            </GenericErrorView>
           </Flex>
 
           <Flex mt={30} flexDirection="column" width="100%">
             <Button type="main" onPress={onRetry} mt={6}>
-              <Trans i18nKey="common.retry" />
+              <Trans i18nKey="DeviceAction.connectAnotherDevice" />
             </Button>
             <Button
               iconPosition="right"
               Icon={IconsLegacy.ExternalLinkMedium}
-              onPress={onOpenHelp}
+              onPress={onClickBuyLedger}
               mb={0}
             >
-              <Trans i18nKey="help.helpCenter.desc" />
+              <Trans i18nKey="onboarding.stepProtect.extraInfo.buyLedger" />
             </Button>
           </Flex>
         </Flex>

--- a/libs/ledger-live-common/src/errors.ts
+++ b/libs/ledger-live-common/src/errors.ts
@@ -30,6 +30,7 @@ export const LanguageInstallTimeout = createCustomErrorClass("LanguageInstallTim
 
 export const DeviceOnboarded = createCustomErrorClass("DeviceOnboarded");
 export const DeviceNotOnboarded = createCustomErrorClass("DeviceNotOnboarded");
+export const DeviceAlreadySetup = createCustomErrorClass("DeviceAlreadySetup");
 export const InvalidAddressBecauseAlreadyDelegated = createCustomErrorClass(
   "InvalidAddressBecauseAlreadyDelegated",
 );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adjust wording on error device already seeded in onboarding Recover on LLD and LLM
Add "buy a ledger" on desktop screen
Add dynamic Device on message

Add generic error on ledger common

### ❓ Context

- **Impacted projects**: `ledger-live-mobile``ledger-live-desktop``ledger-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `[PROTECT-2273](https://ledgerhq.atlassian.net/browse/PROTECT-2273)` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/118977988/3e2a63d8-e9a0-4b3c-9436-7af75daef487

<img width="1429" alt="Capture d’écran 2023-07-28 à 09 36 54" src="https://github.com/LedgerHQ/ledger-live/assets/118977988/8d951069-de53-45ba-8e28-85091dc86cdd">
g Screenrecorder-2023-07-27-11-38-30-256.mp4…


[PROTECT-2273]: https://ledgerhq.atlassian.net/browse/PROTECT-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ