### PR TITLE
Bugfix - add missing teloscan in type guard

### DIFF
--- a/.changeset/wet-toys-jog.md
+++ b/.changeset/wet-toys-jog.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Add missing teloscan in type guard

--- a/libs/coin-evm/src/__tests__/unit/api/explorer/types.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/api/explorer/types.unit.test.ts
@@ -13,6 +13,7 @@ describe("EVM Family", () => {
       it("should narrow the param to an Etherscan-like explorer type", () => {
         expect(isEtherscanLikeExplorerConfig({ type: "etherscan", uri: "anything" })).toBe(true);
         expect(isEtherscanLikeExplorerConfig({ type: "blockscout", uri: "anything" })).toBe(true);
+        expect(isEtherscanLikeExplorerConfig({ type: "teloscan", uri: "anything" })).toBe(true);
       });
     });
   });

--- a/libs/coin-evm/src/api/explorer/types.ts
+++ b/libs/coin-evm/src/api/explorer/types.ts
@@ -43,6 +43,6 @@ export const isLedgerExplorerConfig = (
  */
 export const isEtherscanLikeExplorerConfig = (
   explorerConfig: ExplorerConfig,
-): explorerConfig is ExplorerConfig & { type: "etherscan" | "blockscout" } => {
-  return ["etherscan", "blockscout"].includes(explorerConfig?.type as string);
+): explorerConfig is ExplorerConfig & { type: "etherscan" | "blockscout" | "teloscan" } => {
+  return ["etherscan", "blockscout", "teloscan"].includes(explorerConfig?.type as string);
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add missing teloscan in type guard, making sync fail for Telos

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-7546

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** -> Tested by the Bot
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
