### PR TITLE
fix(FirmwareUpdateLLM): ignore irrelevant errors on the fw update

### DIFF
--- a/.changeset/fair-tables-shop.md
+++ b/.changeset/fair-tables-shop.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+Feat: adds a first step to display the changelog of the fw update
+
+Handling correctly when a user leaves the fw update from this first step

--- a/.changeset/fluffy-rules-shave.md
+++ b/.changeset/fluffy-rules-shave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+This fixes a bug that was created on the new Firmware Update UX where irrelevant errors were being reported to the user.

--- a/.changeset/fluffy-rules-shave.md
+++ b/.changeset/fluffy-rules-shave.md
@@ -1,5 +1,0 @@
----
-"live-mobile": patch
----
-
-This fixes a bug that was created on the new Firmware Update UX where irrelevant errors were being reported to the user.

--- a/.changeset/old-crabs-hug.md
+++ b/.changeset/old-crabs-hug.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix: battery check command logic
+
+The battery check command was updating and keeping (to a lower value) the unresponsive timeout due
+to race conditions. It was creating incorrect locked device errors.

--- a/.changeset/perfect-donuts-hammer.md
+++ b/.changeset/perfect-donuts-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix issue that made it impossible to leave the new Firmware Update UX

--- a/.changeset/perfect-donuts-hammer.md
+++ b/.changeset/perfect-donuts-hammer.md
@@ -1,5 +1,0 @@
----
-"live-mobile": patch
----
-
-Fix issue that made it impossible to leave the new Firmware Update UX

--- a/.changeset/rotten-buses-leave.md
+++ b/.changeset/rotten-buses-leave.md
@@ -1,0 +1,14 @@
+---
+"live-mobile": patch
+---
+
+Fix: several bugs during the firmware update on LLM
+
+Several bug were fixed:
+
+- an issue on how "user solvable" errors were handled on the logic and UI of the fw update
+- a bug on errors that were supposed to be ignored (e.g. an inexistent lockscreen image when backing
+  up) and were actually being reported to the user
+- a bug when a “allow manager”/secure channel was refused as the beginning of the fw update
+- a bug on the battery check UX that made the app re-navigate to the firmware update automatically
+  once the user exited it

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -28,9 +28,10 @@ import InvertTheme from "./theme/InvertTheme";
 import { urls } from "../config/urls";
 import { renderConnectYourDevice } from "./DeviceAction/rendering";
 import { DeviceActionError } from "./DeviceAction/common";
+import type { FirmwareUpdateProps } from "../screens/FirmwareUpdate";
 
 type FirmwareUpdateBannerProps = {
-  onBackFromUpdate?: () => void;
+  onBackFromUpdate?: FirmwareUpdateProps["onBackFromUpdate"];
 };
 
 const requiredBatteryStatuses = [

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -28,10 +28,10 @@ import InvertTheme from "./theme/InvertTheme";
 import { urls } from "../config/urls";
 import { renderConnectYourDevice } from "./DeviceAction/rendering";
 import { DeviceActionError } from "./DeviceAction/common";
-import type { FirmwareUpdateProps } from "../screens/FirmwareUpdate";
+import { UpdateStep } from "../screens/FirmwareUpdate";
 
-type FirmwareUpdateBannerProps = {
-  onBackFromUpdate?: FirmwareUpdateProps["onBackFromUpdate"];
+export type FirmwareUpdateBannerProps = {
+  onBackFromUpdate: (updateState: UpdateStep) => void;
 };
 
 const requiredBatteryStatuses = [
@@ -80,9 +80,9 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
           device: lastConnectedDevice,
           deviceInfo: lastSeenDevice?.deviceInfo,
           firmwareUpdateContext: latestFirmware,
-          onBackFromUpdate: () => {
+          onBackFromUpdate: (updateState: UpdateStep) => {
             cancelBatteryCheck();
-            if (onBackFromUpdate) onBackFromUpdate();
+            if (onBackFromUpdate) onBackFromUpdate(updateState);
           },
         },
       });

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -61,6 +61,16 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
 
   const latestFirmware = useLatestFirmware(lastSeenDevice?.deviceInfo);
 
+  const {
+    requestCompleted: batteryRequestCompleted,
+    batteryStatusesState,
+    triggerRequest: triggerBatteryCheck,
+    cancelRequest: cancelBatteryCheck,
+  } = useBatteryStatuses({
+    deviceId: lastConnectedDevice?.deviceId,
+    statuses: requiredBatteryStatuses,
+  });
+
   const onExperimentalFirmwareUpdate = useCallback(() => {
     if (newFwUpdateUxFeatureFlag?.enabled) {
       navigation.navigate(NavigatorName.Manager, {
@@ -69,7 +79,10 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
           device: lastConnectedDevice,
           deviceInfo: lastSeenDevice?.deviceInfo,
           firmwareUpdateContext: latestFirmware,
-          onBackFromUpdate,
+          onBackFromUpdate: () => {
+            cancelBatteryCheck();
+            if (onBackFromUpdate) onBackFromUpdate();
+          },
         },
       });
       return;
@@ -93,18 +106,9 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     lastConnectedDevice,
     lastSeenDevice?.deviceInfo,
     latestFirmware,
+    cancelBatteryCheck,
     onBackFromUpdate,
   ]);
-
-  const {
-    requestCompleted: batteryRequestCompleted,
-    batteryStatusesState,
-    triggerRequest: triggerBatteryCheck,
-    cancelRequest: cancelBatteryCheck,
-  } = useBatteryStatuses({
-    deviceId: lastConnectedDevice?.deviceId,
-    statuses: requiredBatteryStatuses,
-  });
 
   // Effect that will check the battery of stax before triggering the update and display a warning preventing the update
   // in case the battery is too low and the device is not charging

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/ManagerNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/ManagerNavigator.ts
@@ -3,6 +3,7 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { ScreenName } from "../../../const";
 import { ManagerTab } from "../../../const/manager";
+import type { FirmwareUpdateProps } from "../../../screens/FirmwareUpdate";
 
 export type ManagerNavigatorStackParamList = {
   [ScreenName.Manager]:
@@ -29,6 +30,6 @@ export type ManagerNavigatorStackParamList = {
     deviceInfo?: DeviceInfo | null;
     firmwareUpdateContext?: FirmwareUpdateContext | null;
     device?: Device | null;
-    onBackFromUpdate?: () => void;
+    onBackFromUpdate: FirmwareUpdateProps["onBackFromUpdate"];
   };
 };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4052,7 +4052,9 @@
   },
   "FirmwareUpdate": {
     "title": "Update firmware",
+    "beginUpdate": "Begin update",
     "updateDevice": "{{deviceName}} OS Update",
+    "releaseNotesTitle": "What's in this OS update?",
     "updateDone": "All done! Your {{deviceName}} is up to date",
     "updateDoneDescription": "New OS Version: {{firmwareVersion}}",
     "preparing": "Preparing the firmware update, please keep your device awake and connected. We will notify you of the progress",

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/UpdateReleaseNotes.tsx
@@ -1,0 +1,33 @@
+import { Flex, Text } from "@ledgerhq/native-ui";
+import React from "react";
+import Button from "../../components/wrappedUi/Button";
+import SafeMarkdown from "../../components/SafeMarkdown";
+import { useTranslation } from "react-i18next";
+import { ScrollView } from "react-native";
+
+type UpdateReleaseNotesProps = {
+  firmwareNotes?: string | null;
+  onContinue: () => void;
+};
+
+const UpdateReleaseNotes: React.FC<UpdateReleaseNotesProps> = ({ onContinue, firmwareNotes }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Flex flex={1} px={7} pb={7}>
+      <ScrollView persistentScrollbar>
+        <Flex px={3}>
+          <Text variant="h4" fontWeight="semiBold" mb={4}>
+            {t("FirmwareUpdate.releaseNotesTitle")}
+          </Text>
+          {firmwareNotes ? <SafeMarkdown markdown={firmwareNotes} /> : null}
+        </Flex>
+      </ScrollView>
+      <Button onPress={onContinue} type="main">
+        {t("FirmwareUpdate.beginUpdate")}
+      </Button>
+    </Flex>
+  );
+};
+
+export default UpdateReleaseNotes;

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -164,6 +164,7 @@ export const FirmwareUpdate = ({
     deviceLockedOrUnresponsive,
     hasReconnectErrors,
     restoreStepDeniedError,
+    hasRetriableErrors,
     skipCurrentRestoreStep,
   } = useUpdateFirmwareAndRestoreSettings({
     updateFirmwareAction,
@@ -537,12 +538,13 @@ export const FirmwareUpdate = ({
       );
     }
 
-    const error =
-      updateActionState.error ??
-      restoreAppsState.error ??
-      installLanguageState.error ??
-      staxLoadImageState.error ??
-      staxFetchImageState.error;
+    const error = hasRetriableErrors
+      ? updateActionState.error ??
+        restoreAppsState.error ??
+        installLanguageState.error ??
+        staxLoadImageState.error ??
+        staxFetchImageState.error
+      : undefined;
 
     // a TransportRaceCondition error is to be expected since we chain multiple
     // device actions that use different transport acquisition paradigms
@@ -638,11 +640,12 @@ export const FirmwareUpdate = ({
     staxLoadImageState.imageCommitRequested,
     staxLoadImageState.error,
     restoreAppsState.allowManagerRequestedWording,
-    connectManagerState.allowManagerRequestedWording,
     restoreAppsState.error,
+    connectManagerState.allowManagerRequestedWording,
     installLanguageState.languageInstallationRequested,
     installLanguageState.error,
     restoreStepDeniedError,
+    hasRetriableErrors,
     updateActionState.error,
     updateActionState.step,
     updateActionState.progress,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -53,6 +53,7 @@ import { ImageSourceContext } from "../../components/CustomImage/StaxFramedImage
 import Button from "../../components/wrappedUi/Button";
 import Link from "../../components/wrappedUi/Link";
 import { RestoreStepDenied } from "./RestoreStepDenied";
+import UpdateReleaseNotes from "./UpdateReleaseNotes";
 
 // Screens/components navigating to this screen shouldn't know the implementation fw update
 // -> re-exporting useful types.
@@ -162,6 +163,7 @@ export const FirmwareUpdate = ({
   const [fullUpdateComplete, setFullUpdateComplete] = useState(false);
 
   const {
+    startUpdate,
     connectManagerState,
     updateActionState,
     updateStep,
@@ -692,7 +694,12 @@ export const FirmwareUpdate = ({
 
   return (
     <>
-      {fullUpdateComplete ? (
+      {updateStep === "start" ? (
+        <UpdateReleaseNotes
+          onContinue={startUpdate}
+          firmwareNotes={firmwareUpdateContext.osu?.notes}
+        />
+      ) : fullUpdateComplete ? (
         <Flex flex={1} px={7} pb={7}>
           <TrackScreen category={`${productName} OS successfully updated`} />
           <Flex flex={1} justifyContent="center" alignItems="center">
@@ -716,9 +723,6 @@ export const FirmwareUpdate = ({
           <Flex>
             <Button type="main" outline={false} onPress={quitUpdate}>
               {t("FirmwareUpdate.finishUpdateCTA")}
-            </Button>
-            <Button type="default" mt={5} mb={9} outline={false} onPress={onOpenReleaseNotes}>
-              {t("FirmwareUpdate.viewUpdateChangelog")}
             </Button>
           </Flex>
         </Flex>

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -1,4 +1,4 @@
-import { Image, Linking } from "react-native";
+import { Image } from "react-native";
 import { getDeviceModel } from "@ledgerhq/devices";
 import {
   updateFirmwareActionArgs,
@@ -44,7 +44,6 @@ import {
   UpdateStep,
   useUpdateFirmwareAndRestoreSettings,
 } from "./useUpdateFirmwareAndRestoreSettings";
-import { urls } from "../../config/urls";
 import { TrackScreen } from "../../analytics";
 import ImageHexProcessor from "../../components/CustomImage/ImageHexProcessor";
 import { targetDataDimensions } from "../CustomImage/shared";
@@ -153,10 +152,6 @@ export const FirmwareUpdate = ({
   const { dark } = useTheme();
   const theme: "dark" | "light" = dark ? "dark" : "light";
   const dispatch = useDispatch();
-
-  const onOpenReleaseNotes = useCallback(() => {
-    Linking.openURL(urls.fwUpdateReleaseNotes[device.modelId]);
-  }, [device.modelId]);
 
   const productName = getDeviceModel(device.modelId).productName;
 
@@ -547,8 +542,6 @@ export const FirmwareUpdate = ({
     }
 
     if (restoreStepDeniedError) {
-      console.log(`restore step denied: ${JSON.stringify(restoreStepDeniedError)}`);
-
       return (
         <RestoreStepDenied
           device={device}

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -171,7 +171,7 @@ export const FirmwareUpdate = ({
     deviceLockedOrUnresponsive,
     restoreStepDeniedError,
     hasReconnectErrors,
-    hasUserSolvableErrors,
+    userSolvableError,
     skipCurrentRestoreStep,
   } = useUpdateFirmwareAndRestoreSettings({
     updateFirmwareAction,
@@ -553,27 +553,6 @@ export const FirmwareUpdate = ({
       );
     }
 
-    /**
-     * Finds the user-solvable error from the (current) fw update step, if there is one.
-     * If there is an error during the current fw update step but it is not user-solvable,
-     * then either: this current fw update step is skipped or this error is ignored
-     * (logic handled in `useUpdateFirmwareAndRestoreSettings`).
-     * And in both cases: nothing is displayed to the user (logs are saved from the hook).
-     *
-     * Especially: a `TransportRaceCondition` error is to be expected since we chain multiple
-     * device actions that use different transport acquisition paradigms the action should,
-     * however, retry to execute and resolve the error by itself.
-     * There is no need to present the error to the user.
-     */
-    const userSolvableError = hasUserSolvableErrors
-      ? connectManagerState.error ??
-        updateActionState.error ??
-        restoreAppsState.error ??
-        installLanguageState.error ??
-        staxLoadImageState.error ??
-        staxFetchImageState.error
-      : undefined;
-
     if (userSolvableError) {
       return (
         <DeviceActionError
@@ -661,19 +640,13 @@ export const FirmwareUpdate = ({
     hasReconnectErrors,
     staxLoadImageState.imageLoadRequested,
     staxLoadImageState.imageCommitRequested,
-    staxLoadImageState.error,
     restoreAppsState.allowManagerRequestedWording,
-    restoreAppsState.error,
     connectManagerState.allowManagerRequestedWording,
-    connectManagerState.error,
     installLanguageState.languageInstallationRequested,
-    installLanguageState.error,
     restoreStepDeniedError,
-    hasUserSolvableErrors,
-    updateActionState.error,
+    userSolvableError,
     updateActionState.step,
     updateActionState.progress,
-    staxFetchImageState.error,
     t,
     device,
     theme,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -196,7 +196,6 @@ export const FirmwareUpdate = ({
 
   const quitUpdate = useCallback(() => {
     if (onBackFromUpdate) {
-      console.log(`🦀 QUIT UPDATE ! updateStep: ${updateStep}`);
       onBackFromUpdate(updateStep);
     } else {
       navigation.goBack();
@@ -546,6 +545,8 @@ export const FirmwareUpdate = ({
     }
 
     if (restoreStepDeniedError) {
+      console.log(`restore step denied: ${JSON.stringify(restoreStepDeniedError)}`);
+
       return (
         <RestoreStepDenied
           device={device}
@@ -569,29 +570,34 @@ export const FirmwareUpdate = ({
      * however, retry to execute and resolve the error by itself.
      * There is no need to present the error to the user.
      */
-    const error = hasUserSolvableErrors
-      ? updateActionState.error ??
+    const userSolvableError = hasUserSolvableErrors
+      ? connectManagerState.error ??
+        updateActionState.error ??
         restoreAppsState.error ??
         installLanguageState.error ??
         staxLoadImageState.error ??
         staxFetchImageState.error
       : undefined;
 
-    if (error) {
+    if (userSolvableError) {
       return (
         <DeviceActionError
           device={device}
           t={t}
-          errorName={error.name}
+          errorName={userSolvableError.name}
           translationContext="FirmwareUpdate"
         >
-          <TrackScreen category={`Error: ${error.name}`} refreshSource={false} type="drawer" />
+          <TrackScreen
+            category={`Error: ${userSolvableError.name}`}
+            refreshSource={false}
+            type="drawer"
+          />
           <Button
             event="button_clicked"
             eventProperties={{
               button: "Retry flow",
               page: "Firmware update",
-              drawer: `Error: ${error.name}`,
+              drawer: `Error: ${userSolvableError.name}`,
             }}
             type="main"
             outline={false}
@@ -607,7 +613,7 @@ export const FirmwareUpdate = ({
               eventProperties={{
                 button: "Quit flow",
                 page: "Firmware update",
-                drawer: `Error: ${error.name}`,
+                drawer: `Error: ${userSolvableError.name}`,
               }}
               type="main"
               onPress={quitUpdate}
@@ -664,6 +670,7 @@ export const FirmwareUpdate = ({
     restoreAppsState.allowManagerRequestedWording,
     restoreAppsState.error,
     connectManagerState.allowManagerRequestedWording,
+    connectManagerState.error,
     installLanguageState.languageInstallationRequested,
     installLanguageState.error,
     restoreStepDeniedError,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -206,10 +206,6 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     let hasUnrecoverableError;
 
     switch (updateStep) {
-      case "start":
-        proceedToAppsBackup();
-        break;
-
       case "appsBackup":
         hasUnrecoverableError =
           connectManagerState.error &&
@@ -457,6 +453,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
   }, [updateStep, proceedToImageRestore, proceedToAppsRestore, proceedToUpdateCompleted]);
 
   return {
+    startUpdate: proceedToAppsBackup,
     updateStep,
     connectManagerState,
     staxFetchImageState,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -198,17 +198,17 @@ export const useUpdateFirmwareAndRestoreSettings = ({
   // this hook controls the chaining of device actions by updating the current step
   // when needed. It basically implements a state macgine
   useEffect(() => {
-    let unrecoverableError;
+    let retriableError;
 
     switch (updateStep) {
       case "start":
         proceedToAppsBackup();
         break;
       case "appsBackup":
-        unrecoverableError =
+        retriableError =
           connectManagerState.error &&
           !retriableErrors.some(err => connectManagerState.error instanceof err);
-        if (connectManagerState.result || unrecoverableError) {
+        if (connectManagerState.result || retriableError) {
           if (connectManagerState.error) {
             log("FirmwareUpdate", "error while backing up device apps", connectManagerState.error);
           }
@@ -220,10 +220,10 @@ export const useUpdateFirmwareAndRestoreSettings = ({
         }
         break;
       case "imageBackup":
-        unrecoverableError =
+        retriableError =
           staxFetchImageState.error &&
           !retriableErrors.some(err => staxFetchImageState.error instanceof err);
-        if (staxFetchImageState.imageFetched || unrecoverableError) {
+        if (staxFetchImageState.imageFetched || retriableError) {
           if (staxFetchImageState.error)
             log("FirmwareUpdate", "error while backing up stax image", staxFetchImageState.error);
           proceedToFirmwareUpdate();
@@ -237,20 +237,20 @@ export const useUpdateFirmwareAndRestoreSettings = ({
         }
         break;
       case "languageRestore":
-        unrecoverableError =
+        retriableError =
           installLanguageState.error &&
           !retriableErrors.some(err => installLanguageState.error instanceof err);
-        if (installLanguageState.languageInstalled || unrecoverableError) {
+        if (installLanguageState.languageInstalled || retriableError) {
           if (installLanguageState.error)
             log("FirmwareUpdate", "error while restoring language", installLanguageState.error);
           proceedToImageRestore();
         }
         break;
       case "imageRestore":
-        unrecoverableError =
+        retriableError =
           staxLoadImageState.error &&
           !retriableErrors.some(err => staxLoadImageState.error instanceof err);
-        if (staxLoadImageState.imageLoaded || unrecoverableError || !staxFetchImageState.hexImage) {
+        if (staxLoadImageState.imageLoaded || retriableError || !staxFetchImageState.hexImage) {
           if (staxLoadImageState.error) {
             log("FirmwareUpdate", "error while restoring stax image", staxLoadImageState.error);
           }
@@ -258,10 +258,10 @@ export const useUpdateFirmwareAndRestoreSettings = ({
         }
         break;
       case "appsRestore":
-        unrecoverableError =
+        retriableError =
           restoreAppsState.error &&
           !retriableErrors.some(err => restoreAppsState.error instanceof err);
-        if (restoreAppsState.opened || unrecoverableError) {
+        if (restoreAppsState.opened || retriableError) {
           if (restoreAppsState.error) {
             log("FirmwareUpdate", "error while restoring apps", restoreAppsState.error);
           }
@@ -314,6 +314,25 @@ export const useUpdateFirmwareAndRestoreSettings = ({
       staxLoadImageState.error,
       restoreAppsState.error,
       installLanguageState.error,
+    ],
+  );
+
+  const hasRetriableErrors = useMemo(
+    () =>
+      retriableErrors.some(
+        err =>
+          connectManagerState.error instanceof err ||
+          staxFetchImageState.error instanceof err ||
+          staxLoadImageState.error instanceof err ||
+          restoreAppsState.error instanceof err ||
+          installLanguageState.error instanceof err,
+      ),
+    [
+      connectManagerState.error,
+      installLanguageState.error,
+      restoreAppsState.error,
+      staxFetchImageState.error,
+      staxLoadImageState.error,
     ],
   );
 
@@ -426,6 +445,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     noOfAppsToReinstall: installedApps.length,
     deviceLockedOrUnresponsive,
     hasReconnectErrors,
+    hasRetriableErrors,
     restoreStepDeniedError,
   };
 };

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
@@ -46,6 +46,7 @@ import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/t
 import { ScreenName } from "../../const";
 import { lastSeenDeviceSelector } from "../../reducers/settings";
 import ProviderWarning from "./ProviderWarning";
+import { UpdateStep } from "../FirmwareUpdate";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<ManagerNavigatorStackParamList, ScreenName.ManagerMain>
@@ -69,7 +70,7 @@ type Props = {
   optimisticState: State;
   result: ListAppsResult;
   onLanguageChange: () => void;
-  onBackFromUpdate: () => void;
+  onBackFromUpdate: (updateState: UpdateStep) => void;
 };
 
 const AppsScreen = ({

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -182,8 +182,8 @@ const Manager = ({ navigation, route }: NavigationProps) => {
 
   const onBackFromNewUpdateUx = useCallback(
     (updateState: UpdateStep) => {
-      // If the fw update was completed, we know the device in a correct state
-      if (updateState === "completed") {
+      // If the fw update was completed or not yet started, we know the device in a correct state
+      if (["start", "completed"].includes(updateState)) {
         navigation.replace(ScreenName.Manager, {
           device,
         });

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -180,10 +180,11 @@ const Manager = ({ navigation, route }: NavigationProps) => {
   );
 
   const onBackFromNewUpdateUx = useCallback(() => {
-    navigation.replace(ScreenName.Manager, {
-      device,
-    });
-  }, [device, navigation]);
+    // Navigating back to the main manager screen without settings a device
+    // so it does not try to automatically connect to the device while it
+    // might still be on an unknown state because the fw update was just stopped
+    navigation.replace(ScreenName.Manager);
+  }, [navigation]);
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -24,6 +24,7 @@ import FirmwareUpdateScreen from "../../components/FirmwareUpdate";
 import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/types/ManagerNavigator";
 import { BaseComposite, StackNavigatorProps } from "../../components/RootNavigator/types/helpers";
 import { lastConnectedDeviceSelector } from "../../reducers/settings";
+import { UpdateStep } from "../FirmwareUpdate";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<ManagerNavigatorStackParamList, ScreenName.ManagerMain>
@@ -179,12 +180,23 @@ const Manager = ({ navigation, route }: NavigationProps) => {
     [device, installedApps, navigation, refreshDeviceInfo],
   );
 
-  const onBackFromNewUpdateUx = useCallback(() => {
-    // Navigating back to the main manager screen without settings a device
-    // so it does not try to automatically connect to the device while it
-    // might still be on an unknown state because the fw update was just stopped
-    navigation.replace(ScreenName.Manager);
-  }, [navigation]);
+  const onBackFromNewUpdateUx = useCallback(
+    (updateState: UpdateStep) => {
+      // If the fw update was completed, we know the device in a correct state
+      if (updateState === "completed") {
+        navigation.replace(ScreenName.Manager, {
+          device,
+        });
+        return;
+      }
+
+      // Otherwise navigating back to the main manager screen without settings a device
+      // so it does not try to automatically connect to the device while it
+      // might still be on an unknown state because the fw update was just stopped
+      navigation.replace(ScreenName.Manager);
+    },
+    [device, navigation],
+  );
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/screens/Manager/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/index.tsx
@@ -80,10 +80,11 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
 
     if (result && "result" in result) {
       // FIXME: nullable stuff not taken into account here?
+      // `result` overrides values from `params` (prop `device` for ex)
       // @ts-expect-error Result has nullable fields
       navigation.navigate(ScreenName.ManagerMain, {
-        ...result,
         ...params,
+        ...result,
         searchQuery: params?.searchQuery || params?.installApp,
       });
     }

--- a/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
@@ -37,6 +37,7 @@ import {
 import FirmwareUpdateBanner from "../../../components/FirmwareUpdateBanner";
 import CollapsibleHeaderFlatList from "../../../components/WalletTab/CollapsibleHeaderFlatList";
 import { WalletTabNavigatorStackParamList } from "../../../components/RootNavigator/types/WalletTabNavigator";
+import { UpdateStep } from "../../FirmwareUpdate";
 
 const maxAssetsToDisplay = 5;
 
@@ -158,6 +159,13 @@ function ReadOnlyPortfolio({ navigation }: NavigationProps) {
 
   const { source, setSource, setScreen } = useContext(AnalyticsContext);
 
+  const onBackFromUpdate = useCallback(
+    (_updateState: UpdateStep) => {
+      navigation.goBack();
+    },
+    [navigation],
+  );
+
   useFocusEffect(
     useCallback(() => {
       setScreen && setScreen("Wallet");
@@ -171,7 +179,7 @@ function ReadOnlyPortfolio({ navigation }: NavigationProps) {
   return (
     <>
       <Flex px={6} py={4}>
-        <FirmwareUpdateBanner />
+        <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
       </Flex>
       <CheckLanguageAvailability />
       <CheckTermOfUseUpdate />

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -171,12 +171,11 @@ function PortfolioScreen({ navigation }: NavigationProps) {
           ]),
     ],
     [
+      onBackFromUpdate,
       showAssets,
       colors.background.main,
       hideEmptyTokenAccount,
       openAddModal,
-      // TODO: discreetMode is never used 😱 is it safe to remove
-      // discreetMode,
       isAWalletCardDisplayed,
       t,
     ],

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -48,6 +48,7 @@ import {
 } from "../../reducers/accounts";
 import PortfolioAssets from "./PortfolioAssets";
 import { internetReachable } from "../../logic/internetReachable";
+import { UpdateStep } from "../FirmwareUpdate";
 
 export { default as PortfolioTabIcon } from "./TabIcon";
 
@@ -72,6 +73,13 @@ function PortfolioScreen({ navigation }: NavigationProps) {
   const protectFeature = useFeature("protectServicesMobile");
   const recoverUpsellURL = useLearnMoreURI(protectFeature);
   const dispatch = useDispatch();
+
+  const onBackFromUpdate = useCallback(
+    (_updateState: UpdateStep) => {
+      navigation.goBack();
+    },
+    [navigation],
+  );
 
   useEffect(() => {
     const openProtectUpsell = async () => {
@@ -118,7 +126,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
   const data = useMemo(
     () => [
       <Flex px={6} py={4} key="FirmwareUpdateBanner">
-        <FirmwareUpdateBanner />
+        <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
       </Flex>,
       <PortfolioGraphCard showAssets={showAssets} key="PortfolioGraphCard" />,
       showAssets ? (

--- a/libs/ledger-live-common/src/deviceSDK/actions/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/core.ts
@@ -57,6 +57,7 @@ export function sharedReducer({ event }: { event: SharedTaskEvent }): Partial<Sh
           message,
           retrying,
         },
+        lockedDevice: false,
       };
     }
     default:

--- a/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
@@ -15,9 +15,14 @@ export type UseBateryStatusesArgs = {
 /**
  * Hook used to query one or multiple battery statuses for Ledger Stax. The state will contain an array of with all the
  * requested statuses in corresponding order.
- * @param Args Object containing the arguments of the hook: a deviceId and a list of status types to query
- * @returns An object containing the current state of the request, a boolean that informs if the request is complete,
- * and a function to trigger an retrigger the device action
+ *
+ * @param deviceId
+ * @param statuses A list of status types to query
+ *
+ * @returns An object containing:
+ * - the current state of the request
+ * - a boolean that informs if the request is complete
+ * - a function to trigger an retrigger the device action
  */
 export const useBatteryStatuses = ({
   deviceId,

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -3,6 +3,7 @@ import {
   DisconnectedDevice,
   LockedDeviceError,
   TransportRaceCondition,
+  UnresponsiveDeviceError,
   createCustomErrorClass,
 } from "@ledgerhq/errors";
 import { Observable, from, of, throwError, timer } from "rxjs";
@@ -38,12 +39,13 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
               concatMap(error => {
                 let acceptedError = false;
 
-                // - LockedDeviceError: on every transport if there is a device but it is locked
+                // - LockedDeviceError and UnresponsiveDeviceError: on every transport if there is a device but it is locked
                 // - CantOpenDevice: it can come from hw-transport-node-hid-singleton/TransportNodeHid
                 //   or react-native-hw-transport-ble/BleTransport when no device is found
                 // - DisconnectedDevice: it can come from TransportNodeHid while switching app
                 if (
                   error instanceof LockedDeviceError ||
+                  error instanceof UnresponsiveDeviceError ||
                   error instanceof CantOpenDevice ||
                   error instanceof DisconnectedDevice ||
                   error instanceof TransportRaceCondition

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -52,6 +52,8 @@ function internalGetBatteryStatusesTask({
               allowedErrors: [{ maxRetries: 3, errorClass: DisconnectedDevice }],
             })(transportRef, {}),
           );
+
+          // Runs sequentially the wanted status queries. Waits that the current observable completes.
           return concat(...statusesObservable);
         }),
         map(value => {

--- a/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
@@ -3,6 +3,7 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   LockedDeviceError,
+  UnresponsiveDeviceError,
   UserRefusedFirmwareUpdate,
 } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
@@ -89,7 +90,7 @@ function internalUpdateFirmwareTask({
                     if (e.type === "unresponsive") {
                       return {
                         type: "error" as const,
-                        error: new LockedDeviceError(),
+                        error: new UnresponsiveDeviceError(),
                         // If unresponsive, the command is still waiting for a response
                         retrying: true,
                       };

--- a/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
@@ -2,7 +2,6 @@ import {
   CantOpenDevice,
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
-  LockedDeviceError,
   UnresponsiveDeviceError,
   UserRefusedFirmwareUpdate,
 } from "@ledgerhq/errors";


### PR DESCRIPTION
### 📝 Description

This PR fixes several bugs:
- an issue on how "user solvable" errors were handled on the logic and UI of the fw update
- a bug on errors that were supposed to be ignored (e.g. an inexistent lockscreen image when backing up) and were actually being reported to the user -> original ticket [LIVE-8789](https://ledgerhq.atlassian.net/browse/LIVE-8789)
- a bug when a “allow manager”/secure channel was refused as the beginning of the fw update
- a bug on the battery check UX that made the app re-navigate to the firmware update automatically once the user exited it -> original ticket [LIVE-8796](https://ledgerhq.atlassian.net/browse/LIVE-8796): where https://github.com/LedgerHQ/ledger-live/pull/4155 was an 1st attempt to fix it
- a bug on the battery check device action that was updating and keeping (to a lower value) the unresponsive timeout due to race conditions. It was creating incorrect locked device errors.

And it adds a first step to display the changelog of the fw update, handling correctly when a user leaves the fw update from this first step -> original ticket [LIVE-8640](https://ledgerhq.atlassian.net/browse/LIVE-8640): where https://github.com/LedgerHQ/ledger-live/pull/4132 was a 1st attempt to add this

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-8789](https://ledgerhq.atlassian.net/browse/LIVE-8789) &  [LIVE-8796](https://ledgerhq.atlassian.net/browse/LIVE-8796) & [LIVE-8640](https://ledgerhq.atlassian.net/browse/LIVE-8640)

### ✅ Checklist

- [n/A] **Test coverage** 
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo

<details>
  <summary>Demo video Android</summary>

https://github.com/LedgerHQ/ledger-live/assets/15096913/d62bd81c-8641-4839-ae97-4432281a61d2



</details>

[LIVE-8789]: https://ledgerhq.atlassian.net/browse/LIVE-8789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-8796]: https://ledgerhq.atlassian.net/browse/LIVE-8796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-8640]: https://ledgerhq.atlassian.net/browse/LIVE-8640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ