### PR TITLE
fix: cosmos operation detail fields names destination_validator, source_validator

### DIFF
--- a/.changeset/unlucky-cameras-try.md
+++ b/.changeset/unlucky-cameras-try.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix cosmos operation detail fields names destination_validator and source_validator

--- a/libs/ledger-live-common/src/families/cosmos/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-synchronisation.ts
@@ -120,8 +120,12 @@ const txToOps = (info: AccountShapeInfo, accountId: string, txs: CosmosTx[]): Op
         const redelegateShards: { amount: BigNumber; address: string }[] = [];
         for (const message of correspondingMessages) {
           const amount = message.attributes.find(attr => attr.key === "amount")?.value;
-          const validatorDst = message.attributes.find(attr => attr.key === "validator_dst")?.value;
-          const validatorSrc = message.attributes.find(attr => attr.key === "validator_src")?.value;
+          const validatorDst = message.attributes.find(
+            attr => attr.key === "destination_validator",
+          )?.value;
+          const validatorSrc = message.attributes.find(
+            attr => attr.key === "source_validator",
+          )?.value;
           if (amount && validatorDst && validatorSrc && amount.endsWith(unitCode)) {
             op.extra.sourceValidator = validatorSrc;
             redelegateShards.push({

--- a/libs/ledger-live-common/src/families/cosmos/js-synchronisation.unit.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-synchronisation.unit.test.ts
@@ -521,11 +521,11 @@ describe("getAccountShape", () => {
                       value: "5uatom",
                     },
                     {
-                      key: "validator_src",
+                      key: "source_validator",
                       value: "address_src",
                     },
                     {
-                      key: "validator_dst",
+                      key: "destination_validator",
                       value: "address1",
                     },
                   ],
@@ -538,11 +538,11 @@ describe("getAccountShape", () => {
                       value: "6uatom",
                     },
                     {
-                      key: "validator_src",
+                      key: "source_validator",
                       value: "address_src",
                     },
                     {
-                      key: "validator_dst",
+                      key: "destination_validator",
                       value: "address2",
                     },
                   ],


### PR DESCRIPTION
### 📝 Description

Fix cosmos operation detail fields names destination_validator, source_validator
It was a regression due to the 
https://github.com/LedgerHQ/ledger-live/commit/e775c83ab7fa28b395c149d03679cdd93535b14a
destination_validator was renamed with "validator_dst" by mistake.
source_validator was renamed with "validator_src" by mistake.

### ❓ Context

- **Impacted projects**: LLC, LLD, LLM
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8787

### ✅ Checklist

- [x] **Test coverage**
- [X] **Atomic delivery**
- [X] **No breaking changes**

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
