### PR TITLE
fix(FirmwareUpdateLLM): fix issue that prevented user from correctly leaving the fw update

### DIFF
--- a/.changeset/perfect-donuts-hammer.md
+++ b/.changeset/perfect-donuts-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix issue that made it impossible to leave the new Firmware Update UX

--- a/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/FirmwareUpdateBanner.tsx
@@ -61,6 +61,16 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
 
   const latestFirmware = useLatestFirmware(lastSeenDevice?.deviceInfo);
 
+  const {
+    requestCompleted: batteryRequestCompleted,
+    batteryStatusesState,
+    triggerRequest: triggerBatteryCheck,
+    cancelRequest: cancelBatteryCheck,
+  } = useBatteryStatuses({
+    deviceId: lastConnectedDevice?.deviceId,
+    statuses: requiredBatteryStatuses,
+  });
+
   const onExperimentalFirmwareUpdate = useCallback(() => {
     if (newFwUpdateUxFeatureFlag?.enabled) {
       navigation.navigate(NavigatorName.Manager, {
@@ -69,7 +79,10 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
           device: lastConnectedDevice,
           deviceInfo: lastSeenDevice?.deviceInfo,
           firmwareUpdateContext: latestFirmware,
-          onBackFromUpdate,
+          onBackFromUpdate: () => {
+            cancelBatteryCheck();
+            if (onBackFromUpdate) onBackFromUpdate();
+          },
         },
       });
       return;
@@ -93,18 +106,9 @@ const FirmwareUpdateBanner = ({ onBackFromUpdate }: FirmwareUpdateBannerProps) =
     lastConnectedDevice,
     lastSeenDevice?.deviceInfo,
     latestFirmware,
+    cancelBatteryCheck,
     onBackFromUpdate,
   ]);
-
-  const {
-    requestCompleted: batteryRequestCompleted,
-    batteryStatusesState,
-    triggerRequest: triggerBatteryCheck,
-    cancelRequest: cancelBatteryCheck,
-  } = useBatteryStatuses({
-    deviceId: lastConnectedDevice?.deviceId,
-    statuses: requiredBatteryStatuses,
-  });
 
   // Effect that will check the battery of stax before triggering the update and display a warning preventing the update
   // in case the battery is too low and the device is not charging


### PR DESCRIPTION
### 📝 Description
https://github.com/LedgerHQ/ledger-live/pull/3581 made the battery checks prior to starting the firmware update more robust. However, it also introduced a bug that made the app re-navigate to the firmware update automatically once the user exited it. This PR fixes that issue

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: [LIVE-8796]

### ✅ Checklist

- [n/a] **Test coverage**
- [x] **Atomic delivery**
- [x] **No breaking changes**

### 📸 Demo
Check the videos on [LIVE-8796] for the original bug. This shouldn't happen anymore and the user should go back to the original page they were in before starting the firmware update.


[LIVE-8796]: https://ledgerhq.atlassian.net/browse/LIVE-8796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-8796]: https://ledgerhq.atlassian.net/browse/LIVE-8796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ