### PR TITLE
LLM device actions mock: create DeviceAction model, loadBleState and loadAccounts helpers

### DIFF
--- a/.changeset/fresh-baboons-provide.md
+++ b/.changeset/fresh-baboons-provide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Export Event type from 'app' device actions

--- a/.changeset/late-tips-beg.md
+++ b/.changeset/late-tips-beg.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Introduces use\*DeviceAction() hooks in order to mock test all device actions. It impacts all screens that have device actions.

--- a/.changeset/tidy-rabbits-wonder.md
+++ b/.changeset/tidy-rabbits-wonder.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Introduce testID prop on Form/SelectableList

--- a/apps/ledger-live-mobile/e2e/bridge/server.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/server.ts
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import { NavigatorName } from "../../src/const";
 import { Subject } from "rxjs";
+import { MessageData } from "./client";
 
 type ServerData = {
   type: "walletAPIResponse";
@@ -74,7 +75,7 @@ export function setInstalledApps(apps: string[] = []) {
 }
 
 export function open() {
-  postMessage({ type: "open", payload: null });
+  postMessage({ type: "open" });
 }
 
 function onMessage(messageStr: string) {
@@ -96,10 +97,10 @@ function log(message: string) {
 }
 
 function acceptTerms() {
-  postMessage({ type: "acceptTerms", payload: null });
+  postMessage({ type: "acceptTerms" });
 }
 
-function postMessage(message: { type: string; payload: unknown }) {
+function postMessage(message: MessageData) {
   for (const ws of wss.clients.values()) {
     ws.send(JSON.stringify(message));
   }

--- a/apps/ledger-live-mobile/e2e/bridge/server.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/server.ts
@@ -1,9 +1,12 @@
 import { Server } from "ws";
 import path from "path";
 import fs from "fs";
+import { toAccountRaw } from "@ledgerhq/live-common/account/index";
 import { NavigatorName } from "../../src/const";
 import { Subject } from "rxjs";
-import { MessageData } from "./client";
+import { MessageData, MockDeviceEvent } from "./client";
+import { BleState } from "../../src/reducers/types";
+import { Account } from "@ledgerhq/types-live";
 
 type ServerData = {
   type: "walletAPIResponse";
@@ -48,10 +51,31 @@ export function loadConfig(fileName: string, agreed: true = true): void {
   }
 }
 
+export function loadBleState(bleState: BleState) {
+  postMessage({ type: "importBle", payload: bleState });
+}
+
+export function loadAccounts(accounts: Account[]) {
+  postMessage({
+    type: "importAccounts",
+    payload: accounts.map(account => ({
+      version: 1,
+      data: toAccountRaw(account),
+    })),
+  });
+}
+
 function navigate(name: string) {
   postMessage({
     type: "navigate",
     payload: name,
+  });
+}
+
+export function mockDeviceEvent(...args: MockDeviceEvent[]) {
+  postMessage({
+    type: "mockDeviceEvent",
+    payload: args,
   });
 }
 

--- a/apps/ledger-live-mobile/e2e/helpers.ts
+++ b/apps/ledger-live-mobile/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { by, device, element, waitFor } from "detox";
+import { by, element, waitFor, device } from "detox";
 import { Direction } from "react-native-modal";
 
 const DEFAULT_TIMEOUT = 60000;

--- a/apps/ledger-live-mobile/e2e/models/DeviceAction.ts
+++ b/apps/ledger-live-mobile/e2e/models/DeviceAction.ts
@@ -1,0 +1,216 @@
+import BigNumber from "bignumber.js";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import {
+  deviceInfo155 as deviceInfo,
+  deviceInfo210lo5,
+  mockListAppsResult as innerMockListAppResult,
+} from "@ledgerhq/live-common/apps/mock";
+import { AppOp } from "@ledgerhq/live-common/apps/types";
+import { AppType, DeviceInfo } from "@ledgerhq/types-live/lib/manager";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { Transaction } from "@ledgerhq/live-common/generated/types";
+import { waitForElementById, tapById, delay } from "../helpers";
+import { mockDeviceEvent } from "../bridge/server";
+import { DeviceLike } from "../../src/reducers/types";
+
+const mockListAppsResult = (
+  appDesc: string,
+  installedDesc: string,
+  deviceInfo: DeviceInfo,
+  deviceModelId?: DeviceModelId,
+) => {
+  const result = innerMockListAppResult(appDesc, installedDesc, deviceInfo, deviceModelId);
+  Object.keys(result?.appByName).forEach(key => {
+    result.appByName[key] = { ...result.appByName[key], type: AppType.currency };
+  });
+  return result;
+};
+
+// this implement mock for the "legacy" device action (the one working with live-common/lib/hw/actions/*)
+export default class DeviceAction {
+  deviceLike: DeviceLike;
+  device: Device;
+
+  constructor(deviceLike: DeviceLike) {
+    this.deviceLike = deviceLike;
+    this.device = this.deviceLikeToDevice(deviceLike);
+  }
+
+  deviceLikeToDevice(d: DeviceLike): Device {
+    return {
+      deviceId: d.id,
+      deviceName: d.name,
+      modelId: d.modelId,
+      wired: false,
+    };
+  }
+
+  async selectMockDevice() {
+    const elId = "device-item-" + this.deviceLike.id;
+    await waitForElementById(elId);
+    await tapById(elId);
+  }
+
+  async waitForSpinner() {
+    await waitForElementById("device-action-loading");
+  }
+
+  async openApp() {
+    await this.waitForSpinner();
+    mockDeviceEvent({ type: "opened" });
+  }
+
+  async genuineCheck(appDesc = "Bitcoin", installedDesc = "Bitcoin") {
+    await this.waitForSpinner();
+
+    const { device } = this;
+    const result = mockListAppsResult(appDesc, installedDesc, deviceInfo);
+    mockDeviceEvent(
+      {
+        type: "deviceChange",
+        device,
+      },
+      {
+        type: "listingApps",
+        deviceInfo,
+      },
+      {
+        type: "result",
+        result,
+      },
+      { type: "complete" },
+    );
+  }
+
+  async accessManager(
+    appDesc = "Bitcoin,Tron,Litecoin,Ethereum,Ripple,Stellar",
+    installedDesc = "Bitcoin,Litecoin,Ethereum (outdated)",
+  ) {
+    await this.waitForSpinner();
+
+    const { device } = this;
+
+    const result = mockListAppsResult(appDesc, installedDesc, deviceInfo, device.modelId);
+    mockDeviceEvent(
+      {
+        type: "deviceChange",
+        device,
+      },
+      {
+        type: "listingApps",
+        deviceInfo,
+      },
+      {
+        type: "result",
+        result,
+      },
+      { type: "complete" },
+    );
+  }
+
+  async accessManagerWithL10n(
+    appDesc = "Bitcoin,Tron,Litecoin,Ethereum,Ripple,Stellar",
+    installedDesc = "Bitcoin,Litecoin,Ethereum (outdated)",
+  ) {
+    await this.waitForSpinner();
+
+    const { device } = this;
+
+    const result = mockListAppsResult(appDesc, installedDesc, deviceInfo210lo5);
+    mockDeviceEvent(
+      {
+        type: "deviceChange",
+        device,
+      },
+      {
+        type: "listingApps",
+        deviceInfo: deviceInfo210lo5,
+      },
+      {
+        type: "result",
+        result,
+      },
+      { type: "complete" },
+    );
+  }
+
+  async complete() {
+    mockDeviceEvent({ type: "complete" });
+  }
+
+  async initiateLanguageInstallation() {
+    mockDeviceEvent({ type: "devicePermissionRequested" });
+  }
+
+  async add50ProgressToLanguageInstallation() {
+    mockDeviceEvent({ type: "progress", progress: 0.5 });
+  }
+
+  async installSetOfAppsMocked(
+    progress: number,
+    itemProgress: number,
+    currentAppOp: AppOp,
+    installQueue: string[],
+  ) {
+    mockDeviceEvent({
+      type: "inline-install",
+      progress: progress,
+      itemProgress: itemProgress,
+      currentAppOp: currentAppOp,
+      installQueue: installQueue,
+    });
+  }
+
+  async resolveDependenciesMocked(installQueue: string[]) {
+    mockDeviceEvent({
+      type: "listed-apps",
+      installQueue: installQueue,
+    });
+  }
+
+  async completeLanguageInstallation() {
+    mockDeviceEvent({ type: "languageInstalled" });
+  }
+
+  async requestImageLoad() {
+    mockDeviceEvent({ type: "loadImagePermissionRequested" });
+  }
+
+  async loadImageWithProgress(progress: number) {
+    mockDeviceEvent({ type: "progress", progress });
+  }
+
+  async requestImageCommit() {
+    mockDeviceEvent({ type: "commitImagePermissionRequested" });
+  }
+
+  async confirmImageLoaded(imageSize: number, imageHash: string) {
+    mockDeviceEvent({ type: "imageLoaded", imageSize, imageHash });
+  }
+
+  async initiateSwap(estimatedFees: BigNumber) {
+    mockDeviceEvent({ type: "opened" });
+    await delay(2000); // enough time to allow the UI to switch from one action to another
+    mockDeviceEvent({ type: "init-swap-requested", estimatedFees });
+  }
+
+  async confirmSwap(transaction: Transaction) {
+    mockDeviceEvent(
+      {
+        type: "init-swap-result",
+        initSwapResult: {
+          transaction,
+          swapId: "12345",
+        },
+      },
+      {
+        type: "complete",
+      },
+    );
+  }
+
+  async silentSign() {
+    await this.waitForSpinner();
+    mockDeviceEvent({ type: "opened" }, { type: "complete" });
+  }
+}

--- a/apps/ledger-live-mobile/e2e/models/accounts/accountsPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/accounts/accountsPage.ts
@@ -11,4 +11,7 @@ export default class accountsPage {
   async waitForAccountsPageToLoad() {
     await waitForElementById("accounts-list-title");
   }
+  async waitForAccountsCoinPageToLoad(coin: string) {
+    await waitForElementById(`accounts-title-${coin}`);
+  }
 }

--- a/apps/ledger-live-mobile/e2e/models/accounts/addAccountDrawer.ts
+++ b/apps/ledger-live-mobile/e2e/models/accounts/addAccountDrawer.ts
@@ -1,0 +1,32 @@
+import { openDeeplink, tapById, waitForElementById } from "../../helpers";
+
+export default class AddAccountDrawer {
+  async openViaDeeplink() {
+    await openDeeplink("add-account");
+  }
+
+  async importWithYourLedger() {
+    const id = "add-accounts-modal-add-button";
+    await waitForElementById(id);
+    await tapById(id);
+  }
+
+  async selectCurrency(currencyId: string) {
+    const id = "currency-row-" + currencyId;
+    await waitForElementById(id);
+    await tapById(id);
+  }
+
+  async startAccountsDiscovery() {
+    await waitForElementById("add-accounts-continue-button");
+  }
+
+  async finishAccountsDiscovery() {
+    await tapById("add-accounts-continue-button");
+  }
+
+  async tapSuccessCta() {
+    await waitForElementById("add-accounts-success-cta");
+    await tapById("add-accounts-success-cta");
+  }
+}

--- a/apps/ledger-live-mobile/e2e/models/manager/managerPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/manager/managerPage.ts
@@ -1,3 +1,4 @@
+import { waitFor } from "detox";
 import { getElementById, openDeeplink } from "../../helpers";
 
 const baseLink = "myledger";
@@ -7,5 +8,9 @@ export default class ManagerPage {
 
   async openViaDeeplink() {
     await openDeeplink(baseLink);
+  }
+
+  async waitForManagerPageToLoad() {
+    await waitFor(this.managerTitle()).toBeVisible();
   }
 }

--- a/apps/ledger-live-mobile/e2e/models/receive.ts
+++ b/apps/ledger-live-mobile/e2e/models/receive.ts
@@ -1,0 +1,12 @@
+import { openDeeplink, tapById, waitForElementById } from "../helpers";
+
+export default class ReceivePage {
+  openViaDeeplink() {
+    return openDeeplink("receive");
+  }
+  async selectCurrency(currencyId: string) {
+    const id = "currency-row-" + currencyId;
+    await waitForElementById(id);
+    await tapById(id);
+  }
+}

--- a/apps/ledger-live-mobile/e2e/models/send.ts
+++ b/apps/ledger-live-mobile/e2e/models/send.ts
@@ -1,0 +1,38 @@
+import { getElementById, tapById, waitForElementById } from "../helpers";
+
+export default class ReceivePage {
+  async selectAccount(accountId: string) {
+    const id = "account-card-" + accountId;
+    await waitForElementById(id);
+    await tapById(id);
+  }
+
+  async setRecipient(address: string) {
+    const element = getElementById("recipient-input");
+    await element.replaceText(address);
+    await element.tapReturnKey();
+  }
+
+  async recipientContinue() {
+    await tapById("recipient-continue-button");
+  }
+
+  async setAmount(amount: string) {
+    const element = getElementById("amount-input");
+    await element.replaceText(amount);
+    await element.tapReturnKey();
+  }
+
+  async amountContinue() {
+    await tapById("amount-continue-button");
+  }
+
+  async summaryContinue() {
+    await tapById("summary-continue-button");
+  }
+
+  async successContinue() {
+    await waitForElementById("success-close-button");
+    await tapById("success-close-button");
+  }
+}

--- a/apps/ledger-live-mobile/e2e/models/wallet/portfolioPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/wallet/portfolioPage.ts
@@ -16,6 +16,8 @@ export default class PortfolioPage {
   portfolioSettingsButton = () => getElementById("settings-icon");
   transferButton = () => getElementById("transfer-button");
   swapTransferMenuButton = () => getElementById("swap-transfer-button");
+  sendTransferMenuButton = () => getElementById("transfer-send-button");
+  sendMenuButton = () => getElementById("send-button");
   marketTabButton = () => getElementById("tab-bar-market");
 
   navigateToSettings() {
@@ -35,6 +37,20 @@ export default class PortfolioPage {
     return waitForElementById("settings-icon", 120000);
   }
 
+  async navigateToSendFromTransferMenu() {
+    await tapByElement(this.sendTransferMenuButton());
+  }
+
+  async openAddAccount() {
+    const element = getElementById("add-account-button");
+    await element.tap();
+  }
+
+  async receive() {
+    const element = getElementById("receive-button");
+    await element.tap();
+  }
+
   async waitForPortfolioReadOnly() {
     await waitForElementById(this.readOnlyPortfolioId);
     expect(await getTextOfElement(this.graphCardBalanceId)).toBe(this.zeroBalance);
@@ -48,5 +64,9 @@ export default class PortfolioPage {
 
   openMarketPage() {
     return tapByElement(this.marketTabButton());
+  }
+
+  openMyLedger() {
+    return tapByElement(getElementById("TabBarManager"));
   }
 }

--- a/apps/ledger-live-mobile/e2e/setups/onboardingcompleted.json
+++ b/apps/ledger-live-mobile/e2e/setups/onboardingcompleted.json
@@ -22,6 +22,8 @@
       "loaded": true,
       "shareAnalytics": true,
       "sentryLogs": true,
+      "readOnlyModeEnabled": false,
+      "hasOrderedNano": true,
       "lastUsedVersion": "99.99.99",
       "dismissedBanners": [],
       "accountsViewMode": "list",

--- a/apps/ledger-live-mobile/e2e/specs/addAccounts/bitcoin.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/addAccounts/bitcoin.spec.ts
@@ -1,0 +1,55 @@
+import { expect, device } from "detox";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { loadBleState, loadConfig } from "../../bridge/server";
+import PortfolioPage from "../../models/wallet/portfolioPage";
+import DeviceAction from "../../models/DeviceAction";
+import AccountsPage from "../../models/accounts/accountsPage";
+import AddAccountDrawer from "../../models/accounts/addAccountDrawer";
+import { getElementByText } from "../../helpers";
+
+let portfolioPage: PortfolioPage;
+let deviceAction: DeviceAction;
+let accountsPage: AccountsPage;
+let addAccountDrawer: AddAccountDrawer;
+
+const knownDevice = {
+  name: "Nano X de test",
+  id: "mock_1",
+  modelId: DeviceModelId.nanoX,
+};
+
+describe("Add Bitcoin Accounts", () => {
+  beforeAll(async () => {
+    loadConfig("onboardingcompleted", true);
+    loadBleState({ knownDevices: [knownDevice] });
+
+    portfolioPage = new PortfolioPage();
+    deviceAction = new DeviceAction(knownDevice);
+    accountsPage = new AccountsPage();
+    addAccountDrawer = new AddAccountDrawer();
+
+    await portfolioPage.waitForPortfolioPageToLoad();
+  });
+
+  it("open add accounts from portfolio", async () => {
+    await addAccountDrawer.openViaDeeplink();
+  });
+
+  it("add Bitcoin accounts", async () => {
+    await addAccountDrawer.selectCurrency("bitcoin");
+    // device actions and add accounts modal have animations that requires to disable synchronization default detox behavior
+    await device.disableSynchronization();
+    await deviceAction.selectMockDevice();
+    await deviceAction.openApp();
+    await addAccountDrawer.startAccountsDiscovery();
+    await expect(getElementByText("Bitcoin 2")).toBeVisible();
+    await addAccountDrawer.finishAccountsDiscovery();
+    await addAccountDrawer.tapSuccessCta();
+  });
+
+  it("displays accounts page summary", async () => {
+    await device.disableSynchronization();
+    await accountsPage.waitForAccountsCoinPageToLoad("Bitcoin");
+    await expect(getElementByText("1.19576 BTC")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/e2e/specs/manager.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/manager.spec.ts
@@ -1,0 +1,44 @@
+import { expect, device } from "detox";
+import { loadBleState, loadConfig } from "../bridge/server";
+import PortfolioPage from "../models/wallet/portfolioPage";
+import DeviceAction from "../models/DeviceAction";
+import ManagerPage from "../models/manager/managerPage";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { getElementByText, waitForElementByText } from "../helpers";
+
+let portfolioPage: PortfolioPage;
+let deviceAction: DeviceAction;
+let managerPage: ManagerPage;
+
+const knownDevice = {
+  name: "Nano X de test",
+  id: "mock_1",
+  modelId: DeviceModelId.nanoX,
+};
+
+describe("Bitcoin Account", () => {
+  beforeAll(async () => {
+    loadConfig("onboardingcompleted", true);
+    loadBleState({ knownDevices: [knownDevice] });
+
+    portfolioPage = new PortfolioPage();
+    deviceAction = new DeviceAction(knownDevice);
+    managerPage = new ManagerPage();
+
+    await portfolioPage.waitForPortfolioPageToLoad();
+  });
+
+  it("open manager", async () => {
+    await portfolioPage.openMyLedger();
+    // device actions have animations that requires to disable synchronization default detox behavior
+    await device.disableSynchronization();
+    await deviceAction.selectMockDevice();
+    await deviceAction.accessManager();
+    await managerPage.waitForManagerPageToLoad();
+  });
+
+  it("displays device name", async () => {
+    await waitForElementByText(knownDevice.name);
+    await expect(getElementByText(knownDevice.name)).toExist();
+  });
+});

--- a/apps/ledger-live-mobile/e2e/specs/receive/bitcoin.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/receive/bitcoin.spec.ts
@@ -1,0 +1,56 @@
+import { device } from "detox";
+import { loadBleState, loadConfig } from "../../bridge/server";
+import PortfolioPage from "../../models/wallet/portfolioPage";
+import ReceivePage from "../../models/receive";
+import DeviceAction from "../../models/DeviceAction";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { tapByText, waitForElementById, waitForElementByText } from "../../helpers";
+
+let portfolioPage: PortfolioPage;
+let receivePage: ReceivePage;
+let deviceAction: DeviceAction;
+
+const knownDevice = {
+  name: "Nano X de test",
+  id: "mock_1",
+  modelId: DeviceModelId.nanoX,
+};
+
+describe("Bitcoin 2 account", () => {
+  beforeAll(async () => {
+    loadConfig("onboardingcompleted", true);
+    loadBleState({ knownDevices: [knownDevice] });
+
+    portfolioPage = new PortfolioPage();
+    deviceAction = new DeviceAction(knownDevice);
+    receivePage = new ReceivePage();
+
+    await portfolioPage.waitForPortfolioPageToLoad();
+  });
+
+  it("receive from portfolio", async () => {
+    await receivePage.openViaDeeplink();
+  });
+
+  it("receive on Bitcoin 2 (through scanning)", async () => {
+    await receivePage.selectCurrency("bitcoin");
+
+    // device actions and add accounts modal have animations that requires to disable synchronization default detox behavior
+    await device.disableSynchronization();
+    await deviceAction.selectMockDevice();
+    await deviceAction.openApp();
+
+    await waitForElementByText("Bitcoin 2");
+    await tapByText("Bitcoin 2");
+    await waitForElementById("receive-fresh-address");
+  });
+
+  // TODO: TO BE CONTINUED
+  /*
+  it("verifies the address", async () => {
+    await waitForElementByText("Verify my address");
+    await tapByText("Verify my address");
+    await waitForElementByText("Address verified");
+  });
+  */
+});

--- a/apps/ledger-live-mobile/e2e/specs/send/bitcoin.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/send/bitcoin.spec.ts
@@ -1,0 +1,89 @@
+import { device, expect } from "detox";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+import {
+  formatCurrencyUnit,
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { loadAccounts, loadBleState, loadConfig } from "../../bridge/server";
+import PortfolioPage from "../../models/wallet/portfolioPage";
+import SendPage from "../../models/send";
+import DeviceAction from "../../models/DeviceAction";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { getElementByText } from "../../helpers";
+
+let portfolioPage: PortfolioPage;
+let sendPage: SendPage;
+let deviceAction: DeviceAction;
+
+setSupportedCurrencies(["bitcoin"]);
+
+const knownDevice = {
+  name: "Nano X de test",
+  id: "mock_1",
+  modelId: DeviceModelId.nanoX,
+};
+
+const bitcoinAccount = genAccount("mock1", {
+  currency: getCryptoCurrencyById("bitcoin"),
+});
+
+describe("Bitcoin send flow", () => {
+  beforeAll(async () => {
+    loadConfig("onboardingcompleted", true);
+    loadBleState({ knownDevices: [knownDevice] });
+    loadAccounts([bitcoinAccount]);
+
+    portfolioPage = new PortfolioPage();
+    deviceAction = new DeviceAction(knownDevice);
+    sendPage = new SendPage();
+
+    await portfolioPage.waitForPortfolioPageToLoad();
+  });
+
+  it("open account send flow", async () => {
+    await portfolioPage.openTransferMenu();
+    await portfolioPage.navigateToSendFromTransferMenu();
+  });
+
+  const halfBalance = bitcoinAccount.balance.div(2);
+  const amount =
+    // half of the balance, formatted with the same unit as what the input should use
+    formatCurrencyUnit(bitcoinAccount.unit, halfBalance);
+
+  const amountWithCode = formatCurrencyUnit(bitcoinAccount.unit, halfBalance, {
+    showCode: true,
+  });
+
+  it("traverse through the send flow", async () => {
+    await sendPage.selectAccount(bitcoinAccount.id);
+    await sendPage.setRecipient(bitcoinAccount.freshAddress);
+    await sendPage.recipientContinue();
+
+    await sendPage.setAmount(amount);
+    await sendPage.amountContinue();
+
+    await expect(getElementByText(amountWithCode)).toBeVisible();
+    await sendPage.summaryContinue();
+
+    // device actions and add accounts modal have animations that requires to disable synchronization default detox behavior
+    await device.disableSynchronization();
+    await deviceAction.selectMockDevice();
+    await deviceAction.openApp();
+    await device.enableSynchronization();
+
+    await sendPage.successContinue();
+  });
+
+  /*
+  // FIXME unclear why it doesn't pass
+  it("displays our new operation in the operation list", async () => {
+    const roundedAmountWithCode = formatCurrencyUnit(bitcoinAccount.unit, halfBalance, {
+      showCode: true,
+      disableRounding: false,
+    });
+    await waitForElementByText(roundedAmountWithCode);
+    await expect(getElementByText(roundedAmountWithCode)).toBeVisible();
+  });
+  */
+});

--- a/apps/ledger-live-mobile/src/components/AccountCard.tsx
+++ b/apps/ledger-live-mobile/src/components/AccountCard.tsx
@@ -43,7 +43,7 @@ const AccountCard = ({
     getTagDerivationMode(currency, account.derivationMode as DerivationMode);
 
   return (
-    <TouchableOpacity disabled={disabled} onPress={onPress}>
+    <TouchableOpacity disabled={disabled} onPress={onPress} testID={"account-card-" + account.id}>
       <Card
         flexDirection="row"
         paddingY={4}

--- a/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageAction.tsx
+++ b/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageAction.tsx
@@ -2,12 +2,11 @@ import React, { useEffect, useMemo } from "react";
 
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Language } from "@ledgerhq/types-live";
-import { createAction } from "@ledgerhq/live-common/hw/actions/installLanguage";
-import installLanguage from "@ledgerhq/live-common/hw/installLanguage";
 import { useTranslation } from "react-i18next";
 import { Flex, Alert } from "@ledgerhq/native-ui";
 import DeviceAction from "./DeviceAction";
 import DeviceLanguageInstalled from "./DeviceLanguageInstalled";
+import { useInstallLanguageDeviceAction } from "../hooks/deviceActions";
 
 type Props = {
   device: Device;
@@ -18,7 +17,6 @@ type Props = {
   onError?: (err: Error) => void;
 };
 
-const action = createAction(installLanguage);
 const ChangeDeviceLanguageAction: React.FC<Props> = ({
   device,
   language,
@@ -27,6 +25,7 @@ const ChangeDeviceLanguageAction: React.FC<Props> = ({
   onResult,
   onError,
 }) => {
+  const action = useInstallLanguageDeviceAction();
   const showAlert = !device?.wired;
   const { t } = useTranslation();
   const request = useMemo(() => ({ language }), [language]);

--- a/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/ChangeDeviceLanguageActionModal.tsx
@@ -2,10 +2,9 @@ import React, { useMemo } from "react";
 
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Language } from "@ledgerhq/types-live";
-import { createAction } from "@ledgerhq/live-common/hw/actions/installLanguage";
-import installLanguage from "@ledgerhq/live-common/hw/installLanguage";
 import DeviceActionModal from "./DeviceActionModal";
 import DeviceLanguageInstalled from "./DeviceLanguageInstalled";
+import { useInstallLanguageDeviceAction } from "../hooks/deviceActions";
 
 type Props = {
   device: Device | null;
@@ -15,7 +14,6 @@ type Props = {
   onResult?: () => void;
 };
 
-const action = createAction(installLanguage);
 const ChangeDeviceLanguageActionModal: React.FC<Props> = ({
   device,
   language,
@@ -23,6 +21,7 @@ const ChangeDeviceLanguageActionModal: React.FC<Props> = ({
   onError,
   onResult,
 }) => {
+  const action = useInstallLanguageDeviceAction();
   const request = useMemo(() => ({ language }), [language]);
 
   return (

--- a/apps/ledger-live-mobile/src/components/CurrencyRow.tsx
+++ b/apps/ledger-live-mobile/src/components/CurrencyRow.tsx
@@ -30,7 +30,11 @@ const CurrencyRow = ({ currency, style, isOK = true, iconSize = 32, onPress }: P
   const { colors } = useTheme();
 
   return (
-    <StyledRectButton style={[style]} onPress={onPressAction}>
+    <StyledRectButton
+      testID={"currency-row-" + currency.id}
+      style={[style]}
+      onPress={onPressAction}
+    >
       <CircleCurrencyIcon
         size={iconSize}
         currency={currency}

--- a/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
@@ -2,9 +2,7 @@ import { useNavigation } from "@react-navigation/native";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Flex, InfiniteLoader } from "@ledgerhq/native-ui";
-import { createAction } from "@ledgerhq/live-common/hw/actions/staxRemoveImage";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import removeImage from "@ledgerhq/live-common/hw/staxRemoveImage";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { NavigatorName, ScreenName } from "../../const";
@@ -15,8 +13,7 @@ import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigato
 import { StackNavigatorNavigation } from "../RootNavigator/types/helpers";
 import { TrackScreen } from "../../analytics";
 import DeviceAction from "../DeviceAction";
-
-const action = createAction(removeImage);
+import { useStaxRemoveImageDeviceAction } from "../../hooks/deviceActions";
 
 const analyticsDrawerName = "Choose an image to set as your Stax lockscreen";
 
@@ -117,6 +114,8 @@ const CustomImageBottomModal: React.FC<Props> = props => {
     },
     [setDeviceHasImage],
   );
+
+  const action = useStaxRemoveImageDeviceAction();
 
   return (
     <QueuedDrawer

--- a/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
@@ -5,8 +5,6 @@ import { Flex, IconsLegacy } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { createAction } from "@ledgerhq/live-common/hw/actions/staxLoadImage";
-import loadImage from "@ledgerhq/live-common/hw/staxLoadImage";
 import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { setLastSeenCustomImage, clearLastSeenCustomImage } from "../actions/settings";
 import { DeviceActionDefaultRendering } from "./DeviceAction";
@@ -16,6 +14,7 @@ import CustomImageBottomModal from "./CustomImage/CustomImageBottomModal";
 import Button from "./wrappedUi/Button";
 import Link from "./wrappedUi/Link";
 import { screen, TrackScreen } from "../analytics";
+import { useStaxLoadImageDeviceAction } from "../hooks/deviceActions";
 
 type Props = {
   device: Device;
@@ -36,7 +35,6 @@ const analyticsRefusedOnStaxDoThisLaterEventProps = {
 const analyticsErrorTryAgainEventProps = {
   button: "Try again",
 };
-const action = createAction(loadImage);
 
 const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   device,
@@ -47,6 +45,7 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   source,
   remountMe,
 }) => {
+  const action = useStaxLoadImageDeviceAction();
   const commandRequest = useMemo(() => ({ hexImage }), [hexImage]);
 
   const { t } = useTranslation();

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -1,11 +1,9 @@
 import React, { useCallback, useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SkipReason } from "@ledgerhq/live-common/apps/types";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { Alert, Flex, ProgressLoader, VerticalTimeline } from "@ledgerhq/native-ui";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelInfo } from "@ledgerhq/types-live";
@@ -19,6 +17,7 @@ import Item, { ItemState } from "./Item";
 import Confirmation from "./Confirmation";
 import Restore from "./Restore";
 import { lastSeenDeviceSelector } from "../../../reducers/settings";
+import { useAppDeviceAction } from "../../../hooks/deviceActions";
 
 type Props = {
   restore?: boolean;
@@ -28,8 +27,6 @@ type Props = {
   onError?: (error: Error) => void;
   debugLastSeenDeviceModelId?: DeviceModelId;
 };
-
-const action = createAction(connectApp);
 
 /**
  * This component overrides the default rendering for device actions in some
@@ -47,6 +44,7 @@ const InstallSetOfApps = ({
   remountMe,
   debugLastSeenDeviceModelId,
 }: Props & { remountMe: () => void }) => {
+  const action = useAppDeviceAction();
   const { t } = useTranslation();
   const [userConfirmed, setUserConfirmed] = useState(false);
   const productName = getDeviceModel(selectedDevice.modelId).productName;

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -881,7 +881,9 @@ export function renderLoading({
       <SpinnerContainer>
         <InfiniteLoader />
       </SpinnerContainer>
-      <CenteredText>{description ?? t("DeviceAction.loading")}</CenteredText>
+      <CenteredText testID="device-action-loading">
+        {description ?? t("DeviceAction.loading")}
+      </CenteredText>
       {lockModal ? <ModalLock /> : null}
     </Wrapper>
   );

--- a/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
@@ -32,6 +32,7 @@ export const NavigationHeaderCloseButton: React.FC<Props> = React.memo(({ onPres
   const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
   return (
     <Touchable
+      touchableTestID="NavigationHeaderCloseButton"
       event="HeaderRightClose"
       onPress={() => (onPress ? onPress() : navigation.popToTop())}
     >

--- a/apps/ledger-live-mobile/src/components/RecipientInput.tsx
+++ b/apps/ledger-live-mobile/src/components/RecipientInput.tsx
@@ -37,6 +37,7 @@ const RecipientInput = ({ ref, onPaste, placeholderTranslationKey, ...props }: P
   return (
     <TextInput
       ref={ref}
+      testID="recipient-input"
       placeholder={t(placeholderTranslationKey)}
       renderRight={
         <Flex alignItems="center" justifyContent="center" pr={2}>

--- a/apps/ledger-live-mobile/src/components/SelectDevice/DeviceItem.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/DeviceItem.tsx
@@ -54,6 +54,7 @@ function DeviceItem({
       Icon={CustomIcon || NanoFoldedMedium}
       renderRight={onMore ? renderOnMore : undefined}
       disabled={disabled}
+      testID={"device-item-" + deviceMeta.deviceId}
     >
       {deviceMeta.deviceName}
       {description && (

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/Item.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/Item.tsx
@@ -40,7 +40,7 @@ const Item = ({ device, onPress }: Props) => {
   }, [device.modelId]);
 
   return (
-    <Touchable event="something" onPress={() => onPress(device)}>
+    <Touchable onPress={() => onPress(device)} touchableTestID={"device-item-" + device.deviceId}>
       <Flex
         backgroundColor="neutral.c30"
         borderRadius={2}

--- a/apps/ledger-live-mobile/src/components/TabBar/BackgroundGradient.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/BackgroundGradient.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const BackgroundGradient = ({ height, opacity, stops }: Props) => (
-  <StyledSVG style={{ height }}>
+  <StyledSVG pointerEvents="none" style={{ height }}>
     <Defs>
       <LinearGradient
         id="myGradient"

--- a/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
@@ -132,6 +132,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
       onPress: accountsCount > 0 && !readOnlyModeEnabled && !areAccountsEmpty ? onSendFunds : null,
       Icon: IconsLegacy.ArrowTopMedium,
       disabled: !accountsCount || readOnlyModeEnabled || areAccountsEmpty,
+      testID: "transfer-send-button",
     },
     {
       eventProperties: {
@@ -144,6 +145,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
       onPress: onReceiveFunds,
       Icon: IconsLegacy.ArrowBottomMedium,
       disabled: readOnlyModeEnabled,
+      testID: "transfer-receive-button",
     },
     {
       eventProperties: {
@@ -169,6 +171,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
         }
       },
       disabled: isPtxServiceCtaExchangeDrawerDisabled || readOnlyModeEnabled,
+      testID: "transfer-receive-button",
     },
     {
       eventProperties: {
@@ -197,6 +200,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
         !accountsCount ||
         readOnlyModeEnabled ||
         areAccountsEmpty,
+      testID: "transfer-sell-button",
     },
 
     ...(stakePrograms?.enabled
@@ -212,6 +216,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
             Icon: IconsLegacy.ClaimRewardsMedium,
             onPress: onStake,
             disabled: readOnlyModeEnabled,
+            testID: "transfer-stake-button",
           },
         ]
       : []),
@@ -258,6 +263,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
             Icon: IconsLegacy.WalletConnectMedium,
             onPress: onWalletConnect,
             disabled: readOnlyModeEnabled,
+            testID: "transfer-walletconnect-button",
           },
         ]
       : []),

--- a/apps/ledger-live-mobile/src/components/Touchable.tsx
+++ b/apps/ledger-live-mobile/src/components/Touchable.tsx
@@ -89,6 +89,7 @@ export default class Touchable extends Component<
     const { onPress, children, event, eventProperties, touchableTestID, ...rest } = this.props;
     const { pending } = this.state;
     const disabled = !onPress || pending;
+
     return (
       <TouchableOpacity
         delayPressIn={50}

--- a/apps/ledger-live-mobile/src/components/ValidateSuccess.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateSuccess.tsx
@@ -76,6 +76,7 @@ function ValidateSuccess({
         {secondaryButton ||
           (onClose && (
             <Button
+              testID="success-close-button"
               event="SendSuccessClose"
               type={undefined}
               outline={false}

--- a/apps/ledger-live-mobile/src/hooks/deviceActions.ts
+++ b/apps/ledger-live-mobile/src/hooks/deviceActions.ts
@@ -1,0 +1,126 @@
+import { useMemo } from "react";
+import { createAction as appCreateAction } from "@ledgerhq/live-common/hw/actions/app";
+import { createAction as transactionCreateAction } from "@ledgerhq/live-common/hw/actions/transaction";
+import { createAction as startExchangeCreateAction } from "@ledgerhq/live-common/hw/actions/startExchange";
+import { createAction as initSwapCreateAction } from "@ledgerhq/live-common/hw/actions/initSwap";
+import { createAction as managerCreateAction } from "@ledgerhq/live-common/hw/actions/manager";
+import { createAction as signMessageCreateAction } from "@ledgerhq/live-common/hw/signMessage/index";
+import { createAction as completeExchangeCreateAction } from "@ledgerhq/live-common/hw/actions/completeExchange";
+import { createAction as staxLoadImageCreateAction } from "@ledgerhq/live-common/hw/actions/staxLoadImage";
+import { createAction as staxFetchImageCreateAction } from "@ledgerhq/live-common/hw/actions/staxFetchImage";
+import { createAction as installLanguageCreateAction } from "@ledgerhq/live-common/hw/actions/installLanguage";
+import { createAction as staxRemoveImageCreateAction } from "@ledgerhq/live-common/hw/actions/staxRemoveImage";
+import { createAction as renameDeviceCreateAction } from "@ledgerhq/live-common/hw/actions/renameDevice";
+import renameDevice from "@ledgerhq/live-common/hw/renameDevice";
+import staxLoadImage from "@ledgerhq/live-common/hw/staxLoadImage";
+import installLanguage from "@ledgerhq/live-common/hw/installLanguage";
+import staxFetchImage from "@ledgerhq/live-common/hw/staxFetchImage";
+import staxRemoveImage from "@ledgerhq/live-common/hw/staxRemoveImage";
+import connectManager from "@ledgerhq/live-common/hw/connectManager";
+import initSwap from "@ledgerhq/live-common/exchange/swap/initSwap";
+import connectApp from "@ledgerhq/live-common/hw/connectApp";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
+import startExchange from "@ledgerhq/live-common/exchange/platform/startExchange";
+import completeExchange from "@ledgerhq/live-common/exchange/platform/completeExchange";
+import {
+  connectAppExecMock,
+  initSwapExecMock,
+  connectManagerExecMock,
+  staxFetchImageExecMock,
+  startExchangeExecMock,
+  completeExchangeExecMock,
+  installLanguageExecMock,
+  staxLoadImageExecMock,
+  staxRemoveImageExecMock,
+  renameDeviceExecMock,
+} from "../../e2e/bridge/client";
+
+export function useAppDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(() => appCreateAction(mock ? connectAppExecMock : connectApp), [mock]);
+}
+
+export function useTransactionDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(() => transactionCreateAction(mock ? connectAppExecMock : connectApp), [mock]);
+}
+
+export function useInitSwapDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () =>
+      mock
+        ? initSwapCreateAction(connectAppExecMock, initSwapExecMock)
+        : initSwapCreateAction(connectApp, initSwap),
+    [mock],
+  );
+}
+
+export function useManagerDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(() => managerCreateAction(mock ? connectManagerExecMock : connectManager), [mock]);
+}
+
+export function useSignMessageDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(() => signMessageCreateAction(mock ? connectAppExecMock : connectApp), [mock]);
+}
+
+export function useInstallLanguageDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () => installLanguageCreateAction(mock ? installLanguageExecMock : installLanguage),
+    [mock],
+  );
+}
+
+export function useStaxLoadImageDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () => staxLoadImageCreateAction(mock ? staxLoadImageExecMock : staxLoadImage),
+    [mock],
+  );
+}
+
+export function useStaxFetchImageDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () => staxFetchImageCreateAction(mock ? staxFetchImageExecMock : staxFetchImage),
+    [mock],
+  );
+}
+
+export function useStaxRemoveImageDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () => staxRemoveImageCreateAction(mock ? staxRemoveImageExecMock : staxRemoveImage),
+    [mock],
+  );
+}
+
+export function useStartExchangeDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () =>
+      mock
+        ? startExchangeCreateAction(connectAppExecMock, startExchangeExecMock)
+        : startExchangeCreateAction(connectApp, startExchange),
+    [mock],
+  );
+}
+
+export function useCompleteExchangeDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () => completeExchangeCreateAction(mock ? completeExchangeExecMock : completeExchange),
+    [mock],
+  );
+}
+
+export function useRenameDeviceAction() {
+  const mock = useEnv("MOCK");
+  return useMemo(
+    () => renameDeviceCreateAction(mock ? renameDeviceExecMock : renameDevice),
+    [mock],
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/02-SelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/02-SelectDevice.tsx
@@ -2,9 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { StyleSheet, SafeAreaView } from "react-native";
 import { useDispatch } from "react-redux";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import { Flex } from "@ledgerhq/native-ui";
@@ -24,6 +22,7 @@ import SkipSelectDevice from "../SkipSelectDevice";
 import { setLastConnectedDevice, setReadOnlyMode } from "../../actions/settings";
 import AddAccountsHeaderRightClose from "./AddAccountsHeaderRightClose";
 import { NavigationHeaderBackButton } from "../../components/NavigationHeaderBackButton";
+import { useAppDeviceAction } from "../../hooks/deviceActions";
 
 type Props = StackNavigatorProps<AddAccountsNavigatorParamList, ScreenName.AddAccountsSelectDevice>;
 
@@ -35,9 +34,8 @@ export const addAccountsSelectDeviceHeaderOptions: ReactNavigationHeaderOptions 
   headerLeft: () => <NavigationHeaderBackButton />,
 };
 
-const action = createAction(connectApp);
-
 export default function AddAccountsSelectDevice({ navigation, route }: Props) {
+  const action = useAppDeviceAction();
   const { currency, analyticsPropertyFlow } = route.params;
   const { colors } = useTheme();
   const [device, setDevice] = useState<Device | null | undefined>(null);

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
@@ -546,6 +546,7 @@ class Footer extends PureComponent<{
           />
         ) : (
           <Button
+            testID="add-accounts-continue-button"
             event="AddAccountsSelected"
             type="primary"
             title={<Trans i18nKey="addAccounts.finalCta" />}

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/04-Success.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/04-Success.tsx
@@ -52,6 +52,7 @@ export default function AddAccountsSuccess({ navigation, route }: Props) {
       </LText>
       <View style={styles.buttonsContainer}>
         <Button
+          testID="add-accounts-success-cta"
           event="AddAccountsDone"
           containerStyle={styles.button}
           type="primary"

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/AddAccountsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/AddAccountsModal.tsx
@@ -79,6 +79,7 @@ export default function AddAccountsModal({ navigation, onClose, isOpened, curren
           onPress={onClickAdd}
           imageSource={setupLedgerImg}
           hasMarginBottom
+          testID="add-accounts-modal-add-button"
         />
       )}
 

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/AddAccountsModalCard.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/AddAccountsModalCard.tsx
@@ -9,6 +9,7 @@ type Props = {
   onPress: () => void;
   imageSource: ImageSourcePropType;
   hasMarginBottom?: boolean;
+  testID?: string;
 };
 export default function AddAccountsModalCard({
   title,
@@ -16,6 +17,7 @@ export default function AddAccountsModalCard({
   onPress,
   imageSource,
   hasMarginBottom = false,
+  testID,
 }: Props) {
   return (
     <DiscoverCard
@@ -29,6 +31,7 @@ export default function AddAccountsModalCard({
         mb: hasMarginBottom ? "16px" : 0,
       }}
       Image={<Illustration size={130} darkSource={imageSource} lightSource={imageSource} />}
+      testID={testID}
     />
   );
 }

--- a/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ConnectDevice.tsx
@@ -5,8 +5,6 @@ import { useSelector } from "react-redux";
 import { Edge, SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { createAction } from "@ledgerhq/live-common/hw/actions/transaction";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTheme } from "styled-components/native";
 import { StackNavigationProp } from "@react-navigation/stack";
@@ -54,8 +52,8 @@ import { TezosDelegationFlowParamList } from "../families/tezos/DelegationFlow/t
 import { TronVoteFlowParamList } from "../families/tron/VoteFlow/types";
 import { SignTransactionNavigatorParamList } from "../components/RootNavigator/types/SignTransactionNavigator";
 import { SignMessageNavigatorStackParamList } from "../components/RootNavigator/types/SignMessageNavigator";
+import { useTransactionDeviceAction } from "../hooks/deviceActions";
 
-const action = createAction(connectApp);
 type Props =
   | StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendConnectDevice>
   | StackNavigatorProps<ClaimRewardsNavigatorParamList, ScreenName.ClaimRewardsConnectDevice>
@@ -115,6 +113,7 @@ export const navigateToSelectDevice = (navigation: Props["navigation"], route: P
     },
   );
 export default function ConnectDevice({ route, navigation }: Props) {
+  const action = useTransactionDeviceAction();
   const { colors } = useTheme();
   const { t } = useTranslation();
   const { account, parentAccount } = useSelector(accountScreenSelector(route));

--- a/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/DeviceConnect/index.tsx
@@ -4,9 +4,8 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { TFunction, useTranslation } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { AppResult, createAction } from "@ledgerhq/live-common/hw/actions/app";
+import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { Flex } from "@ledgerhq/native-ui";
 import { TrackScreen } from "../../analytics";
 import SelectDevice2, { SetHeaderOptionsRequest } from "../../components/SelectDevice2";
@@ -22,8 +21,7 @@ import {
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "../../const";
 import { NavigationHeaderBackButton } from "../../components/NavigationHeaderBackButton";
-
-const action = createAction(connectApp);
+import { useAppDeviceAction } from "../../hooks/deviceActions";
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.DeviceConnect>
@@ -96,6 +94,8 @@ export default function DeviceConnect({ navigation, route }: NavigationProps) {
     }),
     [appName],
   );
+
+  const action = useAppDeviceAction();
 
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -6,8 +6,6 @@ import { TextInput as NativeTextInput } from "react-native";
 import { DeviceNameInvalid } from "@ledgerhq/errors";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import { Button, Text, IconsLegacy, Flex } from "@ledgerhq/native-ui";
-import { createAction } from "@ledgerhq/live-common/hw/actions/renameDevice";
-import renameDevice from "@ledgerhq/live-common/hw/renameDevice";
 import getDeviceNameMaxLength from "@ledgerhq/live-common/hw/getDeviceNameMaxLength";
 import { TrackScreen } from "../analytics";
 import KeyboardBackgroundDismiss from "../components/KeyboardBackgroundDismiss";
@@ -21,8 +19,7 @@ import { BaseNavigatorStackParamList } from "../components/RootNavigator/types/B
 import { ScreenName } from "../const";
 import { BaseOnboardingNavigatorParamList } from "../components/RootNavigator/types/BaseOnboardingNavigator";
 import { BleSaveDeviceNamePayload } from "../actions/types";
-
-const action = createAction(renameDevice);
+import { useRenameDeviceAction } from "../hooks/deviceActions";
 
 const mapDispatchToProps = {
   saveBleDeviceName,
@@ -37,6 +34,7 @@ type Props = {
 } & NavigationProps;
 
 function EditDeviceName({ navigation, route, saveBleDeviceName }: Props) {
+  const action = useRenameDeviceAction();
   const originalName = route.params?.deviceName;
   const device = route.params?.device;
   const deviceInfo = route.params?.deviceInfo;

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -1,14 +1,4 @@
 import { log } from "@ledgerhq/logs";
-import staxLoadImage from "@ledgerhq/live-common/hw/staxLoadImage";
-import staxFetchImage from "@ledgerhq/live-common/hw/staxFetchImage";
-import installLanguage from "@ledgerhq/live-common/hw/installLanguage";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
-import connectManager from "@ledgerhq/live-common/hw/connectManager";
-import { createAction as createStaxLoadImageAction } from "@ledgerhq/live-common/hw/actions/staxLoadImage";
-import { createAction as createStaxFetchImageAction } from "@ledgerhq/live-common/hw/actions/staxFetchImage";
-import { createAction as createInstallLanguageAction } from "@ledgerhq/live-common/hw/actions/installLanguage";
-import { createAction as createConnectAppAction } from "@ledgerhq/live-common/hw/actions/app";
-import { createAction as createConnectManagerAction } from "@ledgerhq/live-common/hw/actions/manager";
 import { useUpdateFirmware } from "@ledgerhq/live-common/deviceSDK/hooks/useUpdateFirmware";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import {
@@ -34,6 +24,13 @@ import {
   ImageLoadRefusedOnDevice,
   LanguageInstallRefusedOnDevice,
 } from "@ledgerhq/live-common/errors";
+import {
+  useAppDeviceAction,
+  useInstallLanguageDeviceAction,
+  useManagerDeviceAction,
+  useStaxFetchImageDeviceAction,
+  useStaxLoadImageDeviceAction,
+} from "../../hooks/deviceActions";
 
 export const reconnectDeviceErrors: LedgerErrorConstructor<{
   [key: string]: unknown;
@@ -73,12 +70,6 @@ export type UpdateStep =
   | "appsRestore"
   | "completed";
 
-const installLanguageAction = createInstallLanguageAction(installLanguage);
-const staxLoadImageAction = createStaxLoadImageAction(staxLoadImage);
-const staxFetchImageAction = createStaxFetchImageAction(staxFetchImage);
-const connectManagerAction = createConnectManagerAction(connectManager);
-const connectAppAction = createConnectAppAction(connectApp);
-
 export const useUpdateFirmwareAndRestoreSettings = ({
   updateFirmwareAction,
   device,
@@ -86,6 +77,11 @@ export const useUpdateFirmwareAndRestoreSettings = ({
 }: FirmwareUpdateParams) => {
   const [updateStep, setUpdateStep] = useState<UpdateStep>("start");
   const [installedApps, setInstalledApps] = useState<string[]>([]);
+
+  const installLanguageAction = useInstallLanguageDeviceAction();
+  const staxLoadImageAction = useStaxLoadImageDeviceAction();
+  const staxFetchImageAction = useStaxFetchImageDeviceAction();
+  const connectManagerAction = useManagerDeviceAction();
 
   // device action hooks only get triggered when they have a device passed to them
   // so in order to control the chaining of actions we use a step state and only
@@ -147,6 +143,8 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     }),
     [installedApps],
   );
+
+  const connectAppAction = useAppDeviceAction();
 
   const restoreAppsState = connectAppAction.useHook(
     updateStep === "appsRestore" ? device : null,

--- a/apps/ledger-live-mobile/src/screens/Manager/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/index.tsx
@@ -4,9 +4,7 @@ import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
 import { Trans } from "react-i18next";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { BluetoothRequired } from "@ledgerhq/errors";
-
-import connectManager from "@ledgerhq/live-common/hw/connectManager";
-import { createAction, Result } from "@ledgerhq/live-common/hw/actions/manager";
+import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Flex, Text } from "@ledgerhq/native-ui";
 
@@ -31,8 +29,7 @@ import { TAB_BAR_SAFE_HEIGHT } from "../../components/TabBar/shared";
 
 import { useExperimental } from "../../experimental";
 import { HEIGHT as ExperimentalHeaderHeight } from "../Settings/Experimental/ExperimentalHeader";
-
-const action = createAction(connectManager);
+import { useManagerDeviceAction } from "../../hooks/deviceActions";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<ManagerNavigatorStackParamList, ScreenName.Manager>
@@ -50,6 +47,7 @@ type ChooseDeviceProps = Props & {
 };
 
 const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
+  const action = useManagerDeviceAction();
   const [device, setDevice] = useState<Device | null>();
 
   const [chosenDevice, setChosenDevice] = useState<Device | null>();

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
@@ -3,8 +3,7 @@ import { useDispatch } from "react-redux";
 import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import connectManager from "@ledgerhq/live-common/hw/connectManager";
-import { createAction, Result } from "@ledgerhq/live-common/hw/actions/manager";
+import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import DeviceActionModal from "../../../../../components/DeviceActionModal";
 import SelectDevice from "../../../../../components/SelectDevice";
 import SelectDevice2 from "../../../../../components/SelectDevice2";
@@ -17,8 +16,7 @@ import {
   setLastConnectedDevice,
   setReadOnlyMode,
 } from "../../../../../actions/settings";
-
-const action = createAction(connectManager);
+import { useManagerDeviceAction } from "../../../../../hooks/deviceActions";
 
 const ConnectNanoScene = ({
   onNext,
@@ -27,6 +25,7 @@ const ConnectNanoScene = ({
   onNext: () => void;
   deviceModelId: string;
 }) => {
+  const action = useManagerDeviceAction();
   const dispatch = useDispatch();
   const [device, setDevice] = useState<Device | undefined>();
 

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -1,7 +1,3 @@
-import completeExchange from "@ledgerhq/live-common/exchange/platform/completeExchange";
-import { createAction } from "@ledgerhq/live-common/hw/actions/completeExchange";
-import { createAction as txCreateAction } from "@ledgerhq/live-common/hw/actions/transaction";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -11,6 +7,10 @@ import { useBroadcast } from "../../../components/useBroadcast";
 import { StackNavigatorProps } from "../../../components/RootNavigator/types/helpers";
 import { PlatformExchangeNavigatorParamList } from "../../../components/RootNavigator/types/PlatformExchangeNavigator";
 import { ScreenName } from "../../../const";
+import {
+  useTransactionDeviceAction,
+  useCompleteExchangeDeviceAction,
+} from "../../../hooks/deviceActions";
 
 type Props = StackNavigatorProps<
   PlatformExchangeNavigatorParamList,
@@ -78,6 +78,9 @@ const PlatformCompleteExchange: React.FC<Props> = ({
     [account, parentAccount, tokenCurrency, transaction],
   );
 
+  const sendAction = useTransactionDeviceAction();
+  const exchangeAction = useCompleteExchangeDeviceAction();
+
   return (
     <SafeAreaView style={styles.root}>
       {!transaction ? (
@@ -104,9 +107,6 @@ const PlatformCompleteExchange: React.FC<Props> = ({
     </SafeAreaView>
   );
 };
-
-const exchangeAction = createAction(completeExchange);
-const sendAction = txCreateAction(connectApp);
 
 const styles = StyleSheet.create({
   root: {

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -1,10 +1,7 @@
-import startExchange from "@ledgerhq/live-common/exchange/platform/startExchange";
-import { createAction } from "@ledgerhq/live-common/hw/actions/startExchange";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useIsFocused } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import React, { useCallback, useMemo, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -17,6 +14,7 @@ import {
 import SelectDevice from "../../../components/SelectDevice";
 import SelectDevice2 from "../../../components/SelectDevice2";
 import { ScreenName } from "../../../const";
+import { useStartExchangeDeviceAction } from "../../../hooks/deviceActions";
 
 type Props = StackNavigatorProps<
   PlatformExchangeNavigatorParamList,
@@ -24,6 +22,7 @@ type Props = StackNavigatorProps<
 >;
 
 const PlatformStartExchange: React.FC<Props> = ({ navigation, route }) => {
+  const action = useStartExchangeDeviceAction();
   const [device, setDevice] = useState<Device>();
 
   const isFocused = useIsFocused();
@@ -66,8 +65,6 @@ const PlatformStartExchange: React.FC<Props> = ({ navigation, route }) => {
     </SafeAreaView>
   );
 };
-
-const action = createAction(connectApp, startExchange);
 
 const styles = StyleSheet.create({
   root: {

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioEmptyState.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioEmptyState.tsx
@@ -58,6 +58,7 @@ const PortfolioEmptyState = ({ openAddAccountModal }: { openAddAccountModal: () 
           ml={3}
           onPress={goToReceiveFunds}
           flex={1}
+          testID="receive-button"
         >
           {t("account.receive")}
         </Button>
@@ -79,6 +80,7 @@ const PortfolioEmptyState = ({ openAddAccountModal }: { openAddAccountModal: () 
         width={"100%"}
         mt={7}
         mb={11}
+        testID="add-account-button"
       >
         {t("account.emptyState.addAccountCta")}
       </Button>

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
@@ -3,9 +3,7 @@ import { StyleSheet, SafeAreaView } from "react-native";
 import { useDispatch } from "react-redux";
 import { Flex } from "@ledgerhq/native-ui";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { prepareCurrency } from "../../bridge/cache";
 import { ScreenName } from "../../const";
@@ -23,6 +21,7 @@ import {
 } from "../../components/RootNavigator/types/helpers";
 import { NavigationHeaderCloseButtonAdvanced } from "../../components/NavigationHeaderCloseButton";
 import { NavigationHeaderBackButton } from "../../components/NavigationHeaderBackButton";
+import { useAppDeviceAction } from "../../hooks/deviceActions";
 
 // Defines some of the header options for this screen to be able to reset back to them.
 export const addAccountsSelectDeviceHeaderOptions = (
@@ -32,8 +31,6 @@ export const addAccountsSelectDeviceHeaderOptions = (
   headerLeft: () => <NavigationHeaderBackButton />,
 });
 
-const action = createAction(connectApp);
-
 export default function AddAccountsSelectDevice({
   navigation,
   route,
@@ -42,6 +39,8 @@ export default function AddAccountsSelectDevice({
   const { colors } = useTheme();
   const [device, setDevice] = useState<Device | null>(null);
   const dispatch = useDispatch();
+
+  const action = useAppDeviceAction();
 
   const isFocused = useIsFocused();
   const newDeviceSelectionFeatureFlag = useFeature("llmNewDeviceSelection");

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -280,7 +280,7 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
             width="100%"
             justifyContent={"space-between"}
           >
-            <Text numberOfLines={4} flex={1} fontWeight="semiBold">
+            <Text testID="receive-fresh-address" numberOfLines={4} flex={1} fontWeight="semiBold">
               {mainAccount.freshAddress}
             </Text>
             <CopyLink

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03a-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03a-ConnectDevice.tsx
@@ -8,8 +8,6 @@ import {
 } from "@ledgerhq/live-common/account/index";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { createAction } from "@ledgerhq/live-common/hw/actions/app";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { Flex } from "@ledgerhq/native-ui";
 
 import { accountScreenSelector } from "../../reducers/accounts";
@@ -32,6 +30,7 @@ import {
 } from "../../components/RootNavigator/types/helpers";
 import { NavigationHeaderCloseButton } from "../../components/NavigationHeaderCloseButton";
 import { NavigationHeaderBackButton } from "../../components/NavigationHeaderBackButton";
+import { useAppDeviceAction } from "../../hooks/deviceActions";
 
 // Defines some of the header options for this screen to be able to reset back to them.
 export const connectDeviceHeaderOptions = (
@@ -41,8 +40,6 @@ export const connectDeviceHeaderOptions = (
   headerLeft: () => <NavigationHeaderBackButton onPress={onHeaderBackButtonPress} />,
 });
 
-const action = createAction(connectApp);
-
 export default function ConnectDevice({
   navigation,
   route,
@@ -50,8 +47,8 @@ export default function ConnectDevice({
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const [device, setDevice] = useState<Device | undefined>();
-
   const newDeviceSelectionFeatureFlag = useFeature("llmNewDeviceSelection");
+  const action = useAppDeviceAction();
 
   useEffect(() => {
     const readOnlyTitle = "transfer.receive.titleReadOnly";

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -267,6 +267,7 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
               </View>
             ) : null}
             <Button
+              testID="recipient-continue-button"
               event="SendRecipientContinue"
               type="primary"
               title={<Trans i18nKey="common.continue" />}

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -143,6 +143,7 @@ export default function SendAmountCoin({ navigation, route }: Props) {
           <TouchableWithoutFeedback onPress={blur}>
             <View style={styles.amountWrapper}>
               <AmountInput
+                testID="amount-input"
                 editable={!useAllAmount}
                 account={account}
                 onChange={onChange}
@@ -191,6 +192,7 @@ export default function SendAmountCoin({ navigation, route }: Props) {
                 </View>
                 <View style={styles.continueWrapper}>
                   <Button
+                    testID="amount-continue-button"
                     event="SendAmountCoinContinue"
                     type="primary"
                     title={

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -264,6 +264,7 @@ function SendSummary({ navigation, route }: Props) {
           <Button
             event="SummaryContinue"
             type="primary"
+            testID="summary-continue-button"
             title={<Trans i18nKey="common.continue" />}
             containerStyle={styles.continueButton}
             onPress={() => setContinuing(true)}

--- a/apps/ledger-live-mobile/src/screens/SendFunds/AmountInput.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/AmountInput.tsx
@@ -19,6 +19,8 @@ type Props = {
   error?: Error | null | undefined;
   warning?: Error | null | undefined;
   editable?: boolean;
+  testID?: string;
+  fiatTestID?: string;
 };
 export default function AmountInput({
   onChange,
@@ -27,6 +29,8 @@ export default function AmountInput({
   error,
   warning,
   editable,
+  testID,
+  fiatTestID,
 }: Props) {
   const { t } = useTranslation();
   const fiatCurrency = useSelector(counterValueCurrencySelector);
@@ -56,6 +60,7 @@ export default function AmountInput({
     <View style={styles.container}>
       <View style={styles.wrapper}>
         <CurrencyInput
+          testID={testID}
           editable={editable}
           isActive={isCrypto}
           onFocus={onCryptoFieldFocus}
@@ -81,6 +86,7 @@ export default function AmountInput({
       <CounterValuesSeparator />
       <View style={styles.wrapper}>
         <CurrencyInput
+          testID={fiatTestID}
           isActive={!isCrypto}
           onFocus={onFiatFieldFocus}
           onChange={onChangeFiatAmount}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/FetchCustomImage.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/FetchCustomImage.tsx
@@ -5,9 +5,6 @@ import { Text, Flex, Button } from "@ledgerhq/native-ui";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useSelector, useDispatch } from "react-redux";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { createAction } from "@ledgerhq/live-common/hw/actions/staxFetchImage";
-import staxFetchImage from "@ledgerhq/live-common/hw/staxFetchImage";
-
 import { targetDisplayDimensions } from "../../../CustomImage/shared";
 import { customImageBackupSelector } from "../../../../reducers/settings";
 import { setCustomImageBackup } from "../../../../actions/settings";
@@ -22,6 +19,7 @@ import StaxFramedImage, {
 } from "../../../../components/CustomImage/StaxFramedImage";
 import { NavigationHeaderBackButton } from "../../../../components/NavigationHeaderBackButton";
 import { ReactNavigationHeaderOptions } from "../../../../components/RootNavigator/types/helpers";
+import { useStaxFetchImageDeviceAction } from "../../../../hooks/deviceActions";
 
 // Defines here some of the header options for this screen to be able to reset back to them.
 export const debugFetchCustomImageHeaderOptions: ReactNavigationHeaderOptions = {
@@ -31,9 +29,8 @@ export const debugFetchCustomImageHeaderOptions: ReactNavigationHeaderOptions = 
   headerLeft: () => <NavigationHeaderBackButton />,
 };
 
-const deviceAction = createAction(staxFetchImage);
-
 export default function DebugFetchCustomImage() {
+  const deviceAction = useStaxFetchImageDeviceAction();
   const { colors } = useTheme();
   const navigation = useNavigation();
 

--- a/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.tsx
@@ -3,8 +3,6 @@ import React, { useMemo } from "react";
 import { StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { createAction } from "@ledgerhq/live-common/hw/signMessage/index";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { accountScreenSelector } from "../../reducers/accounts";
 import DeviceAction from "../../components/DeviceAction";
@@ -13,13 +11,13 @@ import { ScreenName } from "../../const";
 import { navigateToSelectDevice } from "../ConnectDevice";
 import { SignMessageNavigatorStackParamList } from "../../components/RootNavigator/types/SignMessageNavigator";
 import { StackNavigatorProps } from "../../components/RootNavigator/types/helpers";
-
-const action = createAction(connectApp);
+import { useSignMessageDeviceAction } from "../../hooks/deviceActions";
 
 export default function ConnectDevice({
   route,
   navigation,
 }: StackNavigatorProps<SignMessageNavigatorStackParamList, ScreenName.SignConnectDevice>) {
+  const action = useSignMessageDeviceAction();
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   invariant(account, "account is required");
   const mainAccount = getMainAccount(account, parentAccount);

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -4,8 +4,6 @@ import { StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { createAction } from "@ledgerhq/live-common/hw/actions/transaction";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useTheme } from "@react-navigation/native";
 import { accountScreenSelector } from "../../reducers/accounts";
@@ -16,8 +14,7 @@ import { navigateToSelectDevice } from "../ConnectDevice";
 import { SignTransactionNavigatorParamList } from "../../components/RootNavigator/types/SignTransactionNavigator";
 import { ScreenName } from "../../const";
 import { StackNavigatorProps } from "../../components/RootNavigator/types/helpers";
-
-const action = createAction(connectApp);
+import { useTransactionDeviceAction } from "../../hooks/deviceActions";
 
 function ConnectDevice({
   navigation,
@@ -26,6 +23,7 @@ function ConnectDevice({
   SignTransactionNavigatorParamList,
   ScreenName.SignTransactionConnectDevice
 >) {
+  const action = useTransactionDeviceAction();
   const { colors } = useTheme();
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   invariant(account, "account is required");

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Connect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Connect.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
-import connectManager from "@ledgerhq/live-common/hw/connectManager";
-import { createAction } from "@ledgerhq/live-common/hw/actions/manager";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import SelectDevice from "../../../components/SelectDevice";
@@ -11,8 +9,7 @@ import DeviceActionModal from "../../../components/DeviceActionModal";
 import { TrackScreen } from "../../../analytics";
 import SkipSelectDevice from "../../SkipSelectDevice";
 import { DeviceMeta } from "./Modal/Confirmation";
-
-const action = createAction(connectManager);
+import { useManagerDeviceAction } from "../../../hooks/deviceActions";
 
 export function Connect({
   setResult,
@@ -21,6 +18,8 @@ export function Connect({
   setResult: (_: DeviceMeta) => void;
   provider?: string;
 }) {
+  const action = useManagerDeviceAction();
+
   const [device, setDevice] = useState<Device>();
   const [result] = useState();
 

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
@@ -12,10 +12,6 @@ import {
   SwapTransactionType,
 } from "@ledgerhq/live-common/exchange/swap/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { createAction } from "@ledgerhq/live-common/hw/actions/transaction";
-import { createAction as initSwapCreateAction } from "@ledgerhq/live-common/hw/actions/initSwap";
-import initSwap from "@ledgerhq/live-common/exchange/swap/initSwap";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import addToSwapHistory from "@ledgerhq/live-common/exchange/swap/addToSwapHistory";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { AccountLike, DeviceInfo, SignedOperation } from "@ledgerhq/types-live";
@@ -33,9 +29,10 @@ import { UnionToIntersection } from "../../../../types/helpers";
 import type { StackNavigatorNavigation } from "../../../../components/RootNavigator/types/helpers";
 import { ScreenName } from "../../../../const";
 import type { SwapNavigatorParamList } from "../../../../components/RootNavigator/types/SwapNavigator";
-
-const silentSigningAction = createAction(connectApp);
-const swapAction = initSwapCreateAction(connectApp, initSwap);
+import {
+  useInitSwapDeviceAction,
+  useTransactionDeviceAction,
+} from "../../../../hooks/deviceActions";
 
 export type DeviceMeta = {
   result: { installed: InstalledItem[] } | null | undefined;
@@ -176,6 +173,9 @@ export function Confirmation({
       );
     }
   }, [broadcast, onComplete, onError, signedOperation, swapData]);
+
+  const silentSigningAction = useTransactionDeviceAction();
+  const swapAction = useInitSwapDeviceAction();
 
   const { t } = useTranslation();
 

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
@@ -5,10 +5,8 @@ import { useSelector } from "react-redux";
 import { useTheme } from "@react-navigation/native";
 import { getMainAccount, getReceiveFlowError } from "@ledgerhq/live-common/account/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Flex } from "@ledgerhq/native-ui";
-import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import { accountScreenSelector } from "../../reducers/accounts";
 import { TrackScreen } from "../../analytics";
 import SelectDevice from "../../components/SelectDevice";
@@ -27,14 +25,14 @@ import {
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "../../const";
 import { RootStackParamList } from "../../components/RootNavigator/types/RootNavigator";
-
-const action = createAction(connectApp);
+import { useAppDeviceAction } from "../../hooks/deviceActions";
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.VerifyAccount>
 >;
 
 export default function VerifyAccount({ navigation, route }: NavigationProps) {
+  const action = useAppDeviceAction();
   const { colors } = useTheme();
   const { parentAccount } = useSelector(accountScreenSelector(route));
   const [device, setDevice] = useState<Device | null | undefined>();

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -102,7 +102,7 @@ export type AppResult = {
 
 type AppAction = Action<AppRequest, AppState, AppResult>;
 
-type Event =
+export type Event =
   | {
       type: "error";
       error: Error;

--- a/libs/ui/packages/native/src/components/Form/SelectableList.tsx
+++ b/libs/ui/packages/native/src/components/Form/SelectableList.tsx
@@ -12,6 +12,7 @@ type BaseElementProps<V> = {
   value?: V;
   onPress?: ((event: GestureResponderEvent) => void) | undefined;
   Icon?: IconType;
+  testID?: string;
 };
 
 export type ElementProps<V> = React.PropsWithChildren<
@@ -38,9 +39,10 @@ function Element<V>(props: ElementProps<V>) {
     children,
     Icon,
     renderRight: RenderRight,
+    testID,
   } = props;
   return (
-    <TouchableOpacity onPress={onPress} disabled={disabled}>
+    <TouchableOpacity onPress={onPress} disabled={disabled} testID={testID}>
       <ElementContainer
         p={6}
         mt={first ? 0 : 4}


### PR DESCRIPTION
### 📝 Description

This work adds the ability to test all parts of our mobile application including the parts requiring a device action to be done. For the first time, we can therefore cover Add Accounts, Send, Receive,...

- The same **DeviceAction** model that exists on LLD has been created for the LLM stack. (with better and more explicit typing. we also share common hooks in order for the dynamic env to be connected)
- a helper `loadBleState` was created for a test to inject mocked "known devices" on the app
- a helper `loadAccounts` was created for a test to inject mocked accounts, directly from the code, notably reusing those provided by the genAccount generator
- all part of the app that use actions has been connected to the mock system.

test example for send

https://github.com/LedgerHQ/ledger-live/assets/211411/ebd332ab-ab54-46e6-a47c-30879a856f4b

test example for add account:

https://github.com/LedgerHQ/ledger-live/assets/211411/489689b2-4c0e-413b-8db2-8a9515106006



### Canonical test example

```ts
import { expect } from "detox";
import { loadBleState, loadConfig } from "../bridge/server";
import PortfolioPage from "../models/wallet/portfolioPage";
import DeviceAction from "../models/DeviceAction";
import { DeviceModelId } from "@ledgerhq/devices";

let portfolioPage: PortfolioPage;
let deviceAction: DeviceAction;

const knownDevice = {
  name: "Nano X de test",
  id: "mock_1",
  modelId: DeviceModelId.nanoX,
};

describe("...", () => {

  beforeAll(async () => {
    loadConfig("onboardingcompleted", true);

    loadBleState({ knownDevices: [knownDevice] });

    portfolioPage = new PortfolioPage();
    deviceAction = new DeviceAction(knownDevice);

    await portfolioPage.waitForPortfolioPageToLoad();
  });

  it("...", async () => {
     // ... do whatever follow that lead to a "select device" step
  });

  it("pass device step", async () => {
    // device actions and add accounts modal have animations that requires to disable synchronization default detox behavior
    await device.disableSynchronization();    
    await deviceAction.selectMockDevice();
    // ... do whatever action with deviceAction. for instance:
    await deviceAction.openApp();
  });
});
```

Currently available API (this took the same API as the one used on LLD. it can grow to cover more device actions when there is a need for it)

```
const deviceAction = new DeviceAction(device);

// Example usages of the DeviceAction API
await deviceAction.selectMockDevice();
await deviceAction.waitForSpinner();
await deviceAction.openApp();
await deviceAction.genuineCheck();
await deviceAction.accessManager();
await deviceAction.accessManagerWithL10n();
await deviceAction.complete();
await deviceAction.initiateLanguageInstallation();
await deviceAction.add50ProgressToLanguageInstallation();
await deviceAction.installSetOfAppsMocked(0.5, 0.2, "install", ["app1", "app2"]);
await deviceAction.resolveDependenciesMocked(["app1", "app2"]);
await deviceAction.completeLanguageInstallation();
await deviceAction.requestImageLoad();
await deviceAction.loadImageWithProgress(0.75);
await deviceAction.requestImageCommit();
await deviceAction.confirmImageLoaded(1024, "hash123");
await deviceAction.initiateSwap(new BigNumber(100));
await deviceAction.confirmSwap(transactionObject);
await deviceAction.silentSign();
```

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `?` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

- [x] taking some improvements from https://github.com/LedgerHQ/ledger-live/pull/2592
  - [x] TypeScript improvements
- [x] providing a first solution similar to LLD device mocks in order to be able to cover all flows. (TBD what it means)
  - [x] DeviceAction model object creation
  - [x] create "mockDeviceEvent" that allows to communicate to all underlying "createAction" (on the same paradigm as in LLD)
  - [x] implement the methods of that model object emitting to that "mockDeviceEvent"
  - [x] create minimal test examples for each section to cover.
    - [x] add accounts
    - [x] send
    - [x] receive
    - [x] manager

### 📸 Demo




<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
