### PR TITLE
feat: handle device in bootloader as a fatal error in the polling mechanism

### DIFF
--- a/.changeset/lemon-pigs-promise.md
+++ b/.changeset/lemon-pigs-promise.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+feat: handle device in bootloader as a fatal error in the polling mechanism


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

During the Sync Onboarding and the Early Security Check: if the user has a problem during the fw update, and their device is in bootloader/update mode, they need to be able to fix their device state.

To be able to know that the device is in bootloader mode, the easiest is for the polling mechanism to return this information.

It will be used by https://github.com/LedgerHQ/ledger-live/pull/3909 and https://github.com/LedgerHQ/ledger-live/pull/3887

### ❓ Context

- **Impacted projects**: `live-common`
- **Linked resource(s)**: [LIVE-8795](https://ledgerhq.atlassian.net/browse/LIVE-8795)

### ✅ Checklist

- [x] **Test coverage** Unit test 🤖 
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8795]: https://ledgerhq.atlassian.net/browse/LIVE-8795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ