### PR TITLE
feat(llm/analytics): replace "screen" by "page" in all usages of track()

### DIFF
--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -260,11 +260,11 @@ export const track = async (
     return;
   }
 
-  const screen = currentRouteNameRef.current;
+  const page = currentRouteNameRef.current;
 
   const userExtraProperties = await extraProperties(storeInstance as AppStore);
   const propertiesWithoutExtra = {
-    screen,
+    page,
     ...eventProperties,
   };
   const allProperties = {

--- a/apps/ledger-live-mobile/src/components/BuyDeviceBanner.tsx
+++ b/apps/ledger-live-mobile/src/components/BuyDeviceBanner.tsx
@@ -98,7 +98,7 @@ export default function BuyDeviceBanner({
       handleOnPress();
       track("button_clicked", {
         button: "Discover the Nano",
-        screen,
+        page: screen,
       });
     }
   }, [handleOnPress, handleSetupCtaOnPress, screen, variant]);
@@ -106,7 +106,7 @@ export default function BuyDeviceBanner({
   const pressMessage = useCallback(() => {
     track("message_clicked", {
       message: "I already have a device, set it up",
-      screen,
+      page: screen,
       currency: eventProperties?.currency,
     });
     handleSetupCtaOnPress();

--- a/apps/ledger-live-mobile/src/components/DeviceAction/common.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/common.tsx
@@ -127,7 +127,7 @@ export const FirmwareUpdateDenied = ({
         event="button_clicked"
         eventProperties={{
           button: "Restart OS update",
-          screen: "Firmware update",
+          page: "Firmware update",
           drawer: drawerName,
         }}
         outline={false}
@@ -142,7 +142,7 @@ export const FirmwareUpdateDenied = ({
         event="button_clicked"
         eventProperties={{
           button: "Exit update",
-          screen: "Firmware update",
+          page: "Firmware update",
           drawer: drawerName,
         }}
         onPress={onPressQuit}

--- a/apps/ledger-live-mobile/src/components/ExploreTab/ExploreTabNavigatorTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/ExploreTab/ExploreTabNavigatorTabBar.tsx
@@ -36,7 +36,7 @@ function Tab({
     if (!isActive && !event.defaultPrevented) {
       track("tab_clicked", {
         tab: route.name,
-        screen: route.name,
+        page: route.name,
       });
       navigation.navigate(route.name);
     }

--- a/apps/ledger-live-mobile/src/components/FabActions/ReadOnlyFabActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/ReadOnlyFabActions.tsx
@@ -23,7 +23,7 @@ function ReadOnlyFabActions() {
     (buttonTitle: string) => {
       track("button_clicked", {
         button: buttonTitle,
-        screen: "Account",
+        page: "Account",
         currency,
       });
       buyDevice();

--- a/apps/ledger-live-mobile/src/components/Nft/NftGallery/NftList.hook.ts
+++ b/apps/ledger-live-mobile/src/components/Nft/NftGallery/NftList.hook.ts
@@ -125,7 +125,7 @@ export function useNftList({ nftList }: { nftList?: ProtoNFT[] }) {
   const onPressMultiselect = useCallback(() => {
     track("button_clicked", {
       button: "Hide NFTs",
-      screen: ScreenName.WalletNftGallery,
+      page: ScreenName.WalletNftGallery,
     });
     triggerMultiSelectMode();
   }, [triggerMultiSelectMode]);
@@ -133,7 +133,7 @@ export function useNftList({ nftList }: { nftList?: ProtoNFT[] }) {
   const onPressHide = useCallback(() => {
     track("button_clicked", {
       button: "Multi Hide NFTs",
-      screen: ScreenName.WalletNftGallery,
+      page: ScreenName.WalletNftGallery,
     });
     onClickHide();
   }, [onClickHide]);
@@ -156,7 +156,7 @@ export function useNftList({ nftList }: { nftList?: ProtoNFT[] }) {
   const onCancelHide = useCallback(() => {
     track("button_clicked", {
       button: "Cancel  Hide NFTs",
-      screen: ScreenName.WalletNftGallery,
+      page: ScreenName.WalletNftGallery,
     });
     exitMultiSelectMode();
   }, [exitMultiSelectMode]);

--- a/apps/ledger-live-mobile/src/components/RootNavigator/NotificationCenterNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/NotificationCenterNavigator.tsx
@@ -29,7 +29,7 @@ export default function NotificationCenterNavigator() {
   const goToNotificationsSettings = useCallback(() => {
     track("button_clicked", {
       button: "Settings",
-      screen: ScreenName.NotificationCenter,
+      page: ScreenName.NotificationCenter,
     });
     navigation.navigate(NavigatorName.Settings, {
       screen: ScreenName.NotificationsSettings,
@@ -39,7 +39,7 @@ export default function NotificationCenterNavigator() {
   const goToStatusCenter = useCallback(() => {
     track("button_clicked", {
       button: "Notification Center Status",
-      screen: ScreenName.NotificationCenterStatus,
+      page: ScreenName.NotificationCenterStatus,
     });
     navigation.navigate(NavigatorName.NotificationCenter, {
       screen: ScreenName.NotificationCenterStatus,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
@@ -32,7 +32,7 @@ export default function ReceiveFundsNavigator() {
   const onClose = useCallback(() => {
     track("button_clicked", {
       button: "Close 'x'",
-      screen: route.name,
+      page: route.name,
     });
   }, [route]);
 
@@ -47,7 +47,7 @@ export default function ReceiveFundsNavigator() {
   const onConnectDeviceBack = useCallback((navigation: NavigationProp<Record<string, unknown>>) => {
     track("button_clicked", {
       button: "Back arrow",
-      screen: ScreenName.ReceiveConnectDevice,
+      page: ScreenName.ReceiveConnectDevice,
     });
     navigation.goBack();
   }, []);
@@ -55,14 +55,14 @@ export default function ReceiveFundsNavigator() {
   const onConfirmationClose = useCallback(() => {
     track("button_clicked", {
       button: "HeaderRight Close",
-      screen: ScreenName.ReceiveConfirmation,
+      page: ScreenName.ReceiveConfirmation,
     });
   }, []);
 
   const onVerificationConfirmationClose = useCallback(() => {
     track("button_clicked", {
       button: "HeaderRight Close",
-      screen: ScreenName.ReceiveVerificationConfirmation,
+      page: ScreenName.ReceiveVerificationConfirmation,
     });
   }, []);
 

--- a/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/index.tsx
@@ -176,7 +176,7 @@ export default function SelectDevice({
   const onPairNewDevice = useCallback(() => {
     track("button_clicked", {
       button: "Pair with bluetooth",
-      screen: route.name,
+      page: route.name,
     });
 
     // We should not pass non-serializable param like onDone when navigating.

--- a/apps/ledger-live-mobile/src/components/WalletTab/WalletTabNavigatorTabBar.tsx
+++ b/apps/ledger-live-mobile/src/components/WalletTab/WalletTabNavigatorTabBar.tsx
@@ -149,7 +149,7 @@ function WalletTabNavigatorTabBar({
 
       track("button_clicked", {
         button: "Referral program",
-        screen: ScreenName.Portfolio,
+        page: ScreenName.Portfolio,
       });
     }
   }, [referralProgramMobile]);

--- a/apps/ledger-live-mobile/src/logic/notifications.tsx
+++ b/apps/ledger-live-mobile/src/logic/notifications.tsx
@@ -331,7 +331,7 @@ const useNotifications = () => {
   const modalAllowNotifications = useCallback(() => {
     track("button_clicked", {
       button: "Allow",
-      screen: pushNotificationsOldRoute,
+      page: pushNotificationsOldRoute,
       drawer: "Notif",
     });
     setPushNotificationsModalOpenCallback(false);
@@ -352,7 +352,7 @@ const useNotifications = () => {
   const modalDelayLater = useCallback(() => {
     track("button_clicked", {
       button: "Maybe Later",
-      screen: pushNotificationsOldRoute,
+      page: pushNotificationsOldRoute,
       drawer: "Notif",
     });
     setPushNotificationsModalOpenCallback(false);

--- a/apps/ledger-live-mobile/src/screens/Account/AccountHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/AccountHeader.tsx
@@ -63,7 +63,7 @@ function AccountHeader({
   const onBackButtonPress = useCallback(() => {
     track("button_clicked", {
       button: "Back",
-      screen: "Account",
+      page: "Account",
     });
     navigation.goBack();
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
@@ -103,7 +103,7 @@ function ReadOnlyAccount({ route }: Props) {
           event="button_clicked"
           eventProperties={{
             button: "Discover the Nano",
-            screen: "Account",
+            page: "Account",
             currency: currency.name,
           }}
           screen="Account"

--- a/apps/ledger-live-mobile/src/screens/Accounts/AccountsNavigationHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/AccountsNavigationHeader.tsx
@@ -18,7 +18,7 @@ function AccountsNavigationHeader({ readOnly, currencyId }: Props) {
   const handleOnReadOnlyAddAccountPress = useCallback(() => {
     track("button_clicked", {
       button: "Add Account '+'",
-      screen: "Accounts",
+      page: "Accounts",
     });
     navigation.navigate(ScreenName.NoDeviceWallScreen);
   }, [navigation]);
@@ -26,7 +26,7 @@ function AccountsNavigationHeader({ readOnly, currencyId }: Props) {
   const goBack = useCallback(() => {
     track("button_clicked", {
       button: "Back",
-      screen: "Accounts",
+      page: "Accounts",
     });
     navigation.goBack();
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/Assets/AssetsNavigationHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Assets/AssetsNavigationHeader.tsx
@@ -17,7 +17,7 @@ function AssetsNavigationHeader({ readOnly }: Props) {
   const handleOnReadOnlyAddAccountPress = useCallback(() => {
     track("button_clicked", {
       button: "Add Account '+'",
-      screen: "Assets",
+      page: "Assets",
     });
     navigation.navigate(ScreenName.NoDeviceWallScreen);
   }, [navigation]);
@@ -25,7 +25,7 @@ function AssetsNavigationHeader({ readOnly }: Props) {
   const goBack = useCallback(() => {
     track("button_clicked", {
       button: "Back",
-      screen: "Assets",
+      page: "Assets",
     });
     navigation.goBack();
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
@@ -52,7 +52,7 @@ export const RestoreStepDenied = ({
         event="button_clicked"
         eventProperties={{
           button: "Retry",
-          screen: "Firmware update",
+          page: "Firmware update",
           drawer: analyticsDrawerName,
         }}
         type="main"
@@ -68,7 +68,7 @@ export const RestoreStepDenied = ({
           event="button_clicked"
           eventProperties={{
             button: "Skip",
-            screen: "Firmware update",
+            page: "Firmware update",
             drawer: analyticsDrawerName,
           }}
           onPress={onPressSkip}

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -92,7 +92,7 @@ const CloseWarning = ({
         event="button_clicked"
         eventProperties={{
           button: "Continue update",
-          screen: "Firmware update",
+          page: "Firmware update",
           drawer: "Error: update not complete yet",
         }}
         type="main"
@@ -107,7 +107,7 @@ const CloseWarning = ({
         event="button_clicked"
         eventProperties={{
           button: "Exit update",
-          screen: "Firmware update",
+          page: "Firmware update",
           drawer: "Error: update not complete yet",
         }}
         type="default"
@@ -566,7 +566,7 @@ export const FirmwareUpdate = ({
             event="button_clicked"
             eventProperties={{
               button: "Retry flow",
-              screen: "Firmware update",
+              page: "Firmware update",
               drawer: `Error: ${error.name}`,
             }}
             type="main"
@@ -582,7 +582,7 @@ export const FirmwareUpdate = ({
               event="button_clicked"
               eventProperties={{
                 button: "Quit flow",
-                screen: "Firmware update",
+                page: "Firmware update",
                 drawer: `Error: ${error.name}`,
               }}
               type="main"

--- a/apps/ledger-live-mobile/src/screens/GetDeviceScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/GetDeviceScreen.tsx
@@ -98,7 +98,7 @@ export default function GetDeviceScreen() {
     if (readOnlyModeEnabled) {
       track("button_clicked", {
         button: "close",
-        screen: "Upsell Nano",
+        page: "Upsell Nano",
       });
     }
   }, [readOnlyModeEnabled, navigation]);
@@ -115,7 +115,7 @@ export default function GetDeviceScreen() {
     if (readOnlyModeEnabled) {
       track("message_clicked", {
         message: "I already have a device, set it up now",
-        screen: "Upsell Nano",
+        page: "Upsell Nano",
       });
     }
   }, [readOnlyModeEnabled, navigation, setFirstTimeOnboarding, setShowWelcome]);
@@ -213,7 +213,7 @@ export default function GetDeviceScreen() {
           testID="market-place-btn"
           eventProperties={{
             button: "Buy your Ledger now",
-            screen: ScreenName.GetDevice,
+            page: ScreenName.GetDevice,
           }}
           onPress={buyLedger}
           size="large"

--- a/apps/ledger-live-mobile/src/screens/Newsfeed/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Newsfeed/index.tsx
@@ -43,7 +43,7 @@ function NewsfeedPage() {
       const url = news?.source?.url || news.url;
       track("card_clicked", {
         url,
-        screen: ScreenName.Newsfeed,
+        page: ScreenName.Newsfeed,
       });
       if (await InAppBrowser.isAvailable()) {
         await InAppBrowser.open(url, {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/discoverLiveInfo.tsx
@@ -61,7 +61,7 @@ const Item = ({
     (value: string) => {
       track("button_clicked", {
         button: value,
-        screen: screenName,
+        page: screenName,
       });
     },
     [screenName],

--- a/apps/ledger-live-mobile/src/screens/Portfolio/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/Header.tsx
@@ -22,7 +22,7 @@ const NotificationsButton = () => {
   const onNotificationButtonPress = useCallback(() => {
     track("button_clicked", {
       button: "notification bell",
-      screen: ScreenName.Portfolio,
+      page: ScreenName.Portfolio,
     });
     navigation.navigate(NavigatorName.NotificationCenter, {
       screen: ScreenName.NotificationCenter,
@@ -109,7 +109,7 @@ function PortfolioHeader({ hidePortfolio }: { hidePortfolio: boolean }) {
             event="button_clicked"
             eventProperties={{
               button: "card",
-              screen: ScreenName.Portfolio,
+              page: ScreenName.Portfolio,
             }}
           >
             <CardMedium size={24} color={"neutral.c100"} />
@@ -122,7 +122,7 @@ function PortfolioHeader({ hidePortfolio }: { hidePortfolio: boolean }) {
               event="button_clicked"
               eventProperties={{
                 button: "Wallet Connect",
-                screen: ScreenName.WalletConnectConnect,
+                page: ScreenName.WalletConnectConnect,
               }}
             >
               <WalletConnectMedium size={24} color={"neutral.c100"} />

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccountSelectDevice.tsx
@@ -82,7 +82,7 @@ export default function AddAccountsSelectDevice({
   const onHeaderCloseButton = useCallback(() => {
     track("button_clicked", {
       button: "Close 'x'",
-      screen: route.name,
+      page: route.name,
     });
   }, [route]);
 

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03a-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03a-ConnectDevice.tsx
@@ -99,7 +99,7 @@ export default function ConnectDevice({
   const onHeaderBackButtonPress = useCallback(() => {
     track("button_clicked", {
       button: "Back arrow",
-      screen: ScreenName.ReceiveConnectDevice,
+      page: ScreenName.ReceiveConnectDevice,
     });
     navigation.goBack();
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/Settings/General/CarouselRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/CarouselRow.tsx
@@ -23,7 +23,7 @@ const CarouselRow = () => {
       track("toggle_clicked", {
         toggle: "Content Cards",
         enabled: checked,
-        screen: ScreenName.GeneralSettings,
+        page: ScreenName.GeneralSettings,
       }); // TODO Handle Analytics correclty
     },
     [dispatch, walletCards, assetsCards],

--- a/apps/ledger-live-mobile/src/screens/Settings/General/DateFormatDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/DateFormatDrawer.tsx
@@ -52,7 +52,7 @@ export function DateFormatDrawer({ isOpen, closeModal }: Props) {
       dispatch(setDateFormat(value));
       track("button_clicked", {
         button: value,
-        screen: ScreenName.SettingsScreen,
+        page: ScreenName.SettingsScreen,
         drawer: drawerNameAnalytics,
       });
       closeModal();

--- a/apps/ledger-live-mobile/src/screens/Settings/General/DateFormatRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/DateFormatRow.tsx
@@ -17,7 +17,7 @@ const DateFormatRow = () => {
   const onClick = useCallback(() => {
     track("button_clicked", {
       button: "Date format",
-      screen: ScreenName.SettingsScreen,
+      page: ScreenName.SettingsScreen,
     });
     setModalOpen(true);
   }, []);

--- a/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
@@ -83,7 +83,7 @@ function NotificationsSettings() {
   const allowPushNotifications = useCallback(() => {
     track("button_clicked", {
       button: "Go to system settings",
-      screen: pushNotificationsOldRoute,
+      page: pushNotificationsOldRoute,
     });
     handlePushNotificationsPermission();
   }, [pushNotificationsOldRoute, handlePushNotificationsPermission]);

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
@@ -38,7 +38,7 @@ function Header({
     if (readOnlyModeEnabled) {
       track("button_clicked", {
         button: "Back",
-        screen: "Account",
+        page: "Account",
       });
     }
     navigation.goBack();

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/ReadOnly/index.tsx
@@ -103,7 +103,7 @@ const ReadOnlyAssetScreen = ({ route }: NavigationProps) => {
             event="button_clicked"
             eventProperties={{
               button: "Discover the Nano",
-              screen: "Account",
+              page: "Account",
               currency: currency.name,
             }}
             screen="Account"

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/referralProgram.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/referralProgram.tsx
@@ -22,7 +22,7 @@ export function ReferralProgram() {
       Linking.canOpenURL(path).then(() => Linking.openURL(path));
       track("banner_clicked", {
         button: "Referral program",
-        screen: ScreenName.Asset,
+        page: ScreenName.Asset,
       });
     }
   }, [referralProgramMobile]);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

On demand of the analytics team we're replacing the `screen` property by the `page` property for all usages of the `track` function.

#### Trade-offs:
This comes at a cost: some events were already sending events with the `page` property set (on top of `screen` which is set by default for all events sent with `track`), so some data will be lost. The way this is done, for those events, the old value of `page` will stay and replace the value that was set by default for `screen`.
This was agreed to be an acceptable solution.

#### Methodology used (if it can be called like that) and potential corner cases not handled:
Usages of the track function are numerous so of course I didn't check them all one by one.
I used these less than desirable regular expressions in the "find in all files" of vs code in order to find _most_ of the places where the track function is used with `screen` being set in the event properties argument:

- `track\s*\([^)]*.*\s*\n*\{\s*\n*[^\}]*\s*\n*screen`: direct usages of the function (I checked and it's never being used under a different name )
- `eventProperties=\{[\n\s]*[^}]*screen`: `eventProperties` prop being used for instance on `Button` components (and then passed to the `track` function)
- `eventProperties\s*:\s*\{[\n\s]*[^}]*screen`: same but not in JSX
- `properties.*\s*=\s*\{[\n\s]*[^}]*screen`: because why not, catches the `propertiesWithoutExtra` that was in `segment.ts` for instance

It's certainly not perfect because in some instances the track function might be called in a way where the `screen` parameter is passed to it but not defined inline (some known particular cases are handled: the `eventProperties` prop).

I'm not a mad CS genius so I don't know how I could easily find such cases, so I will just assume they're very rare and simply ask the data team to flag any new `track` event coming from LLM where the `screen` parameter is still defined.

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7662] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. --> see trade offs above

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7662]: https://ledgerhq.atlassian.net/browse/LIVE-7662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ