### PR TITLE
feat: protect 2292 retry device locked

### DIFF
--- a/.changeset/olive-melons-yell.md
+++ b/.changeset/olive-melons-yell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+user can try again on recover if his device is locked

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -22,7 +22,6 @@ import { FirmwareInfo } from "@ledgerhq/types-live";
 import { renderError } from "../DeviceAction/rendering";
 import { urls } from "~/config/urls";
 import { languageSelector } from "~/renderer/reducers/settings";
-import { LockedDeviceError } from "@ledgerhq/errors";
 import { Subscription } from "@xstate/react/lib/types";
 
 const RecoverRestore = () => {

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -91,22 +91,7 @@ const RecoverRestore = () => {
     }
   }, [currentDevice?.modelId, history, setDeviceModelId, state]);
 
-  // retry if device is locked
-  if (error instanceof LockedDeviceError) {
-    return (
-      <Flex width="100%" height="100%" position="relative">
-        <Flex position="relative" height="100%" width="100%" flexDirection="column">
-          {renderError({
-            t,
-            error,
-            onRetry,
-            device: currentDevice,
-          })}
-        </Flex>
-      </Flex>
-    );
-  }
-
+  // retry if device error
   if (error) {
     return (
       <Flex width="100%" height="100%" position="relative">
@@ -114,6 +99,7 @@ const RecoverRestore = () => {
           {renderError({
             t,
             error,
+            onRetry,
             device: currentDevice,
           })}
         </Flex>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add retry mecanism on error device locked when you try to use Ledger Recover

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [PROTECT-2292](https://ledgerhq.atlassian.net/browse/PROTECT-2292)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-2292]: https://ledgerhq.atlassian.net/browse/PROTECT-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ