### PR TITLE
ci(tests): reactivate windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,10 +114,14 @@ jobs:
           # Commenting because of random node-gyp failures on windows…
           # See:
           #  * https://github.com/serialport/node-serialport/issues/2322
-          # - windows-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:
+      - name: setup Git config
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config --global core.autocrlf false
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
           ref: ${{ (github.event_name == 'workflow_dispatch' && (inputs.ref || github.ref_name)) || github.sha }}
@@ -125,6 +129,8 @@ jobs:
           fetch-depth: 0
       - name: Setup the toolchain
         uses: ./tools/actions/composites/setup-toolchain
+        with:
+          install_dotnet: ${{ matrix.os == 'windows-latest' }}
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"


### PR DESCRIPTION

### 📝 Description

The file test.yml had windows deactivated due to some bugs in the github runners environment. enabling it again to see what's up

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
