### PR TITLE
fix(llm/analyticsconsole): workaround for collapsed items in scrollview

### DIFF
--- a/.changeset/lazy-pens-judge.md
+++ b/.changeset/lazy-pens-judge.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Analytics console: workaround for layout issue that happens after a while in the scrollview

--- a/apps/ledger-live-mobile/src/components/AnalyticsConsole/EventList.tsx
+++ b/apps/ledger-live-mobile/src/components/AnalyticsConsole/EventList.tsx
@@ -7,13 +7,15 @@ import Event from "./Event";
 
 const AnimatedFlex = Animated.createAnimatedComponent(Flex);
 
-type ListProps = {
+type Props = {
   showExtraProps: boolean;
   hideSyncEvents: boolean;
+  hidden: boolean;
 };
 
-const EventList: React.FC<ListProps> = ({ showExtraProps, hideSyncEvents }) => {
+const EventList: React.FC<Props> = ({ showExtraProps, hideSyncEvents, hidden }) => {
   const { items } = useAnalyticsEventsLog();
+  if (hidden) return null;
   return (
     <ScrollView>
       <AnimatedFlex paddingBottom={100} flexDirection="column-reverse">

--- a/apps/ledger-live-mobile/src/components/AnalyticsConsole/index.tsx
+++ b/apps/ledger-live-mobile/src/components/AnalyticsConsole/index.tsx
@@ -122,7 +122,11 @@ const AnalyticsConsole = () => {
             ) : null}
           </AnimatedFlex>
           <AnimatedFlex flexShrink={1} layout={Layout}>
-            <EventList showExtraProps={showExtraProps} hideSyncEvents={hideSyncEvents} />
+            <EventList
+              hidden={visibility === Visibility.hidden}
+              showExtraProps={showExtraProps}
+              hideSyncEvents={hideSyncEvents}
+            />
           </AnimatedFlex>
         </SafeAreaView>
       </Flex>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There is a layout issue, probably due to ScrollView or Reanimated, or the combination of both, that makes items of the console collapse at some point, as if they have a 0 height in terms of layout.
Without digging further in the issue, a quick workaround for that is simply to unmount the list whenever the visibility of the console is "hidden", so that it remounts when become visible, with a clean layout.

![Screenshot_20230802-145851](https://github.com/LedgerHQ/ledger-live/assets/91890529/8d26aa80-8807-4ba9-9fd8-61b28f475a2d)



### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
