### PR TITLE
[Feat/LIVE-8848]: redirect to account or parent account if token on click for NotEnoughGasSwap error.

### DIFF
--- a/.changeset/light-jobs-exercise.md
+++ b/.changeset/light-jobs-exercise.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Add account as query param to multibuy redirect on NotEnoughGasSwap link click

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.tsx
@@ -20,22 +20,32 @@ export function useErrorLinks(error?: Error | null) {
       const safeStringLinks = errorLinks.filter((link): link is string => typeof link === "string");
 
       return safeStringLinks.reduce((prev, curr, index) => {
-        const link = isAbsoluteUrl(curr) ? (
-          <a onClick={() => openURL(curr)} data-test-id={`translated-error-link-${index}`} />
-        ) : (
-          <S.Button
-            onClick={() =>
-              history.push({
-                pathname: curr,
-              })
-            }
-            data-test-id={`translated-error-link-${index}`}
-          />
-        );
+        if (isAbsoluteUrl(curr)) {
+          return {
+            ...prev,
+            [`link${index}`]: (
+              <a onClick={() => openURL(curr)} data-test-id={`translated-error-link-${index}`} />
+            ),
+          };
+        }
+
+        // ledgerlive needed here to "mock" a valid url.
+        // Allows easier splitting of pathname and searchParams.
+        const { pathname, searchParams } = new URL(curr, "ledgerlive:/");
 
         return {
           ...prev,
-          [`link${index}`]: link,
+          [`link${index}`]: (
+            <S.Button
+              onClick={() =>
+                history.push({
+                  pathname,
+                  state: Object.fromEntries(searchParams.entries()),
+                })
+              }
+              data-test-id={`translated-error-link-${index}`}
+            />
+          ),
         };
       }, {});
     }

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -86,7 +86,7 @@ function getProxyURL(url: string) {
   // This is to handle links set in the useFromAmountStatusMessage in LLC.
   // Also handles a difference in paths between LLD on LLD /platform/:app_id
   // but on LLM /discover/:app_id
-  if (hostname === "platform" && !!platform) {
+  if (hostname === "platform" && ["multibuy"].includes(platform)) {
     return url.replace("://platform", "://discover");
   }
 

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -84,7 +84,9 @@ function getProxyURL(url: string) {
   }
 
   // This is to handle links set in the useFromAmountStatusMessage in LLC.
-  if (pathname.includes("//platform/multibuy")) {
+  // Also handles a difference in paths between LLD on LLD /platform/:app_id
+  // but on LLM /discover/:app_id
+  if (hostname === "platform" && !!platform) {
     return url.replace("://platform", "://discover");
   }
 

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -61,16 +61,22 @@ export const useFromAmountStatusMessage = (
       .filter(errorOrWarning => !(errorOrWarning instanceof AmountRequired));
 
     if (relevantStatus instanceof NotEnoughGas && currency && estimatedFees) {
+      const query = new URLSearchParams({
+        // get account id first and set it equal to account.
+        // if parent account exists then overwrite the former.
+        ...(account?.id ? { account: account.id } : {}),
+        ...(parentAccount?.id ? { account: parentAccount.id } : {}),
+      });
       return new NotEnoughGasSwap(undefined, {
         fees: formatCurrencyUnit(getFeesUnit(currency), estimatedFees),
         ticker: currency.ticker,
         cryptoName: currency.name,
-        links: ["/platform/multibuy"],
+        links: [`/platform/multibuy?${query.toString()}`],
       });
     }
 
     return relevantStatus;
-  }, [statusEntries, currency, estimatedFees, transaction?.amount]);
+  }, [statusEntries, currency, estimatedFees, transaction?.amount, account?.id, parentAccount?.id]);
 };
 
 export const useSwapTransaction = ({


### PR DESCRIPTION
### 📝 Description

Redirect to the buy/sell app from the NotEnoughGasSwap and select the account in cases where it's the fee token ( e.g ETH ) or the parent account in cases where the user is swapping something like ( USDC on ETH ).

LLM handles this by default so no need for a change, however I have made the conversion of `/platform/:app_id` to `/discover/:app_id` more generic.

### ❓ Context

- **Impacted projects**: `LLC, LLD, LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8848](https://ledgerhq.atlassian.net/browse/LIVE-8848) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

#### MOBILE:
https://github.com/LedgerHQ/ledger-live/assets/132384348/ea6cab56-3652-48f0-b2f6-e9896b0dd6aa

#### DESKTOP:
https://github.com/LedgerHQ/ledger-live/assets/132384348/b32048dd-acbb-4e97-a182-043f360a22f2











### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8848]: https://ledgerhq.atlassian.net/browse/LIVE-8848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ