### PR TITLE
Bugfix(LIVE-8841): default provider icon to use boxed mode

### DIFF
--- a/.changeset/beige-needles-sip.md
+++ b/.changeset/beige-needles-sip.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Default ProviderIcon to boxed mode in order to support light and dark mode out of the box

--- a/apps/ledger-live-desktop/src/renderer/components/ProviderIcon/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ProviderIcon/index.tsx
@@ -13,7 +13,7 @@ export type Props = {
 const ProviderIcon = ({
   name,
   size = "S",
-  boxed = false,
+  boxed = true,
   alt = `${name} icon`,
 }: Props): JSX.Element | null => {
   const iconUrl = getProviderIconUrl({ boxed, name });

--- a/apps/ledger-live-desktop/src/renderer/families/ethereum/StakeFlowModal/StakingIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/ethereum/StakeFlowModal/StakingIcon.tsx
@@ -46,7 +46,7 @@ export function StakingIcon({ icon }: Props) {
   if (iconType === "provider") {
     return (
       <ProviderIconContainer>
-        <ProviderIcon name={iconName} size="S" boxed={true} />
+        <ProviderIcon name={iconName} size="S" />
       </ProviderIconContainer>
     );
   }

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Rates/Rate.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Rates/Rate.tsx
@@ -59,7 +59,7 @@ function Rate({
     >
       {icon && (
         <Box mr={2}>
-          <ProviderIcon size="S" name={icon} boxed={true} />
+          <ProviderIcon size="S" name={icon} />
         </Box>
       )}
       <Box flex={1}>

--- a/apps/ledger-live-mobile/src/components/ProviderIcon/index.tsx
+++ b/apps/ledger-live-mobile/src/components/ProviderIcon/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { getProviderIconUrl } from "@ledgerhq/live-common/icons/providers/providers";
 import { ProviderIconSize } from "@ledgerhq/live-common/icons/providers/sizes";
 import * as Styles from "./styles";
+import { SvgUri } from "react-native-svg";
 
 export type Props = {
   name: string;
@@ -9,9 +10,13 @@ export type Props = {
   boxed?: boolean;
 };
 
-const ProviderIcon = ({ name, size = "S", boxed = false }: Props): JSX.Element | null => {
+const ProviderIcon = ({ name, size = "S", boxed = true }: Props): JSX.Element | null => {
   const iconUrl = getProviderIconUrl({ boxed, name });
-  return <Styles.Icon uri={iconUrl} size={size} />;
+  return (
+    <Styles.Contianer size={size}>
+      <SvgUri uri={iconUrl} />
+    </Styles.Contianer>
+  );
 };
 
 export default ProviderIcon;

--- a/apps/ledger-live-mobile/src/components/ProviderIcon/styles.ts
+++ b/apps/ledger-live-mobile/src/components/ProviderIcon/styles.ts
@@ -1,12 +1,12 @@
 import styled from "styled-components/native";
-import { SvgUri } from "react-native-svg";
 import { ProviderIconSize, ProviderIconSizes } from "@ledgerhq/live-common/icons/providers/sizes";
+import { View } from "react-native";
 
 type StyledIconProps = {
   size: ProviderIconSize;
 };
 
-export const Icon = styled(SvgUri)<StyledIconProps>`
+export const Contianer = styled(View)<StyledIconProps>`
   border-radius: 8px;
   width: ${({ size }) => ProviderIconSizes[size]}px;
   height: ${({ size }) => ProviderIconSizes[size]}px;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Default ProviderIcon to use boxed mode.
- Ensure ProviderIcon sizes can be varied on LLM
- Ensure changes doesn't effect LLD

Related [PR on Ledger live assets](https://github.com/LedgerHQ/ledger-live-assets/pull/674) to remove `width` & `height` to provide fixed icon sizes on LLM

### ❓ Context

- **Impacted projects**: `LLD` & `LLM`
- **Linked resource(s)**:  [LIVE-8841](https://ledgerhq.atlassian.net/browse/LIVE-8841)

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

| Variant  | Screenshot |
| ------------- | ------------- |
| LLM Light XXS  | ![Simulator Screenshot - iPhone 14 - 2023-08-02 at 21 28 17](https://github.com/LedgerHQ/ledger-live/assets/138497251/7740fecb-fddd-4af8-bb7e-92c3b857fc63)  |
| LLM Light  XS | ![Simulator Screenshot - iPhone 14 - 2023-08-02 at 21 28 19](https://github.com/LedgerHQ/ledger-live/assets/138497251/61b3ffbe-8720-4bb6-bd21-205ccbe92816)  |
| LLM Dark XXS | ![Simulator Screenshot - iPhone 14 - 2023-08-02 at 21 29 15](https://github.com/LedgerHQ/ledger-live/assets/138497251/86ed6f3e-104f-413c-9267-42bdf4c4d778) |
| LLM Dark XS | ![Simulator Screenshot - iPhone 14 - 2023-08-02 at 21 29 18](https://github.com/LedgerHQ/ledger-live/assets/138497251/d416f1c4-c1f7-4f3c-9b99-205d37d74c1a) |
| LLD Light | <img width="1247" alt="Screenshot 2023-08-02 at 21 36 43" src="https://github.com/LedgerHQ/ledger-live/assets/138497251/48a8441d-af5a-4337-bdec-e36ad43a95a4"> |
| LLD Dark | <img width="1247" alt="Screenshot 2023-08-02 at 21 36 22" src="https://github.com/LedgerHQ/ledger-live/assets/138497251/5f9531c8-95c4-4d01-bf4a-4922f53287c4"> |


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8841]: https://ledgerhq.atlassian.net/browse/LIVE-8841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ