### PR TITLE
Fix: LIVE-8887 pending tx for evm family

### DIFF
--- a/.changeset/thin-socks-begin.md
+++ b/.changeset/thin-socks-begin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+fix pending transaction bug in evm family

--- a/libs/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -626,13 +626,17 @@ describe("EVM Family", () => {
         expect(synchronization.postSync(accountWithPending, accountWithPending)).toEqual(
           accountWithPending,
         );
-        // Should remove the pending from tokenAccount as well if removed from main account
-        expect(
-          synchronization.postSync(accountWithPending, {
-            ...accountWithPending,
-            pendingOperations: [],
-          }),
-        ).toEqual(account);
+
+        // Should remove the pending from account if the pending operations become operations from main account
+        const updateAccount = synchronization.postSync(accountWithPending, {
+          ...accountWithPending,
+          operations: [pendingOperation],
+          pendingOperations: [],
+        });
+        expect(updateAccount.pendingOperations).toHaveLength(0);
+
+        // Should remove the pending from tokenAccount if it was confirmed in the main account ops
+        expect(updateAccount.subAccounts?.[0].pendingOperations).toHaveLength(0);
       });
 
       it("should remove pending operation if the token account has confirmed it", () => {

--- a/libs/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -621,9 +621,18 @@ describe("EVM Family", () => {
           subAccounts: [tokenAccountWithPending],
           pendingOperations: [pendingOperation],
         };
+        const accountWithoutPending = {
+          ...accountWithPending,
+          subAccounts: [tokenAccountWithPending],
+          pendingOperations: [],
+        };
 
         // should not change anything if we maintain the pending op
         expect(synchronization.postSync(accountWithPending, accountWithPending)).toEqual(
+          accountWithPending,
+        );
+        // should keep pending ops even if the synced account(second parameter of postSync) has no pending op, because the pending op will be recalculated form the initial account
+        expect(synchronization.postSync(accountWithPending, accountWithoutPending)).toEqual(
           accountWithPending,
         );
 


### PR DESCRIPTION
### 📝 Description

In evm family, the pending transactions in transaction history disappear after OPERATION_OPTIMISTIC_RETENTION timeout. This bug is related to incorrectly removing pending transaction in postSync method in evm family.
I fix this bug by referring the postSync from ethereum family. 

### ❓ Context

- **Impacted projects**: `` LLC
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-8887

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
