### PR TITLE
Fix: LIVE-8269 cosmos amount string parser

### DIFF
--- a/.changeset/hot-llamas-run.md
+++ b/.changeset/hot-llamas-run.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix cosmos amount string parser

--- a/libs/ledger-live-common/src/families/cosmos/helpers.unit.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/helpers.unit.test.ts
@@ -1,4 +1,5 @@
 import { getMainMessage } from "./helpers";
+import { parseAmountStringToNumber } from "./logic";
 
 describe("getMainMessage", () => {
   it("should return delegate message with delegate and reward messages (claim rewards, compound)", () => {
@@ -59,5 +60,19 @@ describe("getMainMessage", () => {
         },
       ]).type,
     ).toEqual("redelegate");
+  });
+});
+
+describe("parseAmountStringToNumber", () => {
+  it("should remove suffix of amount string correctly", () => {
+    expect(parseAmountStringToNumber("1000000uatom", "uatom")).toEqual("1000000");
+  });
+  it("should remove prefix and suffix of amount string correctly", () => {
+    expect(
+      parseAmountStringToNumber(
+        "56ibc/0025F8A87464A471E66B234C4F93AEC5B4DA3D42D7986451A059273426290DD5,512ibc/6B8A3F5C2AD51CD6171FA41A7E8C35AD594AB69226438DB94450436EA57B3A89,10000uatom",
+        "uatom",
+      ),
+    ).toEqual("10000");
   });
 });

--- a/libs/ledger-live-common/src/families/cosmos/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-synchronisation.ts
@@ -12,6 +12,7 @@ import { encodeOperationId } from "../../operation";
 import { CosmosDelegationInfo, CosmosMessage, CosmosTx } from "./types";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import { getMainMessage } from "./helpers";
+import { parseAmountStringToNumber } from "./logic";
 
 const getBlankOperation = (tx, fees, id) => ({
   id: "",
@@ -65,7 +66,7 @@ const txToOps = (info: AccountShapeInfo, accountId: string, txs: CosmosTx[]): Op
           if (amount && sender && recipient && amount.endsWith(unitCode)) {
             if (op.senders.indexOf(sender) === -1) op.senders.push(sender);
             if (op.recipients.indexOf(recipient) === -1) op.recipients.push(recipient);
-            op.value = op.value.plus(amount.replace(unitCode, ""));
+            op.value = op.value.plus(parseAmountStringToNumber(amount, unitCode));
             if (sender === address) {
               op.type = "OUT";
             } else if (recipient === address) {
@@ -86,11 +87,12 @@ const txToOps = (info: AccountShapeInfo, accountId: string, txs: CosmosTx[]): Op
           const validator = message.attributes.find(attr => attr.key === "validator")?.value;
           const amount = message.attributes.find(attr => attr.key === "amount")?.value;
           if (validator && amount && amount.endsWith(unitCode)) {
+            const amountString = parseAmountStringToNumber(amount, unitCode);
             rewardShards.push({
-              amount: new BigNumber(amount.replace(unitCode, "")),
+              amount: new BigNumber(amountString),
               address: validator,
             });
-            txRewardValue = txRewardValue.plus(amount.replace(unitCode, ""));
+            txRewardValue = txRewardValue.plus(amountString);
           }
         }
         op.value = txRewardValue;
@@ -106,7 +108,7 @@ const txToOps = (info: AccountShapeInfo, accountId: string, txs: CosmosTx[]): Op
           const validator = message.attributes.find(attr => attr.key === "validator")?.value;
           if (amount && validator && amount.endsWith(unitCode)) {
             delegateShards.push({
-              amount: new BigNumber(amount.replace(unitCode, "")),
+              amount: new BigNumber(parseAmountStringToNumber(amount, unitCode)),
               address: validator,
             });
           }
@@ -129,7 +131,7 @@ const txToOps = (info: AccountShapeInfo, accountId: string, txs: CosmosTx[]): Op
           if (amount && validatorDst && validatorSrc && amount.endsWith(unitCode)) {
             op.extra.sourceValidator = validatorSrc;
             redelegateShards.push({
-              amount: new BigNumber(amount.replace(unitCode, "")),
+              amount: new BigNumber(parseAmountStringToNumber(amount, unitCode)),
               address: validatorDst,
             });
           }
@@ -146,7 +148,7 @@ const txToOps = (info: AccountShapeInfo, accountId: string, txs: CosmosTx[]): Op
           const validator = message.attributes.find(attr => attr.key === "validator")?.value;
           if (amount && validator && amount.endsWith(unitCode)) {
             unbondShards.push({
-              amount: new BigNumber(amount.replace(unitCode, "")),
+              amount: new BigNumber(parseAmountStringToNumber(amount, unitCode)),
               address: validator,
             });
           }

--- a/libs/ledger-live-common/src/families/cosmos/js-synchronisation.unit.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-synchronisation.unit.test.ts
@@ -305,6 +305,20 @@ describe("getAccountShape", () => {
                     },
                   ],
                 },
+                {
+                  type: "withdraw_rewards",
+                  attributes: [
+                    {
+                      key: "amount",
+                      value:
+                        "56ibc/0025F8A87464A471E66B234C4F93AEC5B4DA3D42D7986451A059273426290DD5,512ibc/6B8A3F5C2AD51CD6171FA41A7E8C35AD594AB69226438DB94450436EA57B3A89,7uatom",
+                    },
+                    {
+                      key: "validator",
+                      value: "validatorAddressThree",
+                    },
+                  ],
+                },
               ],
               attributes: [],
             },
@@ -314,7 +328,7 @@ describe("getAccountShape", () => {
     });
 
     const account = await getAccountShape(infoMock, syncConfig);
-    expect((account.operations as Operation[])[0].value).toEqual(new BigNumber(15));
+    expect((account.operations as Operation[])[0].value).toEqual(new BigNumber(22));
     expect((account.operations as Operation[])[0].extra.validators).toEqual([
       {
         address: "validatorAddressHehe",
@@ -323,6 +337,10 @@ describe("getAccountShape", () => {
       {
         address: "validatorAddressTwo",
         amount: new BigNumber(5),
+      },
+      {
+        address: "validatorAddressThree",
+        amount: new BigNumber(7),
       },
     ]);
   });

--- a/libs/ledger-live-common/src/families/cosmos/logic.ts
+++ b/libs/ledger-live-common/src/families/cosmos/logic.ts
@@ -190,3 +190,7 @@ export function getRedelegationCompletionDate(
   const currentRedelegation = getRedelegation(account, delegation);
   return currentRedelegation ? currentRedelegation.completionDate : null;
 }
+
+export function parseAmountStringToNumber(amountString: string, unitCode): string {
+  return amountString.slice(amountString.lastIndexOf(",") + 1).replace(unitCode, "");
+}

--- a/libs/ledger-live-common/src/families/cosmos/logic.ts
+++ b/libs/ledger-live-common/src/families/cosmos/logic.ts
@@ -191,6 +191,6 @@ export function getRedelegationCompletionDate(
   return currentRedelegation ? currentRedelegation.completionDate : null;
 }
 
-export function parseAmountStringToNumber(amountString: string, unitCode): string {
+export function parseAmountStringToNumber(amountString: string, unitCode: string): string {
   return amountString.slice(amountString.lastIndexOf(",") + 1).replace(unitCode, "");
 }


### PR DESCRIPTION
### 📝 Description
In the response of cosmos events from explorer. The "amount" field string can contain prefix. Our parser should be able to remove this prefix and get the correct amount string. Otherwise, it will cause a bug in the portfolio graph because of the incorrect amount.

It is a problem due to the multi chain rewards update of cosmos. Before the update, we didn't have this prefix as the follows:

```
{
                  "key": "amount",
                  "value": "11717uosmo"
},

```
Now we can have prefix of the amount value since multi chain rewards update
```
{
                  "key": "amount",
                  "value": "56ibc/0025F8A87464A471E66B234C4F93AEC5B4DA3D42D7986451A059273426290DD5,512ibc/6B8A3F5C2AD51CD6171FA41A7E8C35AD594AB69226438DB94450436EA57B3A89,11717uosmo"
},

```
we should remove the prefix to get the correct value


### ❓ Context

- **Impacted projects**: LLC
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8269

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
