### PR TITLE
chore: add resiliency on importing accounts that fail to be decoded

### DIFF
--- a/.changeset/rude-years-flow.md
+++ b/.changeset/rude-years-flow.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Implement resiliency on importing accounts that fail to be decoded (bad currencyId, bad derivationMode,...)

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -21,6 +21,7 @@ import { Announcement } from "@ledgerhq/live-common/notifications/AnnouncementPr
 import { CounterValuesStatus, RateMapRaw } from "@ledgerhq/live-common/countervalues/types";
 import { hubStateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { settingsExportSelector } from "./reducers/settings";
+import logger from "./logger";
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.
@@ -86,7 +87,17 @@ const transforms: Transforms = {
     get: raws => {
       // NB to prevent parsing encrypted string as JSON
       if (typeof raws === "string") return null;
-      return (raws || []).map(accountModel.decode);
+      const accounts = [];
+      if (raws) {
+        for (const row of raws) {
+          try {
+            accounts.push(accountModel.decode(row));
+          } catch (e) {
+            logger.critical(e);
+          }
+        }
+      }
+      return accounts;
     },
     set: accounts => (accounts || []).map(accountModel.encode),
   },

--- a/apps/ledger-live-desktop/tests/specs/accounts/unknown-currency-resilience.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/accounts/unknown-currency-resilience.spec.ts
@@ -1,0 +1,15 @@
+import test from "../../fixtures/common";
+import { expect } from "@playwright/test";
+import { PortfolioPage } from "../../models/PortfolioPage";
+
+test.use({ userdata: "skip-onboarding-with-bad-account-data" });
+
+test("Accounts resiliency works, the portfolio loads and evict 2 bad accounts from data", async ({
+  page,
+}) => {
+  const portfolioPage = new PortfolioPage(page);
+
+  await test.step("portfolio is in empty mode", async () => {
+    await expect(await portfolioPage.emptyStateTitle).toBeVisible();
+  });
+});

--- a/apps/ledger-live-desktop/tests/userdata/skip-onboarding-with-bad-account-data.json
+++ b/apps/ledger-live-desktop/tests/userdata/skip-onboarding-with-bad-account-data.json
@@ -1,0 +1,122 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": null,
+      "region": null,
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": true,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoS",
+      "hasInstalledApps": true,
+      "carouselVisibility": 0,
+      "hasAcceptedSwapKYC": false,
+      "lastSeenDevice": null,
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [
+      {
+        "data": {
+          "id": "mock:1:INVALID_CURRENCY_ID:1_tron_1:",
+          "seedIdentifier": "mock",
+          "name": "Tron 2",
+          "starred": false,
+          "used": true,
+          "derivationMode": "",
+          "index": 1,
+          "freshAddress": "1x1g9m7sH8D2gTfQFiVVKB7kmUF3B",
+          "freshAddressPath": "44'/195'/0'/0/0",
+          "freshAddresses": [
+            {
+              "address": "1x1g9m7sH8D2gTfQFiVVKB7kmUF3B",
+              "derivationPath": "44'/195'/0'/0/0"
+            }
+          ],
+          "blockHeight": 142575,
+          "creationDate": "2023-06-13T02:43:04.148Z",
+          "operationsCount": 100,
+          "operations": [],
+          "pendingOperations": [],
+          "currencyId": "INVALID_CURRENCY_ID",
+          "unitMagnitude": 6,
+          "lastSyncDate": "2023-06-27T13:48:46.036Z",
+          "balance": "42418307",
+          "spendableBalance": "42418307",
+          "balanceHistoryCache": {},
+          "xpub": "38865EF7B7E11DE0F0BA4FEDE6BE23613D67EDAC17BCE14307E268166BCE8794",
+          "subAccounts": [],
+          "swapHistory": []
+        },
+        "version": 1
+      },
+
+      {
+        "data": {
+          "id": "mock:1:tron:1_tron_1:INVALID_DERIVATION_MODE",
+          "seedIdentifier": "mock",
+          "name": "Tron 2",
+          "starred": false,
+          "used": true,
+          "derivationMode": "INVALID_DERIVATION_MODE",
+          "index": 1,
+          "freshAddress": "1x1g9m7sH8D2gTfQFiVVKB7kmUF3B",
+          "freshAddressPath": "44'/195'/0'/0/0",
+          "freshAddresses": [
+            {
+              "address": "1x1g9m7sH8D2gTfQFiVVKB7kmUF3B",
+              "derivationPath": "44'/195'/0'/0/0"
+            }
+          ],
+          "blockHeight": 142575,
+          "creationDate": "2023-06-13T02:43:04.148Z",
+          "operationsCount": 100,
+          "operations": [],
+          "pendingOperations": [],
+          "currencyId": "tron",
+          "unitMagnitude": 6,
+          "lastSyncDate": "2023-06-27T13:48:46.036Z",
+          "balance": "42418307",
+          "spendableBalance": "42418307",
+          "balanceHistoryCache": {},
+          "xpub": "38865EF7B7E11DE0F0BA4FEDE6BE23613D67EDAC17BCE14307E268166BCE8794",
+          "subAccounts": [],
+          "swapHistory": []
+        },
+        "version": 1
+      }
+    ],
+    "countervalues": {}
+  }
+}

--- a/apps/ledger-live-mobile/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/client.ts
@@ -8,7 +8,7 @@ import { Event as AppEvent } from "@ledgerhq/live-common/hw/actions/app";
 import { ConnectManagerEvent } from "@ledgerhq/live-common/hw/connectManager";
 import { store } from "../../src/context/LedgerStore";
 import { importSettings } from "../../src/actions/settings";
-import { setAccounts } from "../../src/actions/accounts";
+import { importStore as importAccounts } from "../../src/actions/accounts";
 import { acceptGeneralTermsLastVersion } from "../../src/logic/terms";
 import accountModel from "../../src/logic/accountModel";
 import { navigate } from "../../src/rootnavigation";
@@ -129,7 +129,7 @@ function onMessage(event: WebSocketMessageEvent) {
       acceptGeneralTermsLastVersion();
       break;
     case "importAccounts": {
-      store.dispatch(setAccounts(msg.payload.map(accountModel.decode)));
+      store.dispatch(importAccounts({ active: msg.payload }));
       break;
     }
     case "mockDeviceEvent": {

--- a/apps/ledger-live-mobile/e2e/bridge/server.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/server.ts
@@ -6,7 +6,7 @@ import { NavigatorName } from "../../src/const";
 import { Subject } from "rxjs";
 import { MessageData, MockDeviceEvent } from "./client";
 import { BleState } from "../../src/reducers/types";
-import { Account } from "@ledgerhq/types-live";
+import { Account, AccountRaw } from "@ledgerhq/types-live";
 
 type ServerData = {
   type: "walletAPIResponse";
@@ -53,6 +53,18 @@ export function loadConfig(fileName: string, agreed: true = true): void {
 
 export function loadBleState(bleState: BleState) {
   postMessage({ type: "importBle", payload: bleState });
+}
+
+export function loadAccountsRaw(
+  payload: {
+    data: AccountRaw;
+    version: number;
+  }[],
+) {
+  postMessage({
+    type: "importAccounts",
+    payload,
+  });
 }
 
 export function loadAccounts(accounts: Account[]) {

--- a/apps/ledger-live-mobile/e2e/specs/unknown-currency-resilience.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/unknown-currency-resilience.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from "detox";
+import { toAccountRaw } from "@ledgerhq/live-common/account/index";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+import {
+  getCryptoCurrencyById,
+  setSupportedCurrencies,
+} from "@ledgerhq/live-common/currencies/index";
+import { loadConfig } from "../bridge/server";
+import PortfolioPage from "../models/wallet/portfolioPage";
+import { loadAccountsRaw } from "../bridge/server";
+
+let portfolioPage: PortfolioPage;
+
+setSupportedCurrencies(["bitcoin"]);
+
+const badAccount1 = toAccountRaw(
+  genAccount("mock1", {
+    currency: getCryptoCurrencyById("bitcoin"),
+  }),
+);
+badAccount1.currencyId = "DO_NOT_EXIST";
+badAccount1.id = badAccount1.id.replace("bitcoin", "DO_NOT_EXIST");
+
+const badAccount2 = toAccountRaw(
+  genAccount("mock1", {
+    currency: getCryptoCurrencyById("bitcoin"),
+  }),
+);
+badAccount2.id += "DO_NOT_EXIST";
+badAccount2.derivationMode += "DO_NOT_EXIST";
+
+describe("Portfolio to load with unknown currency data in accounts", () => {
+  beforeAll(async () => {
+    loadConfig("onboardingcompleted", true);
+    loadAccountsRaw([
+      { data: badAccount1, version: 0 },
+      { data: badAccount2, version: 0 },
+    ]);
+
+    portfolioPage = new PortfolioPage();
+  });
+
+  it("opens to empty state", async () => {
+    await portfolioPage.waitForPortfolioPageToLoad();
+    await expect(await portfolioPage.emptyPortfolioComponent()).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -12,20 +12,26 @@ import type {
   AccountsUpdateAccountWithUpdaterPayload,
 } from "./types";
 import { AccountsActionTypes } from "./types";
+import logger from "../logger";
 
 const version = 0; // FIXME this needs to come from user data
 
 const importStoreAction = createAction<AccountsImportStorePayload>(
   AccountsActionTypes.ACCOUNTS_IMPORT,
 );
-export const importStore = (rawAccounts: { active: { data: AccountRaw }[] }) =>
-  importStoreAction(
-    rawAccounts && Array.isArray(rawAccounts.active)
-      ? implicitMigration(
-          rawAccounts.active.map(({ data }) => accountModel.decode({ data, version })),
-        )
-      : [],
-  );
+export const importStore = (rawAccounts: { active: { data: AccountRaw }[] }) => {
+  const accounts = [];
+  if (rawAccounts && Array.isArray(rawAccounts.active)) {
+    for (const { data } of rawAccounts.active) {
+      try {
+        accounts.push(accountModel.decode({ data, version }));
+      } catch (e) {
+        if (e instanceof Error) logger.critical(e);
+      }
+    }
+  }
+  return importStoreAction(implicitMigration(accounts));
+};
 export const reorderAccounts = createAction<AccountsReorderPayload>(
   AccountsActionTypes.REORDER_ACCOUNTS,
 );


### PR DESCRIPTION
### 📝 Description

This add resiliency on importing accounts that would fail to be decoded in the future on both LLM and LLD.

There are a few possible reasons why an old account could be failed to be imported. For instance, if one of the field including `currencyId`, `derivationMode`, ...other field that have strict assertion (on the `fromAccountRaw` call) are bad (altered, modified, removed).

Some real world examples:
- a derivationMode becomes obsolete and is removed
- a currency becomes obsolete and is removed (example: Ethereum Ropsten)
- one of these field is altered by the user somehow (app.json modified / corrupted)
- exporting/importing an app.json manually from the past / through various backup services

**The previous behavior:**

One bad account data and it was badly crashing the app at boot.

**The new behavior:**

The problematic account that fails to import is evicted from the list of accounts. So, if a currencyId (like ethereum ropsten) becomes obsolete, it will be transparent for the user and account will disappear without a crash at boot.

**Note that a report is also sent to Sentry (if enabled) so we still can have visibility over these failures** because this acts more as a failsafe (resiliency) than a behavior we want to regularly leverage, removing currency is not something we will do often.

### ❓ Context

- **Impacted projects**: `LLD/LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: N/A yet <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** tests both added for LLM and LLD. the app no longer crashes and correctly land on empty portfolio when all data was altered with unsupported currency id data. <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
