### PR TITLE
chore: split ui test from libs tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,6 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
-    outputs:
-      fail: ${{ steps.diff.outputs.diff }}
     runs-on: ubuntu-latest
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
@@ -107,20 +105,9 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
-      CI_OS: ${{ matrix.os }}
+      CI_OS: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          # Commenting because of random node-gyp failures on windows…
-          # See:
-          #  * https://github.com/serialport/node-serialport/issues/2322
-          # - windows-latest
-
-    runs-on: ${{ matrix.os }}
+    runs-on: [ledger-live-4xlarge-linux]
     steps:
       - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
         with:
@@ -147,15 +134,71 @@ jobs:
         run: pnpm i --filter="!./apps/**"
       - name: Build and Test affected libraries
         id: test-libs
-        run: pnpm run test --continue --filter="!./apps/**" --filter="!./tools/**" --filter="!live-common-tools" --filter="!ledger-live...[${{ inputs.since_branch && format('origin/{0}', inputs.since_branch) || 'HEAD^1' }}]" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        run: pnpm run test --continue --filter="!./apps/**" --filter="!./libs/ui/**" --filter="!./tools/**" --filter="!live-common-tools" --filter="!ledger-live...[${{ inputs.since_branch && format('origin/{0}', inputs.since_branch) || 'HEAD^1' }}]" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
         shell: bash
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: ${{ format('live-common-src-{0}', matrix.os) }}
+          name: live-common-src
           path: |
             libs/ledger-live-common/src
+      - uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const fs = require("fs");
+            fs.writeFileSync("summary-tests.txt", "${{ steps.test-libs.outcome }}", "utf-8");
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: outputs
+          path: ${{ github.workspace }}/summary-tests.txt
+
+  test-ui:
+    name: "Test UI Libs"
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: LedgerHQ/ledger-live/tools/actions/composites/checkout-merge@develop
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && (inputs.ref || github.ref_name)) || github.sha }}
+          base: ${{ inputs.since_branch }}
+          fetch-depth: 0
+      - name: Setup the toolchain
+        uses: ./tools/actions/composites/setup-toolchain
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: TurboRepo local caching server
+        id: turborepo-cache-server
+        uses: ./tools/actions/turborepo-s3-cache
+        with:
+          server-token: "yolo"
+          cleanup-cache-folder: "true"
+          aws-access-key: ${{ secrets.AWS_S3_CACHE_ACCESS_KEY }}
+          aws-secret-key: ${{ secrets.AWS_S3_CACHE_SECRET_KEY }}
+      - name: Install dependencies
+        run: pnpm i --filter="./libs/ui/**"
+      - name: Build and Test affected libraries
+        id: test-ui
+        run: pnpm run test --continue --filter="./libs/ui/**" --filter="!ledger-live...[${{ inputs.since_branch && format('origin/{0}', inputs.since_branch) || 'HEAD^1' }}]" --api="http://127.0.0.1:${{ steps.turborepo-cache-server.outputs.port }}" --token="yolo" --team="foo"
+        shell: bash
       - name: (On Failure) Upload react-ui test results
         uses: actions/upload-artifact@v3
         if: failure()
@@ -169,12 +212,12 @@ jobs:
         with:
           script: |
             const fs = require("fs");
-            fs.writeFileSync("summary-tests-${{ matrix.os }}.txt", "${{ steps.test-libs.outcome }}", "utf-8");
+            fs.writeFileSync("summary-ui-${{ matrix.os }}.txt", "${{ steps.test-ui.outcome }}", "utf-8");
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: outputs
-          path: ${{ github.workspace }}/summary-tests-${{ matrix.os }}.txt
+          path: ${{ github.workspace }}/summary-ui-${{ matrix.os }}.txt
 
   codecheck-libraries:
     name: "Codecheck Libraries"
@@ -230,7 +273,7 @@ jobs:
             ${{ github.workspace }}/summary-lint.txt
 
   report:
-    needs: [test-cli, test-docs, test-libraries, codecheck-libraries, test-common-tools]
+    needs: [test-cli, test-docs, test-libraries, test-ui, codecheck-libraries, test-common-tools]
     if: always() && !cancelled() && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -242,15 +285,21 @@ jobs:
         with:
           script: |
             const fs = require("fs");
-            const resultTestsLinux = fs.readFileSync("${{ github.workspace }}/summary-tests-ubuntu-latest.txt", "utf-8");
-            const resultTestsMacos = fs.readFileSync("${{ github.workspace }}/summary-tests-macos-latest.txt", "utf-8");
+            const resultTests = fs.readFileSync("${{ github.workspace }}/summary-tests.txt", "utf-8");
             const resultLint = fs.readFileSync("${{ github.workspace }}/summary-lint.txt", "utf-8");
             const resultTypecheck = fs.readFileSync("${{ github.workspace }}/summary-typecheck.txt", "utf-8");
+            const resultUILinux = fs.readFileSync("${{ github.workspace }}/summary-ui-ubuntu-latest.txt", "utf-8");
+            const resultUImacOS = fs.readFileSync("${{ github.workspace }}/summary-ui-macos-latest.txt", "utf-8");
+            const resultUIWindows = fs.readFileSync("${{ github.workspace }}/summary-ui-windows-latest.txt", "utf-8");
 
             const statuses = {
               doc: {
                 pass: ${{ needs.test-docs.outputs.fail != '1' }},
                 status: "${{ needs.test-docs.result }}",
+              },
+              tool: {
+                pass: ${{ needs.test-common-tools.result == 'success' }},
+                status: "${{ needs.test-common-tools.result }}",
               },
               cli: {
                 pass: ${{ needs.test-cli.outputs.test-fail == 'success' && needs.test-cli.outputs.fail != '1' }},
@@ -264,31 +313,29 @@ jobs:
                 pass: ${{ needs.test-libraries.result == 'success' }},
                 status: "${{ needs.test-libraries.result }}",
               },
-              libs: {
-                lint: {
-                  pass: resultLint == 'success',
-                  status: resultLint,
+              lint: {
+                pass: resultLint == 'success',
+                status: resultLint,
+              },
+              typecheck: {
+                pass: resultTypecheck == 'success',
+                status: resultTypecheck,
+              },
+              ui: {
+                mac: {
+                  pass: resultUImacOS == 'success',
+                  status: resultUImacOS,
                 },
-                typecheck: {
-                  pass: resultTypecheck == 'success',
-                  status: resultTypecheck,
+                linux: {
+                  pass: resultUILinux == 'success',
+                  status: resultUILinux,
                 },
-                tests: {
-                  mac: {
-                    pass: resultTestsMacos == 'success',
-                    status: resultTestsMacos,
-                  },
-                  linux: {
-                    pass: resultTestsLinux == 'success',
-                    status: resultTestsLinux,
-                  },
-                },
+                windows: {
+                  pass: resultUIWindows == 'success',
+                  status: resultUIWindows,
+                }
               },
             };
-
-            const testsOk = Object.values(statuses.libs.tests).every(os => os.pass);
-            const lintOk = Object.values(statuses.libs.lint).every(os => os.pass);
-            const typecheckOk = Object.values(statuses.libs.typecheck).every(os => os.pass);
 
             const summary = `### Test documentation files
             ${statuses.doc.pass ? "Documentation files are fine" : "Documentation files are outdated"}
@@ -305,16 +352,23 @@ jobs:
 
             | Lint | Typecheck |
             | :--: | :--: |
-            | ${statuses.libs.lint.pass ? "✅" : "❌"} (${statuses.libs.lint.status}) | ${statuses.libs.typecheck.pass ? "✅" : "❌"} (${statuses.libs.typecheck.status}) |
+            | ${statuses.lint.pass ? "✅" : "❌"} (${statuses.lint.status}) | ${statuses.typecheck.pass ? "✅" : "❌"} (${statuses.typecheck.status}) |
 
             ### Test Libraries
 
-            ${testsOk ? "All tests are fine" : "Some tests failed"}
+            ${statuses.tests.pass ? "All tests are fine" : "Some tests failed"}
+              - ${statuses.tests.pass ? "✅" : "❌"} **Test Libs** ended with status \`${statuses.tests.status}\`
 
-            | Linux (🤖) | macOS (🍏) |
-            | :--: | :--: |
-            | ${statuses.libs.tests.linux.pass ? "✅" : "❌"} (${statuses.libs.tests.linux.status}) | ${statuses.libs.tests.mac.pass ? "✅" : "❌"} (${statuses.libs.tests.mac.status}) |
+            ### Test UI Design System
 
+            | Linux (🤖) | macOS (🍏) | windows (🪟) |
+            | :--: | :--: | :--: |
+            | ${statuses.ui.linux.pass ? "✅" : "❌"} (${statuses.ui.linux.status}) | ${statuses.ui.mac.pass ? "✅" : "❌"} (${statuses.ui.mac.status}) | ${statuses.ui.windows.pass ? "✅" : "❌"} (${statuses.ui.windows.status}) |
+
+            ### Common Tools
+
+            ${statuses.tool.pass ? "Common Tools are fine" : "Common Tools tests failed"}
+              - ${statuses.tool.pass ? "✅" : "❌"} **Common Tools* tests* ended with status \`${statuses.tool.status}\`
             `;
 
             const actions = [];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Split test.yml with UI tests so we can more granularly decide on which runners to 
run the tests. Also killed the libs tests on all OSes, only one is required 
(libcore, still in our <3), but UI libs tests will now run on each OS.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the 
change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be 
tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, 
does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain 
why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
