### PR TITLE
feat: changing locale prop on the earn app to use the language instead

### DIFF
--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -29,7 +29,6 @@ const DEFAULT_EARN_APP_ID = "earn";
 export function EarnScreen({ route }: Props) {
   const { theme } = useTheme();
   const language = useSelector(languageSelector);
-  const locale = useSelector(localeSelector);
   const { ticker: currencyTicker } = useSelector(counterValueCurrencySelector);
   const discreet = useSelector(discreetModeSelector);
 

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -59,7 +59,7 @@ export function EarnScreen({ route }: Props) {
         inputs={{
           theme,
           lang: language,
-          locale: locale,
+          locale: language, // LLM doesn't support different locales. By doing this we don't have to have specific LLM/LLD logic in earn, and in future if LLM supports locales we will change this from `language` to `locale`
           currencyTicker,
           discreetMode: discreet ? "true" : "false",
           ...params,

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -16,7 +16,6 @@ import {
   counterValueCurrencySelector,
   discreetModeSelector,
   languageSelector,
-  localeSelector,
 } from "../../../reducers/settings";
 import { useSelector } from "react-redux";
 import { TAB_BAR_HEIGHT } from "../../../components/TabBar/shared";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

LLM doesn't have locales like LLD does so we need to use the `language` to determine the formatting for LLM as before. This PR sets the `language` prop as `locale` for Earn in LLM so we don't need to have specific logic in Earn for LLM and LLD regarding the currency formatting. It also means in future if locales are supported in LLM, it just means changing `locale` prop in the Earn web player from `language` to `locale`

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
