### PR TITLE
exploration: Wallet Sync integration AccountDescriptor<>Account reconciliation

### DIFF
--- a/apps/cli/src/commands/exportAccounts.ts
+++ b/apps/cli/src/commands/exportAccounts.ts
@@ -34,6 +34,7 @@ export default {
           },
           exporterName: "ledger-live-cli",
           exporterVersion: "0.0.0",
+          walletSyncAuth: undefined,
         });
         const frames = dataToFrames(data, 80, 4);
 

--- a/apps/ledger-live-desktop/index-types.d.ts
+++ b/apps/ledger-live-desktop/index-types.d.ts
@@ -51,6 +51,7 @@ interface Window {
     addDevice: (device: Device) => void;
     removeDevice: (device: Device) => void;
     resetDevices: () => void;
+    setWalletSyncAuth: (auth: string) => void;
   };
 
   // used for the analytics, initialized in the index.html

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -53,6 +53,11 @@ export const updateAccountWithUpdater: UpdateAccountWithUpdater = (accountId, up
   payload: { accountId, updater },
 });
 
+export const updateAllAccountsWithUpdater = (updater: (account: Account) => Account) => ({
+  type: "DB:UPDATE_ACCOUNTS",
+  payload: { updater },
+});
+
 export type UpdateAccount = (account: Partial<Account>) => UpdateAccountAction;
 export const updateAccount: UpdateAccount = payload => ({
   type: "DB:UPDATE_ACCOUNT",

--- a/apps/ledger-live-desktop/src/renderer/actions/walletsync.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/walletsync.ts
@@ -1,0 +1,22 @@
+import { UnimportedAccountDescriptors } from "@ledgerhq/live-common/bridge/react/types";
+import { WalletSyncState } from "../reducers/walletsync";
+
+export const setAuth = (auth: string | undefined) => ({
+  type: "WALLETSYNC_SET_AUTH",
+  payload: auth,
+});
+
+export const setVersion = (version: number) => ({
+  type: "WALLETSYNC_SET_VERSION",
+  payload: version,
+});
+
+export const setWalletSyncPayload = (descriptors: UnimportedAccountDescriptors) => ({
+  type: "WALLETSYNC_SET_PAYLOAD",
+  payload: descriptors,
+});
+
+export const initWalletSync = (walletsync: WalletSyncState | undefined) => ({
+  type: "WALLETSYNC_INIT",
+  payload: walletsync,
+});

--- a/apps/ledger-live-desktop/src/renderer/bridge/BridgeSyncContext.tsx
+++ b/apps/ledger-live-desktop/src/renderer/bridge/BridgeSyncContext.tsx
@@ -1,20 +1,34 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { BridgeSync } from "@ledgerhq/live-common/bridge/react/index";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector, useDispatch, useStore } from "react-redux";
 import logger from "~/renderer/logger";
-import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
+import {
+  updateAccountWithUpdater,
+  updateAllAccountsWithUpdater,
+} from "~/renderer/actions/accounts";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { recentlyChangedExperimental } from "~/renderer/experimental";
 import { recentlyKilledInternalProcess } from "~/renderer/reset";
 import { track } from "~/renderer/analytics/segment";
 import { prepareCurrency, hydrateCurrency } from "./cache";
 import { blacklistedTokenIdsSelector } from "~/renderer/reducers/settings";
+import {
+  walletSyncAuthSelector,
+  walletSyncVersionSelector,
+  walletSyncDescriptorsSelector,
+} from "../reducers/walletsync";
+import { setWalletSyncPayload, setVersion } from "../actions/walletsync";
+
 export const BridgeSyncProvider = ({ children }: { children: React.ReactNode }) => {
   const accounts = useSelector(accountsSelector);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const dispatch = useDispatch();
   const updateAccount = useCallback(
     (accountId, updater) => dispatch(updateAccountWithUpdater(accountId, updater)),
+    [dispatch],
+  );
+  const updateAllAccounts = useCallback(
+    updater => dispatch(updateAllAccountsWithUpdater(updater)),
     [dispatch],
   );
   const recoverError = useCallback(error => {
@@ -29,15 +43,51 @@ export const BridgeSyncProvider = ({ children }: { children: React.ReactNode }) 
     logger.critical(error);
     return error;
   }, []);
+
+  const walletSyncAuth = useSelector(walletSyncAuthSelector);
+
+  const store = useStore();
+  const getVersion = useCallback(() => walletSyncVersionSelector(store.getState()), [store]);
+  const getLatestWalletSyncPayload = useCallback(
+    () => walletSyncDescriptorsSelector(store.getState()),
+    [store],
+  );
+
+  const onVersionUpdate = useCallback(
+    version => {
+      dispatch(setVersion(version));
+    },
+    [dispatch],
+  );
+  const walletSyncVersionManager = useMemo(
+    () => ({
+      onVersionUpdate,
+      getVersion,
+    }),
+    [onVersionUpdate, getVersion],
+  );
+
+  const setLatestWalletSyncPayload = useCallback(
+    descriptors => {
+      dispatch(setWalletSyncPayload(descriptors));
+    },
+    [dispatch],
+  );
+
   return (
     <BridgeSync
       accounts={accounts}
       updateAccountWithUpdater={updateAccount}
+      updateAllAccounts={updateAllAccounts}
       recoverError={recoverError}
       trackAnalytics={track}
       prepareCurrency={prepareCurrency}
       hydrateCurrency={hydrateCurrency}
       blacklistedTokenIds={blacklistedTokenIds}
+      walletSyncAuth={walletSyncAuth}
+      walletSyncVersionManager={walletSyncVersionManager}
+      setLatestWalletSyncPayload={setLatestWalletSyncPayload}
+      getLatestWalletSyncPayload={getLatestWalletSyncPayload}
     >
       {children}
     </BridgeSync>

--- a/apps/ledger-live-desktop/src/renderer/components/Exporter/QRCodeExporter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Exporter/QRCodeExporter.tsx
@@ -9,10 +9,12 @@ import { activeAccountsSelector } from "~/renderer/reducers/accounts";
 import { exportSettingsSelector } from "~/renderer/reducers/settings";
 import QRCode from "~/renderer/components/QRCode";
 import { Account } from "@ledgerhq/types-live";
+import { walletSyncAuthSelector } from "~/renderer/reducers/walletsync";
 
 const mapStateToProps = createStructuredSelector({
   accounts: (state, props) => props.accounts || activeAccountsSelector(state),
   settings: exportSettingsSelector,
+  walletSyncAuth: walletSyncAuthSelector,
 });
 
 const QRCodeContainer = styled.div`
@@ -30,6 +32,7 @@ type OwnProps = {
 type Props = OwnProps & {
   accounts: Account[];
   settings: Settings;
+  walletSyncAuth: string | undefined;
 };
 class QRCodeExporter extends PureComponent<
   Props,
@@ -45,12 +48,13 @@ class QRCodeExporter extends PureComponent<
 
   constructor(props: Props) {
     super(props);
-    const { accounts, settings } = props;
+    const { accounts, settings, walletSyncAuth } = props;
     const data = encode({
       accounts,
       settings,
       exporterName: "desktop",
       exporterVersion: __APP_VERSION__,
+      walletSyncAuth,
     });
     this.chunks = dataToFrames(data, 160, 4);
     setTimeout(() => {

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/ActivityIndicator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/ActivityIndicator.tsx
@@ -14,6 +14,7 @@ import Tooltip from "../Tooltip";
 import TranslatedError from "../TranslatedError";
 import Box from "../Box";
 import { ItemContainer } from "./shared";
+
 export default function ActivityIndicatorInner() {
   const bridgeSync = useBridgeSync();
   const globalSyncState = useGlobalSyncState();

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -46,6 +46,7 @@ import { expectOperatingSystemSupportStatus } from "~/support/os";
 import { addDevice, removeDevice, resetDevices } from "~/renderer/actions/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { listCachedCurrencyIds } from "./bridge/cache";
+import { initWalletSync, setAuth } from "./actions/walletsync";
 if (process.env.VERBOSE) {
   enableDebugLogger();
 }
@@ -106,6 +107,10 @@ async function init() {
         }
       : initialSettings,
   )(store.dispatch);
+
+  const initialWalletsync = await getKey("app", "walletsync");
+  store.dispatch(initWalletSync(initialWalletsync));
+
   const state = store.getState();
   const language = languageSelector(state);
   const locale = localeSelector(state);
@@ -219,6 +224,9 @@ async function init() {
     },
     resetDevices: () => {
       store.dispatch(resetDevices());
+    },
+    setWalletSyncAuth: (auth: string) => {
+      store.dispatch(setAuth(auth));
     },
   };
 }

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -6,6 +6,7 @@ import { actionTypePrefix as postOnboardingActionTypePrefix } from "@ledgerhq/li
 import { accountsSelector } from "./../reducers/accounts";
 import { settingsExportSelector, areSettingsLoaded } from "./../reducers/settings";
 import { State } from "../reducers";
+import { walletSyncSelector } from "../reducers/walletsync";
 let DB_MIDDLEWARE_ENABLED = true;
 
 // ability to temporary disable the db middleware from outside
@@ -28,6 +29,10 @@ const DBMiddleware: Middleware<{}, State> = store => next => action => {
     next(action);
     const state = store.getState();
     setKey("app", "postOnboarding", postOnboardingSelector(state));
+  } else if (DB_MIDDLEWARE_ENABLED && action.type.startsWith("WALLETSYNC_")) {
+    next(action);
+    const state = store.getState();
+    setKey("app", "walletsync", walletSyncSelector(state));
   } else {
     const oldState = store.getState();
     const res = next(action);

--- a/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
@@ -27,6 +27,7 @@ type HandlersPayloads = {
   ADD_ACCOUNT: Account;
   REPLACE_ACCOUNTS: Account[];
   UPDATE_ACCOUNT: { accountId: string; updater: (a: Account) => Account };
+  UPDATE_ACCOUNTS: { updater: (a: Account[]) => Account[] };
   REMOVE_ACCOUNT: Account;
   CLEAN_FULLNODE_DISCONNECT: never;
   CLEAN_ACCOUNTS_CACHE: never;
@@ -52,6 +53,7 @@ const handlers: AccountsHandlers = {
       }
       return updater(existingAccount);
     }),
+  UPDATE_ACCOUNTS: (state, { payload: { updater } }) => updater(state),
   REMOVE_ACCOUNT: (state, { payload: account }) => state.filter(acc => acc.id !== account.id),
   CLEAN_FULLNODE_DISCONNECT: state => state.filter(acc => acc.currency.id !== "bitcoin"),
   CLEAN_ACCOUNTS_CACHE: state => state.map(clearAccount),

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -9,6 +9,8 @@ import settings, { SettingsState } from "./settings";
 import swap, { SwapStateType } from "./swap";
 import { PostOnboardingState } from "@ledgerhq/types-live";
 import postOnboarding from "@ledgerhq/live-common/postOnboarding/reducer";
+import { WalletSyncState } from "./walletsync";
+import walletsync from "./walletsync";
 
 export type State = {
   accounts: AccountsState;
@@ -20,6 +22,7 @@ export type State = {
   UI: UIState;
   swap: SwapStateType;
   postOnboarding: PostOnboardingState;
+  walletsync: WalletSyncState;
 };
 
 export default combineReducers({
@@ -32,4 +35,5 @@ export default combineReducers({
   UI,
   postOnboarding,
   swap,
+  walletsync,
 });

--- a/apps/ledger-live-desktop/src/renderer/reducers/walletsync.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/walletsync.ts
@@ -1,0 +1,68 @@
+import { createSelector } from "reselect";
+import { handleActions } from "redux-actions";
+import { Handlers } from "./types";
+import { WalletSyncPayload } from "@ledgerhq/live-common/bridge/react/types";
+
+export type WalletSyncState = {
+  // Version that WalletSync need to track what version of the data was applied so far to the current wallet
+  version: number;
+  // a crypto key that authenticate the user. if not set, wallet sync is not active.
+  auth: undefined | string;
+  // holds the latest backend state we have received, regardless if the local accounts had the time to apply it yet.
+  // it can be used to display "pending" state to the UI, comparing that list to the current accounts.
+  descriptors: WalletSyncPayload;
+};
+
+const initialState: WalletSyncState = {
+  version: 0,
+  auth: undefined,
+  descriptors: [],
+};
+
+const state: WalletSyncState = initialState;
+
+type HandlersPayloads = {
+  WALLETSYNC_INIT: WalletSyncState | undefined;
+  WALLETSYNC_SET_AUTH: string;
+  WALLETSYNC_SET_VERSION: number;
+  WALLETSYNC_SET_PAYLOAD: WalletSyncPayload;
+};
+
+type WalletsyncHandlers<PreciseKey = true> = Handlers<
+  WalletSyncState,
+  HandlersPayloads,
+  PreciseKey
+>;
+
+const handlers: WalletsyncHandlers = {
+  WALLETSYNC_INIT: (state, { payload }) => ({ ...state, ...payload }),
+  WALLETSYNC_SET_AUTH: (state, { payload: auth }) =>
+    state.auth !== auth ? { ...initialState, auth } : state,
+  WALLETSYNC_SET_VERSION: (state, { payload: version }) => ({ ...state, version }),
+  WALLETSYNC_SET_PAYLOAD: (state, { payload: descriptors }) => ({ ...state, descriptors }),
+};
+
+export default handleActions<WalletSyncState, HandlersPayloads[keyof HandlersPayloads]>(
+  handlers as unknown as WalletsyncHandlers<false>,
+  state,
+);
+
+// Selectors
+
+export const walletSyncSelector = (state: { walletsync: WalletSyncState }): WalletSyncState =>
+  state.walletsync;
+
+export const walletSyncVersionSelector = createSelector(
+  walletSyncSelector,
+  walletsync => walletsync.version,
+);
+
+export const walletSyncAuthSelector = createSelector(
+  walletSyncSelector,
+  walletsync => walletsync.auth,
+);
+
+export const walletSyncDescriptorsSelector = createSelector(
+  walletSyncSelector,
+  walletsync => walletsync.descriptors,
+);

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -22,6 +22,7 @@ import { CounterValuesStatus, RateMapRaw } from "@ledgerhq/live-common/counterva
 import { hubStateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { settingsExportSelector } from "./reducers/settings";
 import logger from "./logger";
+import { WalletSyncState } from "./reducers/walletsync";
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.
@@ -52,6 +53,7 @@ type DatabaseValues = {
   countervalues: Countervalues;
   postOnboarding: PostOnboarding;
   settings: Settings;
+  walletsync: WalletSyncState;
   PLAYWRIGHT_RUN: {
     localStorage?: Record<string, string>;
   };

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -10,6 +10,7 @@ import type {
   AccountsReplaceAccountsPayload,
   AccountsSetAccountsPayload,
   AccountsUpdateAccountWithUpdaterPayload,
+  AccountsUpdateAccountsWithUpdaterPayload,
 } from "./types";
 import { AccountsActionTypes } from "./types";
 import logger from "../logger";
@@ -47,6 +48,11 @@ export const setAccounts = createAction<AccountsSetAccountsPayload>(
 export const updateAccountWithUpdater = createAction<AccountsUpdateAccountWithUpdaterPayload>(
   AccountsActionTypes.UPDATE_ACCOUNT,
 );
+
+export const updateAllAccountsWithUpdater = createAction<AccountsUpdateAccountsWithUpdaterPayload>(
+  AccountsActionTypes.UPDATE_ACCOUNTS,
+);
+
 export const updateAccount = (payload: Pick<Account, "id"> & Partial<Account>) =>
   updateAccountWithUpdater({
     accountId: payload.id,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -34,6 +34,7 @@ import type {
   ProtectState,
   NftState,
 } from "../reducers/types";
+import { WalletSyncState } from "../reducers/walletsync";
 import type { Unpacked } from "../types/helpers";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
@@ -46,6 +47,7 @@ export enum AccountsActionTypes {
   ACCOUNTS_ADD = "ACCOUNTS_ADD",
   SET_ACCOUNTS = "SET_ACCOUNTS",
   UPDATE_ACCOUNT = "UPDATE_ACCOUNT",
+  UPDATE_ACCOUNTS = "UPDATE_ACCOUNTS",
   DELETE_ACCOUNT = "DELETE_ACCOUNT",
   CLEAN_CACHE = "CLEAN_CACHE",
   DANGEROUSLY_OVERRIDE_STATE = "DANGEROUSLY_OVERRIDE_STATE",
@@ -64,6 +66,9 @@ export type AccountsUpdateAccountWithUpdaterPayload = {
   accountId: string;
   updater: (arg0: Account) => Account;
 };
+export type AccountsUpdateAccountsWithUpdaterPayload = {
+  updater: (arg0: Account[]) => Account[];
+};
 export type AccountsDeleteAccountPayload = Account;
 export type AccountsPayload =
   | AccountsImportStorePayload
@@ -72,7 +77,10 @@ export type AccountsPayload =
   | AccountsReplaceAccountsPayload
   | AccountsSetAccountsPayload
   | AccountsUpdateAccountWithUpdaterPayload
+  | AccountsUpdateAccountsWithUpdaterPayload
   | AccountsDeleteAccountPayload;
+
+export type ActionsWalletSyncPayload = WalletSyncState | undefined;
 
 // === APPSTATE ACTIONS ===
 
@@ -480,6 +488,7 @@ export type ActionsPayload =
   | Action<RatingsPayload>
   | Action<SettingsPayload>
   | Action<WalletConnectPayload>
+  | Action<ActionsWalletSyncPayload>
   | Action<PostOnboardingPayload>
   | Action<SwapPayload>
   | Action<ProtectPayload>

--- a/apps/ledger-live-mobile/src/actions/walletsync.ts
+++ b/apps/ledger-live-mobile/src/actions/walletsync.ts
@@ -1,0 +1,22 @@
+import { WalletSyncPayload } from "@ledgerhq/live-common/bridge/react/types";
+import { WalletSyncState } from "../reducers/walletsync";
+
+export const setAuth = (auth: string | undefined) => ({
+  type: "WALLETSYNC_SET_AUTH",
+  payload: auth,
+});
+
+export const setVersion = (version: number) => ({
+  type: "WALLETSYNC_SET_VERSION",
+  payload: version,
+});
+
+export const setWalletSyncPayload = (descriptors: WalletSyncPayload) => ({
+  type: "WALLETSYNC_SET_PAYLOAD",
+  payload: descriptors,
+});
+
+export const initWalletSync = (state: WalletSyncState | undefined) => ({
+  type: "WALLETSYNC_INIT",
+  payload: state,
+});

--- a/apps/ledger-live-mobile/src/bridge/BridgeSyncContext.tsx
+++ b/apps/ledger-live-mobile/src/bridge/BridgeSyncContext.tsx
@@ -1,12 +1,18 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { BridgeSync } from "@ledgerhq/live-common/bridge/react/index";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector, useDispatch, useStore } from "react-redux";
 import logger from "../logger";
-import { updateAccountWithUpdater } from "../actions/accounts";
+import { updateAccountWithUpdater, updateAllAccountsWithUpdater } from "../actions/accounts";
 import { accountsSelector } from "../reducers/accounts";
 import { blacklistedTokenIdsSelector } from "../reducers/settings";
 import { track } from "../analytics/segment";
 import { prepareCurrency, hydrateCurrency } from "./cache";
+import {
+  walletSyncAuthSelector,
+  walletSyncDescriptorsSelector,
+  walletSyncVersionSelector,
+} from "../reducers/walletsync";
+import { setWalletSyncPayload, setVersion } from "../actions/walletsync";
 
 export const BridgeSyncProvider = ({ children }: { children: React.ReactNode }) => {
   const accounts = useSelector(accountsSelector);
@@ -16,18 +22,58 @@ export const BridgeSyncProvider = ({ children }: { children: React.ReactNode }) 
     (accountId, updater) => dispatch(updateAccountWithUpdater({ accountId, updater })),
     [dispatch],
   );
+  const updateAllAccounts = useCallback(
+    updater => dispatch(updateAllAccountsWithUpdater({ updater })),
+    [dispatch],
+  );
   const recoverError = useCallback(error => {
     logger.critical(error);
   }, []);
+
+  const walletSyncAuth = useSelector(walletSyncAuthSelector);
+
+  const store = useStore();
+  const getVersion = useCallback(() => walletSyncVersionSelector(store.getState()), [store]);
+  const getLatestWalletSyncPayload = useCallback(
+    () => walletSyncDescriptorsSelector(store.getState()),
+    [store],
+  );
+
+  const onVersionUpdate = useCallback(
+    version => {
+      dispatch(setVersion(version));
+    },
+    [dispatch],
+  );
+  const walletSyncVersionManager = useMemo(
+    () => ({
+      onVersionUpdate,
+      getVersion,
+    }),
+    [onVersionUpdate, getVersion],
+  );
+
+  const setLatestWalletSyncPayload = useCallback(
+    descriptors => {
+      dispatch(setWalletSyncPayload(descriptors));
+    },
+    [dispatch],
+  );
+
   return (
     <BridgeSync
       accounts={accounts}
       updateAccountWithUpdater={updateAccount}
+      updateAllAccounts={updateAllAccounts}
       recoverError={recoverError}
       trackAnalytics={track}
       prepareCurrency={prepareCurrency}
       hydrateCurrency={hydrateCurrency}
       blacklistedTokenIds={blacklistedTokenIds}
+      walletSyncAuth={walletSyncAuth}
+      walletSyncVersionManager={walletSyncVersionManager}
+      getLatestWalletSyncPayload={getLatestWalletSyncPayload}
+      setLatestWalletSyncPayload={setLatestWalletSyncPayload}
     >
       {children}
     </BridgeSync>

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -8,6 +8,7 @@ import { CounterValuesStateRaw } from "@ledgerhq/live-common/countervalues/types
 import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import {
   getAccounts,
+  getWalletSync,
   getCountervalues,
   getSettings,
   getBle,
@@ -17,6 +18,7 @@ import {
 import reducers from "../reducers";
 import { importSettings } from "../actions/settings";
 import { importStore as importAccounts } from "../actions/accounts";
+import { initWalletSync as importWalletSync } from "../actions/walletsync";
 import { importBle } from "../actions/ble";
 import { updateProtectData, updateProtectStatus } from "../actions/protect";
 import { INITIAL_STATE as settingsState, supportedCountervalues } from "../reducers/settings";
@@ -94,6 +96,9 @@ export default class LedgerStoreProvider extends Component<
     store.dispatch(importSettings(settingsData));
     const accountsData = await getAccounts();
     store.dispatch(importAccounts(accountsData));
+
+    const walletsyncData = await getWalletSync();
+    store.dispatch(importWalletSync(walletsyncData));
 
     const postOnboardingState = await getPostOnboardingState();
     if (postOnboardingState) {

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -12,6 +12,7 @@ import { Dispatch, SetStateAction } from "react";
 import store from "./logic/storeWrapper";
 import type { User } from "./types/store";
 import type { BleState, ProtectState, SettingsState } from "./reducers/types";
+import { WalletSyncState } from "./reducers/walletsync";
 
 export type Notifications = {
   announcements: Announcement[];
@@ -37,6 +38,13 @@ export async function setUser(user: User): Promise<void> {
 }
 export async function updateUser(user: User): Promise<void> {
   await store.update("user", user);
+}
+export async function getWalletSync(): Promise<WalletSyncState | undefined> {
+  const state = (await store.get("walletsync")) as WalletSyncState | undefined;
+  return state;
+}
+export async function saveWalletSync(state: WalletSyncState) {
+  await store.save("walletsync", state);
 }
 export async function getSettings(): Promise<Partial<SettingsState>> {
   const settings = (await store.get("settings")) as Partial<SettingsState>;

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -27,6 +27,7 @@ import {
   saveAccounts,
   saveBle,
   saveSettings,
+  saveWalletSync,
   saveCountervalues,
   savePostOnboardingState,
 } from "./db";
@@ -81,6 +82,7 @@ import StyleProvider from "./StyleProvider";
 import { performanceReportSubject } from "./components/PerformanceConsole/usePerformanceReportsLog";
 import { setOsTheme } from "./actions/settings";
 import TransactionsAlerts from "./components/TransactionsAlerts";
+import { walletSyncSelector } from "./reducers/walletsync";
 
 if (Config.DISABLE_YELLOW_BOX) {
   LogBox.ignoreAllLogs();
@@ -104,6 +106,7 @@ function App() {
   useListenToHidDevices();
 
   const getSettingsChanged = useCallback((a, b) => a.settings !== b.settings, []);
+  const getWalletSyncChanged = useCallback((a, b) => a.walletsync !== b.walletsync, []);
   const getAccountsChanged = useCallback(
     (
       oldState: State,
@@ -157,6 +160,12 @@ function App() {
     throttle: 500,
     getChangesStats: getAccountsChanged,
     lense: accountsExportSelector,
+  });
+  useDBSaveEffect({
+    save: saveWalletSync,
+    throttle: 500,
+    getChangesStats: getWalletSyncChanged,
+    lense: walletSyncSelector,
   });
   useDBSaveEffect({
     save: saveBle,

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -35,6 +35,7 @@ import type {
   AccountsUpdateAccountWithUpdaterPayload,
   SettingsBlacklistTokenPayload,
   DangerouslyOverrideStatePayload,
+  AccountsUpdateAccountsWithUpdaterPayload,
 } from "../actions/types";
 import { AccountsActionTypes } from "../actions/types";
 import accountModel from "../logic/accountModel";
@@ -89,6 +90,15 @@ const handlers: ReducerMap<AccountsState, Payload> = {
 
     return {
       active: state.active.map(update),
+    };
+  },
+
+  [AccountsActionTypes.UPDATE_ACCOUNTS]: (state, action) => {
+    const {
+      payload: { updater },
+    } = action as Action<AccountsUpdateAccountsWithUpdaterPayload>;
+    return {
+      active: updater(state.active),
     };
   },
 

--- a/apps/ledger-live-mobile/src/reducers/index.ts
+++ b/apps/ledger-live-mobile/src/reducers/index.ts
@@ -14,6 +14,7 @@ import protect from "./protect";
 import nft from "./nft";
 import { State } from "./types";
 import { ActionsPayload } from "../actions/types";
+import walletsync from "./walletsync";
 
 export type AppStore = Store<State>;
 
@@ -31,6 +32,7 @@ const appReducer = combineReducers({
   postOnboarding,
   protect,
   nft,
+  walletsync,
 });
 
 // TODO: EXPORT ALL POSSIBLE ACTION TYPES AND USE ACTION<TYPES>

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -24,6 +24,7 @@ import {
 } from "../dynamicContent/types";
 import { ProtectStateNumberEnum } from "../components/ServicesWidget/types";
 import { ImageType } from "../components/CustomImage/types";
+import { WalletSyncState } from "./walletsync";
 
 // === ACCOUNT STATE ===
 
@@ -322,4 +323,12 @@ export type State = {
   postOnboarding: PostOnboardingState;
   protect: ProtectState;
   nft: NftState;
+  walletsync: WalletSyncState;
+};
+
+export type Handlers<State, Types, PreciseKey = true> = {
+  [Key in keyof Types]: (
+    state: State,
+    body: { payload: Types[PreciseKey extends true ? Key : keyof Types] },
+  ) => State;
 };

--- a/apps/ledger-live-mobile/src/reducers/walletsync.ts
+++ b/apps/ledger-live-mobile/src/reducers/walletsync.ts
@@ -1,0 +1,62 @@
+import { createSelector } from "reselect";
+import { handleActions } from "redux-actions";
+import { Handlers } from "./types";
+import { WalletSyncPayload } from "@ledgerhq/live-common/bridge/react/types";
+
+export type WalletSyncState = {
+  version: undefined | number;
+  auth: undefined | string;
+  descriptors: WalletSyncPayload;
+};
+
+const initialState: WalletSyncState = {
+  version: undefined,
+  auth: undefined,
+  descriptors: [],
+};
+const state: WalletSyncState = initialState;
+
+type HandlersPayloads = {
+  WALLETSYNC_SET_AUTH: string;
+  WALLETSYNC_SET_VERSION: number;
+  WALLETSYNC_SET_PAYLOAD: WalletSyncPayload;
+  WALLETSYNC_INIT: WalletSyncState | undefined;
+};
+type WalletsyncHandlers<PreciseKey = true> = Handlers<
+  WalletSyncState,
+  HandlersPayloads,
+  PreciseKey
+>;
+
+const handlers: WalletsyncHandlers = {
+  WALLETSYNC_SET_AUTH: (state, { payload: auth }) =>
+    state.auth !== auth ? { ...initialState, auth } : state,
+  WALLETSYNC_SET_VERSION: (state, { payload: version }) => ({ ...state, version }),
+  WALLETSYNC_SET_PAYLOAD: (state, { payload: descriptors }) => ({ ...state, descriptors }),
+  WALLETSYNC_INIT: (state, { payload }) => ({ ...state, ...payload }),
+};
+
+export default handleActions<WalletSyncState, HandlersPayloads[keyof HandlersPayloads]>(
+  handlers as unknown as WalletsyncHandlers<false>,
+  state,
+);
+
+// Selectors
+
+export const walletSyncSelector = (state: { walletsync: WalletSyncState }): WalletSyncState =>
+  state.walletsync;
+
+export const walletSyncVersionSelector = createSelector(
+  walletSyncSelector,
+  walletsync => walletsync.version,
+);
+
+export const walletSyncAuthSelector = createSelector(
+  walletSyncSelector,
+  walletsync => walletsync.auth,
+);
+
+export const walletSyncDescriptorsSelector = createSelector(
+  walletSyncSelector,
+  walletsync => walletsync.descriptors,
+);

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/ExportAccounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/ExportAccounts.tsx
@@ -13,11 +13,13 @@ import { exportSettingsSelector } from "../../../../reducers/settings";
 import LText from "../../../../components/LText";
 import NavigationScrollView from "../../../../components/NavigationScrollView";
 import { State } from "../../../../reducers/types";
+import { walletSyncAuthSelector } from "../../../../reducers/walletsync";
 
 export type Props = {
   accounts: Account[];
   settings: Settings;
   children?: React.ReactNode;
+  walletSyncAuth: string | undefined;
 };
 
 class ExportAccounts extends PureComponent<
@@ -33,12 +35,13 @@ class ExportAccounts extends PureComponent<
   timer: NodeJS.Timeout | undefined;
 
   componentDidMount() {
-    const { accounts, settings } = this.props;
+    const { accounts, settings, walletSyncAuth } = this.props;
     const data = encode({
       accounts,
       settings,
       exporterName: "mobile",
       exporterVersion: VersionNumber.appVersion || "",
+      walletSyncAuth,
     });
     this.chunks = dataToFrames(data, 160, 4);
     const fps = 3;
@@ -102,10 +105,12 @@ export default connect(
     {
       accounts: Account[];
       settings: Settings;
+      walletSyncAuth: string | undefined;
     }
   >({
     accounts: accountsSelector,
     settings: exportSettingsSelector,
+    walletSyncAuth: walletSyncAuthSelector,
   }),
 )(ExportAccounts);
 

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -611,6 +611,21 @@ const envDefinitions = {
     parser: boolParser,
     desc: "is walletconnect enabled",
   },
+  WALLET_SYNC_API: {
+    def: "https://cloud-sync-backend.aws.stg.ldg-tech.com",
+    parser: stringParser,
+    desc: "wallet sync api base url",
+  },
+  WALLET_SYNC_POLL_FREQUENCY: {
+    def: 5000,
+    parser: intParser,
+    desc: "wallet sync api poll frequency in ms",
+  },
+  WALLET_SYNC_PUSH_DEBOUNCE: {
+    def: 5000,
+    parser: intParser,
+    desc: "wallet sync api push debounce in ms",
+  },
   WITH_DEVICE_POLLING_DELAY: {
     def: 500,
     parser: floatParser,

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -10,9 +10,9 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common",
-  "main": "lib/index.js",
-  "module": "lib-es/index.js",
-  "types": "lib/index.d.ts",
+  "main": "./lib/index.js",
+  "module": "./lib-es/index.js",
+  "types": "./lib/index.d.ts",
   "typesVersions": {
     "*": {
       "*.json": [
@@ -127,11 +127,11 @@
     "@cosmjs/proto-signing": "^0.26.5",
     "@cosmjs/stargate": "^0.26.5",
     "@crypto-org-chain/chain-jslib": "1.1.2",
-    "@elrondnetwork/erdjs": "11.0.0",
-    "@elrondnetwork/erdjs-network-providers": "^1.1.2",
     "@dfinity/agent": "^0.15.6",
     "@dfinity/candid": "^0.15.6",
     "@dfinity/principal": "^0.15.6",
+    "@elrondnetwork/erdjs": "11.0.0",
+    "@elrondnetwork/erdjs-network-providers": "^1.1.2",
     "@ethereumjs/common": "^2.6.2",
     "@ethereumjs/tx": "^3.5.0",
     "@ethersproject/bignumber": "^5.7.0",
@@ -176,6 +176,7 @@
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/wallet-api-core": "^1.0.2",
     "@ledgerhq/wallet-api-server": "^1.1.1",
+    "@ledgerhq/wss-sdk": "workspace:^",
     "@solana/spl-token": "^0.3.7",
     "@solana/web3.js": "1.77.3",
     "@stacks/network": "1.2.2",
@@ -265,7 +266,8 @@
     "utility-types": "^3.10.0",
     "varuint-bitcoin": "1.1.2",
     "winston": "^3.4.0",
-    "xstate": "^4.30.2"
+    "xstate": "^4.30.2",
+    "zod": "^3.22.1"
   },
   "devDependencies": {
     "@ledgerhq/types-cryptoassets": "workspace:^",

--- a/libs/ledger-live-common/src/__snapshots__/cross.test.ts.snap
+++ b/libs/ledger-live-common/src/__snapshots__/cross.test.ts.snap
@@ -53,5 +53,6 @@ Object {
       "BTC_USD": "KRAKEN",
     },
   },
+  "walletSyncAuth": undefined,
 }
 `;

--- a/libs/ledger-live-common/src/account/importAccounts.integration.test.ts
+++ b/libs/ledger-live-common/src/account/importAccounts.integration.test.ts
@@ -158,6 +158,7 @@ test("importAccounts with a set of real data", async () => {
     accounts: accounts.map(accountToAccountData),
     settings: { currenciesSettings: {}, pairExchanges: {} },
     meta: { exporterName: "Test", exporterVersion: "0" },
+    walletSyncAuth: undefined,
   };
 
   const accountsState = [];

--- a/libs/ledger-live-common/src/account/importAccounts.test.ts
+++ b/libs/ledger-live-common/src/account/importAccounts.test.ts
@@ -77,6 +77,7 @@ describe("importAccountsMakeItems", () => {
         pairExchanges: {},
         developerModeEnabled: false,
       },
+      walletSyncAuth: undefined,
     };
     const accounts = [
       <AccountRaw>{

--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.test.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.test.tsx
@@ -14,11 +14,20 @@ jest.setTimeout(30000);
 const defaultsBridgeSyncOpts = {
   accounts: [],
   updateAccountWithUpdater: () => {},
+  updateAllAccounts: () => {},
   recoverError: e => e,
   trackAnalytics: () => {},
   prepareCurrency: () => Promise.resolve(),
   hydrateCurrency: () => Promise.resolve(),
   blacklistedTokenIds: [],
+  walletSyncAuth: undefined,
+  walletSyncVersionManager: {
+    getVersion: () => undefined,
+    onVersionUpdate: () => {},
+  },
+  setWalletSyncPayload: () => {},
+  getLatestWalletSyncPayload: () => [],
+  setLatestWalletSyncPayload: () => {},
 };
 
 setSupportedCurrencies(["bitcoin", "ethereum"]);
@@ -101,4 +110,6 @@ describe("BridgeSync", () => {
       );
     });
   });
+
+  // TODO add some tests for Wallet Sync related stuff
 });

--- a/libs/ledger-live-common/src/bridge/react/types.ts
+++ b/libs/ledger-live-common/src/bridge/react/types.ts
@@ -1,3 +1,17 @@
+import { AccountDescriptor } from "../../cross";
+
+export type WalletSyncInferredActions = {
+  addedAccounts: AccountDescriptor[];
+  removedAccounts: AccountDescriptor[];
+  updatedAccounts: AccountDescriptor[];
+};
+
+export type UpdatesInput = {
+  type: "SYNC_WITH_WALLET_SYNC";
+  actions: WalletSyncInferredActions;
+  onSuccess: (_: UnimportedAccountDescriptors) => void;
+};
+
 export type SyncAction =
   | {
       type: "BACKGROUND_TICK";
@@ -23,7 +37,8 @@ export type SyncAction =
       type: "SYNC_ALL_ACCOUNTS";
       priority: number;
       reason: string;
-    };
+    }
+  | UpdatesInput;
 export type SyncState = {
   pending: boolean;
   error: Error | null | undefined;
@@ -31,3 +46,15 @@ export type SyncState = {
 export type BridgeSyncState = Record<string, SyncState>;
 // trigger an action
 export type Sync = (action: SyncAction) => void;
+
+export type UnimportedAccountDescriptors = Array<{
+  descriptor: AccountDescriptor;
+  error: string;
+}>;
+
+export type WalletSyncPayload = AccountDescriptor[];
+
+export type UpdatesQueue = {
+  push: (input: UpdatesInput) => void;
+  idle: () => boolean;
+};

--- a/libs/ledger-live-common/src/bridge/react/useWalletSync.ts
+++ b/libs/ledger-live-common/src/bridge/react/useWalletSync.ts
@@ -1,0 +1,225 @@
+// NOTE: this part connects WalletSync paradigm (@ledgerhq/wss-sdk) with BridgeSync paradigm.
+// regardless of the conflict resolution implementation, "SYNC_WITH_WALLET_SYNC" message sent to the BridgeSync will trigger Accounts update.
+import { WalletSyncClient } from "@ledgerhq/wss-sdk";
+import { useEffect, useMemo } from "react";
+import type {
+  SyncAction,
+  UnimportedAccountDescriptors,
+  UpdatesQueue,
+  WalletSyncInferredActions,
+  WalletSyncPayload,
+} from "./types";
+import useEnv from "../../hooks/useEnv";
+import { Account } from "@ledgerhq/types-live";
+import { useThrottledFunction } from "../../hooks/useThrottledFunction";
+import { AccountDescriptor, accountToAccountData } from "../../cross";
+import { log } from "@ledgerhq/logs";
+import { isEqual } from "lodash";
+import { useDebounce } from "../../hooks/useDebounce";
+
+export type VersionManager = {
+  onVersionUpdate: (version: number) => void;
+  getVersion: () => number | undefined;
+};
+
+/**
+ * TODO: in future, .balance should disappear from AccountData and we won't need this clean up anymore
+ */
+function customAccountToAccountData(a: Account): AccountDescriptor {
+  const data = accountToAccountData(a);
+  delete data.balance;
+  return data;
+}
+
+function accountDescriptorsDiff(
+  before: WalletSyncPayload,
+  after: WalletSyncPayload,
+): WalletSyncInferredActions | undefined {
+  const beforeById = {};
+  const afterById = {};
+  for (const descriptor of before) {
+    beforeById[descriptor.id] = descriptor;
+  }
+  for (const descriptor of after) {
+    afterById[descriptor.id] = descriptor;
+  }
+  const addedAccounts: AccountDescriptor[] = [];
+  const removedAccounts: AccountDescriptor[] = [];
+  const updatedAccounts: AccountDescriptor[] = [];
+  for (const descriptor of after) {
+    const old = beforeById[descriptor.id];
+    if (!old) {
+      addedAccounts.push(descriptor);
+    } else if (old.name !== descriptor.name) {
+      updatedAccounts.push(descriptor);
+    }
+  }
+  for (const descriptor of before) {
+    const old = afterById[descriptor.id];
+    if (!old) {
+      removedAccounts.push(descriptor);
+    }
+  }
+  if (!addedAccounts.length && !removedAccounts.length && !updatedAccounts.length) return;
+  return {
+    addedAccounts,
+    removedAccounts,
+    updatedAccounts,
+  };
+}
+
+function isSamePayload(before: WalletSyncPayload, after: WalletSyncPayload): boolean {
+  const data = after.concat([]);
+  // we need to stabilize the data order to avoid unnecessary diff (before is the server stable data)
+  data.sort((a, b) => (a.id === b.id ? 0 : a.id < b.id ? -1 : 1));
+  return isEqual(before, data);
+}
+
+// this hooks 'Wallet Sync' logic with BridgeSync paradigm
+
+export function useWalletSync({
+  accounts,
+  sync,
+  walletSyncAuth,
+  walletSyncVersionManager,
+  getLatestWalletSyncPayload,
+  setLatestWalletSyncPayload,
+  updatesQueue,
+}: {
+  accounts: Account[];
+  sync: (action: SyncAction) => void;
+  walletSyncAuth: string | undefined;
+  walletSyncVersionManager: VersionManager;
+  getLatestWalletSyncPayload: () => WalletSyncPayload | undefined;
+  setLatestWalletSyncPayload: (payload: WalletSyncPayload) => void;
+  updatesQueue: UpdatesQueue;
+}): WalletSyncClient | null {
+  const client = useClient(walletSyncAuth, walletSyncVersionManager);
+
+  /////////////////////////////////////////////////////////////////////////////
+  // { local Account[] <= server AccountDescriptor[] } updates reconciliation
+  //
+  // we determines the diff actions and apply them to the local accounts, and finally save the version locally to "commit" it
+  //
+  useEffect(() => {
+    if (!client) return;
+
+    // FIXME: at the moment, the present code creates backpressure on the syncbridge due to the polling implementation.
+    // OPINION: this is the limit of observables. i think the SDK should provide another paradigm where we could have an "async job" that it would need to wait on
+
+    const sub = client.observable().subscribe(([descriptors, version]) => {
+      // from the local diff, we infer the actions to apply on the accounts[]
+      const actions = accountDescriptorsDiff(getLatestWalletSyncPayload() || [], descriptors);
+      if (!actions) {
+        log("walletsync", "accounts=> received new version. no local diff");
+        setLatestWalletSyncPayload(descriptors);
+        walletSyncVersionManager.onVersionUpdate(version);
+        return;
+      }
+
+      // this propagate to the bridge sync underlying logic the intent of wallet sync and hook a way to save it back when it's ready
+      sync({
+        type: "SYNC_WITH_WALLET_SYNC",
+        actions,
+        // FIXME: we want this to be done atomic instead. there should be just one redux action to save once the version and the descriptor!
+        onSuccess: (_unimported: UnimportedAccountDescriptors) => {
+          setLatestWalletSyncPayload(descriptors);
+          walletSyncVersionManager.onVersionUpdate(version);
+        },
+      });
+    });
+
+    client.start();
+
+    return () => {
+      sub.unsubscribe();
+      client.stop();
+    };
+  }, [
+    client,
+    sync,
+    getLatestWalletSyncPayload,
+    setLatestWalletSyncPayload,
+    walletSyncVersionManager,
+  ]);
+
+  ///////////////////////////////////////////////////////////////////
+  // { local Account[] => server AccountDescriptor[] } data reconciliation
+  // we determine the current descriptors and push it to the server when necessary (when it changed)
+  //
+  const delay = useEnv("WALLET_SYNC_PUSH_DEBOUNCE");
+  let update = useThrottledFunction<
+    [] | [string] | [string, WalletSyncPayload],
+    [typeof client, typeof accounts, typeof getLatestWalletSyncPayload, typeof updatesQueue]
+  >(
+    (client, accounts, getLatestWalletSyncPayload, updatesQueue) => {
+      if (!client || !updatesQueue || !accounts || !getLatestWalletSyncPayload) {
+        return [];
+      }
+
+      // we cancel if there is a pending wallet sync. we will enter again once accounts[] change
+      if (!updatesQueue.idle()) {
+        return ["=>accounts: queue is busy"];
+      }
+
+      // from our local accounts state, we infer what would be the data to push
+      const data = accounts.map(customAccountToAccountData);
+
+      // FIXME NOT IMPLEMENTED: we need to also send back the descriptors that was not yet correctly imported
+      /*
+      if (unimported) {
+        unimported.forEach(descriptor => {
+          if (!data.find(d => d.id === descriptor.id)) {
+            data.push(descriptor);
+          }
+        });
+      }
+      */
+
+      const old = getLatestWalletSyncPayload();
+
+      // we compare if the data has changed from the latest data available on server
+      if (isSamePayload(old || [], data)) {
+        return ["=>accounts: no local changes"];
+      }
+
+      return ["=>accounts: pushing " + data.length + " descriptors", data];
+    },
+    delay,
+    [client, accounts, getLatestWalletSyncPayload, updatesQueue],
+  );
+  // on top of the throttling, we debounce a bit the update to avoid too much push to the server
+  update = useDebounce(update, delay);
+
+  // update have a debounced state of what should be pushed to server. we apply it here
+  useEffect(() => {
+    const [msg, data] = update;
+    if (msg) log("walletsync", msg);
+    if (data && client) client.saveData(data);
+  }, [update, client]);
+
+  return client;
+}
+
+// get the wallet sync client instance. null if the auth is not yet set
+/**
+ * TODO: in future, to make this independent of the 'Accounts' topic,
+ * we will probably make this accessible from the "context".
+ * But TBD how the wss-sdk will evolve to allow more than just /accounts
+ */
+function useClient(
+  auth: string | undefined,
+  versionManager: VersionManager,
+): WalletSyncClient | null {
+  const url = useEnv("WALLET_SYNC_API");
+  const clientInfo = useEnv("LEDGER_CLIENT_VERSION");
+  const pollFrequencyMs = useEnv("WALLET_SYNC_POLL_FREQUENCY");
+  const client = useMemo(
+    () =>
+      auth
+        ? new WalletSyncClient({ url, pollFrequencyMs, auth, clientInfo }, versionManager)
+        : null,
+    [url, auth, clientInfo, pollFrequencyMs, versionManager],
+  );
+  return client;
+}

--- a/libs/ledger-live-common/src/cross.test.ts
+++ b/libs/ledger-live-common/src/cross.test.ts
@@ -38,6 +38,7 @@ test("encode/decode", () => {
     },
     exporterName: "test你好👋",
     exporterVersion: "0.0.0",
+    walletSyncAuth: undefined,
   };
   const exp = decode(encode(data));
   expect(exp.meta.exporterName).toEqual(data.exporterName);
@@ -65,6 +66,7 @@ test("encode/decode", () => {
     exporterName: "test",
     exporterVersion: "0.0.0",
     chunkSize: 100,
+    walletSyncAuth: undefined,
   };
   const data = encode(arg);
   const res = decode(data);

--- a/libs/wss-sdk/.eslintrc.js
+++ b/libs/wss-sdk/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+  },
+  overrides: [
+    {
+      files: ["src/**/*.test.{ts,tsx}"],
+      env: {
+        "jest/globals": true,
+      },
+      plugins: ["jest"],
+    },
+  ],
+  rules: {
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+  },
+};

--- a/libs/wss-sdk/CHANGELOG.md
+++ b/libs/wss-sdk/CHANGELOG.md
@@ -1,0 +1,24 @@
+# @ledgerhq/wss-sdk
+
+## 0.3.0
+
+### Minor Changes
+
+- [#12](https://github.com/LedgerHQ/wallet-sync-system/pull/12) [`60c8cb2`](https://github.com/LedgerHQ/wallet-sync-system/commit/60c8cb223058172ffa6fe02efa395ed7ee582feb) Thanks [@IAmMorrow](https://github.com/IAmMorrow)! - Implemented the real backend
+
+### Patch Changes
+
+- Updated dependencies [[`60c8cb2`](https://github.com/LedgerHQ/wallet-sync-system/commit/60c8cb223058172ffa6fe02efa395ed7ee582feb)]:
+  - @ledgerhq/wss-shared@0.1.0
+
+## 0.2.0
+
+### Minor Changes
+
+- [#10](https://github.com/LedgerHQ/wallet-sync-system/pull/10) [`c15df17`](https://github.com/LedgerHQ/wallet-sync-system/commit/c15df175c5bf915cfe78ee5d8551259f60b3810f) Thanks [@IAmMorrow](https://github.com/IAmMorrow)! - AtomicPostUpdated now include the accepted version
+
+## 0.1.0
+
+### Minor Changes
+
+- [`e79c672`](https://github.com/LedgerHQ/wallet-sync-system/commit/e79c672cde7556db98b5e7a063936543f401003b) Thanks [@IAmMorrow](https://github.com/IAmMorrow)! - First version

--- a/libs/wss-sdk/package.json
+++ b/libs/wss-sdk/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@ledgerhq/wss-sdk",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "main": "./lib/index.js",
+  "module": "./lib-es/index.js",
+  "types": "./lib/index.d.ts",
+  "files": [
+    "./lib",
+    "./lib-es"
+  ],
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc && tsc -m ES6 --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch",
+    "doc": "documentation readme src/** --section=API --pe ts --re ts --re d.ts",
+    "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --cache",
+    "lint:fix": "pnpm lint --fix",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.12",
+    "@types/uuid": "^9.0.1",
+    "eslint": "^8.41.0",
+    "rimraf": "^5.0.0",
+    "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "@ledgerhq/logs": "workspace:*",
+    "axios": "^1.4.0",
+    "rxjs": "^7.8.1",
+    "superjson": "^1.12.3",
+    "uuid": "^9.0.0",
+    "zod": "^3.21.4"
+  }
+}

--- a/libs/wss-sdk/src/WalletSyncClient.ts
+++ b/libs/wss-sdk/src/WalletSyncClient.ts
@@ -1,0 +1,180 @@
+import crypto from "crypto";
+import { schemaAtomicGetResponse, schemaAtomicPostResponse } from "./types/api/index";
+import { Observable, Subject } from "rxjs";
+import axios, { Axios } from "axios";
+import { AccountMetadata } from "./dataTypes/Account/1.0.0/types";
+import { IV_LENGTH } from "./constants";
+import { schemaWalletDecryptedData } from "./dataTypes/schemas";
+import { WalletDecryptedData } from "./dataTypes/types";
+import { getUserIdForPrivateKey } from "./helpers";
+
+type SaveDataParams = AccountMetadata[];
+
+type WalletSyncVersionManager = {
+  onVersionUpdate: (version: number) => void;
+  getVersion: () => number | undefined;
+};
+
+type WalletSyncClientParams = {
+  pollFrequencyMs: number;
+  url: string;
+  auth: string;
+  clientInfo: string; // lld/1.0.0
+};
+
+export class WalletSyncClient {
+  private _versionManager: WalletSyncVersionManager;
+
+  private _intervalHandle: NodeJS.Timer | null = null;
+
+  private _params: WalletSyncClientParams;
+
+  private _subject: Subject<[WalletDecryptedData, number]> = new Subject();
+
+  private _axios: Axios;
+
+  private _userId: string;
+
+  private _auth: Buffer;
+
+  constructor(params: WalletSyncClientParams, versionManager: WalletSyncVersionManager) {
+    this._auth = Buffer.from(params.auth, "hex");
+    this._params = params;
+    this._versionManager = versionManager;
+    this._userId = getUserIdForPrivateKey(this._auth);
+
+    // FIXME quick hack. we will need to implement this properly. just to get a unique user
+    const publicKey = `aaaaaa000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000${this._userId.slice(
+      this._userId.length - 8,
+    )}`;
+
+    this._axios = axios.create({
+      baseURL: params.url,
+      headers: {
+        "X-Ledger-Public-Key": publicKey,
+        "X-Ledger-Client-Version": params.clientInfo,
+      },
+    });
+  }
+
+  /**
+   * allows consumer to get incoming updates
+   * the data with the version associated to it is attached and
+   * it is the userland responsability to do the onVersionUpdate associated to it once the data is entirely handled.
+   */
+  observable(): Observable<[WalletDecryptedData, number]> {
+    return this._subject;
+  }
+
+  private async _poll() {
+    const version = this._versionManager.getVersion();
+
+    const rawResponse = await this._axios.get<unknown>(`/atomic/v1/accounts`, {
+      params: { version },
+      headers: {
+        // TODO set these fields properly in the future
+        "X-Ledger-Timestamp": "2000-01-01T00:00:00.000000000+00:00",
+        "X-Ledger-Signature": "0000000000000000000000000000000000000000000000000000000000000000",
+      },
+    });
+
+    const response = schemaAtomicGetResponse.parse(rawResponse.data);
+
+    // eslint-disable-next-line default-case
+    switch (response.status) {
+      case "no-data": {
+        break;
+      }
+      case "up-to-date": {
+        break;
+      }
+      case "out-of-sync": {
+        const rawPayload = Buffer.from(response.payload, "base64");
+        const iv = rawPayload.slice(0, IV_LENGTH);
+        const encryptedData = rawPayload.slice(IV_LENGTH);
+
+        const decipher = crypto.createDecipheriv("aes-256-cbc", this._auth, iv);
+
+        const decryptedData = Buffer.concat([decipher.update(encryptedData), decipher.final()]);
+
+        const parsedData: unknown = JSON.parse(decryptedData.toString());
+
+        const safeData = schemaWalletDecryptedData.parse(parsedData);
+
+        this._subject.next([safeData, response.version]);
+        break;
+      }
+    }
+  }
+
+  async saveData(data: SaveDataParams) {
+    const version = this._versionManager.getVersion();
+
+    const serializedData = Buffer.from(JSON.stringify(data), "utf8");
+
+    const iv = crypto.randomBytes(IV_LENGTH);
+
+    const cipher = crypto.createCipheriv("aes-256-cbc", this._auth, iv);
+    const encryptedData = Buffer.concat([cipher.update(serializedData), cipher.final()]);
+
+    const rawPayload = Buffer.concat([iv, encryptedData]);
+
+    const newVersion = (version ?? 0) + 1;
+
+    const rawResponse = await this._axios.post<unknown>(
+      `/atomic/v1/accounts`,
+      {
+        payload: rawPayload.toString("base64"),
+      },
+      {
+        params: {
+          version: newVersion,
+        },
+        headers: {
+          "X-Ledger-Timestamp": "2000-01-01T00:00:00.000000000+00:00",
+          "X-Ledger-Signature": "0000000000000000000000000000000000000000000000000000000000000000",
+        },
+      },
+    );
+
+    const response = schemaAtomicPostResponse.parse(rawResponse.data);
+
+    // FIXME code was commented because: why doing this here? shouldn't we receive it on the observable() side anyway?
+    // I think doing this here introduce race conditions due to fact the http POST was async
+    /*
+    if (response.status === "updated") {
+      this._versionManager.onVersionUpdate(response.version);
+    }
+    */
+
+    return response;
+  }
+
+  start() {
+    if (this._intervalHandle !== null) {
+      throw new Error("WalletSyncClient already started");
+    }
+
+    // starting the update loop
+    this._intervalHandle = setInterval(() => {
+      void this._poll();
+    }, this._params.pollFrequencyMs);
+
+    // doing an initial poll
+    void this._poll();
+  }
+
+  stop() {
+    if (this._intervalHandle === null) {
+      throw new Error("WalletSyncClient not started");
+    }
+
+    // stopping the update loop
+    clearInterval(this._intervalHandle);
+    this._intervalHandle = null;
+  }
+
+  isStarted(): boolean {
+    return this._intervalHandle !== null;
+  }
+}

--- a/libs/wss-sdk/src/constants.ts
+++ b/libs/wss-sdk/src/constants.ts
@@ -1,0 +1,4 @@
+export const UUIDV5_NAMESPACE = "4e55d1da-c290-490c-8525-e18c98884119";
+
+export const SIGN_ALGORITHM = "SHA256";
+export const IV_LENGTH = 16;

--- a/libs/wss-sdk/src/dataTypes/Account/1.0.0/index.ts
+++ b/libs/wss-sdk/src/dataTypes/Account/1.0.0/index.ts
@@ -1,0 +1,7 @@
+import { getAccountId } from "./logic";
+import { schemaAccountMetadata } from "./schemas";
+
+export const BP_1_0_0 = {
+  getItemId: getAccountId,
+  itemSchema: schemaAccountMetadata,
+};

--- a/libs/wss-sdk/src/dataTypes/Account/1.0.0/logic.ts
+++ b/libs/wss-sdk/src/dataTypes/Account/1.0.0/logic.ts
@@ -1,0 +1,7 @@
+import { v5 as uuidv5 } from "uuid";
+import { AccountMetadata } from "./types";
+import { UUIDV5_NAMESPACE } from "../../../constants";
+
+export function getAccountId(accountMetadata: AccountMetadata) {
+  return uuidv5(accountMetadata.id, UUIDV5_NAMESPACE);
+}

--- a/libs/wss-sdk/src/dataTypes/Account/1.0.0/schemas.ts
+++ b/libs/wss-sdk/src/dataTypes/Account/1.0.0/schemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const schemaAccountMetadata = z.object({
+  id: z.string(),
+  currencyId: z.string(),
+  freshAddress: z.string(),
+  seedIdentifier: z.string(),
+  derivationMode: z.string(),
+  name: z.string(),
+  index: z.number(),
+});

--- a/libs/wss-sdk/src/dataTypes/Account/1.0.0/types.ts
+++ b/libs/wss-sdk/src/dataTypes/Account/1.0.0/types.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { schemaAccountMetadata } from "./schemas";
+
+export type AccountMetadata = z.infer<typeof schemaAccountMetadata>;

--- a/libs/wss-sdk/src/dataTypes/schemas.ts
+++ b/libs/wss-sdk/src/dataTypes/schemas.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { schemaAccountMetadata } from "./Account/1.0.0/schemas";
+
+export const schemaWalletDecryptedData = z.array(schemaAccountMetadata);

--- a/libs/wss-sdk/src/dataTypes/types.ts
+++ b/libs/wss-sdk/src/dataTypes/types.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+import { schemaWalletDecryptedData } from "./schemas";
+
+export type WalletDecryptedData = z.infer<typeof schemaWalletDecryptedData>;

--- a/libs/wss-sdk/src/helpers.ts
+++ b/libs/wss-sdk/src/helpers.ts
@@ -1,0 +1,6 @@
+import { v5 as uuidv5 } from "uuid";
+import { UUIDV5_NAMESPACE } from "./constants";
+
+export function getUserIdForPrivateKey(key: Buffer): string {
+  return uuidv5(key, UUIDV5_NAMESPACE);
+}

--- a/libs/wss-sdk/src/index.tsx
+++ b/libs/wss-sdk/src/index.tsx
@@ -1,0 +1,3 @@
+export * from "./WalletSyncClient";
+export * from "./helpers";
+export * from "./types/api/index";

--- a/libs/wss-sdk/src/types/api/index.ts
+++ b/libs/wss-sdk/src/types/api/index.ts
@@ -1,0 +1,2 @@
+export * from "./schemas";
+export * from "./types";

--- a/libs/wss-sdk/src/types/api/schemas.ts
+++ b/libs/wss-sdk/src/types/api/schemas.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+
+// COMMON
+export const schemaDataType = z.enum([
+  "configuration",
+  "accounts",
+  "addresses",
+  "transaction-tags",
+]);
+
+// ATOMIC GET
+export const schemaAtomicGetNoData = z.object({
+  status: z.literal("no-data"),
+});
+export const schemaAtomicGetUpToDate = z.object({
+  status: z.literal("up-to-date"),
+});
+export const schemaAtomicGetOutOfSync = z.object({
+  status: z.literal("out-of-sync"),
+  version: z.number(),
+  payload: z.string(),
+  date: z.string(),
+  info: z.string().optional(),
+});
+export const schemaAtomicGetResponse = z.discriminatedUnion("status", [
+  schemaAtomicGetNoData,
+  schemaAtomicGetUpToDate,
+  schemaAtomicGetOutOfSync,
+]);
+
+// ATOMIC POST
+export const schemaAtomicPostRequest = z.object({
+  payload: z.string(),
+});
+export const schemaAtomicPostUpdated = z.object({
+  status: z.literal("updated"),
+  version: z.number(),
+});
+export const schemaAtomicPostOutOfSync = z.object({
+  status: z.literal("out-of-sync"),
+  version: z.number(),
+  payload: z.string(),
+  date: z.string(),
+  info: z.string().optional(),
+});
+export const schemaAtomicPostResponse = z.discriminatedUnion("status", [
+  schemaAtomicPostUpdated,
+  schemaAtomicPostOutOfSync,
+]);
+
+// INCREMENTAL COMMON
+export const schemaIncrementalUpdate = z.object({
+  version: z.number(),
+  payload: z.string(),
+  date: z.string(),
+  info: z.string().optional(),
+});
+
+// INCREMENTAL GET
+export const schemaIncrementalGetNoData = z.object({
+  status: z.literal("no-data"),
+});
+export const schemaIncrementalGetUpToDate = z.object({
+  status: z.literal("up-to-date"),
+});
+export const schemaIncrementalGetOutOfSync = z.object({
+  status: z.literal("out-of-sync"),
+  updates: z.array(schemaIncrementalUpdate),
+});
+export const schemaIncrementalGetResponse = z.discriminatedUnion("status", [
+  schemaIncrementalGetNoData,
+  schemaIncrementalGetUpToDate,
+  schemaIncrementalGetOutOfSync,
+]);
+
+// INCREMENTAL POST
+export const schemaIncrementalPostRequest = z.object({
+  payload: z.string(),
+});
+export const schemaIncrementalPostUpdated = z.object({
+  status: z.literal("updated"),
+  version: z.number(),
+});
+export const schemaIncrementalPostOutOfSync = z.object({
+  status: z.literal("out-of-sync"),
+  updates: z.array(schemaIncrementalUpdate),
+});
+export const schemaIncrementalPostResponse = z.discriminatedUnion("status", [
+  schemaIncrementalPostUpdated,
+  schemaIncrementalPostOutOfSync,
+]);

--- a/libs/wss-sdk/src/types/api/types.ts
+++ b/libs/wss-sdk/src/types/api/types.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import {
+  schemaAtomicGetNoData,
+  schemaAtomicGetOutOfSync,
+  schemaAtomicGetResponse,
+  schemaAtomicGetUpToDate,
+  schemaAtomicPostOutOfSync,
+  schemaAtomicPostRequest,
+  schemaAtomicPostResponse,
+  schemaAtomicPostUpdated,
+  schemaIncrementalGetNoData,
+  schemaIncrementalGetOutOfSync,
+  schemaIncrementalGetResponse,
+  schemaIncrementalGetUpToDate,
+  schemaIncrementalUpdate,
+  schemaIncrementalPostRequest,
+  schemaIncrementalPostUpdated,
+  schemaIncrementalPostOutOfSync,
+  schemaIncrementalPostResponse,
+  schemaDataType,
+} from "./schemas";
+
+// COMMON
+export type DataType = z.infer<typeof schemaDataType>;
+
+// ATOMIC GET
+export type AtomicGetNoData = z.infer<typeof schemaAtomicGetNoData>;
+export type AtomicGetUpToDate = z.infer<typeof schemaAtomicGetUpToDate>;
+export type AtomicGetOutOfSync = z.infer<typeof schemaAtomicGetOutOfSync>;
+export type AtomicGetResponse = z.infer<typeof schemaAtomicGetResponse>;
+
+// ATOMIC POST
+export type AtomicPostRequest = z.infer<typeof schemaAtomicPostRequest>;
+export type AtomicPostUpdated = z.infer<typeof schemaAtomicPostUpdated>;
+export type AtomicPostOutOfSync = z.infer<typeof schemaAtomicPostOutOfSync>;
+export type AtomicPostResponse = z.infer<typeof schemaAtomicPostResponse>;
+
+// INCREMENTAL COMMON
+export type IncrementalUpdate = z.infer<typeof schemaIncrementalUpdate>;
+
+// INCREMENTAL GET
+export type IncrementalGetNoData = z.infer<typeof schemaIncrementalGetNoData>;
+export type IncrementalGetUpToDate = z.infer<typeof schemaIncrementalGetUpToDate>;
+export type IncrementalGetOutOfSync = z.infer<typeof schemaIncrementalGetOutOfSync>;
+export type IncrementalGetResponse = z.infer<typeof schemaIncrementalGetResponse>;
+
+// INCREMENTAL POST
+export type IncrementalPostRequest = z.infer<typeof schemaIncrementalPostRequest>;
+export type IncrementalPostUpdated = z.infer<typeof schemaIncrementalPostUpdated>;
+export type IncrementalPostOutOfSync = z.infer<typeof schemaIncrementalPostOutOfSync>;
+export type IncrementalPostResponse = z.infer<typeof schemaIncrementalPostResponse>;

--- a/libs/wss-sdk/src/types/schemas.ts
+++ b/libs/wss-sdk/src/types/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const schemaEncryptedClientData = z.object({
+  id: z.string(),
+  ownerId: z.string(),
+  dataTypeId: z.number(),
+  encryptedData: z.string(),
+  date: z.string(),
+});
+
+export type EncryptedClientData = z.infer<typeof schemaEncryptedClientData>;
+
+/*
+model EncryptedClientData {
+  id           Int      @id @default(autoincrement())
+  ownerId      String // indexed
+  type         DataType @relation(fields: [objectTypeId], references: [id])
+  data         Bytes
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  objectTypeId String
+}
+
+model DataType {
+  id                  String                @id @default(cuid()) // indexed
+  type                String // indexed
+  jsonSchema          String // JSONB
+  EncryptedClientData EncryptedClientData[]
+}
+
+*/

--- a/libs/wss-sdk/tsconfig.json
+++ b/libs/wss-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "module": "commonjs",
+    "downlevelIteration": true,
+    "lib": ["es2020", "dom"],
+    "outDir": "lib"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1985,6 +1985,9 @@ importers:
       '@ledgerhq/wallet-api-server':
         specifier: ^1.1.1
         version: 1.1.1(react@17.0.2)
+      '@ledgerhq/wss-sdk':
+        specifier: workspace:^
+        version: link:../wss-sdk
       '@solana/spl-token':
         specifier: ^0.3.7
         version: 0.3.8(@solana/web3.js@1.77.3)
@@ -2255,6 +2258,9 @@ importers:
       xstate:
         specifier: ^4.30.2
         version: 4.32.0
+      zod:
+        specifier: ^3.22.1
+        version: 3.22.1
     devDependencies:
       '@ledgerhq/types-cryptoassets':
         specifier: workspace:^
@@ -4882,6 +4888,43 @@ importers:
         specifier: ^0.2.9
         version: 0.2.9
 
+  libs/wss-sdk:
+    dependencies:
+      '@ledgerhq/logs':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/logs
+      axios:
+        specifier: ^1.4.0
+        version: 1.4.0
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.1
+      superjson:
+        specifier: ^1.12.3
+        version: 1.12.3
+      uuid:
+        specifier: ^9.0.0
+        version: 9.0.0
+      zod:
+        specifier: ^3.21.4
+        version: 3.22.1
+    devDependencies:
+      '@types/node':
+        specifier: ^17.0.12
+        version: 17.0.45
+      '@types/uuid':
+        specifier: ^9.0.1
+        version: 9.0.1
+      eslint:
+        specifier: ^8.41.0
+        version: 8.41.0
+      rimraf:
+        specifier: ^5.0.0
+        version: 5.0.0
+      typescript:
+        specifier: ^5.0.4
+        version: 5.1.3
+
   tools/actions:
     devDependencies:
       '@types/node':
@@ -5211,6 +5254,9 @@ importers:
       webpack:
         specifier: '4.46'
         version: 4.46.0
+      winston:
+        specifier: ^3.5.1
+        version: 3.9.0
     devDependencies:
       '@babel/plugin-proposal-class-properties':
         specifier: ^7.13.0
@@ -6211,10 +6257,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.22.5
 
-  /@babel/compat-data@7.22.5:
-    resolution: {integrity: sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==}
-    engines: {node: '>=6.9.0'}
-
   /@babel/compat-data@7.22.9:
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
@@ -6266,28 +6308,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /@babel/core@7.21.0:
-    resolution: {integrity: sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.5
-      '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.0)
-      '@babel/helper-module-transforms': 7.22.5
-      '@babel/helpers': 7.22.5
-      '@babel/parser': 7.22.5
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.5
-      '@babel/types': 7.22.5
-      convert-source-map: 1.8.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/core@7.22.8:
     resolution: {integrity: sha512-75+KxFB4CZqYRXjx4NlR4J7yGvKumBuZTmV4NV6v09dVXXkuYVYLT68N6HCzLvfJ+fWCxQsntNzKwwIXL4bHnw==}
@@ -6404,6 +6424,7 @@ packages:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.22.9:
     resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
@@ -6432,19 +6453,6 @@ packages:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
       '@babel/types': 7.22.5
-
-  /@babel/helper-compilation-targets@7.22.5(@babel/core@7.21.0):
-    resolution: {integrity: sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.22.5
-      '@babel/core': 7.21.0
-      '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.5
-      lru-cache: 5.1.1
-      semver: 6.3.0
 
   /@babel/helper-compilation-targets@7.22.9:
     resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
@@ -6818,21 +6826,6 @@ packages:
     dependencies:
       '@babel/types': 7.22.5
 
-  /@babel/helper-module-transforms@7.22.5:
-    resolution: {integrity: sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-
   /@babel/helper-module-transforms@7.22.9:
     resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
     engines: {node: '>=6.9.0'}
@@ -7044,12 +7037,6 @@ packages:
     dependencies:
       '@babel/types': 7.22.5
 
-  /@babel/helper-split-export-declaration@7.22.5:
-    resolution: {integrity: sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
-
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
@@ -7079,16 +7066,6 @@ packages:
       '@babel/helper-function-name': 7.22.5
       '@babel/template': 7.22.5
       '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
-    transitivePeerDependencies:
-      - supports-color
-
-  /@babel/helpers@7.22.5:
-    resolution: {integrity: sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.5
       '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
@@ -7129,13 +7106,6 @@ packages:
 
   /@babel/parser@7.21.4:
     resolution: {integrity: sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.22.5
-
-  /@babel/parser@7.22.5:
-    resolution: {integrity: sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
@@ -10641,6 +10611,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.22.8:
     resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
@@ -13094,10 +13065,6 @@ packages:
       eslint: 8.41.0
       eslint-visitor-keys: 3.4.1
 
-  /@eslint-community/regexpp@4.5.0:
-    resolution: {integrity: sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
   /@eslint-community/regexpp@4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -15181,6 +15148,18 @@ packages:
       multiformats: 12.0.1
     dev: false
 
+  /@isaacs/cliui@8.0.2:
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: /string-width@4.2.3
+      strip-ansi: 7.0.1
+      strip-ansi-cjs: /strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: /wrap-ansi@7.0.0
+    dev: true
+
   /@istanbuljs/load-nyc-config@1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -16685,7 +16664,7 @@ packages:
       '@ledgerhq/errors': 6.12.7
       bignumber.js: 9.1.1
       uuid: 9.0.0
-      zod: 3.21.4
+      zod: 3.22.1
     dev: false
 
   /@ledgerhq/wallet-api-server@1.1.1(react@17.0.2):
@@ -17521,6 +17500,13 @@ packages:
     resolution: {integrity: sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==}
     engines: {node: '>=8.0.0'}
     dev: true
+
+  /@pkgjs/parseargs@0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@pkgr/utils@2.3.1:
     resolution: {integrity: sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==}
@@ -24184,7 +24170,7 @@ packages:
   /@types/babel__core@7.1.19:
     resolution: {integrity: sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==}
     dependencies:
-      '@babel/parser': 7.22.5
+      '@babel/parser': 7.22.7
       '@babel/types': 7.22.5
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
@@ -24699,6 +24685,10 @@ packages:
 
   /@types/node@16.18.16:
     resolution: {integrity: sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA==}
+    dev: true
+
+  /@types/node@17.0.45:
+    resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
     dev: true
 
   /@types/node@18.15.11:
@@ -25303,6 +25293,10 @@ packages:
 
   /@types/uuid@8.3.4:
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+    dev: true
+
+  /@types/uuid@9.0.1:
+    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
     dev: true
 
   /@types/verror@1.10.6:
@@ -26925,7 +26919,6 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: false
 
   /ansi-sequence-parser@1.1.0:
     resolution: {integrity: sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==}
@@ -26950,6 +26943,11 @@ packages:
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  /ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+    dev: true
 
   /ansi-to-html@0.6.15:
     resolution: {integrity: sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==}
@@ -27553,6 +27551,14 @@ packages:
       follow-redirects: 1.15.0
       form-data: 4.0.0
       proxy-from-env: 1.1.0
+
+  /axios@1.4.0:
+    resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
+    dependencies:
+      follow-redirects: 1.15.0
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    dev: false
 
   /axobject-query@2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
@@ -28727,6 +28733,7 @@ packages:
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
+    requiresBuild: true
 
   /binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
@@ -29249,16 +29256,6 @@ packages:
       node-releases: 2.0.13
       update-browserslist-db: 1.0.10(browserslist@4.21.3)
 
-  /browserslist@4.21.5:
-    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001515
-      electron-to-chromium: 1.4.459
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.10(browserslist@4.21.5)
-
   /browserslist@4.21.9:
     resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -29456,7 +29453,7 @@ packages:
     dev: false
 
   /builtin-status-codes@3.0.0:
-    resolution: {integrity: sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=}
+    resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
   /builtins@1.0.3:
     resolution: {integrity: sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==}
@@ -30675,7 +30672,7 @@ packages:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   /constants-browserify@1.0.0:
-    resolution: {integrity: sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=}
+    resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
 
   /contains-path@0.1.0:
     resolution: {integrity: sha512-OKZnPGeMQy2RPaUIBPFFd71iNf4791H12MCRuVQDnzGRwCYNYmTDy5pdafo2SLAcEMKzTOQnLWG4QdcjeJUMEg==}
@@ -30924,6 +30921,13 @@ packages:
       depd: 2.0.0
       keygrip: 1.1.0
     dev: true
+
+  /copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.15
+    dev: false
 
   /copy-concurrently@1.0.5:
     resolution: {integrity: sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==}
@@ -33250,6 +33254,10 @@ packages:
       readable-stream: 2.3.8
       stream-shift: 1.0.1
 
+  /eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+    dev: true
+
   /easy-stack@1.0.1:
     resolution: {integrity: sha512-wK2sCs4feiiJeFXn3zvY0p41mdU5VUgbgs1rNsc/y5ngFUijdWd+iIN8eoyuZHKB8xN6BL4PdWmzqFmxNg6V2w==}
     engines: {node: '>=6.0.0'}
@@ -34754,7 +34762,7 @@ packages:
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
-      '@eslint-community/regexpp': 4.5.0
+      '@eslint-community/regexpp': 4.6.2
       '@eslint/eslintrc': 2.0.3
       '@eslint/js': 8.41.0
       '@humanwhocodes/config-array': 0.11.10
@@ -36603,6 +36611,7 @@ packages:
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       to-regex-range: 5.0.1
 
@@ -36894,6 +36903,14 @@ packages:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 3.0.7
+    dev: true
+
+  /foreground-child@3.1.1:
+    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.1.0
     dev: true
 
   /forever-agent@0.6.1:
@@ -37236,7 +37253,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       at-least-node: 1.0.0
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
 
@@ -37620,6 +37637,18 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  /glob@10.3.3:
+    resolution: {integrity: sha512-92vPiMb/iqpmEgsOoIDvTjc50wf9CCCvMzsi6W0JLPeUKE8TWP1a73PgqSrqy7iAZxaSD1YdzU7QZR5LF51MJw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.3.0
+      minimatch: 9.0.3
+      minipass: 5.0.0
+      path-scurry: 1.10.1
+    dev: true
 
   /glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
@@ -38770,7 +38799,7 @@ packages:
       resolve-alpn: 1.2.1
 
   /https-browserify@1.0.0:
-    resolution: {integrity: sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=}
+    resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -39266,6 +39295,7 @@ packages:
   /is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       binary-extensions: 2.2.0
 
@@ -39395,6 +39425,7 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
 
   /is-finite@1.1.0:
     resolution: {integrity: sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==}
@@ -39524,6 +39555,7 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    requiresBuild: true
 
   /is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
@@ -39764,6 +39796,11 @@ packages:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
     dev: false
 
+  /is-what@4.1.15:
+    resolution: {integrity: sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==}
+    engines: {node: '>=12.13'}
+    dev: false
+
   /is-whitespace-character@1.0.4:
     resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
 
@@ -39970,6 +40007,15 @@ packages:
     dependencies:
       es-get-iterator: 1.1.2
       iterate-iterator: 1.0.2
+
+  /jackspeak@2.3.0:
+    resolution: {integrity: sha512-uKmsITSsF4rUWQHzqaRUuyAir3fZfW3f202Ee34lz/gZCi970CPZwyQXLGNgWJvvZbvFyzeyGq0+4fcG/mBKZg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: true
 
   /jake@10.8.5:
     resolution: {integrity: sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==}
@@ -42619,7 +42665,7 @@ packages:
       '@types/node': 18.16.19
       chalk: 4.1.2
       ci-info: 3.3.2
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
       picomatch: 2.3.1
 
   /jest-util@29.5.0:
@@ -44968,6 +45014,11 @@ packages:
       highlight.js: 10.7.3
     dev: true
 
+  /lru-cache@10.0.1:
+    resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
+    engines: {node: 14 || >=16.14}
+    dev: true
+
   /lru-cache@4.1.5:
     resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
     dependencies:
@@ -46352,7 +46403,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.21.0
+      '@babel/core': 7.22.9
       '@babel/plugin-proposal-async-generator-functions': 7.20.7
       '@babel/plugin-proposal-class-properties': 7.18.6
       '@babel/plugin-proposal-export-default-from': 7.16.7
@@ -46554,7 +46605,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
     dependencies:
-      '@babel/core': 7.21.0
+      '@babel/core': 7.22.9
       babel-preset-fbjs: 3.4.0
       hermes-parser: 0.8.0
       metro-babel-transformer: 0.73.9
@@ -47650,6 +47701,13 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
+
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
 
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
@@ -49070,7 +49128,7 @@ packages:
       url-parse: 1.5.10
 
   /os-browserify@0.3.0:
-    resolution: {integrity: sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=}
+    resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
 
   /os-homedir@1.0.2:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
@@ -49450,6 +49508,7 @@ packages:
 
   /path-dirname@1.0.2:
     resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
+    requiresBuild: true
 
   /path-exists@2.1.0:
     resolution: {integrity: sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==}
@@ -49499,6 +49558,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       path-root-regex: 0.1.2
+    dev: true
+
+  /path-scurry@1.10.1:
+    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 10.0.1
+      minipass: 5.0.0
     dev: true
 
   /path-scurry@1.7.0:
@@ -51903,7 +51970,7 @@ packages:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   /prr@0.0.0:
-    resolution: {integrity: sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=}
+    resolution: {integrity: sha512-LmUECmrW7RVj6mDWKjTXfKug7TFGdiz9P18HMcO4RHL+RW7MCOGNvpj5j47Rnp6ne6r4fZ2VzyUWEpKbg+tsjQ==}
     dev: false
 
   /prr@1.0.1:
@@ -52082,11 +52149,11 @@ packages:
       strict-uri-encode: 2.0.0
 
   /querystring-es3@0.2.1:
-    resolution: {integrity: sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=}
+    resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
 
   /querystring@0.2.0:
-    resolution: {integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=}
+    resolution: {integrity: sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
 
@@ -54251,6 +54318,7 @@ packages:
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+    requiresBuild: true
     dependencies:
       picomatch: 2.3.1
 
@@ -55110,6 +55178,14 @@ packages:
     hasBin: true
     dependencies:
       glob: 9.3.5
+
+  /rimraf@5.0.0:
+    resolution: {integrity: sha512-Jf9llaP+RvaEVS5nPShYFhtXIrb3LRKP281ib3So0KkeZKo2wIKyq0Re7TOSwanasA423PSr6CCIL4bP6T040g==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      glob: 10.3.3
+    dev: true
 
   /ripemd160-min@0.0.6:
     resolution: {integrity: sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A==}
@@ -56000,6 +56076,11 @@ packages:
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  /signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+    dev: true
+
   /simple-cbor@0.4.1:
     resolution: {integrity: sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==}
     dev: false
@@ -56879,6 +56960,15 @@ packages:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  /string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.0.1
+    dev: true
+
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
@@ -57008,7 +57098,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: false
 
   /strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -57501,6 +57590,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /superjson@1.12.3:
+    resolution: {integrity: sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      copy-anything: 3.0.5
+    dev: false
 
   /superstruct@0.14.2:
     resolution: {integrity: sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==}
@@ -58378,7 +58474,7 @@ packages:
     dev: true
 
   /to-arraybuffer@1.0.1:
-    resolution: {integrity: sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=}
+    resolution: {integrity: sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==}
 
   /to-camel-case@1.0.0:
     resolution: {integrity: sha512-nD8pQi5H34kyu1QDMFjzEIYqk0xa9Alt6ZfrdEMuHCFOfTLhDG5pgTu/aAM9Wt9lXILwlXmWP43b8sav0GNE8Q==}
@@ -58415,6 +58511,7 @@ packages:
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+    requiresBuild: true
     dependencies:
       is-number: 7.0.0
 
@@ -59147,7 +59244,7 @@ packages:
       typescript: 5.1.3
 
   /tty-browserify@0.0.0:
-    resolution: {integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=}
+    resolution: {integrity: sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==}
 
   /tty-table@4.1.6:
     resolution: {integrity: sha512-kRj5CBzOrakV4VRRY5kUWbNYvo/FpOsz65DzI5op9P+cHov3+IqPbo1JE1ZnQGkHdZgNFDsrEjrfqqy/Ply9fw==}
@@ -59867,16 +59964,6 @@ packages:
       escalade: 3.1.1
       picocolors: 1.0.0
 
-  /update-browserslist-db@1.0.10(browserslist@4.21.5):
-    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.5
-      escalade: 3.1.1
-      picocolors: 1.0.0
-
   /update-browserslist-db@1.0.11(browserslist@4.21.9):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
@@ -60006,7 +60093,7 @@ packages:
     dev: false
 
   /url@0.11.0:
-    resolution: {integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=}
+    resolution: {integrity: sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==}
     dependencies:
       punycode: 1.3.2
       querystring: 0.2.0
@@ -62529,6 +62616,23 @@ packages:
       winston-transport: 4.5.0
     dev: false
 
+  /winston@3.9.0:
+    resolution: {integrity: sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==}
+    engines: {node: '>= 12.0.0'}
+    dependencies:
+      '@colors/colors': 1.5.0
+      '@dabh/diagnostics': 2.0.3
+      async: 3.2.3
+      is-stream: 2.0.1
+      logform: 2.4.0
+      one-time: 1.0.0
+      readable-stream: 3.6.2
+      safe-stable-stringify: 2.3.1
+      stack-trace: 0.0.10
+      triple-beam: 1.3.0
+      winston-transport: 4.5.0
+    dev: false
+
   /wonka@4.0.15:
     resolution: {integrity: sha512-U0IUQHKXXn6PFo9nqsHphVCE5m3IntqZNB9Jjn7EB1lrR7YTDY3YWgFvEvwniTzXSvOH/XMzAZaIfJF/LvHYXg==}
 
@@ -62861,6 +62965,15 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  /wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.0.1
+    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -63337,6 +63450,10 @@ packages:
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+
+  /zod@3.22.1:
+    resolution: {integrity: sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==}
+    dev: false
 
   /zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}

--- a/tools/common-tools/package.json
+++ b/tools/common-tools/package.json
@@ -41,7 +41,8 @@
     "semver": "^7.3.7",
     "styled-components": "^4.4.0",
     "tslib": "^2.5.0",
-    "webpack": "4.46"
+    "webpack": "4.46",
+    "winston": "^3.5.1"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/tools/common-tools/src/demos/sync/index.js
+++ b/tools/common-tools/src/demos/sync/index.js
@@ -1,17 +1,21 @@
 import "./live-common-setup";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useHistory } from "react-router-dom";
 import { BigNumber } from "bignumber.js";
 import {
   encodeAccountId,
   decodeAccountId,
   shortAddressPreview,
   emptyHistoryCache,
+  toAccountRaw,
 } from "@ledgerhq/live-common/lib/account";
 import {
   findCryptoCurrencyById,
   getCryptoCurrencyById,
+  formatCurrencyUnit,
 } from "@ledgerhq/live-common/lib/currencies/index";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
+import { BridgeSync } from "@ledgerhq/live-common/lib/bridge/react/index";
 import { reduce } from "rxjs/operators";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/lib/bridge/cache";
 import {
@@ -19,6 +23,67 @@ import {
   runDerivationScheme,
   asDerivationMode,
 } from "@ledgerhq/coin-framework/derivation";
+
+function App() {
+  const location = useLocation();
+  const history = useHistory();
+
+  const [accounts, setAccounts] = useState([]);
+  const [selectedAccount, setSelectedAccount] = useState(null);
+
+  const queryParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const initialWalletSyncAuth = queryParams.get("wallet-sync-auth") || undefined;
+  const [walletSyncAuth, setWalletSyncAuth] = useState(initialWalletSyncAuth);
+
+  useEffect(() => {
+    if (!walletSyncAuth) return;
+    // Update the query parameter whenever the state changes
+    queryParams.set("wallet-sync-auth", walletSyncAuth);
+    history.replace({ search: queryParams.toString() });
+  }, [walletSyncAuth, history, queryParams]);
+
+  const onAddAccount = useCallback(account => {
+    setAccounts(accounts => accounts.concat(account));
+    setSelectedAccount(account);
+  }, []);
+  const onRemoveAccount = useCallback(
+    accountId => setAccounts(accounts => accounts.filter(a => a.id !== accountId)),
+    [],
+  );
+  const onEditAccount = useCallback(
+    (accountId, patch) =>
+      setAccounts(accounts => accounts.map(a => (a.id === accountId ? { ...a, ...patch } : a))),
+    [],
+  );
+
+  const onSelectAccount = useCallback(account => {
+    setSelectedAccount(account);
+  }, []);
+
+  const onUnselect = useCallback(() => {
+    setSelectedAccount(null);
+  }, []);
+
+  return (
+    <BridgeSyncProvider
+      accounts={accounts}
+      setAccounts={setAccounts}
+      walletSyncAuth={walletSyncAuth}
+    >
+      <div style={{ margin: "20px auto", maxWidth: 600 }}>
+        <WalletSyncAuthForm walletSyncAuth={walletSyncAuth} setWalletSyncAuth={setWalletSyncAuth} />
+        <AccountsList
+          accounts={accounts}
+          onRemoveAccount={onRemoveAccount}
+          onEditAccount={onEditAccount}
+          onSelectAccount={onSelectAccount}
+        />
+        <AddAccountForm onAddAccount={onAddAccount} />
+        <AccountDetails account={selectedAccount} onUnselect={onUnselect} />
+      </div>
+    </BridgeSyncProvider>
+  );
+}
 
 const localCache = {};
 const bridgeCache = makeBridgeCacheSystem({
@@ -47,12 +112,7 @@ function inferAccount(id) {
   });
   const account = {
     type: "Account",
-    name:
-      currency.name +
-      " " +
-      (derivationMode || "legacy") +
-      " " +
-      shortAddressPreview(xpubOrAddress),
+    name: `${currency.name} ${derivationMode || "legacy"} ${shortAddressPreview(xpubOrAddress)}`,
     xpub: xpubOrAddress,
     seedIdentifier: xpubOrAddress,
     starred: true,
@@ -93,7 +153,151 @@ async function syncAccount(id) {
   return synced;
 }
 
-function App() {
+function BridgeSyncProvider({ children, accounts, setAccounts, walletSyncAuth }) {
+  const track = useCallback(() => {}, []);
+  const updateAccount = useCallback(
+    (accountId, updater) =>
+      setAccounts(accounts => accounts.map(a => (a.id === accountId ? updater(a) : a))),
+    [setAccounts],
+  );
+
+  const updateAllAccounts = setAccounts;
+
+  const recoverError = useCallback(error => error, []);
+
+  const versionRef = useRef(0);
+  const getVersion = useCallback(() => versionRef.current, []);
+
+  const latestWalletSyncRef = useRef([]);
+  const getLatestWalletSyncPayload = useCallback(() => latestWalletSyncRef.current, []);
+
+  const onVersionUpdate = useCallback(version => {
+    versionRef.current = version;
+  }, []);
+
+  const walletSyncVersionManager = useMemo(
+    () => ({ onVersionUpdate, getVersion }),
+    [onVersionUpdate, getVersion],
+  );
+
+  const setLatestWalletSyncPayload = useCallback(descriptors => {
+    latestWalletSyncRef.current = descriptors;
+  }, []);
+
+  return (
+    <BridgeSync
+      accounts={accounts}
+      updateAccountWithUpdater={updateAccount}
+      updateAllAccounts={updateAllAccounts}
+      recoverError={recoverError}
+      trackAnalytics={track}
+      prepareCurrency={bridgeCache.prepareCurrency}
+      hydrateCurrency={bridgeCache.hydrateCurrency}
+      blacklistedTokenIds={undefined}
+      walletSyncAuth={walletSyncAuth}
+      walletSyncVersionManager={walletSyncVersionManager}
+      setLatestWalletSyncPayload={setLatestWalletSyncPayload}
+      getLatestWalletSyncPayload={getLatestWalletSyncPayload}
+    >
+      {children}
+    </BridgeSync>
+  );
+}
+
+function AccountDetails({ account, onUnselect }) {
+  if (!account) return null;
+  return (
+    <div>
+      <h2>
+        {"Account details "}
+        <button onClick={onUnselect}>{"X"}</button>
+      </h2>
+      <pre>
+        <code>{JSON.stringify(toAccountRaw(account), null, 2)}</code>
+      </pre>
+    </div>
+  );
+}
+
+function AccountsList({ accounts, onRemoveAccount, onEditAccount, onSelectAccount }) {
+  return (
+    <div>
+      <h2>Accounts</h2>
+      {accounts.length === 0 ? <p>nothing yet</p> : null}
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {accounts.map(account => (
+          <li
+            key={account.id}
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <button
+              style={{ border: "none", background: "none" }}
+              onClick={() => {
+                console.log(account);
+                onSelectAccount(account);
+              }}
+            >
+              {"🔎"}
+            </button>
+
+            <input
+              value={account.name}
+              onChange={e => {
+                onEditAccount(account.id, { name: e.target.value });
+              }}
+              style={{ width: 100 }}
+            />
+
+            <strong style={{ display: "inline-block", minWidth: 100 }}>
+              {formatCurrencyUnit(account.unit, account.balance, {
+                showCode: true,
+              })}
+            </strong>
+
+            <input
+              value={account.id}
+              style={{ background: "none", border: "none", color: "#666" }}
+              onClick={e => e.target.select()}
+            />
+
+            <button onClick={() => onRemoveAccount(account.id)}>{"❌"}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function WalletSyncAuthForm({ walletSyncAuth, setWalletSyncAuth }) {
+  return (
+    <div>
+      <h2>Set Wallet Sync Auth</h2>
+      <input
+        type="text"
+        placeholder="wallet sync auth"
+        name="walletSyncAuth"
+        value={walletSyncAuth}
+        onChange={e => setWalletSyncAuth(e.target.value)}
+      />
+      <button
+        onClick={() =>
+          setWalletSyncAuth(
+            [...Array(64)].map(() => Math.floor(Math.random() * 16).toString(16)).join(""),
+          )
+        }
+      >
+        RANDOMIZE
+      </button>
+    </div>
+  );
+}
+
+function AddAccountForm({ onAddAccount }) {
   // synchronise account with an id that is input in a input text field
   const [accountId, setAccountId] = useState("");
   const [accountIdError, setAccountIdError] = useState("");
@@ -113,37 +317,49 @@ function App() {
     }
   }, [accountId]);
 
-  useEffect(() => {
-    // if we have an accountId, we try to synchronise it
-    if (accountId) {
-      try {
-        decodeAccountId(accountId);
-        setAccountError("");
-        setAccount(undefined);
-        syncAccount(accountId).then(setAccount, setAccountError);
-      } catch (e) {
-        setAccount(null);
-        console.error(e);
+  let onSubmit = useCallback(
+    e => {
+      e.preventDefault();
+      // if we have an accountId, we try to synchronise it
+      if (accountId) {
+        try {
+          decodeAccountId(accountId);
+          setAccountError("");
+          setAccount(undefined);
+          syncAccount(accountId).then(setAccount, setAccountError);
+        } catch (e) {
+          setAccount(null);
+          console.error(e);
+        }
       }
+    },
+    [accountId],
+  );
+
+  useEffect(() => {
+    if (account) {
+      onAddAccount(account);
     }
-  }, [accountId]);
+  }, [account, onAddAccount]);
 
   return (
-    <div>
-      <h1>Synchronisation</h1>
-      <p>
-        <input
-          type="text"
-          placeholder="account id"
-          value={accountId}
-          onChange={(e) => setAccountId(e.target.value)}
-        />
-        <span style={{ color: "red" }}>{accountIdError}</span>
-      </p>
+    <form onSubmit={onSubmit}>
+      <h2>Add account by its identifier</h2>
+      <input
+        type="text"
+        name="accountId"
+        placeholder="account id"
+        value={accountId}
+        onChange={e => setAccountId(e.target.value)}
+      />
+      <span style={{ color: "red" }}>{accountIdError}</span>
+      <button type="submit" disabled={!accountId || account === undefined}>
+        ADD
+      </button>
       <pre>
         <code>
           {account
-            ? JSON.stringify(account, null, 2)
+            ? "synchronised!"
             : accountError
             ? String(accountError)
             : account === null
@@ -151,12 +367,12 @@ function App() {
             : "loading..."}
         </code>
       </pre>
-    </div>
+    </form>
   );
 }
 
 App.demo = {
-  title: "Synchronisation",
+  title: "Sync",
   url: "/sync",
 };
 
@@ -168,7 +384,7 @@ function inferAccountId(id) {
   } catch (e) {
     const splitted = id.split(":");
 
-    const findAndEat = (predicate) => {
+    const findAndEat = predicate => {
       const res = splitted.find(predicate);
 
       if (typeof res === "string") {
@@ -177,20 +393,20 @@ function inferAccountId(id) {
       }
     };
 
-    const currencyId = findAndEat((s) => findCryptoCurrencyById(s));
+    const currencyId = findAndEat(s => findCryptoCurrencyById(s));
     if (!currencyId) {
       throw new Error("invalid id='" + id + "': missing currency part");
     }
     const type = "js";
-    const version = findAndEat((s) => s.match(/^\d+$/)) || "1";
+    const version = findAndEat(s => s.match(/^\d+$/)) || "1";
     const derivationMode = asDerivationMode(
-      findAndEat((s) => {
+      findAndEat(s => {
         try {
           return asDerivationMode(s);
         } catch (e) {
           // this is therefore not a derivation mode
         }
-      }) ?? ""
+      }) ?? "",
     );
 
     if (splitted.length === 0) {
@@ -202,7 +418,7 @@ function inferAccountId(id) {
         "invalid id='" +
           id +
           "': couldn't understand which of these are the xpub or address part: " +
-          splitted.join(" | ")
+          splitted.join(" | "),
       );
     }
 

--- a/tools/common-tools/src/demos/sync/live-common-setup.js
+++ b/tools/common-tools/src/demos/sync/live-common-setup.js
@@ -1,4 +1,8 @@
 // @flow
+import winston from "winston";
+import { listen } from "@ledgerhq/logs";
+import simple from "@ledgerhq/live-common/lib/logs/simple";
+
 import { setSupportedCurrencies } from "@ledgerhq/live-common/lib/currencies/index";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/lib/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/lib/wallet-api/constants";
@@ -60,3 +64,31 @@ setSupportedCurrencies([
   "near",
   "coreum",
 ]);
+
+const logger = winston.createLogger({
+  level: "debug",
+  transports: [
+    new winston.transports.Console({
+      format: simple(),
+      silent: false,
+      level: "debug",
+    }),
+  ],
+});
+
+listen(log => {
+  const { type } = log;
+  let level = "info";
+
+  if (type === "apdu" || type === "hw" || type === "speculos" || type.includes("debug")) {
+    level = "debug";
+  } else if (type.includes("warn")) {
+    level = "warn";
+  } else if (type.startsWith("network") || type.startsWith("socket")) {
+    level = "http";
+  } else if (type.includes("error")) {
+    level = "error";
+  }
+
+  logger.log(level, log);
+});


### PR DESCRIPTION
### 📝 Description

This is not mergeable as-is.

**IMPORTANT: this is PoC that won't be merged. This PR documents the current state of the work. the technical limitations and remaining tasks are directly documented in the code by TODOs and FIXMEs, and we can go through them to determine the next steps.**

## Testability

In order to easily test Wallet Sync and observe its various behaviours, you need 2 wallets running at same time. which is not something Ledger Live allows to do easily. So one focus of this PR is to make sure we can test everywhere.

- **on the web**: go to https://live-common-tools-git-feat-live-8691-ledgerhq.vercel.app/sync and click on RANDOMIZE. it will give you a first auth token to play with.
- on Ledger Live Desktop
  - you will need at least once to set the Wallet Sync auth token. There is no UI for it so we do it on the console. It will fall inside the `app.json`. To do this, on the chrome devtools console: 
```js
ledger.setWalletSyncAuth("INSERT_HERE_THE_TOKEN")
```
- on Ledger Live Mobile
  - once you have set up LLD, you can use the "Export to Mobile" QR Code feature of Ledger Live Desktop. this PR added the auth as part of what gets exported to mobile.

NB: on the web we are literally testing with the real implementation of blockchain and using the exact same BridgeSync stack (yes, literally Ledger Live stack on the web).

![Screenshot 2023-08-24 at 18 16 29](https://github.com/LedgerHQ/ledger-live/assets/211411/16640f63-a4f6-4141-9d88-38347d05829a)


## Technical Documentation

to sum it up how it works on this initial PoC:

`auth token` (one key unique to the user) <> `AccountDescriptor[]` (small js objects that describes the minimal identifiers of accounts) <> `Account[]` (the whole account data)

Two instances of Ledger Live can use the same auth token and therefore restore the additions/deletions/edit done on other instances.

To sync the data between the client and the server, we implement reconciliation and do some basic conflict management choices.

### wss-sdk libraries

The libraries wss-sdk and wss-shared were embedded to ease the development of this PoC, especially as I had to make evolutions in it and make it work in tools + LLM projects (which both don't support the `link:../..` dependency pattern).

I also had to merge wss-shared into wss-sdk due to the limitation of the web tools project to support "exports" package.json format: it couldn't resolve properly the import `from "@ledgerhq/wss-shared/types/api/index"`,...

The evolution will be regularly kept in https://github.com/LedgerHQ/wallet-sync-system/pull/15 but it is worth asking ourself if we really want to split into two monorepo just yet: there is a lot of moving parts and uncertainty if the SDK satisfies all our needs here, we will try to detail on this PR all the current limitations.


### `AccountDescriptor`, the minimal data model to export/import an account with

An evolution from the previous wss-sdk PoC was to evolve slightly the data model to make it matches what Ledger Live uses internally: the "AccountData" from `cross.ts`, that we now will rename to `AccountDescriptor`.

```typescript
type AccountDescriptor = {
  id: string;
  currencyId: string;
  freshAddress: string;
  seedIdentifier: string;
  derivationMode: string;
  name: string;
  index: number;
}
```

This data is sufficient and minimal to fully restore an account with both the user's edits (currently only the "name") and with the public blockchain.

### restore an account with the public Blockchain

to actually "fully restore an account with the public blockchain", we need to do a "Full Synchronisation" with the blockchain implementation. Without this step, we can have issues: (1) partial data that could break the UI or (2) mocked data that shouldn't be shown to the user because it's temporary and "fake" data (like we can prefill the balance to "0" but this is stressy to show as-is for a user). => so we need to do a full synchronisation, and this is **asynchronous & possibly slow** job to perform, it can takes times (seconds to minutes).

**This work is implemented in the file `BridgeSync.tsx`.**

### About AccountDescriptor<>Account Reconciliation

So in the world of Wallet Sync, on one side we have `AccountDescriptor`.
in the world of Ledger Live, we have `Account`.

We have to bridge the two worlds together, when one side updates, we need to propagate the impact on the other side, in the most minimal amount of steps possible.  So we have to implement this **reconciliation** on the two ways.

**This work is implemented in the file `useWalletSync.ts`.**

Note that in future, we may want to decouple this even more, possibly making the `useClient` a more general hook.

### ❓ Context

- **Impacted projects**: LLD & LLM <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-8691 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
