### PR TITLE
fix(RecoverRestore): add onRetry to error handling [PROTECT-2292]

### DIFF
--- a/.changeset/curly-tables-chew.md
+++ b/.changeset/curly-tables-chew.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(RecoverRestore): add onRetry to error handling

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
@@ -13,7 +13,7 @@ import { ScreenId } from "../Onboarding/Screens/Tutorial";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getVersion from "@ledgerhq/live-common/hw/getVersion";
 import { first } from "rxjs/operators";
-import { from } from "rxjs";
+import { Subscription, from } from "rxjs";
 import {
   OnboardingState,
   extractOnboardingState,
@@ -31,34 +31,48 @@ const RecoverRestore = () => {
   const [error, setError] = useState<Error>();
   const { setDeviceModelId } = useContext(OnboardingContext);
   const locale = useSelector(languageSelector) || "en";
+  const sub = useRef<Subscription>();
+
+  const getOnboardingState = useCallback((device: Device) => {
+    sub.current?.unsubscribe();
+
+    const requestObservable = withDevice(device.deviceId)(t => from(getVersion(t))).pipe(first());
+
+    sub.current = requestObservable.subscribe({
+      next: (firmware: FirmwareInfo) => {
+        try {
+          setState(extractOnboardingState(firmware.flags));
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            setError(error);
+          }
+        }
+      },
+      error: (error: Error) => {
+        setError(error);
+      },
+    });
+  }, []);
 
   // check if device is seeded when selected
   useEffect(() => {
     if (currentDevice) {
-      const requestObservable = withDevice(currentDevice.deviceId)(t => from(getVersion(t))).pipe(
-        first(),
-      );
-
-      const sub = requestObservable.subscribe({
-        next: (firmware: FirmwareInfo) => {
-          try {
-            setState(extractOnboardingState(firmware.flags));
-          } catch (error: unknown) {
-            if (error instanceof Error) {
-              setError(error);
-            }
-          }
-        },
-        error: (error: Error) => {
-          setError(error);
-        },
-      });
+      getOnboardingState(currentDevice);
 
       return () => {
-        sub.unsubscribe();
+        sub.current?.unsubscribe();
+        sub.current = undefined;
       };
     }
-  }, [currentDevice]);
+  }, [currentDevice, getOnboardingState]);
+
+  // cleanup subscription in case of retry and component unmount
+  useEffect(() => {
+    return () => {
+      sub.current?.unsubscribe();
+      sub.current = undefined;
+    };
+  }, []);
 
   useEffect(() => {
     if (state && !state.isOnboarded) {
@@ -76,11 +90,18 @@ const RecoverRestore = () => {
     }
   }, [currentDevice?.modelId, history, setDeviceModelId, state]);
 
+  const onRetry = useCallback(() => {
+    setState(undefined);
+    setError(undefined);
+    if (currentDevice) getOnboardingState(currentDevice);
+  }, [currentDevice, getOnboardingState]);
+
   if (error) {
     return renderError({
       t,
       error,
       device: currentDevice,
+      onRetry,
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add retry mecanism on error device locked when you try to use Ledger Recover.

Superseeds #4202 

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `PROTECT-2292` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** We might want to look at testing this error handling in playwright, tested manually for now <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
