### PR TITLE
fix(wallet-api): missing new on error constructor

### DIFF
--- a/.changeset/cyan-peas-sit.md
+++ b/.changeset/cyan-peas-sit.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(wallet-api): missing new on error constructor

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -414,7 +414,7 @@ export function useWalletAPIServer({
               },
               onCancel: () => {
                 tracking.signMessageFail(manifest);
-                reject(UserRefusedOnDevice());
+                reject(new UserRefusedOnDevice());
               },
               onError: error => {
                 tracking.signMessageFail(manifest);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix missing new on an error used for `message.sign` when the user cancels the flow
Reported from sentry: https://ledger.sentry.io/issues/4382287269/?project=6488659&query=release%3A2.66.0-next.0&referrer=release-issue-stream

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` & `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** We are adding tests in playwright to cover this <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
