### PR TITLE
fix(lld/deviceaction/error): broken layout

### DIFF
--- a/.changeset/twenty-apes-sort.md
+++ b/.changeset/twenty-apes-sort.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix errors layout regression

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -635,12 +635,12 @@ export const ErrorBody: React.FC<{
   list?: string | React.ReactNode;
 }> = ({ Icon, title, description, list }) => {
   return (
-    <Flex flex={1} flexDirection={"column"} justifyContent={"center"} alignItems={"center"}>
+    <>
       <BoxedIcon Icon={Icon} size={64} iconSize={24} />
       <ErrorTitle>{title}</ErrorTitle>
       <ErrorDescription>{description}</ErrorDescription>
       {list ? <ErrorDescription>{list}</ErrorDescription> : null}
-    </Flex>
+    </>
   );
 };
 

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/DeviceNotGenuineDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/DeviceNotGenuineDrawer.tsx
@@ -41,7 +41,13 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({ productName }) => {
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="space-between" height="100%">
       <TrackPage category={analyticsDrawerName} type="drawer" refreshSource={false} />
-      <Flex px={13} flex={1}>
+      <Flex
+        px={13}
+        flex={1}
+        flexDirection={"column"}
+        justifyContent={"center"}
+        alignItems={"center"}
+      >
         <ErrorBody
           Icon={ErrorIcon}
           title={t(

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/ErrorDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/ErrorDrawer.tsx
@@ -49,16 +49,18 @@ const ErrorDrawer: React.FC<Props> = ({ error, onClickRetry, closeable = false }
       <TrackPage category={drawerAnalyticsName} type="drawer" refreshSource={false} />
       <Flex px={13} flex={1}>
         {isNotFoundEntityError ? (
-          <ErrorBody
-            Icon={ErrorIcon}
-            title={t(
-              "syncOnboarding.manual.softwareCheckContent.genuineCheckErrorDrawer.notFoundEntityError.title",
-            )}
-            description={t(
-              "syncOnboarding.manual.softwareCheckContent.genuineCheckErrorDrawer.notFoundEntityError.description",
-              { providerNumber },
-            )}
-          />
+          <Flex flex={1} flexDirection={"column"} justifyContent={"center"} alignItems={"center"}>
+            <ErrorBody
+              Icon={ErrorIcon}
+              title={t(
+                "syncOnboarding.manual.softwareCheckContent.genuineCheckErrorDrawer.notFoundEntityError.title",
+              )}
+              description={t(
+                "syncOnboarding.manual.softwareCheckContent.genuineCheckErrorDrawer.notFoundEntityError.description",
+                { providerNumber },
+              )}
+            />
+          </Flex>
         ) : (
           <ErrorDisplay error={error} Icon={ErrorIcon} />
         )}

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/ExitChecksDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/ExitChecksDrawer.tsx
@@ -23,11 +23,15 @@ const ExitChecksDrawer: React.FC<Props> = ({ onClose, onClickExit }) => {
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="space-between" height="100%">
       <TrackPage category={analyticsDrawerName} type="drawer" refreshSource={false} />
-      <ErrorBody
-        Icon={ErrorIcon}
-        title={t("syncOnboarding.manual.softwareCheckContent.exitWarningDrawer.title")}
-        description={t("syncOnboarding.manual.softwareCheckContent.exitWarningDrawer.description")}
-      />
+      <Flex flex={1} flexDirection={"column"} justifyContent={"center"} alignItems={"center"}>
+        <ErrorBody
+          Icon={ErrorIcon}
+          title={t("syncOnboarding.manual.softwareCheckContent.exitWarningDrawer.title")}
+          description={t(
+            "syncOnboarding.manual.softwareCheckContent.exitWarningDrawer.description",
+          )}
+        />
+      </Flex>
       <DrawerFooter>
         <Link
           mr={8}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Some refactoring of the error rendering of device actions done in #3909 broke the layout (buttons are pushed to the bottom).

![screenshot_2023-08-17_at_10 53 07](https://github.com/LedgerHQ/ledger-live/assets/91890529/c901772c-ff66-483d-acea-2f5f91bab49a)


### ❓ Context

- **Impacted projects**: `lld` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8965] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="1136" alt="Screenshot 2023-08-17 at 11 21 32" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/a0dcb6fe-6da7-44f4-b532-19e91f6de8fc">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8965]: https://ledgerhq.atlassian.net/browse/LIVE-8965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ