### PR TITLE
fix: don't pop from live app when verifying address

### DIFF
--- a/.changeset/spotty-pumpkins-sparkle.md
+++ b/.changeset/spotty-pumpkins-sparkle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: do not pop from live app when verifying address

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
@@ -49,7 +49,19 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
   const onDone = useCallback(() => {
     const n = navigation.getParent<StackNavigatorNavigation<RootStackParamList>>();
 
-    if (n) {
+    // get the route at the given index on navigation
+    const { index, routes } = navigation.getState();
+    const { name: routeAtIndexName } = routes[index];
+
+    // if this route is a live app we do not want to pop
+    // as doing so would take the user out of the live app.
+    // an example of this is the BTCDirect app.
+    const isRouteAtIndexALiveApp = [ScreenName.Exchange, ScreenName.PlatformApp].includes(
+      routeAtIndexName as ScreenName,
+    );
+
+    // if we have n and the route is not a live app then pop as normal
+    if (!isRouteAtIndexALiveApp && n) {
       n.pop();
     }
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
@@ -51,16 +51,19 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
 
     // get the route at the given index on navigation
     const { index, routes } = navigation.getState();
-    const { name: routeAtIndexName } = routes[index];
+    const { name, params } = routes[index];
+
+    const screenName = params && "screen" in params ? (params.screen as ScreenName) : undefined;
 
     // if this route is a live app we do not want to pop
     // as doing so would take the user out of the live app.
     // an example of this is the BTCDirect app.
-    const isRouteAtIndexALiveApp = [ScreenName.Exchange, ScreenName.PlatformApp].includes(
-      routeAtIndexName as ScreenName,
+    const isRouteAtIndexALiveApp = [ScreenName.ExchangeBuy, ScreenName.PlatformApp].includes(
+      (screenName ?? name) as ScreenName,
     );
 
-    // if we have n and the route is not a live app then pop as normal
+    // if we have n ( parent route ) and the route is not a live app then
+    // pop the navigation as normal
     if (!isRouteAtIndexALiveApp && n) {
       n.pop();
     }


### PR DESCRIPTION
### 📝 Description

Verifying addresses within a live app would cause a redirection out of the live app for users. In cases where the user was already in a live app like "buy/sell" and was then directed to a provider like "BTCDirect" then the user would be redirected back to the buy/sell app and they were unable to continue with their purchase.

In cases where a user loaded from the discover section they would be redirected back to the discover homepage after they verified their address.

The fix:
- check if we are about to pop from a live app screen. If we are then do not pop, otherwise continue as normal.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8928 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
