### PR TITLE
[B2CQA-1920] Detox : Fix Android Flaky tests

### DIFF
--- a/.github/workflows/test-mobile-e2e.yml
+++ b/.github/workflows/test-mobile-e2e.yml
@@ -186,6 +186,7 @@ jobs:
         with:
           api-level: 31
           arch: x86_64
+          profile: pixel_5
           target: google_apis
           avd-name: "Pixel_5_API_31"
           force-avd-creation: true

--- a/apps/ledger-live-mobile/.env.mock
+++ b/apps/ledger-live-mobile/.env.mock
@@ -8,7 +8,7 @@ ADJUST_APP_TOKEN=cbxft2ch7wn4
 BRAZE_ANDROID_API_KEY="be5e1bc8-43f1-4864-b097-076a3c693a43"
 BRAZE_IOS_API_KEY="e0a7dfaf-fc30-48f6-b998-01dbebbb73a4"
 BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"
-FEATURE_FLAGS={"syncOnboarding":{"enabled":false},"llmNewDeviceSelection":{"enabled":false},"protectServicesMobile":{"enabled":false},"brazePushNotifications":{"enabled":false}}
+FEATURE_FLAGS={"syncOnboarding":{"enabled":false},"llmNewDeviceSelection":{"enabled":false},"protectServicesMobile":{"enabled":false},"brazePushNotifications":{"enabled":false},"ratingsPrompt":{"enabled":false}}
 # Fix random iOS app crash https://github.com/wix/Detox/pull/3135
 SIMCTL_CHILD_NSZombieEnabled=YES
 MOCK_REMOTE_LIVE_MANIFEST=[{"name":"Dummy Wallet API Live App","homepageUrl":"https://developers.ledger.com/","icon":"","platforms":["ios","android","desktop"],"apiVersion":"2.0.0","manifestVersion":"1","branch":"stable","categories":["tools"],"currencies":"*","content":{"shortDescription":{"en":"App to test the Wallet API"},"description":{"en":"App to test the Wallet API with Playwright"}},"permissions":["account.list","account.receive","account.request","currency.list","device.close","device.exchange","device.transport","message.sign","transaction.sign","transaction.signAndBroadcast","storage.set","storage.get","bitcoin.getXPub","wallet.capabilities","wallet.userId","wallet.info"],"domains":["http://*"],"visibility":"complete","id":"dummy-live-app","url":"http://localhost:52619"}]

--- a/apps/ledger-live-mobile/e2e/helpers.ts
+++ b/apps/ledger-live-mobile/e2e/helpers.ts
@@ -44,11 +44,16 @@ export async function typeTextById(id: string, text: string, focus = true) {
   return getElementById(id).typeText(text);
 }
 
-export async function typeTextByElement(elem: Detox.NativeElement, text: string, focus = true) {
+export async function typeTextByElement(
+  elem: Detox.NativeElement,
+  text: string,
+  closeKeyboard = true,
+  focus = true,
+) {
   if (focus) {
     await tapByElement(elem);
   }
-  await elem.typeText(text);
+  await elem.typeText(text + (closeKeyboard ? "\n" : "")); // ' \n' close keyboard if open
 }
 
 export async function clearTextByElement(elem: Detox.NativeElement) {

--- a/apps/ledger-live-mobile/e2e/models/accounts/addAccountDrawer.ts
+++ b/apps/ledger-live-mobile/e2e/models/accounts/addAccountDrawer.ts
@@ -22,6 +22,7 @@ export default class AddAccountDrawer {
   }
 
   async finishAccountsDiscovery() {
+    await waitForElementById("add-accounts-continue-button");
     await tapById("add-accounts-continue-button");
   }
 

--- a/apps/ledger-live-mobile/e2e/models/passwordEntryPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/passwordEntryPage.ts
@@ -5,7 +5,7 @@ export default class PasswordEntryPage {
   getLogin = () => getElementByText("Log in");
 
   async enterPassword(password: string) {
-    await typeTextByElement(this.getPasswordTextInput(), password);
+    await typeTextByElement(this.getPasswordTextInput(), password, false);
   }
 
   async login() {

--- a/apps/ledger-live-mobile/e2e/models/trade/receivePage.ts
+++ b/apps/ledger-live-mobile/e2e/models/trade/receivePage.ts
@@ -5,7 +5,6 @@ const baseLink = "receive";
 export default class ReceivePage {
   getStep1HeaderTitle = () => getElementById("receive-header-step1-title");
   getStep2HeaderTitle = () => getElementById("receive-header-step2-title");
-  getStep3HeaderTitle = () => getElementById("receive-header-step3-title");
   getStep2Accounts = () => getElementById("receive-header-step2-accounts");
   getStep2Networks = () => getElementById("receive-header-step2-networks");
 

--- a/apps/ledger-live-mobile/e2e/models/trade/swapFormPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/trade/swapFormPage.ts
@@ -16,6 +16,7 @@ export default class SwapFormPage {
   swapDestinationSelector = () => getElementById("swap-destination-selector");
   swapSourceInputTextbox = () => getElementById("swap-source-amount-textbox");
   exchangeButton = () => getElementById("exchange-button");
+  exchangeScrollView = () => getElementById("exchange-scrollView");
   chooseProviderButton = () => getElementById("choose-provider-button");
   sendMaxToggle = () => getElementById("exchange-send-max-toggle");
   termsAcceptButton = () => getElementById("terms-accept-button");
@@ -62,7 +63,8 @@ export default class SwapFormPage {
     return tapByElement(this.sendMaxToggle());
   }
 
-  startExchange() {
-    return tapByElement(this.exchangeButton());
+  async startExchange() {
+    await this.exchangeScrollView().scrollTo("bottom");
+    return await tapByElement(this.exchangeButton());
   }
 }

--- a/apps/ledger-live-mobile/e2e/specs/languageChange.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/languageChange.spec.ts
@@ -3,7 +3,6 @@ import PortfolioPage from "../models/wallet/portfolioPage";
 import SettingsPage from "../models/settings/settingsPage";
 import GeneralSettingsPage from "../models/settings/generalSettingsPage";
 import { loadConfig } from "../bridge/server";
-import { isAndroid } from "../helpers";
 
 let portfolioPage: PortfolioPage;
 let settingsPage: SettingsPage;
@@ -32,10 +31,6 @@ describe("Change Language", () => {
   ];
 
   beforeAll(async () => {
-    if (isAndroid()) {
-      console.warn("Skipping flaky android test");
-      return;
-    }
     loadConfig("1AccountBTC1AccountETHReadOnlyFalse", true);
 
     portfolioPage = new PortfolioPage();
@@ -46,15 +41,12 @@ describe("Change Language", () => {
   });
 
   it("should go to General Settings", async () => {
-    if (isAndroid()) return;
     await portfolioPage.navigateToSettings();
     await settingsPage.navigateToGeneralSettings();
   });
 
   // test steps for each language
-  if (!isAndroid()) {
-    for (const l10n of langButtonText) {
-      verifyLanguageCanBeChanged(l10n);
-    }
+  for (const l10n of langButtonText) {
+    verifyLanguageCanBeChanged(l10n);
   }
 });

--- a/apps/ledger-live-mobile/e2e/specs/market.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/market.spec.ts
@@ -22,7 +22,6 @@ describe("Market page for user with no device", () => {
   });
 
   it("should filter starred asset in the list", async () => {
-    if (isAndroid()) return;
     await marketPage.openAssetPage("Bitcoin (BTC)");
     await marketPage.starFavoriteCoin();
     await marketPage.backToAssetList();
@@ -31,7 +30,6 @@ describe("Market page for user with no device", () => {
   });
 
   it("should redirect to the buy a nano marketplace page", async () => {
-    if (isAndroid()) return;
     await marketPage.openAssetPage("Bitcoin (BTC)");
     await marketPage.buyNano();
     await marketPage.openMarketPlace();

--- a/apps/ledger-live-mobile/e2e/specs/nftGallery.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/nftGallery.spec.ts
@@ -3,7 +3,7 @@ import PortfolioPage from "../models/wallet/portfolioPage";
 import WalletTabNavigatorPage from "../models/wallet/walletTabNavigator";
 import NftViewerPage from "../models/nft/nftViewerPage";
 import NftGalleryPage from "../models/wallet/nftGalleryPage";
-import { isAndroid, tapByElement, tapByText } from "../helpers";
+import { tapByElement, tapByText } from "../helpers";
 import ReceivePage from "../models/trade/receivePage";
 import { loadConfig } from "../bridge/server";
 
@@ -69,13 +69,9 @@ describe("NFT Gallery screen", () => {
     await expect(receivePage.getStep1HeaderTitle()).toBeVisible();
     await expect(receivePage.getStep2HeaderTitle()).not.toExist();
     await tapByText("Ethereum");
-    // NOTE: Use .toExist because the modal overlay with an opacity
-    // means we cannot use .toBeVisible
-    if (!isAndroid()) {
-      await expect(receivePage.getStep2HeaderTitle()).toExist();
-      await tapByText("Ethereum");
-      await expect(receivePage.getStep2Accounts()).toBeVisible();
-    }
+    await expect(receivePage.getStep2HeaderTitle()).toBeVisible();
+    await tapByText("Ethereum");
+    await expect(receivePage.getStep2Accounts()).toBeVisible();
   });
 
   it("should let users hide NFT's", async () => {

--- a/apps/ledger-live-mobile/e2e/specs/swap/swap.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/swap/swap.spec.ts
@@ -26,18 +26,15 @@ describe("Swap", () => {
     await swapPage.selectAccount("Bitcoin 1 (legacy)");
   });
 
-  // FIXME: different behaviour on CI and locally. CI shows the keyboard which is failing it, whereas local the keyboard never appears. Will need to fix this
-  it.skip("should show an error for too low an amount", async () => {
+  it("should show an error for too low an amount", async () => {
     await swapPage.enterSourceAmount("0.00001");
-    await swapPage.navigateToSwapForm(); // needed to clear any keyboard that may be covering the screen (issue on CI)
     // unfortunately there's no way to check if a button that is disabled in the JS is actually disabled on the native side (which is what Detox checks)
     // we tap the `Exchange` button to see if the next step fails as a way of checking if the exchange button disabled. If it proceeds then the button was incorrectly available and the next test will fail
     await swapPage.startExchange();
   });
 
-  it.skip("should show an error for not enough funds", async () => {
+  it("should show an error for not enough funds", async () => {
     await swapPage.enterSourceAmount("10");
-    await swapPage.navigateToSwapForm();
     await swapPage.startExchange();
   });
 

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -363,7 +363,7 @@ export function SwapForm({
 
   if (providers?.length) {
     return (
-      <KeyboardAwareScrollView>
+      <KeyboardAwareScrollView testID="exchange-scrollView">
         <Flex flex={1} justifyContent="space-between" padding={6}>
           <Flex flex={1}>
             <TrackScreen category="Swap" providerName={provider} {...sharedSwapTracking} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Aiming to fix flaky detox tests skipped on Android by PR [4133](https://github.com/LedgerHQ/ledger-live/pull/4133)_
- languageChange.spec.ts -> Aspect ratio issue. Fixed by applying Pixel 5 profile.
- market.spec.ts -> Rating pop-up. Fixed by disabling '_ratingsPrompt_' feature flag
- nftGallery.spec.ts ->  Fixed by new deposit flow [PR](https://github.com/LedgerHQ/ledger-live/pull/3928/files#top)
- swap.spec.ts -> Keyboard on CI. Fixed by sending '_\n_' to close keyboard.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[B2CQA-1920]: https://ledgerhq.atlassian.net/browse/B2CQA-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ