### PR TITLE
🐛 [FIX] : Notifications get re-enabled when updating the app

### DIFF
--- a/.changeset/breezy-cherries-talk.md
+++ b/.changeset/breezy-cherries-talk.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Notifications get re-enabled when updating the app

--- a/apps/ledger-live-mobile/src/logic/notifications.tsx
+++ b/apps/ledger-live-mobile/src/logic/notifications.tsx
@@ -250,7 +250,7 @@ const useNotifications = () => {
     } else {
       const newNotificationsState = { ...notifications };
       for (const [key, value] of Object.entries(settingsInitialState.notifications)) {
-        if (!notifications[key as keyof NotificationsSettings]) {
+        if (notifications[key as keyof NotificationsSettings] === undefined) {
           newNotificationsState[key as keyof NotificationsSettings] = value;
         }
       }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Notifications get re-enabled when updating the app

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:  [LIVE-8797] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->

BUILDS : 
- https://github.com/LedgerHQ/ledger-live-build/actions/runs/5904096063 🍎 
- https://github.com/LedgerHQ/ledger-live-build/actions/runs/5904104923 🤖 

[LIVE-8797]: https://ledgerhq.atlassian.net/browse/LIVE-8797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ