### PR TITLE
[Bugfix/LIVE-8914]: Info message not triggered when user accesses a coin from the Market tab

### DIFF
--- a/.changeset/green-games-obey.md
+++ b/.changeset/green-games-obey.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/native-ui": minor
+"live-mobile": patch
+---
+
+Allow passing of onPressWhenDisabled prop to native ui button

--- a/apps/ledger-live-mobile/src/components/FabActions/FabButtonBar.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/FabButtonBar.tsx
@@ -15,22 +15,28 @@ function FabButtonBar({ data }: Props) {
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={{ paddingHorizontal: 16 }}
     >
-      {data.map(({ children, onPress, Icon, buttonProps, disabled, testId }, index) => (
-        <Button
-          size={"small"}
-          Icon={Icon}
-          iconPosition={"left"}
-          type={buttonProps?.type ?? "shade"}
-          outline={buttonProps?.outline ?? true}
-          disabled={disabled}
-          onPress={onPress}
-          key={index}
-          mr={3}
-          testID={testId}
-        >
-          {children}
-        </Button>
-      ))}
+      {data.map(
+        (
+          { children, onPress, Icon, buttonProps, disabled, testId, onPressWhenDisabled },
+          index,
+        ) => (
+          <Button
+            size={"small"}
+            Icon={Icon}
+            iconPosition={"left"}
+            type={buttonProps?.type ?? "shade"}
+            outline={buttonProps?.outline ?? true}
+            disabled={disabled}
+            onPress={onPress}
+            onPressWhenDisabled={onPressWhenDisabled}
+            key={index}
+            mr={3}
+            testID={testId}
+          >
+            {children}
+          </Button>
+        ),
+      )}
     </ScrollContainer>
   );
 }

--- a/apps/ledger-live-mobile/src/components/wrappedUi/Button.tsx
+++ b/apps/ledger-live-mobile/src/components/wrappedUi/Button.tsx
@@ -2,11 +2,13 @@ import React, { useCallback } from "react";
 import { ButtonProps } from "@ledgerhq/native-ui/components/cta/Button/index";
 import { Button as UiButton } from "@ledgerhq/native-ui";
 import { track } from "../../analytics";
+import { TouchableOpacityProps } from "react-native";
 
 export type WrappedButtonProps = ButtonProps & {
   event?: string;
   eventProperties?: unknown;
   buttonTestId?: string;
+  onPressWhenDisabled?: TouchableOpacityProps["onPress"];
 };
 
 function Button({
@@ -27,7 +29,7 @@ function Button({
     [event, eventProperties, onPress],
   );
 
-  return <UiButton onPress={onPressHandler} {...othersProps} buttonTestId={buttonTestId} />;
+  return <UiButton {...othersProps} onPress={onPressHandler} buttonTestId={buttonTestId} />;
 }
 
 export default Button;

--- a/libs/ui/packages/native/src/components/cta/Button/index.tsx
+++ b/libs/ui/packages/native/src/components/cta/Button/index.tsx
@@ -12,6 +12,7 @@ import { IconType } from "../../Icon/type";
 export type ButtonProps = TouchableOpacityProps &
   BaseStyledProps & {
     Icon?: IconType;
+    onPressWhenDisabled?: TouchableOpacityProps["onPress"];
     iconName?: string;
     type?: "main" | "shade" | "error" | "color" | "default";
     size?: "small" | "medium" | "large";
@@ -33,12 +34,21 @@ const IconContainer = styled.View<{
     p.iconButton ? "" : p.iconPosition === "left" ? `margin-right: 10px;` : `margin-left: 10px;`}
 `;
 
-export const Base = baseStyled(TouchableOpacity).attrs<ButtonProps>((p) => ({
-  ...getButtonColorStyle(p.theme.colors, p).button,
-  // Avoid conflict with styled-system's size property by nulling size and renaming it
-  size: undefined,
-  sizeVariant: p.size,
-}))<
+export const Base = baseStyled(TouchableOpacity).attrs<ButtonProps>((p) => {
+  // if onPressWhenDisabled prop exists then the button will look
+  // disabled but will still be press-able.
+  const disabled = !p.onPressWhenDisabled && p.disabled;
+  const visuallyDisabled = p.onPressWhenDisabled && p.disabled;
+  const onPress = visuallyDisabled ? p.onPressWhenDisabled : p.onPress;
+  return {
+    ...getButtonColorStyle(p.theme.colors, p).button,
+    // Avoid conflict with styled-system's size property by nulling size and renaming it
+    size: undefined,
+    sizeVariant: p.size,
+    disabled,
+    onPress,
+  };
+})<
   {
     iconButton?: boolean;
     sizeVariant?: ButtonProps["size"];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

* Add `onPressWhenDisabled` prop to native ui component.
* Market detail screen pop will now occur when user clicks on "disabled" looking button.

### ❓ Context

- **Impacted projects**: `LLM, UI` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8914](https://ledgerhq.atlassian.net/browse/LIVE-8914) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://github.com/LedgerHQ/ledger-live/assets/132384348/40004e82-80d2-4d49-91c4-9d5007a73dfb



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8914]: https://ledgerhq.atlassian.net/browse/LIVE-8914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ