### PR TITLE
Bugfix/back button hide market details

### DIFF
--- a/.changeset/fair-mangos-double.md
+++ b/.changeset/fair-mangos-double.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove stake banner from nft receive flow

--- a/.changeset/green-turkeys-learn.md
+++ b/.changeset/green-turkeys-learn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix back arrow on market detail when ptxEarn feature enabled

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MarketNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MarketNavigator.tsx
@@ -18,6 +18,7 @@ export default function MarketNavigator() {
         headerShown: true,
         title: "",
         headerRight: undefined,
+        headerLeft: () => null,
       }
     : {
         headerShown: false,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Removes back button in market details screen that was overlapping the Market header when ptxEarn enabled.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-7162` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
