### PR TITLE
[BUGFIX][LIVE-9016] synchronisation issues with bad address

### DIFF
--- a/libs/coin-evm/package.json
+++ b/libs/coin-evm/package.json
@@ -83,6 +83,7 @@
     "doc": "documentation readme src/** --section=API --pe ts --re ts --re d.ts",
     "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --cache",
     "lint:fix": "pnpm lint --fix",
+    "typecheck": "tsc --noEmit",
     "test": "jest"
   }
 }

--- a/libs/coin-evm/src/__tests__/unit/adapters/ledger.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/adapters/ledger.unit.test.ts
@@ -293,6 +293,73 @@ describe("EVM Family", () => {
           ]);
         });
 
+        it("should convert ledger explorer legacy coin none operation (smart contract creation) to a Ledger Live Operation", () => {
+          // This operation represents a smart contract creation
+          // cf. https://polygonscan.com/tx/0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1
+          // For some reason the explorer API returns a "to" address of "0x0"
+
+          const ledgerOperation: LedgerExplorerOperation = {
+            hash: "0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1",
+            transaction_type: 0,
+            nonce: "0x3",
+            nonce_value: 3,
+            value: "0",
+            gas: "21356033",
+            gas_price: "42392511388",
+            // this is a legacy operation (transaction_type === 0), so we don't have max_fee_per_gas and max_priority_fee_per_gas
+            max_fee_per_gas: null,
+            max_priority_fee_per_gas: null,
+            from: "0x787acf62ffc81bb171d1f46fb8b3fc6503d503e8",
+            to: "0x0",
+            transfer_events: [],
+            erc721_transfer_events: [
+              {
+                contract: "0xe22eab38e8325ae03aeb53390c00a66eb0218c25",
+                sender: "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45",
+                receiver: "0x84c9a36721eb21da9244fe50177180d8f4a7caf7",
+                token_id: "63",
+              },
+            ],
+            erc1155_transfer_events: [],
+            approval_events: [],
+            actions: [],
+            confirmations: 9822660,
+            input: null,
+            gas_used: "21356033",
+            cumulative_gas_used: "24822433",
+            status: 1,
+            received_at: "2022-12-13T21:41:37Z",
+            block: {
+              hash: "0xcf0072dc5eb6e39ae5377b5323914f750da0cf5d2538f7d3ce7d8739c0624199",
+              height: 36795782,
+              time: "2022-12-13T21:41:37Z",
+            },
+          };
+
+          const expectedOperation: Operation = {
+            id: "js:2:ethereum:0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d:-0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1-NONE",
+            hash: "0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1",
+            accountId,
+            blockHash: "0xcf0072dc5eb6e39ae5377b5323914f750da0cf5d2538f7d3ce7d8739c0624199",
+            blockHeight: 36795782,
+            recipients: [""],
+            senders: ["0x787aCF62fFC81Bb171d1f46fB8b3Fc6503D503e8"],
+            value: new BigNumber("0"),
+            fee: new BigNumber("905335872155003804"),
+            date: new Date("2022-12-13T21:41:37Z"),
+            transactionSequenceNumber: 3,
+            hasFailed: false,
+            nftOperations: [],
+            subOperations: [],
+            type: "NONE",
+            extra: {},
+          };
+
+          expect(ledgerOperationToOperations(accountId, ledgerOperation)).toEqual([
+            expectedOperation,
+          ]);
+        });
+
         it("should convert ledger explorer self send coin operation to 2 Ledger Live Operations", () => {
           const ledgerOperation: LedgerExplorerOperation = {
             hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",

--- a/libs/coin-evm/src/api/explorer/etherscan.ts
+++ b/libs/coin-evm/src/api/explorer/etherscan.ts
@@ -185,7 +185,7 @@ export const getLastERC721Operations = async (
 };
 
 /**
- * Get all the last ERC71155 transactions
+ * Get all the last ERC1155 transactions
  */
 export const getLastERC1155Operations = async (
   currency: CryptoCurrency,

--- a/libs/coin-evm/src/types/ledger.ts
+++ b/libs/coin-evm/src/types/ledger.ts
@@ -48,8 +48,8 @@ export type LedgerExplorerOperation = {
   value: string;
   gas: string;
   gas_price: string;
-  max_fee_per_gas: string;
-  max_priority_fee_per_gas: string;
+  max_fee_per_gas: string | null;
+  max_priority_fee_per_gas: string | null;
   from: string;
   to: string;
   transfer_events: LedgerExplorerERC20TransferEvent[];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When synchronising evm tx using the ledger explorer, the api sometime returns `0x0` as a `to` address value, for example in the case of smart contract creation.

This poses a problem because we are expecting an [eip55](https://eips.ethereum.org/EIPS/eip-55) encoded address in the adapter code.

For example with [this tx `0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1`](https://polygonscan.com/tx/0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1)

<details><summary>Returned operation from Ledger explorer API</summary>

https://explorers.api.live.ledger.com/blockchain/v4/matic/tx/0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1

```ts
{
    hash: '0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1',
    transaction_type: 0,
    nonce: '0x3',
    nonce_value: 3,
    value: '0',
    gas: '21356033',
    gas_price: '42392511388',
    max_fee_per_gas: null,
    max_priority_fee_per_gas: null,
    from: '0x787acf62ffc81bb171d1f46fb8b3fc6503d503e8',
    to: '0x0',
    transfer_events: [],
    erc721_transfer_events: [ [Object] ],
    erc1155_transfer_events: [],
    approval_events: [],
    actions: [],
    confirmations: 9820768,
    input: null,
    gas_used: '21356033',
    cumulative_gas_used: '24822433',
    status: 1,
    received_at: '2022-12-13T21:41:37Z',
    block: {
      hash: '0xcf0072dc5eb6e39ae5377b5323914f750da0cf5d2538f7d3ce7d8739c0624199',
      height: 36795782,
      time: '2022-12-13T21:41:37Z'
    }
  }
```

</details> 

It works fine when using an external API like the PolygonScan API because the same hash is associated with an event (in this case an ERC-721 event)

<details><summary>PolygonScan API return</summary>

```ts
{
    blockNumber: '36795782',
    timeStamp: '1670967697',
    hash: '0x11a358387669d58f3791461124212e40e6899fd286074636f745990f57f87eb1',
    nonce: '3',
    blockHash: '0xcf0072dc5eb6e39ae5377b5323914f750da0cf5d2538f7d3ce7d8739c0624199',
    from: '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45',
    contractAddress: '0xe22eab38e8325ae03aeb53390c00a66eb0218c25',
    to: '0x84c9a36721eb21da9244fe50177180d8f4a7caf7',
    tokenID: '63',
    tokenName: 'UnisNFT 1670967691784',
    tokenSymbol: 'UnisNFT 1670967691784',
    tokenDecimal: '0',
    transactionIndex: '25',
    gas: '21356033',
    gasPrice: '42392511388',
    gasUsed: '21356033',
    cumulativeGasUsed: '24822433',
    input: 'deprecated',
    confirmations: '9820637'
  }
```

</details> 

The proposed solution is to use a `safeEncodeEIP55` version (similar to what was done on the "ethereum" family, cf. [here](https://github.com/jnicoulaud-ledger/ledger-live/blob/develop/libs/ledger-live-common/src/families/ethereum/synchronisation.ts#L203-L211))

>  * Some addresses returned by Ledger explorers are not 40 characters hex addresses
>  * For example the explorers may return "0x0" as an address (for example for
>  * some events or contract interactions, like a contract creation transaction)
>  *
>  * This is not a valid EIP55 address and thus will fail when trying to encode it
>  * with a "Bad address" error.
>  * cf:
>  * https://github.com/cryptocoinjs/eip55/blob/v2.1.1/index.js#L5-L6
>  * https://github.com/cryptocoinjs/eip55/blob/v2.1.1/index.js#L63-L65
>  *
>  * Since we can't control what the explorer returns, and we don't want the app to crash
>  * in these cases, we simply ignore the address and return an empty string.
>  *
>  * For now this has only been observed on the from or to fields of an operation
>  * so we only use this function for these fields.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
