### PR TITLE
fix: close cta on NFT fullscreen

### DIFF
--- a/.changeset/silver-cherries-carry.md
+++ b/.changeset/silver-cherries-carry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix close cta when a NFT is displayed in fullscreen

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNftLinks.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNftLinks.ts
@@ -147,11 +147,15 @@ export default (
               isFromNFTEntryPoint: true,
               reopenPreviousDrawer: isInsideDrawer
                 ? () =>
-                    setDrawer(NFTViewerDrawer, {
-                      account,
-                      nftId: nft.id,
-                      isOpen: true,
-                    })
+                    setDrawer(
+                      NFTViewerDrawer,
+                      {
+                        account,
+                        nftId: nft.id,
+                        isOpen: true,
+                      },
+                      { forceDisableFocusTrap: true },
+                    )
                 : undefined,
             },
             { forceDisableFocusTrap: true },

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Gallery/TokensList/Item.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Gallery/TokensList/Item.tsx
@@ -67,11 +67,15 @@ const NftCard = ({ id, mode, account, withContextMenu = false, onHideCollection 
   const show = useMemo(() => status === "loading", [status]);
   const isGrid = mode === "grid";
   const onItemClick = useCallback(() => {
-    setDrawer(NFTViewerDrawer, {
-      account,
-      nftId: id,
-      isOpen: true,
-    });
+    setDrawer(
+      NFTViewerDrawer,
+      {
+        account,
+        nftId: id,
+        isOpen: true,
+      },
+      { forceDisableFocusTrap: true },
+    );
   }, [id, account]);
   const MaybeContext = ({ children }: { children: React.ReactNode }) =>
     withContextMenu && nft && metadata ? (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Today we can't close a NFT when opened in fullscreen because onClick event is trapped by the drawer.

### ❓ Context

- **Impacted projects**: `lld` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-7360

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->
https://github.com/LedgerHQ/ledger-live/assets/31533861/4ad191c8-ed27-448b-85fa-ee58be63aecb

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
