### PR TITLE
chore: prevent SYNC_SOME_ACCOUNTS log with empty accounts[]

### DIFF
--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
@@ -379,13 +379,14 @@ function useSyncContinouslyPendingOperations({ sync, accounts }) {
     let timeout;
 
     const update = () => {
+      timeout = setTimeout(update, getEnv("SYNC_PENDING_INTERVAL"));
+      if (!refIds.current.length) return;
       sync({
         type: "SYNC_SOME_ACCOUNTS",
         accountIds: refIds.current,
         priority: 20,
         reason: "pending-operations",
       });
-      timeout = setTimeout(update, getEnv("SYNC_PENDING_INTERVAL"));
     };
 
     timeout = setTimeout(update, getEnv("SYNC_PENDING_INTERVAL"));


### PR DESCRIPTION

### 📝 Description

every 20 seconds, Ledger Live log a useless "SYNC_SOME_ACCOUNTS" with the reason "pending-operations" even when you had no accounts with pending operations.

practically it doesn't change anything for the user, but it pollutes the logs. it doesn't change the performance that much but it's just dumb to spam the sync events with these.

### ❓ Context

- **Impacted projects**: `LLD/LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-9091` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** nothing really covers this because it's not an observable "bug" beside log spams <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
