### PR TITLE
[BUGFIX][LIVE-9118] add back fee too high warning on evm get transaction status

### DIFF
--- a/libs/coin-evm/package.json
+++ b/libs/coin-evm/package.json
@@ -72,6 +72,7 @@
     "@types/invariant": "^2.2.2",
     "@types/jest": "^29.2.4",
     "@types/lodash": "^4.14.191",
+    "fast-check": "^3.12.0",
     "jest": "^28.1.1",
     "ts-jest": "^28.0.5"
   },

--- a/libs/coin-evm/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -1,7 +1,9 @@
+import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
 import {
   AmountRequired,
   ETHAddressNonEIP,
   FeeNotLoaded,
+  FeeTooHigh,
   GasLessThanEstimate,
   InvalidAddress,
   MaxFeeTooLow,
@@ -13,12 +15,13 @@ import {
   PriorityFeeTooLow,
   RecipientRequired,
 } from "@ledgerhq/errors";
+import { ProtoNFT } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
-import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
-import { EvmTransactionEIP1559, EvmTransactionLegacy, GasOptions } from "../../types";
-import getTransactionStatus from "../../getTransactionStatus";
+import fc from "fast-check";
 import { NotEnoughNftOwned, NotOwnedNft, QuantityNeedsToBePositive } from "../../errors";
+import getTransactionStatus from "../../getTransactionStatus";
+import { EvmTransactionEIP1559, EvmTransactionLegacy, GasOptions, Transaction } from "../../types";
+import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
 
 const recipient = "0xe2ca7390e76c5A992749bB622087310d2e63ca29"; // rambo.eth
 const testData = Buffer.from("testBufferString").toString("hex");
@@ -54,6 +57,23 @@ const eip1559Tx: EvmTransactionEIP1559 = {
   maxFeePerGas: new BigNumber(100),
   maxPriorityFeePerGas: new BigNumber(100),
   type: 2,
+};
+const erc721Nft: ProtoNFT = {
+  contract: "0xNftContract",
+  tokenId: "1",
+  amount: new BigNumber(1),
+  currencyId: account.currency.id,
+  id: "doesn't matter",
+  standard: "ERC721" as const,
+};
+
+const erc1155Nft: ProtoNFT = {
+  contract: "0xAnotherNftContract",
+  tokenId: "2",
+  amount: new BigNumber(2),
+  currencyId: account.currency.id,
+  id: "still doesn't matter",
+  standard: "ERC1155" as const,
 };
 
 const gasOptions: GasOptions = {
@@ -117,7 +137,7 @@ describe("EVM Family", () => {
         );
       });
 
-      it("should detect the recipient not being an EIP55 address and have an warning", async () => {
+      it("should detect the recipient not being an EIP55 address and have a warning", async () => {
         const tx = { ...eip1559Tx, recipient: recipient.toLowerCase() };
         const res = await getTransactionStatus(account, tx);
         expect(res.warnings).toEqual(
@@ -427,23 +447,14 @@ describe("EVM Family", () => {
 
     describe("Nft", () => {
       describe("ERC721", () => {
-        const nft = {
-          contract: "0xNftContract",
-          tokenId: "1",
-          amount: new BigNumber(1),
-          currencyId: account.currency.id,
-          id: "doesn't matter",
-          standard: "ERC721" as const,
-        };
-
         it("should detect a transaction for an ERC721 nft not owned by the account and have an error", async () => {
           const tx = {
             ...eip1559Tx,
             mode: "erc721" as const,
             nft: {
               collectionName: "",
-              contract: nft.contract,
-              tokenId: nft.tokenId,
+              contract: erc721Nft.contract,
+              tokenId: erc721Nft.tokenId,
               quantity: new BigNumber(1),
             },
           };
@@ -462,12 +473,12 @@ describe("EVM Family", () => {
             mode: "erc721" as const,
             nft: {
               collectionName: "",
-              contract: nft.contract,
-              tokenId: nft.tokenId,
+              contract: erc721Nft.contract,
+              tokenId: erc721Nft.tokenId,
               quantity: new BigNumber(1),
             },
           };
-          const res = await getTransactionStatus({ ...account, nfts: [nft] }, tx);
+          const res = await getTransactionStatus({ ...account, nfts: [erc721Nft] }, tx);
 
           expect(res.errors).toEqual(
             expect.objectContaining({
@@ -479,23 +490,14 @@ describe("EVM Family", () => {
       });
 
       describe("ERC1155", () => {
-        const nft = {
-          contract: "0xAnotherNftContract",
-          tokenId: "2",
-          amount: new BigNumber(2),
-          currencyId: account.currency.id,
-          id: "still doesn't matter",
-          standard: "ERC1155" as const,
-        };
-
         it("should detect a transaction for an ERC1155 nft not owned by the account and have an error", async () => {
           const tx = {
             ...eip1559Tx,
             mode: "erc1155" as const,
             nft: {
               collectionName: "",
-              contract: nft.contract,
-              tokenId: nft.tokenId,
+              contract: erc1155Nft.contract,
+              tokenId: erc1155Nft.tokenId,
               quantity: new BigNumber(1),
             },
           };
@@ -514,15 +516,15 @@ describe("EVM Family", () => {
             mode: "erc1155" as const,
             nft: {
               collectionName: "",
-              contract: nft.contract,
-              tokenId: nft.tokenId,
+              contract: erc1155Nft.contract,
+              tokenId: erc1155Nft.tokenId,
               quantity: new BigNumber(0),
             },
           };
           const res = await getTransactionStatus(
             {
               ...account,
-              nfts: [nft],
+              nfts: [erc1155Nft],
             },
             tx,
           );
@@ -540,15 +542,15 @@ describe("EVM Family", () => {
             mode: "erc1155" as const,
             nft: {
               collectionName: "",
-              contract: nft.contract,
-              tokenId: nft.tokenId,
+              contract: erc1155Nft.contract,
+              tokenId: erc1155Nft.tokenId,
               quantity: new BigNumber(3),
             },
           };
           const res = await getTransactionStatus(
             {
               ...account,
-              nfts: [nft],
+              nfts: [erc1155Nft],
             },
             tx,
           );
@@ -566,15 +568,15 @@ describe("EVM Family", () => {
             mode: "erc1155" as const,
             nft: {
               collectionName: "",
-              contract: nft.contract,
-              tokenId: nft.tokenId,
+              contract: erc1155Nft.contract,
+              tokenId: erc1155Nft.tokenId,
               quantity: new BigNumber(1),
             },
           };
           const res = await getTransactionStatus(
             {
               ...account,
-              nfts: [nft],
+              nfts: [erc1155Nft],
             },
             tx,
           );
@@ -585,6 +587,288 @@ describe("EVM Family", () => {
               gasPrice: new NotEnoughGas(),
             }),
           );
+        });
+      });
+    });
+
+    describe("Fee Ratio", () => {
+      /**
+       * Helper function to narrow down the type of transaction and set the
+       * specific field depending on the type of transaction
+       */
+      const specifyTx = ({
+        tx,
+        specificField,
+      }: {
+        tx: Transaction;
+        specificField: number;
+      }): Transaction => {
+        if (tx.type === 2) {
+          return {
+            ...tx,
+            maxFeePerGas: new BigNumber(specificField),
+          } as EvmTransactionEIP1559;
+        } else {
+          return {
+            ...tx,
+            gasPrice: new BigNumber(specificField),
+          } as EvmTransactionLegacy;
+        }
+      };
+
+      describe.each([
+        { type: "Legacy", defaultTx: legacyTx },
+        { type: "EIP1559", defaultTx: eip1559Tx },
+      ])("Transaction Type: $type", ({ defaultTx }: { defaultTx: Transaction }) => {
+        describe("when fees are too high compared to the amount (fees are more than 10% of the amount)", () => {
+          it("should have a warning", async () => {
+            await fc.assert(
+              fc.asyncProperty(
+                fc
+                  .record({
+                    amount: fc.integer({ min: 1 }),
+                    gasLimit: fc.integer({ min: 1 }),
+                    specificField: fc.integer({ min: 1 }),
+                  })
+                  .filter(({ amount, gasLimit, specificField }) =>
+                    BigNumber(gasLimit)
+                      .multipliedBy(BigNumber(specificField))
+                      .times(10)
+                      .gt(BigNumber(amount)),
+                  ),
+                async ({ amount, gasLimit, specificField }) => {
+                  const tx: Transaction = specifyTx({
+                    tx: {
+                      ...defaultTx,
+                      amount: new BigNumber(amount),
+                      gasLimit: new BigNumber(gasLimit),
+                      data: undefined,
+                    },
+                    specificField,
+                  });
+
+                  const res = await getTransactionStatus(account, tx);
+
+                  expect(res.warnings).toEqual(
+                    expect.objectContaining({
+                      feeTooHigh: new FeeTooHigh(),
+                    }),
+                  );
+                },
+              ),
+            );
+          });
+
+          /**
+           * Note: This is to test the lower bound of the x*y*r=a equation
+           * with x = gasPrice, y = gasLimit, a = amount, r = ratio
+           * This test would pass for r = 10 but would fail for r = 9
+           */
+          it("should have a warning for lower bound", async () => {
+            const amount = 990;
+            const gasLimit = 11;
+            const specificField = 10;
+
+            const tx: Transaction = specifyTx({
+              tx: {
+                ...defaultTx,
+                amount: new BigNumber(amount),
+                gasLimit: new BigNumber(gasLimit),
+                data: undefined,
+              },
+              specificField,
+            });
+
+            const res = await getTransactionStatus(account, tx);
+
+            expect(res.warnings).toEqual(
+              expect.objectContaining({
+                feeTooHigh: new FeeTooHigh(),
+              }),
+            );
+          });
+        });
+
+        describe("when fees are not too high compared to the amount (fees are less than or equal to 10% of the amount)", () => {
+          it("should not have a warning", async () => {
+            await fc.assert(
+              fc.asyncProperty(
+                fc
+                  .record({
+                    amount: fc.integer({ min: 1 }),
+                    gasLimit: fc.integer({ min: 1 }),
+                    specificField: fc.integer({ min: 1 }),
+                  })
+                  .filter(({ amount, specificField, gasLimit }) =>
+                    BigNumber(specificField)
+                      .multipliedBy(BigNumber(gasLimit))
+                      .times(10)
+                      .lt(BigNumber(amount)),
+                  ),
+                async ({ amount, specificField, gasLimit }) => {
+                  const tx: Transaction = specifyTx({
+                    tx: {
+                      ...defaultTx,
+                      amount: new BigNumber(amount),
+                      gasLimit: new BigNumber(gasLimit),
+                      data: undefined,
+                    },
+                    specificField,
+                  });
+
+                  const res = await getTransactionStatus(account, tx);
+
+                  expect(res.warnings).toEqual(
+                    expect.not.objectContaining({
+                      feeTooHigh: new FeeTooHigh(),
+                    }),
+                  );
+                },
+              ),
+            );
+          });
+
+          /**
+           * Note: This is to test the upper bound of the x*y*r=a equation
+           * with x = gasPrice, y = gasLimit, a = amount, r = ratio
+           * This test would pass for r = 10 but would fail for r = 11
+           */
+          it("should not have a warning for upper bound", async () => {
+            const amount = 100;
+            const gasLimit = 1;
+            const specificField = 10;
+
+            const tx: Transaction = specifyTx({
+              tx: {
+                ...defaultTx,
+                amount: new BigNumber(amount),
+                gasLimit: new BigNumber(gasLimit),
+                data: undefined,
+              },
+              specificField,
+            });
+
+            const res = await getTransactionStatus(account, tx);
+
+            expect(res.warnings).toEqual(
+              expect.not.objectContaining({
+                feeTooHigh: new FeeTooHigh(),
+              }),
+            );
+          });
+        });
+
+        describe("when tx has data", () => {
+          it("should not have a warning", async () => {
+            const amount = 1;
+            const gasLimit = 1;
+            const specificField = 1;
+
+            const tx: Transaction = specifyTx({
+              tx: {
+                ...defaultTx,
+                amount: new BigNumber(amount),
+                gasLimit: new BigNumber(gasLimit),
+              },
+              specificField,
+            });
+
+            const res = await getTransactionStatus(account, tx);
+
+            expect(res.warnings).toEqual(
+              expect.not.objectContaining({
+                feeTooHigh: new FeeTooHigh(),
+              }),
+            );
+          });
+        });
+
+        describe("when tx is nft tx", () => {
+          it("should not have a warning for ERC721 NFT", async () => {
+            const amount = 1;
+            const gasLimit = 1;
+            const specificField = 1;
+
+            const tx: Transaction = specifyTx({
+              tx: {
+                ...defaultTx,
+                amount: new BigNumber(amount),
+                gasLimit: new BigNumber(gasLimit),
+                mode: "erc721" as const,
+                nft: {
+                  collectionName: "",
+                  contract: erc721Nft.contract,
+                  tokenId: erc721Nft.tokenId,
+                  quantity: new BigNumber(1),
+                },
+              },
+              specificField,
+            });
+
+            const res = await getTransactionStatus(account, tx);
+
+            expect(res.warnings).toEqual(
+              expect.not.objectContaining({
+                feeTooHigh: new FeeTooHigh(),
+              }),
+            );
+          });
+
+          it("should not have a warning for ERC1155 NFT", async () => {
+            const amount = 1;
+            const gasLimit = 1;
+            const specificField = 1;
+
+            const tx: Transaction = specifyTx({
+              tx: {
+                ...defaultTx,
+                amount: new BigNumber(amount),
+                gasLimit: new BigNumber(gasLimit),
+                mode: "erc1155" as const,
+                nft: {
+                  collectionName: "",
+                  contract: erc1155Nft.contract,
+                  tokenId: erc1155Nft.tokenId,
+                  quantity: new BigNumber(1),
+                },
+              },
+              specificField,
+            });
+
+            const res = await getTransactionStatus(account, tx);
+
+            expect(res.warnings).toEqual(
+              expect.not.objectContaining({
+                feeTooHigh: new FeeTooHigh(),
+              }),
+            );
+          });
+        });
+
+        describe("when tx is token tx", () => {
+          it("should not have a warning", async () => {
+            const amount = 1;
+            const gasLimit = 1;
+            const specificField = 1;
+
+            const tx: Transaction = specifyTx({
+              tx: {
+                ...defaultTx,
+                amount: new BigNumber(amount),
+                gasLimit: new BigNumber(gasLimit),
+                subAccountId: tokenAccount.id,
+              },
+              specificField,
+            });
+
+            const res = await getTransactionStatus(account, tx);
+
+            expect(res.warnings).toEqual(
+              expect.not.objectContaining({
+                feeTooHigh: new FeeTooHigh(),
+              }),
+            );
+          });
         });
       });
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1515,6 +1515,9 @@ importers:
       '@types/lodash':
         specifier: ^4.14.191
         version: 4.14.191
+      fast-check:
+        specifier: ^3.12.0
+        version: 3.12.0
       jest:
         specifier: ^28.1.1
         version: 28.1.3
@@ -36243,6 +36246,13 @@ packages:
     resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
     dev: false
 
+  /fast-check@3.12.0:
+    resolution: {integrity: sha512-SqahE9mlL3+lhjJ39joMLwcj6F+24hfZdf/tchlNO8sHcTdrUUdA5P/ZbSFZM9Xpzs36XaneGwE0FWepm/zyOA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      pure-rand: 6.0.2
+    dev: true
+
   /fast-deep-equal@2.0.1:
     resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
     dev: true
@@ -41918,7 +41928,7 @@ packages:
       jest-resolve:
         optional: true
     dependencies:
-      jest-resolve: 28.1.3(metro@0.76.0)
+      jest-resolve: 28.1.3
     dev: true
 
   /jest-pnp-resolver@1.2.2(jest-resolve@29.6.2):


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add (back) the `FeeTooHigh` warning present on the ethereum family on the evm family.

https://github.com/LedgerHQ/ledger-live/blob/42a90710a7c68ea97b2f6867cda603116c76282f/libs/ledger-live-common/src/families/ethereum/modules/send.ts#L384-L386

- Updated tests for `getTransactionStatus` by adding [property based testing](https://fast-check.dev/docs/introduction/why-property-based/) using [fast-check](https://fast-check.dev/)
- Refacto tests for `getTransactionStatus` by using [`describe.each`](https://jestjs.io/docs/api#describeeachtablename-fn-timeout) where suitable to reduce code duplication and improve consistency and readability

### ❓ Context

- **Impacted projects**: `coin-evm`
- **Linked resource(s)**:
    - https://ledgerhq.atlassian.net/browse/LIVE-9118
    - https://github.com/LedgerHQ/ledger-live/pull/4285

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

| Before | After |
|--------|--------|
| ![before](https://github.com/LedgerHQ/ledger-live/assets/9203826/9c213741-811d-4fe7-8f04-98a64578b12a) | ![after](https://github.com/LedgerHQ/ledger-live/assets/9203826/ac3ad63a-6f73-481b-babc-ae2ad8d352b2) | 





### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
