### PR TITLE
Support/Live 8495 cosmos chains bot fix

### DIFF
--- a/.changeset/fifty-bats-leave.md
+++ b/.changeset/fifty-bats-leave.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-framework": patch
+---
+
+fix cosmos family bot

--- a/libs/coin-framework/src/account/helpers.ts
+++ b/libs/coin-framework/src/account/helpers.ts
@@ -106,6 +106,17 @@ export const getAccountSpendableBalance = (account: AccountLike): BigNumber => {
 };
 
 export const isAccountEmpty = (a: AccountLike): boolean => {
+  // FIXME LIVE-5966 why do we need this? also this shouldn't be implemented here / this part must be removed back to the coin specifics
+  if (a.type === "Account" && a.currency.family === "tron") {
+    return (a as any).tronResources && (a as any).tronResources.bandwidth.freeLimit.eq(0);
+  }
+  if (a.type === "Account" && a.currency.family === "cosmos") {
+    return (
+      (a as any).cosmosResources &&
+      (a as any).cosmosResources.sequence === 0 &&
+      (a as any).balance.isZero()
+    );
+  }
   const hasSubAccounts = a.type === "Account" && a.subAccounts && a.subAccounts.length;
   return a.operationsCount === 0 && a.balance.isZero() && !hasSubAccounts;
 };

--- a/libs/coin-framework/src/bot/types.ts
+++ b/libs/coin-framework/src/bot/types.ts
@@ -144,6 +144,8 @@ export type AppSpec<T extends TransactionCommon> = {
   skipMutationsTimeout?: number;
   // do not expect an account to always be found (Hedera case)
   allowEmptyAccounts?: boolean;
+  // do not keep operations in accounts (Cosmos family case)
+  skipOperationHistory?: boolean;
 };
 export type SpecReport<T extends TransactionCommon> = {
   spec: AppSpec<T>;

--- a/libs/ledger-live-common/src/account/helpers.ts
+++ b/libs/ledger-live-common/src/account/helpers.ts
@@ -63,12 +63,6 @@ export {
 };
 
 export const isAccountEmpty = (a: AccountLike): boolean => {
-  // FIXME LIVE-5966 why do we need this? also this shouldn't be implemented here / this part must be removed back to the coin specifics
-  if (a.type === "Account" && a.currency.family === "tron") {
-    const tronAcc = a as TronAccount;
-    return tronAcc.tronResources && tronAcc.tronResources.bandwidth.freeLimit.eq(0);
-  }
-
   return commonIsAccountEmpty(a);
 };
 

--- a/libs/ledger-live-common/src/bot/engine.ts
+++ b/libs/ledger-live-common/src/bot/engine.ts
@@ -603,6 +603,9 @@ export async function runOnAccount<T extends Transaction>({
     const testBefore = now();
     const timeOut = mutation.testTimeout || spec.testTimeout || 5 * 60 * 1000;
     const step = account => {
+      if (spec.skipOperationHistory) {
+        return optimisticOperation;
+      }
       const timedOut = now() - testBefore > timeOut;
       const operation = account.operations.find(o => o.id === optimisticOperation.id);
 
@@ -663,6 +666,9 @@ export async function runOnAccount<T extends Transaction>({
       log("bot", "remaining time to test destination: " + (newTimeOut / 1000).toFixed(0) + "s");
       const sendingOperation = operation;
       const step = account => {
+        if (spec.skipOperationHistory) {
+          return sendingOperation;
+        }
         const timedOut = now() - ntestBefore > newTimeOut;
         let operation;
         try {

--- a/libs/ledger-live-common/src/families/cosmos/api/Cosmos.ts
+++ b/libs/ledger-live-common/src/families/cosmos/api/Cosmos.ts
@@ -33,20 +33,31 @@ export class CosmosAPI {
     redelegations: CosmosRedelegation[];
     unbondings: CosmosUnbonding[];
     withdrawAddress: string;
+    accountInfo: { sequence: number; accountNumber: number };
   }> => {
     try {
-      const [balances, blockHeight, txs, delegations, redelegations, unbondings, withdrawAddress] =
-        await Promise.all([
-          this.getAllBalances(address, currency),
-          this.getHeight(),
-          this.getTransactions(address, 100),
-          this.getDelegations(address, currency),
-          this.getRedelegations(address),
-          this.getUnbondings(address),
-          this.getWithdrawAddress(address),
-        ]);
+      const [
+        accountInfo,
+        balances,
+        blockHeight,
+        txs,
+        delegations,
+        redelegations,
+        unbondings,
+        withdrawAddress,
+      ] = await Promise.all([
+        this.getAccount(address),
+        this.getAllBalances(address, currency),
+        this.getHeight(),
+        this.getTransactions(address, 100),
+        this.getDelegations(address, currency),
+        this.getRedelegations(address),
+        this.getUnbondings(address),
+        this.getWithdrawAddress(address),
+      ]);
 
       return {
+        accountInfo,
         balances,
         blockHeight,
         txs,

--- a/libs/ledger-live-common/src/families/cosmos/banner.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/banner.test.ts
@@ -88,6 +88,7 @@ const account: CosmosAccount = {
     pendingRewardsBalance: new BigNumber("0"),
     unbondingBalance: new BigNumber("0"),
     withdrawAddress: "",
+    sequence: 0,
   },
 };
 

--- a/libs/ledger-live-common/src/families/cosmos/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-synchronisation.ts
@@ -178,8 +178,16 @@ export const getAccountShape: GetAccountShape = async info => {
     derivationMode,
   });
 
-  const { balances, blockHeight, txs, delegations, redelegations, unbondings, withdrawAddress } =
-    await new CosmosAPI(currency.id).getAccountInfo(address, currency);
+  const {
+    accountInfo,
+    balances,
+    blockHeight,
+    txs,
+    delegations,
+    redelegations,
+    unbondings,
+    withdrawAddress,
+  } = await new CosmosAPI(currency.id).getAccountInfo(address, currency);
   const oldOperations = initialAccount?.operations || [];
   const newOperations = txToOps(info, accountId, txs);
   const operations = mergeOps(oldOperations, newOperations);
@@ -221,6 +229,7 @@ export const getAccountShape: GetAccountShape = async info => {
       pendingRewardsBalance,
       unbondingBalance,
       withdrawAddress,
+      sequence: accountInfo.sequence,
     },
   };
 

--- a/libs/ledger-live-common/src/families/cosmos/mock.ts
+++ b/libs/ledger-live-common/src/families/cosmos/mock.ts
@@ -34,6 +34,7 @@ function setCosmosResources(
     withdrawAddress: account.id,
     unbondings: unbondings ?? account.cosmosResources?.unbondings ?? [],
     redelegations: redelegations ?? account.cosmosResources?.redelegations ?? [],
+    sequence: account.cosmosResources.sequence + 1,
   };
   return account;
 }
@@ -94,6 +95,7 @@ function addDelegationOperation(account: CosmosAccount, rng: Prando): CosmosAcco
         withdrawAddress: "",
         unbondings: [],
         redelegations: [],
+        sequence: 1,
       };
   if (spendableBalance.isZero()) return account;
 
@@ -161,6 +163,7 @@ function addRedelegationOperation(account: CosmosAccount, rng: Prando): CosmosAc
         withdrawAddress: "",
         unbondings: [],
         redelegations: [],
+        sequence: 1,
       };
   if (!cosmosResources.delegations.length) return account;
 
@@ -220,6 +223,7 @@ function addClaimRewardsOperation(account: CosmosAccount, rng: Prando): CosmosAc
         withdrawAddress: "",
         unbondings: [],
         redelegations: [],
+        sequence: 1,
       };
   if (!cosmosResources.delegations.length) return account;
 
@@ -268,6 +272,7 @@ function addUndelegationOperation(account: CosmosAccount, rng: Prando): CosmosAc
         withdrawAddress: "",
         unbondings: [],
         redelegations: [],
+        sequence: 1,
       };
   if (!cosmosResources.delegations.length) return account;
 
@@ -366,6 +371,7 @@ function postScanAccount(
       withdrawAddress: account.id,
       unbondings: [],
       redelegations: [],
+      sequence: 0,
     };
     account.operations = [];
   }

--- a/libs/ledger-live-common/src/families/cosmos/serialization.ts
+++ b/libs/ledger-live-common/src/families/cosmos/serialization.ts
@@ -11,6 +11,7 @@ export function toCosmosResourcesRaw(r: CosmosResources): CosmosResourcesRaw {
     withdrawAddress,
     redelegations,
     unbondings,
+    sequence,
   } = r;
 
   return {
@@ -37,6 +38,7 @@ export function toCosmosResourcesRaw(r: CosmosResources): CosmosResourcesRaw {
     pendingRewardsBalance: pendingRewardsBalance.toString(),
     unbondingBalance: unbondingBalance.toString(),
     withdrawAddress,
+    sequence,
   };
 }
 export function fromCosmosResourcesRaw(r: CosmosResourcesRaw): CosmosResources {
@@ -48,6 +50,7 @@ export function fromCosmosResourcesRaw(r: CosmosResourcesRaw): CosmosResources {
     unbondingBalance,
     withdrawAddress,
     unbondings,
+    sequence,
   } = r;
   return {
     delegations: delegations.map(({ amount, status, pendingRewards, validatorAddress }) => ({
@@ -73,6 +76,7 @@ export function fromCosmosResourcesRaw(r: CosmosResourcesRaw): CosmosResources {
     pendingRewardsBalance: new BigNumber(pendingRewardsBalance),
     unbondingBalance: new BigNumber(unbondingBalance),
     withdrawAddress,
+    sequence,
   };
 }
 

--- a/libs/ledger-live-common/src/families/cosmos/specs.ts
+++ b/libs/ledger-live-common/src/families/cosmos/specs.ts
@@ -74,6 +74,7 @@ const cosmosLikeTest: ({
   delete opExpected.blockHeight;
   delete opExpected.extra;
   delete opExpected.transactionSequenceNumber;
+  delete opExpected.nftOperations;
 
   const op: Partial<CosmosOperationRaw> = toOperationRaw(operation) as CosmosOperationRaw;
   const opExtra: CosmosOperationExtraRaw = op.extra || {};

--- a/libs/ledger-live-common/src/families/cosmos/specs.ts
+++ b/libs/ledger-live-common/src/families/cosmos/specs.ts
@@ -444,12 +444,14 @@ const osmosis = {
 const desmos = {
   ...generateGenericCosmosTest("desmos", {
     testTimeout: 8 * 60 * 1000,
+    skipOperationHistory: true,
   }),
 };
 
 const umee = {
   ...generateGenericCosmosTest("umee", {
     testTimeout: 8 * 60 * 1000,
+    skipOperationHistory: true,
   }),
 };
 
@@ -462,6 +464,7 @@ const persistence = {
 const quicksilver = {
   ...generateGenericCosmosTest("quicksilver", {
     testTimeout: 8 * 60 * 1000,
+    skipOperationHistory: true,
   }),
 };
 

--- a/libs/ledger-live-common/src/families/cosmos/types.ts
+++ b/libs/ledger-live-common/src/families/cosmos/types.ts
@@ -62,6 +62,7 @@ export type CosmosResources = {
   pendingRewardsBalance: BigNumber;
   unbondingBalance: BigNumber;
   withdrawAddress: string;
+  sequence: number;
 };
 export type CosmosDelegationRaw = {
   validatorAddress: string;
@@ -88,6 +89,7 @@ export type CosmosResourcesRaw = {
   pendingRewardsBalance: string;
   unbondingBalance: string;
   withdrawAddress: string;
+  sequence: number;
 };
 // NB this must be serializable (no Date, no BigNumber)
 export type CosmosValidatorItem = {

--- a/libs/ledger-live-common/src/mock/account.ts
+++ b/libs/ledger-live-common/src/mock/account.ts
@@ -57,6 +57,7 @@ export function genAccount(id: number | string, opts: GenAccountOptions = {}): A
             pendingRewardsBalance: new BigNumber(0),
             unbondingBalance: new BigNumber(0),
             withdrawAddress: address,
+            sequence: 0,
           };
           break;
         case "bitcoin":


### PR DESCRIPTION
### 📝 Description

1. Currently, We check the empty cosmos account by using the balance = 0 and operation array is empty. But it is not correct for the currencies that do support operation history since operation arrays are always empty for them. So we should use sequence = 0 to check whether an account is empty.
2. Ignore "nftoperations" field that is not used by cosmos family but breaks the bot tests.
3. Fix cosmos family bot, especially for the errors related to currencies that do support operation history.

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
