### PR TITLE
[bugfix] Fix regression when serializing cosmos operation extra

### DIFF
--- a/.changeset/olive-oranges-know.md
+++ b/.changeset/olive-oranges-know.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix regression when serializing cosmos operation extra

--- a/libs/coin-framework/src/account/serialization.ts
+++ b/libs/coin-framework/src/account/serialization.ts
@@ -140,10 +140,6 @@ export const fromOperationRaw = (
     value: new BigNumber(value),
     fee: new BigNumber(fee),
     extra,
-    contract,
-    operator,
-    standard,
-    tokenId,
   };
 
   if (transactionSequenceNumber !== undefined) {
@@ -152,6 +148,26 @@ export const fromOperationRaw = (
 
   if (hasFailed !== undefined) {
     res.hasFailed = hasFailed;
+  }
+
+  if (transactionRaw !== undefined) {
+    res.transactionRaw = transactionRaw;
+  }
+
+  if (contract !== undefined) {
+    res.contract = contract;
+  }
+
+  if (operator !== undefined) {
+    res.operator = operator;
+  }
+
+  if (standard !== undefined) {
+    res.standard = standard;
+  }
+
+  if (tokenId !== undefined) {
+    res.tokenId = tokenId;
   }
 
   if (subAccounts) {
@@ -168,10 +184,6 @@ export const fromOperationRaw = (
 
   if (nftOperations) {
     res.nftOperations = nftOperations.map((o: OperationRaw) => fromOperationRaw(o, o.accountId));
-  }
-
-  if (transactionRaw !== undefined) {
-    res.transactionRaw = transactionRaw;
   }
 
   return res;

--- a/libs/ledger-live-common/src/families/cosmos/account.ts
+++ b/libs/ledger-live-common/src/families/cosmos/account.ts
@@ -127,7 +127,7 @@ export function fromOperationExtraRaw(extraRaw: CosmosOperationExtraRaw): Cosmos
     };
   }
 
-  if (extraRaw.validators) {
+  if (extraRaw.validators && extraRaw.validators.length > 0) {
     extra.validators = extraRaw.validators.map(validator => ({
       address: validator.address,
       amount: new BigNumber(validator.amount),
@@ -159,7 +159,7 @@ export function toOperationExtraRaw(extra: CosmosOperationExtra): CosmosOperatio
     };
   }
 
-  if (extra.validators) {
+  if (extra.validators && extra.validators.length > 0) {
     extraRaw.validators = extra.validators.map(validator => ({
       address: validator.address,
       amount: validator.amount.toString(),

--- a/libs/ledger-live-common/src/families/cosmos/account.ts
+++ b/libs/ledger-live-common/src/families/cosmos/account.ts
@@ -166,16 +166,16 @@ export function toOperationExtraRaw(extra: CosmosOperationExtra): CosmosOperatio
     }));
   }
 
-  if (extraRaw.sourceValidator) {
-    extra.sourceValidator = extraRaw.sourceValidator;
+  if (extra.sourceValidator) {
+    extraRaw.sourceValidator = extra.sourceValidator;
   }
 
-  if (extraRaw.autoClaimedRewards) {
-    extra.autoClaimedRewards = extraRaw.autoClaimedRewards;
+  if (extra.autoClaimedRewards) {
+    extraRaw.autoClaimedRewards = extra.autoClaimedRewards;
   }
 
-  if (extraRaw.memo) {
-    extra.memo = extraRaw.memo;
+  if (extra.memo) {
+    extraRaw.memo = extra.memo;
   }
 
   return extraRaw;

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/coreum.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/coreum.integration.test.ts.snap
@@ -119,7 +119,6 @@ Array [
       "contract": undefined,
       "extra": Object {
         "memo": "lb",
-        "validators": Array [],
       },
       "fee": "8880",
       "hash": "0B17FF19A1E8DC703A3AEC457B414DE88845DD76BB4D95F8F6368F68D59248DF",
@@ -144,7 +143,6 @@ Array [
       "contract": undefined,
       "extra": Object {
         "memo": "Lc",
-        "validators": Array [],
       },
       "fee": "10000",
       "hash": "B128DC8C3D820F0832BEBD81045FA65ABFDC88FB83246B37E3F1298AF3DE778A",
@@ -171,7 +169,6 @@ Array [
       "contract": undefined,
       "extra": Object {
         "memo": "lb",
-        "validators": Array [],
       },
       "fee": "8880",
       "hash": "0B17FF19A1E8DC703A3AEC457B414DE88845DD76BB4D95F8F6368F68D59248DF",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

https://github.com/LedgerHQ/ledger-live/pull/4235 introduced a regression when serializing Operation extra for cosmos.
The root cause is a dumb typo, mixing up the serialized and deserialized variables... False confidence from TS, which was of no help on that mistake. Wondering if the language could help prevent this anyhow :thinking:

Covered by our integration tests, but issue went unnoticed because of them being unstable for other reasons... :disappointed: 

### ❓ Context

- **Impacted projects**: `LLC` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: n/a <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
