### PR TITLE
[BUGFIX][LIVE-9165] fix request token crypto wallet api

### DIFF
--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -404,4 +404,7 @@ export const defaultFeatures = {
   listAppsV2: {
     enabled: false,
   },
+  ptxEarn: {
+    enabled: false,
+  },
 } as const satisfies DefaultFeatures;

--- a/libs/ledger-live-common/src/wallet-api/constants.ts
+++ b/libs/ledger-live-common/src/wallet-api/constants.ts
@@ -1,7 +1,14 @@
 import Fuse from "fuse.js";
 import { AppManifest } from "../wallet-api/types";
 
-export { FAMILIES as WALLET_API_FAMILIES } from "@ledgerhq/wallet-api-core";
+import { FAMILIES } from "@ledgerhq/wallet-api-core";
+
+/**
+ * FIXME
+ * This is not robust, we should have an explicit adapter between the wallet API currencies (families) and live currencies (families)
+ * For example here, the `ethereum` family on `wallet-api` should be mapped to the `evm` family on LL
+ */
+export const WALLET_API_FAMILIES = [...FAMILIES, "evm"];
 
 export const WALLET_API_VERSION = "2.0.0";
 

--- a/libs/ledger-live-common/src/wallet-api/helpers.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.ts
@@ -13,7 +13,7 @@ export function isWalletAPISupportedCurrency(
   currency: Currency,
 ): currency is WalletAPISupportedCurrency {
   if (isCryptoCurrency(currency)) {
-    return includes([...WALLET_API_FAMILIES, "evm"], currency.family);
+    return includes(WALLET_API_FAMILIES, currency.family);
   }
 
   if (isTokenCurrency(currency)) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Add `evm` to `WALLET_API_FAMILIES` (representing the list of LL cryptos handled by wallet-api)
This is a fixup of [this commit](https://github.com/LedgerHQ/ledger-live/commit/ef171ecf7c7f318f890d819be6b69fd185531939#diff-258e482de005245d8c37bc82a691d6eb884b2bbf1235a2e916feb9c8993efe1cR16) that originally introduced this issue

- Add a default value for the `ptxEarn` feature flag, like this is done for most (all?) of the other feature flags.
It looks like the feature flag is not visible on LL under the _debug_ > _feature flag_ screen otherwise




### ❓ Context

- **Impacted projects**: `LLC`
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9165

### ✅ Checklist

- [ ] **Test coverage** -> @LedgerHQ/wallet-api 
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/LedgerHQ/ledger-live/assets/9203826/37030c0b-164a-489f-853f-96b398988870">  | <video src="https://github.com/LedgerHQ/ledger-live/assets/9203826/c1f221c4-4983-4217-85c7-3c50df76396f">|


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
