### PR TITLE
fix(llm/synconboarding): add device to known devices as soon as device is seeded

### DIFF
--- a/.changeset/poor-donuts-swim.md
+++ b/.changeset/poor-donuts-swim.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix sync onboarding: if the sync onboarding is aborted after the device has been seeded, the device should appear in the list of known devices


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

If the sync onboarding is aborted after the device has been seeded, the device should appear in the list of known devices.

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7221] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/91890529/3351c63d-104f-42cb-9fe8-43bbcf477937



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7221]: https://ledgerhq.atlassian.net/browse/LIVE-7221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ