### PR TITLE
Bugfix/live 9191 deposit address verification device selection

### DIFF
--- a/.changeset/brave-rivers-buy.md
+++ b/.changeset/brave-rivers-buy.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LLM - Fixed the following issue : User cannot select device on device selection screen when verifying address a second time

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ReceiveFundsNavigator.tsx
@@ -75,7 +75,7 @@ export default function ReceiveFundsNavigator() {
   const onVerificationConfirmationClose = useCallback(() => {
     track("button_clicked", {
       button: "HeaderRight Close",
-      page: ScreenName.ReceiveVerificationConfirmation,
+      page: "ReceiveVerificationConfirmation",
     });
   }, []);
 
@@ -185,7 +185,7 @@ export default function ReceiveFundsNavigator() {
       <Stack.Screen
         name={ScreenName.ReceiveConfirmation}
         component={ReceiveConfirmation}
-        options={{
+        options={({ route }) => ({
           // Nice to know: headerTitle is manually set in a useEffect of ReceiveConfirmation
           headerTitle: "",
           headerLeft: () => <NavigationHeaderBackButton />,
@@ -198,31 +198,14 @@ export default function ReceiveFundsNavigator() {
                   eventButton="How to withdraw from exchange"
                 />
               )}
-              <NavigationHeaderCloseButtonAdvanced onClose={onConfirmationClose} />
+              <NavigationHeaderCloseButtonAdvanced
+                onClose={
+                  route.params.verified ? onVerificationConfirmationClose : onConfirmationClose
+                }
+              />
             </Flex>
           ),
-        }}
-      />
-      {/* Receive Address Device Verification */}
-      <Stack.Screen
-        name={ScreenName.ReceiveVerificationConfirmation}
-        component={ReceiveConfirmation}
-        options={{
-          headerTitle: "",
-          headerLeft: () => <NavigationHeaderBackButton />,
-          headerRight: () => (
-            <Flex alignItems="center" justifyContent="center" flexDirection="row">
-              {hasClosedWithdrawBanner && (
-                <HelpButton
-                  url={depositWithdrawBannerMobile?.params.url}
-                  enabled={depositWithdrawBannerMobile?.enabled ?? false}
-                  eventButton="How to withdraw from exchange"
-                />
-              )}
-              <NavigationHeaderCloseButtonAdvanced onClose={onVerificationConfirmationClose} />
-            </Flex>
-          ),
-        }}
+        })}
       />
     </Stack.Navigator>
   );

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
@@ -76,17 +76,4 @@ export type ReceiveFundsStackParamList = {
     onSuccess?: (_?: string) => void;
     onError?: () => void;
   };
-  [ScreenName.ReceiveVerificationConfirmation]: {
-    account?: AccountLike;
-    accountId: string;
-    parentId?: string;
-    modelId?: DeviceModelId;
-    verified?: boolean;
-    wired?: boolean;
-    device?: Device;
-    currency?: Currency;
-    createTokenAccount?: boolean;
-    onSuccess?: (_?: string) => void;
-    onError?: () => void;
-  };
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -122,7 +122,6 @@ export enum ScreenName {
   ReceiveSelectAccount = "ReceiveSelectAccount",
   ReceiveSelectCrypto = "ReceiveSelectCrypto",
   DepositSelectNetwork = "DepositSelectNetwork",
-  ReceiveVerificationConfirmation = "ReceiveVerificationConfirmation",
   ReceiveVerifyAddress = "ReceiveVerifyAddress",
   Recover = "Recover",
   RegionSettings = "RegionSettings",

--- a/apps/ledger-live-mobile/src/families/hedera/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Confirmation.tsx
@@ -40,10 +40,7 @@ import type {
 } from "../../components/RootNavigator/types/helpers";
 
 type ScreenProps = CompositeScreenProps<
-  StackNavigatorProps<
-    ReceiveFundsStackParamList,
-    ScreenName.ReceiveConfirmation | ScreenName.ReceiveVerificationConfirmation
-  >,
+  StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveConfirmation>,
   StackNavigatorProps<BaseNavigatorStackParamList>
 >;
 

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2945,7 +2945,7 @@
         }
       },
       "receiveConfirmation": {
-        "title": "Receive {{currencyTicker}}",
+        "title": "Deposit {{currencyTicker}}",
         "onCurrencyName": "On {{currencyName}}",
         "copyAdress": "Copy address",
         "addressCopied": "Address copied!",

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -42,10 +42,7 @@ import * as Animatable from "react-native-animatable";
 const AnimatedView = Animatable.View;
 
 type ScreenProps = BaseComposite<
-  StackNavigatorProps<
-    ReceiveFundsStackParamList,
-    ScreenName.ReceiveConfirmation | ScreenName.ReceiveVerificationConfirmation
-  >
+  StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveConfirmation>
 >;
 
 type Props = {

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03b-VerifyAddress.tsx
@@ -76,7 +76,7 @@ export default function ReceiveVerifyAddress({ navigation, route }: Props) {
         complete: () => {
           if (onSuccess) onSuccess(mainAccount.freshAddress);
           else
-            navigation.navigate(ScreenName.ReceiveVerificationConfirmation, {
+            navigation.navigate(ScreenName.ReceiveConfirmation, {
               ...route.params,
               verified: true,
               createTokenAccount: false,


### PR DESCRIPTION
Fixed the following issue : User cannot select device on device selection screen when verifying address a second time

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Replaced the "Receive" by "Deposit" in the title of the DepositConfirmation screen
Removed ReceiveVerificationConfirmation from the ReceiveFundsNavigator as it was just rendering the same component as ReceiveConfirmation => this fixes the issue preventing to verify twice the address

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-9190] [LIVE-9191] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

Build to test : https://github.com/LedgerHQ/ledger-live-build/actions/runs/6038623487

https://github.com/LedgerHQ/ledger-live/assets/17146928/462de0a7-a544-46e1-8341-b766f5ec69dc



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9190]: https://ledgerhq.atlassian.net/browse/LIVE-9190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-9191]: https://ledgerhq.atlassian.net/browse/LIVE-9191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ