### PR TITLE
[Bugfix/LIVE-9189]: ios app store alert appearing on navigation change

### DIFF
--- a/.changeset/friendly-maps-design.md
+++ b/.changeset/friendly-maps-design.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix for ios alert appearing on screen change

--- a/.changeset/friendly-maps-design.md
+++ b/.changeset/friendly-maps-design.md
@@ -1,5 +1,0 @@
----
-"live-mobile": patch
----
-
-Fix for ios alert appearing on screen change

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { AccountLikeArray } from "@ledgerhq/types-live";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
@@ -16,7 +16,7 @@ import {
 import { ActionButtonEvent } from "..";
 import ZeroBalanceDisabledModalContent from "../modals/ZeroBalanceDisabledModalContent";
 import { sharedSwapTracking } from "../../../screens/Swap/utils";
-import { Toast } from "../../Toast/Toast";
+import { PtxToast } from "../../Toast/PtxToast";
 
 type useAssetActionsProps = {
   currency?: CryptoCurrency | TokenCurrency;
@@ -85,14 +85,7 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
               Icon: iconBuy,
               disabled: isPtxServiceCtaScreensDisabled,
               modalOnDisabledClick: {
-                component: () => (
-                  <Toast
-                    id="ptx-services"
-                    type="success"
-                    title={t("notifications.ptxServices.toast.title")}
-                    icon="info"
-                  />
-                ),
+                component: PtxToast,
               },
               testId: "market-buy-btn",
               navigationParams: [
@@ -125,14 +118,7 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
               disabled: isPtxServiceCtaScreensDisabled || areAccountsBalanceEmpty,
               modalOnDisabledClick: {
                 component: isPtxServiceCtaScreensDisabled
-                  ? () => (
-                      <Toast
-                        id="ptx-services"
-                        type="success"
-                        title={t("notifications.ptxServices.toast.title")}
-                        icon="info"
-                      />
-                    )
+                  ? PtxToast
                   : ZeroBalanceDisabledModalContent,
               },
             },
@@ -160,14 +146,7 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
                     disabled: isPtxServiceCtaScreensDisabled || areAccountsBalanceEmpty,
                     modalOnDisabledClick: {
                       component: isPtxServiceCtaScreensDisabled
-                        ? () => (
-                            <Toast
-                              id="ptx-services"
-                              type="success"
-                              title={t("notifications.ptxServices.toast.title")}
-                              icon="info"
-                            />
-                          )
+                        ? PtxToast
                         : ZeroBalanceDisabledModalContent,
                     },
                   },

--- a/apps/ledger-live-mobile/src/components/Toast/PtxToast.tsx
+++ b/apps/ledger-live-mobile/src/components/Toast/PtxToast.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Toast } from "./Toast";
+
+export const PtxToast = ({ onClose, isOpen }: { onClose(): void; isOpen?: boolean }) => {
+  const { t } = useTranslation();
+  if (isOpen) {
+    return (
+      <Toast
+        id="ptx-services-ios-modal"
+        type="success"
+        onClose={onClose}
+        title={t("notifications.ptxServices.toast.title")}
+        icon="info"
+      />
+    );
+  }
+  return null;
+};

--- a/apps/ledger-live-mobile/src/components/Toast/Toast.tsx
+++ b/apps/ledger-live-mobile/src/components/Toast/Toast.tsx
@@ -1,21 +1,32 @@
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import { ToastData } from "@ledgerhq/live-common/notifications/ToastProvider/types";
-import { useEffect } from "react";
-import { v4 as uuidV4 } from "uuid";
+import { useEffect, useState } from "react";
 
-type Props = Omit<ToastData, "id"> & { id?: string };
+type Props = Omit<ToastData, "id"> & { id: string; onClose(): void };
 
-export function Toast(props: Props) {
-  const { pushToast, dismissToast } = useToasts();
+export function Toast({ onClose, ...props }: Props) {
+  const { pushToast, dismissToast, toasts } = useToasts();
+  const [hasPushedToast, setHasPushedToast] = useState(false);
 
   useEffect(() => {
-    const id = props.id ?? uuidV4();
+    if (hasPushedToast) {
+      const foundToast = toasts.find(toast => toast.id === props.id);
+      if (!foundToast) {
+        onClose();
+      }
+    }
+  }, [toasts, props.id, hasPushedToast, onClose]);
+
+  useEffect(() => {
     pushToast({
       ...props,
-      id,
     });
-    return () => dismissToast(id);
-  }, [pushToast, dismissToast, props]);
+    setHasPushedToast(true);
+    return () => {
+      dismissToast(props.id);
+      onClose();
+    };
+  }, [props.id]);
 
   return null;
 }

--- a/apps/ledger-live-mobile/src/components/Toast/Toast.tsx
+++ b/apps/ledger-live-mobile/src/components/Toast/Toast.tsx
@@ -26,6 +26,7 @@ export function Toast({ onClose, ...props }: Props) {
       dismissToast(props.id);
       onClose();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.id]);
 
   return null;

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import { AccountLike, Account } from "@ledgerhq/types-live";
 import {
   getAccountCurrency,
@@ -23,7 +23,7 @@ import perFamilyAccountActions from "../../../generated/accountActions";
 import ZeroBalanceDisabledModalContent from "../../../components/FabActions/modals/ZeroBalanceDisabledModalContent";
 import { ActionButtonEvent } from "../../../components/FabActions";
 import { useCanShowStake } from "./useCanShowStake";
-import { Toast } from "../../../components/Toast/Toast";
+import { PtxToast } from "../../../components/Toast/PtxToast";
 
 type Props = {
   account: AccountLike;
@@ -114,16 +114,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
     Icon: iconSwap,
     disabled: isPtxServiceCtaScreensDisabled || isZeroBalance,
     modalOnDisabledClick: {
-      component: isPtxServiceCtaScreensDisabled
-        ? () => (
-            <Toast
-              id="ptx-services"
-              title={t("notifications.ptxServices.toast.title")}
-              icon="info"
-              type="success"
-            />
-          )
-        : ZeroBalanceDisabledModalContent,
+      component: isPtxServiceCtaScreensDisabled ? PtxToast : ZeroBalanceDisabledModalContent,
     },
     event: "Swap Crypto Account Button",
     eventProperties: { currencyName: currency.name },
@@ -133,14 +124,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
     id: "buy",
     disabled: isPtxServiceCtaScreensDisabled,
     modalOnDisabledClick: {
-      component: () => (
-        <Toast
-          id="ptx-services"
-          type="success"
-          title={t("notifications.ptxServices.toast.title")}
-          icon="info"
-        />
-      ),
+      component: PtxToast,
     },
     navigationParams: [
       NavigatorName.Exchange,
@@ -176,16 +160,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
     Icon: iconSell,
     disabled: isPtxServiceCtaScreensDisabled || isZeroBalance,
     modalOnDisabledClick: {
-      component: isPtxServiceCtaScreensDisabled
-        ? () => (
-            <Toast
-              id="ptx-services"
-              title={t("notifications.ptxServices.toast.title")}
-              icon="info"
-              type="success"
-            />
-          )
-        : ZeroBalanceDisabledModalContent,
+      component: isPtxServiceCtaScreensDisabled ? PtxToast : ZeroBalanceDisabledModalContent,
     },
     event: "Sell Crypto Account Button",
     eventProperties: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Fix where ios ptx alert continued to re-appear when user navigated to other screens.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

#### Before
https://github.com/LedgerHQ/ledger-live/assets/132384348/0814084a-6009-4b04-b8d4-7bb750850785



#### After
https://github.com/LedgerHQ/ledger-live/assets/132384348/2d1b88ce-8140-47cb-9bab-4d51e212a77e



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
