### PR TITLE
[SUPPORT] update-bot-staging-explorer-eth

### DIFF
--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -37,5 +37,5 @@ jobs:
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN}}
           SLACK_ICON_EMOJI: ":bot-seed2:"
           SLACK_CHANNEL: explorer-bot-stg
-          BOT_FILTER_FAMILIES: evm
+          BOT_FILTER_CURRENCIES: avalanche_c_chain,bsc,polygon,ethereum,ethereum_classic,ethereum_goerli
           BOT_ENVIRONMENT: staging

--- a/.github/workflows/bot-staging-explorer-eth.yml
+++ b/.github/workflows/bot-staging-explorer-eth.yml
@@ -1,4 +1,4 @@
-name: "[Bot] Ethereum on Staging"
+name: "[Bot] Evm on Staging"
 on:
   workflow_dispatch:
   schedule:
@@ -37,5 +37,5 @@ jobs:
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN}}
           SLACK_ICON_EMOJI: ":bot-seed2:"
           SLACK_CHANNEL: explorer-bot-stg
-          BOT_FILTER_FAMILIES: ethereum
+          BOT_FILTER_FAMILIES: evm
           BOT_ENVIRONMENT: staging

--- a/libs/ledger-live-common/src/bot/cli.ts
+++ b/libs/ledger-live-common/src/bot/cli.ts
@@ -23,7 +23,7 @@ if (BOT_FILTER_CURRENCIES) {
 }
 
 if (BOT_FILTER_FAMILIES) {
-  arg.filter.families = BOT_FILTER_FAMILIES?.split(",");
+  arg.filter.families = BOT_FILTER_FAMILIES.split(",");
 }
 
 if (BOT_DISABLED_CURRENCIES) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Since the `ethereum` family does not exist anymore, replace it's reference in the `update-bot-staging-explorer-eth` job by `evm`

Questions:
Based on the name of the jobs, it seems like we are expecting to test a currency and not a full family.
Does it make sense for [this job](https://github.com/LedgerHQ/ledger-live/blob/develop/.github/workflows/bot-staging-explorer-eth.yml) (as well as for [the bitcoin one](https://github.com/LedgerHQ/ledger-live/blob/develop/.github/workflows/bot-staging-explorer-btc.yml)) to test the whole family or should they rather only test the `ethereum` and `bitcoin` currencies (replacing `BOT_FILTER_FAMILIES: bitcoin` by `BOT_FILTER_CURRENCIES: bitcoin` and `BOT_FILTER_FAMILIES: evm` by `BOT_FILTER_CURRENCIES: ethereum`)?





### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://github.com/LedgerHQ/ledger-live/pull/4285

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
