### PR TITLE
Support/LIVE-8495 Fix Elrond bot test

### DIFF
--- a/.changeset/late-fishes-promise.md
+++ b/.changeset/late-fishes-promise.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/cryptoassets": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-framework": patch
+---
+
+fix elrond bot tests

--- a/libs/coin-framework/src/account/serialization.ts
+++ b/libs/coin-framework/src/account/serialization.ts
@@ -65,7 +65,7 @@ export const toOperationRaw = (
     copy.internalOperations = internalOperations.map((o: Operation) => toOperationRaw(o));
   }
 
-  if (nftOperations) {
+  if (nftOperations && nftOperations.length > 0) {
     copy.nftOperations = nftOperations.map((o: Operation) => toOperationRaw(o));
   }
 
@@ -182,7 +182,7 @@ export const fromOperationRaw = (
     );
   }
 
-  if (nftOperations) {
+  if (nftOperations && nftOperations.length > 0) {
     res.nftOperations = nftOperations.map((o: OperationRaw) => fromOperationRaw(o, o.accountId));
   }
 

--- a/libs/ledger-live-common/src/families/elrond/account.ts
+++ b/libs/ledger-live-common/src/families/elrond/account.ts
@@ -77,7 +77,7 @@ function formatOperationSpecifics(op: Operation, unit: Unit | null | undefined):
 
 export function fromOperationExtraRaw(extraRaw: ElrondOperationExtraRaw) {
   const extra: ElrondOperationExtra = {};
-  if (extraRaw.amount) {
+  if (extraRaw.amount != null) {
     extra.amount = new BigNumber(extraRaw.amount);
   }
   return extra;
@@ -85,7 +85,7 @@ export function fromOperationExtraRaw(extraRaw: ElrondOperationExtraRaw) {
 
 export function toOperationExtraRaw(extra: ElrondOperationExtra) {
   const extraRaw: ElrondOperationExtraRaw = {};
-  if (extra.amount) {
+  if (extra.amount != null) {
     extraRaw.amount = extra.amount.toString();
   }
   return extraRaw;

--- a/libs/ledger-live-common/src/families/elrond/account.ts
+++ b/libs/ledger-live-common/src/families/elrond/account.ts
@@ -77,7 +77,7 @@ function formatOperationSpecifics(op: Operation, unit: Unit | null | undefined):
 
 export function fromOperationExtraRaw(extraRaw: ElrondOperationExtraRaw) {
   const extra: ElrondOperationExtra = {};
-  if (extraRaw.amount != null) {
+  if (extraRaw.amount) {
     extra.amount = new BigNumber(extraRaw.amount);
   }
   return extra;
@@ -85,7 +85,7 @@ export function fromOperationExtraRaw(extraRaw: ElrondOperationExtraRaw) {
 
 export function toOperationExtraRaw(extra: ElrondOperationExtra) {
   const extraRaw: ElrondOperationExtraRaw = {};
-  if (extra.amount != null) {
+  if (extra.amount) {
     extraRaw.amount = extra.amount.toString();
   }
   return extraRaw;

--- a/libs/ledger-live-common/src/families/elrond/specs.ts
+++ b/libs/ledger-live-common/src/families/elrond/specs.ts
@@ -11,7 +11,6 @@ import type { AppSpec, TransactionTestInput } from "../../bot/types";
 import { toOperationRaw } from "../../account";
 import { DeviceModelId } from "@ledgerhq/devices";
 import expect from "expect";
-import { log } from "@ledgerhq/logs";
 import {
   acceptDelegateTransaction,
   acceptEsdtTransferTransaction,

--- a/libs/ledger-live-common/src/families/elrond/specs.ts
+++ b/libs/ledger-live-common/src/families/elrond/specs.ts
@@ -11,6 +11,7 @@ import type { AppSpec, TransactionTestInput } from "../../bot/types";
 import { toOperationRaw } from "../../account";
 import { DeviceModelId } from "@ledgerhq/devices";
 import expect from "expect";
+import { log } from "@ledgerhq/logs";
 import {
   acceptDelegateTransaction,
   acceptEsdtTransferTransaction,
@@ -121,10 +122,13 @@ function expectCorrectOptimisticOperation(input: TransactionTestInput<Transactio
       optimisticOperation.transactionSequenceNumber,
     ),
   );
-
-  botTest("raw optimistic operation matches", () =>
-    expect(toOperationRaw(operation)).toMatchObject(opExpected),
-  );
+  const ggg = toOperationRaw(operation);
+  log("bot", "GGGGGGGGG");
+  log("bot", JSON.stringify(operation));
+  log("bot", JSON.stringify(ggg));
+  log("bot", JSON.stringify(opExpected));
+  log("bot", "FFFFFFFFF");
+  botTest("raw optimistic operation matches", () => expect(ggg).toMatchObject(opExpected));
 }
 
 function expectCorrectSpendableBalanceChange(input: TransactionTestInput<Transaction>) {

--- a/libs/ledger-live-common/src/families/elrond/specs.ts
+++ b/libs/ledger-live-common/src/families/elrond/specs.ts
@@ -122,13 +122,9 @@ function expectCorrectOptimisticOperation(input: TransactionTestInput<Transactio
       optimisticOperation.transactionSequenceNumber,
     ),
   );
-  const ggg = toOperationRaw(operation);
-  log("bot", "GGGGGGGGG");
-  log("bot", JSON.stringify(operation));
-  log("bot", JSON.stringify(ggg));
-  log("bot", JSON.stringify(opExpected));
-  log("bot", "FFFFFFFFF");
-  botTest("raw optimistic operation matches", () => expect(ggg).toMatchObject(opExpected));
+  botTest("raw optimistic operation matches", () =>
+    expect(toOperationRaw(operation)).toMatchObject(opExpected),
+  );
 }
 
 function expectCorrectSpendableBalanceChange(input: TransactionTestInput<Transaction>) {

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -1071,6 +1071,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
         address: "https://explorer.elrond.com/accounts/$address",
       },
     ],
+    keywords: ["elrond"],
   },
   eos: {
     type: "CryptoCurrency",


### PR DESCRIPTION
### 📝 Description

Fix Elrond failed bot tests.
Elrond bot tests failure is related to the following assert in specs.ts:
```
  botTest("raw optimistic operation matches", () =>
    expect(toOperationRaw(operation)).toMatchObject(opExpected),
  );
```
The opExpected includes a unnecessary field: "nftOperations"

### ❓ Context

- **Impacted projects**: LLC
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-8495

### ✅ Checklist

- [ ] **Test coverage** It is a PR to fix broken bot tests. No additional tests provided.
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
