### PR TITLE
Ble Pairing during Sync Onboarding: Missing help icon and help message

### DIFF
--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicesScanning.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicesScanning.tsx
@@ -8,10 +8,12 @@ import { useSelector } from "react-redux";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { useNavigation } from "@react-navigation/native";
+import { IconsLegacy } from "@ledgerhq/native-ui";
 import TransportBLE from "../../react-native-hw-transport-ble";
 import { knownDevicesSelector } from "../../reducers/ble";
 import Animation from "../Animation";
 import BleDeviceItem from "./BleDeviceItem";
+import Link from "../../components/wrappedUi/Link";
 import lottie from "./assets/bluetooth.json";
 import { urls } from "../../config/urls";
 import { TrackScreen, track } from "../../analytics";
@@ -193,15 +195,15 @@ const BleDevicesScanning = ({
         </Flex>
       </Flex>
       {productName !== null && isCantSeeDeviceShown && (
-        <Text
-          textAlign="center"
-          mb={40}
-          fontSize={14}
-          fontWeight="semiBold"
+        <Link
           onPress={onCantSeeDevicePress}
+          size={"medium"}
+          Icon={IconsLegacy.HelpMedium}
+          type="shade"
+          iconPosition="right"
         >
           {t("blePairingFlow.scanning.cantSeeDevice", { productName })}
-        </Text>
+        </Link>
       )}
     </Flex>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

Add Help Icon and update design

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed._

### ❓ Context

- **Impacted projects**: `` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/463?modal=detail&selectedIssue=LIVE-6340` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->
![Simulator Screenshot - iPhone 14 Pro - 2023-09-04 at 11 46 36](https://github.com/LedgerHQ/ledger-live/assets/31533861/befe2455-2025-4a8d-9356-90c824a32909)
![Simulator Screenshot - iPhone 14 Pro - 2023-09-04 at 11 47 10](https://github.com/LedgerHQ/ledger-live/assets/31533861/fb0a95d4-e375-44a7-b893-32b3b976a756)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
