### PR TITLE
fix: add react-native-webview isLoading state on loadEnd

### DIFF
--- a/.changeset/honest-fans-cover.md
+++ b/.changeset/honest-fans-cover.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+bugfix for infinite load on react-native-webview

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -8,7 +8,12 @@ import { NetworkError } from "./NetworkError";
 
 export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   ({ manifest, inputs = {}, onStateChange, allowsBackForwardNavigationGestures = true }, ref) => {
-    const { onMessage, onLoadError, webviewProps, webviewRef } = useWebView(
+    const {
+      onMessage,
+      onLoadError,
+      webviewProps: { onLoadEnd, ...webviewStateProps },
+      webviewRef,
+    } = useWebView(
       {
         manifest,
         inputs,
@@ -38,7 +43,16 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         renderError={() => <NetworkError handleTryAgain={() => webviewRef.current?.reload()} />}
         testID="wallet-api-webview"
         allowsUnsecureHttps={__DEV__ && !!Config.IGNORE_CERTIFICATE_ERRORS}
-        {...webviewProps}
+        {...webviewStateProps}
+        onLoadEnd={event => {
+          if (onLoadEnd) {
+            onLoadEnd(event);
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore next-line
+            this.isLoading = event.nativeEvent.loading;
+          }
+        }}
       />
     );
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

A bug was observed on Earn dashboard where switching tabs caused the webview to display an infinitely loading icon.  After an investigation this appears to be due to onLoadEnd not setting the `isLoading` property on react-native-webview component as detailed https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#onloadend [here](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#onloadend).  This fix should hopefully avoid this from occuring.

### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `LIVE-9185` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
