### PR TITLE
fix: add isDeepLinking state to prevent deeplink lock

### DIFF
--- a/.changeset/light-planes-cry.md
+++ b/.changeset/light-planes-cry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a deeplinking state in redux to inform the AuthPass component not to lock when app is temporarily backgrounded by ptx player deeplinks.

--- a/apps/ledger-live-mobile/src/actions/appstate.ts
+++ b/apps/ledger-live-mobile/src/actions/appstate.ts
@@ -38,3 +38,6 @@ export const updateMainNavigatorVisibility =
   createAction<AppStateUpdateMainNavigatorVisibilityPayload>(
     AppStateActionTypes.UPDATE_MAIN_NAVIGATOR_VISIBILITY,
   );
+
+/** Set to true to prevent privacy lock being triggered by deep links. Reset to false on re-focus or on close. */
+export const setIsDeepLinking = createAction<boolean>(AppStateActionTypes.SET_IS_DEEP_LINKING);

--- a/apps/ledger-live-mobile/src/actions/earn.ts
+++ b/apps/ledger-live-mobile/src/actions/earn.ts
@@ -5,5 +5,3 @@ import type { EarnSetInfoModalPayload } from "./types";
 export const setEarnInfoModal = createAction<EarnSetInfoModalPayload>(
   EarnActionTypes.EARN_INFO_MODAL,
 );
-
-export const setIsDeepLinking = createAction<boolean>(EarnActionTypes.SET_IS_DEEP_LINKING);

--- a/apps/ledger-live-mobile/src/actions/earn.ts
+++ b/apps/ledger-live-mobile/src/actions/earn.ts
@@ -5,3 +5,5 @@ import type { EarnSetInfoModalPayload } from "./types";
 export const setEarnInfoModal = createAction<EarnSetInfoModalPayload>(
   EarnActionTypes.EARN_INFO_MODAL,
 );
+
+export const setIsDeepLinking = createAction<boolean>(EarnActionTypes.SET_IS_DEEP_LINKING);

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -453,11 +453,13 @@ export type SwapPayload = UpdateProvidersPayload | UpdateTransactionPayload | Up
 // === EARN ACTIONS ==
 export enum EarnActionTypes {
   EARN_INFO_MODAL = "EARN_INFO_MODAL",
+  SET_IS_DEEP_LINKING = "SET_IS_DEEP_LINKING",
 }
+export type EarnSetIsDeeplinkingPayload = boolean;
 
 export type EarnSetInfoModalPayload = EarnState["infoModal"] | undefined;
 
-export type EarnPayload = EarnSetInfoModalPayload;
+export type EarnPayload = EarnSetInfoModalPayload | EarnSetIsDeeplinkingPayload;
 
 // === PROTECT ACTIONS ===
 export enum ProtectActionTypes {

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -86,6 +86,7 @@ export enum AppStateActionTypes {
   CLEAR_BACKGROUND_EVENTS = "CLEAR_BACKGROUND_EVENTS",
   DANGEROUSLY_OVERRIDE_STATE = "DANGEROUSLY_OVERRIDE_STATE",
   UPDATE_MAIN_NAVIGATOR_VISIBILITY = "UPDATE_MAIN_NAVIGATOR_VISIBILITY",
+  SET_IS_DEEP_LINKING = "SET_IS_DEEP_LINKING",
 }
 
 export type AppStateIsConnectedPayload = AppState["isConnected"];
@@ -94,6 +95,7 @@ export type AppStateSetModalLockPayload = AppState["modalLock"];
 export type AppStateAddBackgroundEventPayload = {
   event: FwUpdateBackgroundEvent;
 };
+export type AppStateIsDeeplinkingPayload = boolean;
 
 export type AppStateUpdateMainNavigatorVisibilityPayload = AppState["isMainNavigatorVisible"];
 export type AppStatePayload =
@@ -101,7 +103,8 @@ export type AppStatePayload =
   | AppStateSetHasConnectedDevicePayload
   | AppStateSetModalLockPayload
   | AppStateAddBackgroundEventPayload
-  | AppStateUpdateMainNavigatorVisibilityPayload;
+  | AppStateUpdateMainNavigatorVisibilityPayload
+  | AppStateIsDeeplinkingPayload;
 
 // === BLE ACTIONS ===
 
@@ -453,13 +456,11 @@ export type SwapPayload = UpdateProvidersPayload | UpdateTransactionPayload | Up
 // === EARN ACTIONS ==
 export enum EarnActionTypes {
   EARN_INFO_MODAL = "EARN_INFO_MODAL",
-  SET_IS_DEEP_LINKING = "SET_IS_DEEP_LINKING",
 }
-export type EarnSetIsDeeplinkingPayload = boolean;
 
 export type EarnSetInfoModalPayload = EarnState["infoModal"] | undefined;
 
-export type EarnPayload = EarnSetInfoModalPayload | EarnSetIsDeeplinkingPayload;
+export type EarnPayload = EarnSetInfoModalPayload;
 
 // === PROTECT ACTIONS ===
 export enum ProtectActionTypes {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -15,7 +15,7 @@ import { EarnScreen } from "../../screens/PTX/Earn";
 import { shallowAccountsSelector } from "../../reducers/accounts";
 import { EarnInfoDrawer } from "../../screens/PTX/Earn/EarnInfoDrawer";
 import { useStakingDrawer } from "../Stake/useStakingDrawer";
-import { setIsDeepLinking } from "../../actions/earn";
+import { setIsDeepLinking } from "../../actions/appstate";
 
 const Stack = createStackNavigator<EarnLiveAppNavigatorParamList>();
 

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -19,6 +19,10 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       onStateChange,
     );
 
+    const reloadWebView = () => {
+      webviewRef.current?.reload();
+    };
+
     const javaScriptCanOpenWindowsAutomatically = manifest.id === DEFAULT_MULTIBUY_APP_ID;
 
     return (
@@ -39,7 +43,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         automaticallyAdjustContentInsets={false}
         scrollEnabled={true}
         style={styles.webview}
-        renderError={() => <NetworkError handleTryAgain={() => webviewRef.current?.reload()} />}
+        renderError={() => <NetworkError handleTryAgain={reloadWebView} />}
         testID="wallet-api-webview"
         allowsUnsecureHttps={__DEV__ && !!Config.IGNORE_CERTIFICATE_ERRORS}
         javaScriptCanOpenWindowsAutomatically={javaScriptCanOpenWindowsAutomatically}

--- a/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
@@ -6,9 +6,9 @@ import { withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { compose } from "redux";
 import { privacySelector } from "../../reducers/settings";
-import { isDeepLinkingSelector } from "../../reducers/earn";
+import { isDeepLinkingSelector } from "../../reducers/appstate";
 import { SkipLockContext } from "../../components/behaviour/SkipLock";
-import type { Privacy, State as GlobalState, EarnState } from "../../reducers/types";
+import type { Privacy, State as GlobalState, AppState as EventState } from "../../reducers/types";
 import AuthScreen from "./AuthScreen";
 import RequestBiometricAuth from "../../components/RequestBiometricAuth";
 
@@ -16,7 +16,7 @@ const mapStateToProps = createStructuredSelector<
   GlobalState,
   {
     privacy: Privacy | null | undefined;
-    isDeepLinking: EarnState["isDeepLinking"]; // skips screen lock for internal deeplinks from ptx web player.
+    isDeepLinking: EventState["isDeepLinking"]; // skips screen lock for internal deeplinks from ptx web player.
   }
 >({
   privacy: privacySelector,
@@ -37,7 +37,7 @@ type OwnProps = {
 type Props = OwnProps & {
   t: TFunction;
   privacy: Privacy | null | undefined;
-  isDeepLinking: EarnState["isDeepLinking"];
+  isDeepLinking: EventState["isDeepLinking"];
 };
 // as we needs to be resilient to reboots (not showing unlock again after a reboot)
 // we need to store this global variable to know if we need to isLocked initially

--- a/apps/ledger-live-mobile/src/context/RootDrawerContext.tsx
+++ b/apps/ledger-live-mobile/src/context/RootDrawerContext.tsx
@@ -3,7 +3,9 @@ import React, { PropsWithChildren, createContext, useCallback, useContext, useSt
 import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { NavigatorName } from "../const";
-import { DrawerProps, RootDrawerProps } from "../components/RootDrawer/types";
+import type { DrawerProps, RootDrawerProps } from "../components/RootDrawer/types";
+import { setIsDeepLinking } from "../actions/earn";
+import { useDispatch } from "react-redux";
 
 const rootDrawerEmitter = new EventEmitter();
 
@@ -33,6 +35,7 @@ export function useRootDrawerContext() {
 export function RootDrawerProvider({ drawer, children }: PropsWithChildren<RootDrawerProps>) {
   const [isOpen, setIsOpen] = useState(false);
   const navigation = useNavigation<StackNavigationProp<ParamListBase, string, NavigatorName>>();
+  const dispatch = useDispatch();
 
   const onModalHide = () => {
     const parent = navigation.getParent(NavigatorName.RootNavigator);
@@ -61,8 +64,10 @@ export function RootDrawerProvider({ drawer, children }: PropsWithChildren<RootD
       if (callback) {
         rootDrawerEmitter.once("ll-root-drawer-on-modal-hide", callback);
       }
+
+      dispatch(setIsDeepLinking(false));
     },
-    [setIsOpen],
+    [setIsOpen, dispatch],
   );
 
   const openDrawer = useCallback(() => setIsOpen(true), [setIsOpen]);

--- a/apps/ledger-live-mobile/src/context/RootDrawerContext.tsx
+++ b/apps/ledger-live-mobile/src/context/RootDrawerContext.tsx
@@ -4,7 +4,7 @@ import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { NavigatorName } from "../const";
 import type { DrawerProps, RootDrawerProps } from "../components/RootDrawer/types";
-import { setIsDeepLinking } from "../actions/earn";
+import { setIsDeepLinking } from "../actions/appstate";
 import { useDispatch } from "react-redux";
 
 const rootDrawerEmitter = new EventEmitter();

--- a/apps/ledger-live-mobile/src/reducers/appstate.ts
+++ b/apps/ledger-live-mobile/src/reducers/appstate.ts
@@ -7,13 +7,14 @@ import type { AppState, State } from "./types";
 import type {
   AppStateAddBackgroundEventPayload,
   AppStateIsConnectedPayload,
+  AppStateIsDeeplinkingPayload,
   AppStatePayload,
   AppStateSetHasConnectedDevicePayload,
   AppStateSetModalLockPayload,
   AppStateUpdateMainNavigatorVisibilityPayload,
   DangerouslyOverrideStatePayload,
 } from "../actions/types";
-import { AppStateActionTypes } from "../actions/types";
+import { AppStateActionTypes, EarnActionTypes } from "../actions/types";
 
 export type AsyncState = {
   isConnected: boolean | null;
@@ -26,6 +27,7 @@ export const INITIAL_STATE: AppState = {
   backgroundEvents: [],
   debugMenuVisible: false,
   isMainNavigatorVisible: true,
+  isDeepLinking: false,
 };
 
 const handlers: ReducerMap<AppState, AppStatePayload> = {
@@ -80,6 +82,17 @@ const handlers: ReducerMap<AppState, AppStatePayload> = {
     isMainNavigatorVisible: (action as Action<AppStateUpdateMainNavigatorVisibilityPayload>)
       .payload,
   }),
+
+  /** Prevents deep links from triggering privacy lock. */
+  [AppStateActionTypes.SET_IS_DEEP_LINKING]: (state, action) => ({
+    ...state,
+    isDeepLinking: (action as Action<AppStateIsDeeplinkingPayload>)?.payload || false,
+  }),
+
+  [EarnActionTypes.EARN_INFO_MODAL]: state => ({
+    ...state,
+    isDeepLinking: true,
+  }),
 };
 
 // Selectors
@@ -102,5 +115,7 @@ export const networkErrorSelector = createSelector(
   isConnectedSelector,
   (isConnected: boolean | null) => (!isConnected ? globalNetworkDown : null),
 );
+
+export const isDeepLinkingSelector = (state: State) => state.appstate.isDeepLinking;
 
 export default handleActions<AppState, AppStatePayload>(handlers, INITIAL_STATE);

--- a/apps/ledger-live-mobile/src/reducers/earn.ts
+++ b/apps/ledger-live-mobile/src/reducers/earn.ts
@@ -2,16 +2,28 @@ import { handleActions } from "redux-actions";
 import type { Action, ReducerMap } from "redux-actions";
 import { createSelector } from "reselect";
 import type { EarnState, State } from "./types";
-import { EarnPayload, EarnSetInfoModalPayload } from "../actions/types";
+import {
+  EarnActionTypes,
+  EarnPayload,
+  EarnSetInfoModalPayload,
+  EarnSetIsDeeplinkingPayload,
+} from "../actions/types";
 
 export const INITIAL_STATE: EarnState = {
   infoModal: {},
+  isDeepLinking: false,
 };
 
 const handlers: ReducerMap<EarnState, EarnPayload> = {
-  EARN_INFO_MODAL: (state, action) => ({
+  [EarnActionTypes.EARN_INFO_MODAL]: (state, action) => ({
     ...state,
+    isDeepLinking: true,
     infoModal: (action as Action<EarnSetInfoModalPayload>)?.payload || {},
+  }),
+  /** Prevents deep links from triggering privacy lock. */
+  [EarnActionTypes.SET_IS_DEEP_LINKING]: (state, action) => ({
+    ...state,
+    isDeepLinking: (action as Action<EarnSetIsDeeplinkingPayload>)?.payload || false,
   }),
 };
 
@@ -20,6 +32,11 @@ const storeSelector = (state: State): EarnState => state.earn;
 export const exportSelector = storeSelector;
 
 export default handleActions<EarnState, EarnPayload>(handlers, INITIAL_STATE);
+
 export const earnInfoModalSelector = createSelector(storeSelector, (state: EarnState) => {
   return state.infoModal;
+});
+
+export const isDeepLinkingSelector = createSelector(storeSelector, (state: EarnState) => {
+  return state.isDeepLinking;
 });

--- a/apps/ledger-live-mobile/src/reducers/earn.ts
+++ b/apps/ledger-live-mobile/src/reducers/earn.ts
@@ -2,28 +2,16 @@ import { handleActions } from "redux-actions";
 import type { Action, ReducerMap } from "redux-actions";
 import { createSelector } from "reselect";
 import type { EarnState, State } from "./types";
-import {
-  EarnActionTypes,
-  EarnPayload,
-  EarnSetInfoModalPayload,
-  EarnSetIsDeeplinkingPayload,
-} from "../actions/types";
+import { EarnActionTypes, EarnPayload, EarnSetInfoModalPayload } from "../actions/types";
 
 export const INITIAL_STATE: EarnState = {
   infoModal: {},
-  isDeepLinking: false,
 };
 
 const handlers: ReducerMap<EarnState, EarnPayload> = {
   [EarnActionTypes.EARN_INFO_MODAL]: (state, action) => ({
     ...state,
-    isDeepLinking: true,
     infoModal: (action as Action<EarnSetInfoModalPayload>)?.payload || {},
-  }),
-  /** Prevents deep links from triggering privacy lock. */
-  [EarnActionTypes.SET_IS_DEEP_LINKING]: (state, action) => ({
-    ...state,
-    isDeepLinking: (action as Action<EarnSetIsDeeplinkingPayload>)?.payload || false,
   }),
 };
 
@@ -35,8 +23,4 @@ export default handleActions<EarnState, EarnPayload>(handlers, INITIAL_STATE);
 
 export const earnInfoModalSelector = createSelector(storeSelector, (state: EarnState) => {
   return state.infoModal;
-});
-
-export const isDeepLinkingSelector = createSelector(storeSelector, (state: EarnState) => {
-  return state.isDeepLinking;
 });

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -69,6 +69,8 @@ export type AppState = {
   modalLock: boolean;
   backgroundEvents: Array<FwUpdateBackgroundEvent>;
   isMainNavigatorVisible: boolean;
+  /** For deep links that inadvertently trigger privacy lock. Reset to false on close. */
+  isDeepLinking: boolean;
 };
 
 // === BLE STATE ===
@@ -268,8 +270,6 @@ export type EarnState = {
     message?: string;
     messageTitle?: string;
   };
-  /** Earn web player deeplinks need to skip privacy lock. Resets on return to Earn dashboard. If other deeplinks also need to skip lock, could move this to AppState or somewhere more global. */
-  isDeepLinking: boolean;
 };
 
 // === PROTECT STATE ===

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -268,6 +268,8 @@ export type EarnState = {
     message?: string;
     messageTitle?: string;
   };
+  /** Earn web player deeplinks need to skip privacy lock. Resets on return to Earn dashboard. If other deeplinks also need to skip lock, could move this to AppState or somewhere more global. */
+  isDeepLinking: boolean;
 };
 
 // === PROTECT STATE ===

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
@@ -6,7 +6,7 @@ import { Track } from "../../../analytics";
 import QueuedDrawer from "../../../components/QueuedDrawer";
 import { useDispatch, useSelector } from "react-redux";
 import { earnInfoModalSelector } from "../../../reducers/earn";
-import { setEarnInfoModal } from "../../../actions/earn";
+import { setEarnInfoModal, setIsDeepLinking } from "../../../actions/earn";
 
 export function EarnInfoDrawer() {
   const { t } = useTranslation();
@@ -16,6 +16,8 @@ export function EarnInfoDrawer() {
   const closeModal = useCallback(async () => {
     await dispatch(setEarnInfoModal({}));
     await setModalOpened(false);
+
+    dispatch(setIsDeepLinking(false));
   }, [dispatch]);
   const { message, messageTitle } = useSelector(earnInfoModalSelector);
 
@@ -39,7 +41,7 @@ export function EarnInfoDrawer() {
             </Text>
           </Flex>
         </Flex>
-        <Button onPress={() => closeModal()} type="main">
+        <Button onPress={closeModal} type="main">
           {t("common.close")}
         </Button>
       </Flex>

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
@@ -6,17 +6,19 @@ import { Track } from "../../../analytics";
 import QueuedDrawer from "../../../components/QueuedDrawer";
 import { useDispatch, useSelector } from "react-redux";
 import { earnInfoModalSelector } from "../../../reducers/earn";
-import { setEarnInfoModal, setIsDeepLinking } from "../../../actions/earn";
+import { setEarnInfoModal } from "../../../actions/earn";
+import { setIsDeepLinking } from "../../../actions/appstate";
 
 export function EarnInfoDrawer() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [modalOpened, setModalOpened] = useState(false);
+
   const openModal = useCallback(() => setModalOpened(true), []);
+
   const closeModal = useCallback(async () => {
     await dispatch(setEarnInfoModal({}));
     await setModalOpened(false);
-
     dispatch(setIsDeepLinking(false));
   }, [dispatch]);
   const { message, messageTitle } = useSelector(earnInfoModalSelector);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

EARN dashboard on Android deep links (e.g. on tapping "Get [coin]" button) were triggering the LLM password lock.`<SkipLock />` does not work in this case because the background state is triggered more than once.

- Adds `isDeepLinking` to state
- Set on when deep link initiated
- Reset to false when earn screen is returned to, or drawer is closed

### ❓ Context

- **Impacted projects**: `` ledger-live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-9180

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->



### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
