### PR TITLE
fix(protect-2352): change don't see recover button better ui

### DIFF
--- a/.changeset/neat-colts-glow.md
+++ b/.changeset/neat-colts-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+change ui button device select restore flow

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RestoreWithProtect.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/RestoreWithProtect.tsx
@@ -5,7 +5,6 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Linking } from "react-native";
 import Button from "../../../../../components/wrappedUi/Button";
 import { TrackScreen } from "../../../../../analytics";
-import Touchable from "../../../../../components/Touchable";
 import QueuedDrawer from "../../../../../components/QueuedDrawer";
 import { urls } from "../../../../../config/urls";
 
@@ -98,11 +97,16 @@ const Next = ({ onNext }: { onNext: () => void }) => {
         />
       </QueuedDrawer>
       {restoreInfoDrawer?.enabled ? (
-        <Touchable onPress={onOpen}>
-          <Text textAlign="center" variant="large">
-            {t("onboarding.stepProtect.extraInfo.tooltip")}
-          </Text>
-        </Touchable>
+        <Button
+          type="shade"
+          outline
+          size="large"
+          onPress={onOpen}
+          event={"button_clicked"}
+          eventProperties={{ button: "Can't see recover" }}
+        >
+          <Text variant="small">{t("onboarding.stepProtect.extraInfo.tooltip")}</Text>
+        </Button>
       ) : null}
     </>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In order to have a better user experience, the text "I don't see Restore with Ledger recover" is replaced by a button.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [protect-2352](https://ledgerhq.atlassian.net/browse/PROTECT-2352) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

| BEFORE | AFTER |
|:--:|:--:|
| ![image](https://github.com/LedgerHQ/ledger-live/assets/118977988/67a4e46f-5204-43fe-87ec-8ec0f820e4e4) | ![image](https://github.com/LedgerHQ/ledger-live/assets/118977988/b63f6bb4-d92b-4cc8-bfb6-63ed879f4d1c) |

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
