### PR TITLE
[B2CQA] Detox disable failing detox market test

### DIFF
--- a/apps/ledger-live-mobile/e2e/specs/market.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/market.spec.ts
@@ -29,7 +29,8 @@ describe("Market page for user with no device", () => {
     await detox.expect(getElementByText("Bitcoin (BTC)")).toBeVisible();
   });
 
-  it("should redirect to the buy a nano marketplace page", async () => {
+  // FIXME Javascript error on webview
+  it.skip("should redirect to the buy a nano marketplace page", async () => {
     await marketPage.openAssetPage("Bitcoin (BTC)");
     await marketPage.buyNano();
     await marketPage.openMarketPlace();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Since yesterday, Detox E2E mobile market.spec.ts test fails.
We have an error when opening browser to buy nano [link](https://shop.ledger.com/products/ledger-nano-x?utm_source=ledger_live_mobile&utm_medium=buy_from_live&apptracking=false). 
Tested locally on emulator, error happens also when opening directly the link on Google Chrome. No issue on real device._

Disabling test until we find a proper fix.

https://github.com/LedgerHQ/ledger-live/assets/106583189/d7147154-c17e-4e1a-ab57-41c0dfc9bd85


### ❓ Context

- **Impacted projects**: [`Slack`](https://ledger.slack.com/archives/C030L0D26FN/p1694610593257559) <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [X] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [X] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [X] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
