### PR TITLE
Bugfix/live 9059 replace no funds with get staking funds flow

### DIFF
--- a/.changeset/real-wolves-lie.md
+++ b/.changeset/real-wolves-lie.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Conditionally render different text when user arrives at the buy funds modal from a get funds button rather than default of no funds. Applies to mobile and desktop.

--- a/apps/ledger-live-desktop/src/renderer/modals/NoFundsStake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/NoFundsStake/index.tsx
@@ -16,12 +16,30 @@ import { trackPage, track } from "~/renderer/analytics/segment";
 import { stakeDefaultTrack } from "~/renderer/screens/stake/constants";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
+const useText = (entryPoint: "noFunds" | "getFunds", currency: CryptoCurrency) => {
+  const { t } = useTranslation();
+
+  const textMap = {
+    noFunds: {
+      title: t("stake.noFundsModal.text", { coin: currency.ticker }),
+      body: t("stake.noFundsModal.description"),
+    },
+    getFunds: {
+      title: t("stake.getFundsModal.text", { coin: currency.ticker }),
+      body: t("stake.getFundsModal.description"),
+    },
+  };
+
+  return textMap[entryPoint];
+};
+
 interface NoFundsStakeModalProps {
   account: AccountLike | undefined | null;
   parentAccount?: Account | undefined | null;
+  entryPoint?: "get-funds" | undefined;
 }
 
-const NoFundsStakeModal = ({ account, parentAccount }: NoFundsStakeModalProps) => {
+const NoFundsStakeModal = ({ account, parentAccount, entryPoint }: NoFundsStakeModalProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -45,7 +63,11 @@ const NoFundsStakeModal = ({ account, parentAccount }: NoFundsStakeModalProps) =
   }, [providers, storedProviders]);
 
   const currency: CryptoCurrency = parentAccount?.currency || (account as Account).currency;
+
+  const text = useText(entryPoint === "get-funds" ? "getFunds" : "noFunds", currency);
+
   const availableOnBuy = currency && onRampAvailableTickers.includes(currency.ticker.toUpperCase());
+
   const availableOnSwap = useMemo(() => {
     return currency && swapAvailableIds.includes(currency.id);
   }, [currency, swapAvailableIds]);
@@ -143,13 +165,11 @@ const NoFundsStakeModal = ({ account, parentAccount }: NoFundsStakeModalProps) =
               <CoinsIcon />
             </Box>
             <Box textAlign="center" mb={16}>
-              <Text fontWeight="semiBold">
-                {t("stake.noFundsModal.text", { coin: currency.ticker })}
-              </Text>
+              <Text fontWeight="semiBold">{text.title}</Text>
             </Box>
             <Box textAlign="center" mb={24}>
               <Text fontSize={13} fontWeight="regular" color="neutral.c70">
-                {t("stake.noFundsModal.description")}
+                {text.body}
               </Text>
             </Box>
             {availableOnBuy && (

--- a/apps/ledger-live-desktop/src/renderer/modals/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/types.ts
@@ -62,6 +62,7 @@ export type GlobalModalData = {
   MODAL_NO_FUNDS_STAKE: {
     account: AccountLike | undefined | null;
     parentAccount?: Account | undefined | null;
+    entryPoint?: "get-funds" | undefined;
   };
   MODAL_PASSWORD: undefined;
   MODAL_DISABLE_PASSWORD: undefined;

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/useDeepLinkListener.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/useDeepLinkListener.ts
@@ -60,6 +60,7 @@ export const useDeepLinkListener = () => {
             shouldRedirect: false,
             currencies: [currencyId],
             alwaysShowNoFunds: true,
+            entryPoint: "get-funds",
           });
         }
         queryParams.delete("currencyId");

--- a/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/stake/index.tsx
@@ -16,6 +16,8 @@ type Props = {
   shouldRedirect?: boolean;
   alwaysShowNoFunds?: boolean;
   source?: string;
+  /** "get-funds" shows different text on no funds modal if entry point is "get coins" button. Default is undefined. */
+  entryPoint?: "get-funds" | undefined;
 };
 
 const useStakeFlow = () => {
@@ -24,7 +26,13 @@ const useStakeFlow = () => {
   const dispatch = useDispatch();
 
   return useCallback(
-    ({ currencies, shouldRedirect = true, alwaysShowNoFunds = false, source }: Props = {}) => {
+    ({
+      currencies,
+      shouldRedirect = true,
+      alwaysShowNoFunds = false,
+      source,
+      entryPoint,
+    }: Props = {}) => {
       const cryptoCurrencies = filterCurrencies(listCurrencies(true), {
         currencies: currencies || list,
       });
@@ -51,7 +59,13 @@ const useStakeFlow = () => {
             setDrawer();
 
             if (alwaysShowNoFunds) {
-              dispatch(openModal("MODAL_NO_FUNDS_STAKE", { account, parentAccount }));
+              dispatch(
+                openModal("MODAL_NO_FUNDS_STAKE", {
+                  account,
+                  parentAccount,
+                  entryPoint,
+                }),
+              );
             } else {
               dispatch(openModal("MODAL_START_STAKE", { account, parentAccount, source }));
             }

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -546,6 +546,10 @@
           "body": "Receive crypto in your wallet"
         }
       }
+    },
+    "getFundsModal": {
+      "text": "Get {{coin}} to stake",
+      "description": "Buy, swap or receive crypto directly to your Ledger using Ledger Live."
     }
   },
   "lottieDebugger": {

--- a/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
+++ b/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
@@ -14,6 +14,24 @@ import { NavigatorName, ScreenName } from "../../const";
 import { TrackScreen, useAnalytics, track } from "../../analytics";
 import type { NoFundsNavigatorParamList } from "../RootNavigator/types/NoFundsNavigator";
 import { StackNavigatorProps } from "../RootNavigator/types/helpers";
+import { Currency } from "@ledgerhq/types-cryptoassets";
+
+const useText = (entryPoint: "noFunds" | "getFunds", currency: Currency) => {
+  const { t } = useTranslation();
+
+  const textMap = {
+    noFunds: {
+      title: t("stake.noFundsModal.text", { coin: currency.ticker }),
+      body: t("stake.noFundsModal.description", { coin: currency.name }),
+    },
+    getFunds: {
+      title: t("stake.getFundsModal.text", { coin: currency.ticker }),
+      body: t("stake.getFundsModal.description", { coin: currency.name }),
+    },
+  };
+
+  return textMap[entryPoint];
+};
 
 type Props = StackNavigatorProps<NoFundsNavigatorParamList, ScreenName.NoFunds>;
 
@@ -30,12 +48,16 @@ type ButtonItem = {
   rightArrow: boolean;
 };
 
+/** Entry point is either "stake" button but user has insufficient funds in account, or "Get <ticker>" button on Earn dashboard, so text differs accordingly.  */
 export default function NoFunds({ route }: Props) {
   const { t } = useTranslation();
-  const { account, parentAccount } = route?.params;
+  const { account, parentAccount, entryPoint } = route?.params;
   const rampCatalog = useRampCatalog();
   const { providers } = useProviders();
   const navigation = useNavigation();
+
+  const text = useText(entryPoint === "get-funds" ? "getFunds" : "noFunds", account.currency);
+
   const onRampAvailableTickers = useMemo(() => {
     if (!rampCatalog.value) {
       return [];
@@ -142,10 +164,10 @@ export default function NoFunds({ route }: Props) {
           <CoinsIcon />
         </Flex>
         <Text variant="h4" textAlign="center" mt={10}>
-          {t("stake.noFundsModal.text", { coin: currency.ticker })}
+          {text.title}
         </Text>
         <Text variant="body" textAlign="center" color="neutral.c70" mt={6}>
-          {t("stake.noFundsModal.description", { coin: currency.name })}
+          {text.body}
         </Text>
       </Flex>
       <Flex my={8} mx={6}>

--- a/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
+++ b/apps/ledger-live-mobile/src/components/NoFunds/NoFunds.tsx
@@ -22,11 +22,11 @@ const useText = (entryPoint: "noFunds" | "getFunds", currency: Currency) => {
   const textMap = {
     noFunds: {
       title: t("stake.noFundsModal.text", { coin: currency.ticker }),
-      body: t("stake.noFundsModal.description", { coin: currency.name }),
+      body: t("stake.noFundsModal.description"),
     },
     getFunds: {
       title: t("stake.getFundsModal.text", { coin: currency.ticker }),
-      body: t("stake.getFundsModal.description", { coin: currency.name }),
+      body: undefined,
     },
   };
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -100,6 +100,7 @@ const Earn = (props: NavigationProps) => {
                 parentRoute: route,
                 // Stake flow will skip step 1 (select CryptoCurrency) and step 2 (select Account), and navigate straight to NoFunds flow:
                 alwaysShowNoFunds: true, // Navigate to NoFunds even if some funds available.
+                entryPoint: "get-funds",
               },
             });
           }

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/NoFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/NoFundsNavigator.ts
@@ -5,5 +5,6 @@ export type NoFundsNavigatorParamList = {
   [ScreenName.NoFunds]: {
     account: Account;
     parentAccount?: Account;
+    entryPoint?: "get-funds" | undefined;
   };
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/StakeNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/StakeNavigator.ts
@@ -7,6 +7,9 @@ export type StakeNavigatorParamList = {
     currencies?: string[];
     parentRoute?: RouteProp<ParamListBase>;
     account?: Account; // NB: not serialisable
-    alwaysShowNoFunds?: boolean; // Navigates to NoFunds to get more funds, even if there are funds
+    /** Navigate to NoFunds to get more funds, even if there are funds. */
+    alwaysShowNoFunds?: boolean;
+    /** Entry point is either account "stake" button but user has insufficient funds (default = undefined), or "Get <ticker>" button on Earn dashboard ("get-funds"). Text differs accordingly. */
+    entryPoint?: "get-funds" | undefined;
   };
 };

--- a/apps/ledger-live-mobile/src/components/Stake/index.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/index.tsx
@@ -26,7 +26,12 @@ const StakeFlow = ({ route }: Props) => {
     });
   }, [currencies]);
 
-  const goToAccountStakeFlow = useStakingDrawer({ navigation, parentRoute, alwaysShowNoFunds });
+  const goToAccountStakeFlow = useStakingDrawer({
+    navigation,
+    parentRoute,
+    alwaysShowNoFunds,
+    entryPoint: route.params.entryPoint,
+  });
 
   const requestAccount = useCallback(() => {
     if (cryptoCurrencies.length === 1) {

--- a/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/Stake/useStakingDrawer.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { ParamListBase, RouteProp } from "@react-navigation/native";
 import { Account } from "@ledgerhq/types-live";
@@ -9,60 +10,67 @@ export function useStakingDrawer({
   navigation,
   parentRoute,
   alwaysShowNoFunds,
+  entryPoint = undefined,
 }: {
   navigation: StackNavigationProp<{ [key: string]: object | undefined }>;
   parentRoute: RouteProp<ParamListBase> | undefined;
   alwaysShowNoFunds?: boolean | undefined;
+  entryPoint?: "get-funds" | undefined;
 }) {
-  return (account: Account, parentAccount?: Account) => {
-    if (alwaysShowNoFunds) {
-      // get funds to stake with
-      navigation.navigate(NavigatorName.Base, {
-        screen: NavigatorName.NoFundsFlow,
-        drawer: undefined,
-        params: {
-          screen: ScreenName.NoFunds,
+  return useCallback(
+    (account: Account, parentAccount?: Account) => {
+      if (alwaysShowNoFunds) {
+        // get funds to stake with
+        navigation.navigate(NavigatorName.Base, {
+          screen: NavigatorName.NoFundsFlow,
+          drawer: undefined,
           params: {
+            screen: ScreenName.NoFunds,
+            params: {
+              account,
+              parentAccount,
+              entryPoint,
+            },
+          },
+        });
+        return;
+      }
+
+      // @ts-expect-error issue in typing
+      const decorators = perFamilyAccountActions[account?.currency?.family];
+      // get the stake flow for the specific currency
+      const familySpecificMainActions =
+        (decorators &&
+          decorators.getMainActions &&
+          decorators.getMainActions({
+            account,
+            parentAccount,
+            colors: {},
+            parentRoute,
+          })) ||
+        [];
+      const stakeFlow = familySpecificMainActions.find(
+        (action: { id: string }) => action.id === "stake",
+      )?.navigationParams;
+
+      if (!stakeFlow) return null;
+
+      const [name, options] = stakeFlow;
+
+      // open staking drawer (or stake flow screens) for the specific currency, inside the current navigator
+      navigation.navigate(NavigatorName.Base, {
+        screen: name,
+        drawer: options?.drawer,
+        params: {
+          screen: options.screen,
+          params: {
+            ...(options?.params || {}),
             account,
             parentAccount,
           },
         },
       });
-      return;
-    }
-
-    // @ts-expect-error issue in typing
-    const decorators = perFamilyAccountActions[account?.currency?.family];
-    // get the stake flow for the specific currency
-    const familySpecificMainActions =
-      (decorators &&
-        decorators.getMainActions &&
-        decorators.getMainActions({
-          account,
-          parentAccount,
-          colors: {},
-          parentRoute,
-        })) ||
-      [];
-    const stakeFlow = familySpecificMainActions.find(
-      (action: { id: string }) => action.id === "stake",
-    )?.navigationParams;
-    if (!stakeFlow) return null;
-
-    const [name, options] = stakeFlow;
-
-    // open staking drawer (or stake flow screens) for the specific currency, inside the current navigator
-    navigation.navigate(NavigatorName.Base, {
-      screen: name,
-      drawer: options?.drawer,
-      params: {
-        screen: options.screen,
-        params: {
-          ...(options?.params || {}),
-          account,
-          parentAccount,
-        },
-      },
-    });
-  };
+    },
+    [alwaysShowNoFunds, parentRoute, navigation, entryPoint],
+  );
 }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6430,6 +6430,10 @@
           "body": "Receive crypto in your wallet"
         }
       }
+    },
+    "getFundsModal": {
+      "text": "Get {{coin}} to stake for rewards*",
+      "description": "Buy, swap or receive {{coin}} directly to your Ledger using Ledger Live."
     }
   }
 }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6432,8 +6432,8 @@
       }
     },
     "getFundsModal": {
-      "text": "Get {{coin}} to stake for rewards*",
-      "description": "Buy, swap or receive {{coin}} directly to your Ledger using Ledger Live."
+      "text": "Get {{coin}} to stake",
+      "description": "Buy, swap or receive crypto directly to your Ledger using Ledger Live."
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Conditionally display different text when user arrives at "no funds" modal from a "get funds" button and therefore may already have funds.
- Fix for both desktop and mobile.

### ❓ Context

- **Impacted projects**: `desktop` `mobile` (earn dashboard --> get coins --> buy flow)
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-9059

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/11fe329e-1720-44ad-b77f-50521cf7f5bc)



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
