### PR TITLE
feat: setup new log system and record logs from LLD internal thread

### DIFF
--- a/.changeset/lazy-months-smash.md
+++ b/.changeset/lazy-months-smash.md
@@ -1,0 +1,11 @@
+---
+"ledger-live-desktop": patch
+---
+
+feat: enable printing logs to stdout for debug and record logs from internal thread
+
+- Logs from the internal thread are forward to the main thread
+- The main thread records them, and can export them
+- If `VERBOSE` env var is set, filtered logs can be stdout from the main thread
+- Same from the renderer thread
+- Setup simple tracing system (context) on LLD

--- a/.changeset/little-squids-repair.md
+++ b/.changeset/little-squids-repair.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/logs": minor
+---
+
+feat: new trace and LocalTracer definition
+
+Without breaking the behavior of the existing log function

--- a/.changeset/purple-chefs-hear.md
+++ b/.changeset/purple-chefs-hear.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-env": patch
+---
+
+feat: enable printing logs to stdout for debug
+
+- Setup simple tracing system on LLM with context
+- If `VERBOSE` env var is set, filtered logs can be stdout from the main thread

--- a/.changeset/thirty-coats-dance.md
+++ b/.changeset/thirty-coats-dance.md
@@ -1,0 +1,12 @@
+---
+"@ledgerhq/hw-transport-node-hid-singleton": minor
+"@ledgerhq/hw-transport-node-hid-noevents": minor
+"@ledgerhq/react-native-hw-transport-ble": minor
+"@ledgerhq/hw-transport": minor
+"@ledgerhq/live-common": patch
+---
+
+feat: usage of new tracing system
+
+The tracing helps keeping a context (for ex a `job id`) that is propagated to other logs,
+creating a (simple) tracing span

--- a/apps/ledger-live-desktop/src/internal/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/internal/live-common-setup.ts
@@ -10,18 +10,18 @@ import { DisconnectedDevice } from "@ledgerhq/errors";
 import { TraceContext, listen as listenLogs } from "@ledgerhq/logs";
 import { ForwardToMainLogger } from "./logger";
 
+/* eslint-disable guard-for-in */
+for (const k in process.env) {
+  setEnvUnsafe(k, process.env[k]);
+}
+/* eslint-enable guard-for-in */
+
 const forwardToMainLogger = ForwardToMainLogger.getLogger();
 
 // Listens to logs from the internal threads, and forwards them to the main thread
 listenLogs(log => {
   forwardToMainLogger.log(log);
 });
-
-/* eslint-disable guard-for-in */
-for (const k in process.env) {
-  setEnvUnsafe(k, process.env[k]);
-}
-/* eslint-enable guard-for-in */
 
 setErrorRemapping(e => {
   // NB ideally we should solve it in ledgerjs

--- a/apps/ledger-live-desktop/src/internal/logger.ts
+++ b/apps/ledger-live-desktop/src/internal/logger.ts
@@ -1,0 +1,31 @@
+import { Log } from "@ledgerhq/logs";
+
+/**
+ * Simple logger sending recorded logs directly to the main process
+ *
+ * Usage: records logs coming from `@ledgerhq/logs` in the internal thread
+ *
+ * If performance issues are seen because of this direct send to the main process, several ideas could be implemented:
+ * - a filtering on the `type` (or/and a level if it is implemented in `@ledgerhq/logs`) set from an env variable
+ * - a `bulkLog` that records logs until a given threshold, and send them to the main process when reached
+ */
+export class ForwardToMainLogger {
+  private static instance: ForwardToMainLogger | undefined;
+
+  // Simple singleton factory
+  static getLogger() {
+    if (!ForwardToMainLogger.instance) {
+      ForwardToMainLogger.instance = new ForwardToMainLogger();
+    }
+    return ForwardToMainLogger.instance;
+  }
+
+  // We could have a "log:bulk-log"
+  log(log: Log) {
+    process?.send?.({
+      type: "log:log",
+      data: log,
+      requestId: "log", // Not used
+    });
+  }
+}

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require("@electron/remote/main").initialize();
 
-import "./setup";
+import "./setup"; // Needs to be imported first
 import { app, Menu, ipcMain, session, webContents, shell, BrowserWindow } from "electron";
 import Store from "electron-store";
 import menu from "./menu";

--- a/apps/ledger-live-desktop/src/main/internal-lifecycle.ts
+++ b/apps/ledger-live-desktop/src/main/internal-lifecycle.ts
@@ -14,23 +14,31 @@ import {
   transportListenUnsubscribeChannel,
 } from "~/config/transportChannels";
 import { Message as ToInternalMessage } from "~/internal/types";
+import { ConsoleLogger, InMemoryLogger, isALog } from "./logger";
 
 // ~~~
 
 const LEDGER_CONFIG_DIRECTORY = app.getPath("userData");
 const HOME_DIRECTORY = app.getPath("home");
-const internal = new InternalProcess({
-  timeout: 3000,
-});
 let sentryEnabled: boolean | null = null;
 let userId: string | null = null;
 let sentryTags: string | null = null;
+
+const internal = new InternalProcess({
+  timeout: 3000,
+});
+
+const inMemoryLogger = InMemoryLogger.getLogger();
+const consoleLogger = ConsoleLogger.getLogger();
+
 export function getSentryEnabled(): boolean | null {
   return sentryEnabled;
 }
+
 export function setUserId(id: string) {
   userId = id;
 }
+
 ipcMain.handle("set-sentry-tags", (event, tags) => {
   setTags(tags);
   const tagsJSON = JSON.stringify(tags);
@@ -40,6 +48,7 @@ ipcMain.handle("set-sentry-tags", (event, tags) => {
     tagsJSON,
   });
 });
+
 const spawnCoreProcess = () => {
   const env = {
     ...getAllEnvs(),
@@ -52,31 +61,50 @@ const spawnCoreProcess = () => {
     INITIAL_SENTRY_ENABLED: String(!!sentryEnabled),
     SENTRY_USER_ID: userId,
   };
+
   internal.configure(path.resolve(__dirname, "main.bundle.js"), [], {
     silent: true,
     // @ts-expect-error Some envs are not typed as strings…
     env,
+    // Passes a list of env variables set on `LEDGER_INTERNAL_ARGS` to the internal thread
     execArgv: (process.env.LEDGER_INTERNAL_ARGS || "").split(/[ ]+/).filter(Boolean),
   });
   internal.start();
 };
+
 internal.onStart(() => {
   internal.process?.on("message", handleGlobalInternalMessage);
 });
+
 app.on("window-all-closed", async () => {
   if (internal.active) {
     await internal.stop();
   }
   app.quit();
 });
+
 ipcMain.on("clean-processes", async () => {
   if (internal.active) {
     await internal.stop();
   }
   spawnCoreProcess();
 });
+
 const ongoing: Record<string, Electron.IpcMainEvent> = {};
+
+// Sets up callback on messages coming from the internal process
 internal.onMessage(message => {
+  if (message.type === "log:log") {
+    if (!message.data || !isALog(message.data)) {
+      console.error(`Log not in correct format: ${JSON.stringify(message.data)}`);
+    } else {
+      inMemoryLogger.log(message.data);
+      consoleLogger.log(message.data);
+    }
+
+    return;
+  }
+
   const event = ongoing[message.requestId];
   if (event) {
     event.reply("command-event", message);
@@ -85,6 +113,7 @@ internal.onMessage(message => {
     }
   }
 });
+
 internal.onExit((code, signal, unexpected) => {
   if (unexpected) {
     Object.keys(ongoing).forEach(requestId => {
@@ -169,7 +198,9 @@ ipcMain.on("setEnv", async (event, env) => {
   }
 });
 
-// route internal process messages to renderer
+// Routes a (request) message from the renderer process to the internal process,
+// and sets a handler to receive the response from the internal thread and reply it to the renderer process
+// Only 1 response from the internal process is expected.
 const internalHandlerPromise = (channel: string) => {
   ipcMain.on(channel, (event, { data, requestId }) => {
     const replyChannel = `${channel}_RESPONSE_${requestId}`;
@@ -198,7 +229,8 @@ const internalHandlerPromise = (channel: string) => {
   });
 };
 
-// multi event version of internalHandler
+// Multi event version of internalHandlerPromise:
+// Several response from the internal process can be expected
 const internalHandlerObservable = (channel: string) => {
   ipcMain.on(channel, (event, { data, requestId }) => {
     const replyChannel = `${channel}_RESPONSE_${requestId}`;
@@ -230,7 +262,8 @@ const internalHandlerObservable = (channel: string) => {
   });
 };
 
-// simple event routing
+// Only routes a (request) message from the renderer process to the internal process
+// No response from the internal process is expected.
 const internalHandlerEvent = (channel: string) => {
   ipcMain.on(channel, (event, { data, requestId }) => {
     internal.send({
@@ -240,6 +273,7 @@ const internalHandlerEvent = (channel: string) => {
     } as ToInternalMessage);
   });
 };
+
 internalHandlerPromise(transportOpenChannel);
 internalHandlerPromise(transportExchangeChannel);
 internalHandlerPromise(transportCloseChannel);

--- a/apps/ledger-live-desktop/src/main/internal-lifecycle.ts
+++ b/apps/ledger-live-desktop/src/main/internal-lifecycle.ts
@@ -183,7 +183,13 @@ ipcMain.on("internalCrashTest", () => {
 });
 ipcMain.on("setEnv", async (event, env) => {
   const { name, value } = env;
+
   if (setEnvUnsafe(name, value)) {
+    // Enables updating at runtime the settings of logs printed on stdout
+    if (name === "VERBOSE") {
+      consoleLogger.refreshSetup();
+    }
+
     if (isRestartNeeded(name)) {
       if (internal.active) {
         await internal.stop();

--- a/apps/ledger-live-desktop/src/main/logger.ts
+++ b/apps/ledger-live-desktop/src/main/logger.ts
@@ -70,8 +70,8 @@ export class InMemoryLogger {
  */
 export class ConsoleLogger {
   private static instance: ConsoleLogger | undefined;
-  private everyLogs: boolean;
-  private filters: Array<string>;
+  private everyLogs: boolean = false;
+  private filters: Array<string> = [];
 
   /**
    * Sets up debug console printing of logs
@@ -81,12 +81,27 @@ export class ConsoleLogger {
    * - VERBOSE=1 or VERBOSE=true : to print all logs
    */
   private constructor() {
-    // `VERBOSE` cannot be changed at runtime
-    const { VERBOSE } = process.env;
+    this.refreshSetup();
+  }
 
-    if (VERBOSE) {
-      this.everyLogs = VERBOSE === "true" || VERBOSE === "1";
-      this.filters = this.everyLogs ? [] : VERBOSE.split(",");
+  // Simple singleton factory
+  static getLogger() {
+    if (!ConsoleLogger.instance) {
+      ConsoleLogger.instance = new ConsoleLogger();
+    }
+    return ConsoleLogger.instance;
+  }
+
+  /**
+   * Refreshes the logger config from the `VERBOSE` env variable
+   */
+  refreshSetup() {
+    const logVerbose = getEnv("VERBOSE");
+
+    if (logVerbose) {
+      this.everyLogs =
+        logVerbose.length === 1 && (logVerbose[0] === "true" || logVerbose[0] === "1");
+      this.filters = this.everyLogs ? [] : logVerbose;
 
       // eslint-disable-next-line no-console
     } else {
@@ -98,17 +113,8 @@ export class ConsoleLogger {
       `Logs console display setup (main thread): ${JSON.stringify({
         everyLogs: this.everyLogs,
         filters: this.filters,
-        verbose: VERBOSE,
       })}`,
     );
-  }
-
-  // Simple singleton factory
-  static getLogger() {
-    if (!ConsoleLogger.instance) {
-      ConsoleLogger.instance = new ConsoleLogger();
-    }
-    return ConsoleLogger.instance;
   }
 
   /**

--- a/apps/ledger-live-desktop/src/main/logger.ts
+++ b/apps/ledger-live-desktop/src/main/logger.ts
@@ -1,0 +1,132 @@
+import { getEnv } from "@ledgerhq/live-env";
+import { Log } from "@ledgerhq/logs";
+export type { Log };
+
+// Runtime type check (type predicate) on the logs
+export function isALog(log: unknown): log is Log {
+  return (
+    (log as Log).id !== undefined &&
+    (log as Log).type !== undefined &&
+    (log as Log).date !== undefined
+  );
+}
+
+/**
+ * Simple logger recording logs in memory (in the main thread)
+ *
+ * Used to record logs coming from the internal process.
+ * The logs follow the structure of `Log` from `@ledgerhq/logs`
+ *
+ * Works as a singleton
+ */
+export class InMemoryLogger {
+  private logRecord: Log[];
+  private static instance: InMemoryLogger | undefined;
+
+  private constructor() {
+    this.logRecord = [];
+  }
+
+  // Simple singleton factory
+  static getLogger() {
+    if (!InMemoryLogger.instance) {
+      InMemoryLogger.instance = new InMemoryLogger();
+    }
+    return InMemoryLogger.instance;
+  }
+
+  /**
+   * Records a log in memory.
+   * If more logs are recorded than `maxLogCount`, the oldest ones are removed.
+   */
+  log(log: Log) {
+    // Those env variables can be updated at runtime
+    const maxLogCount = getEnv("EXPORT_MAX_LOGS");
+    const excludedLogTypes = getEnv("EXPORT_EXCLUDED_LOG_TYPES").split(",");
+
+    if (!excludedLogTypes.includes(log.type)) {
+      this.logRecord.unshift(log);
+
+      while (this.logRecord.length > maxLogCount) {
+        this.logRecord.pop();
+      }
+    }
+  }
+
+  /**
+   * Returns the list of recorded logs, from the most recent to the oldest.
+   */
+  getLogs(): Log[] {
+    return this.logRecord;
+  }
+}
+
+/**
+ * Simple logger displaying on the console/stdout logs from the main thread
+ *
+ * The filtering is set from the `VERBOSE` env variable.
+ *
+ * Works as a singleton.
+ */
+export class ConsoleLogger {
+  private static instance: ConsoleLogger | undefined;
+  private everyLogs: boolean;
+  private filters: Array<string>;
+
+  /**
+   * Sets up debug console printing of logs
+   *
+   * Usage: a filtering (only on console printing) on Ledger libs are possible:
+   * - VERBOSE="apdu,hw,transport,hid-verbose" : filtering on a list of log `type` separated by a `,`
+   * - VERBOSE=1 or VERBOSE=true : to print all logs
+   */
+  private constructor() {
+    // `VERBOSE` cannot be changed at runtime
+    const { VERBOSE } = process.env;
+
+    if (VERBOSE) {
+      this.everyLogs = VERBOSE === "true" || VERBOSE === "1";
+      this.filters = this.everyLogs ? [] : VERBOSE.split(",");
+
+      // eslint-disable-next-line no-console
+    } else {
+      this.everyLogs = false;
+      this.filters = [];
+    }
+
+    console.log(
+      `Logs console display setup (main thread): ${JSON.stringify({
+        everyLogs: this.everyLogs,
+        filters: this.filters,
+        verbose: VERBOSE,
+      })}`,
+    );
+  }
+
+  // Simple singleton factory
+  static getLogger() {
+    if (!ConsoleLogger.instance) {
+      ConsoleLogger.instance = new ConsoleLogger();
+    }
+    return ConsoleLogger.instance;
+  }
+
+  /**
+   * Displays a log in the console, if not filtered out.
+   */
+  log({ type, message, context, ...rest }: Log) {
+    if (!this.everyLogs && !this.filters.includes(type)) {
+      return;
+    }
+
+    if (context) {
+      // Displays the tracing context before the message for better readability in the console
+      console.log(
+        `------------------------------\n${type}: ${JSON.stringify(context)}\n${message || ""}\n`,
+        rest,
+      );
+    } else {
+      console.log(`------------------------------\n${type}: ${message || ""}`, rest);
+    }
+  }
+}

--- a/apps/ledger-live-desktop/src/main/logger.ts
+++ b/apps/ledger-live-desktop/src/main/logger.ts
@@ -119,14 +119,27 @@ export class ConsoleLogger {
       return;
     }
 
-    if (context) {
-      // Displays the tracing context before the message for better readability in the console
-      console.log(
-        `------------------------------\n${type}: ${JSON.stringify(context)}\n${message || ""}\n`,
-        rest,
-      );
-    } else {
-      console.log(`------------------------------\n${type}: ${message || ""}`, rest);
+    try {
+      if (context) {
+        // Displays the tracing context before the message for better readability in the console
+        // eslint-disable-next-line no-console
+        console.log(
+          `------------------------------\n${type}: ${JSON.stringify(context, null, 2)}\n${
+            message || ""
+          }\n${JSON.stringify(rest, null, 2)}`,
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(
+          `------------------------------\n${type}: ${message || ""}${JSON.stringify(
+            rest,
+            null,
+            2,
+          )}`,
+        );
+      }
+    } catch (_e) {
+      console.error("Badly formatted log");
     }
   }
 }

--- a/apps/ledger-live-desktop/src/main/setup.ts
+++ b/apps/ledger-live-desktop/src/main/setup.ts
@@ -8,6 +8,17 @@ import updater from "./updater";
 import resolveUserDataDirectory from "~/helpers/resolveUserDataDirectory";
 import path from "path";
 import { InMemoryLogger } from "./logger";
+import { setEnvUnsafe } from "@ledgerhq/live-env";
+
+/**
+ * Sets env variables for the main thread.
+ *
+ * The renderer thread will also set some env variables via the `setEnv` IPC channel
+ * but we might need some envs before the renderer thread is spawned.
+ */
+for (const k in process.env) {
+  setEnvUnsafe(k, process.env[k]);
+}
 
 ipcMain.on("mainCrashTest", () => {
   captureException(new Error("CrashTestMain"));

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -14,6 +14,7 @@ import {
 } from "~/config/transportChannels";
 import { Observer } from "rxjs";
 import { DescriptorEvent } from "@ledgerhq/types-devices";
+
 const rendererRequest = (channel: string, data: unknown) => {
   return new Promise((resolve, reject) => {
     const requestId = uuidv4();
@@ -87,18 +88,18 @@ export class IPCTransport extends Transport {
 
   async exchange(apdu: Buffer): Promise<Buffer> {
     const apduHex = apdu.toString("hex");
-    log("apdu", "=> " + apduHex);
+    log("ipc-apdu", "=> " + apduHex);
     const responseHex = await rendererRequest(transportExchangeChannel, {
       descriptor: this.id,
       apduHex,
     });
-    log("apdu", "<= " + responseHex);
+    log("ipc-apdu", "<= " + responseHex);
     return Buffer.from(responseHex as string, "hex");
   }
 
   exchangeBulk(apdus: Buffer[], observer: Observer<Buffer>) {
     const apdusHex = apdus.map(apdu => apdu.toString("hex"));
-    log("apdu-info", "bulk of " + apdusHex.length + " apdus");
+    log("ipc-apdu-info", "bulk of " + apdusHex.length + " apdus");
     const requestId = uuidv4();
     const replyChannel = `${transportExchangeBulkChannel}_RESPONSE_${requestId}`;
     const handler = (

--- a/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.tsx
@@ -13,8 +13,17 @@ import Button, { Props as ButtonProps } from "~/renderer/components/Button";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 
 const saveLogs = async (path: Electron.SaveDialogReturnValue) => {
-  // Requests the main thread to save logs in a file
-  await ipcRenderer.invoke("save-logs", path, memoryLogger.getMemoryLogs());
+  const memoryLogs = memoryLogger.getMemoryLogs();
+
+  try {
+    // Serializes ourself with `stringify` to avoid "object could not be cloned" errors from the electron IPC serializer.
+    const memoryLogsStr = JSON.stringify(memoryLogs, null, 2);
+
+    // Requests the main thread to save logs in a file
+    await ipcRenderer.invoke("save-logs", path, memoryLogsStr);
+  } catch (error) {
+    console.error("Error while requesting to save logs from the renderer thread", error);
+  }
 };
 
 type RestProps = ButtonProps & {

--- a/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ExportLogsButton.tsx
@@ -13,11 +13,8 @@ import Button, { Props as ButtonProps } from "~/renderer/components/Button";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 
 const saveLogs = async (path: Electron.SaveDialogReturnValue) => {
-  await ipcRenderer.invoke(
-    "save-logs",
-    path,
-    JSON.stringify(memoryLogger.getMemoryLogs(), null, 2),
-  );
+  // Requests the main thread to save logs in a file
+  await ipcRenderer.invoke("save-logs", path, memoryLogger.getMemoryLogs());
 };
 
 type RestProps = ButtonProps & {

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -48,32 +48,33 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { listCachedCurrencyIds } from "./bridge/cache";
 import { LogEntry } from "winston";
 
-const { VERBOSE } = process.env;
-/**
- * Sets up a debug console printing of logs (from the renderer thread)
- *
- * Usage: a filtering (only on console printing) on Ledger libs are possible:
- * - VERBOSE="apdu,hw,transport,hid-verbose" : filtering on a list of log `type` separated by a `,`
- * - VERBOSE=1 or VERBOSE=true : to print all logs
- */
-if (VERBOSE) {
-  const everyLogs = VERBOSE === "true" || VERBOSE === "1";
-  const filters = everyLogs ? [] : VERBOSE.split(",");
-
-  // eslint-disable-next-line no-console
-  console.log(
-    `Logs console display setup (renderer thread): ${JSON.stringify({
-      everyLogs,
-      filters,
-      verbose: VERBOSE,
-    })}`,
-  );
-  enableDebugLogger((log: LogEntry) => everyLogs || (log?.type && filters.includes(log.type)));
-}
-
 const rootNode = document.getElementById("react-root");
 const TAB_KEY = 9;
+
 async function init() {
+  const logVerbose = getEnv("VERBOSE");
+
+  // Sets up a debug console printing of logs (from the renderer thread)
+  //
+  // Usage: a filtering (only on console printing) on Ledger libs are possible:
+  // - VERBOSE="apdu,hw,transport,hid-verbose" : filtering on a list of log `type` separated by a `,`
+  // - VERBOSE=1 or VERBOSE=true : to print all logs
+  if (logVerbose) {
+    const everyLogs =
+      logVerbose.length === 1 && (logVerbose[0] === "true" || logVerbose[0] === "1");
+
+    const filters = everyLogs ? [] : logVerbose;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `Logs console display setup (renderer thread): ${JSON.stringify({
+        everyLogs,
+        filters,
+      })}`,
+    );
+    enableDebugLogger((log: LogEntry) => everyLogs || (log?.type && filters.includes(log.type)));
+  }
+
   checkLibs({
     NotEnoughBalance,
     React,

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -46,9 +46,31 @@ import { expectOperatingSystemSupportStatus } from "~/support/os";
 import { addDevice, removeDevice, resetDevices } from "~/renderer/actions/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { listCachedCurrencyIds } from "./bridge/cache";
-if (process.env.VERBOSE) {
-  enableDebugLogger();
+import { LogEntry } from "winston";
+
+const { VERBOSE } = process.env;
+/**
+ * Sets up a debug console printing of logs (from the renderer thread)
+ *
+ * Usage: a filtering (only on console printing) on Ledger libs are possible:
+ * - VERBOSE="apdu,hw,transport,hid-verbose" : filtering on a list of log `type` separated by a `,`
+ * - VERBOSE=1 or VERBOSE=true : to print all logs
+ */
+if (VERBOSE) {
+  const everyLogs = VERBOSE === "true" || VERBOSE === "1";
+  const filters = everyLogs ? [] : VERBOSE.split(",");
+
+  // eslint-disable-next-line no-console
+  console.log(
+    `Logs console display setup (renderer thread): ${JSON.stringify({
+      everyLogs,
+      filters,
+      verbose: VERBOSE,
+    })}`,
+  );
+  enableDebugLogger((log: LogEntry) => everyLogs || (log?.type && filters.includes(log.type)));
 }
+
 const rootNode = document.getElementById("react-root");
 const TAB_KEY = 9;
 async function init() {

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -11,23 +11,18 @@ import { setEnvOnAllThreads } from "./../helpers/env";
 import { IPCTransport } from "./IPCTransport";
 import logger from "./logger";
 import { currentMode, setDeviceMode } from "@ledgerhq/live-common/hw/actions/app";
-import { ipcRenderer } from "electron";
-
-listenLogs(({ id, date, ...log }) => {
-  // console.log(`🐬 listenLogs: ${JSON.stringify(log)}`);
-  if (log.type === "hid-frame") return;
-
-  logger.debug(log);
-});
-
-ipcRenderer.on("log:internal", event => {
-  console.log(`👽 LOG from internal: ${JSON.stringify(event)}`);
-});
 
 setEnvOnAllThreads("USER_ID", getUserId());
 
 const originalDeviceMode = currentMode;
 const vaultTransportPrefixID = "vault-transport:";
+
+// Listens to logs from `@ledgerhq/logs` (happening on the renderer thread) and transfers them to the LLD logger system
+listenLogs(({ id, date, ...log }) => {
+  if (log.type === "hid-frame") return;
+
+  logger.debug(log);
+});
 
 // This defines our IPC Transport that will proxy to an internal process (we shouldn't use node-hid on renderer)
 registerTransportModule({

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -11,11 +11,19 @@ import { setEnvOnAllThreads } from "./../helpers/env";
 import { IPCTransport } from "./IPCTransport";
 import logger from "./logger";
 import { currentMode, setDeviceMode } from "@ledgerhq/live-common/hw/actions/app";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { ipcRenderer } from "electron";
+
 listenLogs(({ id, date, ...log }) => {
+  // console.log(`🐬 listenLogs: ${JSON.stringify(log)}`);
   if (log.type === "hid-frame") return;
+
   logger.debug(log);
 });
+
+ipcRenderer.on("log:internal", event => {
+  console.log(`👽 LOG from internal: ${JSON.stringify(event)}`);
+});
+
 setEnvOnAllThreads("USER_ID", getUserId());
 
 const originalDeviceMode = currentMode;

--- a/apps/ledger-live-desktop/src/renderer/logger/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/index.ts
@@ -307,7 +307,6 @@ export default {
   debug: (...args: unknown[]) => {
     // @ts-expect-error spreading unknowns is fine
     logger.log("debug", ...args);
-    console.log(`LOGGER: debug: ${JSON.stringify(args)}`);
   },
   info: (...args: unknown[]) => {
     // @ts-expect-error spreading unknowns is fine

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -137,16 +137,27 @@ if (VERBOSE) {
       return;
     }
 
-    if (context) {
-      // Displays the tracing context before the message for better readability in the console
-      // eslint-disable-next-line no-console
-      console.log(
-        `------------------------------\n${type}: ${JSON.stringify(context)}\n${message || ""}\n`,
-        rest,
-      );
-    } else {
-      // eslint-disable-next-line no-console
-      console.log(`------------------------------\n${type}: ${message || ""}`, rest);
+    try {
+      if (context) {
+        // Displays the tracing context before the message for better readability in the console
+        // eslint-disable-next-line no-console
+        console.log(
+          `------------------------------\n${type}: ${JSON.stringify(context, null, 2)}\n${
+            message || ""
+          }\n${JSON.stringify(rest, null, 2)}`,
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(
+          `------------------------------\n${type}: ${message || ""}${JSON.stringify(
+            rest,
+            null,
+            2,
+          )}`,
+        );
+      }
+    } catch (_e) {
+      console.error("Badly formatted log");
     }
   });
 }

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -25,7 +25,12 @@ import { setGlobalOnBridgeError } from "@ledgerhq/live-common/bridge/useBridgeTr
 import { prepareCurrency } from "./bridge/cache";
 import BluetoothTransport from "./react-native-hw-transport-ble";
 import "./experimental";
-import logger from "./logger";
+import logger, { ConsoleLogger } from "./logger";
+
+const consoleLogger = ConsoleLogger.getLogger();
+listen(log => {
+  consoleLogger.log(log);
+});
 
 setGlobalOnBridgeError(e => logger.critical(e));
 setDeviceMode("polling");
@@ -111,56 +116,6 @@ setSupportedCurrencies([
   "coreum",
   "injective",
 ]);
-
-const { VERBOSE } = Config;
-
-/**
- * Sets up a printing of logs in the console/stdout
- *
- * The configuration is done with the env variable `VERBOSE`
- *
- * Usage: a filtering (only on console printing) on Ledger libs are possible:
- * - VERBOSE="apdu,hw,transport,hid-verbose" : filtering on a list of log `type` separated by a `,`
- * - VERBOSE=1 or VERBOSE=true : to print all logs
- *
- * Note: we should add a log level defined in our logger, different that `type`.
- */
-if (VERBOSE) {
-  const everyLogs = VERBOSE === "true" || VERBOSE === "1";
-  const filters = everyLogs ? [] : VERBOSE.split(",");
-
-  // eslint-disable-next-line no-console
-  console.log(`Logs console display setup: ${JSON.stringify({ everyLogs, filters })}`);
-
-  listen(({ type, message, context, ...rest }) => {
-    if (!everyLogs && !filters.includes(type)) {
-      return;
-    }
-
-    try {
-      if (context) {
-        // Displays the tracing context before the message for better readability in the console
-        // eslint-disable-next-line no-console
-        console.log(
-          `------------------------------\n${type}: ${JSON.stringify(context, null, 2)}\n${
-            message || ""
-          }\n${JSON.stringify(rest, null, 2)}`,
-        );
-      } else {
-        // eslint-disable-next-line no-console
-        console.log(
-          `------------------------------\n${type}: ${message || ""}${JSON.stringify(
-            rest,
-            null,
-            2,
-          )}`,
-        );
-      }
-    } catch (_e) {
-      console.error("Badly formatted log");
-    }
-  });
-}
 
 if (Config.BLE_LOG_LEVEL) BluetoothTransport.setLogLevel(Config.BLE_LOG_LEVEL);
 if (Config.FORCE_PROVIDER && !isNaN(parseInt(Config.FORCE_PROVIDER, 10)))

--- a/apps/ledger-live-mobile/src/logger.ts
+++ b/apps/ledger-live-mobile/src/logger.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
 import * as Sentry from "@sentry/react-native";
 import Config from "react-native-config"; // for now we have the bare minimum
+import { Log } from "@ledgerhq/logs";
+import { getEnv, setEnvUnsafe } from "@ledgerhq/live-env";
 
 export default {
   critical: (e: Error) => {
@@ -12,3 +14,97 @@ export default {
     }
   },
 };
+
+/**
+ * Simple logger displaying on the console/stdout logs
+ *
+ * The filtering is set from the `VERBOSE` env variable.
+ *
+ * Works as a singleton.
+ *
+ * Note: we should add a log level defined in our logger, different that `type`.
+ */
+export class ConsoleLogger {
+  private static instance: ConsoleLogger | undefined;
+  private everyLogs: boolean = false;
+  private filters: Array<string> = [];
+
+  /**
+   * Sets up debug console printing of logs
+   *
+   * Usage: a filtering (only on console printing) on Ledger libs are possible:
+   * - VERBOSE="apdu,hw,transport,hid-verbose" : filtering on a list of log `type` separated by a `,`
+   * - VERBOSE=1 or VERBOSE=true : to print all logs
+   */
+  private constructor() {
+    // Makes sure the `VERBOSE` env has been set before the logger is created
+    setEnvUnsafe("VERBOSE", Config.VERBOSE);
+
+    this.refreshSetup();
+  }
+
+  // Simple singleton factory
+  static getLogger() {
+    if (!ConsoleLogger.instance) {
+      ConsoleLogger.instance = new ConsoleLogger();
+    }
+    return ConsoleLogger.instance;
+  }
+
+  /**
+   * Refreshes the logger config from the `VERBOSE` env variable
+   */
+  refreshSetup() {
+    const logVerbose = getEnv("VERBOSE");
+
+    if (logVerbose) {
+      this.everyLogs =
+        logVerbose.length === 1 && (logVerbose[0] === "true" || logVerbose[0] === "1");
+      this.filters = this.everyLogs ? [] : logVerbose;
+
+      // eslint-disable-next-line no-console
+    } else {
+      this.everyLogs = false;
+      this.filters = [];
+    }
+
+    console.log(
+      `Logs console display setup: ${JSON.stringify({
+        everyLogs: this.everyLogs,
+        filters: this.filters,
+      })}`,
+    );
+  }
+
+  /**
+   * Displays a log in the console, if not filtered out.
+   */
+  log({ type, message, context, ...rest }: Log) {
+    if (!this.everyLogs && !this.filters.includes(type)) {
+      return;
+    }
+
+    try {
+      if (context) {
+        // Displays the tracing context before the message for better readability in the console
+        // eslint-disable-next-line no-console
+        console.log(
+          `------------------------------\n${type}: ${JSON.stringify(context, null, 2)}\n${
+            message || ""
+          }\n${JSON.stringify(rest, null, 2)}`,
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(
+          `------------------------------\n${type}: ${message || ""}${JSON.stringify(
+            rest,
+            null,
+            2,
+          )}`,
+        );
+      }
+    } catch (_e) {
+      console.error("Badly formatted log");
+    }
+  }
+}

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -783,6 +783,11 @@ const envDefinitions = {
     parser: floatParser,
     desc: "Cancel transaction gasprice gap factor for NON-EIP1559 for edit eth transaction feature",
   },
+  VERBOSE: {
+    def: [] as Array<string>,
+    parser: stringArrayParser,
+    desc: 'Sets up debug console printing of logs. `VERBOSE=1` or `VERBOSE=true`: to print all logs | `VERBOSE="apdu,hw,transport,hid-verbose"` : filtering on a list of log `type` separated by a `,`',
+  },
 };
 
 export const getDefinition = (name: string): EnvDef<any> => {

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -15,6 +15,8 @@ export type SharedTaskEvent = { type: "error"; error: Error; retrying: boolean }
 export const NO_RESPONSE_TIMEOUT_MS = 30000;
 export const RETRY_ON_ERROR_DELAY_MS = 500;
 
+export const LOG_TYPE = "device-sdk-task";
+
 /**
  * Wraps a task function to add some common logic to it:
  * - Timeout for no response

--- a/libs/ledger-live-common/src/deviceSDK/transports/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/transports/core.ts
@@ -1,5 +1,5 @@
 import { Observable, throwError } from "rxjs";
-import { log } from "@ledgerhq/logs";
+import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import { open, close, setAllowAutoDisconnect } from "../../hw/index";
 import {
@@ -7,6 +7,8 @@ import {
   CantOpenDevice,
   DeviceHalted,
   FirmwareOrAppUpdateRequired,
+  PairingFailed,
+  PeerRemovedPairing,
   TransportInterfaceNotAvailable,
   TransportStatusError,
   TransportWebUSBGestureRequired,
@@ -15,12 +17,7 @@ import { catchError } from "rxjs/operators";
 
 export { Transport };
 
-// The devicesQueues object only stores, for each device, the latest void promise that will resolve when the device is ready to be opened again.
-// They are scheduled to resolve whenever the job associated to the device is finished.
-// When calling withTransport several times, the new promise will be chained to the "then" of the previous promise:
-// open(device) -> execute job -> clean connection -> resolve promise -> next promise can start: open(device) -> etc.
-// So a queue is indeed created for each device, by creating a chain of promises, but only the end of the queue is stored for each device.
-const deviceQueues: { [deviceId: string]: Promise<void> } = {};
+const LOG_TYPE = "device-sdk-transport";
 
 const identifyTransport = t => (typeof t.id === "string" ? t.id : "");
 
@@ -28,11 +25,15 @@ const needsCleanup = {};
 // When a series of APDUs are interrupted, this is called
 // so we don't forget to cleanup on the next withTransport
 export const cancelDeviceAction = (transport: Transport): void => {
+  const transportId = identifyTransport(transport);
+  trace({
+    type: LOG_TYPE,
+    message: "Cancelling device action",
+    data: { transportId },
+  });
+
   needsCleanup[identifyTransport(transport)] = true;
 };
-
-// To be able to differentiate withTransport calls in our logs
-let withRefreshableTransportNonce = 0;
 
 export type TransportRef = {
   // the instance of the current opened transport
@@ -47,6 +48,16 @@ export type JobArgs = {
   transportRef: TransportRef;
 };
 
+// The devicesQueues object only stores, for each device, the latest void promise that will resolve when the device is ready to be opened again.
+// They are scheduled to resolve whenever the job associated to the device is finished.
+// When calling withDevice several times, the new promise will be chained to the "then" of the previous promise:
+// open(device) -> execute job -> clean connection -> resolve promise -> next promise can start: open(device) -> etc.
+// So a queue is indeed created for each device, by creating a chain of promises, but only the end of the queue is stored for each device.
+const deviceQueues: { [deviceId: string]: { job: Promise<void>; id: number } } = {};
+
+// To be able to differentiate withDevice calls in our logs
+let jobId = 0;
+
 /**
  * Wrapper providing a transport that can be refreshed to a job that can be executed
  *
@@ -55,23 +66,28 @@ export type JobArgs = {
  * The transportRef.current will be updated with the new transport when transportRef.refreshTransport is called
  *
  * @param deviceId the id of the device to open the transport channel with
+ * @param options contains optional configuration
+ *   - openTimeoutMs: TODO: to keep, will be used in a separate PR
  * @returns a function that takes a job and returns an observable on the result of the job
  *  job: the job to execute with the transport. It takes:
  *   - transportRef: a reference to the transport that can be updated by calling a transportRef.refreshTransport()
  */
-export const withTransport = (deviceId: string) => {
+export const withTransport = (deviceId: string, options?: { openTimeoutMs?: number }) => {
   return <T>(job: ({ transportRef }: JobArgs) => Observable<T>): Observable<T> =>
     new Observable(subscriber => {
-      const nonce = withRefreshableTransportNonce++;
-      log("withTransport", `${nonce}: New job: deviceId=${deviceId || "USB"}`);
+      jobId++;
+      const tracer = new LocalTracer(LOG_TYPE, { jobId: jobId });
+      tracer.trace(`New job for device: ${deviceId || "USB"}`);
 
       let unsubscribed;
       let sub;
-      const deviceQueue = deviceQueues[deviceId] || Promise.resolve();
+      const deviceQueue = deviceQueues[deviceId] || { job: Promise.resolve(), id: -1 };
 
+      // To call to cleanup the current transport
       const finalize = (transport, cleanups) => {
-        setAllowAutoDisconnect(transport, deviceId, true);
+        tracer.trace("Closing and cleaning transport");
 
+        setAllowAutoDisconnect(transport, deviceId, true);
         return close(transport, deviceId)
           .catch(() => {})
           .then(() => {
@@ -80,21 +96,25 @@ export const withTransport = (deviceId: string) => {
       };
 
       // When we'll finish all the current job, we'll call finish
+      // resolveQueuedJob
       let resolveQueuedDevice;
-      // This new promise is the next exec queue
-      deviceQueues[deviceId] = new Promise(resolve => {
-        resolveQueuedDevice = resolve;
-      });
 
-      log("withTransport", `${nonce}: Waiting for queue to complete`, {
-        deviceQueue,
-      });
+      // Queue of linked Promises that wait after each other
+      // Blocking any future job on this device
+      deviceQueues[deviceId] = {
+        job: new Promise(resolve => {
+          resolveQueuedDevice = resolve;
+        }),
+        id: jobId,
+      };
 
+      // Setups a given transport
       const setupTransport = async (transport: Transport) => {
-        log("withTransport", `${nonce}: Starting job`);
+        tracer.trace("Setting up the transport instance");
         setAllowAutoDisconnect(transport, deviceId, false);
 
         if (unsubscribed) {
+          tracer.trace("Unsubscribed (1) while processing job");
           // It was unsubscribed prematurely
           return finalize(transport, [resolveQueuedDevice]);
         }
@@ -109,33 +129,43 @@ export const withTransport = (deviceId: string) => {
 
       // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
       const onErrorDuringTransportSetup = (error: unknown) => {
+        tracer.trace("Error while setting up a transport: ", { error });
         resolveQueuedDevice();
         if (error instanceof BluetoothRequired) throw error;
         if (error instanceof TransportWebUSBGestureRequired) throw error;
         if (error instanceof TransportInterfaceNotAvailable) throw error;
+        if (error instanceof PeerRemovedPairing) throw error;
+        if (error instanceof PairingFailed) throw error;
         if (error instanceof Error) throw new CantOpenDevice(error.message);
         else throw new CantOpenDevice("Unknown error");
       };
 
       // Returns an object containing: the reference to a transport and a function to refresh it
       const buildRefreshableTransport = (transport: Transport): TransportRef => {
+        tracer.trace("Creating a refreshable transport from a given instance");
+
         const transportRef: TransportRef = {
           current: transport,
           _refreshedCounter: 0,
           refreshTransport: Promise.resolve,
         };
 
+        tracer.updateContext({ transportRefreshedCounter: transportRef._refreshedCounter });
+
         transportRef.refreshTransport = async () => {
+          tracer.trace("Refreshing current transport");
           return (
             close(transportRef.current, deviceId)
               // Silently ignore errors on transport close
               .catch(() => {})
-              .then(async () => open(deviceId))
+              .then(async () => open(deviceId, options?.openTimeoutMs, tracer.getContext()))
               .then(async newTransport => {
                 await setupTransport(transportRef.current);
 
                 transportRef.current = newTransport;
                 transportRef._refreshedCounter++;
+                tracer.updateContext({ transportRefreshedCounter: transportRef._refreshedCounter });
+                tracer.trace("Transport was refreshed");
               })
               .catch(onErrorDuringTransportSetup)
           );
@@ -144,9 +174,18 @@ export const withTransport = (deviceId: string) => {
         return transportRef;
       };
 
-      deviceQueue
+      tracer.trace("Waiting for the previous job in the queue to complete", {
+        previousJobId: deviceQueue.id,
+      });
+      // For any new job, we'll now wait the exec queue to be available
+      deviceQueue.job
         .then(() => {
-          return open(deviceId);
+          tracer.trace("Previous queued job resolved, now trying to get a Transport instance", {
+            previousJobId: deviceQueue.id,
+            currentJobId: jobId,
+          });
+
+          return open(deviceId, options?.openTimeoutMs, tracer.getContext());
         })
         .then(transport => {
           return buildRefreshableTransport(transport);
@@ -159,19 +198,20 @@ export const withTransport = (deviceId: string) => {
         .catch(onErrorDuringTransportSetup)
         // Executes the job
         .then(transportRef => {
+          tracer.trace("Executing job", { hasTransport: !!transportRef, unsubscribed });
           if (!transportRef.current) return;
 
           if (unsubscribed) {
+            tracer.trace("Unsubscribed (2) while processing job");
             // It was unsubscribed prematurely
             return finalize(transportRef.current, [resolveQueuedDevice]);
           }
 
           sub = job({ transportRef })
             .pipe(
-              catchError(initialErrorRemapping),
+              catchError(error => initialErrorRemapping(error, tracer.getContext())),
               catchError(errorRemapping), // close the transport and clean up everything
               transportFinally(() => {
-                log("withTransport", `${nonce}: job fully completed`);
                 return finalize(transportRef.current, [resolveQueuedDevice]);
               }),
             )
@@ -184,13 +224,19 @@ export const withTransport = (deviceId: string) => {
       // Returns function to unsubscribe from the job if we don't need it anymore.
       // This will prevent us from executing the job unnecessarily later on
       return () => {
-        log("withTransport", `${nonce}: Unsubscribing job: ${!!sub}`);
+        tracer.trace(`Unsubscribing withDevice flow. Ongoing job to unsubscribe from ? ${!!sub}`);
         unsubscribed = true;
         if (sub) sub.unsubscribe();
       };
     });
 };
 
+/**
+ * Wrapper to pipe a "cleanup" function at then end of an Observable flow.
+ *
+ * The `finalize` is only called once if there is an error and a complete
+ * (but normally an error event completes automatically the Observable pipes. Is it needed ?)
+ */
 const transportFinally =
   (cleanup: () => Promise<void>) =>
   <T>(observable: Observable<T>): Observable<T> =>
@@ -218,17 +264,26 @@ const transportFinally =
       };
     });
 
-const initialErrorRemapping = error => {
-  return throwError(
-    error &&
-      error instanceof TransportStatusError &&
-      // @ts-expect-error typescript not checking agains the instanceof
-      error.statusCode === 0x6faa
-      ? new DeviceHalted(error.message)
-      : error.statusCode === 0x6b00
-      ? new FirmwareOrAppUpdateRequired(error.message)
-      : error,
-  );
+const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
+  let mappedError = error;
+
+  if (error && error instanceof TransportStatusError) {
+    // @ts-expect-error TS only inferring Error and not TransportStatusError
+    if (error.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(error.message);
+      // @ts-expect-error TransportStatusError
+    } else if (error.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+    }
+  }
+
+  trace({
+    type: LOG_TYPE,
+    message: "Initial error remapping",
+    data: { error, mappedError },
+    context,
+  });
+  return throwError(mappedError);
 };
 
 let errorRemapping = e => throwError(e);

--- a/libs/ledger-live-common/src/deviceSDK/transports/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/transports/core.ts
@@ -76,7 +76,7 @@ export const withTransport = (deviceId: string, options?: { openTimeoutMs?: numb
   return <T>(job: ({ transportRef }: JobArgs) => Observable<T>): Observable<T> =>
     new Observable(subscriber => {
       jobId++;
-      const tracer = new LocalTracer(LOG_TYPE, { jobId: jobId });
+      const tracer = new LocalTracer(LOG_TYPE, { jobId: jobId, origin: "deviceSdk:withTransport" });
       tracer.trace(`New job for device: ${deviceId || "USB"}`);
 
       let unsubscribed;

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -208,7 +208,7 @@ export const withDevice =
             .subscribe({
               next: event => {
                 // This kind of log should be a "debug" level for ex
-                tracer.trace("Job next", { event });
+                // tracer.trace("Job next", { event });
                 o.next(event);
               },
               error: error => {
@@ -216,7 +216,6 @@ export const withDevice =
                 o.error(error);
               },
               complete: () => {
-                tracer.trace("Job completed");
                 o.complete();
               },
             });

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -90,7 +90,14 @@ const needsCleanup = {};
 // When a series of APDUs are interrupted, this is called
 // so we don't forget to cleanup on the next withDevice
 export const cancelDeviceAction = (transport: Transport): void => {
-  needsCleanup[identifyTransport(transport)] = true;
+  const transportId = identifyTransport(transport);
+  trace({
+    type: LOG_TYPE,
+    message: "Cancelling device action",
+    data: { transportId },
+  });
+
+  needsCleanup[transportId] = true;
 };
 
 // The devicesQueues object only stores, for each device, the latest void promise that will resolve when the device is ready to be opened again.
@@ -147,7 +154,9 @@ export const withDevice =
         id: jobId,
       };
 
-      tracer.trace("Waiting for queue to complete previous job", { previousJobId: deviceQueue.id });
+      tracer.trace("Waiting for the previous job in the queue to complete", {
+        previousJobId: deviceQueue.id,
+      });
       // For any new job, we'll now wait the exec queue to be available
       deviceQueue.job
         .then(() => {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -15,21 +15,33 @@ import {
   PeerRemovedPairing,
   PairingFailed,
 } from "@ledgerhq/errors";
-import { log } from "@ledgerhq/logs";
+import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import { getEnv } from "@ledgerhq/live-env";
 import { open, close, setAllowAutoDisconnect } from ".";
 
-const initialErrorRemapping = error =>
-  throwError(
-    error &&
-      error instanceof TransportStatusError &&
-      // @ts-expect-error typescript not checking agains the instanceof
-      error.statusCode === 0x6faa
-      ? new DeviceHalted(error.message)
-      : error.statusCode === 0x6b00
-      ? new FirmwareOrAppUpdateRequired(error.message)
-      : error,
-  );
+const LOG_TYPE = "hw";
+
+const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
+  let mappedError = error;
+
+  if (error && error instanceof TransportStatusError) {
+    // @ts-expect-error TS only inferring Error and not TransportStatusError
+    if (error.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(error.message);
+      // @ts-expect-error TransportStatusError
+    } else if (error.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+    }
+  }
+
+  trace({
+    type: LOG_TYPE,
+    message: "Initial error remapping",
+    data: { error, mappedError },
+    context,
+  });
+  return throwError(mappedError);
+};
 
 let errorRemapping = e => throwError(e);
 
@@ -38,10 +50,15 @@ export const setErrorRemapping = (f: (arg0: Error) => Observable<never>): void =
 };
 const never = new Promise(() => {});
 
-const transportFinally =
-  (cleanup: () => Promise<void>) =>
-  <T>(observable: Observable<T>): Observable<T> =>
-    Observable.create(o => {
+/**
+ * Wrapper to pipe a "cleanup" function at then end of an Observable flow.
+ *
+ * The `finalize` is only called once if there is an error and a complete
+ * (but normally an error event completes automatically the Observable pipes. Is it needed ?)
+ */
+function transportFinally(cleanup: () => Promise<void>) {
+  return <T>(observable: Observable<T>): Observable<T> => {
+    return new Observable(o => {
       let done = false;
 
       const finalize = () => {
@@ -64,6 +81,8 @@ const transportFinally =
         finalize();
       };
     });
+  };
+}
 
 const identifyTransport = t => (typeof t.id === "string" ? t.id : "");
 
@@ -79,23 +98,34 @@ export const cancelDeviceAction = (transport: Transport): void => {
 // When calling withDevice several times, the new promise will be chained to the "then" of the previous promise:
 // open(device) -> execute job -> clean connection -> resolve promise -> next promise can start: open(device) -> etc.
 // So a queue is indeed created for each device, by creating a chain of promises, but only the end of the queue is stored for each device.
-const deviceQueues: { [deviceId: string]: Promise<void> } = {};
+const deviceQueues: { [deviceId: string]: { job: Promise<void>; id: number } } = {};
 
 // To be able to differentiate withDevice calls in our logs
-let withDeviceNonce = 0;
+let jobId = 0;
 
+/**
+ * Provides a Transport instance to a given job
+ *
+ * @param deviceId
+ * @param options contains optional configuration
+ *   - openTimeoutMs: TODO: to keep, will be used in a separate PR
+ */
 export const withDevice =
-  (deviceId: string) =>
+  (deviceId: string, options?: { openTimeoutMs?: number }) =>
   <T>(job: (t: Transport) => Observable<T>): Observable<T> =>
     new Observable(o => {
-      const nonce = withDeviceNonce++;
-      log("withDevice", `${nonce}: New job: deviceId=${deviceId || "USB"}`);
+      jobId++;
+      const tracer = new LocalTracer(LOG_TYPE, { jobId: jobId });
+      tracer.trace(`New job for device: ${deviceId || "USB"}`);
 
       let unsubscribed;
       let sub;
-      const deviceQueue = deviceQueues[deviceId] || Promise.resolve();
+      const deviceQueue = deviceQueues[deviceId] || { job: Promise.resolve(), id: -1 };
 
-      const finalize = (transport, cleanups) => {
+      // To call to cleanup the current transport
+      const finalize = (transport: Transport, cleanups: Array<() => void>) => {
+        tracer.trace("Closing and cleaning transport");
+
         setAllowAutoDisconnect(transport, deviceId, true);
         return close(transport, deviceId)
           .catch(() => {})
@@ -105,24 +135,33 @@ export const withDevice =
       };
 
       // When we'll finish all the current job, we'll call finish
+      // notifyJobCompleted ? resolveCurrentJob
       let resolveQueuedDevice;
 
-      // This new promise is the next exec queue
-      deviceQueues[deviceId] = new Promise(resolve => {
-        resolveQueuedDevice = resolve;
-      });
+      // Queue of linked Promises that wait after each other
+      // Blocking any future job on this device
+      deviceQueues[deviceId] = {
+        job: new Promise(resolve => {
+          resolveQueuedDevice = resolve;
+        }),
+        id: jobId,
+      };
 
-      log("withDevice", `${nonce}: Waiting for queue to complete`, {
-        deviceQueue,
-      });
+      tracer.trace("Waiting for queue to complete previous job", { previousJobId: deviceQueue.id });
       // For any new job, we'll now wait the exec queue to be available
-      deviceQueue
-        .then(() => open(deviceId)) // open the transport
+      deviceQueue.job
+        .then(() => {
+          tracer.trace("Previous queued job resolved, now trying to get a Transport instance", {
+            previousJobId: deviceQueue.id,
+            currentJobId: jobId,
+          });
+          return open(deviceId, options?.openTimeoutMs, tracer.getContext());
+        }) // open the transport
         .then(async transport => {
-          log("withDevice", `${nonce}: got a transport`);
+          tracer.trace("Got a Transport instance from open");
 
           if (unsubscribed) {
-            log("withDevice", `${nonce}: but we're unsubscribed`);
+            tracer.trace("Unsubscribed (1) while processing job");
             // It was unsubscribed prematurely
             return finalize(transport, [resolveQueuedDevice]);
           }
@@ -137,6 +176,7 @@ export const withDevice =
         })
         // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
         .catch(e => {
+          tracer.trace("Error while opening Transport: ", { e });
           resolveQueuedDevice();
           if (e instanceof BluetoothRequired) throw e;
           if (e instanceof TransportWebUSBGestureRequired) throw e;
@@ -147,31 +187,49 @@ export const withDevice =
         })
         // Executes the job
         .then(transport => {
+          tracer.trace("Executing job", { hasTransport: !!transport, unsubscribed });
           if (!transport) return;
 
+          // It was unsubscribed prematurely
           if (unsubscribed) {
-            // It was unsubscribed prematurely
+            tracer.trace("Unsubscribed (2) while processing job");
             return finalize(transport, [resolveQueuedDevice]);
           }
 
-          log("withDevice", `${nonce}: Starting job`);
           sub = job(transport)
             .pipe(
-              catchError(initialErrorRemapping),
-              catchError(errorRemapping), // close the transport and clean up everything
+              catchError(error => initialErrorRemapping(error, tracer.getContext())),
+              catchError(errorRemapping),
               transportFinally(() => {
-                log("withDevice", `${nonce}: job fully completed`);
+                // Closes the transport and cleans up everything
                 return finalize(transport, [resolveQueuedDevice]);
               }),
             )
-            .subscribe(o);
+            .subscribe({
+              next: event => {
+                // This kind of log should be a "debug" level for ex
+                tracer.trace("Job next", { event });
+                o.next(event);
+              },
+              error: error => {
+                tracer.trace("Job error", { error });
+                o.error(error);
+              },
+              complete: () => {
+                tracer.trace("Job completed");
+                o.complete();
+              },
+            });
         })
-        .catch(error => o.error(error));
+        .catch(error => {
+          tracer.trace("Caught error on job execution step", { error });
+          o.error(error);
+        });
 
       // Returns function to unsubscribe from the job if we don't need it anymore.
       // This will prevent us from executing the job unnecessarily later on
       return () => {
-        log("withDevice", `${nonce}: Unsubscribing job: ${!!sub}`);
+        tracer.trace(`Unsubscribing withDevice flow. Ongoing job to unsubscribe from ? ${!!sub}`);
         unsubscribed = true;
         if (sub) sub.unsubscribe();
       };

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -122,7 +122,7 @@ export const withDevice =
   <T>(job: (t: Transport) => Observable<T>): Observable<T> =>
     new Observable(o => {
       jobId++;
-      const tracer = new LocalTracer(LOG_TYPE, { jobId: jobId });
+      const tracer = new LocalTracer(LOG_TYPE, { jobId: jobId, origin: "hw:withDevice" });
       tracer.trace(`New job for device: ${deviceId || "USB"}`);
 
       let unsubscribed;

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -3,6 +3,10 @@ import type { Observable } from "rxjs";
 import { catchError } from "rxjs/operators";
 import type { DeviceModel } from "@ledgerhq/types-devices";
 import Transport from "@ledgerhq/hw-transport";
+import { TraceContext, trace } from "@ledgerhq/logs";
+import { CantOpenDevice } from "@ledgerhq/errors";
+
+const LOG_TYPE = "hw";
 
 export type DeviceEvent = {
   type: "add" | "remove";
@@ -17,30 +21,47 @@ export type Discovery = Observable<DeviceEvent>;
 export type TransportModule = {
   // unique transport name that identify the transport module
   id: string;
-  // open a device by an id, this id must be unique across all modules
-  // you can typically prefix it with `something|` that identify it globally
-  // returns falsy if the transport module can't handle this id
-  // here, open means we want to START doing something with the transport
-  open: (id: string) => Promise<Transport> | null | undefined;
+  /*
+   * Opens a device by an id, this id must be unique across all modules
+   * you can typically prefix it with `something|` that identify it globally
+   * returns falsy if the transport module can't handle this id
+   * here, open means we want to START doing something with the transport
+   *
+   * @param deviceId
+   * @param timeoutMs Optional timeout that can be used by the Transport implementation when opening a communication channel
+   * @param context Optional context to be used in logs/tracing
+   */
+  open: (
+    deviceId: string,
+    timeoutMs?: number,
+    context?: TraceContext,
+  ) => Promise<Transport> | null | undefined;
   // here, close means we want to STOP doing something with the transport
   close?: (transport: Transport, id: string) => Promise<void> | null | undefined;
   // disconnect/interrupt a device connection globally
   // returns falsy if the transport module can't handle this id
   disconnect: (id: string) => Promise<void> | null | undefined;
-  // here, setAllowAutoDisconnect determines whether an autodisconnect can
-  // happen at this time or not. Currently only used by TransportNodeHid
+
+  /**
+   * Determines whether an auto-disconnect can happen at this time or not. 
+   *
+   * Currently only used by TransportNodeHid
+   */
   setAllowAutoDisconnect?: (
     transport: Transport,
     id: string,
     allow: boolean,
   ) => Promise<void> | null | undefined;
+
   // optional observable that allows to discover a transport
   discovery?: Discovery;
 };
+
 const modules: TransportModule[] = [];
 export const registerTransportModule = (module: TransportModule): void => {
   modules.push(module);
 };
+
 export const discoverDevices = (
   accept: (module: TransportModule) => boolean = () => true,
 ): Discovery => {
@@ -57,28 +78,55 @@ export const discoverDevices = (
   return merge(
     ...all.map(o =>
       o.pipe(
-        catchError(e => {
-          console.warn(`One Transport provider failed: ${e}`);
+        catchError(error => {
+          trace({ type: LOG_TYPE, message: "One Transport provider failed", data: { error } });
           return EMPTY;
         }),
       ),
     ),
   );
 };
-export const open = (deviceId: string): Promise<Transport> => {
+
+/**
+ * Tries to call `open` on the 1st matching registered transport implementation
+ *
+ * @param deviceId
+ * @param timeoutMs TODO: too keep, will be used in separate PR
+ * @param context Optional context to be used in logs/tracing
+ * @returns a Promise that resolves to a Transport instance, and rejects with a `CantOpenDevice`
+ *   if no transport implementation can open the device
+ */
+export const open = (
+  deviceId: string,
+  timeoutMs?: number,
+  context?: TraceContext,
+): Promise<Transport> => {
+  // The first registered Transport (TransportModule) accepting the given device will be returned.
+  // The open is not awaited, the check on the device is done synchronously.
+  // A TransportModule can check the prefix of the device id to guess if it should use USB or not on LLM for ex.
   for (let i = 0; i < modules.length; i++) {
     const m = modules[i];
-    const p = m.open(deviceId);
+    const p = m.open(deviceId, timeoutMs, context);
     if (p) return p;
   }
 
-  return Promise.reject(new Error(`Can't find handler to open ${deviceId}`));
+  return Promise.reject(new CantOpenDevice(`Cannot find registered transport to open ${deviceId}`));
 };
-export const close = (transport: Transport, deviceId: string): Promise<void> => {
+
+export const close = (
+  transport: Transport,
+  deviceId: string,
+  context?: TraceContext,
+): Promise<void> => {
+  trace({ type: LOG_TYPE, message: "Trying to close transport", context });
+  // Tries on the registered TransportModule implementation of close
   for (let i = 0; i < modules.length; i++) {
     const m = modules[i];
     const p = m.close && m.close(transport, deviceId);
-    if (p) return p;
+    if (p) {
+      trace({ type: LOG_TYPE, message: `Closing transport ${m.id}`, context });
+      return p;
+    }
   }
 
   // fallback on an actual close

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -43,7 +43,7 @@ export type TransportModule = {
   disconnect: (id: string) => Promise<void> | null | undefined;
 
   /**
-   * Determines whether an auto-disconnect can happen at this time or not. 
+   * Determines whether an auto-disconnect can happen at this time or not.
    *
    * Currently only used by TransportNodeHid
    */

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -27,12 +27,12 @@ export type TransportModule = {
    * returns falsy if the transport module can't handle this id
    * here, open means we want to START doing something with the transport
    *
-   * @param deviceId
+   * @param id
    * @param timeoutMs Optional timeout that can be used by the Transport implementation when opening a communication channel
    * @param context Optional context to be used in logs/tracing
    */
   open: (
-    deviceId: string,
+    id: string,
     timeoutMs?: number,
     context?: TraceContext,
   ) => Promise<Transport> | null | undefined;

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/README.md
@@ -38,6 +38,10 @@ node-hid Transport minimal implementation
 #### Parameters
 
 *   `device` **HID.HID** 
+*   `$1` **{context: TraceContext?, logType: LogType?}**  (optional, default `{}`)
+
+    *   `$1.context`  
+    *   `$1.logType`  
 
 #### Examples
 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -1,5 +1,5 @@
 import HID, { Device } from "node-hid";
-import { log } from "@ledgerhq/logs";
+import { LogType, TraceContext } from "@ledgerhq/logs";
 import Transport, {
   Observer,
   DescriptorEvent,
@@ -32,7 +32,6 @@ export function getDevices(): (Device & { deviceName?: string })[] {
  * ...
  * TransportNodeHid.create().then(transport => ...)
  */
-
 export default class TransportNodeHidNoEvents extends Transport {
   /**
    *
@@ -83,9 +82,13 @@ export default class TransportNodeHidNoEvents extends Transport {
   packetSize = 64;
   disconnected = false;
 
-  constructor(device: HID.HID) {
-    super();
+  constructor(
+    device: HID.HID,
+    { context, logType }: { context?: TraceContext; logType?: LogType } = {},
+  ) {
+    super({ context, logType });
     this.device = device;
+
     // @ts-expect-error accessing low level API in C
     const info = device.getDeviceInfo();
     this.deviceModel = info && info.product ? identifyProductName(info.product) : null;
@@ -141,14 +144,22 @@ export default class TransportNodeHidNoEvents extends Transport {
 
   /**
    * Exchange with the device using APDU protocol.
+   *
    * @param apdu
    * @returns a promise of apdu response
    */
   async exchange(apdu: Buffer): Promise<Buffer> {
+    const tracer = this.tracer.withAdditionalContext({
+      function: "exchange",
+    });
+    tracer.trace("Exchanging APDU ...");
+
     const b = await this.exchangeAtomicImpl(async () => {
       const { channel, packetSize } = this;
-      log("apdu", "=> " + apdu.toString("hex"));
+      tracer.withType("apdu").trace(`=> ${apdu.toString("hex")}`);
+
       const framing = hidFraming(channel, packetSize);
+
       // Write...
       const blocks = framing.makeBlocks(apdu);
 
@@ -165,7 +176,7 @@ export default class TransportNodeHidNoEvents extends Transport {
         acc = framing.reduceResponse(acc, buffer);
       }
 
-      log("apdu", "<= " + result.toString("hex"));
+      tracer.withType("apdu").trace(`<= ${result.toString("hex")}`);
       return result;
     });
 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -149,7 +149,7 @@ export default class TransportNodeHidNoEvents extends Transport {
    * @returns a promise of apdu response
    */
   async exchange(apdu: Buffer): Promise<Buffer> {
-    const tracer = this.tracer.withAdditionalContext({
+    const tracer = this.tracer.withUpdatedContext({
       function: "exchange",
     });
     tracer.trace("Exchanging APDU ...");

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/README.md
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/README.md
@@ -30,22 +30,31 @@ For a smooth and quick integration:
 #### Table of Contents
 
 *   [TransportNodeHidSingleton](#transportnodehidsingleton)
+    *   [Parameters](#parameters)
     *   [Examples](#examples)
     *   [exchange](#exchange)
-        *   [Parameters](#parameters)
+        *   [Parameters](#parameters-1)
     *   [isSupported](#issupported)
     *   [list](#list)
     *   [listen](#listen)
-        *   [Parameters](#parameters-1)
+        *   [Parameters](#parameters-2)
     *   [autoDisconnect](#autodisconnect)
     *   [disconnect](#disconnect)
     *   [open](#open)
+        *   [Parameters](#parameters-3)
 
 ### TransportNodeHidSingleton
 
 **Extends TransportNodeHidNoEvents**
 
 node-hid Transport implementation
+
+#### Parameters
+
+*   `device` **HID.HID** 
+*   `$1` **{context: TraceContext?}**  (optional, default `{}`)
+
+    *   `$1.context`  
 
 #### Examples
 
@@ -89,6 +98,17 @@ globally disconnect the transport singleton
 
 #### open
 
-if path="" is not provided, the library will take the first device
+Connects to the first Ledger device connected via USB
+
+Reusing the same TransportNodeHidSingleton instance until a disconnection happens.
+Pitfall: this implementation only handles 1 device connected via USB
+
+Legacy: `_descriptor` is needed to follow the Transport definition
+
+##### Parameters
+
+*   `_descriptor` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+*   `_timeoutMs` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
+*   `context` **TraceContext?** 
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[TransportNodeHidSingleton](#transportnodehidsingleton)>** 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/listenDevices.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/src/listenDevices.ts
@@ -1,6 +1,8 @@
 import { usb } from "usb";
 import { ledgerUSBVendorId } from "@ledgerhq/devices";
-import { log } from "@ledgerhq/logs";
+import { LocalTracer } from "@ledgerhq/logs";
+
+const LOG_TYPE = "usb-detection";
 
 export type Device = {
   locationId: number;
@@ -36,11 +38,12 @@ const mapRawDevice = ({
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const listenDevices = (onAdd: (arg0: Device) => void, onRemove: (arg0: Device) => void) => {
+  const tracer = new LocalTracer(LOG_TYPE, { function: "listenDevices " });
   let timeout;
 
   const add = device => {
     if (device.deviceDescriptor.idVendor !== ledgerUSBVendorId) return;
-    log("usb-detection", "add: " + deviceToLog(device));
+    tracer.trace(`add: ${deviceToLog(device)}`, { device });
 
     if (!timeout) {
       // a time is needed for the device to actually be connectable over HID..
@@ -54,7 +57,7 @@ export const listenDevices = (onAdd: (arg0: Device) => void, onRemove: (arg0: De
 
   const remove = device => {
     if (device.deviceDescriptor.idVendor !== ledgerUSBVendorId) return;
-    log("usb-detection", "remove: " + deviceToLog(device));
+    tracer.trace(`remove: ${deviceToLog(device)}`, { device });
 
     if (timeout) {
       clearTimeout(timeout);

--- a/libs/ledgerjs/packages/hw-transport/README.md
+++ b/libs/ledgerjs/packages/hw-transport/README.md
@@ -20,35 +20,38 @@
 *   [DescriptorEvent](#descriptorevent)
 *   [Observer](#observer)
 *   [Transport](#transport)
+    *   [Parameters](#parameters)
     *   [exchange](#exchange)
-        *   [Parameters](#parameters)
-    *   [exchangeBulk](#exchangebulk)
         *   [Parameters](#parameters-1)
-    *   [setScrambleKey](#setscramblekey)
+    *   [exchangeBulk](#exchangebulk)
         *   [Parameters](#parameters-2)
+    *   [setScrambleKey](#setscramblekey)
+        *   [Parameters](#parameters-3)
     *   [close](#close)
     *   [on](#on)
-        *   [Parameters](#parameters-3)
-    *   [off](#off)
         *   [Parameters](#parameters-4)
+    *   [off](#off)
+        *   [Parameters](#parameters-5)
     *   [setDebugMode](#setdebugmode)
     *   [setExchangeTimeout](#setexchangetimeout)
-        *   [Parameters](#parameters-5)
-    *   [setExchangeUnresponsiveTimeout](#setexchangeunresponsivetimeout)
         *   [Parameters](#parameters-6)
-    *   [send](#send)
+    *   [setExchangeUnresponsiveTimeout](#setexchangeunresponsivetimeout)
         *   [Parameters](#parameters-7)
+    *   [send](#send)
+        *   [Parameters](#parameters-8)
+    *   [setTraceContext](#settracecontext)
+        *   [Parameters](#parameters-9)
     *   [isSupported](#issupported)
     *   [list](#list)
         *   [Examples](#examples)
     *   [listen](#listen)
-        *   [Parameters](#parameters-8)
+        *   [Parameters](#parameters-10)
         *   [Examples](#examples-1)
     *   [open](#open)
-        *   [Parameters](#parameters-9)
+        *   [Parameters](#parameters-11)
         *   [Examples](#examples-2)
     *   [create](#create)
-        *   [Parameters](#parameters-10)
+        *   [Parameters](#parameters-12)
         *   [Examples](#examples-3)
 
 ### Subscription
@@ -82,6 +85,13 @@ Type: Readonly<{next: function (event: EventType): any, error: function (e: Even
 The Transport class defines a generic interface for communicating with a Ledger hardware wallet.
 There are different kind of transports based on the technology (channels like U2F, HID, Bluetooth, Webusb) and environment (Node, Web,...).
 It is an abstract class that needs to be implemented.
+
+#### Parameters
+
+*   `$0` **{context: TraceContext?, logType: LogType?}**  (optional, default `{}`)
+
+    *   `$0.context`  
+    *   `$0.logType`  
 
 #### exchange
 
@@ -190,6 +200,17 @@ Send data to the device using the higher level API.
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Buffer](https://nodejs.org/api/buffer.html)>** A promise that resolves with the response data from the device.
 
+#### setTraceContext
+
+Updates the context used by the logging/tracing mechanism
+
+Useful when re-using (cached) the same Transport instance,
+but with a new tracing context.
+
+##### Parameters
+
+*   `context` **TraceContext?** A TraceContext, that can undefined to reset the context
+
 #### isSupported
 
 Check if the transport is supported on the current platform/browser.
@@ -247,12 +268,13 @@ Returns **[Subscription](#subscription)** A Subscription object on which you can
 
 Attempt to create a Transport instance with a specific descriptor.
 
-Type: function (descriptor: any, timeout: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Transport](#transport)>
+Type: function (descriptor: any, timeoutMs: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), context: TraceContext): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Transport](#transport)>
 
 ##### Parameters
 
 *   `descriptor` **any** The descriptor to open the transport with.
 *   `timeout` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** An optional timeout for the transport connection.
+*   `context` **TraceContext** Optional tracing/log context
 
 ##### Examples
 

--- a/libs/ledgerjs/packages/hw-transport/package.json
+++ b/libs/ledgerjs/packages/hw-transport/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@ledgerhq/devices": "workspace:^",
     "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/logs": "workspace:^",
     "events": "^3.3.0"
   },
   "scripts": {

--- a/libs/ledgerjs/packages/hw-transport/src/Transport.ts
+++ b/libs/ledgerjs/packages/hw-transport/src/Transport.ts
@@ -296,7 +296,7 @@ export default class Transport {
 
   exchangeBusyPromise: Promise<void> | null | undefined;
   exchangeAtomicImpl = async (f: () => Promise<Buffer | void>): Promise<Buffer | void> => {
-    const tracer = this.tracer.withAdditionalContext({ function: "exchangeAtomicImpl" });
+    const tracer = this.tracer.withUpdatedContext({ function: "exchangeAtomicImpl" });
     tracer.trace("Starting an atomic APDU exchange");
 
     if (this.exchangeBusyPromise) {

--- a/libs/ledgerjs/packages/hw-transport/src/Transport.ts
+++ b/libs/ledgerjs/packages/hw-transport/src/Transport.ts
@@ -7,7 +7,9 @@ import {
   getAltStatusMessage,
   TransportStatusError,
 } from "@ledgerhq/errors";
+import { LocalTracer, TraceContext, LogType } from "@ledgerhq/logs";
 export { TransportError, TransportStatusError, StatusCodes, getAltStatusMessage };
+const DEFAULT_LOG_TYPE = "transport";
 
 /**
  */
@@ -52,6 +54,11 @@ export default class Transport {
   exchangeTimeout = 30000;
   unresponsiveTimeout = 15000;
   deviceModel: DeviceModel | null | undefined = null;
+  tracer: LocalTracer;
+
+  constructor({ context, logType }: { context?: TraceContext; logType?: LogType } = {}) {
+    this.tracer = new LocalTracer(logType ?? DEFAULT_LOG_TYPE, context);
+  }
 
   /**
    * Check if the transport is supported on the current platform/browser.
@@ -94,11 +101,16 @@ export default class Transport {
    * Attempt to create a Transport instance with a specific descriptor.
    * @param {any} descriptor - The descriptor to open the transport with.
    * @param {number} timeout - An optional timeout for the transport connection.
+   * @param {TraceContext} context Optional tracing/log context
    * @returns {Promise<Transport>} A promise that resolves with a Transport instance.
    * @example
   TransportFoo.open(descriptor).then(transport => ...)
    */
-  static readonly open: (descriptor?: any, timeout?: number) => Promise<Transport>;
+  static readonly open: (
+    descriptor?: any,
+    timeoutMs?: number,
+    context?: TraceContext,
+  ) => Promise<Transport>;
 
   /**
    * Send data to the device using a low level API.
@@ -284,12 +296,17 @@ export default class Transport {
 
   exchangeBusyPromise: Promise<void> | null | undefined;
   exchangeAtomicImpl = async (f: () => Promise<Buffer | void>): Promise<Buffer | void> => {
+    const tracer = this.tracer.withAdditionalContext({ function: "exchangeAtomicImpl" });
+    tracer.trace("Starting an atomic APDU exchange");
+
     if (this.exchangeBusyPromise) {
+      tracer.trace("Atomic exchange is already busy");
       throw new TransportRaceCondition(
         "An action was already pending on the Ledger device. Please deny or reconnect.",
       );
     }
 
+    // Sets the atomic guard
     let resolveBusy;
     const busyPromise: Promise<void> = new Promise(r => {
       resolveBusy = r;
@@ -297,14 +314,17 @@ export default class Transport {
     this.exchangeBusyPromise = busyPromise;
     let unresponsiveReached = false;
     const timeout = setTimeout(() => {
+      tracer.trace(`Timeout reached, emitting Transport event "unresponsive"`);
       unresponsiveReached = true;
       this.emit("unresponsive");
     }, this.unresponsiveTimeout);
 
     try {
       const res = await f();
+      tracer.trace("Received a response from atomic exchange");
 
       if (unresponsiveReached) {
+        tracer.trace("Device was unresponsive, emitting responsive");
         this.emit("responsive");
       }
 
@@ -347,6 +367,18 @@ export default class Transport {
         this._appAPIlock = null;
       }
     };
+  }
+
+  /**
+   * Updates the context used by the logging/tracing mechanism
+   *
+   * Useful when re-using (cached) the same Transport instance,
+   * but with a new tracing context.
+   *
+   * @param context A TraceContext, that can undefined to reset the context
+   */
+  setTraceContext(context?: TraceContext) {
+    this.tracer = this.tracer.withContext(context);
   }
 
   static ErrorMessage_ListenTimeout = "No Ledger device found (timeout)";

--- a/libs/ledgerjs/packages/logs/README.md
+++ b/libs/ledgerjs/packages/logs/README.md
@@ -11,28 +11,136 @@ Utility library that is used by all Ledger libraries to dispatch logs so we can 
 #### Table of Contents
 
 *   [Log](#log)
+    *   [type](#type)
+    *   [data](#data)
+    *   [context](#context)
+    *   [id](#id)
 *   [log](#log-1)
     *   [Parameters](#parameters)
-*   [listen](#listen)
+*   [trace](#trace)
     *   [Parameters](#parameters-1)
+*   [LocalTracer](#localtracer)
+    *   [Parameters](#parameters-2)
+    *   [withType](#withtype)
+        *   [Parameters](#parameters-3)
+    *   [withContext](#withcontext)
+        *   [Parameters](#parameters-4)
+    *   [withAdditionalContext](#withadditionalcontext)
+        *   [Parameters](#parameters-5)
+*   [listen](#listen)
+    *   [Parameters](#parameters-6)
 
 ### Log
 
 A Log object
 
+#### type
+
+A namespaced identifier of the log (not a level like "debug", "error" but more like "apdu", "hw", etc...)
+
+Type: LogType
+
+#### data
+
+Data associated to the log event
+
+Type: LogData
+
+#### context
+
+Context data, coming for example from the caller's parent, to enable a simple tracing system
+
+Type: TraceContext
+
+#### id
+
+Unique id among all logs
+
+Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
+
 ### log
 
-log something
+Logs something
 
 #### Parameters
 
-*   `type` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a namespaced identifier of the log (it is not a level like "debug", "error" but more like "apdu-in", "apdu-out", etc...)
+*   `type` **LogType** a namespaced identifier of the log (it is not a level like "debug", "error" but more like "apdu-in", "apdu-out", etc...)
 *   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a clear message of the log associated to the type
-*   `data` **any?** 
+*   `data` **LogData?** 
+
+### trace
+
+A simple tracer function, only expanding the existing log function
+
+Its goal is to capture more context than a log function.
+This is simple for now, but can be improved later.
+
+#### Parameters
+
+*   `context` **{type: LogType, message: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?, data: LogData?, context: TraceContext?}** Anything representing the context where the log occurred
+
+    *   `context.type`  
+    *   `context.message`  
+    *   `context.data`  
+    *   `context.context`  
+
+### LocalTracer
+
+A simple tracer class, that can be used to avoid repetition when using the `trace` function
+
+Its goal is to capture more context than a log function.
+This is simple for now, but can be improved later.
+
+#### Parameters
+
+*   ``  
+*   ``  
+*   `type`  A given type (not level) for the current local tracer ("hw", "withDevice", etc.)
+*   `context`  Anything representing the context where the log occurred
+
+#### withType
+
+Create a new instance of the LocalTracer with an updated `type`
+
+It does not mutate the calling instance, but returns a new LocalTracer,
+following a simple builder pattern.
+
+##### Parameters
+
+*   `type` **LogType** 
+
+Returns **[LocalTracer](#localtracer)** 
+
+#### withContext
+
+Create a new instance of the LocalTracer with a new `context`
+
+It does not mutate the calling instance, but returns a new LocalTracer,
+following a simple builder pattern.
+
+##### Parameters
+
+*   `context` **TraceContext?** A TraceContext, that can undefined to reset the context
+
+Returns **[LocalTracer](#localtracer)** 
+
+#### withAdditionalContext
+
+Create a new instance of the LocalTracer with an updated `context`,
+on which an additional context is merged with the existing one.
+
+It does not mutate the calling instance, but returns a new LocalTracer,
+following a simple builder pattern.
+
+##### Parameters
+
+*   `contextToAdd` **TraceContext** 
+
+Returns **[LocalTracer](#localtracer)** 
 
 ### listen
 
-listen to logs.
+Adds a subscribers to the emitted logs.
 
 #### Parameters
 

--- a/libs/ledgerjs/packages/logs/README.md
+++ b/libs/ledgerjs/packages/logs/README.md
@@ -25,7 +25,7 @@ Utility library that is used by all Ledger libraries to dispatch logs so we can 
         *   [Parameters](#parameters-3)
     *   [withContext](#withcontext)
         *   [Parameters](#parameters-4)
-    *   [withAdditionalContext](#withadditionalcontext)
+    *   [withUpdatedContext](#withupdatedcontext)
         *   [Parameters](#parameters-5)
 *   [listen](#listen)
     *   [Parameters](#parameters-6)
@@ -124,7 +124,7 @@ following a simple builder pattern.
 
 Returns **[LocalTracer](#localtracer)** 
 
-#### withAdditionalContext
+#### withUpdatedContext
 
 Create a new instance of the LocalTracer with an updated `context`,
 on which an additional context is merged with the existing one.

--- a/libs/ledgerjs/packages/logs/src/index.ts
+++ b/libs/ledgerjs/packages/logs/src/index.ts
@@ -1,26 +1,47 @@
+export type TraceContext = Record<string, unknown>;
+export type LogData = any;
+export type LogType = string;
+
 /**
  * A Log object
  */
 export interface Log {
-  type: string;
+  /**
+   * A namespaced identifier of the log (not a level like "debug", "error" but more like "apdu", "hw", etc...)
+   */
+  type: LogType;
   message?: string;
-  data?: any;
-  // unique amount all logs
+  /**
+   * Data associated to the log event
+   */
+  data?: LogData;
+  /**
+   * Context data, coming for example from the caller's parent, to enable a simple tracing system
+   */
+  context?: TraceContext;
+  /**
+   * Unique id among all logs
+   */
   id: string;
-  // date of the log
+  /*
+   * Date when the log occurred
+   */
   date: Date;
 }
+
 export type Unsubscribe = () => void;
 export type Subscriber = (arg0: Log) => void;
+
 let id = 0;
 const subscribers: Subscriber[] = [];
 
 /**
- * log something
+ * Logs something
+ *
  * @param type a namespaced identifier of the log (it is not a level like "debug", "error" but more like "apdu-in", "apdu-out", etc...)
  * @param message a clear message of the log associated to the type
  */
-export const log = (type: string, message?: string, data?: any) => {
+export const log = (type: LogType, message?: string, data?: LogData) => {
   const obj: Log = {
     type,
     id: String(++id),
@@ -32,7 +53,111 @@ export const log = (type: string, message?: string, data?: any) => {
 };
 
 /**
- * listen to logs.
+ * A simple tracer function, only expanding the existing log function
+ *
+ * Its goal is to capture more context than a log function.
+ * This is simple for now, but can be improved later.
+ *
+ * @param context Anything representing the context where the log occurred
+ */
+export const trace = ({
+  type,
+  message,
+  data,
+  context,
+}: {
+  type: LogType;
+  message?: string;
+  data?: LogData;
+  context?: TraceContext;
+}) => {
+  const obj: Log = {
+    type,
+    id: String(++id),
+    date: new Date(),
+  };
+
+  if (message) obj.message = message;
+  if (data) obj.data = data;
+  if (context) obj.context = context;
+
+  dispatch(obj);
+};
+
+/**
+ * A simple tracer class, that can be used to avoid repetition when using the `trace` function
+ *
+ * Its goal is to capture more context than a log function.
+ * This is simple for now, but can be improved later.
+ *
+ * @param type A given type (not level) for the current local tracer ("hw", "withDevice", etc.)
+ * @param context Anything representing the context where the log occurred
+ */
+export class LocalTracer {
+  constructor(private type: LogType, private context?: TraceContext) {}
+
+  trace(message: string, data?: TraceContext) {
+    trace({
+      type: this.type,
+      message,
+      data,
+      context: this.context,
+    });
+  }
+
+  getContext(): TraceContext | undefined {
+    return this.context;
+  }
+
+  setContext(context?: TraceContext) {
+    this.context = context;
+  }
+
+  getType(): LogType {
+    return this.type;
+  }
+
+  setType(type: LogType) {
+    this.type = type;
+  }
+
+  /**
+   * Create a new instance of the LocalTracer with an updated `type`
+   *
+   * It does not mutate the calling instance, but returns a new LocalTracer,
+   * following a simple builder pattern.
+   */
+  withType(type: LogType): LocalTracer {
+    return new LocalTracer(type, this.context);
+  }
+
+  /**
+   * Create a new instance of the LocalTracer with a new `context`
+   *
+   * It does not mutate the calling instance, but returns a new LocalTracer,
+   * following a simple builder pattern.
+   *
+   * @param context A TraceContext, that can undefined to reset the context
+   */
+  withContext(context?: TraceContext): LocalTracer {
+    return new LocalTracer(this.type, context);
+  }
+
+  /**
+   * Create a new instance of the LocalTracer with an updated `context`,
+   * on which an additional context is merged with the existing one.
+   *
+   * It does not mutate the calling instance, but returns a new LocalTracer,
+   * following a simple builder pattern.
+   */
+  withAdditionalContext(contextToAdd: TraceContext): LocalTracer {
+    return new LocalTracer(this.type, { ...this.context, ...contextToAdd });
+  }
+}
+
+/**
+ * Adds a subscribers to the emitted logs.
+ *
  * @param cb that is called for each future log() with the Log object
  * @return a function that can be called to unsubscribe the listener
  */

--- a/libs/ledgerjs/packages/logs/src/index.ts
+++ b/libs/ledgerjs/packages/logs/src/index.ts
@@ -113,6 +113,10 @@ export class LocalTracer {
     this.context = context;
   }
 
+  updateContext(contextToAdd: TraceContext) {
+    this.context = { ...this.context, ...contextToAdd };
+  }
+
   getType(): LogType {
     return this.type;
   }
@@ -150,7 +154,7 @@ export class LocalTracer {
    * It does not mutate the calling instance, but returns a new LocalTracer,
    * following a simple builder pattern.
    */
-  withAdditionalContext(contextToAdd: TraceContext): LocalTracer {
+  withUpdatedContext(contextToAdd: TraceContext): LocalTracer {
     return new LocalTracer(this.type, { ...this.context, ...contextToAdd });
   }
 }

--- a/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
+++ b/libs/ledgerjs/packages/react-native-hw-transport-ble/src/BleTransport.ts
@@ -581,7 +581,7 @@ export default class BleTransport extends Transport {
    * @returns {Promise<Buffer>} A promise that resolves with the response data from the device.
    */
   exchange = (apdu: Buffer): Promise<any> => {
-    const tracer = this.tracer.withAdditionalContext({
+    const tracer = this.tracer.withUpdatedContext({
       function: "exchange",
     });
     tracer.trace("Exchanging APDU ...");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3299,6 +3299,9 @@ importers:
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../errors
+      '@ledgerhq/logs':
+        specifier: workspace:^
+        version: link:../logs
       events:
         specifier: ^3.3.0
         version: 3.3.0


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### `ledgerjs/logs`
- new `trace` and `LocalTracer` definitions, **without breaking the behavior** of the existing `log` function

#### `hw-transport`, `hw-transport-node-hid-noevents`, `hw-transport-node-hid-singleton`, `react-native-hw-transport-ble`, `ledger-live-common` 

- Usage of new tracing system in some transports
- The tracing helps keeping a context (for ex a `job id`) that is propagated to other logs, creating a (simple) tracing span

Note on the "tracing": for now added a simple "context" that is propagated from `withDevice` to called functions, mainly from Transport. This is a preview of what could be done to have a real tracing system in the DeviceSDK

Note: the optional `openTimeoutMs` on the different `open` function is necessary for legacy (used by one of the Transport), and will actually be used in another PR. Don't mind it during the code review. But it should only by passed to a couple of other functions, not directly used (in this PR).

#### LLD:
- Logs from the `internal` thread are forwarded to the `main` thread
- The `main` thread records them, and can export them
  - on export, recorded logs from the `renderer` thread are sent to the `main` thread, and the `main` thread expand (not a merge, just pushed at the end) them with the logs it recorded from the `internal` thread
- If `VERBOSE` env var is set, filtered logs can be stdout from the main thread
  - Same from the `renderer` thread
- Setup simple tracing system (context) on LLD

Usage with `VERBOSE`:
```
VERBOSE="apdu,hw,hid-verbose,usb-detection" pnpm dev:lld
```

#### LLM:
- Setup simple tracing system on LLM with context
- If `VERBOSE` env var is set, filtered logs can be stdout from the main thread

Usage with `VERBOSE`: in a `.env` file, add (for ex)
```
VERBOSE="apdu,hw,ble-verbose,ble-error,transport"
```
You will need to re-build fully the app so the new `.env` file is transfered.

### ❓ Context

- **Impacted projects**: `hw-transport`, `hw-transport-node-hid-noevents`, `hw-transport-node-hid-singleton`, `react-native-hw-transport-ble`, `ledger-live-common` , `ledgerjs/logs`, LLM and LLD
- **Linked resource(s)**:  [LIVE-9405](https://ledgerhq.atlassian.net/browse/LIVE-9405)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

#### LLD performance

Non-scientific manual measurements (on dev build): beginning of the fw update until the end of the fw transfer:

<details>
  <summary>Measurements fw update transfer</summary>

With new log system (without `VERBOSE`):
- 47.909 s
- 48.228 s
- 46.515 s
- 47.181 s
- 47.807 s

Without new log system:
- 47.311 s
- 48.783 s
- 48.184 s
- 47.092 s
- 47.667 s

-> no obvious performance decline
</details>

#### Exported logs from LLD

<details>
  <summary>Example separation `renderer` and `internal` thread</summary>

<img width="885" alt="LLD_export_logs_separation" src="https://github.com/LedgerHQ/ledger-live/assets/15096913/9cf189c6-ec9f-4c28-bb68-b8c40fc28a67">


</details>

#### Stdout debug logs on LLD with `VERBOSE`

<details>
  <summary>LLD logs on terminal</summary>

<img width="722" alt="LLD_stdout_logs_VERBOSE" src="https://github.com/LedgerHQ/ledger-live/assets/15096913/0db4577b-1799-476d-9947-c0749625f310">


</details>

#### Stdout debug logs on LLM with `VERBOSE`

<details>
  <summary>LLM logs on terminal</summary>

<img width="431" alt="LLM_stdout_ex" src="https://github.com/LedgerHQ/ledger-live/assets/15096913/2e3faef2-d405-4364-b5ed-7aaf8c794315">

</details>

### 🚀 Expectations to reach



[LIVE-9405]: https://ledgerhq.atlassian.net/browse/LIVE-9405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ