### PR TITLE
chore: fix Mac gen screenshots consistently to others

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -140,6 +140,7 @@ jobs:
       - uses: actions/checkout@v3
         if: ${{ inputs.ref != null }}
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
       - uses: actions/checkout@v3


### PR DESCRIPTION

### 📝 Description

when you strictly compare Mac with Windows and Linux on the github actions, you spot this missing line to be provided. this probably create issue discussed at https://ledger.slack.com/archives/C0308JT8WS2/p1695041718845589?thread_ts=1695031274.456919&cid=C0308JT8WS2 ( https://github.com/LedgerHQ/ledger-live/actions/runs/6221200154/job/16884314639 )

### ❓ Context

- **Impacted projects**: `github ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `na` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
