### PR TITLE
fix(wallet-api): request account was not showing token accounts in some cases

### DIFF
--- a/.changeset/neat-insects-sin.md
+++ b/.changeset/neat-insects-sin.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+fix(wallet-api): request account was not showing token accounts in some cases
+
+The issue was only visible on mobile but is also prevented on desktop now
+The issue was only reproducible when omitting the parent account currency from the currencyIds of the request account query

--- a/apps/ledger-live-desktop/src/renderer/components/PerCurrencySelectAccount/state.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PerCurrencySelectAccount/state.ts
@@ -14,11 +14,13 @@ export function getAccountTuplesForCurrency(
 ): AccountTuple[] {
   if (currency.type === "TokenCurrency") {
     return allAccounts
-      .filter(
-        account =>
-          account.currency.id === currency.parentCurrency.id &&
-          (accountIds ? accountIds.has(account.id) : true),
-      )
+      .filter(account => {
+        // not checking subAccounts against accountIds for TokenCurrency
+        // because the wallet-api is not able to setup empty accounts
+        // for all parentAccounts and currencies we support
+        // and we would lose the empty token accounts in the drawer
+        return account.currency.id === currency.parentCurrency.id;
+      })
       .map(account => ({
         account,
         subAccount:

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
@@ -95,7 +95,13 @@ function SelectAccountAndCurrencyDrawer(props: SelectAccountAndCurrencyDrawerPro
     [onAccountSelected, props, onClose, accounts$],
   );
   if (currencies.length === 1) {
-    return <SelectAccountDrawer currency={currencies[0]} onAccountSelected={onAccountSelected} />;
+    return (
+      <SelectAccountDrawer
+        currency={currencies[0]}
+        onAccountSelected={onAccountSelected}
+        accounts$={accounts$}
+      />
+    );
   }
   return (
     <SelectAccountAndCurrencyDrawerContainer>

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -184,11 +184,13 @@ export const accountsTuplesByCurrencySelector = createSelector(
   (accounts, currency, accountIds): { account: AccountLike; subAccount: SubAccount | null }[] => {
     if (currency.type === "TokenCurrency") {
       return accounts
-        .filter(
-          account =>
-            account.currency.id === currency.parentCurrency.id &&
-            (accountIds ? accountIds.has(account.id) : true),
-        )
+        .filter(account => {
+          // not checking subAccounts against accountIds for TokenCurrency
+          // because the wallet-api is not able to setup empty accounts
+          // for all parentAccounts and currencies we support
+          // and we would lose the empty token accounts in the select account
+          return account.currency.id === currency.parentCurrency.id;
+        })
         .map(account => ({
           account,
           subAccount:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The issue was only visible on mobile but is also prevented on desktop now
The issue was only reproducible when omitting the parent account currency from the currencyIds of the request account query

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` & `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [`LIVE-8954`](https://ledgerhq.atlassian.net/browse/LIVE-8954) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** We have another PR for the automated tests <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
