### PR TITLE
Bugfix Stax LLD early security checks race condition

### DIFF
--- a/.changeset/swift-items-hear.md
+++ b/.changeset/swift-items-hear.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Stax early security checks: fix race condition between "toggle early check" and "get device info"

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -41,8 +41,10 @@ export type Props = {
    * */
   isInitialRunOfSecurityChecks: boolean;
   restartChecksAfterUpdate: () => void;
-  setFwUpdateInterrupted: (finalFirmware: FinalFirmware) => void;
+  // Pulling this state out of the early security check component because it gets
+  // unmounted when we restart the polling after the user interrupts an update."
   fwUpdateInterrupted: FinalFirmware | null;
+  setFwUpdateInterrupted: (finalFirmware: FinalFirmware) => void;
 };
 
 const commonDrawerProps = {

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/useChangeLanguagePrompt.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/useChangeLanguagePrompt.tsx
@@ -1,3 +1,4 @@
+import useIsMounted from "@ledgerhq/live-common/hooks/useIsMounted";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
@@ -12,22 +13,25 @@ import { setDrawer } from "~/renderer/drawers/Provider";
 import { languageSelector } from "~/renderer/reducers/settings";
 import ChangeDeviceLanguagePromptDrawer from "~/renderer/screens/settings/sections/General/ChangeDeviceLanguagePromptDrawer";
 
-type useChangeLanguagePromptParams = {
+type UseChangeLanguagePromptParams = {
   device: Device | undefined;
 };
 
-export const useChangeLanguagePrompt = ({ device }: useChangeLanguagePromptParams) => {
+export const useChangeLanguagePrompt = ({ device }: UseChangeLanguagePromptParams) => {
   const [deviceModelInfo, setDeviceModelInfo] = useState<DeviceModelInfo | null | undefined>();
+
+  const isMounted = useIsMounted();
 
   const refreshDeviceInfo = useCallback(() => {
     if (!device) return;
     withDevice(device.deviceId)(transport => from(getDeviceInfo(transport)))
       .toPromise()
       .then((deviceInfo: DeviceInfo) => {
+        if (!isMounted()) return;
         if (!isEqual(deviceInfo, deviceModelInfo?.deviceInfo))
           setDeviceModelInfo({ deviceInfo, modelId: device.modelId, apps: [] });
       });
-  }, [device, deviceModelInfo?.deviceInfo]);
+  }, [device, deviceModelInfo?.deviceInfo, isMounted]);
 
   const currentLanguage = useSelector(languageSelector);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

**Issue**: unseeded Stax device, device not on the "early security checks" screen
When starting the early security checks, there is a race condition that manifests with an error drawer:

https://github.com/LedgerHQ/ledger-live/assets/91890529/a50fb33e-bb3f-4b6d-81c7-6bc33b2304bd

This issue is not blocking but we would rather avoid this.
It is caused by what I added in #4705 (the error handler in the `getDeviceInfo` that is used to determine if the device is in bootloader mode).

**The fix**:

This `getDeviceInfo` was necessary in case the user interrupted the fw update by unplugging the device at the wrong moment, resulting in the device being in bootloader mode. We would perform this check when the `device` object changes (so for instance when the device gets plugged back in). It was resulting in a race condition because the first time the `device` object changes we also send an APDU to put the device on the "early security checks" screen (`toggleEarlyOnboardingCheck`).

Now, we remove this check so the race condition cannot happen anymore.
And to handle the case in which the user cancels the firmware update and it results in the device being in bootloader mode, when the fw update drawer gets closed, we simply restart the onboarding state polling mechanism which will itself detect if the device is in bootloader mode, and then we get a `fatalError` which we use to trigger the "repair" mechanism (`isBootloader` is set to true and we mount a device action that puts the device out of bootloader mode).


### ❓ Context

- **Impacted projects**: `lld` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-9495] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9495]: https://ledgerhq.atlassian.net/browse/LIVE-9495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ