### PR TITLE
chore: introduce GENERATE_METAFILES for bundle size analyze

### DIFF
--- a/apps/ledger-live-desktop/.gitignore
+++ b/apps/ledger-live-desktop/.gitignore
@@ -137,3 +137,5 @@ ui-lib/storybook-static/*
 
 # release-notes generated file
 release-notes.json
+
+metafile.*.json

--- a/apps/ledger-live-desktop/tools/main.js
+++ b/apps/ledger-live-desktop/tools/main.js
@@ -142,17 +142,18 @@ const build = async argv => {
     );
   }
 
-  // Enable this code if you want to analyze bundle sizes
-  /*
-  fs.writeFileSync("metafile.main.json", JSON.stringify(results[0].metafile), "utf-8");
-  fs.writeFileSync("metafile.preloader.json", JSON.stringify(results[1].metafile), "utf-8");
-  fs.writeFileSync("metafile.webviewPreloader.json", JSON.stringify(results[2].metafile), "utf-8");
-  fs.writeFileSync(
-    JSON.stringify(results[3].metafile),
-    "utf-8",
-  );
-  fs.writeFileSync("metafile.renderer.json", JSON.stringify(results[4].metafile), "utf-8");
-  */
+  if (process.env.GENERATE_METAFILES) {
+    // analyze bundle sizes. use it with https://esbuild.github.io/analyze/
+    fs.writeFileSync("metafile.main.json", JSON.stringify(results[0].metafile), "utf-8");
+    fs.writeFileSync("metafile.preloader.json", JSON.stringify(results[1].metafile), "utf-8");
+    fs.writeFileSync(
+      "metafile.webviewPreloader.json",
+      JSON.stringify(results[2].metafile),
+      "utf-8",
+    );
+    fs.writeFileSync("metafile.renderer.json", JSON.stringify(results[3].metafile), "utf-8");
+    fs.writeFileSync("metafile.renderer.worker.json", JSON.stringify(results[4].metafile), "utf-8");
+  }
 };
 
 yargs


### PR DESCRIPTION

### 📝 Description

to ease the generation of metafiles that can be dropped in https://esbuild.github.io/analyze/ we makes it easier to activate with just an env, instead of having to modify the source code of the build system.

build the LLD app

```
GENERATE_METAFILES=1 pnpm build:lld
```

find in apps/ledger-live-desktop some metafile.*.json files. Typically you can use the renderer one.

### ❓ Context

- **Impacted projects**: `LLD builds` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `na` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** trivial to manually test, no impact on the prod <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
