### PR TITLE
fix:(protect-2538): previous cta redirect to disclaimer screen

### DIFF
--- a/.changeset/unlucky-cups-hunt.md
+++ b/.changeset/unlucky-cups-hunt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+on previous cta recover onboarding, the app redirect to disclaimer screen

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
@@ -25,12 +26,16 @@ import { useDynamicUrl } from "~/renderer/terms";
 const RecoverRestore = () => {
   const { t } = useTranslation();
   const history = useHistory();
+  const recoverFF = useFeature("protectServicesDesktop");
   const currentDevice = useSelector(getCurrentDevice);
   const [state, setState] = useState<OnboardingState>();
   const [error, setError] = useState<Error>();
   const { setDeviceModelId } = useContext(OnboardingContext);
   const buyNew = useDynamicUrl("buyNew");
   const sub = useRef<Subscription>();
+  const recoverDiscoverPath = useMemo(() => {
+    return `/recover/${recoverFF?.params?.protectId}?redirectTo=disclaimerRestore`;
+  }, [recoverFF?.params?.protectId]);
 
   const getOnboardingState = useCallback((device: Device) => {
     sub.current?.unsubscribe();
@@ -116,7 +121,7 @@ const RecoverRestore = () => {
     return (
       <Flex width="100%" height="100%" position="relative">
         <Flex position="relative" height="100%" width="100%" flexDirection="column">
-          <OnboardingNavHeader onClickPrevious={() => history.push("/onboarding/select-device")} />
+          <OnboardingNavHeader onClickPrevious={() => history.push(recoverDiscoverPath)} />
           {renderError({
             t,
             error: new DeviceAlreadySetup("", { device: currentDevice?.modelId ?? "device" }),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

During, device pairing, if has an error on lld the previous button redirect to LiveApp disclaimer screen.

### ❓ Context

- **Impacted projects**: `ledger-live-desktop` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [protect-2538](https://ledgerhq.atlassian.net/browse/PROTECT-2538) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/118977988/82d5d35d-bde5-4dd6-93d5-9bff0cd634c1



<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
