### PR TITLE
Feat/LIVE-8384 - LLM - Add custom ordering to content cards

### DIFF
--- a/apps/ledger-live-mobile/src/dynamicContent/dynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/dynamicContent.tsx
@@ -113,14 +113,6 @@ const useDynamicContent = () => {
     () => assetsCards.filter((ac: AssetContentCard) => !hiddenCards.includes(ac.id)),
     [assetsCards, hiddenCards],
   );
-  const orderedNotificationsCards = useMemo(
-    () =>
-      notificationCards.sort(
-        (notif: NotificationContentCard, nt: NotificationContentCard) =>
-          nt.createdAt - notif.createdAt,
-      ),
-    [notificationCards],
-  );
   const isAWalletCardDisplayed = useMemo(
     () => walletCardsDisplayed.length >= 1,
     [walletCardsDisplayed],
@@ -182,7 +174,6 @@ const useDynamicContent = () => {
     dismissCard,
     trackContentCardEvent,
     notificationCards,
-    orderedNotificationsCards,
     refreshDynamicContent,
   };
 };

--- a/apps/ledger-live-mobile/src/dynamicContent/dynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/dynamicContent.tsx
@@ -17,6 +17,7 @@ import {
   LocationContentCard,
   NotificationContentCard,
   WalletContentCard,
+  ContentCard as LedgerContentCard,
 } from "./types";
 import { track } from "../analytics";
 import { setDismissedDynamicCards } from "../actions/settings";
@@ -26,6 +27,19 @@ export const getMobileContentCards = (array: BrazeContentCard[]) =>
 
 export const filterByPage = (array: BrazeContentCard[], page: string) =>
   array.filter(elem => elem.extras.location === page);
+
+export const compareCards = (a: LedgerContentCard, b: LedgerContentCard) => {
+  if (a.order && !b.order) {
+    return -1;
+  }
+  if (!a.order && b.order) {
+    return 1;
+  }
+  if ((!a.order && !b.order) || a.order === b.order) {
+    return b.createdAt - a.createdAt;
+  }
+  return (a.order || 0) - (b.order || 0);
+};
 
 export const mapAsWalletContentCard = (card: BrazeContentCard) =>
   ({
@@ -37,6 +51,7 @@ export const mapAsWalletContentCard = (card: BrazeContentCard) =>
     link: card.extras.link,
     background: Background[card.extras.background as Background] || Background.purple,
     createdAt: card.created,
+    order: parseInt(card.extras.order) ? parseInt(card.extras.order) : undefined,
   }) as WalletContentCard;
 
 export const mapAsAssetContentCard = (card: BrazeContentCard) =>
@@ -51,6 +66,7 @@ export const mapAsAssetContentCard = (card: BrazeContentCard) =>
     assets: card.extras.assets ?? "",
     displayOnEveryAssets: Boolean(card.extras.displayOnEveryAssets) ?? false,
     createdAt: card.created,
+    order: parseInt(card.extras.order) ? parseInt(card.extras.order) : undefined,
   }) as AssetContentCard;
 
 export const mapAsLearnContentCard = (card: BrazeContentCard) =>
@@ -62,6 +78,7 @@ export const mapAsLearnContentCard = (card: BrazeContentCard) =>
     image: card.extras.image,
     link: card.extras.link,
     createdAt: card.created,
+    order: parseInt(card.extras.order) ? parseInt(card.extras.order) : undefined,
   }) as LearnContentCard;
 
 export const mapAsNotificationContentCard = (card: BrazeContentCard) =>
@@ -75,6 +92,7 @@ export const mapAsNotificationContentCard = (card: BrazeContentCard) =>
     cta: card.extras.cta,
     createdAt: card.created,
     viewed: card.viewed,
+    order: parseInt(card.extras.order) ? parseInt(card.extras.order) : undefined,
   }) as NotificationContentCard;
 
 const useDynamicContent = () => {

--- a/apps/ledger-live-mobile/src/dynamicContent/types.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/types.ts
@@ -18,6 +18,7 @@ type ContentCard = {
   image?: string;
   tag: string;
   createdAt: number;
+  order?: number;
 };
 
 type WalletContentCard = ContentCard & {

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContentLogic.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContentLogic.ts
@@ -14,6 +14,7 @@ import {
   mapAsNotificationContentCard,
   mapAsLearnContentCard,
   getMobileContentCards,
+  compareCards,
 } from "./dynamicContent";
 import { LocationContentCard } from "./types";
 
@@ -26,22 +27,24 @@ export const useDynamicContentLogic = () => {
     const contentCards = await Braze.getContentCards();
     const mobileContentCards = getMobileContentCards(contentCards);
     // Filtering v0
-    const walletCards = filterByPage(mobileContentCards, LocationContentCard.Wallet).map(card =>
-      mapAsWalletContentCard(card),
-    );
+    const walletCards = filterByPage(mobileContentCards, LocationContentCard.Wallet)
+      .map(card => mapAsWalletContentCard(card))
+      .sort(compareCards);
 
-    const assetCards = filterByPage(mobileContentCards, LocationContentCard.Asset).map(card =>
-      mapAsAssetContentCard(card),
-    );
+    const assetCards = filterByPage(mobileContentCards, LocationContentCard.Asset)
+      .map(card => mapAsAssetContentCard(card))
+      .sort(compareCards);
 
     const notificationCards = filterByPage(
       mobileContentCards,
       LocationContentCard.NotificationCenter,
-    ).map(card => mapAsNotificationContentCard(card));
+    )
+      .map(card => mapAsNotificationContentCard(card))
+      .sort(compareCards);
 
-    const learnCards = filterByPage(mobileContentCards, LocationContentCard.Learn).map(card =>
-      mapAsLearnContentCard(card),
-    );
+    const learnCards = filterByPage(mobileContentCards, LocationContentCard.Learn)
+      .map(card => mapAsLearnContentCard(card))
+      .sort(compareCards);
 
     dispatch(setDynamicContentWalletCards(walletCards));
     dispatch(setDynamicContentAssetsCards(assetCards));

--- a/apps/ledger-live-mobile/src/screens/Learn/learn.tsx
+++ b/apps/ledger-live-mobile/src/screens/Learn/learn.tsx
@@ -1,6 +1,6 @@
 import { InformativeCard, Flex } from "@ledgerhq/native-ui";
 import { useNavigation } from "@react-navigation/native";
-import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import { FlatList } from "react-native";
 import { TouchableHighlight } from "react-native-gesture-handler";
 import styled, { useTheme } from "styled-components/native";

--- a/apps/ledger-live-mobile/src/screens/Learn/learn.tsx
+++ b/apps/ledger-live-mobile/src/screens/Learn/learn.tsx
@@ -23,11 +23,6 @@ function LearnSection() {
     setTimeout(() => setIsLoading(false), 750);
   }, []);
 
-  const sortedLearnCards = useMemo(
-    () => learnCards.sort((a, b) => b.createdAt - a.createdAt),
-    [learnCards],
-  );
-
   const onClickItem = useCallback(
     (card: LearnContentCard) => {
       if (!card.link) return;
@@ -63,7 +58,7 @@ function LearnSection() {
     <Flex>
       <TrackScreen category="Learn" />
       <FlatList
-        data={sortedLearnCards}
+        data={learnCards}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         showsVerticalScrollIndicator={false}

--- a/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
+++ b/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
@@ -43,7 +43,7 @@ export default function NotificationCenter() {
   const dispatch = useDispatch();
   const { colors } = useTheme();
   const {
-    orderedNotificationsCards,
+    notificationCards,
     logImpressionCard,
     logDismissCard,
     logClickCard,
@@ -54,17 +54,17 @@ export default function NotificationCenter() {
 
   const logCardsImpression = useCallback(() => {
     // TODO: REWORK like in the Carousel maybe? For Log impression only when it's clearly visible
-    orderedNotificationsCards.forEach(item => {
+    notificationCards.forEach(item => {
       logImpressionCard(item.id);
     });
 
-    const cards = orderedNotificationsCards.map(n => ({
+    const cards = notificationCards.map(n => ({
       ...n,
       viewed: true,
     }));
 
     dispatch(setDynamicContentNotificationCards(cards));
-  }, [orderedNotificationsCards, dispatch, logImpressionCard]);
+  }, [notificationCards, dispatch, logImpressionCard]);
 
   const refreshNotifications = useCallback(async () => {
     setIsDynamicContentLoading(true);
@@ -118,10 +118,10 @@ export default function NotificationCenter() {
       });
 
       dispatch(
-        setDynamicContentNotificationCards(orderedNotificationsCards.filter(n => n.id !== item.id)),
+        setDynamicContentNotificationCards(notificationCards.filter(n => n.id !== item.id)),
       );
     },
-    [dispatch, logDismissCard, orderedNotificationsCards, trackContentCardEvent],
+    [dispatch, logDismissCard, notificationCards, trackContentCardEvent],
   );
 
   const onClickCard = useCallback(
@@ -200,7 +200,7 @@ export default function NotificationCenter() {
       }
     >
       <FlatList<NotificationContentCard>
-        data={orderedNotificationsCards}
+        data={notificationCards}
         keyExtractor={(card: NotificationContentCard) => card.id}
         renderItem={elem => ListItem(elem.item)}
         ItemSeparatorComponent={() => <Box height={1} width="100%" backgroundColor="neutral.c30" />}

--- a/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
+++ b/apps/ledger-live-mobile/src/screens/NotificationCenter/Notifications.tsx
@@ -117,9 +117,7 @@ export default function NotificationCenter() {
         contentcard: item.title,
       });
 
-      dispatch(
-        setDynamicContentNotificationCards(notificationCards.filter(n => n.id !== item.id)),
-      );
+      dispatch(setDynamicContentNotificationCards(notificationCards.filter(n => n.id !== item.id)));
     },
     [dispatch, logDismissCard, notificationCards, trackContentCardEvent],
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add custom ordering to content cards
When a Braze content card have the property "order", it will be placed before other cards that don't possess this property

Order is as follow : 

First, content cards that have order extra property, ordered by "order" ascending
Then, other content cards, ordered by "createdAt" decreasing

### ❓ Context

- **Impacted projects**: `` live-mobile
- **Linked resource(s)**: `` https://ledgerhq.atlassian.net/browse/LIVE-8384

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
