### PR TITLE
[BUGFIX] Add missing GasOptions in Swap flows for Custom Fee Strategy

### DIFF
--- a/.changeset/purple-lobsters-accept.md
+++ b/.changeset/purple-lobsters-accept.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Prevent crash on Custom Fees selection when no GasOptions is set for EVM transactions

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
@@ -3,7 +3,7 @@ import { Account, AccountLike, ProtoNFT } from "@ledgerhq/types-live";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { Operation } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import type { Transaction as EvmTransaction, GasOptions } from "@ledgerhq/coin-evm/types/index";
 import type {
   CardanoAccount,
   Transaction as CardanoTransaction,
@@ -170,6 +170,8 @@ export type SendFundsNavigatorStackParamList = {
     parentId?: string;
     transaction: EvmTransaction;
     setTransaction: Result<EvmTransaction>["setTransaction"];
+    gasOptions?: GasOptions;
+    goBackOnSetTransaction?: boolean;
     currentNavigation:
       | ScreenName.SignTransactionSummary
       | ScreenName.SignTransactionSummary

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
@@ -1,5 +1,5 @@
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import type { Transaction as EvmTransaction, GasOptions } from "@ledgerhq/coin-evm/types/index";
 import type {
   CardanoAccount,
   Transaction as CardanoTransaction,
@@ -128,6 +128,8 @@ export type SignTransactionNavigatorParamList = {
     accountId: string;
     parentId?: string;
     transaction: EvmTransaction;
+    gasOptions?: GasOptions;
+    goBackOnSetTransaction?: boolean;
     currentNavigation:
       | ScreenName.SignTransactionSummary
       | ScreenName.SignTransactionSummary

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapNavigator.ts
@@ -1,7 +1,7 @@
 import { ExchangeRate, SwapDataType } from "@ledgerhq/live-common/exchange/swap/types";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
-import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import type { Transaction as EvmTransaction, GasOptions } from "@ledgerhq/coin-evm/types/index";
 
 import type {
   DetailsSwapParamList,
@@ -138,6 +138,8 @@ export type SwapNavigatorParamList = {
     accountId: string;
     parentId?: string;
     transaction: EvmTransaction;
+    gasOptions?: GasOptions;
+    goBackOnSetTransaction?: boolean;
     currentNavigation:
       | ScreenName.SignTransactionSummary
       | ScreenName.SignTransactionSummary

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/Evm1559CustomFees.tsx
@@ -36,6 +36,9 @@ const Evm1559CustomFees = ({
 
   const { gasOptions } = originalTransaction;
 
+  // TODO: Make GasOptions optional in the future.
+  // Use fallback mechanisms to infer min & max values based on the FeeData returned by a node
+  // This will make this "advanced" mode compatible with EVM chains without gasTracker
   invariant(gasOptions, "PriorityFeeField: 'transaction.gasOptions' should be defined");
 
   const [maxFeePerGas, setMaxFeePerGas] = useState<BigNumber>(

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/EvmLegacyCustomFees.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/EvmLegacyCustomFees.tsx
@@ -29,6 +29,9 @@ const EvmLegacyCustomFees = ({ account, onValidateFees, transaction }: Props) =>
 
   const { gasOptions } = transaction;
 
+  // TODO: Make GasOptions optional in the future.
+  // Use fallback mechanisms to infer min & max values based on the FeeData returned by a node
+  // This will make this "advanced" mode compatible with EVM chains without gasTracker
   invariant(gasOptions, "GasPriceField: 'transaction.gasOptions' should be defined");
 
   const networkGasPrice = useMemo(() => {

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import invariant from "invariant";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -26,7 +26,12 @@ const options = {
 };
 
 export default function EvmCustomFees({ route }: Props) {
-  const { setTransaction, transaction } = route.params;
+  const {
+    setTransaction,
+    transaction: baseTransaction,
+    gasOptions,
+    goBackOnSetTransaction = true,
+  } = route.params;
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   const navigation = useNavigation();
   invariant(account, "no account found");
@@ -38,9 +43,25 @@ export default function EvmCustomFees({ route }: Props) {
   const onValidateFees = useCallback(
     (transactionPatch: Partial<Transaction>) => () => {
       setTransaction(bridge.updateTransaction(route.params.transaction, transactionPatch));
-      navigation.goBack();
+      // In the context of some UI flows like the swap, the main component might already
+      // be providing a navigation after updating the transaction. On those cases,
+      // we'll remove the default "go back" behaviour and
+      // let the parent UI decide how to navigate.
+      if (goBackOnSetTransaction) {
+        navigation.goBack();
+      }
     },
-    [bridge, navigation, route.params, setTransaction],
+    [bridge, navigation, route.params, setTransaction, goBackOnSetTransaction],
+  );
+
+  // The transaction might be coming without gasOptions already added to it, like for the swap flow
+  //
+  // TODO: Make the Evm1559CustomFees & EvmLegacyCustomFees Components capable of working without
+  // GasOptions provided by just using fallback values like actual 1% of FeeData as min and
+  // 10_000% of FeeData as max
+  const transaction = useMemo(
+    () => (baseTransaction.gasOptions ? baseTransaction : { ...baseTransaction, gasOptions }),
+    [baseTransaction, gasOptions],
   );
 
   const shouldUseEip1559 = transaction.type === 2;

--- a/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
@@ -86,9 +86,19 @@ export default function EvmFeesStrategy({
       transaction,
       currentNavigation: ScreenName.SendSummary,
       nextNavigation: ScreenName.SendSelectDevice,
+      gasOptions,
+      goBackOnSetTransaction: false,
       setTransaction,
     });
-  }, [navigation, route.params, account.id, parentAccount, transaction, setTransaction]);
+  }, [
+    navigation,
+    route.params,
+    account.id,
+    parentAccount,
+    gasOptions,
+    transaction,
+    setTransaction,
+  ]);
 
   if (loading) {
     return <InfiniteLoader size={32} />;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the context of the Swap, a transaction might not be containing `gasOptions` yet, making some flow that requires them fail & crash. 
This PR adds them as a fallback prop for the Custom Fee Strategy screen when the transaction doesn't include it already.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/44363395/aaa40845-9499-464a-88f0-a79912724e75


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
