### PR TITLE
feat(protect-2592): add other link on firebase for quick access recover

### DIFF
--- a/.changeset/dry-numbers-sniff.md
+++ b/.changeset/dry-numbers-sniff.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+"ledger-libs": patch
+"@ledgerhq/types-live": patch
+---
+
+feat(protect-2592): add other link on firebase for quick access recover

--- a/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
@@ -20,7 +20,7 @@ import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/ind
 import useQuickActions from "../../hooks/useQuickActions";
 import { PTX_SERVICES_TOAST_ID } from "../../constants";
 
-import { useLearnMoreURI } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { useQuickAccessURI } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 
 type ButtonItem = {
   title: string;
@@ -58,7 +58,7 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
 
   const recoverConfig = useFeature("protectServicesMobile");
 
-  const learnMoreURI = useLearnMoreURI(recoverConfig);
+  const quickAccessURI = useQuickAccessURI(recoverConfig);
 
   const onNavigate = useCallback(
     (name: string, options?: object) => {
@@ -71,11 +71,11 @@ export default function TransferDrawer({ onClose }: Omit<ModalProps, "isRequesti
     [navigation, onClose],
   );
   const onNavigateRecover = useCallback(() => {
-    if (learnMoreURI) {
-      Linking.canOpenURL(learnMoreURI).then(() => Linking.openURL(learnMoreURI));
+    if (quickAccessURI) {
+      Linking.canOpenURL(quickAccessURI).then(() => Linking.openURL(quickAccessURI));
     }
     onClose?.();
-  }, [learnMoreURI, onClose]);
+  }, [onClose, quickAccessURI]);
 
   const buttonsList: ButtonItem[] = [
     {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -284,8 +284,9 @@ export const DEFAULT_FEATURES: Features = {
       },
       managerStatesData: {
         NEW: {
-          alreadySubscribedURI: `ledgerlive://recover/protect-simu?redirectTo=login`,
-          learnMoreURI: `ledgerlive://recover/protect-simu?redirectTo=upsell`,
+          alreadySubscribedURI: `ledgerlive://recover/protect-simu?redirectTo=login&source=llm_onboarding_24&ajs_prop_source=llm_onboarding_24&ajs_prop_campaign=launch`,
+          learnMoreURI: `ledgerlive://recover/protect-simu?redirectTo=upsell&source=llm_onboarding_24&ajs_prop_source=llm_onboarding_24&ajs_prop_campaign=launch`,
+          quickAccessURI: `ledgerlive://recover/protect-simu?redirectTo=login&source=llm-navbar-quick-access&ajs_prop_source=llm-navbar-quick-access&ajs_prop_campaign=launch`,
         },
       },
       onboardingRestore: {

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
@@ -43,6 +43,15 @@ export function useLearnMoreURI(
   return useReplacedURI(uri, id);
 }
 
+export function useQuickAccessURI(
+  servicesConfig: Feature_ProtectServicesMobile | null,
+): string | undefined {
+  const uri = servicesConfig?.params?.managerStatesData?.NEW?.quickAccessURI;
+  const id = servicesConfig?.params?.protectId;
+
+  return useReplacedURI(uri, id);
+}
+
 export function useAlreadySubscribedURI(
   servicesConfig: Feature_ProtectServicesMobile | null,
 ): string | undefined {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -307,6 +307,7 @@ export type Feature_ProtectServicesMobile = Feature<{
     NEW: {
       learnMoreURI: string;
       alreadySubscribedURI: string;
+      quickAccessURI: string;
     };
   };
   login: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

We need to redirect to specific link on featureflag on quick access recover LiveApp

### ❓ Context

- **Impacted projects**: `live-mobile` `types-live` `live-common` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [PROTECT-2592](https://ledgerhq.atlassian.net/browse/PROTECT-2592) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-2592]: https://ledgerhq.atlassian.net/browse/PROTECT-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ