### PR TITLE
Bugfix/live 8698 Manager API v2 breaking changes adaptations

### DIFF
--- a/.changeset/fresh-squids-cheer.md
+++ b/.changeset/fresh-squids-cheer.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Feature flag listAppsV2 replaced by listAppsV2minor1
+Fix listApps v2 logic: adapt to breaking changes in the API and fix "polyfilling" logic of data of apps

--- a/.changeset/poor-cobras-laugh.md
+++ b/.changeset/poor-cobras-laugh.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": patch
+---
+
+Fix interaction between "InstalledAppsModal" and "UninstallDependenciesModal", the later one was not getting opened in case an app with dependents was getting uninstalled from the first one, due to a bad usage of drawers (not using QueuedDrawer).
+Refactor prop drilling nightmare of setAppInstallWithDependencies/setAppUninstallWithDependencies with a simple React.Context.
+Refactor InstalledAppDependenciesModal and UninstallAppDependenciesModal to have no business logic inside
+Rename action creator installAppFirstTime to setHasInstalledAnyApp for more clarity

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -190,7 +190,7 @@ export default function Default() {
   useFetchCurrencyFrom();
   const discoverDB = useDiscoverDB();
 
-  const listAppsV2 = useFeature("listAppsV2dot1");
+  const listAppsV2 = useFeature("listAppsV2minor1");
   useEffect(() => {
     if (!listAppsV2) return;
     enableListAppsV2(listAppsV2.enabled);

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -190,7 +190,7 @@ export default function Default() {
   useFetchCurrencyFrom();
   const discoverDB = useDiscoverDB();
 
-  const listAppsV2 = useFeature("listAppsV2");
+  const listAppsV2 = useFeature("listAppsV2dot1");
   useEffect(() => {
     if (!listAppsV2) return;
     enableListAppsV2(listAppsV2.enabled);

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -14,7 +14,7 @@ import {
   SettingsHideNftCollectionPayload,
   SettingsImportDesktopPayload,
   SettingsImportPayload,
-  SettingsInstallAppFirstTimePayload,
+  SettingsSetHasInstalledAnyAppPayload,
   SettingsLastSeenDeviceInfoPayload,
   SettingsLastSeenDevicePayload,
   SettingsRemoveStarredMarketcoinsPayload,
@@ -115,8 +115,8 @@ export const clearLastSeenCustomImage = () =>
 export const completeOnboarding = createAction<SettingsCompleteOnboardingPayload>(
   SettingsActionTypes.SETTINGS_COMPLETE_ONBOARDING,
 );
-export const installAppFirstTime = createAction<SettingsInstallAppFirstTimePayload>(
-  SettingsActionTypes.SETTINGS_INSTALL_APP_FIRST_TIME,
+export const setHasInstalledAnyApp = createAction<SettingsSetHasInstalledAnyAppPayload>(
+  SettingsActionTypes.SETTINGS_SET_HAS_INSTALLED_ANY_APP,
 );
 export const switchCountervalueFirst = createAction(
   SettingsActionTypes.SETTINGS_SWITCH_COUNTERVALUE_FIRST,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -225,7 +225,7 @@ export enum SettingsActionTypes {
   SETTINGS_SET_SELECTED_TIME_RANGE = "SETTINGS_SET_SELECTED_TIME_RANGE",
   SETTINGS_COMPLETE_ONBOARDING = "SETTINGS_COMPLETE_ONBOARDING",
   SETTINGS_COMPLETE_CUSTOM_IMAGE_FLOW = "SETTINGS_COMPLETE_CUSTOM_IMAGE_FLOW",
-  SETTINGS_INSTALL_APP_FIRST_TIME = "SETTINGS_INSTALL_APP_FIRST_TIME",
+  SETTINGS_SET_HAS_INSTALLED_ANY_APP = "SETTINGS_SET_HAS_INSTALLED_ANY_APP",
   SETTINGS_SET_READONLY_MODE = "SETTINGS_SET_READONLY_MODE",
   SETTINGS_SET_EXPERIMENTAL_USB_SUPPORT = "SETTINGS_SET_EXPERIMENTAL_USB_SUPPORT",
   SETTINGS_SWITCH_COUNTERVALUE_FIRST = "SETTINGS_SWITCH_COUNTERVALUE_FIRST",
@@ -297,7 +297,7 @@ export type SettingsSetCountervaluePayload = SettingsState["counterValue"];
 export type SettingsSetOrderAccountsPayload = SettingsState["orderAccounts"];
 export type SettingsSetPairsPayload = { pairs: Array<Pair> };
 export type SettingsSetSelectedTimeRangePayload = SettingsState["selectedTimeRange"];
-export type SettingsInstallAppFirstTimePayload = SettingsState["hasInstalledAnyApp"];
+export type SettingsSetHasInstalledAnyAppPayload = SettingsState["hasInstalledAnyApp"];
 export type SettingsSetReadOnlyModePayload = SettingsState["readOnlyModeEnabled"];
 export type SettingsHideEmptyTokenAccountsPayload = SettingsState["hideEmptyTokenAccounts"];
 export type SettingsFilterTokenOperationsZeroAmountPayload =
@@ -388,7 +388,7 @@ export type SettingsPayload =
   | SettingsSetOrderAccountsPayload
   | SettingsSetPairsPayload
   | SettingsSetSelectedTimeRangePayload
-  | SettingsInstallAppFirstTimePayload
+  | SettingsSetHasInstalledAnyAppPayload
   | SettingsSetReadOnlyModePayload
   | SettingsHideEmptyTokenAccountsPayload
   | SettingsShowTokenPayload

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -16,7 +16,7 @@ export default function RootNavigator() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const goToOnboarding = !hasCompletedOnboarding && !Config.SKIP_ONBOARDING;
 
-  const listAppsV2 = useFeature("listAppsV2");
+  const listAppsV2 = useFeature("listAppsV2dot1");
   useEffect(() => {
     if (!listAppsV2) return;
     enableListAppsV2(listAppsV2.enabled);

--- a/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/index.tsx
@@ -16,7 +16,7 @@ export default function RootNavigator() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const goToOnboarding = !hasCompletedOnboarding && !Config.SKIP_ONBOARDING;
 
-  const listAppsV2 = useFeature("listAppsV2dot1");
+  const listAppsV2 = useFeature("listAppsV2minor1");
   useEffect(() => {
     if (!listAppsV2) return;
     enableListAppsV2(listAppsV2.enabled);

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -26,7 +26,7 @@ import type {
   SettingsHideNftCollectionPayload,
   SettingsImportDesktopPayload,
   SettingsImportPayload,
-  SettingsInstallAppFirstTimePayload,
+  SettingsSetHasInstalledAnyAppPayload,
   SettingsLastSeenDeviceInfoPayload,
   SettingsPayload,
   SettingsRemoveStarredMarketcoinsPayload,
@@ -304,9 +304,9 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     };
   },
 
-  [SettingsActionTypes.SETTINGS_INSTALL_APP_FIRST_TIME]: (state, action) => ({
+  [SettingsActionTypes.SETTINGS_SET_HAS_INSTALLED_ANY_APP]: (state, action) => ({
     ...state,
-    hasInstalledAnyApp: (action as Action<SettingsInstallAppFirstTimePayload>).payload,
+    hasInstalledAnyApp: (action as Action<SettingsSetHasInstalledAnyAppPayload>).payload,
   }),
 
   [SettingsActionTypes.SETTINGS_SET_READONLY_MODE]: (state, action) => ({

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsInstallUninstallWithDependenciesContext.ts
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsInstallUninstallWithDependenciesContext.ts
@@ -1,0 +1,43 @@
+import { App } from "@ledgerhq/types-live";
+import React, { useContext } from "react";
+
+/**
+ * Represents an installed app that depends on other installed apps.
+ * For instance:
+ * `{ app: polygonApp, dependents: [ethereumApp] }`
+ */
+export type AppWithDependencies = {
+  app: App;
+  dependencies: App[];
+};
+
+/**
+ * Represents an installed app that has other installed apps depending on it.
+ * For instance:
+ * { app: ethereumApp, dependents: [polygonApp] }`
+ */
+export type AppWithDependents = {
+  app: App;
+  dependents: App[];
+};
+
+type AppsInstallUninstallWithDependenciesValue = {
+  setAppWithDependenciesToInstall: (appWithDependencies: AppWithDependencies | null) => void;
+  setAppWithDependentsToUninstall: (appWithDependents: AppWithDependents | null) => void; // TODO: rename in uninstall with dependents
+};
+
+const AppsInstallUninstallWithDependenciesContext = React.createContext<
+  AppsInstallUninstallWithDependenciesValue | undefined
+>(undefined);
+
+export const AppsInstallUninstallWithDependenciesContextProvider =
+  AppsInstallUninstallWithDependenciesContext.Provider;
+
+export function useSetAppsWithDependenciesToInstallUninstall() {
+  const contextValue = useContext(AppsInstallUninstallWithDependenciesContext);
+  if (contextValue === undefined)
+    throw new Error(
+      "useAppsInstallUninstallWithDependencies must be used within a context provider",
+    );
+  return contextValue;
+}

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsInstallUninstallWithDependenciesContext.ts
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsInstallUninstallWithDependenciesContext.ts
@@ -23,7 +23,7 @@ export type AppWithDependents = {
 
 type AppsInstallUninstallWithDependenciesValue = {
   setAppWithDependenciesToInstall: (appWithDependencies: AppWithDependencies | null) => void;
-  setAppWithDependentsToUninstall: (appWithDependents: AppWithDependents | null) => void; // TODO: rename in uninstall with dependents
+  setAppWithDependentsToUninstall: (appWithDependents: AppWithDependents | null) => void;
 };
 
 /**

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsInstallUninstallWithDependenciesContext.ts
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsInstallUninstallWithDependenciesContext.ts
@@ -14,7 +14,7 @@ export type AppWithDependencies = {
 /**
  * Represents an installed app that has other installed apps depending on it.
  * For instance:
- * { app: ethereumApp, dependents: [polygonApp] }`
+ * `{ app: ethereumApp, dependents: [polygonApp] }`
  */
 export type AppWithDependents = {
   app: App;
@@ -26,6 +26,11 @@ type AppsInstallUninstallWithDependenciesValue = {
   setAppWithDependentsToUninstall: (appWithDependents: AppWithDependents | null) => void; // TODO: rename in uninstall with dependents
 };
 
+/**
+ * Defines setters for apps to install with their dependencies or apps to
+ * uninstall with their dependents.
+ * This context was introduced to avoid prop drilling.
+ */
 const AppsInstallUninstallWithDependenciesContext = React.createContext<
   AppsInstallUninstallWithDependenciesValue | undefined
 >(undefined);

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppInstallButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppInstallButton.tsx
@@ -10,13 +10,13 @@ import styled from "styled-components/native";
 import { IconsLegacy, Box } from "@ledgerhq/native-ui";
 import { hasInstalledAnyAppSelector } from "../../../reducers/settings";
 import { installAppFirstTime } from "../../../actions/settings";
+import { useSetAppsWithDependenciesToInstallUninstall } from "../AppsInstallUninstallWithDependenciesContext";
 
 type Props = {
   app: App;
   state: State;
   dispatch: (_: Action) => void;
   notEnoughMemoryToInstall: boolean;
-  setAppInstallWithDependencies: (_: { app: App; dependencies: App[] }) => void;
   storageWarning: (_: string) => void;
 };
 
@@ -34,7 +34,6 @@ export default function AppInstallButton({
   state,
   dispatch: dispatchProps,
   notEnoughMemoryToInstall,
-  setAppInstallWithDependencies,
   storageWarning,
 }: Props) {
   const dispatch = useDispatch();
@@ -45,6 +44,8 @@ export default function AppInstallButton({
   const { updateAllQueue } = state;
 
   const needsDependencies = useAppInstallNeedsDeps(state, app);
+
+  const { setAppWithDependenciesToInstall } = useSetAppsWithDependenciesToInstallUninstall();
 
   const disabled = useMemo(
     () => !canBeInstalled || updateAllQueue.length > 0,
@@ -57,8 +58,8 @@ export default function AppInstallButton({
       storageWarning(name);
       return;
     }
-    if (needsDependencies && setAppInstallWithDependencies) {
-      setAppInstallWithDependencies(needsDependencies);
+    if (needsDependencies) {
+      setAppWithDependenciesToInstall(needsDependencies);
     } else {
       dispatchProps({ type: "install", name });
     }
@@ -71,7 +72,7 @@ export default function AppInstallButton({
     dispatchProps,
     name,
     needsDependencies,
-    setAppInstallWithDependencies,
+    setAppWithDependenciesToInstall,
     hasInstalledAnyApp,
     notEnoughMemoryToInstall,
     storageWarning,

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppInstallButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppInstallButton.tsx
@@ -9,7 +9,7 @@ import { useAppInstallNeedsDeps } from "@ledgerhq/live-common/apps/react";
 import styled from "styled-components/native";
 import { IconsLegacy, Box } from "@ledgerhq/native-ui";
 import { hasInstalledAnyAppSelector } from "../../../reducers/settings";
-import { installAppFirstTime } from "../../../actions/settings";
+import { setHasInstalledAnyApp } from "../../../actions/settings";
 import { useSetAppsWithDependenciesToInstallUninstall } from "../AppsInstallUninstallWithDependenciesContext";
 
 type Props = {
@@ -64,7 +64,7 @@ export default function AppInstallButton({
       dispatchProps({ type: "install", name });
     }
     if (!hasInstalledAnyApp) {
-      dispatch(installAppFirstTime(true));
+      dispatch(setHasInstalledAnyApp(true));
     }
   }, [
     disabled,

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppRow.tsx
@@ -17,8 +17,6 @@ type Props = {
   app: App;
   state: State;
   dispatch: (_: Action) => void;
-  setAppInstallWithDependencies: (_: { app: App; dependencies: App[] }) => void;
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
   setStorageWarning: (value: string | null) => void;
   optimisticState: State;
 };
@@ -52,15 +50,7 @@ const VersionContainer = styled(Flex).attrs({
   marginTop: 2,
 })``;
 
-const AppRow = ({
-  app,
-  state,
-  dispatch,
-  setAppInstallWithDependencies,
-  setAppUninstallWithDependencies,
-  setStorageWarning,
-  optimisticState,
-}: Props) => {
+const AppRow = ({ app, state, dispatch, setStorageWarning, optimisticState }: Props) => {
   const { name, bytes, version: appVersion, displayName } = app;
   const { installed, deviceInfo } = state;
   const canBeInstalled = useMemo(() => manager.canHandleInstall(app), [app]);
@@ -111,8 +101,6 @@ const AppRow = ({
         dispatch={dispatch}
         notEnoughMemoryToInstall={notEnoughMemoryToInstall}
         isInstalled={!!isInstalled}
-        setAppInstallWithDependencies={setAppInstallWithDependencies}
-        setAppUninstallWithDependencies={setAppUninstallWithDependencies}
         storageWarning={onSizePress}
       />
     </RowContainer>

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppStateButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppStateButton.tsx
@@ -16,8 +16,6 @@ type Props = {
   dispatch: (_: Action) => void;
   notEnoughMemoryToInstall: boolean;
   isInstalled: boolean;
-  setAppInstallWithDependencies: (_: { app: App; dependencies: App[] }) => void;
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
   storageWarning: (appName: string) => void;
 };
 
@@ -34,8 +32,6 @@ const AppStateButton = ({
   dispatch,
   notEnoughMemoryToInstall,
   isInstalled,
-  setAppInstallWithDependencies,
-  setAppUninstallWithDependencies,
   storageWarning,
 }: Props) => {
   const { installed, installQueue, uninstallQueue, updateAllQueue } = state;
@@ -63,14 +59,7 @@ const AppStateButton = ({
       case canUpdate:
         return <AppUpdateButton app={app} state={state} dispatch={dispatch} />;
       case isInstalled:
-        return (
-          <AppUninstallButton
-            app={app}
-            state={state}
-            dispatch={dispatch}
-            setAppUninstallWithDependencies={setAppUninstallWithDependencies}
-          />
-        );
+        return <AppUninstallButton app={app} state={state} dispatch={dispatch} />;
       default:
         return (
           <AppInstallButton
@@ -78,7 +67,6 @@ const AppStateButton = ({
             dispatch={dispatch}
             app={app}
             notEnoughMemoryToInstall={notEnoughMemoryToInstall}
-            setAppInstallWithDependencies={setAppInstallWithDependencies}
             storageWarning={storageWarning}
           />
         );

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppUninstallButton.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsList/AppUninstallButton.tsx
@@ -8,12 +8,12 @@ import type { Action, State } from "@ledgerhq/live-common/apps/index";
 
 import styled from "styled-components/native";
 import { IconsLegacy, Box } from "@ledgerhq/native-ui";
+import { useSetAppsWithDependenciesToInstallUninstall } from "../AppsInstallUninstallWithDependenciesContext";
 
 type Props = {
   app: App;
   state: State;
   dispatch: (_: Action) => void;
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
   size?: number;
 };
 
@@ -23,16 +23,13 @@ const ButtonContainer = styled(Box).attrs({
   justifyContent: "center",
 })``;
 
-const AppUninstallButton = ({
-  app,
-  state,
-  dispatch,
-  setAppUninstallWithDependencies,
-  size = 48,
-}: Props) => {
+const AppUninstallButton = ({ app, state, dispatch, size = 48 }: Props) => {
   const { name } = app;
 
   const needsDependencies = useAppUninstallNeedsDeps(state, app);
+
+  const { setAppWithDependentsToUninstall: setAppUninstallWithDependencies } =
+    useSetAppsWithDependenciesToInstallUninstall();
 
   const uninstallApp = useCallback(() => {
     if (needsDependencies && setAppUninstallWithDependencies)

--- a/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/AppsScreen.tsx
@@ -55,8 +55,6 @@ type NavigationProps = BaseComposite<
 type Props = {
   state: State;
   dispatch: (_: Action) => void;
-  setAppInstallWithDependencies: (_: { app: App; dependencies: App[] }) => void;
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
   setStorageWarning: (value: string | null) => void;
   deviceId: string;
   initialDeviceName?: string | null;
@@ -76,8 +74,6 @@ type Props = {
 const AppsScreen = ({
   state,
   dispatch,
-  setAppInstallWithDependencies,
-  setAppUninstallWithDependencies,
   setStorageWarning,
   updateModalOpened,
   deviceId,
@@ -232,20 +228,11 @@ const AppsScreen = ({
         app={item}
         state={state}
         dispatch={dispatch}
-        setAppInstallWithDependencies={setAppInstallWithDependencies}
-        setAppUninstallWithDependencies={setAppUninstallWithDependencies}
         setStorageWarning={setStorageWarning}
         optimisticState={optimisticState}
       />
     ),
-    [
-      state,
-      dispatch,
-      setAppInstallWithDependencies,
-      setAppUninstallWithDependencies,
-      setStorageWarning,
-      optimisticState,
-    ],
+    [state, dispatch, setStorageWarning, optimisticState],
   );
 
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
@@ -267,7 +254,6 @@ const AppsScreen = ({
               initialDeviceName={initialDeviceName}
               pendingInstalls={pendingInstalls}
               deviceInfo={deviceInfo}
-              setAppUninstallWithDependencies={setAppUninstallWithDependencies}
               dispatch={dispatch}
               device={device}
               appList={deviceApps}
@@ -325,7 +311,6 @@ const AppsScreen = ({
       initialDeviceName,
       pendingInstalls,
       deviceInfo,
-      setAppUninstallWithDependencies,
       dispatch,
       device,
       deviceApps,

--- a/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Device/index.tsx
@@ -50,7 +50,6 @@ type Props = PropsWithChildren<{
   pendingInstalls: boolean;
   deviceInfo: DeviceInfo;
   device: Device;
-  setAppUninstallWithDependencies: (params: { dependents: App[]; app: App }) => void;
   dispatch: (action: Action) => void;
   appList: App[];
   onLanguageChange: () => void;
@@ -69,7 +68,6 @@ const DeviceCard = ({
   initialDeviceName,
   pendingInstalls,
   deviceInfo,
-  setAppUninstallWithDependencies,
   dispatch,
   appList,
   onLanguageChange,
@@ -202,7 +200,6 @@ const DeviceCard = ({
         state={state}
         dispatch={dispatch}
         appList={appList}
-        setAppUninstallWithDependencies={setAppUninstallWithDependencies}
         illustration={illustration}
         deviceInfo={deviceInfo}
       />

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -204,11 +204,11 @@ const Manager = ({ navigation, route }: NavigationProps) => {
 
   const installAppWithDependencies = useCallback(() => {
     if (appWithDependenciesToInstall) {
-      dispatch(setHasInstalledAnyApp(true));
+      reduxDispatch(setHasInstalledAnyApp(true));
       dispatch({ type: "install", name: appWithDependenciesToInstall?.app.name });
     }
     onCloseInstallAppDependenciesModal();
-  }, [appWithDependenciesToInstall, onCloseInstallAppDependenciesModal, dispatch]);
+  }, [appWithDependenciesToInstall, onCloseInstallAppDependenciesModal, reduxDispatch, dispatch]);
 
   const onCloseUninstallAppDependenciesModal = useCallback(() => {
     setAppWithDependentsToUninstall(null);

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -17,7 +17,7 @@ import StorageWarningModal from "./Modals/StorageWarningModal";
 import InstallAppDependenciesModal from "./Modals/InstallAppDependenciesModal";
 import UninstallAppDependenciesModal from "./Modals/UninstallAppDependenciesModal";
 import { useLockNavigation } from "../../components/RootNavigator/CustomBlockRouterNavigator";
-import { setLastSeenDeviceInfo } from "../../actions/settings";
+import { setHasInstalledAnyApp, setLastSeenDeviceInfo } from "../../actions/settings";
 import { ScreenName } from "../../const";
 import FirmwareUpdateScreen from "../../components/FirmwareUpdate";
 import { ManagerNavigatorStackParamList } from "../../components/RootNavigator/types/ManagerNavigator";
@@ -204,6 +204,7 @@ const Manager = ({ navigation, route }: NavigationProps) => {
 
   const installAppWithDependencies = useCallback(() => {
     if (appWithDependenciesToInstall) {
+      dispatch(setHasInstalledAnyApp(true));
       dispatch({ type: "install", name: appWithDependenciesToInstall?.app.name });
     }
     onCloseInstallAppDependenciesModal();

--- a/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Manager.tsx
@@ -14,8 +14,8 @@ import GenericErrorBottomModal from "../../components/GenericErrorBottomModal";
 import { TrackScreen } from "../../analytics";
 import QuitManagerModal from "./Modals/QuitManagerModal";
 import StorageWarningModal from "./Modals/StorageWarningModal";
-import AppDependenciesModal from "./Modals/AppDependenciesModal";
-import UninstallDependenciesModal from "./Modals/UninstallDependenciesModal";
+import InstallAppDependenciesModal from "./Modals/InstallAppDependenciesModal";
+import UninstallAppDependenciesModal from "./Modals/UninstallAppDependenciesModal";
 import { useLockNavigation } from "../../components/RootNavigator/CustomBlockRouterNavigator";
 import { setLastSeenDeviceInfo } from "../../actions/settings";
 import { ScreenName } from "../../const";
@@ -139,14 +139,6 @@ const Manager = ({ navigation, route }: NavigationProps) => {
 
   const closeErrorModal = useCallback(() => setError(null), [setError]);
 
-  const resetAppInstallWithDependencies = useCallback(() => {
-    setAppWithDependenciesToInstall(null);
-  }, []);
-
-  const resetAppUninstallWithDependencies = useCallback(() => {
-    setAppWithDependentsToUninstall(null);
-  }, []);
-
   const closeQuitManagerModal = useCallback(
     () => setQuitManagerAction(null),
     [setQuitManagerAction],
@@ -198,13 +190,35 @@ const Manager = ({ navigation, route }: NavigationProps) => {
     [device, navigation],
   );
 
-  const contextValue = useMemo(
+  const appsInstallUninstallWithDependenciesContextValue = useMemo(
     () => ({
       setAppWithDependenciesToInstall,
       setAppWithDependentsToUninstall,
     }),
     [],
   );
+
+  const onCloseInstallAppDependenciesModal = useCallback(() => {
+    setAppWithDependenciesToInstall(null);
+  }, []);
+
+  const installAppWithDependencies = useCallback(() => {
+    if (appWithDependenciesToInstall) {
+      dispatch({ type: "install", name: appWithDependenciesToInstall?.app.name });
+    }
+    onCloseInstallAppDependenciesModal();
+  }, [appWithDependenciesToInstall, onCloseInstallAppDependenciesModal, dispatch]);
+
+  const onCloseUninstallAppDependenciesModal = useCallback(() => {
+    setAppWithDependentsToUninstall(null);
+  }, []);
+
+  const uninstallAppsWithDependents = useCallback(() => {
+    if (appWithDependentsToUninstall) {
+      dispatch({ type: "uninstall", name: appWithDependentsToUninstall?.app.name });
+    }
+    onCloseUninstallAppDependenciesModal();
+  }, [appWithDependentsToUninstall, dispatch, onCloseUninstallAppDependenciesModal]);
 
   return (
     <>
@@ -216,7 +230,9 @@ const Manager = ({ navigation, route }: NavigationProps) => {
         appLength={result ? result.installed.length : 0}
       />
       <SyncSkipUnderPriority priority={100} />
-      <AppsInstallUninstallWithDependenciesContextProvider value={contextValue}>
+      <AppsInstallUninstallWithDependenciesContextProvider
+        value={appsInstallUninstallWithDependenciesContextValue}
+      >
         <AppsScreen
           state={state}
           dispatch={dispatch}
@@ -245,15 +261,15 @@ const Manager = ({ navigation, route }: NavigationProps) => {
         uninstallQueue={uninstallQueue}
       />
       <StorageWarningModal warning={storageWarning} onClose={resetStorageWarning} />
-      <AppDependenciesModal
+      <InstallAppDependenciesModal
         appWithDependenciesToInstall={appWithDependenciesToInstall}
-        onClose={resetAppInstallWithDependencies}
-        dispatch={dispatch}
+        onClose={onCloseInstallAppDependenciesModal}
+        installAppWithDependencies={installAppWithDependencies}
       />
-      <UninstallDependenciesModal
+      <UninstallAppDependenciesModal
         appWithDependentsToUninstall={appWithDependentsToUninstall}
-        onClose={resetAppUninstallWithDependencies}
-        dispatch={dispatch}
+        onClose={onCloseUninstallAppDependenciesModal}
+        uninstallAppsWithDependents={uninstallAppsWithDependents}
       />
       <FirmwareUpdateScreen
         device={device}

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/AppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/AppDependenciesModal.tsx
@@ -4,7 +4,6 @@ import { TouchableOpacity } from "react-native";
 import { Trans } from "react-i18next";
 
 import { Action } from "@ledgerhq/live-common/apps/index";
-import { App } from "@ledgerhq/types-live";
 
 import styled from "styled-components/native";
 import { Flex, IconsLegacy, Text, Button } from "@ledgerhq/native-ui";
@@ -12,9 +11,10 @@ import { hasInstalledAnyAppSelector } from "../../../reducers/settings";
 import { installAppFirstTime } from "../../../actions/settings";
 import AppIcon from "../AppsList/AppIcon";
 import QueuedDrawer from "../../../components/QueuedDrawer";
+import { AppWithDependencies } from "../AppsInstallUninstallWithDependenciesContext";
 
 type Props = {
-  appInstallWithDependencies: { app: App; dependencies: App[] };
+  appWithDependenciesToInstall: AppWithDependencies | null;
   dispatch: (_: Action) => void;
   onClose: () => void;
 };
@@ -60,14 +60,14 @@ const CancelButton = styled(TouchableOpacity)`
 `;
 
 function AppDependenciesModal({
-  appInstallWithDependencies,
+  appWithDependenciesToInstall,
   dispatch: dispatchProps,
   onClose,
 }: Props) {
   const dispatch = useDispatch();
   const hasInstalledAnyApp = useSelector(hasInstalledAnyAppSelector);
 
-  const { app, dependencies = [] } = appInstallWithDependencies || {};
+  const { app, dependencies = [] } = appWithDependenciesToInstall || {};
   const { name } = app || {};
 
   const installAppDependencies = useCallback(() => {

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstallAppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstallAppDependenciesModal.tsx
@@ -6,6 +6,7 @@ import { Flex, IconsLegacy, Text, Button } from "@ledgerhq/native-ui";
 import AppIcon from "../AppsList/AppIcon";
 import QueuedDrawer from "../../../components/QueuedDrawer";
 import { AppWithDependencies } from "../AppsInstallUninstallWithDependenciesContext";
+import Link from "../../../components/wrappedUi/Link";
 
 type Props = {
   appWithDependenciesToInstall: AppWithDependencies | null;
@@ -50,7 +51,7 @@ const ButtonsContainer = styled(Flex).attrs({
 const CancelButton = styled(TouchableOpacity)`
   align-items: center;
   justify-content: center;
-  margin-top: 25;
+  margin-top: 25px;
 `;
 
 function InstallAppDependenciesModal({
@@ -95,14 +96,12 @@ function InstallAppDependenciesModal({
               </ModalText>
             </TextContainer>
             <ButtonsContainer>
-              <Button size="large" type="main" onPress={installAppWithDependencies}>
+              <Button size="large" type="main" mb={7} onPress={installAppWithDependencies}>
                 <Trans i18nKey="AppAction.install.continueInstall" />
               </Button>
-              <CancelButton onPress={onClose}>
-                <Text variant="large" fontWeight="semiBold" color="neutral.c100">
-                  <Trans i18nKey="common.cancel" />
-                </Text>
-              </CancelButton>
+              <Link size="large" onPress={onClose}>
+                <Trans i18nKey="common.cancel" />
+              </Link>
             </ButtonsContainer>
           </>
         )}

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstallAppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstallAppDependenciesModal.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { TouchableOpacity } from "react-native";
 import { Trans } from "react-i18next";
 import styled from "styled-components/native";
 import { Flex, IconsLegacy, Text, Button } from "@ledgerhq/native-ui";
@@ -47,12 +46,6 @@ const SeparatorText = styled(Text).attrs({
 const ButtonsContainer = styled(Flex).attrs({
   width: "100%",
 })``;
-
-const CancelButton = styled(TouchableOpacity)`
-  align-items: center;
-  justify-content: center;
-  margin-top: 25px;
-`;
 
 function InstallAppDependenciesModal({
   appWithDependenciesToInstall,

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstallAppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstallAppDependenciesModal.tsx
@@ -1,22 +1,16 @@
-import React, { memo, useCallback } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React, { memo } from "react";
 import { TouchableOpacity } from "react-native";
 import { Trans } from "react-i18next";
-
-import { Action } from "@ledgerhq/live-common/apps/index";
-
 import styled from "styled-components/native";
 import { Flex, IconsLegacy, Text, Button } from "@ledgerhq/native-ui";
-import { hasInstalledAnyAppSelector } from "../../../reducers/settings";
-import { installAppFirstTime } from "../../../actions/settings";
 import AppIcon from "../AppsList/AppIcon";
 import QueuedDrawer from "../../../components/QueuedDrawer";
 import { AppWithDependencies } from "../AppsInstallUninstallWithDependenciesContext";
 
 type Props = {
   appWithDependenciesToInstall: AppWithDependencies | null;
-  dispatch: (_: Action) => void;
   onClose: () => void;
+  installAppWithDependencies: () => void;
 };
 
 const IconContainer = styled(Flex).attrs({
@@ -59,24 +53,13 @@ const CancelButton = styled(TouchableOpacity)`
   margin-top: 25;
 `;
 
-function AppDependenciesModal({
+function InstallAppDependenciesModal({
   appWithDependenciesToInstall,
-  dispatch: dispatchProps,
   onClose,
+  installAppWithDependencies,
 }: Props) {
-  const dispatch = useDispatch();
-  const hasInstalledAnyApp = useSelector(hasInstalledAnyAppSelector);
-
   const { app, dependencies = [] } = appWithDependenciesToInstall || {};
   const { name } = app || {};
-
-  const installAppDependencies = useCallback(() => {
-    if (!hasInstalledAnyApp) {
-      dispatch(installAppFirstTime(true));
-    }
-    dispatchProps({ type: "install", name });
-    onClose();
-  }, [dispatch, dispatchProps, onClose, name, hasInstalledAnyApp]);
 
   return (
     <QueuedDrawer isRequestingToBeOpened={!!app} onClose={onClose}>
@@ -112,7 +95,7 @@ function AppDependenciesModal({
               </ModalText>
             </TextContainer>
             <ButtonsContainer>
-              <Button size="large" type="main" onPress={installAppDependencies}>
+              <Button size="large" type="main" onPress={installAppWithDependencies}>
                 <Trans i18nKey="AppAction.install.continueInstall" />
               </Button>
               <CancelButton onPress={onClose}>
@@ -128,4 +111,4 @@ function AppDependenciesModal({
   );
 }
 
-export default memo(AppDependenciesModal);
+export default memo(InstallAppDependenciesModal);

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useMemo, useEffect } from "react";
 
-import { Text, Flex, Button, BaseModal } from "@ledgerhq/native-ui";
+import { Text, Flex, Button } from "@ledgerhq/native-ui";
 import { FlatList } from "react-native";
 import { App, DeviceInfo } from "@ledgerhq/types-live";
 import { State, Action } from "@ledgerhq/live-common/apps/index";
@@ -9,6 +9,7 @@ import AppIcon from "../AppsList/AppIcon";
 import ByteSize from "../../../components/ByteSize";
 import AppUninstallButton from "../AppsList/AppUninstallButton";
 import AppProgressButton from "../AppsList/AppProgressButton";
+import QueuedDrawer from "../../../components/QueuedDrawer";
 
 type HeaderProps = {
   illustration: JSX.Element;
@@ -141,14 +142,8 @@ const InstalledAppsModal = ({
   }, [appList, onClose]);
 
   return (
-    <BaseModal
-      isOpen={isOpen}
-      onClose={onClose}
-      modalStyle={modalStyleOverrides.modal}
-      containerStyle={{ height: "100%" }}
-      propagateSwipe={true}
-    >
-      <Flex flex={1}>
+    <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose} propagateSwipe={true}>
+      <Flex flexShrink={0} flexGrow={1}>
         <FlatList
           data={appList}
           renderItem={renderItem}
@@ -160,7 +155,7 @@ const InstalledAppsModal = ({
       <Button mt={6} mb={6} size="large" type="error" onPress={onUninstallAll}>
         <Trans i18nKey={"manager.uninstall.uninstallAll"} />
       </Button>
-    </BaseModal>
+    </QueuedDrawer>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
@@ -28,15 +28,9 @@ type UninstallButtonProps = {
   app: App;
   state: State;
   dispatch: (_: Action) => void;
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
 };
 
-const UninstallButton = ({
-  app,
-  state,
-  dispatch,
-  setAppUninstallWithDependencies,
-}: UninstallButtonProps) => {
+const UninstallButton = ({ app, state, dispatch }: UninstallButtonProps) => {
   const { uninstallQueue } = state;
   const uninstalling = useMemo(() => uninstallQueue.includes(app.name), [uninstallQueue, app.name]);
   const renderAppState = () => {
@@ -44,15 +38,7 @@ const UninstallButton = ({
       case uninstalling:
         return <AppProgressButton state={state} name={app.name} size={34} />;
       default:
-        return (
-          <AppUninstallButton
-            app={app}
-            state={state}
-            dispatch={dispatch}
-            setAppUninstallWithDependencies={setAppUninstallWithDependencies}
-            size={34}
-          />
-        );
+        return <AppUninstallButton app={app} state={state} dispatch={dispatch} size={34} />;
     }
   };
 
@@ -63,11 +49,10 @@ type RowProps = {
   app: App;
   state: State;
   dispatch: (_: Action) => void;
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
   deviceInfo: DeviceInfo;
 };
 
-const Row = ({ app, state, dispatch, setAppUninstallWithDependencies, deviceInfo }: RowProps) => (
+const Row = ({ app, state, dispatch, deviceInfo }: RowProps) => (
   <Flex flexDirection="row" py={4} alignItems="center" justifyContent="space-between">
     <Flex flexDirection="row" alignItems="center">
       <AppIcon app={app} size={24} radius={8} />
@@ -83,12 +68,7 @@ const Row = ({ app, state, dispatch, setAppUninstallWithDependencies, deviceInfo
           firmwareVersion={deviceInfo.version}
         />
       </Text>
-      <UninstallButton
-        app={app}
-        state={state}
-        dispatch={dispatch}
-        setAppUninstallWithDependencies={setAppUninstallWithDependencies}
-      />
+      <UninstallButton app={app} state={state} dispatch={dispatch} />
     </Flex>
   </Flex>
 );
@@ -99,7 +79,6 @@ type Props = {
   state: State;
   dispatch: (_: Action) => void;
   appList?: App[];
-  setAppUninstallWithDependencies: (_: { dependents: App[]; app: App }) => void;
   illustration: JSX.Element;
   deviceInfo: DeviceInfo;
 };
@@ -110,7 +89,6 @@ const InstalledAppsModal = ({
   state,
   dispatch,
   appList,
-  setAppUninstallWithDependencies,
   illustration,
   deviceInfo,
 }: Props) => {
@@ -118,15 +96,9 @@ const InstalledAppsModal = ({
 
   const renderItem = useCallback(
     ({ item }: { item: App }) => (
-      <Row
-        app={item}
-        state={state}
-        dispatch={dispatch}
-        setAppUninstallWithDependencies={setAppUninstallWithDependencies}
-        deviceInfo={deviceInfo}
-      />
+      <Row app={item} state={state} dispatch={dispatch} deviceInfo={deviceInfo} />
     ),
-    [deviceInfo, dispatch, setAppUninstallWithDependencies, state],
+    [deviceInfo, dispatch, state],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
@@ -93,14 +93,6 @@ const Row = ({ app, state, dispatch, setAppUninstallWithDependencies, deviceInfo
   </Flex>
 );
 
-const modalStyleOverrides = {
-  modal: {
-    flex: 1,
-    justifyContent: "flex-end" as const,
-    margin: 0,
-  },
-};
-
 type Props = {
   isOpen: boolean;
   onClose: () => void;

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/InstalledAppsModal.tsx
@@ -135,16 +135,15 @@ const InstalledAppsModal = ({
 
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose} propagateSwipe={true}>
-      <Flex flexShrink={0} flexGrow={1}>
-        <FlatList
-          data={appList}
-          renderItem={renderItem}
-          keyExtractor={item => "" + item.id}
-          ListHeaderComponent={<Header illustration={illustration} />}
-          showsVerticalScrollIndicator={false}
-        />
-      </Flex>
-      <Button mt={6} mb={6} size="large" type="error" onPress={onUninstallAll}>
+      <Header illustration={illustration} />
+      <FlatList
+        data={appList}
+        renderItem={renderItem}
+        keyExtractor={item => "" + item.id}
+        overScrollMode="never"
+        showsVerticalScrollIndicator={false}
+      />
+      <Button mt={6} size="large" type="error" onPress={onUninstallAll}>
         <Trans i18nKey={"manager.uninstall.uninstallAll"} />
       </Button>
     </QueuedDrawer>

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallAppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallAppDependenciesModal.tsx
@@ -22,8 +22,8 @@ const { height } = getWindowDimensions();
 
 type Props = {
   appWithDependentsToUninstall: AppWithDependents | null;
-  dispatch: (_: Action) => void;
   onClose: () => void;
+  uninstallAppsWithDependents: () => void;
 };
 
 const LIST_HEIGHT = height - 420;
@@ -57,15 +57,14 @@ const ButtonsContainer = styled(Flex).attrs({
   width: "100%",
 })``;
 
-const UninstallDependenciesModal = ({ appWithDependentsToUninstall, dispatch, onClose }: Props) => {
+const UninstallAppDependenciesModal = ({
+  appWithDependentsToUninstall,
+  uninstallAppsWithDependents,
+  onClose,
+}: Props) => {
   const { colors } = useTheme() as DefaultTheme & Theme;
   const { app, dependents = [] } = appWithDependentsToUninstall || {};
   const { name } = app || {};
-
-  const unInstallApp = useCallback(() => {
-    dispatch({ type: "uninstall", name });
-    onClose();
-  }, [dispatch, onClose, name]);
 
   const renderDepLine = useCallback(
     ({ item }: { item: App }) => (
@@ -117,7 +116,7 @@ const UninstallDependenciesModal = ({ appWithDependentsToUninstall, dispatch, on
               }}
             />
             <ButtonsContainer>
-              <Button size="large" type="error" onPress={unInstallApp}>
+              <Button size="large" type="error" onPress={uninstallAppsWithDependents}>
                 <Trans i18nKey="AppAction.uninstall.continueUninstall" values={{ app: name }} />
               </Button>
             </ButtonsContainer>
@@ -128,4 +127,4 @@ const UninstallDependenciesModal = ({ appWithDependentsToUninstall, dispatch, on
   );
 };
 
-export default memo(UninstallDependenciesModal);
+export default memo(UninstallAppDependenciesModal);

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallAppDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallAppDependenciesModal.tsx
@@ -1,8 +1,6 @@
 import React, { memo, useCallback } from "react";
 import { View } from "react-native";
 import { Trans } from "react-i18next";
-
-import { Action } from "@ledgerhq/live-common/apps/index";
 import { App } from "@ledgerhq/types-live";
 
 import styled, { DefaultTheme, useTheme } from "styled-components/native";

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallDependenciesModal.tsx
@@ -86,8 +86,9 @@ const UninstallDependenciesModal = ({ appUninstallWithDependencies, dispatch, on
     ),
     [colors.grey],
   );
+
   return (
-    <QueuedDrawer isRequestingToBeOpened={!!app} onClose={onClose}>
+    <QueuedDrawer isForcingToBeOpened={!!app} onClose={onClose}>
       <Flex alignItems="center">
         {app && dependents.length && (
           <View style={{ width: "100%" }}>

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallDependenciesModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UninstallDependenciesModal.tsx
@@ -16,11 +16,12 @@ import ListTreeLine from "../../../icons/ListTreeLine";
 
 import getWindowDimensions from "../../../logic/getWindowDimensions";
 import { Theme } from "../../../colors";
+import { AppWithDependents } from "../AppsInstallUninstallWithDependenciesContext";
 
 const { height } = getWindowDimensions();
 
 type Props = {
-  appUninstallWithDependencies: { app: App; dependents: App[] };
+  appWithDependentsToUninstall: AppWithDependents | null;
   dispatch: (_: Action) => void;
   onClose: () => void;
 };
@@ -56,9 +57,9 @@ const ButtonsContainer = styled(Flex).attrs({
   width: "100%",
 })``;
 
-const UninstallDependenciesModal = ({ appUninstallWithDependencies, dispatch, onClose }: Props) => {
+const UninstallDependenciesModal = ({ appWithDependentsToUninstall, dispatch, onClose }: Props) => {
   const { colors } = useTheme() as DefaultTheme & Theme;
-  const { app, dependents = [] } = appUninstallWithDependencies || {};
+  const { app, dependents = [] } = appWithDependentsToUninstall || {};
   const { name } = app || {};
 
   const unInstallApp = useCallback(() => {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
@@ -11,7 +11,7 @@ import { TrackScreen } from "../../../../../analytics";
 import Button from "../../../../../components/PreventDoubleClickButton";
 
 import {
-  installAppFirstTime,
+  setHasInstalledAnyApp,
   setHasOrderedNano,
   setLastConnectedDevice,
   setReadOnlyMode,
@@ -65,7 +65,7 @@ const ConnectNanoScene = ({
           info.result.installed.length > 0
         );
 
-        dispatch(installAppFirstTime(hasAnyAppinstalled));
+        dispatch(setHasInstalledAnyApp(hasAnyAppinstalled));
         setDevice(undefined);
         dispatch(setReadOnlyMode(false));
         dispatch(setHasOrderedNano(false));

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -15,7 +15,7 @@ import TransportBLE from "../../react-native-hw-transport-ble";
 import { GENUINE_CHECK_TIMEOUT } from "@utils/constants";
 import { addKnownDevice } from "../../actions/ble";
 import {
-  installAppFirstTime,
+  setHasInstalledAnyApp,
   setLastSeenDeviceInfo,
   setReadOnlyMode,
 } from "../../actions/settings";
@@ -154,7 +154,7 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
                     const hasAnyAppInstalled = e.result && e.result.installed.length > 0;
 
                     if (!hasAnyAppInstalled) {
-                      dispatchRedux(installAppFirstTime(false));
+                      dispatchRedux(setHasInstalledAnyApp(false));
                     }
                   }
 

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -128,12 +128,9 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
 
       const installedList: App[] = [];
 
-      // Nb We can't reliably get the ordered result from the backend because of apps with
-      // inconsistent hashes. An iteration of the backend would be to return a key-value result
-      // instead of an unordered array but I think that's a needless optimization.
-      listApps.forEach(({ name: localName, hash: localHash }) => {
-        const matchFromHash = matches.find(({ hash }) => hash === localHash);
-        if (matchFromHash) {
+      listApps.forEach(({ name: localName, hash: localHash }, index) => {
+        const matchFromHash = matches[index];
+        if (matchFromHash && matchFromHash.hash === localHash) {
           installedList.push(matchFromHash);
           return;
         }

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -51,7 +51,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
        * Sequence 1: obtain the full data regarding apps installed on the device
        *  -> list raw data of apps installed on device
        *  -> then filter apps (eliminate language packs and such)
-       *  -> then fetch matching app metadata using apps' hashes 
+       *  -> then fetch matching app metadata using apps' hashes
        */
 
       let listAppsResponsePromise: Promise<ListAppResponse>;
@@ -148,7 +148,6 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
           sortedCryptoCurrenciesPromise,
         ]);
 
-      
       /**
        * Associate a market cap sorting index to each app of the catalog of
        * available apps.
@@ -160,7 +159,6 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
           app.indexOfMarketCap = sortedCryptoCurrencies.indexOf(crypto);
         }
       });
-
 
       /**
        * Aggregate the data obtained above to build the list of installed apps

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -45,7 +45,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
       const deviceModel = getDeviceModel(deviceModelId);
       const bytesPerBlock = deviceModel.getBlockSize(deviceInfo.version);
 
-      /** The following are several asynchonous sequences running in parallel */
+      /** The following are several asynchronous sequences running in parallel */
 
       /**
        * Sequence 1: obtain the full data regarding apps installed on the device
@@ -86,7 +86,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
       }
 
       const filteredListAppsPromise = listAppsResponsePromise.then(result => {
-        // Empty HashData can come from apps that are not real apps (such as langauge packs)
+        // Empty HashData can come from apps that are not real apps (such as language packs)
         // or custom applications that have been sideloaded.
         return result
           .filter(({ hash_code_data }) => hash_code_data !== emptyHashData)

--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -1,11 +1,7 @@
 // polyfill the unfinished support of apps logic
 import uniq from "lodash/uniq";
 import semver from "semver";
-import {
-  listCryptoCurrencies,
-  findCryptoCurrencyById,
-  findCryptoCurrency,
-} from "@ledgerhq/cryptoassets";
+import { listCryptoCurrencies, findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { App, AppType, Application, ApplicationV2 } from "@ledgerhq/types-live";
 import type { CryptoCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 const directDep = {};

--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -97,13 +97,18 @@ export const getDependencies = (appName: string, appVersion?: string): string[] 
 
 export const getDependents = (appName: string): string[] => reverseDep[appName] || [];
 
+function matchAppNameAndCryptoCurrency(appName: string, crypto: CryptoCurrency) {
+  return (
+    appName.toLowerCase() === crypto.managerAppName.toLowerCase() &&
+    (crypto.managerAppName !== "Ethereum" ||
+      // if it's ethereum, we have a specific case that we must only allow the Ethereum app
+      appName === "Ethereum")
+  );
+}
+
 export const polyfillApplication = (app: Application): Application => {
-  const crypto = listCryptoCurrencies(true, true).find(
-    crypto =>
-      app.name.toLowerCase() === crypto.managerAppName.toLowerCase() &&
-      (crypto.managerAppName !== "Ethereum" ||
-        // if it's ethereum, we have a specific case that we must only allow the Ethereum app
-        app.name === "Ethereum"),
+  const crypto = listCryptoCurrencies(true, true).find(crypto =>
+    matchAppNameAndCryptoCurrency(app.name, crypto),
   );
 
   if (crypto && !app.currencyId) {
@@ -114,13 +119,13 @@ export const polyfillApplication = (app: Application): Application => {
 };
 
 export const getCurrencyIdFromAppName = (
-  name: string,
+  appName: string,
 ): CryptoCurrencyId | "LBRY" | "groestcoin" | "osmo" | undefined => {
   const crypto =
     // try to find the "official" currency when possible (2 currencies can have the same manager app and ticker)
-    findCryptoCurrency(c => c.name === name) ||
-    // Else take the first one with that manager app
-    findCryptoCurrency(c => c.managerAppName === name);
+    listCryptoCurrencies(true, true).find(
+      c => c.name === appName || matchAppNameAndCryptoCurrency(appName, c),
+    );
   return crypto?.id;
 };
 
@@ -140,8 +145,9 @@ export const mapApplicationV2ToApp = ({
   applicationType: type,
   compatibleWallets,
   parentName,
+  currencyId,
   ...rest
-}: ApplicationV2): App => ({
+}: ApplicationV2) => ({
   id,
   name,
   displayName,
@@ -151,7 +157,7 @@ export const mapApplicationV2ToApp = ({
   indexOfMarketCap: -1, // We don't know at this point.
   type: name === "Exchange" ? AppType.swap : type,
   ...rest,
-  currencyId: getCurrencyIdFromAppName(name),
+  currencyId: currencyId || getCurrencyIdFromAppName(name),
   compatibleWallets: parseCompatibleWallets(compatibleWallets, name),
 });
 

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -75,7 +75,6 @@ export const DEFAULT_FEATURES: Features = {
   syncOnboarding: DEFAULT_FEATURE,
   walletConnectEntryPoint: DEFAULT_FEATURE,
   counterValue: DEFAULT_FEATURE,
-  listAppsV2: DEFAULT_FEATURE,
   llmNewDeviceSelection: DEFAULT_FEATURE,
   llmNewFirmwareUpdateUx: DEFAULT_FEATURE,
   mockFeature: DEFAULT_FEATURE,
@@ -91,7 +90,7 @@ export const DEFAULT_FEATURES: Features = {
   staxWelcomeScreen: DEFAULT_FEATURE,
   protectServicesDiscoverDesktop: DEFAULT_FEATURE,
   llmWalletQuickActions: DEFAULT_FEATURE,
-
+  listAppsV2minor1: DEFAULT_FEATURE,
   ethStakingProviders: initFeature(),
   referralProgramDiscoverCard: initFeature(),
   newsfeedPage: initFeature(),

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -399,13 +399,15 @@ const getFinalFirmwareById: (id: number) => Promise<FinalFirmware> = makeLRUCach
  * Given an array of hashes that we can obtain by either listInstalledApps in this same
  * API (a websocket connection to a scriptrunner) or via direct apdus using hw/listApps.ts
  * retrieve all the information needed from the backend for those applications.
+ * The apps in the output are mapped in the same order as the hashes in the input
+ * and if no match is found for a given hash the result for that hash will be null.
  */
-const getAppsByHash: (hashes: string[]) => Promise<Array<App>> = makeLRUCache(
+const getAppsByHash: (hashes: string[]) => Promise<Array<App | null>> = makeLRUCache(
   async hashes => {
     const {
       data,
     }: {
-      data: Array<ApplicationV2>;
+      data: Array<ApplicationV2 | null>;
     } = await network({
       method: "POST",
       url: URL.format({
@@ -421,7 +423,7 @@ const getAppsByHash: (hashes: string[]) => Promise<Array<App>> = makeLRUCache(
       throw new NetworkDown("");
     }
 
-    return data.map(mapApplicationV2ToApp);
+    return data.map(appV2 => (appV2 ? mapApplicationV2ToApp(appV2) : null));
   },
   hashes => String(hashes),
 );

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -130,7 +130,10 @@ const applicationsByDevice: (params: {
     });
     return r.data.application_versions;
   },
-  p => `${p.provider}_${p.current_se_firmware_final_version}_${p.device_version}`,
+  p =>
+    `${getEnv("MANAGER_API_BASE")}_${p.provider}_${p.current_se_firmware_final_version}_${
+      p.device_version
+    }`,
 );
 
 /**
@@ -168,7 +171,7 @@ const catalogForDevice: (params: {
 
     return data.map(mapApplicationV2ToApp);
   },
-  _ => "",
+  a => `${getEnv("MANAGER_API_BASE")}_${a.provider}_${a.targetId}_${a.firmwareVersion}`,
 );
 
 const listApps: () => Promise<Array<Application>> = makeLRUCache(
@@ -189,7 +192,7 @@ const listApps: () => Promise<Array<Application>> = makeLRUCache(
 
     return data;
   },
-  () => "",
+  () => getEnv("MANAGER_API_BASE"),
 );
 
 const listCategories = async (): Promise<Array<Category>> => {
@@ -218,7 +221,7 @@ const getMcus: () => Promise<any> = makeLRUCache(
     });
     return data;
   },
-  () => "",
+  () => getEnv("MANAGER_API_BASE"),
 );
 
 const compatibleMCUForDeviceInfo = (
@@ -320,7 +323,10 @@ const getLatestFirmware: (arg0: {
 
     return data.se_firmware_osu_version;
   },
-  a => `${a.current_se_firmware_final_version}_${a.device_version}_${a.provider}`,
+  a =>
+    `${getEnv("MANAGER_API_BASE")}_${a.current_se_firmware_final_version}_${a.device_version}_${
+      a.provider
+    }`,
 );
 
 const getCurrentOSU: (input: {
@@ -345,7 +351,7 @@ const getCurrentOSU: (input: {
     });
     return data;
   },
-  a => `${a.version}_${a.deviceId}_${a.provider}`,
+  a => `${getEnv("MANAGER_API_BASE")}_${a.version}_${a.deviceId}_${a.provider}`,
 );
 const getCurrentFirmware: (input: {
   version: string;
@@ -373,7 +379,7 @@ const getCurrentFirmware: (input: {
     });
     return data;
   },
-  a => `${a.version}_${a.deviceId}_${a.provider}`,
+  a => `${getEnv("MANAGER_API_BASE")}_${a.version}_${a.deviceId}_${a.provider}`,
 );
 const getFinalFirmwareById: (id: number) => Promise<FinalFirmware> = makeLRUCache(
   async id => {
@@ -392,7 +398,7 @@ const getFinalFirmwareById: (id: number) => Promise<FinalFirmware> = makeLRUCach
     });
     return data;
   },
-  id => String(id),
+  id => `${getEnv("MANAGER_API_BASE")}}_${String(id)}`,
 );
 
 /**
@@ -428,7 +434,7 @@ const getAppsByHash: (hashes: string[]) => Promise<Array<App | null>> = makeLRUC
 
     return data.map(appV2 => (appV2 ? mapApplicationV2ToApp(appV2) : null));
   },
-  hashes => String(hashes),
+  hashes => `${getEnv("MANAGER_API_BASE")}_${String(hashes)}`,
 );
 
 const getDeviceVersion: (targetId: string | number, provider: number) => Promise<DeviceVersion> =
@@ -463,7 +469,7 @@ const getDeviceVersion: (targetId: string | number, provider: number) => Promise
       });
       return data;
     },
-    (targetId, provider) => `${targetId}_${provider}`,
+    (targetId, provider) => `${getEnv("MANAGER_API_BASE")}_${targetId}_${provider}`,
   );
 
 const install = (

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -434,7 +434,7 @@ const getAppsByHash: (hashes: string[]) => Promise<Array<App | null>> = makeLRUC
 
     return data.map(appV2 => (appV2 ? mapApplicationV2ToApp(appV2) : null));
   },
-  hashes => `${getEnv("MANAGER_API_BASE")}_${String(hashes)}`,
+  hashes => `${getEnv("MANAGER_API_BASE")}_${hashes.join("-")}`,
 );
 
 const getDeviceVersion: (targetId: string | number, provider: number) => Promise<DeviceVersion> =

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -396,11 +396,14 @@ const getFinalFirmwareById: (id: number) => Promise<FinalFirmware> = makeLRUCach
 );
 
 /**
+ * Resolve applications details by hashes.
+ * Order of outputs matches order of inputs.
+ * If an application version is not found, a null is returned instead.
+ * If several versions match the same hash, only the latest one is returned.
+ *
  * Given an array of hashes that we can obtain by either listInstalledApps in this same
  * API (a websocket connection to a scriptrunner) or via direct apdus using hw/listApps.ts
  * retrieve all the information needed from the backend for those applications.
- * The apps in the output are mapped in the same order as the hashes in the input
- * and if no match is found for a given hash the result for that hash will be null.
  */
 const getAppsByHash: (hashes: string[]) => Promise<Array<App | null>> = makeLRUCache(
   async hashes => {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -173,7 +173,7 @@ export type Features = CurrencyFeatures & {
   discover: Feature_Discover;
   protectServicesDiscoverDesktop: Feature_ProtectServicesDiscoverDesktop;
   transactionsAlerts: Feature_TransactionsAlerts;
-  listAppsV2: Feature_ListAppsV2;
+  listAppsV2dot1: Feature_ListAppsV2dot1;
   llmWalletQuickActions: Feature_LlmWalletQuickActions;
   cexDepositEntryPointsDesktop: Feature_CexDepositEntryPointsDesktop;
   cexDepositEntryPointsMobile: Feature_CexDepositEntryPointsMobile;
@@ -467,7 +467,7 @@ export type Feature_PortfolioExchangeBanner = DefaultFeature;
 export type Feature_Objkt = DefaultFeature;
 export type Feature_EditEthTx = DefaultFeature;
 export type Feature_ProtectServicesDiscoverDesktop = DefaultFeature;
-export type Feature_ListAppsV2 = DefaultFeature;
+export type Feature_ListAppsV2dot1 = DefaultFeature;
 export type Feature_BrazeLearn = DefaultFeature;
 export type Feature_LlmNewDeviceSelection = DefaultFeature;
 export type Feature_LlmWalletQuickActions = DefaultFeature;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -173,7 +173,7 @@ export type Features = CurrencyFeatures & {
   discover: Feature_Discover;
   protectServicesDiscoverDesktop: Feature_ProtectServicesDiscoverDesktop;
   transactionsAlerts: Feature_TransactionsAlerts;
-  listAppsV2dot1: Feature_ListAppsV2dot1;
+  listAppsV2minor1: Feature_ListAppsV2minor1;
   llmWalletQuickActions: Feature_LlmWalletQuickActions;
   cexDepositEntryPointsDesktop: Feature_CexDepositEntryPointsDesktop;
   cexDepositEntryPointsMobile: Feature_CexDepositEntryPointsMobile;
@@ -467,7 +467,7 @@ export type Feature_PortfolioExchangeBanner = DefaultFeature;
 export type Feature_Objkt = DefaultFeature;
 export type Feature_EditEthTx = DefaultFeature;
 export type Feature_ProtectServicesDiscoverDesktop = DefaultFeature;
-export type Feature_ListAppsV2dot1 = DefaultFeature;
+export type Feature_ListAppsV2minor1 = DefaultFeature;
 export type Feature_BrazeLearn = DefaultFeature;
 export type Feature_LlmNewDeviceSelection = DefaultFeature;
 export type Feature_LlmWalletQuickActions = DefaultFeature;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Some breaking changes have been introduced on the Manager API v2 (in staging so far).
Today we are using v1 of the API unless a feature flag `listAppsV2` is enabled, but we should still handle those breaking changes anyway because using the v2 API brings a big network optimisation and we should aim to activate the flag soon.

**Changes in the Manager v2 API (backend)**
- Optimisations
  - `/api/v2/apps/hash`: now outputs the apps in the same order as the input which makes it easier for us to use.
- Breaking changes:
  - `/api/v2/apps/hash`: now can return some apps as `null` if the hash does not match any app

**Changes in LL (this PR):**

- Both of those API changes are addressed in this PR.
- A new feature flag `listAppsV2minor1` is introduced in order to not activate the old one by mistake which would break old versions of LL.
- The polyfilling of app's data has also been fixed to match the behaviour of v1:
  - Previously, in list apps v2, the `currencyId` from the backend was never taken so in some cases ("Binance Chain" or "Persistence") there would be no associated currency, so in the My Ledger list of apps there would be a different icon, no ticker ("Persistence (XPRT)" with "(XPRT)" being the ticker), and no associated market cap, so the app would be at the bottom of the list when the "ranking by market cap" option is chosen.
  - Now the `currencyId` from the backend is taken by default and if it doesn't exist, it is polyfilled with the same logic as in list apps v1 (matching app's name and a `currency`'s `currency.name` or `currency.managerName`. 
- A fix regarding the uninstallation of apps which other installed apps depends on, from the `InstalledAppsModal`. For instance with Ethereum and Polygon installed, if you open the `InstalledAppsModal` listing all the installed apps, it would be impossible to uninstall Ethereum from there because the drawer `UninstallDependenciesModal` would be blocked by the currently opened modal (`InstalledAppsModal`).
  - The reason is that `InstalledAppsModal` was not using a `QueuedDrawer`, and also `UninstallDependenciesModal` should use the `isForcingToBeOpened` prop of `QueuedDrawer`. This is actually unrelated to listAppsV2 but it was noticed by QA so I fixed it here 🤷‍♂️ .
  - Refactor prop drilling nightmare of `setAppInstallWithDependencies`/`setAppUninstallWithDependencies` with a simple `React.Context`.
- Refactor `InstalledAppDependenciesModal` and `UninstallAppDependenciesModal` to have no business logic inside
- Rename action creator `installAppFirstTime` to `setHasInstalledAnyApp` for more clarity
- sorry i got a bit carried away with refactos unrelated to the initial purpose of the PR but it was itching me 😆 

**More context:** 
As a reminder this is the original work from Juan with more details about the optimisation in the PR description: https://github.com/LedgerHQ/ledger-live/pull/3097
And as an example of the optimisation, here's a before/after of networking when opening the manager on LLD:

before: <img width="320" alt="Screenshot 2023-10-02 at 14 22 12" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/cf4e2a42-77ca-471f-80ad-4c926a3de5bd">
after: <img width="314" alt="Screenshot 2023-10-02 at 14 20 39" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/7ca7990b-d32d-4bf2-ae3a-d0b3d407eb02">

**What I tested:**
- [x] LLD macOS
  - build from this PR
  - Infra VPN setup
  - open with `MANAGER_API_BASE=https://manager.api.live.stg.ledger-test.com/api /Applications/Ledger\ Live\ Beta.app/Contents/MacOS/Ledger\ Live\ Beta`
  - activate `listAppsV2minor1` feature flag
  - restart LLD
  - open manager
  - all apps installed on device are listed (eth, bitcoin, xrp, cardano ada, fido (this one is special because it doesn't have a fixed hash so the `/api/hash` returns null for it, which would break on a `develop` build), tron)
- [x] LLM Android
  - build from https://github.com/LedgerHQ/ledger-live/actions/runs/6394873605
  - Infra VPN setup
  - open app
  - activate `listAppsV2minor1` feature flag
  - set env var `MANAGER_API_BASE=https://manager.api.live.stg.ledger-test.com/api` in debug settings
  - open manager
  - all apps installed on device are listed (eth, bitcoin, xrp, cardano ada, fido (this one is special because it doesn't have a fixed hash so the `/api/hash` returns null for it, which would break on a `develop` build), tron)



### ❓ Context

- **Impacted projects**: `lld, llm, common, types-live` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8698] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

How to test ?
- [activate the Infra VPN](https://ledgerhq.atlassian.net/wiki/spaces/PKB/pages/3478650893/Infra+VPN+access+and+connect)
- the feature flag `listAppsV2minor1` must be enabled
- different APIs:
  - staging API (requires VPN): `MANAGER_API_BASE=https://manager.api.live.stg.ledger-test.com/api`
  - degraded staging API (required VPN) in case the other one returns 403 (no HTTPS): `MANAGER_API_BASE=http://appstore.api.aws.stg.ldg-tech.com/api`
    - LLD: also bypass CORS with `BYPASS_CORS=1`
    - LLM: does not work outside of debug builds because of HTTP cleartext
  - prod API (for now the changes are not in the prod api) `MANAGER_API_BASE=https://manager.api.live.ledger.com/api`
    - no additional config

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8698]: https://ledgerhq.atlassian.net/browse/LIVE-8698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ