### PR TITLE
chore: check if playwright concurrency created instability

### DIFF
--- a/apps/ledger-live-desktop/tests/playwright.config.ts
+++ b/apps/ledger-live-desktop/tests/playwright.config.ts
@@ -37,8 +37,7 @@ const config: PlaywrightTestConfig = {
   preserveOutput: process.env.CI ? "failures-only" : "always",
   maxFailures: process.env.CI ? 5 : undefined,
   reportSlowTests: process.env.CI ? { max: 0, threshold: 60000 } : null,
-  fullyParallel: true,
-  workers: "50%", // NOTE: 'macos-latest' and 'windows-latest' can't run 3 concurrent workers
+  workers: 1,
   retries: process.env.CI ? 2 : 0, // FIXME: --update-snapshots doesn't work with --retries
   reporter: process.env.CI
     ? [


### PR DESCRIPTION
### 📝 Description

attempt to disable the test runs concurrency introduced by https://github.com/LedgerHQ/ledger-live/pull/4787 in the possibility that it may be the reason of instabilities lately.

### ❓ Context

- **Impacted projects**: LLD tests <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: LIVE-9602 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
