### PR TITLE
fix(protect-2522): can restore during onboarding

### DIFF
--- a/.changeset/poor-moons-jog.md
+++ b/.changeset/poor-moons-jog.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Need to allow restore on onboarding state without device selected yet

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/protectFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/protectFlow.tsx
@@ -15,7 +15,10 @@ import {
 } from "../../../components/RootNavigator/types/helpers";
 import { OnboardingNavigatorParamList } from "../../../components/RootNavigator/types/OnboardingNavigator";
 import { Step } from "./setupDevice/scenes/BaseStepperView";
-import { lastConnectedDeviceSelector } from "../../../reducers/settings";
+import {
+  hasCompletedOnboardingSelector,
+  lastConnectedDeviceSelector,
+} from "../../../reducers/settings";
 
 type Metadata = {
   id: string;
@@ -33,6 +36,7 @@ function OnboardingStepProtectFlow({ navigation, route }: NavigationProps) {
   const { theme } = useTheme();
 
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const protectFeature = useFeature("protectServicesMobile");
 
   const dispatch = useDispatch();
@@ -67,11 +71,11 @@ function OnboardingStepProtectFlow({ navigation, route }: NavigationProps) {
     dispatch(completeOnboarding());
     resetCurrentStep();
 
-    if (protectFeature?.enabled && lastConnectedDevice) {
+    if (protectFeature?.enabled && (lastConnectedDevice || !hasCompletedOnboarding)) {
       navigation.navigate(NavigatorName.Base, {
         screen: ScreenName.Recover,
         params: {
-          device: lastConnectedDevice,
+          device: lastConnectedDevice || undefined,
           platform: protectFeature.params?.protectId,
           redirectTo: "restore",
           date: new Date().toISOString(), // adding a date to reload the page in case of same device restored again
@@ -80,6 +84,7 @@ function OnboardingStepProtectFlow({ navigation, route }: NavigationProps) {
     }
   }, [
     dispatch,
+    hasCompletedOnboarding,
     lastConnectedDevice,
     navigation,
     protectFeature?.enabled,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Before onboarding device, we need to allow restore with recover. You have not device selected yet but you can continue restore flow selected recover after login on Ledger Recover.

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [PROTECT-2522](https://ledgerhq.atlassian.net/browse/PROTECT-2522) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/118977988/96999c81-343e-4687-a3e6-4d713c715948




<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[PROTECT-2522]: https://ledgerhq.atlassian.net/browse/PROTECT-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ