### PR TITLE
chore: speed up detox tests

### DIFF
--- a/.github/workflows/test-mobile-e2e.yml
+++ b/.github/workflows/test-mobile-e2e.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           pnpm mobile e2e:build -c ios.sim.release
       - uses: actions/cache/save@v3
+        if: steps.detox-build.outputs.cache-hit != 'true'
         with:
           path: ${{ github.workspace }}/apps/ledger-live-mobile/ios/build/Build/Products/Release-iphonesimulator
           key: ${{ steps.detox-build.outputs.cache-primary-key }}
@@ -107,7 +108,7 @@ jobs:
       - name: Test iOS app
         id: detox
         run: |
-          pnpm mobile e2e:test -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --detectOpenHandles --headless
+          pnpm mobile e2e:test -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --detectOpenHandles --headless --maxWorkers 2
       - name: Delete iOS simulator
         if: always()
         run: |

--- a/.github/workflows/test-mobile-e2e.yml
+++ b/.github/workflows/test-mobile-e2e.yml
@@ -62,6 +62,11 @@ jobs:
             ~/Library/Caches/CocoaPods
             ~/.cocoapods
           key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
+      - uses: actions/cache/restore@v3
+        id: detox-build
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-mobile/ios/build/Build/Products/Release-iphonesimulator
+          key: ${{ runner.os }}-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock', 'apps/ledger-live-mobile/ios/ledgerlivemobile.xcodeproj/project.pbxproj') }}
       - name: TurboRepo local caching server
         id: turborepo-cache-server
         uses: ./tools/actions/turborepo-s3-cache
@@ -86,8 +91,19 @@ jobs:
           ID=$(xcrun simctl create "iPhone 13" "iPhone 13")
           echo "id=$ID" >> $GITHUB_OUTPUT
       - name: Build iOS app for Detox test run
+        if: steps.detox-build.outputs.cache-hit != 'true'
         run: |
           pnpm mobile e2e:build -c ios.sim.release
+      - uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-mobile/ios/build/Build/Products/Release-iphonesimulator
+          key: ${{ steps.detox-build.outputs.cache-primary-key }}
+      - name: Build JS Bundle app for Detox test run
+        if: steps.detox-build.outputs.cache-hit == 'true'
+        run: |
+          pnpm mobile bundle:ios
+          cd apps/ledger-live-mobile
+          mv main.jsbundle ios/build/Build/Products/Release-iphonesimulator/main.jsbundle
       - name: Test iOS app
         id: detox
         run: |

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -32,7 +32,7 @@ import { languageSelector } from "./src/reducers/settings";
 import { store } from "./src/context/LedgerStore";
 
 if (__DEV__) {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   require("react-native-performance-flipper-reporter").setupDefaultFlipperReporter();
 }
 

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -6,6 +6,8 @@
     "postinstall": "zx ./scripts/post.mjs",
     "pod": "cd ios && bundle exec pod install --repo-update",
     "start": "react-native start",
+    "bundle:ios": "react-native bundle --entry-file index.js --bundle-output main.jsbundle",
+    "bundle:android": "react-native bundle --platform android --entry-file index.js --bundle-output main.jsbundle",
     "ios": "react-native run-ios",
     "android": "react-native run-android --appIdSuffix=debug --active-arch-only",
     "android:gradleClean": "cd android && ./gradlew clean",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In order to speed up the mobile end to end tests, try to reuse previous detox 
builds and inject only the jsbundle, saving ourselves from rebuilding the native 
parts each time.

### ❓ Context

- **Impacted projects**: `llm`, `ci` <!-- The list of end user projects impacted by 
the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9618 <!-- 
Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be 
tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, 
does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain 
why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
