### PR TITLE
[BUGFIX] : Tap and drag to see price over time on graph is buggy on LLM

### DIFF
--- a/.changeset/gorgeous-items-shave.md
+++ b/.changeset/gorgeous-items-shave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Tap and drag to see price over time on graph is buggy on LLM

--- a/apps/ledger-live-mobile/src/components/DateFormat/FormatDate.tsx
+++ b/apps/ledger-live-mobile/src/components/DateFormat/FormatDate.tsx
@@ -25,6 +25,7 @@ const hoursAndMinutesOptionsSelector = createSelector(
 
 function FormatDate({ date, withHoursMinutes = false }: Props): JSX.Element | null {
   const defaultOptions = useSelector(defaultOptionsSelector);
+
   const hoursAndMinutesOptions = useSelector(hoursAndMinutesOptionsSelector);
   const dateFormat = useSelector(dateFormatSelector);
   const dateFormatOptions =
@@ -36,9 +37,9 @@ function FormatDate({ date, withHoursMinutes = false }: Props): JSX.Element | nu
 
   const jsx =
     date && date.getTime()
-      ? withHoursMinutes
-        ? dateFormatOptions.format(date)
-        : hoursAndMinutesOptions.format(date)
+      ? dateFormatOptions
+          .format(date)
+          .concat(withHoursMinutes ? ` - ${hoursAndMinutesOptions.format(date)}` : "")
       : null;
   return <>{jsx}</>;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Tap and drag to see price over time on graph is buggy on LLM
### ❓ Context

- **Impacted projects**: `LLM` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-8128] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/112866305/c48d8a48-c94f-4e83-a631-cfee635218ca


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8128]: https://ledgerhq.atlassian.net/browse/LIVE-8128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ