### PR TITLE
[LLM][Stax onboarding] No thumbnail displayed on Stax onboarding for Secret Recovery Phrase stories

### DIFF
--- a/.changeset/silver-experts-hammer.md
+++ b/.changeset/silver-experts-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix display thumbnail of a story

--- a/apps/ledger-live-mobile/src/components/StorylyStories/StoryGroupItem.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/StoryGroupItem.tsx
@@ -50,6 +50,7 @@ const Border: React.FC<{ seen: boolean }> = ({ seen }) => {
           cy={containerSize / 2}
           r={innerImageSize / 2 + borderInnerPadding}
           strokeWidth={borderWidth}
+          fill="none"
           stroke="url(#grad)"
         />
       </Svg>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix thumbnail display in stories


### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-9249](https://ledgerhq.atlassian.net/browse/LIVE-9249) <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
https://github.com/LedgerHQ/ledger-live/assets/145363160/80ba3664-0e26-4535-a2e1-44e122a4bdfc

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9549]: https://ledgerhq.atlassian.net/browse/LIVE-9549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-9249]: https://ledgerhq.atlassian.net/browse/LIVE-9249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ