### PR TITLE
fix(llm/stax/CustomImageDeviceAction): disable renderError "save logs" button

### DIFF
--- a/.changeset/old-moons-add.md
+++ b/.changeset/old-moons-add.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Custom lock screen: remove the "save logs" button if the error is a "refused on device" error

--- a/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
@@ -113,8 +113,9 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
               t,
               error,
               device,
-              ...(isRefusedOnStaxError ? { Icon: Icons.Warning, iconColor: "warning.c60" } : {}),
-              hasExportLogButton: false,
+              ...(isRefusedOnStaxError
+                ? { Icon: Icons.Warning, iconColor: "warning.c60", hasExportLogButton: false }
+                : {}),
             })}
             {}
             <Button

--- a/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImageDeviceAction.tsx
@@ -114,6 +114,7 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
               error,
               device,
               ...(isRefusedOnStaxError ? { Icon: Icons.Warning, iconColor: "warning.c60" } : {}),
+              hasExportLogButton: false,
             })}
             {}
             <Button


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the custom lock screen device action, in case the user refuses to load / commit the picture on their Stax, we display an error and there is a "save logs" button that should not be present in that case.

### ❓ Context

- **Impacted projects**: `llm` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-6488] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<img width="480" alt="Screenshot 2023-10-04 at 14 06 44" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/36bb5a9f-2b1c-4c1f-b394-5d441e640a0a">


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6488]: https://ledgerhq.atlassian.net/browse/LIVE-6488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ