### PR TITLE
[LIVE-9628] Bugfix - Update currency used in OpDetails NFT hooks with TokenAccount operations

### DIFF
--- a/.changeset/purple-dogs-shake.md
+++ b/.changeset/purple-dogs-shake.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix of OperationDetails view using the wrong currency in the `useNftMetadata` & `useNftCollectionMetadata` hooks

--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
@@ -170,12 +170,12 @@ export default function Content({
     ["NFT_IN", "NFT_OUT"].includes(type) && operation.contract && operation.tokenId;
   const { status: collectionStatus, metadata: collectionMetadata } = useNftCollectionMetadata(
     operation.contract,
-    currency.id,
+    mainAccount.currency.id,
   );
   const { status: nftStatus, metadata: nftMetadata } = useNftMetadata(
     operation.contract,
     operation.tokenId,
-    currency.id,
+    mainAccount.currency.id,
   ) as NFTResource & {
     metadata: NFTMetadataResponse["result"];
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Prevent error in OpDetails for TokenAccounts, using wrong currency with `useNftMetadata` & `useNftCollectionMetadata` hooks (`TokenCurrency` vs `CryptoCurrency`)

### ❓ Context

- **Impacted projects**: `ledger-live-mobile` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9628 <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

> Steps of the non-reg demo:
> - Going into a TokenAccount operation does not break (this is were the error was before, invisible to the end user)
> - Going into an NFT operation still display the correct informations about the NFT: title of the NFT & title of the collection 

https://github.com/LedgerHQ/ledger-live/assets/44363395/2836a98a-9ab0-423d-9cd4-eebbb8ba808d



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
