### PR TITLE
feat(lld,llm/nft/stax): align custom lock screen entrypoint condition

### DIFF
--- a/.changeset/cold-rats-sell.md
+++ b/.changeset/cold-rats-sell.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+NFT screen/Stax: only display "custom lock screen" option if the user has connected a Stax once

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNftLinks.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNftLinks.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { Account, ProtoNFT, NFTMetadata, NFTMedias } from "@ledgerhq/types-live";
@@ -14,6 +14,8 @@ import { setDrawer } from "../drawers/Provider";
 import CustomImage from "~/renderer/screens/customImage";
 import NFTViewerDrawer from "~/renderer/drawers/NFTViewerDrawer";
 import { ContextMenuItemType } from "../components/ContextMenu/ContextMenuWrapper";
+import { devicesModelListSelector } from "../reducers/settings";
+import { DeviceModelId } from "@ledgerhq/devices";
 
 function safeList(items: (ContextMenuItemType | "" | undefined)[]): ContextMenuItemType[] {
   return items.filter(Boolean) as ContextMenuItemType[];
@@ -166,21 +168,25 @@ export default (
   }, [account, customImageUri, isInsideDrawer, nft.id, t]);
 
   const customImageEnabled = useFeature("customImage")?.enabled;
+  const devicesModelList = useSelector(devicesModelListSelector);
   const links = useMemo(() => {
     const metadataLinks = linksPerCurrency[account.currency.id]?.(t, metadata?.links) || [];
     return [
       ...metadataLinks,
-      ...(customImageEnabled && customImageUri ? [customImage] : []),
+      ...(devicesModelList?.includes(DeviceModelId.stax) && customImageEnabled && customImageUri
+        ? [customImage]
+        : []),
       hideCollection,
     ];
   }, [
     account.currency.id,
-    hideCollection,
-    metadata?.links,
-    customImageUri,
-    customImageEnabled,
-    customImage,
     t,
+    metadata?.links,
+    devicesModelList,
+    customImageEnabled,
+    customImageUri,
+    customImage,
+    hideCollection,
   ]);
   return links;
 };

--- a/apps/ledger-live-mobile/src/components/Nft/NftLinksPanel.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftLinksPanel.tsx
@@ -53,7 +53,7 @@ const NftLink = ({
   <LinkTouchable style={style} onPress={onPress}>
     <Flex flexDirection="row" alignItems="center">
       <Box mr={16}>{leftIcon}</Box>
-      <Flex flexDirection="column">
+      <Flex flexDirection="column" flexShrink={1}>
         <Text fontWeight="semiBold" fontSize={16} color={primary ? "primary.c90" : "neutral.c100"}>
           {title}
         </Text>

--- a/apps/ledger-live-mobile/src/components/Nft/NftLinksPanel.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftLinksPanel.tsx
@@ -15,6 +15,8 @@ import { rgba } from "../../colors";
 import HideNftDrawer from "./HideNftDrawer";
 import { track, TrackScreen } from "../../analytics";
 import { extractImageUrlFromNftMetadata } from "../CustomImage/imageUtils";
+import { knownDeviceModelIdsSelector } from "../../reducers/settings";
+import { useSelector } from "react-redux";
 
 type Props = {
   links?: NFTMetadata["links"] | null;
@@ -76,8 +78,10 @@ const NftLinksPanel = ({ nftContract, nftId, links, isOpen, onClose, nftMetadata
     useFeature("disableNftRaribleOpensea")?.enabled && Platform.OS === "ios";
 
   const customImageUri = extractImageUrlFromNftMetadata(nftMetadata);
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
 
-  const showCustomImageButton = customImage?.enabled && !!customImageUri;
+  const showCustomImageButton =
+    knownDeviceModelIds.stax && customImage?.enabled && !!customImageUri;
 
   const handleOpenOpenSea = useCallback(() => {
     track("button_clicked", {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

On LLM and LLD, the "use NFT for Stax custom lock screen" option should be visible only if
- the `customImage` flag is enabled
- AND the user has connected a Stax once
- AND the NFT has some metadata with a picture that can be used as a custom lock screen

builds
- android https://github.com/LedgerHQ/ledger-live-build/actions/runs/6406832356
- ios https://github.com/LedgerHQ/ledger-live-build/actions/runs/6428883444
- lld https://github.com/LedgerHQ/ledger-live/actions/runs/6406844468

### ❓ Context

- **Impacted projects**: LLM, LLD <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: [LIVE-7108] <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/91890529/a8cf876b-8ecf-4505-b9fa-4396ad80cdb9


https://github.com/LedgerHQ/ledger-live/assets/91890529/5a491f55-7098-437d-af40-9f3c481c67df



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-7108]: https://ledgerhq.atlassian.net/browse/LIVE-7108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ