### PR TITLE
fix: add more bottom margin on earn screen

### DIFF
--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -19,7 +19,7 @@ import {
   languageSelector,
 } from "../../../reducers/settings";
 import { useSelector } from "react-redux";
-import { MAIN_BUTTON_SIZE } from "../../../components/TabBar/shared";
+import { MAIN_BUTTON_BOTTOM, MAIN_BUTTON_SIZE } from "../../../components/TabBar/shared";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 
 export type Props = StackNavigatorProps<EarnLiveAppNavigatorParamList, ScreenName.Earn>;
@@ -63,6 +63,8 @@ export function EarnScreen({ route }: Props) {
       flex={1}
       pt={insets.top}
       pb={MAIN_BUTTON_SIZE} // Avoid nav button at the bottom
+      mb={MAIN_BUTTON_BOTTOM}
+      backgroundColor={"background.main"} // Earn app bg color
     >
       <TrackScreen category="EarnDashboard" name="Earn" />
       <WebPTXPlayer


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add (more) padding at bottom to make "Feedback" button clickable (on more devices).

### ❓ Context

- **Impacted projects**: `ledger-live-mobile`
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9626

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/904cf47c-2bea-4a9f-908c-4f77b0ba11ea)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
