### PR TITLE
Deactivate PNPM cache on Test e2e macOS

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -109,7 +109,6 @@ jobs:
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
         with:
-          skip_python: true
           skip_ruby: true
           install_playwright: true
           upgrade_npm: true
@@ -156,9 +155,9 @@ jobs:
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
         with:
-          skip_python: true
           skip_ruby: true
           install_playwright: true
+          no_pnpm_cache: true
           pnpm_dest: ${{ runner.temp }}/setup-pnpm
           aws-access-key: ${{ secrets.AWS_S3_CACHE_ACCESS_KEY }}
           aws-secret-key: ${{ secrets.AWS_S3_CACHE_SECRET_KEY }}

--- a/.github/workflows/test-desktop-external.yml
+++ b/.github/workflows/test-desktop-external.yml
@@ -114,7 +114,6 @@ jobs:
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
         with:
-          skip_python: true
           skip_ruby: true
           install_playwright: true
       - name: Run playwright tests [Linux => xvfb-run]

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -201,7 +201,6 @@ jobs:
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
         with:
-          skip_python: true
           skip_ruby: true
           install_playwright: true
           aws-access-key: ${{ secrets.AWS_S3_CACHE_ACCESS_KEY }}
@@ -267,12 +266,12 @@ jobs:
       - uses: ./tools/actions/composites/setup-test-desktop
         id: setup-test-desktop
         with:
-          skip_python: true
           skip_ruby: true
           install_playwright: true
           pnpm_dest: ${{ runner.temp }}/setup-pnpm
           aws-access-key: ${{ secrets.AWS_S3_CACHE_ACCESS_KEY }}
           aws-secret-key: ${{ secrets.AWS_S3_CACHE_SECRET_KEY }}
+          no_pnpm_cache: true
       - name: Run playwright tests
         id: tests
         run: |

--- a/tools/actions/composites/setup-test-desktop/action.yml
+++ b/tools/actions/composites/setup-test-desktop/action.yml
@@ -41,14 +41,14 @@ runs:
         pnpm_dest: ${{ inputs.pnpm_dest }}
         upgrade_npm: ${{ inputs.upgrade_npm }}
         install_dotnet: ${{ inputs.install_dotnet }}
-    - uses: actions/setup-python@v4
-      if: ${{ !inputs.skip_python }}
-      with:
-        python-version: "3.x"
+    # - uses: actions/setup-python@v4
+    #   if: ${{ !inputs.skip_python }}
+    #   with:
+    #     python-version: "3.x"
     - uses: ruby/setup-ruby@v1
       if: ${{ !inputs.skip_ruby }}
       with:
-        ruby-version: 3.1.2
+        ruby-version: 3.2.2
     - name: Install node-gyp globally
       if: ${{ inputs.install_node_gyp }}
       run: |

--- a/tools/actions/composites/setup-test-desktop/action.yml
+++ b/tools/actions/composites/setup-test-desktop/action.yml
@@ -1,9 +1,6 @@
 name: "Setup Ledger Live Desktop Tests"
 description: "Composite job to setup the CI for Ledger Live Desktop tests"
 inputs:
-  skip_python:
-    description: "skip the step to setup python"
-    required: false
   skip_ruby:
     description: "skip the step to setup ruby"
     required: false
@@ -31,6 +28,9 @@ inputs:
   aws-secret-key:
     description: "aws secret key"
     required: false
+  no_pnpm_cache:
+    description: install node without pnpm cache
+    required: false
 
 runs:
   using: "composite"
@@ -41,10 +41,7 @@ runs:
         pnpm_dest: ${{ inputs.pnpm_dest }}
         upgrade_npm: ${{ inputs.upgrade_npm }}
         install_dotnet: ${{ inputs.install_dotnet }}
-    # - uses: actions/setup-python@v4
-    #   if: ${{ !inputs.skip_python }}
-    #   with:
-    #     python-version: "3.x"
+        no_pnpm_cache: ${{ inputs.no_pnpm_cache }}
     - uses: ruby/setup-ruby@v1
       if: ${{ !inputs.skip_ruby }}
       with:

--- a/tools/actions/composites/setup-toolchain/action.yml
+++ b/tools/actions/composites/setup-toolchain/action.yml
@@ -22,21 +22,19 @@ runs:
         dotnet-version: 2.1.816
     - uses: pnpm/action-setup@v2
       if: inputs.pnpm_dest != ''
-      # if: ${{ runner.os == 'Windows' }}
       with:
         version: 8.8
         dest: ${{ inputs.pnpm_dest }}
     - uses: pnpm/action-setup@v2
       if: inputs.pnpm_dest == ''
-      # if: ${{ runner.os == 'Windows' }}
       with:
         version: 8.8
     - uses: actions/setup-node@v3
-      # if: ${{ runner.os == 'Windows' }}
+
       with:
         node-version: 18
-        cache: pnpm
-        cache-dependency-path: "**/pnpm-lock.yaml"
+        # cache: pnpm
+        # cache-dependency-path: "**/pnpm-lock.yaml"
         registry-url: "https://registry.npmjs.org"
     - name: upgrade npm
       if: inputs.upgrade_npm == 'true'

--- a/tools/actions/composites/setup-toolchain/action.yml
+++ b/tools/actions/composites/setup-toolchain/action.yml
@@ -10,6 +10,9 @@ inputs:
   install_dotnet:
     description: "dotnet setup for Windows"
     required: false
+  no_pnpm_cache:
+    description: should install without pnpm cache
+    required: false
 
 runs:
   using: "composite"
@@ -30,11 +33,16 @@ runs:
       with:
         version: 8.8
     - uses: actions/setup-node@v3
-
+      if: inputs.no_pnpm_cache != ''
       with:
         node-version: 18
-        # cache: pnpm
-        # cache-dependency-path: "**/pnpm-lock.yaml"
+        registry-url: "https://registry.npmjs.org"
+    - uses: actions/setup-node@v3
+      if: inputs.no_pnpm_cache == ''
+      with:
+        node-version: 18
+        cache: pnpm
+        cache-dependency-path: "**/pnpm-lock.yaml"
         registry-url: "https://registry.npmjs.org"
     - name: upgrade npm
       if: inputs.upgrade_npm == 'true'


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Deactivating the pnpm cache during the macos e2e tests desktop to make sure there are no issues with Electron.Framework when we restore cache.

### ❓ Context

- **Impacted projects**: `ci` <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**: `` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
