### PR TITLE
chore: workaround to restore a broken electron install on CI

### DIFF
--- a/tools/actions/composites/setup-test-desktop/action.yml
+++ b/tools/actions/composites/setup-test-desktop/action.yml
@@ -57,7 +57,21 @@ runs:
     - name: Install dependencies
       env:
         LANG: en_US.UTF-8
-      run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live" --filter="dummy-*" --unsafe-perm
+      run: |
+        pnpm i --filter="ledger-live-desktop..." --filter="ledger-live" --filter="dummy-*" --unsafe-perm
+        F=apps/ledger-live-desktop/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework
+        if [ -x "$F" ] ; then
+          if [ ! -x "$F/Electron Framework" ] ; then
+            echo "ELECTRON is broken, trying to restore it..."
+            rm -rf node_modules/.pnpm/electron@* apps/ledger-live-desktop/node_modules/electron
+            pnpm i --filter="ledger-live-desktop..." --filter="ledger-live" --filter="dummy-*" --unsafe-perm
+          fi
+          if [ ! -x "$F/Electron Framework" ] ; then
+            echo "ELECTRON is still broken, aborting..."
+            exit 1
+          fi
+        fi
+
       shell: bash
     - name: Install playwright dependencies
       if: ${{ inputs.install_playwright }}


### PR DESCRIPTION
NB: creating this PR to save the code. for now it's on hodl to be run (stays in draft), until we know where we go for sure.

### 📝 Description

as we are understanding better and better the issue still at stake on CI on our Mac OS runners, we suspect something bad going on between the Electron install (https://github.com/electron/electron/blob/main/npm/install.js) and the Github Actions caching mechanism (`setup-node` with `cache: pnpm`).

This PR will "feature detect" the problem and will reinstall Electron in case it misses the necessary file for Electron to properly work on the Playwright end to end tests.

### ❓ Context

- **Impacted projects**: LLD e2e tests <!-- The list of end user projects impacted by the change. -->
- **Linked resource(s)**:  <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
