### PR TITLE
Fix/live 6393 display stax locked drawer

### DIFF
--- a/.changeset/sharp-readers-occur.md
+++ b/.changeset/sharp-readers-occur.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+add correct drawer when device is locked during pairing

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
@@ -15,7 +15,7 @@ import {
   Icons,
 } from "@ledgerhq/native-ui";
 
-import { LockedDeviceError, PeerRemovedPairing } from "@ledgerhq/errors";
+import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { getDeviceAnimation } from "../../helpers/getDeviceAnimation";
 import Animation from "../Animation";
 import { TrackScreen } from "../../analytics";
@@ -128,26 +128,14 @@ const BleDevicePairing = ({ deviceToPair, onPaired, onRetry }: BleDevicePairingP
     );
   } else if (pairingError) {
     // TODO refactor this into the generic error rendering when possible.
-    let title;
-    let subtitle;
-
-    if ((pairingError as unknown) instanceof LockedDeviceError) {
-      title = t("blePairingFlow.pairing.error.lockedDevice.title");
-      subtitle = t("blePairingFlow.pairing.error.lockedDevice.subtitle", {
-        productName,
-      });
-    } else {
-      title = t("blePairingFlow.pairing.error.generic.title");
-      subtitle = t("blePairingFlow.pairing.error.generic.subtitle", {
-        productName,
-      });
-    }
-
     content = (
       <Flex flex={1}>
         <TrackScreen category="BT failed to pair" />
         <Flex flex={1} alignItems="center" justifyContent="center">
-          <GenericInformationBody title={title} description={subtitle} />
+          <GenericInformationBody
+            title={t("blePairingFlow.pairing.error.generic.title")}
+            description={t("blePairingFlow.pairing.error.generic.subtitle")}
+          />
         </Flex>
         <Button type="main" onPress={onRetry} mb={8}>
           {t("blePairingFlow.pairing.error.retryCta")}

--- a/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.ts
+++ b/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.ts
@@ -7,7 +7,7 @@ import getVersion from "../../hw/getVersion";
 import { BleError } from "../types";
 
 export type useBleDevicePairingArgs = {
-  deviceId: string;
+  deviceId: string | undefined;
 };
 
 export type PairingError = BleError | null;
@@ -31,6 +31,8 @@ export const useBleDevicePairing = ({
   const [pairingError, setPairingError] = useState<PairingError>(null);
 
   useEffect(() => {
+    if (!deviceId) return;
+
     const requestObservable = withDevice(deviceId)(t => from(getVersion(t))).pipe(first());
 
     const sub = requestObservable.subscribe({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

display a drawer when stax is locked during pairing. This is working only if device has been already paired since this information is not available when not paired. If not, the previous generic error is displayed.

### ❓ Context

- **Impacted projects**: `LLM` '`edger-live-common`
- **Linked resource(s)**: [LIVE-6393]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6393]: https://ledgerhq.atlassian.net/browse/LIVE-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ