### PR TITLE
Bugfix/live 6393 unlock ble drawer

### DIFF
--- a/.changeset/sharp-readers-occur.md
+++ b/.changeset/sharp-readers-occur.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+add correct drawer when device is locked during pairing

--- a/apps/ledger-live-mobile/src/components/UnlockDeviceDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/UnlockDeviceDrawer.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTheme } from "styled-components/native";
-import { renderConnectYourDevice as ConnectYourDevice } from "../../components/DeviceAction/rendering";
-import QueuedDrawer from "../../components/QueuedDrawer";
+import { renderConnectYourDevice as ConnectYourDevice } from "./DeviceAction/rendering";
+import QueuedDrawer from "./QueuedDrawer";
 
 export type Props = {
   isOpen: boolean;

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -23,7 +23,7 @@ import EarlySecurityCheckMandatoryDrawer from "./EarlySecurityCheckMandatoryDraw
 import { PlainOverlay } from "./DesyncOverlay";
 import { track } from "../../analytics";
 import { NavigationHeaderCloseButton } from "../../components/NavigationHeaderCloseButton";
-import UnlockDeviceDrawer from "./UnlockDeviceDrawer";
+import UnlockDeviceDrawer from "../../components/UnlockDeviceDrawer";
 import AutoRepairDrawer from "./AutoRepairDrawer";
 
 export type SyncOnboardingScreenProps = CompositeScreenProps<


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

display a drawer when stax is locked during pairing. This is working only if device has been already paired since this information is not available when not paired. If not, the previous generic error is displayed.

### ❓ Context

- **Impacted projects**: `LLM` `ledger-live-common`
- **Linked resource(s)**: [LIVE-6393]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/35492518/196f157f-b84c-4b69-9927-75dc5e2184a8


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-6393]: https://ledgerhq.atlassian.net/browse/LIVE-6393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ