### PR TITLE
[feat/LIVE-8381]: add 10s timeout on estimate gas calls for

### DIFF
--- a/.changeset/silver-lamps-warn.md
+++ b/.changeset/silver-lamps-warn.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/errors": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/coin-evm": patch
+---
+
+add 10s timeout to estimate gas

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5423,6 +5423,9 @@
     "FeeNotLoaded": {
       "title": "Couldn't load fee rates. Please set manual fees"
     },
+    "FeeNotLoadedSwap": {
+      "title": "Network fee estimation failed because of technical issues. Try again or change the assets."
+    },
     "FeeRequired": {
       "title": "Fees are required"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -304,6 +304,9 @@
     "FeeNotLoaded": {
       "title": "Could not load fee rates"
     },
+    "FeeNotLoadedSwap": {
+      "title": "Network fee estimation failed because of technical issues. Try again or change the assets."
+    },
     "FeeRequired": {
       "title": "Fees are required"
     },

--- a/libs/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
@@ -275,6 +275,22 @@ describe("EVM Family", () => {
         }
       });
 
+      it("should throw GasEstimationError if request throws ECONNABORTED", async () => {
+        jest
+          .spyOn(axios, "request")
+          .mockImplementation(() => Promise.reject({ code: "ECONNABORTED" }));
+
+        try {
+          await LEDGER_API.getGasEstimation(account, {} as any);
+          fail("Promise should have been rejected");
+        } catch (e) {
+          if (e instanceof AssertionError) {
+            throw e;
+          }
+          expect(e).toBeInstanceOf(GasEstimationError);
+        }
+      });
+
       it("should return the expected payload", async () => {
         jest.spyOn(axios, "request").mockImplementation(async ({ data: transaction }) => {
           return (transaction as any)?.data?.length > 2

--- a/libs/coin-evm/src/api/node/ledger.ts
+++ b/libs/coin-evm/src/api/node/ledger.ts
@@ -15,7 +15,7 @@ import { NodeApi, isLedgerNodeConfig } from "./types";
 import { getGasOptions } from "../gasTracker/ledger";
 import { padHexString } from "../../logic";
 
-export const LEDGER_TIMEOUT = 10000;
+export const LEDGER_TIMEOUT = 10_000; // 10_000ms (10s) for network call timeout
 export const LEDGER_TIME_BETWEEN_TRIES = 200; // 200ms between 2 calls
 export const DEFAULT_RETRIES_API = 2;
 

--- a/libs/coin-evm/src/api/node/ledger.ts
+++ b/libs/coin-evm/src/api/node/ledger.ts
@@ -15,7 +15,8 @@ import { NodeApi, isLedgerNodeConfig } from "./types";
 import { getGasOptions } from "../gasTracker/ledger";
 import { padHexString } from "../../logic";
 
-export const LEDGER_TIMEOUT = 200; // 200ms between 2 calls
+export const LEDGER_TIMEOUT = 10000;
+export const LEDGER_TIME_BETWEEN_TRIES = 200; // 200ms between 2 calls
 export const DEFAULT_RETRIES_API = 2;
 
 export async function fetchWithRetries<T>(
@@ -35,7 +36,7 @@ export async function fetchWithRetries<T>(
   } catch (e) {
     if (retries) {
       // wait the API timeout before trying again
-      await delay(LEDGER_TIMEOUT);
+      await delay(LEDGER_TIME_BETWEEN_TRIES);
       // decrement with prefix here or it won't work
       return fetchWithRetries<T>(params, --retries);
     }
@@ -185,6 +186,7 @@ export const getGasEstimation: NodeApi["getGasEstimation"] = async (
       estimated_gas_limit: string;
     }>({
       method: "POST",
+      timeout: LEDGER_TIMEOUT,
       url: `${getEnv("EXPLORER")}/blockchain/v4/${node.explorerId}/tx/estimate-gas-limit`,
       data: {
         from: account.freshAddress, // should be necessary for some estimations

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -1,4 +1,10 @@
-import { AmountRequired, NotEnoughGas, NotEnoughGasSwap } from "@ledgerhq/errors";
+import {
+  AmountRequired,
+  FeeNotLoaded,
+  FeeNotLoadedSwap,
+  NotEnoughGas,
+  NotEnoughGasSwap,
+} from "@ledgerhq/errors";
 import { useMemo } from "react";
 import {
   SwapSelectorStateType,
@@ -73,6 +79,11 @@ export const useFromAmountStatusMessage = (
       });
     }
 
+    // convert to swap variation of error to display correct message to frontend.
+    if (relevantStatus instanceof FeeNotLoaded) {
+      return new FeeNotLoadedSwap();
+    }
+
     return relevantStatus;
   }, [statusEntries, currency, estimatedFees, transaction?.amount, account?.id, parentAccount?.id]);
 };
@@ -123,7 +134,7 @@ export const useSwapTransaction = ({
   const { account: toAccount } = toState;
   const transaction = bridgeTransaction?.transaction;
 
-  const fromAmountError = useFromAmountStatusMessage(bridgeTransaction, ["amount"]);
+  const fromAmountError = useFromAmountStatusMessage(bridgeTransaction, ["amount", "gasLimit"]);
   // treat the gasPrice error as a warning for swap.
   const fromAmountWarning = useFromAmountStatusMessage(bridgeTransaction, ["gasPrice"]);
 

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -140,6 +140,7 @@ export const WrongAppForCurrency = createCustomErrorClass("WrongAppForCurrency")
 export const ETHAddressNonEIP = createCustomErrorClass("ETHAddressNonEIP");
 export const CantScanQRCode = createCustomErrorClass("CantScanQRCode");
 export const FeeNotLoaded = createCustomErrorClass("FeeNotLoaded");
+export const FeeNotLoadedSwap = createCustomErrorClass("FeeNotLoadedSwap");
 export const FeeRequired = createCustomErrorClass("FeeRequired");
 export const FeeTooHigh = createCustomErrorClass("FeeTooHigh");
 export const PendingOperation = createCustomErrorClass("PendingOperation");


### PR DESCRIPTION
### 📝 Description

- Add 10 second timeout to `estimate-gas` evm endpoint.
- Convert error message in swap app to display correct message.

### ❓ Context

- **Impacted projects**: `LLM,LLC,LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
