### PR TITLE
[LIVE-8686][STAX ESC] Stax not correctly detected as disconnected if user unplugs during genuine check

### DIFF
--- a/.changeset/little-onions-exercise.md
+++ b/.changeset/little-onions-exercise.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": major
+---
+
+Display troubleshooting usb drawer instead of locked device drawer if stax is unplugged during genuine check

--- a/.changeset/quick-starfishes-check.md
+++ b/.changeset/quick-starfishes-check.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": major
+"ledger-live-desktop": patch
 ---
 
 Display troubleshooting usb drawer instead of locked device drawer if stax is unplugged during genuine check

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -29,6 +29,7 @@ import { track } from "~/renderer/analytics/segment";
 import { log } from "@ledgerhq/logs";
 import { useDynamicUrl } from "~/renderer/terms";
 import { FinalFirmware } from "@ledgerhq/types-live";
+import { useHistory } from "react-router-dom";
 
 export type Props = {
   onComplete: () => void;
@@ -81,6 +82,7 @@ const EarlySecurityChecks = ({
     SoftwareCheckStatus.inactive,
   );
   const [availableFirmwareVersion, setAvailableFirmwareVersion] = useState<string>("");
+  const history = useHistory();
 
   const deviceId = device.deviceId ?? "";
   const deviceModelId = device.modelId;
@@ -247,7 +249,10 @@ const EarlySecurityChecks = ({
     if (disconnectedDeviceModalIsOpen) {
       const props: TroubleshootingDrawerProps = {
         lastKnownDeviceId: deviceModelId,
-        onClose: resetGenuineCheckState,
+        onClose: () => {
+          resetGenuineCheckState();
+          history.push("/onboarding/select-device");
+        },
       };
       setDrawer(TroubleshootingDrawer, props, commonDrawerProps);
     } else if (allowSecureChannelIsOpen) {
@@ -304,6 +309,7 @@ const EarlySecurityChecks = ({
     notGenuineIsOpen,
     productName,
     resetGenuineCheckState,
+    history,
   ]);
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -4,7 +4,9 @@ import manager from "@ledgerhq/live-common/manager/index";
 import { useGenuineCheck } from "@ledgerhq/live-common/hw/hooks/useGenuineCheck";
 import { useGetLatestAvailableFirmware } from "@ledgerhq/live-common/deviceSDK/hooks/useGetLatestAvailableFirmware";
 import Body from "./Body";
-import LockedDeviceDrawer, { Props as LockedDeviceDrawerProps } from "../LockedDeviceDrawer";
+import TroubleshootingDrawer, {
+  Props as TroubleshootingDrawerProps,
+} from "../TroubleshootingDrawer";
 import SoftwareCheckAllowSecureChannelDrawer, {
   Props as SoftwareCheckAllowSecureChannelDrawerProps,
 } from "./SoftwareCheckAllowSecureChannelDrawer";
@@ -229,7 +231,8 @@ const EarlySecurityChecks = ({
     getLatestAvailableFirmwareError,
   ]);
 
-  const lockedDeviceModalIsOpen =
+  // at this step we can't have an unlocked device; it's inevitably disconnected
+  const disconnectedDeviceModalIsOpen =
     (devicePermissionState === "unlock-needed" && genuineCheckActive) ||
     (lockedDevice && firmwareUpdateStatus === SoftwareCheckStatus.active);
 
@@ -241,11 +244,12 @@ const EarlySecurityChecks = ({
 
   /** Opening and closing of drawers */
   useEffect(() => {
-    if (lockedDeviceModalIsOpen) {
-      const props: LockedDeviceDrawerProps = {
-        deviceModelId,
+    if (disconnectedDeviceModalIsOpen) {
+      const props: TroubleshootingDrawerProps = {
+        lastKnownDeviceId: deviceModelId,
+        onClose: resetGenuineCheckState,
       };
-      setDrawer(LockedDeviceDrawer, props, commonDrawerProps);
+      setDrawer(TroubleshootingDrawer, props, commonDrawerProps);
     } else if (allowSecureChannelIsOpen) {
       const props: SoftwareCheckAllowSecureChannelDrawerProps = {
         deviceModelId,
@@ -296,7 +300,7 @@ const EarlySecurityChecks = ({
     deviceModelId,
     genuineCheckError,
     getLatestAvailableFirmwareError,
-    lockedDeviceModalIsOpen,
+    disconnectedDeviceModalIsOpen,
     notGenuineIsOpen,
     productName,
     resetGenuineCheckState,

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/TroubleshootingDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/TroubleshootingDrawer.tsx
@@ -25,7 +25,7 @@ const TroubleshootingDrawer: React.FC<Props> = ({ onClose, lastKnownDeviceId }) 
   const theme = useTheme();
 
   const handleFixClicked = useCallback(() => {
-    history.push("/USBTroubleshooting");
+    history.replace("/USBTroubleshooting");
     track("button_clicked", {
       button: "fix it",
       page: "drawer troubleshoot USB connection",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Display troubleshooting usb drawer instead of locked device drawer if stax is unplugged during genuine check

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-8686](https://ledgerhq.atlassian.net/browse/LIVE-8686) <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/145363160/dbec4543-41cc-468b-aebc-7e639605943b


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8686]: https://ledgerhq.atlassian.net/browse/LIVE-8686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ