### PR TITLE
Bugfix/live 9554 Fix design of bluetooth pairing error screen

### DIFF
--- a/.changeset/sixty-pets-promise.md
+++ b/.changeset/sixty-pets-promise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix design of bluetooth pairing error screen

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
@@ -22,6 +22,7 @@ import { TrackScreen } from "../../analytics";
 import GenericErrorView from "../GenericErrorView";
 import { GenericInformationBody } from "../GenericInformationBody";
 import { urls } from "../../config/urls";
+import ExternalLink from "../ExternalLink";
 
 export type BleDevicePairingProps = {
   onPaired: (device: Device) => void;
@@ -144,14 +145,19 @@ const BleDevicePairing = ({ deviceToPair, onPaired, onRetry }: BleDevicePairingP
     }
 
     content = (
-      <Flex flex={1}>
+      <Flex flex={1} mb={6}>
         <TrackScreen category="BT failed to pair" />
         <Flex flex={1} alignItems="center" justifyContent="center">
           <GenericInformationBody title={title} description={subtitle} />
         </Flex>
-        <Button type="main" size="large" onPress={onRetry} mb={8}>
+        <Button type="main" size="large" onPress={onRetry} mb={7}>
           {t("blePairingFlow.pairing.error.retryCta")}
         </Button>
+        <ExternalLink
+          type="main"
+          text={t("blePairingFlow.pairing.error.howToFixPairingIssue")}
+          onPress={onOpenHelp}
+        />
       </Flex>
     );
   } else {

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
@@ -149,7 +149,7 @@ const BleDevicePairing = ({ deviceToPair, onPaired, onRetry }: BleDevicePairingP
         <Flex flex={1} alignItems="center" justifyContent="center">
           <GenericInformationBody title={title} description={subtitle} />
         </Flex>
-        <Button type="main" onPress={onRetry} mb={8}>
+        <Button type="main" size="large" onPress={onRetry} mb={8}>
           {t("blePairingFlow.pairing.error.retryCta")}
         </Button>
       </Flex>

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -58,6 +58,7 @@ type Props = {
   isChoiceDrawerDisplayedOnAddDevice?: boolean;
   withMyLedgerTracking?: boolean;
   filterByDeviceModelId?: DeviceModelId;
+  paddingBottom?: number;
 };
 
 export default function SelectDevice({
@@ -69,6 +70,7 @@ export default function SelectDevice({
   hasPostOnboardingEntryPointCard,
   withMyLedgerTracking,
   filterByDeviceModelId,
+  paddingBottom,
 }: Props) {
   const [USBDevice, setUSBDevice] = useState<Device | undefined>();
   const [ProxyDevice, setProxyDevice] = useState<Device | undefined>();
@@ -307,7 +309,7 @@ export default function SelectDevice({
   );
 
   return (
-    <>
+    <Flex flex={1} pb={paddingBottom && !isPairingDevices ? paddingBottom : 0}>
       {withMyLedgerTracking ? <TrackScreen {...trackScreenProps} /> : null}
       <RequiresBluetoothDrawer
         isOpenedOnIssue={isBleRequired}
@@ -486,6 +488,6 @@ export default function SelectDevice({
           </QueuedDrawer>
         </Flex>
       )}
-    </>
+    </Flex>
   );
 }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1900,13 +1900,13 @@
       "error": {
         "generic": {
           "title": "Pairing unsuccessful",
-          "subtitle": "Looks like something went wrong!\nCheck that your Bluetooth is switched on and your {{productName}} is nearby."
+          "subtitle": "Make sure your {{productName}} is close to\nyour mobile phone and try again."
         },
         "lockedDevice": {
           "title": "Your device is locked",
           "subtitle": "Unlock your {{ productName }} and try again."
         },
-        "retryCta": "Retry",
+        "retryCta": "Retry pairing",
         "openSettingsCta": "Go to Bluetooth settings",
         "howToFixPairingIssue": "How to fix pairing issues"
       }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1907,7 +1907,8 @@
           "subtitle": "Unlock your {{ productName }} and try again."
         },
         "retryCta": "Retry",
-        "openSettingsCta": "Go to Bluetooth settings"
+        "openSettingsCta": "Go to Bluetooth settings",
+        "howToFixPairingIssue": "How to fix pairing issues"
       }
     }
   },

--- a/apps/ledger-live-mobile/src/screens/Manager/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/index.tsx
@@ -154,7 +154,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
       ) : null}
 
       {newDeviceSelectionFeatureFlag?.enabled ? (
-        <Flex flex={1} px={16} pb={insets.bottom + TAB_BAR_SAFE_HEIGHT}>
+        <Flex flex={1} px={16}>
           <SelectDevice2
             onSelect={onSelectDevice}
             stopBleScanning={!!device}
@@ -162,6 +162,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
             requestToSetHeaderOptions={requestToSetHeaderOptions}
             withMyLedgerTracking
             hasPostOnboardingEntryPointCard
+            paddingBottom={insets.bottom + TAB_BAR_SAFE_HEIGHT}
           />
         </Flex>
       ) : (

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
@@ -1,15 +1,8 @@
 import React, { useCallback } from "react";
-import { StyleSheet } from "react-native";
+import { ScrollView, StyleProp, StyleSheet, ViewStyle } from "react-native";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RenderTransitionProps } from "@ledgerhq/native-ui/components/Navigation/FlowStepper/index";
-import {
-  Flex,
-  FlowStepper,
-  IconsLegacy,
-  Transitions,
-  SlideIndicator,
-  ScrollListContainer,
-} from "@ledgerhq/native-ui";
+import { Flex, FlowStepper, IconsLegacy, Transitions, SlideIndicator } from "@ledgerhq/native-ui";
 
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
@@ -107,6 +100,7 @@ export type Step = {
   (props: StepProp): JSX.Element;
   id: string;
   Next: (props: StepProp) => JSX.Element;
+  contentContainerStyle?: StyleProp<ViewStyle>;
 };
 
 export function BaseStepperView({
@@ -150,12 +144,16 @@ export function BaseStepperView({
       >
         {steps.map((Children, i) => (
           <Scene key={Children.id + i}>
-            <ScrollListContainer contentContainerStyle={{ padding: 16 }}>
+            <ScrollView
+              contentContainerStyle={
+                Children?.contentContainerStyle ? Children.contentContainerStyle : { padding: 16 }
+              }
+            >
               <Flex mb={30} mx={8} justifyContent="center" alignItems="flex-start">
                 {metadata[i]?.illustration}
               </Flex>
               <Children onNext={nextPage} deviceModelId={deviceModelId} {...params} />
-            </ScrollListContainer>
+            </ScrollView>
             {Children.Next ? (
               <Flex p={6}>
                 <Children.Next onNext={nextPage} deviceModelId={deviceModelId} />

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
@@ -111,6 +111,7 @@ const ConnectNanoScene = ({
 };
 
 ConnectNanoScene.id = "ConnectNanoScene";
+ConnectNanoScene.contentContainerStyle = { padding: 16, flex: 1 };
 
 const Next = ({ onNext }: { onNext: () => void }) => {
   const dispatch = useDispatch();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR fix the design of new bluetooth pairing error screen using the FF flag `llmNewDeviceSelection `. This screen can appear on **My Ledger**, and during the new **onboarding.**

For the **previous onboarding** flow (Access your wallet -> Connect your ledger -> Pair my nano -> Add with bluetooth), the design is also improved but not totally correct. Since this older flow will be replaced we will not fix it right now.

### ❓ Context

- **Impacted projects**: `llm`
- **Linked resource(s)**: [LIVE-9554] ; [Figma](https://www.figma.com/file/x9nwU0JtDtyUIhAyBB2El8/Onboarding?type=design&node-id=10078-34306&mode=design&t=RRo0LwguVpuw0RW8-0)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo



https://github.com/LedgerHQ/ledger-live/assets/35492518/8239f729-43f9-4e5c-ae24-29907d773f14



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9554]: https://ledgerhq.atlassian.net/browse/LIVE-9554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ