### PR TITLE
[LIVE-9388][Stax] Modal for device language change when changing LLD language is wrong

### DIFF
--- a/.changeset/angry-shirts-explode.md
+++ b/.changeset/angry-shirts-explode.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": major
+---
+
+display appropriate device image in change language prompt drawer

--- a/.changeset/forty-balloons-invite.md
+++ b/.changeset/forty-balloons-invite.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": major
+"ledger-live-desktop": patch
 ---
 
 display appropriate device image in change language prompt drawer

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ChangeDeviceLanguagePromptDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ChangeDeviceLanguagePromptDrawer.tsx
@@ -12,7 +12,7 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { setDrawer } from "~/renderer/drawers/Provider";
 
-type Props = {
+export type Props = {
   currentLanguage: Language;
   analyticsContext: string;
   deviceModelInfo?: DeviceModelInfo;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
@@ -82,7 +82,7 @@ const LanguageSelect: React.FC<Props> = ({ disableLanguagePrompt }) => {
       setDrawer(
         ChangeDeviceLanguagePromptDrawer,
         {
-          deviceModeInfo: lastSeenDevice,
+          deviceModelInfo: lastSeenDevice ?? undefined,
           analyticsContext: "Page LiveLanguageChange",
           onSuccess: refreshDeviceInfo,
           onError: refreshDeviceInfo,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
@@ -1,4 +1,3 @@
-import { DeviceModelId } from "@ledgerhq/devices";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
 import { useAvailableLanguagesForDevice } from "@ledgerhq/live-common/manager/hooks";
@@ -21,7 +20,9 @@ import {
   lastSeenDeviceSelector,
   useSystemLanguageSelector,
 } from "~/renderer/reducers/settings";
-import ChangeDeviceLanguagePromptDrawer from "./ChangeDeviceLanguagePromptDrawer";
+import ChangeDeviceLanguagePromptDrawer, {
+  Props as ChangeDeviceLanguagePromptDrawerProps,
+} from "./ChangeDeviceLanguagePromptDrawer";
 
 type ChangeLangArgs = { value: Language | null; label: string };
 
@@ -79,14 +80,13 @@ const LanguageSelect: React.FC<Props> = ({ disableLanguagePrompt }) => {
 
   const openDrawer = useCallback(
     (language?: Language | null) => {
-      setDrawer(
+      setDrawer<ChangeDeviceLanguagePromptDrawerProps>(
         ChangeDeviceLanguagePromptDrawer,
         {
           deviceModelInfo: lastSeenDevice ?? undefined,
           analyticsContext: "Page LiveLanguageChange",
           onSuccess: refreshDeviceInfo,
           onError: refreshDeviceInfo,
-          deviceModelId: lastSeenDevice?.modelId ?? DeviceModelId.nanoX,
           currentLanguage: language ?? getInitialLanguageAndLocale().language,
         },
         {},


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Display appropriate device image in change device language prompt drawer

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-9388](https://ledgerhq.atlassian.net/browse/LIVE-9388) <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo
[Demo.webm](https://github.com/LedgerHQ/ledger-live/assets/145363160/4639355f-a931-4e2d-8bf3-48a9bfd4521c)

<!--

For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->



[LIVE-9388]: https://ledgerhq.atlassian.net/browse/LIVE-9388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ