### PR TITLE
chore: also run on macos-latest in case runners are busy

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -95,7 +95,7 @@ jobs:
 
   build-desktop-app-macos:
     name: "Build Ledger Live Desktop (Mac OS X)"
-    runs-on: [m1, ARM64]
+    runs-on: [m1, ARM64, macos-latest]
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -128,7 +128,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-    runs-on: [m1, ARM64]
+    runs-on: [m1, ARM64, macos-latest]
     steps:
       - name: generate token
         id: generate-token

--- a/.github/workflows/healthchecks-runners.yaml
+++ b/.github/workflows/healthchecks-runners.yaml
@@ -217,7 +217,7 @@ jobs:
           ref: main
           token: ${{ github.token }}
   checks-macos:
-    runs-on: [m1, ARM64]
+    runs-on: [m1, ARM64, macos-latest]
     outputs:
       check-node: ${{ steps.check-node.outputs.result }}
       check-pnpm: ${{ steps.check-pnpm.outputs.result }}

--- a/.github/workflows/test-desktop.yml
+++ b/.github/workflows/test-desktop.yml
@@ -245,7 +245,7 @@ jobs:
 
   e2e-tests-mac:
     name: "Desktop E2E (macOS X)"
-    runs-on: [m1, ARM64]
+    runs-on: [m1, ARM64, macos-latest]
     outputs:
       status: ${{ steps.tests.outcome }}
     env:

--- a/.github/workflows/test-mobile-e2e.yml
+++ b/.github/workflows/test-mobile-e2e.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   detox-tests-ios:
     name: "Ledger Live Mobile - iOS Detox Tests"
-    runs-on: [m1, ARM64]
+    runs-on: [m1, ARM64, macos-latest]
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       LANG: en_US.UTF-8


### PR DESCRIPTION


### 📝 Description

in context of not having enough runners for Mac. we reopen the possibility to consider a Github runner, even if slower, will relieve a bit the current queuing which takes more time that the low performance that github have.

### ❓ Context

- **Impacted projects**: `ci` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9699 <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
