### PR TITLE
test: fix an await in the LLD eth tests

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/families/ethereum.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/families/ethereum.spec.ts
@@ -25,6 +25,6 @@ test("Send flow", async ({ page }) => {
     await sendFeeMode.waitFor({ state: "visible" });
 
     await expect.soft(sendModal.container).toHaveScreenshot("send-modal-eth-max-network-fees.png");
-    expect(sendModal.container.getByText("Max Network fees").isVisible()).toBeTruthy();
+    expect(await sendModal.container.getByText("Max Network fees").isVisible()).toBeTruthy();
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/families/polkadot.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/families/polkadot.spec.ts
@@ -13,7 +13,7 @@ test("Nomination flow", async ({ page }) => {
     await page.locator('[data-test-id="account-component-Polkadot 1"]').click();
     await page.getByRole("button", { name: "Nominate" }).scrollIntoViewIfNeeded();
     await page.getByRole("button", { name: "Nominate" }).click();
-    expect(page.getByText("Validators (8)").isVisible()).toBeTruthy();
+    expect(await page.getByText("Validators (8)").isVisible()).toBeTruthy();
     await expect
       .soft(page.locator('[data-test-id="modal-content"]'))
       .toHaveScreenshot("nominate-modal-dot-nominator-row.png");


### PR DESCRIPTION


### 📝 Description

```
locator.isVisible: Target closed
```

seems to happen from time to time on this test.

as far as i understand, the test actually wasn't properly testing anything, we were expecting the truthyness of the **Promise** and not of the actual boolean it contains. the error that sometimes happens is triggered due to fact the test redeems the DOM which makes the promise eventually will get the unmounting error (target closed) and possibly the test may catch the promise failures (globally?)

### ❓ Context

- **Impacted projects**: `tests` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
