### PR TITLE
fix(ui): wallet/account gradient displays correctly on large phones (samsung fold)

### DIFF
--- a/.changeset/grumpy-adults-warn.md
+++ b/.changeset/grumpy-adults-warn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix wallet/account background gradient on large phones

--- a/.changeset/metal-rats-sell.md
+++ b/.changeset/metal-rats-sell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+My ledger Tab: change nano device size for large phones

--- a/apps/ledger-live-mobile/src/components/CurrencyGradient.tsx
+++ b/apps/ledger-live-mobile/src/components/CurrencyGradient.tsx
@@ -24,8 +24,8 @@ function CurrencyGradient({ gradientColor }: { gradientColor: string }) {
       </Mask>
       <G mask="url(#a)">
         <Path fill={colors.background.main} d="M0 0H850V454H0z" />
-        <Path fill="url(#paint0_linear_22_3)" fillOpacity={0.3} d="M0 0H850V450.077H0z" />
-        <Path fill="url(#paint1_linear_22_3)" d="M0 0H850V450.077H0z" />
+        <Path fill="url(#paint0_linear_22_3)" fillOpacity={0.3} d="M0 0H850V454.077H0z" />
+        <Path fill="url(#paint1_linear_22_3)" d="M0 0H850V454.077H0z" />
       </G>
       <Defs>
         <LinearGradient

--- a/apps/ledger-live-mobile/src/components/CurrencyGradient.tsx
+++ b/apps/ledger-live-mobile/src/components/CurrencyGradient.tsx
@@ -7,7 +7,7 @@ function CurrencyGradient({ gradientColor }: { gradientColor: string }) {
   const { colors } = useTheme();
   const contrastedColor = ensureContrast(gradientColor, colors.background.main);
   return (
-    <Svg width={541} height={454} viewBox="0 0 541 454" fill="none">
+    <Svg width={850} height={454} viewBox="0 0 850 454" fill="none">
       <Mask
         id="a"
         // @ts-expect-error maskType is not in the type definition
@@ -17,15 +17,15 @@ function CurrencyGradient({ gradientColor }: { gradientColor: string }) {
         maskUnits={"userSpaceOnUse" as const}
         x={0}
         y={0}
-        width={541}
+        width={850}
         height={454}
       >
-        <Path fill="#fff" d="M0 0H541V454H0z" />
+        <Path fill="#fff" d="M0 0H850V454H0z" />
       </Mask>
       <G mask="url(#a)">
-        <Path fill={colors.background.main} d="M0 0H541V454H0z" />
-        <Path fill="url(#paint0_linear_22_3)" fillOpacity={0.3} d="M0 0H541V450.077H0z" />
-        <Path fill="url(#paint1_linear_22_3)" d="M0 0H541V450.077H0z" />
+        <Path fill={colors.background.main} d="M0 0H850V454H0z" />
+        <Path fill="url(#paint0_linear_22_3)" fillOpacity={0.3} d="M0 0H850V450.077H0z" />
+        <Path fill="url(#paint1_linear_22_3)" d="M0 0H850V450.077H0z" />
       </G>
       <Defs>
         <LinearGradient

--- a/apps/ledger-live-mobile/src/components/SelectDevice/BluetoothEmpty.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice/BluetoothEmpty.tsx
@@ -44,6 +44,7 @@ function BluetoothEmpty({ onPairNewDevice, hideAnimation }: Props) {
 const styles = StyleSheet.create({
   imageContainer: {
     minHeight: 200,
+    maxWidth: 550,
     position: "relative",
     overflow: "visible",
   },

--- a/apps/ledger-live-mobile/src/components/WalletTab/WalletTabBackgroundGradient.tsx
+++ b/apps/ledger-live-mobile/src/components/WalletTab/WalletTabBackgroundGradient.tsx
@@ -36,25 +36,25 @@ function WalletTabBackgroundGradient({ color, scrollX }: Props) {
         {
           backgroundColor: colors.background.main,
           position: "absolute",
-          width: 541,
-          height: 450,
+          width: 850,
+          height: 480,
           top: -130,
           opacity,
         },
       ]}
     >
-      <Svg width={541} height={454} viewBox="0 0 541 454" fill="none">
-        <Path fill="url(#paint0_linear_9_2)" d="M0 0H541V454H0z" />
-        <Path fill="url(#paint1_radial_9_2)" d="M0 0H541V454H0z" />
-        <Path fill="url(#paint2_radial_9_2)" d="M0 0H541V454H0z" />
-        <Path fill="url(#paint3_linear_9_2)" d="M0 0H541V454H0z" />
+      <Svg width={850} height={480} viewBox="0 0 850 480" fill="none">
+        <Path fill="url(#paint0_linear_9_2)" d="M0 0H850V480H0z" />
+        <Path fill="url(#paint1_radial_9_2)" d="M0 0H850V480H0z" />
+        <Path fill="url(#paint2_radial_9_2)" d="M0 0H850V480H0z" />
+        <Path fill="url(#paint3_linear_9_2)" d="M0 0H850V480H0z" />
         <Defs>
           <LinearGradient
             id="paint0_linear_9_2"
             x1={270.5}
             y1={0}
             x2={270.5}
-            y2={454}
+            y2={480}
             gradientUnits="userSpaceOnUse"
           >
             <Stop offset={0.380208} stopColor={color || "#BE96FF"} />
@@ -89,7 +89,7 @@ function WalletTabBackgroundGradient({ color, scrollX }: Props) {
             x1={270.5}
             y1={-73.5}
             x2={270.5}
-            y2={454}
+            y2={480}
             gradientUnits="userSpaceOnUse"
           >
             <Stop offset={0.46223} stopColor={colors.background.main} stopOpacity={0.6} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Background gradient are now adapt to larger phones (ex: samsung fold).
Also fix the nano animation in 'my ledger' tab.

### ❓ Context

- **Impacted projects**: `LLM` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-9519] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

Vidéo 'Wallet' tab
[capture fold ui.webm](https://github.com/LedgerHQ/ledger-live/assets/146743014/74ceb904-f32f-4c85-a961-110e1b4713b2)

Capture 'My Ledger' tab
<img width="769" alt="Screenshot 2023-10-19 at 16 10 19" src="https://github.com/LedgerHQ/ledger-live/assets/146743014/533859aa-8278-4eba-8dee-be2854964d55">


<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9519]: https://ledgerhq.atlassian.net/browse/LIVE-9519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ