### PR TITLE
chore: increase default expect timeout of playwright

### DIFF
--- a/apps/ledger-live-desktop/tests/playwright.config.ts
+++ b/apps/ledger-live-desktop/tests/playwright.config.ts
@@ -6,7 +6,8 @@ const config: PlaywrightTestConfig = {
   outputDir: "./artifacts/test-results",
   timeout: process.env.CI ? 190000 : 600000,
   expect: {
-    timeout: 30000,
+    // we need to give enough time for the playwright app to start. when the CI is slow, 30s was apprently not enough.
+    timeout: 61000,
     toHaveScreenshot: {
       /**
        * do not increase unless it makes most tests flaky


### PR DESCRIPTION
### 📝 Description

the macOS CI is sometimes too slow and we can't appreciate if the issue is related to the app not having enough time to load / the test itself OR if it's an actual test bug, so we are going to give more time for the `expect()` to run.

the CI issues appears relatively rarely so the impact of this is very limited, we will almost never reach higher than 30s, but when we do, at least we will know something really is wrong in the test, and not in the CI.

### ❓ Context

- **Impacted projects**: `playwright tests` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [na] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
