### PR TITLE
Skip pod reinstall if already there

### DIFF
--- a/apps/ledger-live-mobile/.gitignore
+++ b/apps/ledger-live-mobile/.gitignore
@@ -94,6 +94,7 @@ src/generated/
 
 # CocoaPods
 /ios/Pods/
+/ios/.podhash.json
 /vendor/bundle/
 
 # jest

--- a/apps/ledger-live-mobile/scripts/post.mjs
+++ b/apps/ledger-live-mobile/scripts/post.mjs
@@ -120,12 +120,22 @@ BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"`;
     );
   }
 
-  const hashesAreEquals = runHashChecks();
+  let hashesAreEquals = false;
+  try {
+    hashesAreEquals = runHashChecks();
+  } catch (error) {
+    echo(chalk.red(error));
+  }
+
   if (os.platform() === "darwin" && !process.env["SKIP_BUNDLE_CHECK"] && !hashesAreEquals) {
     cd("ios");
     try {
       await $`bundle exec pod install --deployment --repo-update`;
-      runHashChecks(true);
+      try {
+        runHashChecks(true);
+      } catch (error) {
+        echo(chalk.red(error));
+      }
     } catch (error) {
       const str = `
         ________________________________________

--- a/apps/ledger-live-mobile/scripts/post.mjs
+++ b/apps/ledger-live-mobile/scripts/post.mjs
@@ -1,10 +1,86 @@
 #!/usr/bin/env zx
 import "zx/globals";
+import { createHash } from "crypto";
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+
+function computeMetaHash(paths, inputHash) {
+  const hash = inputHash ? inputHash : createHash("sha1");
+  for (const path of paths) {
+    const statInfo = statSync(path);
+    if (statInfo.isDirectory()) {
+      const directoryEntries = readdirSync(path, { withFileTypes: true });
+      const fullPaths = directoryEntries.map(e => join(path, e.name));
+      // recursively walk sub-folders
+      computeMetaHash(fullPaths, hash);
+    } else {
+      const statInfo = statSync(path);
+      // compute hash string name:size:mtime
+      const fileInfo = `${path}:${statInfo.size}:${statInfo.mtimeMs}`;
+      hash.update(fileInfo);
+    }
+  }
+  // if not being called recursively, get the digest and return it as the hash result
+  if (!inputHash) {
+    return hash.digest().toString("base64");
+  }
+  return;
+}
+
+function compareHashes(cacheFile = {}, current = {}) {
+  if (!cacheFile || !current) return false;
+  return cacheFile.lock === current.lock && cacheFile.podsHash === current.podsHash;
+}
+
+function getCache(path) {
+  const exists = existsSync(path);
+
+  if (exists) {
+    const file = readFileSync(path);
+    const json = JSON.parse(file);
+    return json;
+  }
+
+  return null;
+}
+
+function runHashChecks(writeCache = false) {
+  const pods = join(__dirname, "..", "ios", "Pods");
+  const lock = join(__dirname, "..", "ios", "Podfile.lock");
+
+  if (!existsSync(pods)) return false;
+
+  const podsHash = computeMetaHash([pods]);
+  const lockHash = computeMetaHash([lock]);
+  const cachePath = join(__dirname, "..", "ios", ".podhash.json");
+
+  const result = {
+    lock: lockHash,
+    pod: podsHash,
+  };
+
+  const cache = getCache(cachePath);
+
+  if (!cache) {
+    if (writeCache) {
+      try {
+        const data = JSON.stringify(result);
+        writeFileSync(cachePath, data);
+      } catch (error) {
+        echo(chal.red(error));
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  return compareHashes(cache, result);
+}
 
 cd(path.join(__dirname, ".."));
 
-const syncFamilies = async () =>
-  await $`zx ./scripts/sync-families-dispatch.mjs`;
+const syncFamilies = async () => await $`zx ./scripts/sync-families-dispatch.mjs`;
 
 const final = async () => {
   // Had to remove the following because we already have the AsyncSocket lib as a dependency from Flipper 🐬
@@ -17,7 +93,7 @@ const final = async () => {
   });
 
   // Create the dev .env file with APP_NAME if it doesn't exist
-  const exists = fs.existsSync(".env");
+  const exists = existsSync(".env");
   if (!exists) {
     const str = `APP_NAME="LL [DEV]"
 ANALYTICS_TOKEN=ICid4O5K4AE2Utbv1ZT5CLmZalVWz8V9
@@ -40,16 +116,16 @@ BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"`;
     }
   } catch (error) {
     echo(
-      chalk.red(
-        "Error: `bundle` command is missing. Please install Bundler. https://bundler.io",
-      ),
+      chalk.red("Error: `bundle` command is missing. Please install Bundler. https://bundler.io"),
     );
   }
 
-  if (os.platform() === "darwin" && !process.env["SKIP_BUNDLE_CHECK"]) {
+  const hashesAreEquals = runHashChecks();
+  if (os.platform() === "darwin" && !process.env["SKIP_BUNDLE_CHECK"] && !hashesAreEquals) {
     cd("ios");
     try {
       await $`bundle exec pod install --deployment --repo-update`;
+      runHashChecks(true);
     } catch (error) {
       const str = `
         ________________________________________


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When reinstalling packages, skip pod reinstall if already there.
before
<img width="220" alt="CleanShot 2023-10-23 at 17 15 37@2x" src="https://github.com/LedgerHQ/ledger-live/assets/671786/bebad89a-9415-4dbc-b092-fb6f28af786a">
after
<img width="238" alt="CleanShot 2023-10-23 at 17 15 44@2x" src="https://github.com/LedgerHQ/ledger-live/assets/671786/61478d99-9a29-4253-89c4-3d87027073c9">

When installing pods, check if cache file exists, compare hashes with the current filesystem, and skip if they are equal.


### ❓ Context

- **Impacted projects**: `dx` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
