### PR TITLE
fix(navtabs): refer a friend tab selection no longer select discover tab

### DIFF
--- a/.changeset/brave-rabbits-doubt.md
+++ b/.changeset/brave-rabbits-doubt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+When refer a friend tab is open, discover tab is no longer selected

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -331,11 +331,15 @@ const MainSideBar = () => {
     push,
     dispatch,
   ]);
-  const isReferralProgramActive = useMemo(() => {
-    return (
-      referralProgramConfig?.params &&
-      location.pathname.startsWith(referralProgramConfig.params.path)
-    );
+
+  // Check if the selected tab is a Live-App under discovery tab
+  const isLiveAppTabSelected = useCallback(() => {
+    const tabs = [];
+
+    // Add "refer-a-friend"
+    referralProgramConfig?.params && tabs.push(referralProgramConfig.params.path);
+
+    return tabs.find((liveTab: string) => location.pathname.includes(liveTab));
   }, [referralProgramConfig, location]);
 
   return (
@@ -415,7 +419,7 @@ const MainSideBar = () => {
                   icon={IconsLegacy.PlanetMedium}
                   iconSize={20}
                   iconActiveColor="wallet"
-                  isActive={location.pathname.startsWith("/platform") && !isReferralProgramActive}
+                  isActive={location.pathname.startsWith("/platform") && !isLiveAppTabSelected()}
                   onClick={handleClickCatalog}
                   collapsed={secondAnim}
                 />
@@ -489,7 +493,10 @@ const MainSideBar = () => {
                     iconSize={20}
                     iconActiveColor="wallet"
                     onClick={handleClickRefer}
-                    isActive={isReferralProgramActive}
+                    isActive={
+                      referralProgramConfig?.params &&
+                      location.pathname.startsWith(referralProgramConfig.params.path)
+                    }
                     collapsed={secondAnim}
                     NotifComponent={
                       referralProgramConfig?.params?.amount ? (

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useHistory, useLocation } from "react-router-dom";
+import { Link, useHistory, useLocation, PromptProps } from "react-router-dom";
 import { Transition } from "react-transition-group";
 import styled from "styled-components";
 import { useManagerBlueDot } from "@ledgerhq/live-common/manager/hooks";
@@ -34,6 +34,8 @@ import { CARD_APP_ID } from "~/renderer/screens/card";
 import TopGradient from "./TopGradient";
 import Hide from "./Hide";
 import { track } from "~/renderer/analytics/segment";
+
+type Location = Parameters<Exclude<PromptProps["message"], string>>[0];
 
 const MAIN_SIDEBAR_WIDTH = 230;
 const TagText = styled.div.attrs<{ collapsed?: boolean }>(p => ({
@@ -210,6 +212,11 @@ const TagContainerFeatureFlags = ({ collapsed }: { collapsed: boolean }) => {
     </Tag>
   ) : null;
 };
+
+// Check if the selected tab is a Live-App under discovery tab
+const checkLiveAppTabSelection = (location: Location, liveAppPaths: Array<string>) =>
+  liveAppPaths.find((liveTab: string) => location?.pathname?.includes(liveTab));
+
 const MainSideBar = () => {
   const history = useHistory();
   const location = useLocation();
@@ -332,15 +339,13 @@ const MainSideBar = () => {
     dispatch,
   ]);
 
-  // Check if the selected tab is a Live-App under discovery tab
-  const isLiveAppTabSelected = useCallback(() => {
-    const tabs = [];
-
-    // Add "refer-a-friend"
-    referralProgramConfig?.params && tabs.push(referralProgramConfig.params.path);
-
-    return tabs.find((liveTab: string) => location.pathname.includes(liveTab));
-  }, [referralProgramConfig, location]);
+  // Add your live-app path here if you don't want discovery and the live-app tabs to be both selected
+  const isLiveAppTabSelected = checkLiveAppTabSelection(
+    location,
+    [
+      referralProgramConfig.params.path, // Refer-a-friend
+    ].filter(Boolean),
+  );
 
   return (
     <Transition
@@ -419,7 +424,7 @@ const MainSideBar = () => {
                   icon={IconsLegacy.PlanetMedium}
                   iconSize={20}
                   iconActiveColor="wallet"
-                  isActive={location.pathname.startsWith("/platform") && !isLiveAppTabSelected()}
+                  isActive={location.pathname.startsWith("/platform") && !isLiveAppTabSelected}
                   onClick={handleClickCatalog}
                   collapsed={secondAnim}
                 />

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -344,7 +344,7 @@ const MainSideBar = () => {
     location,
     [
       referralProgramConfig?.params?.path, // Refer-a-friend
-    ].filter(Boolean),
+    ].filter((path): path is string => !!path), // Filter undefined values,
   );
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -343,7 +343,7 @@ const MainSideBar = () => {
   const isLiveAppTabSelected = checkLiveAppTabSelection(
     location,
     [
-      referralProgramConfig.params.path, // Refer-a-friend
+      referralProgramConfig?.params?.path, // Refer-a-friend
     ].filter(Boolean),
   );
 

--- a/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/MainSideBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useHistory, useLocation } from "react-router-dom";
@@ -331,6 +331,12 @@ const MainSideBar = () => {
     push,
     dispatch,
   ]);
+  const isReferralProgramActive = useMemo(() => {
+    return (
+      referralProgramConfig?.params &&
+      location.pathname.startsWith(referralProgramConfig.params.path)
+    );
+  }, [referralProgramConfig, location]);
 
   return (
     <Transition
@@ -409,7 +415,7 @@ const MainSideBar = () => {
                   icon={IconsLegacy.PlanetMedium}
                   iconSize={20}
                   iconActiveColor="wallet"
-                  isActive={location.pathname.startsWith("/platform")}
+                  isActive={location.pathname.startsWith("/platform") && !isReferralProgramActive}
                   onClick={handleClickCatalog}
                   collapsed={secondAnim}
                 />
@@ -483,10 +489,7 @@ const MainSideBar = () => {
                     iconSize={20}
                     iconActiveColor="wallet"
                     onClick={handleClickRefer}
-                    isActive={
-                      referralProgramConfig?.params &&
-                      location.pathname.startsWith(referralProgramConfig.params.path)
-                    }
+                    isActive={isReferralProgramActive}
                     collapsed={secondAnim}
                     NotifComponent={
                       referralProgramConfig?.params?.amount ? (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Discover tab can no longer be selected at the same time as the refer a friend one.

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-8869] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->
<img width="1033" alt="Screenshot 2023-10-25 at 12 17 32" src="https://github.com/LedgerHQ/ledger-live/assets/146743014/de6fb32a-9c6b-42a7-a81f-7d48d83f66aa">

[LIVE-8869]: https://ledgerhq.atlassian.net/browse/LIVE-8869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ