### PR TITLE
chore: ignore symlink copy of an existing file within the copyFolderRecursively

### DIFF
--- a/tools/native-modules-tools/index.js
+++ b/tools/native-modules-tools/index.js
@@ -7,8 +7,16 @@ async function copyFolderRecursively(source, target) {
   if (fs.existsSync(target) && !fs.lstatSync(target).isDirectory()) {
     return; // we skip if the top level folder already exists and isn't a dir (e.g. a symlink)
   }
-
-  await cp(source, target, { recursive: true });
+  await cp(source, target, {
+    recursive: true,
+    filter: (src, dest) => {
+      if (fs.existsSync(dest) && fs.lstatSync(dest).isSymbolicLink()) {
+        // cp don't manage to copy symlinks, if the dest exists
+        return false;
+      }
+      return true;
+    },
+  });
 }
 
 // Given a module subfolder, finds the nearest root.


### PR DESCRIPTION

### 📝 Description

it appears that on a second run of `pnpm desktop build:js`, it would fail to copy again a symlink within one of the cp()-ed folder.

we ignore for now the cp if the dest symlink already exists.

### ❓ Context

- **Impacted projects**: `lld build when you have a cache` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [n/a] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
