### PR TITLE
chore: lock renderer bundle size to not exceed 40mb

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -56,11 +56,19 @@ jobs:
           aws-secret-key: ${{ secrets.AWS_S3_CACHE_SECRET_KEY }}
       - name: Build the app
         run: pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
+        env:
+          GENERATE_METAFILES: 1
       - name: Upload linux app
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build-desktop.outputs.version }}-linux-x86_64.AppImage
           path: ${{ github.workspace }}/apps/ledger-live-desktop/dist/${{ steps.build-desktop.outputs.name }}-${{ steps.build-desktop.outputs.version }}-linux-x86_64.AppImage
+      - name: Upload bundle metafiles
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: linux-js-bundle-metafiles
+          path: ${{ github.workspace }}/apps/ledger-live-desktop/metafile.*
 
   build-desktop-app-windows:
     name: "Build Ledger Live Desktop (Windows)"
@@ -92,11 +100,19 @@ jobs:
         run: |
           pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
         shell: bash
+        env:
+          GENERATE_METAFILES: 1
       - name: Upload windows
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build-desktop.outputs.version }}-win-x64.exe
           path: ${{ github.workspace }}/apps/ledger-live-desktop/dist/${{ steps.build-desktop.outputs.name }}-${{ steps.build-desktop.outputs.version }}-win-x64.exe
+      - name: Upload bundle metafiles
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: windows-js-bundle-metafiles
+          path: ${{ github.workspace }}/apps/ledger-live-desktop/metafile.*
 
   build-desktop-app-macos:
     name: "Build Ledger Live Desktop (Mac OS X)"
@@ -127,11 +143,19 @@ jobs:
       - name: Build the app
         run: |
           pnpm build:lld --api="http://127.0.0.1:${{ steps.build-desktop.outputs.port }}" --token="yolo" --team="foo"
+        env:
+          GENERATE_METAFILES: 1
       - name: Upload macOS app
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.build-desktop.outputs.version }}-mac.dmg
           path: ${{ github.workspace }}/apps/ledger-live-desktop/dist/${{ steps.build-desktop.outputs.name }}-${{ steps.build-desktop.outputs.version }}-mac.dmg
+      - name: Upload bundle metafiles
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: mac-js-bundle-metafiles
+          path: ${{ github.workspace }}/apps/ledger-live-desktop/metafile.*
 
   report:
     needs: [build-desktop-app-linux, build-desktop-app-macos, build-desktop-app-windows]

--- a/apps/ledger-live-desktop/tools/main.js
+++ b/apps/ledger-live-desktop/tools/main.js
@@ -135,13 +135,6 @@ const build = async argv => {
     ),
   ]);
 
-  // Ensure that we keep our bundle size under thresholds
-  if (results[0].metafile.outputs[".webpack/main.bundle.js"].bytes > 5 * 1024 * 1024) {
-    throw new Error(
-      "main bundle must be kept under 5 MB. This indicates a possible regression of importing too much modules. Most of Ledger Live must be run on renderer side.",
-    );
-  }
-
   if (process.env.GENERATE_METAFILES) {
     // analyze bundle sizes. use it with https://esbuild.github.io/analyze/
     fs.writeFileSync("metafile.main.json", JSON.stringify(results[0].metafile), "utf-8");
@@ -153,6 +146,18 @@ const build = async argv => {
     );
     fs.writeFileSync("metafile.renderer.json", JSON.stringify(results[3].metafile), "utf-8");
     fs.writeFileSync("metafile.renderer.worker.json", JSON.stringify(results[4].metafile), "utf-8");
+  }
+
+  // Ensure that we keep our bundle size under thresholds
+  if (results[0].metafile.outputs[".webpack/main.bundle.js"].bytes > 5 * 1024 * 1024) {
+    throw new Error(
+      "main bundle must be kept under 5 MB. This indicates a possible regression of importing too much modules. Most of Ledger Live must be run on renderer side.",
+    );
+  }
+  if (results[3].metafile.outputs[".webpack/renderer.bundle.js"].bytes > 40 * 1024 * 1024) {
+    throw new Error(
+      "renderer bundle must be kept under 40 MB. This indicates a possible regression of importing too much modules. If you change the threshold, please justify why / schedule tech debt tasks to reduce it back to lower.",
+    );
   }
 };
 


### PR DESCRIPTION

### 📝 Description

now that renderer bundle size is around 31 MB, we can lock the renderer bundle size to not go higher than 40 MB.

### ❓ Context

- **Impacted projects**: `LLD build` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [n/a] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
