### PR TITLE
Safer Solana staking

### DIFF
--- a/.changeset/tricky-needles-allow.md
+++ b/.changeset/tricky-needles-allow.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Safer Solana staking

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepAmount.tsx
@@ -1,4 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { SOLANA_DELEGATION_RESERVE } from "@ledgerhq/live-common/families/solana/utils";
 import React, { Fragment, PureComponent } from "react";
 import { Trans } from "react-i18next";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -7,9 +8,11 @@ import Button from "~/renderer/components/Button";
 import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import SpendableBanner from "~/renderer/components/SpendableBanner";
+import Alert from "~/renderer/components/Alert";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import AmountField from "~/renderer/modals/Send/fields/AmountField";
 import { StepProps } from "../types";
+
 const StepAmount = ({
   t,
   account,
@@ -52,6 +55,14 @@ const StepAmount = ({
             t={t}
             withUseMaxLabel={true}
           />
+          <Alert type="warning" small>
+            <Trans
+              i18nKey="solana.delegation.flow.steps.amount.reserveWarning"
+              values={{
+                amount: SOLANA_DELEGATION_RESERVE,
+              }}
+            />
+          </Alert>
         </Fragment>
       )}
     </Box>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3483,7 +3483,8 @@
             "title": "Validator"
           },
           "amount": {
-            "title": "Amount"
+            "title": "Amount",
+            "reserveWarning": "Please ensure you reserve at least {{amount}} SOL in your wallet to cover future network fees to deactivate and withdraw your stake"
           },
           "confirmation": {
             "success": {

--- a/libs/ledger-live-common/src/families/solana/js-estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/families/solana/js-estimateMaxSpendable.ts
@@ -24,16 +24,21 @@ const estimateMaxSpendableWithAPI = async (
       const txKind = transaction?.model.kind ?? "transfer";
       const txFee = await estimateTxFee(api, mainAccount, txKind);
 
+      const rentExemptMin = await getAccountMinimumBalanceForRentExemption(
+        api,
+        account.freshAddress,
+      );
+
       switch (txKind) {
         case "stake.createAccount": {
           const stakeAccRentExempt = await getStakeAccountMinimumBalanceForRentExemption(api);
-          return BigNumber.max(account.spendableBalance.minus(txFee).minus(stakeAccRentExempt), 0);
+
+          return BigNumber.max(
+            account.spendableBalance.minus(txFee).minus(rentExemptMin).minus(stakeAccRentExempt),
+            0,
+          );
         }
         default: {
-          const rentExemptMin = await getAccountMinimumBalanceForRentExemption(
-            api,
-            account.freshAddress,
-          );
           return BigNumber.max(account.spendableBalance.minus(txFee).minus(rentExemptMin), 0);
         }
       }

--- a/libs/ledger-live-common/src/families/solana/utils.ts
+++ b/libs/ledger-live-common/src/families/solana/utils.ts
@@ -16,6 +16,8 @@ export const LEDGER_VALIDATOR: ValidatorsAppValidator = {
   totalScore: 6,
 };
 
+export const SOLANA_DELEGATION_RESERVE = 0.01;
+
 export const assertUnreachable = (_: never): never => {
   throw new Error("unreachable assertion failed");
 };


### PR DESCRIPTION
### 📝 Description

As described in the [support article](https://support.ledger.com/hc/en-us/articles/12568029655453-Fixing-a-Sorry-internet-seems-to-be-down-error-with-Solana?support=true), Solana users faces the issue with not enough funds to unstake their SOL pretty often.  To make the process safer this PR adds a friendly warning to reserve some SOL to cover future unstaking fees.

After a small research, we found out that:
- Everstake recommends to keep at least 0.05 SOL
- Phantom also recommends  0.05 SOL
- Solflare recommends 0.01 but keeps 0.05 when “Use Max” is involved

Therefore, we think that 0.01 is a reasonable amount. 

In addition, we found and fixed the discrepancy between maximum spendable amount in the upper text and in the amount field when “Use Max” is selected.

![image](https://github.com/LedgerHQ/ledger-live/assets/2322774/7f9c2c6d-b504-4e6e-bdd2-923efca36174)


### 📸 Demo

<img width="592" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/2322774/a278275b-8392-4a5e-8054-d63d0b692b78">


