### PR TITLE
test(playwright): fix flaky case of settings/localization

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/Select/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Select/index.tsx
@@ -44,7 +44,6 @@ export type Props<
   };
   // Allows overriding react-select components. See: https://react-select.com/components
   disabledTooltipText?: string;
-  selectDataTestId?: string;
   theme?: DefaultTheme;
 } & ReactSelectProps<OptionType, IsMulti, GroupType>;
 
@@ -107,7 +106,6 @@ class MenuList<
       maxHeight,
       getValue,
       selectProps: { noOptionsMessage, rowHeight },
-      selectDataTestId,
     } = this.props;
     const { children } = this.state;
     if (!children) return null;
@@ -136,7 +134,6 @@ class MenuList<
         itemCount={children.length}
         itemSize={rowHeight}
         initialScrollOffset={initialOffset}
-        data-test-id={selectDataTestId}
       >
         {({ index, style }) => (
           <Row className={"option"} style={style}>
@@ -217,7 +214,6 @@ class Select<
       rowHeight = small ? 34 : 48,
       autoFocus,
       extraRenderers,
-      selectDataTestId,
       ...props
     } = this.props;
     const Comp = (async ? AsyncReactSelect : ReactSelect) as typeof ReactSelect;
@@ -279,7 +275,6 @@ class Select<
         menuPortalTarget={document.body}
         rowHeight={rowHeight}
         onChange={this.handleChange}
-        data-test-id={selectDataTestId}
       />
     );
   }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
@@ -137,7 +137,12 @@ const LanguageSelect: React.FC<Props> = ({ disableLanguagePrompt }) => {
       <Track onUpdate event="LanguageSelect" currentRegion={selectedLanguage.value} />
 
       <Select
-        aria-label="Select language"
+        aria-label={
+          // we only set the aria lavel once the device languages are fully loaded and available
+          availableDeviceLanguages && availableDeviceLanguages.length > 0
+            ? "Select language"
+            : undefined
+        }
         small
         minWidth={260}
         isSearchable={false}

--- a/apps/ledger-live-desktop/tests/models/SettingsPage.ts
+++ b/apps/ledger-live-desktop/tests/models/SettingsPage.ts
@@ -78,6 +78,10 @@ export class SettingsPage {
     await this.themeChoiceLight.click();
   }
 
+  async waitForDeviceLanguagesLoaded() {
+    await this.page.waitForSelector('[aria-label="Select language"]', { state: "attached" });
+  }
+
   async enableAndGoToDeveloperTab() {
     await this.goToAboutTab();
     for (let i = 0; i < 10; i++) {

--- a/apps/ledger-live-desktop/tests/specs/settings/localization.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/settings/localization.spec.ts
@@ -22,20 +22,21 @@ test("Settings", async ({ page }) => {
   });
 
   await test.step("go to settings -> change language with device in English", async () => {
-    await page.route("**/language-package?**", route =>
+    await page.route("**/language-package?**", route => {
       route.fulfill({
         headers: { teststatus: "mocked" },
         status: 200,
         body: JSON.stringify(languagePacksData),
-      }),
-    );
+      });
+    });
     await layout.goToManager();
     await deviceAction.accessManagerWithL10n();
     await layout.goToSettings();
-    // the device language prompt only opens once the app has charged the available languages for the device
-    // I've tried to wait for a network idle state here, but it seemed flaky, timeout seems more reliable
-    await page.waitForTimeout(3000);
+
+    await settingsPage.waitForDeviceLanguagesLoaded();
+
     await settingsPage.changeLanguage("Français", "Español");
+
     await expect(page).toHaveScreenshot("settings-français-with-device-l10n.png");
   });
 


### PR DESCRIPTION
remove a waitForTimeout(3000) flaky approach into a proper waiting of the "devices languages" load by only setting aria-label at the time its loaded.


### 📝 Description

this fixes this flaky test: https://github.com/LedgerHQ/ledger-live/actions/runs/6667012374/job/18119665421

```
  1) settings/localization.spec.ts:12:5 › Settings › go to settings -> change language with device in English 

    Error: Screenshot comparison failed:

      37 |     await page.waitForTimeout(3000);
      38 |     await settingsPage.changeLanguage("Français", "Español");
    > 39 |     await expect(page).toHaveScreenshot("settings-français-with-device-l10n.png");
         |                        ^
      40 |   });
```

### ❓ Context

- **Impacted projects**: `` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
