### PR TITLE
[BUGFIX] usage of explorer block endpoint in coin evm

### DIFF
--- a/.changeset/khaki-cups-try.md
+++ b/.changeset/khaki-cups-try.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix wrong usage of explorer block endpoint in coin evm

--- a/libs/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
@@ -417,24 +417,26 @@ describe("EVM Family", () => {
                 },
               }
             : {
-                data: {
-                  hash: "0xhash",
-                  height: 123,
-                  time: new Date().toISOString(),
-                  txs: ["0xTx1", "0xTx2"],
-                },
+                data: [
+                  {
+                    hash: "0xhash",
+                    height: 123,
+                    time: new Date().toISOString(),
+                    txs: ["0xTx1", "0xTx2"],
+                  },
+                ],
               },
         );
 
         expect(await LEDGER_API.getBlockByHeight(currency, 12)).toEqual({
           hash: "0xhash",
           height: 123,
-          timestamp: Date.now(),
+          timestamp: Math.floor(Date.now() / 1000),
         });
         expect(await LEDGER_API.getBlockByHeight(currency, "latest")).toEqual({
           hash: "0xhashLatest",
           height: 456,
-          timestamp: Date.now(),
+          timestamp: Math.floor(Date.now() / 1000),
         });
       });
     });

--- a/libs/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
@@ -431,12 +431,12 @@ describe("EVM Family", () => {
         expect(await LEDGER_API.getBlockByHeight(currency, 12)).toEqual({
           hash: "0xhash",
           height: 123,
-          timestamp: Math.floor(Date.now() / 1000),
+          timestamp: Date.now(),
         });
         expect(await LEDGER_API.getBlockByHeight(currency, "latest")).toEqual({
           hash: "0xhashLatest",
           height: 456,
-          timestamp: Math.floor(Date.now() / 1000),
+          timestamp: Date.now(),
         });
       });
     });

--- a/libs/coin-evm/src/__tests__/unit/api/node/rpc.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/api/node/rpc.unit.test.ts
@@ -401,7 +401,10 @@ describe("EVM Family", () => {
     it("should return the expected payload", async () => {
       expect(await RPC_API.getBlockByHeight(fakeCurrency as CryptoCurrency, 0)).toEqual({
         hash: "0x474dee0136108e9412e9d84197b468bb057a8dad0f2024fc55adebc4a28fa8c5",
-        timestamp: Math.floor(Date.now() / 1000),
+        // for this specific assertion we can't use Date.now() directly because
+        // the timestamp returned by ethers (and mocked at the beginning of
+        // thetestsuite) is rounded to the second
+        timestamp: Math.floor(Date.now() / 1000) * 1000,
         height: 1,
       });
     });

--- a/libs/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -42,7 +42,7 @@ describe("EVM Family", () => {
         jest.spyOn(nodeApi, "getBlockByHeight").mockImplementation(async () => ({
           hash: "blockHash6969",
           height: 6969,
-          timestamp: Math.floor(Date.now() / 1000),
+          timestamp: Date.now(),
         }));
       });
 
@@ -521,7 +521,7 @@ describe("EVM Family", () => {
           hash: "0xTransactionHash",
           blockHeight: 10,
           blockHash: "hash",
-          timestamp: Date.now() / 1000,
+          timestamp: Date.now(),
           nonce: 123,
         }));
 
@@ -559,12 +559,11 @@ describe("EVM Family", () => {
           hash: "0xTransactionHash",
           blockHeight: 10,
           blockHash: "hash",
-          timestamp: Date.now() / 1000,
           nonce: 123,
         }));
         jest
           .spyOn(nodeApi, "getBlockByHeight")
-          .mockImplementationOnce(async () => ({ timestamp: Date.now() / 1000 }) as any);
+          .mockImplementationOnce(async () => ({ timestamp: Date.now() }) as any);
 
         const expectedAddition = {
           blockHash: "hash",

--- a/libs/coin-evm/src/api/node/ledger.ts
+++ b/libs/coin-evm/src/api/node/ledger.ts
@@ -283,7 +283,7 @@ export const getBlockByHeight: NodeApi["getBlockByHeight"] = async (
       url: `${getEnv("EXPLORER")}/blockchain/v4/${node.explorerId}/block/current`,
     });
 
-    return { hash, height, timestamp: Math.floor(new Date(time).getTime() / 1000) };
+    return { hash, height, timestamp: new Date(time).getTime() };
   }
 
   /**
@@ -307,7 +307,7 @@ export const getBlockByHeight: NodeApi["getBlockByHeight"] = async (
   return {
     hash,
     height,
-    timestamp: Math.floor(new Date(time).getTime() / 1000),
+    timestamp: new Date(time).getTime(),
   };
 };
 

--- a/libs/coin-evm/src/api/node/rpc.common.ts
+++ b/libs/coin-evm/src/api/node/rpc.common.ts
@@ -228,7 +228,8 @@ export const getBlockByHeight: NodeApi["getBlockByHeight"] = (currency, blockHei
     return {
       hash,
       height: number,
-      timestamp,
+      // timestamp is returned in seconds by getBlock, we need milliseconds
+      timestamp: timestamp * 1000,
     };
   });
 

--- a/libs/coin-evm/src/api/node/types.ts
+++ b/libs/coin-evm/src/api/node/types.ts
@@ -26,6 +26,7 @@ export type NodeApi = {
   getBlockByHeight: (
     currency: CryptoCurrency,
     blockHeight: number | "latest",
+    // timestamp is in milliseconds
   ) => Promise<{ hash: string; height: number; timestamp: number }>;
   getOptimismAdditionalFees: (
     currency: CryptoCurrency,

--- a/libs/coin-evm/src/editTransaction/getEditTransactionPatch.ts
+++ b/libs/coin-evm/src/editTransaction/getEditTransactionPatch.ts
@@ -1,14 +1,14 @@
 import type { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
-import { getGasTracker } from "..//api/gasTracker/index";
+import { getGasTracker } from "../api/gasTracker/index";
 import type {
   EditType,
   EvmTransactionEIP1559,
   EvmTransactionLegacy,
   GasOptions,
   Transaction,
-} from "..//types/index";
+} from "../types/index";
 import { getMinEip1559Fees, getMinLegacyFees } from "./getMinEditTransactionFees";
 
 /**

--- a/libs/coin-evm/src/synchronization.ts
+++ b/libs/coin-evm/src/synchronization.ts
@@ -221,7 +221,7 @@ export const getOperationStatus = async (
     }
 
     const { timestamp } = await nodeApi.getBlockByHeight(currency, blockHeight);
-    const date = new Date(timestamp * 1000);
+    const date = new Date(timestamp);
 
     return {
       ...op,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28070,7 +28070,7 @@ packages:
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.5(react-is@18.1.0)(react@18.2.0)
+      styled-components: 5.3.5(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
 
   /babel-plugin-syntax-jsx@6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
@@ -55230,6 +55230,7 @@ packages:
       react-is: 18.1.0
       shallowequal: 1.1.0
       supports-color: 5.5.0
+    dev: false
 
   /styled-components@6.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xIwWuiRMYR43mskVsW9MGTRjSo7ol4bcVjT595fGUp3OLBJOlOgaiKaxsHdC4a2HqWKqKnh0CmcRbk5ogyDjTg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28070,7 +28070,7 @@ packages:
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.5(react-dom@18.2.0)(react-is@17.0.2)(react@18.2.0)
+      styled-components: 5.3.5(react-is@18.1.0)(react@18.2.0)
 
   /babel-plugin-syntax-jsx@6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
@@ -55230,7 +55230,6 @@ packages:
       react-is: 18.1.0
       shallowequal: 1.1.0
       supports-color: 5.5.0
-    dev: false
 
   /styled-components@6.0.7(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-xIwWuiRMYR43mskVsW9MGTRjSo7ol4bcVjT595fGUp3OLBJOlOgaiKaxsHdC4a2HqWKqKnh0CmcRbk5ogyDjTg==}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

For some legacy reasons, there is a difference in the response shape of `/blockchain/v4/eth/block/current` and `/blockchain/v4/eth/block/{height}`.

The first endpoint (`/current`) returns a block object in the shape
```
{
  "hash": "string",
  "height": 1073741824,
  "time": "string",
  "txs": [
    "string"
  ]
}
```
Whereas the second endpoint (`{height}`) returns an array of block objects (but with only one block inside)
```
[
  {
    "hash": "string",
    "height": 1073741824,
    "time": "string",
    "txs": [
      "string"
    ]
  }
]
```

cf. https://explorers.api.live.ledger.com/blockchain/v4/eth/docs/

The coin-evm implementation assumed both endpoints had the same response shape (the one returning a single object), leading to issues when the block heigh specific endpoint was called (values returned where null.

This PR also harmonise the `timestamp` value returned by `getBlockByHeight` to make it a milliseconds value.
Until then, the value returned by the different implementations (rpc and  ledger) where not consistent. The rpc implementation returned it in seconds while the ledger one returned it in milliseconds.
This leads to some issues when called inside the `getOperationStatus` (the only place it is called) since this function was multiplying the `timestamp` value returned by calls to `getBlockByHeight` by 1000 to convert it back to milliseconds (which lead to issues when the ledger implementation of `getBlockByHeight` was called).

We could have updated the ledger implementation to make it return the value in seconds instead of milliseconds but this has 2 downsides:
- loss of data when converting the timestamp from milliseconds to seconds in the ledger implementation
- unnecessary conversion since the value is the converted back to milliseconds to be used inside `getOperationStatus`

### ❓ Context

- **Impacted projects**: `coin-evm` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9981
  - https://github.com/LedgerHQ/ledger-live/pull/4886

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
