### PR TITLE
test: allow loader not to even have time to appear (LIVE-9623)

### DIFF
--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -38,7 +38,12 @@ export class DeviceAction {
       window.mock.events.mockDeviceEvent({ type: "opened" });
     });
 
-    await this.loader.waitFor({ state: "visible" });
+    await this.loader.waitFor({ state: "visible" }).catch(e => {
+      console.warn(
+        "loader is accepted not to be visible at all if the UI was fast enough. this is a very rare case.",
+        e,
+      );
+    });
     await this.loader.waitFor({ state: "detached" });
   }
 


### PR DESCRIPTION

### 📝 Description

deviceActions can very rarely be fast enough for the test not to have opportunity to see the spinner, so we allows this case.

```
Error:   1) accounts/account.spec.ts:18:9 › Accounts @smoke › [BTC] Add account › [BTC] Open device app ───
    TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
    =========================== logs ===========================
    waiting for locator('data-test-id=device-action-loader') to be visible
    ============================================================

       at ../models/DeviceAction.ts:41

      39 |     });
      40 |
    > 41 |     await this.loader.waitFor({ state: "visible" });
         |                       ^
      42 |     await this.loader.waitFor({ state: "detached" });
      43 |   }
      44 |
```

### ❓ Context

- **Impacted projects**: `lld tests` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: https://ledgerhq.atlassian.net/browse/LIVE-9623

 
### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
