### PR TITLE
[LLD] - [LIVE-10016] - Fix exit on Send modal

### DIFF
--- a/.changeset/new-squids-hope.md
+++ b/.changeset/new-squids-hope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix exit from beginning of Send flow modal

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/index.tsx
@@ -11,7 +11,7 @@ type Props = {
 const MODAL_LOCKED: {
   [key in StepId]: boolean;
 } = {
-  recipient: true,
+  recipient: false,
   amount: true,
   summary: true,
   device: true,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The Send modal is locked on its initial screen while it should be allowed to exit from it freely as long as we haven't entered in the second step of the Send flow.

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-10016] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

https://github.com/LedgerHQ/ledger-live/assets/25589782/10f49e74-b507-4d9c-9cef-d8475cc73c1b

https://github.com/LedgerHQ/ledger-live/assets/25589782/fd40186c-ff01-4eed-bea4-a32af1594da8

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-10016]: https://ledgerhq.atlassian.net/browse/LIVE-10016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ