### PR TITLE
fix(recover): remove 'Log in to Ledger Recover' button

### DIFF
--- a/.changeset/tough-ladybugs-do.md
+++ b/.changeset/tough-ladybugs-do.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Remove "Login to Ledger Recover" button

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Welcome/index.tsx
@@ -1,5 +1,3 @@
-import { FeatureToggle, useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useLoginPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { Button, Flex, IconsLegacy, InvertThemeV3, Logos, Text } from "@ledgerhq/react-ui";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -93,17 +91,6 @@ export function Welcome() {
     }
   }, [hasCompletedOnboarding, history]);
 
-  const recoverFeature = useFeature("protectServicesDesktop");
-  const loginPath = useLoginPath(recoverFeature);
-
-  const recoverLogIn = useCallback(() => {
-    if (!loginPath) return;
-
-    acceptTerms();
-    dispatch(saveSettings({ hasCompletedOnboarding: true }));
-    history.push(loginPath);
-  }, [dispatch, history, loginPath]);
-
   const urlBuyNew = useDynamicUrl("buyNew");
   const buyNanoX = () => openURL(urlBuyNew);
 
@@ -179,19 +166,6 @@ export function Welcome() {
           >
             {t("onboarding.screens.welcome.nextButton")}
           </Button>
-          <FeatureToggle featureId="protectServicesDesktop">
-            <Button
-              iconPosition="right"
-              variant="main"
-              onClick={recoverLogIn}
-              outline={true}
-              flexDirection="column"
-              whiteSpace="normal"
-              mb="5"
-            >
-              {t("onboarding.screens.welcome.recoverSignIn")}
-            </Button>
-          </FeatureToggle>
           <Button
             iconPosition="right"
             variant="main"

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4268,7 +4268,6 @@
         "nextButton": "Get started",
         "noDevice": "No device?",
         "buyLink": "No device? Buy a Ledger Nano X",
-        "recoverSignIn": "Log in to Ledger Recover",
         "byTapping": "By tapping \"Get Started\" you consent and agree to our",
         "termsAndConditions": "Terms and conditions",
         "and": "and",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1238,8 +1238,7 @@
       "terms": "By continuing, you agree to Ledger's",
       "termsLink": "Terms & Conditions",
       "privacyLink": "Privacy Policy",
-      "and": "and",
-      "recoverLogIn": "Log in to Ledger Recover"
+      "and": "and"
     },
     "postWelcomeStep": {
       "title": "Let’s get started",

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/welcome.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/welcome.tsx
@@ -114,22 +114,6 @@ function OnboardingStepWelcome({ navigation }: NavigationProps) {
     ? videoSources.welcomeScreenStax
     : videoSources.welcomeScreen;
 
-  {
-    /* @TODO need to disable temporary because of issue pairing device onboarding RECOVER - LLM
-    const recoverFeature = useFeature("protectServicesMobile");
-      const recoverLogIn = useCallback(() => {
-        acceptTerms();
-        dispatch(setAnalytics(true));
-
-        const url = `${recoverFeature?.params?.account?.loginURI}&shouldBypassLLOnboarding=true`;
-
-        Linking.canOpenURL(url).then(canOpen => {
-          if (canOpen) Linking.openURL(url);
-        });
-      }, [acceptTerms, dispatch, recoverFeature?.params?.login?.loginURI]);
-    */
-  }
-
   return (
     <ForceTheme selectedPalette={"dark"}>
       <Flex flex={1} position="relative" bg="constant.purple">
@@ -210,15 +194,6 @@ function OnboardingStepWelcome({ navigation }: NavigationProps) {
           >
             {t("onboarding.stepWelcome.start")}
           </Button>
-          {/* @TODO check if proper URL */}
-          {/* @TODO need to disable temporary because of issue pairing device onboarding 
-          {recoverFeature?.enabled &&
-          recoverFeature?.params?.onboardingRestore?.postOnboardingURI ? (
-            <Button outline type="main" size="large" onPress={recoverLogIn} mt={0} mb={7}>
-              {t("onboarding.stepWelcome.recoverLogIn")}
-            </Button>
-          ) : null}
-          */}
           <Text variant="small" textAlign="center" color="neutral.c100">
             {t("onboarding.stepWelcome.terms")}
           </Text>

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
@@ -105,14 +105,6 @@ export function useLoginURI(
   return useReplacedURI(uri, id);
 }
 
-export function useLoginPath(
-  servicesConfig: Feature_ProtectServicesDesktop | null,
-): string | undefined {
-  const uri = useLoginURI(servicesConfig);
-
-  return usePath(servicesConfig, uri);
-}
-
 export function useRestore24URI(
   servicesConfig: Feature_ProtectServicesDesktop | null,
 ): string | undefined {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Remove ' Log in to Ledger Recover' button. 
Deleted code for LLD and commented code for LLM.

### ❓ Context

- **Impacted projects**: `LLD, LLM` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-9992] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

Before:
![image](https://github.com/LedgerHQ/ledger-live/assets/146743014/8b376fdb-1b18-451b-8319-089378ff693d)

After:
![image](https://github.com/LedgerHQ/ledger-live/assets/146743014/27e27b28-ba91-4733-9962-4c56a1994e34)


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9992]: https://ledgerhq.atlassian.net/browse/LIVE-9992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ