### PR TITLE
test(lld/playwright/customImage): avoid firmware update click jacking

### DIFF
--- a/apps/ledger-live-desktop/tests/models/ManagerPage.ts
+++ b/apps/ledger-live-desktop/tests/models/ManagerPage.ts
@@ -83,7 +83,7 @@ export class ManagerPage {
   }
 
   async openCustomImage() {
-    await this.customImageButton.waitFor({ state: "attached" });
+    await this.waitForFirmwareUpdateButton(); // this avoids click jacking when the firmware update banner appears
     await this.customImageButton.click();
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There is an issue if the firmware update banner appears exactly at the same time as playwright tries to click on the "add" button for the lock screen picture.
The simple fix here is to wait for the banner to be visible before clicking this button.

<img width="977" alt="Screenshot 2023-11-02 at 10 15 05" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/2d63e29d-605d-46a1-977e-7d5922c745e9">

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-10030] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-10030]: https://ledgerhq.atlassian.net/browse/LIVE-10030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ