### PR TITLE
[LIVE-8460] LLD - No timeout if user loses connection after Allowing Genuine check

### DIFF
--- a/.changeset/early-squids-think.md
+++ b/.changeset/early-squids-think.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Immediatly display a network down error drawer during ESC

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -30,6 +30,8 @@ import { log } from "@ledgerhq/logs";
 import { useDynamicUrl } from "~/renderer/terms";
 import { FinalFirmware } from "@ledgerhq/types-live";
 import { useHistory } from "react-router-dom";
+import { NetworkDown } from "@ledgerhq/errors";
+import { NetworkStatus, useNetworkStatus } from "~/renderer/hooks/useNetworkStatus";
 
 export type Props = {
   onComplete: () => void;
@@ -101,6 +103,8 @@ const EarlySecurityChecks = ({
     isHookEnabled: genuineCheckActive,
     deviceId,
   });
+
+  const { networkStatus } = useNetworkStatus();
 
   const {
     state: {
@@ -277,6 +281,18 @@ const EarlySecurityChecks = ({
       };
       setDrawer(ErrorDrawer, props, commonDrawerProps);
     } else if (
+      networkStatus === NetworkStatus.OFFLINE &&
+      genuineCheckStatus !== SoftwareCheckStatus.inactive
+    ) {
+      const props: ErrorDrawerProps = {
+        onClickRetry: () => {
+          resetGenuineCheckState();
+          setGenuineCheckStatus(SoftwareCheckStatus.active);
+        },
+        error: new NetworkDown(),
+      };
+      setDrawer(ErrorDrawer, props, commonDrawerProps);
+    } else if (
       getLatestAvailableFirmwareError &&
       !(
         getLatestAvailableFirmwareError.type === "SharedError" &&
@@ -310,6 +326,8 @@ const EarlySecurityChecks = ({
     productName,
     resetGenuineCheckState,
     history,
+    networkStatus,
+    genuineCheckStatus,
   ]);
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNetworkStatus.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNetworkStatus.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export enum NetworkStatus {
+  OFFLINE = "offline",
+  ONLINE = "online",
+}
+export const useNetworkStatus = () => {
+  const [networkStatus, setNetworkStatus] = useState<NetworkStatus>(
+    navigator.onLine ? NetworkStatus.ONLINE : NetworkStatus.OFFLINE,
+  );
+
+  useEffect(() => {
+    const onlineListener = () => setNetworkStatus(NetworkStatus.ONLINE);
+    const offlineListener = () => setNetworkStatus(NetworkStatus.OFFLINE);
+    window.addEventListener(NetworkStatus.ONLINE, onlineListener);
+    window.addEventListener(NetworkStatus.OFFLINE, offlineListener);
+
+    return () => {
+      window.removeEventListener(NetworkStatus.ONLINE, onlineListener);
+      window.removeEventListener(NetworkStatus.OFFLINE, offlineListener);
+    };
+  }, []);
+
+  return { networkStatus };
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Improve timeout network down error during ESC:
- creation & usage of `useNetworkStatus` hook that set `networkStatus = 'online'|'offline'` state variable by listening on `window.addEventListener("online"|"offline")`
- adding a condition in `SyncOnboarding/Manual/EarlySecurityChecks/index.tsx` useEffect to display a drawer with `NetworkDown` error

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-8460] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

https://github.com/LedgerHQ/ledger-live/assets/145363160/5a462bf2-ca83-4b1a-bc23-d1f4fe719271


### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8460]: https://ledgerhq.atlassian.net/browse/LIVE-8460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ