### PR TITLE
test: adjust openApp edge case failure by defining a timeout

### DIFF
--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -38,7 +38,7 @@ export class DeviceAction {
       window.mock.events.mockDeviceEvent({ type: "opened" });
     });
 
-    await this.loader.waitFor({ state: "visible" }).catch(e => {
+    await this.loader.waitFor({ state: "visible", timeout: 20000 }).catch(e => {
       console.warn(
         "loader is accepted not to be visible at all if the UI was fast enough. this is a very rare case.",
         e,


### PR DESCRIPTION

### 📝 Description

fix an edge case of flakyness found in https://github.com/LedgerHQ/ledger-live/pull/4918

### ❓ Context

- **Impacted projects**: `LLD playwright` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [na] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
