### PR TITLE
Fix: added locked device errors to Sentry ignore list

### DIFF
--- a/.changeset/good-mirrors-retire.md
+++ b/.changeset/good-mirrors-retire.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix: added locked device errors to Sentry ignore list

--- a/apps/ledger-live-desktop/src/sentry/install.ts
+++ b/apps/ledger-live-desktop/src/sentry/install.ts
@@ -81,6 +81,8 @@ const ignoreErrors = [
   "Invalid channel",
   "Ledger Device is busy",
   "ManagerDeviceLocked",
+  "LockedDeviceError",
+  "UnresponsiveDeviceError",
   "PairingFailed",
   "Ledger device: UNKNOWN_ERROR",
   // errors coming from the usage of a Transport implementation

--- a/apps/ledger-live-mobile/index.js
+++ b/apps/ledger-live-mobile/index.js
@@ -59,6 +59,8 @@ const excludedErrorName = [
   "GetAppAndVersionUnsupportedFormat",
   "BluetoothRequired",
   "ManagerDeviceLocked",
+  "LockedDeviceError",
+  "UnresponsiveDeviceError",
   // errors coming from the usage of a Transport implementation
   "HwTransportError",
   // other


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

A `LockedDeviceError` was being sent to Sentry while it represents a behavior errors. After testing, this is just due to a new tracking of errors in [apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ChangeDeviceLanguagePromptDrawer.tsx](https://github.com/LedgerHQ/ledger-live/blob/b65fc66ae7fbd3c02732862305a2bcc010b249de/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ChangeDeviceLanguagePromptDrawer.tsx#L57).

I also added the error `UnresponsiveDeviceError` which represents a locked device error when the device has not been responsive for a certain time (former way to detect a locked device before the response `0x5515`).

And i did the same for LLM.


### ❓ Context

- **Impacted projects**: `LLD` and `LLM`
- **Linked resource(s)**: [LIVE-10048](https://ledgerhq.atlassian.net/browse/LIVE-10048)

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-10048]: https://ledgerhq.atlassian.net/browse/LIVE-10048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ