### PR TITLE
fix: remoteLiveApp hook not returning filtered manifest

### DIFF
--- a/.changeset/old-laws-melt.md
+++ b/.changeset/old-laws-melt.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix: remoteLiveApp hook not returning filtered manifest
+
+This has an impact now that we return customized manifest when filtering we need to return this one in priority

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
@@ -55,7 +55,9 @@ export function useRemoteLiveAppManifest(appId?: string): LiveAppManifest | unde
     return undefined;
   }
 
-  return liveAppRegistry.value.liveAppById[appId];
+  return (
+    liveAppRegistry.value.liveAppFilteredById[appId] || liveAppRegistry.value.liveAppById[appId]
+  );
 }
 
 export function useRemoteLiveAppContext(): LiveAppContextType {
@@ -131,6 +133,10 @@ export function RemoteLiveAppProvider({
         value: {
           liveAppByIndex: allManifests,
           liveAppFiltered: catalogManifests,
+          liveAppFilteredById: catalogManifests.reduce((acc, liveAppManifest) => {
+            acc[liveAppManifest.id] = liveAppManifest;
+            return acc;
+          }, {}),
           liveAppById: allManifests.reduce((acc, liveAppManifest) => {
             acc[liveAppManifest.id] = liveAppManifest;
             return acc;

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/types.ts
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/types.ts
@@ -3,6 +3,7 @@ import { LiveAppManifest } from "../../types";
 export type LiveAppRegistry = {
   liveAppById: { [appId: string]: LiveAppManifest };
   liveAppByIndex: LiveAppManifest[];
+  liveAppFilteredById: { [appId: string]: LiveAppManifest };
   liveAppFiltered: LiveAppManifest[];
 };
 


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Update the removeLiveApp hook to get a manifest by id to return filtered manifest first.
This has an impact now that we return customized manifest when filtering we need to return this one in priority.

### ❓ Context

- **Impacted projects**: `LLD, LLM` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** Tested manually as we cannot easily test overrides currently <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
