### PR TITLE
fix(drawer): close drawer when arriving on auth screen

### DIFF
--- a/.changeset/itchy-islands-marry.md
+++ b/.changeset/itchy-islands-marry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Close open drawer when lock screen appears

--- a/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/QueuedDrawer.tsx
@@ -319,3 +319,15 @@ function cleanCurrentDisplayedDrawer() {
 function checkCurrentDisplayedDrawer() {
   return !!currentDisplayedDrawer;
 }
+
+/**
+ * Reset displayed and waiting list drawers
+ *
+ * Only used when lock screen appears.
+ */
+export function resetQueuedDrawer() {
+  if (checkCurrentDisplayedDrawer()) {
+    cleanWaitingDrawers();
+    cleanCurrentDisplayedDrawer();
+  }
+}

--- a/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/index.tsx
@@ -13,6 +13,7 @@ import { SkipLockContext } from "../../components/behaviour/SkipLock";
 import type { Privacy, State as GlobalState, AppState as EventState } from "../../reducers/types";
 import AuthScreen from "./AuthScreen";
 import RequestBiometricAuth from "../../components/RequestBiometricAuth";
+import { resetQueuedDrawer } from "../../components/QueuedDrawer";
 
 const mapDispatchToProps = {
   setPrivacy,
@@ -165,6 +166,9 @@ class AuthPass extends PureComponent<Props, State> {
   lock = () => {
     if (!this.props.privacy?.hasPassword || this.state.skipLockCount) return;
     wasUnlocked = false;
+
+    // Close the drawer if one was opened
+    resetQueuedDrawer();
 
     if (this.state.mounted) {
       this.setState(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Close drawer on lock screen. 
Not optimal since we would have preferred to keep the drawer open for after the login. But since we use a react-native-modal nothing can be displayed over it (CF: [stackoverflow](https://stackoverflow.com/questions/39766350/bring-view-on-top-of-modal-using-zindex-style-with-react-native)).

It is also possible to open a drawer from the auth screen with the 'i lost my password' button making it hard to find an adequate solution.

### ❓ Context

- **Impacted projects**: `LLM` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-9178] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [ ] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [ ] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

https://github.com/LedgerHQ/ledger-live/assets/146743014/9b86bd7a-d0fa-4940-9a19-f91ca3880c4f



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9178]: https://ledgerhq.atlassian.net/browse/LIVE-9178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ