### PR TITLE
fix(common/listappsv2): don't use currencyId if no matching currency

### DIFF
--- a/.changeset/nice-knives-attack.md
+++ b/.changeset/nice-knives-attack.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix list apps v2 polyfill: don't use currencyId if there is no matching cryptocurrency

--- a/libs/ledger-live-common/src/apps/polyfill.ts
+++ b/libs/ledger-live-common/src/apps/polyfill.ts
@@ -153,7 +153,7 @@ export const mapApplicationV2ToApp = ({
   indexOfMarketCap: -1, // We don't know at this point.
   type: name === "Exchange" ? AppType.swap : type,
   ...rest,
-  currencyId: currencyId || getCurrencyIdFromAppName(name),
+  currencyId: findCryptoCurrencyById(currencyId) ? currencyId : getCurrencyIdFromAppName(name),
   compatibleWallets: parseCompatibleWallets(compatibleWallets, name),
 });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the "polyfilling" logic of apps data in list apps v2, we were not checking that the `currencyId` coming from the backend was matching a currency locally. This was causing a crash at rendering:
![image (6)](https://github.com/LedgerHQ/ledger-live/assets/91890529/8166ba19-b9fa-4083-8d02-c3ff9b904f9e)

The fix is to only keep the `currencyId` coming from the backend if it actually matches a known currency.

### ❓ Context

- **Impacted projects**: `common` `llm` `lld` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-10067] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-10067]: https://ledgerhq.atlassian.net/browse/LIVE-10067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ