### PR TITLE
Bugfix/live 9116 LLD firmware update: retry button if device is locked

### DIFF
--- a/.changeset/modern-plants-relate.md
+++ b/.changeset/modern-plants-relate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Firmware update: add retry button to footer if there is a LockedDeviceError

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { log } from "@ledgerhq/logs";
-import { UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
+import { LockedDeviceError, UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
 import { useHistory } from "react-router-dom";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Track from "~/renderer/analytics/Track";
@@ -84,14 +84,16 @@ export const StepConfirmFooter = ({
 
   if (error) {
     const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
+    const isDeviceLockedError = error instanceof LockedDeviceError;
+    const isRetryableError = isUserRefusedFirmwareUpdate || isDeviceLockedError;
     return (
       <>
-        <Button variant={!isUserRefusedFirmwareUpdate ? "main" : undefined} onClick={onCloseReload}>
+        <Button variant={"main"} outline={isRetryableError} onClick={onCloseReload}>
           {t("common.close")}
         </Button>
-        {isUserRefusedFirmwareUpdate ? (
+        {isRetryableError ? (
           <Button variant="main" ml={4} onClick={() => onRetry()}>
-            {t("manager.modal.cancelReinstallCTA")}
+            {isDeviceLockedError ? t("common.retry") : t("manager.modal.cancelReinstallCTA")}
           </Button>
         ) : null}
       </>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

If the firmware update is interrupted because the device is locked, there should be a retry button in the footer.

### ❓ Context

- **Impacted projects**: `lld` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-9116] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x]  **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo


https://github.com/LedgerHQ/ledger-live/assets/91890529/f7ff6ee8-d902-442d-9973-5836897b237f



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9116]: https://ledgerhq.atlassian.net/browse/LIVE-9116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ