### PR TITLE
Bugfix/live 8799 fix storage available

### DIFF
--- a/.changeset/two-cows-kiss.md
+++ b/.changeset/two-cows-kiss.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Fix the available free storage for stax

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/StorageBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/StorageBar.tsx
@@ -182,7 +182,7 @@ const StorageBar = ({
                   name,
                   currency,
                 })}
-                ratio={blocks / (distribution.totalBlocks - distribution.osBlocks)}
+                ratio={blocks / distribution.appsSpaceBlocks}
               >
                 <Tooltip
                   hideOnClick={false}

--- a/libs/ledger-live-common/src/apps/listApps/v1.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v1.ts
@@ -2,7 +2,7 @@ import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId, getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { Observable, throwError } from "rxjs";
-import { App, AppType, DeviceInfo } from "@ledgerhq/types-live";
+import { App, AppType, DeviceInfo, idsToLanguage } from "@ledgerhq/types-live";
 import { LocalTracer } from "@ledgerhq/logs";
 import type { ListAppsEvent, ListAppsResult } from "../types";
 import manager, { getProviderId } from "../../manager";
@@ -104,18 +104,22 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
           }),
       );
 
+      const languagePackForDeviceP = ManagerAPI.getLanguagePackagesForDevice(deviceInfo);
+
       const [
         [partialInstalledList, installedAvailable],
         applicationsList,
         compatibleAppVersionsList,
         firmware,
         sortedCryptoCurrencies,
+        languages,
       ] = await Promise.all([
         installedP,
         ManagerAPI.listApps().then(apps => apps.map(polyfillApplication)),
         applicationsByDeviceP,
         firmwareP,
         currenciesByMarketcap(listCryptoCurrencies(getEnv("MANAGER_DEV_MODE"), true)),
+        languagePackForDeviceP,
       ]);
       calculateDependencies();
 
@@ -272,6 +276,11 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
         }
       }
 
+      const languageId: number = deviceInfo.languageId || 0;
+      const installedLanguagePack = languages.find(
+        lang => lang.language === idsToLanguage[languageId],
+      );
+
       // Harmless to run here since we are already in a secure channel, leading to
       // no prompt for the user. Introduced for the device renaming for LLD.
       const deviceName = await getDeviceName(transport);
@@ -285,6 +294,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
         deviceModelId,
         firmware,
         customImageBlocks,
+        installedLanguagePack,
         deviceName,
       };
       o.next({

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -2,7 +2,7 @@ import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId, getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { Observable, throwError, Subscription } from "rxjs";
-import { App, DeviceInfo } from "@ledgerhq/types-live";
+import { App, DeviceInfo, idsToLanguage } from "@ledgerhq/types-live";
 import { LocalTracer } from "@ledgerhq/logs";
 import type { ListAppsEvent, ListAppsResult, ListAppResponse } from "../types";
 import manager, { getProviderId } from "../../manager";
@@ -141,13 +141,20 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
         listCryptoCurrencies(isDevMode, true),
       );
 
-      /* Running all sequences 1 2 3 4 defined above in parallel */
-      const [[listApps, matches], catalogForDevice, firmware, sortedCryptoCurrencies] =
+      /**
+       * Sequence 5: get language pack available for the device
+       */
+
+      const languagePackForDevicePromise = ManagerAPI.getLanguagePackagesForDevice(deviceInfo);
+
+      /* Running all sequences 1 2 3 4 5 defined above in parallel */
+      const [[listApps, matches], catalogForDevice, firmware, sortedCryptoCurrencies, languages] =
         await Promise.all([
           listAppsAndMatchesPromise,
           catalogForDevicesPromise,
           latestFirmwarePromise,
           sortedCryptoCurrenciesPromise,
+          languagePackForDevicePromise,
         ]);
 
       /**
@@ -228,6 +235,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
       /**
        * Obtain remaining metadata:
        * - Ledger Stax custom picture: number of blocks taken in storage
+       * - Installed language pack
        * - Device name
        * */
 
@@ -240,6 +248,11 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
         }
       }
 
+      const languageId: number = deviceInfo.languageId || 0;
+      const installedLanguagePack = languages.find(
+        lang => lang.language === idsToLanguage[languageId],
+      );
+
       // Will not prompt user since we've allowed secure channel already.
       const deviceName = await getDeviceName(transport);
 
@@ -250,6 +263,7 @@ const listApps = (transport: Transport, deviceInfo: DeviceInfo): Observable<List
         deviceModelId,
         installed,
         installedAvailable: !!installedList,
+        installedLanguagePack,
 
         // Not strictly listApps content.
         firmware,

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -437,12 +437,13 @@ export function getBlockSize(state: State): number {
 export const isIncompleteState = (state: State): boolean => state.installed.some(a => !a.name);
 // calculate if a given state (typically a predicted one) is out of memory (meaning impossible to reach with a device)
 export const isOutOfMemoryState = (state: State): boolean => {
+  const { customImageBlocks } = state;
   const blockSize = getBlockSize(state);
   const totalBytes = state.deviceModel.memorySize;
   const totalBlocks = Math.floor(totalBytes / blockSize);
   const osBytes = (state.firmware && state.firmware.bytes) || 0;
   const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks;
+  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
   const totalAppsBlocks = state.installed.reduce((sum, app) => sum + app.blocks, 0);
   return totalAppsBlocks > appsSpaceBlocks;
 };

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -437,14 +437,7 @@ export function getBlockSize(state: State): number {
 export const isIncompleteState = (state: State): boolean => state.installed.some(a => !a.name);
 // calculate if a given state (typically a predicted one) is out of memory (meaning impossible to reach with a device)
 export const isOutOfMemoryState = (state: State): boolean => {
-  const { customImageBlocks } = state;
-  const blockSize = getBlockSize(state);
-  const totalBytes = state.deviceModel.memorySize;
-  const totalBlocks = Math.floor(totalBytes / blockSize);
-  const osBytes = (state.firmware && state.firmware.bytes) || 0;
-  const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
-  const totalAppsBlocks = state.installed.reduce((sum, app) => sum + app.blocks, 0);
+  const { totalAppsBlocks, appsSpaceBlocks } = distribute(state);
   return totalAppsBlocks > appsSpaceBlocks;
 };
 export const isLiveSupportedApp = (app: App): boolean => {

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -386,7 +386,9 @@ export const distribute = (
   const totalBlocks = Math.floor(totalBytes / blockSize);
   const osBytes = (state.firmware && state.firmware.bytes) || 0;
   const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
+  const languagePackBytes = state.installedLanguagePack?.bytes || 0;
+  const languagePackBlocks = Math.ceil(languagePackBytes / blockSize);
+  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks - languagePackBlocks;
   const appsSpaceBytes = appsSpaceBlocks * blockSize;
   let totalAppsBlocks = 0;
   const apps = state.installed.map(app => {
@@ -423,6 +425,7 @@ export const distribute = (
     appsSpaceBytes,
     totalAppsBlocks,
     customImageBlocks,
+    languagePackBlocks,
     totalAppsBytes,
     freeSpaceBlocks,
     freeSpaceBytes,

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -187,6 +187,7 @@ export function mockListAppsResult(
     installed,
     installedAvailable: true,
     customImageBlocks: 0,
+    installedLanguagePack: undefined,
   };
 }
 

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -1,6 +1,6 @@
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { DeviceModel, DeviceModelId } from "@ledgerhq/devices";
-import { App, DeviceInfo, FinalFirmware } from "@ledgerhq/types-live";
+import { App, DeviceInfo, FinalFirmware, Language, LanguagePackage } from "@ledgerhq/types-live";
 import type { Observable, Subject } from "rxjs";
 export type Exec = (
   appOp: AppOp,
@@ -75,6 +75,7 @@ export type ListAppsResult = {
   appsListNames: string[];
   installedAvailable: boolean;
   installed: InstalledItem[];
+  installedLanguagePack: LanguagePackage | undefined;
   deviceInfo: DeviceInfo;
   deviceModelId: DeviceModelId;
   deviceName: string;
@@ -90,6 +91,7 @@ export type State = {
   customImageBlocks: number;
   installedAvailable: boolean;
   installed: InstalledItem[];
+  installedLanguagePack: LanguagePackage | undefined;
   recentlyInstalledApps: string[];
   installQueue: string[];
   uninstallQueue: string[];
@@ -209,4 +211,5 @@ export type AppsDistribution = {
   freeSpaceBytes: number;
   shouldWarnMemory: boolean;
   customImageBlocks: number;
+  languagePackBlocks: number;
 };


### PR DESCRIPTION
### 📝 Description

On LLD with Stax only, the size of free memory was incorrect, since the reserved space for stax image was not accounted for.
Now, the application show the correct amount of free storage.


### ❓ Context

- **Impacted projects**: `LLD` `common`
- **Linked resource(s)**: [LIVE-8799]

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8799]: https://ledgerhq.atlassian.net/browse/LIVE-8799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ