### PR TITLE
[LIVE-8781][LLD][Stax ESC] Wrong drawer displayed when Stax is disconnection

### DIFF
--- a/.changeset/violet-bulldogs-pull.md
+++ b/.changeset/violet-bulldogs-pull.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix disconnected device drawer during stax ESC

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/index.tsx
@@ -50,6 +50,7 @@ export type Props = {
   // unmounted when we restart the polling after the user interrupts an update."
   fwUpdateInterrupted: FinalFirmware | null;
   setFwUpdateInterrupted: (finalFirmware: FinalFirmware) => void;
+  isDeviceConnected: boolean;
 };
 
 const commonDrawerProps = {
@@ -72,6 +73,7 @@ const EarlySecurityChecks = ({
   isInitialRunOfSecurityChecks,
   setFwUpdateInterrupted,
   fwUpdateInterrupted,
+  isDeviceConnected,
 }: Props) => {
   const { t } = useTranslation();
   const whySecurityChecksUrl = useDynamicUrl("genuineCheck");
@@ -244,7 +246,8 @@ const EarlySecurityChecks = ({
 
   const allowSecureChannelIsOpen =
     devicePermissionState === "requested" &&
-    (genuineCheckActive || firmwareUpdateStatus === SoftwareCheckStatus.active);
+    (genuineCheckActive || firmwareUpdateStatus === SoftwareCheckStatus.active) &&
+    isDeviceConnected;
 
   const notGenuineIsOpen = genuineCheckStatus === SoftwareCheckStatus.notGenuine;
 

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -285,6 +285,7 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
     stepContent = (
       <EarlySecurityChecks
         device={lastSeenDevice}
+        isDeviceConnected={!!device}
         onComplete={notifyOnboardingEarlyCheckEnded}
         restartChecksAfterUpdate={restartChecksAfterUpdate}
         isInitialRunOfSecurityChecks={isInitialRunOfSecurityChecks}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix disconnected device drawer during stax ESC

### ❓ Context

- **Impacted projects**: `LLD` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [LIVE-8781] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [ ] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo



https://github.com/LedgerHQ/ledger-live/assets/145363160/be44601a-ac29-4205-abef-4d6e00aab7d1


<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For libraries, you can add a code sample.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-8781]: https://ledgerhq.atlassian.net/browse/LIVE-8781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ