### PR TITLE
Bugfix/LIVE-8007 - LLD - Allow text to break in onboarding link

### DIFF
--- a/.changeset/real-berries-suffer.md
+++ b/.changeset/real-berries-suffer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix link in LLD Onboarding

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Help/RecoverySeed.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Help/RecoverySeed.tsx
@@ -32,6 +32,7 @@ export function RecoverySeed(props: { handleNextInDrawer: () => void }) {
           </Text>
           <FakeLink onClick={onClickLink}>
             <Text
+              display="contents"
               mt="8px"
               color="neutral.c100"
               ff="Inter|Regular"


### PR DESCRIPTION
### 📝 Description

Allow text to break in onboarding link, thus fixing long text in link getting cropped

Before: 

![image](https://github.com/LedgerHQ/ledger-live/assets/89014981/983dfeff-04b4-468e-8bdd-966a3e678c06)


After:

![image](https://github.com/LedgerHQ/ledger-live/assets/89014981/ceac6369-b37e-4cbb-b913-158acadd076e)


### ❓ Context

- **JIRA or GitHub issue**: LIVE-8007 <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:**
  - <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on. -->

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
