### PR TITLE
fix: platform dependent padding on earn ptx webview

### DIFF
--- a/.changeset/violet-days-beg.md
+++ b/.changeset/violet-days-beg.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Update earn dashboard player padding to be platform dependent.

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Platform } from "react-native";
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/platform/providers/LocalLiveAppProvider/index";
 import {
   useRemoteLiveAppContext,
@@ -19,7 +20,7 @@ import {
   languageSelector,
 } from "../../../reducers/settings";
 import { useSelector } from "react-redux";
-import { TAB_BAR_SAFE_HEIGHT } from "../../../components/TabBar/shared";
+import { MAIN_BUTTON_BOTTOM, MAIN_BUTTON_SIZE } from "../../../components/TabBar/shared";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 
 export type Props = StackNavigatorProps<EarnLiveAppNavigatorParamList, ScreenName.Earn>;
@@ -54,6 +55,8 @@ export function EarnScreen({ route }: Props) {
     }
   }, [localManifest, remoteManifest, manifest]);
 
+  const isAndroid = Platform.OS === "android";
+
   return manifest ? (
     <Flex
       /**
@@ -62,7 +65,7 @@ export function EarnScreen({ route }: Props) {
        */
       flex={1}
       pt={insets.top}
-      pb={TAB_BAR_SAFE_HEIGHT} // Avoid nav button at the bottom
+      pb={isAndroid ? MAIN_BUTTON_BOTTOM : MAIN_BUTTON_SIZE} // iOS calculates differently
       backgroundColor={"background.main"} // Earn app bg color
     >
       <TrackScreen category="EarnDashboard" name="Earn" />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already.
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Android handles webview padding differently from iOS. Padding at the end of the earn dash page was overlapping too much content on Android. 

### ❓ Context

- **Impacted projects**: `` <!-- Add the list of end user projects impacted by the change inside of the ` `, like so `LLM, LLD`. -->
- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant inside the brackets, like so [LIVE-0000]. (JIRA / Github issue number) -->

### ✅ Checklist

- [x] **Test coverage** <!-- Are your changes covered by tests? Features must be tested, bugfixes must include a test that would have detected the issue. -->
- [x] **Atomic delivery** <!-- Is this pull request standalone? In order words, does it depend on nothing else? Please explain if not checked. -->
- [x] **No breaking changes** <!-- If there are breaking changes, please explain why. -->

### 📸 Demo

**BEFORE**
![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/bd226ed5-a62d-4c08-9960-25e2c727f671)


**AFTER**
(Padding has been added to the mobile version of the web app itself, instead.)

screenshots (background blue for clarity):
![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/5ae6ca3e-06e9-4d44-aca7-f075122f8f2e)

![IMG_8783](https://github.com/LedgerHQ/ledger-live/assets/123105524/12956586-7b64-4bf4-9af2-884f918a852c)

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/98d2ffb9-5ca1-4e0c-ac48-3a198f18a9da)

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/b9cfdb91-2b82-43bd-8eec-0ef8c5fd35f3)



### 🚀 Expectations to reach

_Please make sure you follow these [**Important Steps**](https://github.com/LedgerHQ/ledger-live/blob/develop/CONTRIBUTING.md#important-steps)._

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
