### PR TITLE
[BUGFIX][LLM] set custom fees evm flow

### DIFF
--- a/.changeset/shaggy-bats-behave.md
+++ b/.changeset/shaggy-bats-behave.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": patch
+---
+
+Fix set custom fees in evm flow
+
+When updating the fees in custom mode for an EVM transaction, clicking on the "Valide Fees" CTA would't do anything (expected behaviour would be to return the fee strategy selection screen with new custom entry selected).
+Fixes this and returns to fee strategy selection screen with the new custom entry selected.
+PS: for the swap flow, updating the transaction will redirect to the swap summary screen, which is the expected behaviour as of today

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SendFundsNavigator.ts
@@ -172,7 +172,6 @@ export type SendFundsNavigatorStackParamList = {
     transaction: EvmTransaction;
     setTransaction: Result<EvmTransaction>["setTransaction"];
     gasOptions?: GasOptions;
-    goBackOnSetTransaction?: boolean;
     setCustomStrategyTransactionPatch: React.Dispatch<
       React.SetStateAction<Partial<EvmTransaction> | undefined>
     >;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
@@ -130,7 +130,6 @@ export type SignTransactionNavigatorParamList = {
     parentId?: string;
     transaction: EvmTransaction;
     gasOptions?: GasOptions;
-    goBackOnSetTransaction?: boolean;
     currentNavigation:
       | ScreenName.SignTransactionSummary
       | ScreenName.SignTransactionSummary

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapNavigator.ts
@@ -140,7 +140,6 @@ export type SwapNavigatorParamList = {
     parentId?: string;
     transaction: EvmTransaction;
     gasOptions?: GasOptions;
-    goBackOnSetTransaction?: boolean;
     currentNavigation:
       | ScreenName.SignTransactionSummary
       | ScreenName.SignTransactionSummary

--- a/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmCustomFees/index.tsx
@@ -29,7 +29,6 @@ export default function EvmCustomFees({ route }: Props) {
     setCustomStrategyTransactionPatch,
     transaction: baseTransaction,
     gasOptions,
-    goBackOnSetTransaction = true,
   } = route.params;
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   const navigation = useNavigation();
@@ -50,15 +49,10 @@ export default function EvmCustomFees({ route }: Props) {
   const onValidateFees = useCallback(
     (transactionPatch: Partial<Transaction>) => () => {
       setCustomStrategyTransactionPatch(transactionPatch);
-      // In the context of some UI flows like the swap, the main component might already
-      // be providing a navigation after updating the transaction. On those cases,
-      // we'll remove the default "go back" behaviour and
-      // let the parent UI decide how to navigate.
-      if (goBackOnSetTransaction) {
-        navigation.goBack();
-      }
+
+      navigation.goBack();
     },
-    [navigation, setCustomStrategyTransactionPatch, goBackOnSetTransaction],
+    [navigation, setCustomStrategyTransactionPatch],
   );
 
   const shouldUseEip1559 = transaction.type === 2;

--- a/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
@@ -21,6 +21,13 @@ const getCustomStrategyFees = (transaction: Transaction): BigNumber | null => {
   return null;
 };
 
+/**
+ * ⚠️ In the context of some UI flows like the swap, the main component might
+ * be providing a navigation after updating the transaction
+ * (i.e: calling `setTransaction`).
+ * One should therefore be careful regarding this side effect when calling
+ * `setTransaction`.
+ */
 export default function EvmFeesStrategy({
   account,
   parentAccount,
@@ -110,6 +117,32 @@ export default function EvmFeesStrategy({
     setCustomStrategyTransactionPatch(newCustomStrategyTransactionPatch);
   }, [transaction, customStrategyTransactionPatch]);
 
+  useEffect(() => {
+    if (!customStrategyTransactionPatch) {
+      return;
+    }
+    const bridge = getAccountBridge<Transaction>(account, parentAccount);
+
+    /**
+     * If the customStrategyTransactionPatch is present, this means the custom
+     * fee has been edited by the user. In this case, we need to update the
+     * transaction with the new fee data.
+     * This also selects the new "custom" strategy in the fees strategy list.
+     */
+    const updatedTransaction = bridge.updateTransaction(transaction, {
+      ...customStrategyTransactionPatch,
+    });
+
+    setTransaction(updatedTransaction);
+  }, [
+    setTransaction,
+    account,
+    parentAccount,
+    transaction,
+    customStrategyTransactionPatch,
+    gasOptions,
+  ]);
+
   const onFeesSelected = useCallback(
     ({ feesStrategy }: { feesStrategy: StrategyWithCustom }) => {
       const bridge = getAccountBridge<Transaction>(account, parentAccount);
@@ -142,7 +175,6 @@ export default function EvmFeesStrategy({
       currentNavigation: ScreenName.SendSummary,
       nextNavigation: ScreenName.SendSelectDevice,
       gasOptions,
-      goBackOnSetTransaction: false,
       setTransaction,
       setCustomStrategyTransactionPatch,
     });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When updating the fees in custom mode for an EVM transaction, clicking on the "Valide Fees" CTA would't do anything (expected behaviour would be to return the fee strategy selection screen with new custom entry selected).

This is happening on `develop` and prod as well and probably originated from the last release merge conflict (cf. https://github.com/LedgerHQ/ledger-live/pull/4905)

This PR fixes this and returns to fee strategy selection screen with the new custom entry selected.
PS: for the swap flow, updating the transaction will redirect to the swap summary screen, which is the expected behaviour as of today.

🎥  Normal flow

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/LedgerHQ/ledger-live/assets/9203826/b9585fd5-f3d6-4acd-b22d-df4819e0b7fa">  | <video src="https://github.com/LedgerHQ/ledger-live/assets/9203826/5000056a-42b7-43d7-932a-d9f80053bdb4">|


🎥  Swap flow
| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/LedgerHQ/ledger-live/assets/9203826/f583f083-d9b6-4cc0-bf52-775ecc7146d1">  | <video src="https://github.com/LedgerHQ/ledger-live/assets/9203826/f42183f0-6570-423a-ad85-07bfd6e353f5">|









<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub issue**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] ~**Covered by automatic tests.**~ No proper tooling in place to efficiently tests these kind of flows
- [x] **Impact of the changes:**
  - LLM only
  - evm family only
  - sign tx flow, at the select fee step
  - for a normal send flow as well as the swap flow

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
