### PR TITLE
[BUGFIX] : Wallet Connect CTA was displayed in the Earn section on supported account page, now it's on the Asset & Account header page when supported

### DIFF
--- a/.changeset/giant-stingrays-train.md
+++ b/.changeset/giant-stingrays-train.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Wallet Connect CTA was displayed in the Earn section on supported account page, now it's on the Asset & Account header page when supported

--- a/.changeset/many-ravens-rhyme.md
+++ b/.changeset/many-ravens-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add isWalletConnectSupported in live-common to be used in both platforms

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -38,6 +38,7 @@ import { getLLDCoinFamily } from "~/renderer/families";
 import { ManageAction } from "~/renderer/families/types";
 import { getAvailableProviders } from "@ledgerhq/live-common/exchange/swap/index";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
+import { isWalletConnectSupported } from "@ledgerhq/live-common/walletConnect/index";
 
 type RenderActionParams = {
   label: React.ReactNode;
@@ -141,6 +142,8 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
     });
   }, [mainAccount.id, history]);
 
+  const isWalletConnectActionDisplayable = isWalletConnectSupported(currency);
+
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2}>
       <Tooltip content={t("stars.tooltip")}>
@@ -151,7 +154,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
           rounded
         />
       </Tooltip>
-      {["ethereum", "bsc", "polygon"].includes(currency.id) ? (
+      {isWalletConnectActionDisplayable ? (
         <Tooltip content={t("walletconnect.titleAccount")}>
           <ButtonSettings onClick={onWalletConnectLiveApp}>
             <Box justifyContent="center">

--- a/apps/ledger-live-mobile/src/components/CurrencyHeaderLayout.tsx
+++ b/apps/ledger-live-mobile/src/components/CurrencyHeaderLayout.tsx
@@ -68,21 +68,6 @@ function CurrencyHeaderLayout({
     };
   }, [graphCardEndPosition]);
 
-  const Header = styled(Flex)`
-    position: absolute;
-  `;
-
-  const CenteredElement = styled(Flex).attrs((p: { width: number }) => ({
-    flexDirection: "row",
-    justifyContent: "center",
-    alignItems: "center",
-    height: 48,
-    left: -p.width / 2 + p.width * 0.15,
-    width: p.width * 0.7,
-  }))`
-    position: absolute;
-  `;
-
   return (
     <Header
       flexDirection="row"
@@ -109,7 +94,7 @@ function CurrencyHeaderLayout({
           <CurrencyGradient gradientColor={currencyColor} />
         </Box>
       </Animated.View>
-      <Box width={24}>{leftElement}</Box>
+      <Box>{leftElement}</Box>
       <Flex flexDirection={"row"} alignItems={"center"}>
         <CenteredElement width={windowsWidth}>
           <Animated.View style={[AfterScrollAnimation]}>{centerAfterScrollElement}</Animated.View>
@@ -118,9 +103,24 @@ function CurrencyHeaderLayout({
           <Animated.View style={[BeforeScrollAnimation]}>{centerBeforeScrollElement}</Animated.View>
         </CenteredElement>
       </Flex>
-      <Box width={24}>{rightElement}</Box>
+      <Box>{rightElement}</Box>
     </Header>
   );
 }
 
 export default CurrencyHeaderLayout;
+
+const Header = styled(Flex)`
+  position: absolute;
+`;
+
+const CenteredElement = styled(Flex).attrs((p: { width: number }) => ({
+  flexDirection: "row",
+  justifyContent: "center",
+  alignItems: "center",
+  height: 48,
+  left: -p.width / 2 + p.width * 0.15,
+  width: p.width * 0.7,
+}))`
+  position: absolute;
+`;

--- a/apps/ledger-live-mobile/src/screens/Account/AccountHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/AccountHeader.tsx
@@ -1,7 +1,5 @@
-import React, { useCallback } from "react";
-import { useNavigation } from "@react-navigation/native";
+import React from "react";
 import { Flex, Text } from "@ledgerhq/native-ui";
-import { ArrowLeftMedium } from "@ledgerhq/native-ui/assets/icons";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import {
   getAccountCurrency,
@@ -11,13 +9,13 @@ import {
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import { AccountLike, Account, BalanceHistoryWithCountervalue } from "@ledgerhq/types-live";
 import Animated from "react-native-reanimated";
-import Touchable from "../../components/Touchable";
 import { withDiscreetMode } from "../../context/DiscreetModeContext";
-import { track } from "../../analytics";
+
 import AccountHeaderRight from "./AccountHeaderRight";
 import CurrencyHeaderLayout from "../../components/CurrencyHeaderLayout";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import Placeholder from "../../components/Placeholder";
+import AccountHeaderLeft from "./AccountHeaderLeft";
 
 function AccountHeader({
   currentPositionY,
@@ -57,16 +55,7 @@ function AccountHeader({
     items.reverse();
   }
 
-  const navigation = useNavigation();
   const currency = getAccountCurrency(account);
-
-  const onBackButtonPress = useCallback(() => {
-    track("button_clicked", {
-      button: "Back",
-      page: "Account",
-    });
-    navigation.goBack();
-  }, [navigation]);
 
   const isToken = parentAccount && parentAccount.name !== undefined;
 
@@ -74,11 +63,7 @@ function AccountHeader({
     <CurrencyHeaderLayout
       currentPositionY={currentPositionY}
       graphCardEndPosition={graphCardEndPosition}
-      leftElement={
-        <Touchable onPress={onBackButtonPress}>
-          <ArrowLeftMedium size={24} />
-        </Touchable>
-      }
+      leftElement={<AccountHeaderLeft currency={currency} />}
       centerAfterScrollElement={
         <Flex flexDirection={"column"} alignItems={"center"}>
           {typeof items[1]?.value === "number" ? (

--- a/apps/ledger-live-mobile/src/screens/Account/AccountHeaderLeft.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/AccountHeaderLeft.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from "react";
+import { NavigationProp, useNavigation } from "@react-navigation/native";
+import { ArrowLeftMedium } from "@ledgerhq/native-ui/assets/icons";
+import { ScreenName } from "../../const";
+import Touchable from "../../components/Touchable";
+import type { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
+import type { AccountsNavigatorParamList } from "../../components/RootNavigator/types/AccountsNavigator";
+
+import { Flex } from "@ledgerhq/native-ui";
+import { track } from "../../analytics";
+import { isWalletConnectSupported } from "@ledgerhq/live-common/walletConnect/index";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+type Props = {
+  currency: CryptoOrTokenCurrency;
+};
+export default function AccountHeaderLeft({ currency }: Props) {
+  const isWalletConnectActionDisplayable = isWalletConnectSupported(currency);
+
+  const navigation =
+    useNavigation<
+      NavigationProp<AccountsNavigatorParamList & BaseNavigatorStackParamList, ScreenName.Account>
+    >();
+
+  const onBackButtonPress = useCallback(() => {
+    track("button_clicked", {
+      button: "Back",
+      page: "Account",
+    });
+    navigation.goBack();
+  }, [navigation]);
+
+  return (
+    <Flex flexDirection={"row"}>
+      <Touchable onPress={onBackButtonPress}>
+        <ArrowLeftMedium size={24} />
+      </Touchable>
+      {isWalletConnectActionDisplayable && <Flex ml={7} width={24} />}
+    </Flex>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Account/AccountHeaderRight.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/AccountHeaderRight.tsx
@@ -11,6 +11,10 @@ import TokenContextualModal from "../Settings/Accounts/TokenContextualModal";
 import type { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import type { AccountsNavigatorParamList } from "../../components/RootNavigator/types/AccountsNavigator";
 
+import { Flex } from "@ledgerhq/native-ui";
+import { WalletConnectAction } from "../WalletCentricAsset/WalletConnectHeader";
+import { isWalletConnectSupported } from "@ledgerhq/live-common/walletConnect/index";
+
 export default function AccountHeaderRight() {
   const navigation =
     useNavigation<
@@ -32,6 +36,7 @@ export default function AccountHeaderRight() {
 
   const currency = getAccountCurrency(account);
   const cryptoAccounts = accounts.filter(account => account.currency.id === currency.id);
+  const isWalletConnectActionDisplayable = isWalletConnectSupported(currency);
 
   useEffect(() => {
     if (!account) {
@@ -60,26 +65,31 @@ export default function AccountHeaderRight() {
 
   if (account.type === "Account") {
     return (
-      <Touchable
-        event="button_clicked"
-        eventProperties={{
-          button: "Account Settings",
-        }}
-        onPress={() => {
-          navigation.navigate(NavigatorName.AccountSettings, {
-            screen: ScreenName.AccountSettingsMain,
-            params: {
-              accountId: account.id,
-              hasOtherAccountsForThisCrypto: cryptoAccounts && cryptoAccounts.length > 1,
-            },
-          });
-        }}
-        style={{ alignItems: "center", justifyContent: "center" }}
-      >
-        <View>
-          <SettingsMedium size={24} color="neutral.c100" />
-        </View>
-      </Touchable>
+      <Flex flexDirection="row">
+        {isWalletConnectActionDisplayable && (
+          <Flex mr={7}>
+            <WalletConnectAction currency={currency} event={"WalletConnect Account Button"} />
+          </Flex>
+        )}
+
+        <Touchable
+          event="button_clicked"
+          eventProperties={{
+            button: "Account Settings",
+          }}
+          onPress={() => {
+            navigation.navigate(NavigatorName.AccountSettings, {
+              screen: ScreenName.AccountSettingsMain,
+              params: {
+                accountId: account.id,
+                hasOtherAccountsForThisCrypto: cryptoAccounts && cryptoAccounts.length > 1,
+              },
+            });
+          }}
+        >
+          <SettingsMedium size={24} />
+        </Touchable>
+      </Flex>
     );
   }
 

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -56,8 +56,6 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
   // @ts-expect-error issue in typing
   const decorators = perFamilyAccountActions[mainAccount?.currency?.family];
 
-  const isWalletConnectSupported = ["ethereum", "bsc", "polygon"].includes(currency.id);
-
   const { isCurrencyAvailable } = useRampCatalog();
 
   const canBeBought = !!currency && isCurrencyAvailable(currency.id, "onRamp");
@@ -222,29 +220,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
       })) ||
     [];
 
-  const secondaryActions = [
-    ...familySpecificSecondaryActions,
-    ...(isWalletConnectSupported
-      ? [
-          {
-            id: "walletconnect",
-            navigationParams: [
-              NavigatorName.Base,
-              {
-                screen: NavigatorName.WalletConnect,
-                params: {
-                  screen: ScreenName.WalletConnectConnect,
-                },
-              },
-            ],
-            label: t("account.walletconnect"),
-            Icon: IconsLegacy.WalletConnectMedium,
-            event: "WalletConnect Account Button",
-            eventProperties: { currencyName: currency?.name },
-          },
-        ]
-      : []),
-  ];
+  const secondaryActions = [...familySpecificSecondaryActions];
 
   return {
     mainActions,

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
@@ -76,7 +76,9 @@ function Header({
   const { t } = useTranslation();
   const shouldUseCounterValue = useSelector(countervalueFirstSelector);
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
-  const isWalletConnectActionDisplayable = isWalletConnectSupported(currency);
+  const isWalletConnectActionDisplayable = isWalletConnectSupported(
+    currency as CryptoOrTokenCurrency,
+  );
 
   const onBackButtonPress = useCallback(() => {
     if (readOnlyModeEnabled) {

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Flex, Text } from "@ledgerhq/native-ui";
-import { Currency, FiatCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoOrTokenCurrency, Currency, FiatCurrency } from "@ledgerhq/types-cryptoassets";
 import { useSelector } from "react-redux";
 import { ArrowLeftMedium, SettingsMedium } from "@ledgerhq/native-ui/assets/icons";
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
@@ -17,6 +17,49 @@ import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import Placeholder from "../../components/Placeholder";
 import CurrencyHeaderLayout from "../../components/CurrencyHeaderLayout";
 import CounterValue from "../../components/CounterValue";
+import { WalletConnectAction } from "./WalletConnectHeader";
+import { isWalletConnectSupported } from "@ledgerhq/live-common/walletConnect/index";
+
+type LeftProps = {
+  onBackButtonPress: () => void;
+  displayWalletConnectAction: boolean;
+};
+
+function HeaderLeft({ onBackButtonPress, displayWalletConnectAction }: LeftProps) {
+  return (
+    <Flex flexDirection="row">
+      <Touchable onPress={onBackButtonPress}>
+        <ArrowLeftMedium size={24} />
+      </Touchable>
+      {displayWalletConnectAction && <Flex ml={7} width={24} />}
+    </Flex>
+  );
+}
+
+type RightProps = {
+  currency: Currency;
+  onSettingsButtonPress: () => void;
+  displayWalletConnectAction: boolean;
+};
+
+function HeaderRight({ currency, displayWalletConnectAction, onSettingsButtonPress }: RightProps) {
+  return currency.type !== "TokenCurrency" ? (
+    <Flex flexDirection="row">
+      {displayWalletConnectAction && (
+        <Flex mr={7}>
+          <WalletConnectAction
+            currency={currency as CryptoOrTokenCurrency}
+            event="WalletConnect Asset Button"
+          />
+        </Flex>
+      )}
+
+      <Touchable onPress={onSettingsButtonPress}>
+        <SettingsMedium size={24} />
+      </Touchable>
+    </Flex>
+  ) : null;
+}
 
 function Header({
   currentPositionY,
@@ -33,6 +76,7 @@ function Header({
   const { t } = useTranslation();
   const shouldUseCounterValue = useSelector(countervalueFirstSelector);
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
+  const isWalletConnectActionDisplayable = isWalletConnectSupported(currency);
 
   const onBackButtonPress = useCallback(() => {
     if (readOnlyModeEnabled) {
@@ -58,9 +102,10 @@ function Header({
       currentPositionY={currentPositionY}
       graphCardEndPosition={graphCardEndPosition}
       leftElement={
-        <Touchable onPress={onBackButtonPress}>
-          <ArrowLeftMedium size={24} />
-        </Touchable>
+        <HeaderLeft
+          onBackButtonPress={onBackButtonPress}
+          displayWalletConnectAction={isWalletConnectActionDisplayable}
+        />
       }
       centerBeforeScrollElement={
         <Flex flexDirection={"row"} alignItems={"center"}>
@@ -110,11 +155,11 @@ function Header({
         </Flex>
       }
       rightElement={
-        currency.type !== "TokenCurrency" ? (
-          <Touchable onPress={goToSettings}>
-            <SettingsMedium size={24} />
-          </Touchable>
-        ) : null
+        <HeaderRight
+          currency={currency}
+          onSettingsButtonPress={goToSettings}
+          displayWalletConnectAction={isWalletConnectActionDisplayable}
+        />
       }
       currencyColor={getCurrencyColor(currency)}
     />

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/WalletConnectHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/WalletConnectHeader.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { WalletConnectMedium } from "@ledgerhq/native-ui/assets/icons";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import Touchable from "../../components/Touchable";
+import { useWalletConnectAction } from "./hooks/useWalletConnectAction";
+
+type Props = {
+  currency: CryptoOrTokenCurrency;
+  event: string;
+};
+
+export function WalletConnectAction({ currency, event }: Props) {
+  const { onWalletConnectPress, isWalletConnectActionDisplayable } = useWalletConnectAction({
+    currency,
+    event,
+  });
+
+  if (!isWalletConnectActionDisplayable) {
+    return null;
+  }
+  return (
+    <Touchable onPress={onWalletConnectPress}>
+      <WalletConnectMedium size={24} color={"neutral.c100"} />
+    </Touchable>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/hooks/useWalletConnectAction.ts
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/hooks/useWalletConnectAction.ts
@@ -1,0 +1,39 @@
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { isWalletConnectSupported } from "@ledgerhq/live-common/walletConnect/index";
+import { useNavigation } from "@react-navigation/core";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { useCallback } from "react";
+import { track } from "../../../analytics";
+import { NavigatorName, ScreenName } from "../../../const";
+
+type Props = {
+  currency: CryptoOrTokenCurrency;
+  event: string;
+};
+
+export function useWalletConnectAction({ currency, event }: Props) {
+  const navigation = useNavigation();
+
+  const onNavigate = useCallback(
+    (name: string, options?: object) => {
+      (navigation as StackNavigationProp<{ [key: string]: object | undefined }>).navigate(
+        name,
+        options,
+      );
+    },
+    [navigation],
+  );
+  const onWalletConnectPress = useCallback(() => {
+    track(event, { currencyName: currency?.name });
+    onNavigate(NavigatorName.WalletConnect, {
+      screen: ScreenName.WalletConnectConnect,
+    });
+  }, [currency?.name, event, onNavigate]);
+
+  const isWalletConnectActionDisplayable = isWalletConnectSupported(currency);
+
+  return {
+    onWalletConnectPress,
+    isWalletConnectActionDisplayable,
+  };
+}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -269,6 +269,7 @@
     "src/transaction/signOperation.ts",
     "src/transactionsAlerts/index.ts",
     "src/user.ts",
+    "src/walletConnect/index.ts",
     "src/wallet-api/CustomLogger/client.ts",
     "src/wallet-api/constants.ts",
     "src/wallet-api/converters.ts",

--- a/libs/ledger-live-common/src/walletConnect/index.ts
+++ b/libs/ledger-live-common/src/walletConnect/index.ts
@@ -1,0 +1,20 @@
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+/**
+ * The full list comes from the WalletConnect repo
+ * https://github.com/LedgerHQ/wallet-connect-live-app/blob/ce792e808115308ef7d36e9954bc9dae23fd8f9e/src/data/network.config.ts#L84C14-L84C31
+ */
+
+export const currenciesSupportedOnWalletConnect = [
+  "ethereum",
+  "polygon",
+  "bsc",
+  "optimism",
+  "arbitrum",
+  "avalanche_c_chain",
+  "ethereum_goerli",
+  "optimism_goerli",
+];
+
+export const isWalletConnectSupported = (currency: CryptoOrTokenCurrency) =>
+  currenciesSupportedOnWalletConnect.includes(currency.id);


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

 Wallet Connect CTA was displayed in the Earn section on supported account page (ETH, BSC and Matic)


Demo 

https://github.com/LedgerHQ/ledger-live/assets/112866305/c1d4610c-1378-46e5-a55c-70e47caa4b0d


### ❓ Context

- **JIRA or GitHub link**: [LIVE-10088]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:**  Add WalletConnect Entry point when supported on Asset & Account header in LLM

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10088]: https://ledgerhq.atlassian.net/browse/LIVE-10088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ