### PR TITLE
LIVE-10046 Fix invalid address message wording

### DIFF
--- a/.changeset/lucky-hairs-behave.md
+++ b/.changeset/lucky-hairs-behave.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix invalid recipient address messages wording

--- a/libs/ledger-live-common/src/families/algorand/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/algorand/bridge/mock.ts
@@ -61,7 +61,9 @@ const getTransactionStatus = (account: Account, t: Transaction) => {
   if (!t.recipient) {
     errors.recipient = new RecipientRequired("");
   } else if (isInvalidRecipient(t.recipient)) {
-    errors.recipient = new InvalidAddress("");
+    errors.recipient = new InvalidAddress("", {
+      currencyName: account.currency.name,
+    });
   }
 
   return Promise.resolve({

--- a/libs/ledger-live-common/src/families/crypto_org/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/crypto_org/js-getTransactionStatus.ts
@@ -39,7 +39,9 @@ const getTransactionStatus = async (a: Account, t: Transaction): Promise<Transac
   if (!t.recipient) {
     errors.recipient = new RecipientRequired();
   } else if (!isValidAddress(t.recipient, a.currency.id)) {
-    errors.recipient = new InvalidAddress();
+    errors.recipient = new InvalidAddress("", {
+      currencyName: a.currency.name,
+    });
   } else if (t.mode === "send" && a.freshAddress === t.recipient) {
     errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
   }

--- a/libs/ledger-live-common/src/families/internet_computer/bridge/account.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/bridge/account.ts
@@ -79,13 +79,17 @@ const getTransactionStatus = async (a: Account, t: Transaction): Promise<Transac
   if (!recipient) {
     errors.recipient = new RecipientRequired();
   } else if (!(await validateAddress(recipient)).isValid) {
-    errors.recipient = new InvalidAddress();
+    errors.recipient = new InvalidAddress("", {
+      currencyName: a.currency.name,
+    });
   } else if (recipient.toLowerCase() === address.toLowerCase()) {
     errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
   }
 
   if (!(await validateAddress(address)).isValid) {
-    errors.sender = new InvalidAddress();
+    errors.sender = new InvalidAddress("", {
+      currencyName: a.currency.name,
+    });
   }
 
   if (!validateMemo(t.memo).isValid) {

--- a/libs/ledger-live-common/src/families/near/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/near/js-getTransactionStatus.ts
@@ -118,7 +118,9 @@ const getSendTransactionStatus = async (
   if (!t.recipient) {
     errors.recipient = new RecipientRequired();
   } else if (!isValidAddress(t.recipient)) {
-    errors.recipient = new InvalidAddress();
+    errors.recipient = new InvalidAddress("", {
+      currencyName: a.currency.name,
+    });
   } else {
     const accountDetails = await fetchAccountDetails(t.recipient);
 

--- a/libs/ledger-live-common/src/families/solana/js-prepareTransaction.ts
+++ b/libs/ledger-live-common/src/families/solana/js-prepareTransaction.ts
@@ -554,7 +554,9 @@ async function deriveStakeSplitCommandDescriptor(
   // TODO: else if amount > stake balance
 
   if (!isValidBase58Address(uiState.stakeAccAddr)) {
-    errors.stakeAccAddr = new InvalidAddress();
+    errors.stakeAccAddr = new InvalidAddress("", {
+      currencyName: mainAccount.currency.name,
+    });
   }
 
   mainAccount.solanaResources?.stakes ?? [];
@@ -617,7 +619,9 @@ async function validateRecipientCommon(
   } else if (mainAccount.freshAddress === tx.recipient) {
     errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
   } else if (!isValidBase58Address(tx.recipient)) {
-    errors.recipient = new InvalidAddress();
+    errors.recipient = new InvalidAddress("", {
+      currencyName: mainAccount.currency.name,
+    });
   } else {
     const recipientWalletIsUnfunded = !(await isAccountFunded(tx.recipient, api));
 
@@ -645,7 +649,9 @@ async function validateValidatorCommon(addr: string, errors: Record<string, Erro
   if (addr.length === 0) {
     errors.voteAccAddr = new SolanaValidatorRequired();
   } else if (!isValidBase58Address(addr)) {
-    errors.voteAccAddr = new InvalidAddress();
+    errors.voteAccAddr = new InvalidAddress("", {
+      currencyName: "Solana",
+    });
   } else {
     const voteAcc = await getMaybeVoteAccount(addr, api);
 
@@ -663,7 +669,9 @@ function validateAndTryGetStakeAccount(
   if (stakeAccAddr.length === 0) {
     errors.stakeAccAddr = new SolanaStakeAccountRequired();
   } else if (!isValidBase58Address(stakeAccAddr)) {
-    errors.stakeAccAddr = new InvalidAddress();
+    errors.stakeAccAddr = new InvalidAddress("", {
+      currencyName: account.currency.name,
+    });
   }
 
   if (!errors.stakeAccAddr) {

--- a/libs/ledger-live-common/src/families/stacks/bridge/account.ts
+++ b/libs/ledger-live-common/src/families/stacks/bridge/account.ts
@@ -87,7 +87,9 @@ const getTransactionStatus = async (a: Account, t: Transaction): Promise<Transac
   if (!recipient) {
     errors.recipient = new RecipientRequired();
   } else if (!validateAddress(recipient).isValid) {
-    errors.recipient = new InvalidAddress();
+    errors.recipient = new InvalidAddress("", {
+      currencyName: a.currency.name,
+    });
   } else if (address === recipient) {
     errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
   } else if (!fee || fee.eq(0)) {
@@ -208,7 +210,9 @@ const signOperation: SignOperationFnSignature<Transaction> = ({
           const { recipient, fee, anchorMode, network, memo, amount, nonce } = transaction;
 
           if (!xpub) {
-            throw new InvalidAddress();
+            throw new InvalidAddress("", {
+              currencyName: account.currency.name,
+            });
           }
 
           if (!fee) {

--- a/libs/ledger-live-common/src/families/stellar/js-getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/stellar/js-getTransactionStatus.ts
@@ -96,7 +96,9 @@ const getTransactionStatus = async (
     if (!t.recipient) {
       errors.recipient = new RecipientRequired("");
     } else if (!isAddressValid(t.recipient)) {
-      errors.recipient = new InvalidAddress("");
+      errors.recipient = new InvalidAddress("", {
+        currencyName: a.currency.name,
+      });
     } else if (a.freshAddress === t.recipient) {
       errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
     }

--- a/libs/ledger-live-common/src/families/tron/bridge/js.ts
+++ b/libs/ledger-live-common/src/families/tron/bridge/js.ts
@@ -619,7 +619,9 @@ const getTransactionStatus = async (a: TronAccount, t: Transaction): Promise<Tra
       );
 
       if (!isValidAddresses) {
-        errors.vote = new InvalidAddress();
+        errors.vote = new InvalidAddress("", {
+          currencyName: a.currency.name,
+        });
       } else if (!isValidVoteCounts) {
         errors.vote = new TronInvalidVoteCount();
       } else {


### PR DESCRIPTION
### 📝 Description
When user input an incorrect address in the send crypto modal in LLD/LLM
Users may see an error: 
This is not a valid {{currencyName}} address

We should replay the {{currencyName}} with the real crypto asset name.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10046

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests. No test needed as we just change the wording by adding a missing parameter in error message.
- [X] **Impact of the changes:  It is a UI fix on LLD/LLM, First, open the send funds modal from one of these crypto:  crypto_org, internet_computer, near, solana, stacks, stellar, tron. Second, Input an invalid recipient address. Now the error message "This is not a valid XXX address" can be displayed correctly.

The screenshot after my fix
<img width="537" alt="Screenshot 2023-11-10 at 12 39 34" src="https://github.com/LedgerHQ/ledger-live/assets/71653044/774b3825-849d-48f3-838d-1a4afff0d9ca">

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
