### PR TITLE
Bugfix: LLD uses Overridden Manifests

### DIFF
--- a/.changeset/orange-elephants-sleep.md
+++ b/.changeset/orange-elephants-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Make lld uses overrided manifests

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/index.tsx
@@ -117,7 +117,10 @@ export function RemoteLiveAppProvider({
     allowDebugApps && branches.push("debug");
 
     try {
-      const allManifests = await api.fetchLiveAppManifests(providerURL);
+      const allManifests = await api.fetchLiveAppManifests(providerURL, {
+        platform,
+        llVersion,
+      });
 
       const catalogManifests = await api.fetchLiveAppManifests(providerURL, {
         apiVersion,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Steps to Reproduce:
Open 1inch on LedgerLive 2.71 desktopn with overrided manifests → [change account]

Expected behavior:
All the networks after version 2.71on desktop should be displayed 

Actual behavior:
Only bsc, eth and polygon are displayed

Fix: 
Adding params to the request

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD
  - LLM

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
