### PR TITLE
[FEAT][LIVE-10138] Add supported currencies id param to editEvmTx feature flag

### DIFF
--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -283,7 +283,7 @@ export const urls = {
     learnMore:
       "https://support.ledger.com/hc/en-us/articles/360020499920-Celo-CELO-?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=celo",
   },
-  editEthTx: {
+  editEvmTx: {
     learnMore: "https://support.ledger.com/hc/articles/9756122596765?support=true",
   },
   ledgerByFigmentTC:

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
@@ -1,12 +1,14 @@
-import React, { useCallback, memo } from "react";
-import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
+import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+import invariant from "invariant";
+import React, { memo, useCallback } from "react";
 import { Trans } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { closeModal, openModal } from "~/renderer/actions/modals";
 import Alert from "~/renderer/components/Alert";
 import Link from "~/renderer/components/Link";
-import { openModal, closeModal } from "~/renderer/actions/modals";
-import { useDispatch } from "react-redux";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import invariant from "invariant";
 
 type Props = {
   operation: Operation;
@@ -17,7 +19,11 @@ type Props = {
 const EditOperationPanel = (props: Props) => {
   const { operation, account, parentAccount } = props;
   const dispatch = useDispatch();
-  const editEthTx = useFeature("editEthTx");
+  const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
+  const mainAccount = getMainAccount(account, parentAccount);
+  const isCurrencySupported =
+    params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) || false;
+
   const handleOpenEditModal = useCallback(() => {
     invariant(operation.transactionRaw, "operation.transactionRaw is required");
     dispatch(closeModal("MODAL_SEND"));
@@ -31,7 +37,7 @@ const EditOperationPanel = (props: Props) => {
     );
   }, [parentAccount, account, operation, dispatch]);
 
-  if (!editEthTx?.enabled) {
+  if (!isEditEvmTxEnabled || !isCurrencySupported) {
     return null;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -19,6 +19,7 @@ import {
   isStuckOperation,
 } from "@ledgerhq/live-common/operation";
 import { getEnv } from "@ledgerhq/live-env";
+import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, NFTMetadata, Operation, OperationType } from "@ledgerhq/types-live";
 import { TFunction } from "i18next";
 import invariant from "invariant";
@@ -235,8 +236,16 @@ const OperationD = (props: Props) => {
       ? currency.parentCurrency.name
       : currency.name
     : undefined;
-  const editEthTx = useFeature("editEthTx");
-  const editable = editEthTx?.enabled && isEditableOperation({ account: mainAccount, operation });
+
+  const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
+  const isCurrencySupported =
+    params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) || false;
+
+  const editable =
+    isEditEvmTxEnabled &&
+    isCurrencySupported &&
+    isEditableOperation({ account: mainAccount, operation });
+
   const dispatch = useDispatch();
 
   const handleOpenEditModal = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/EditStuckTransactionPanelBodyHeader.tsx
@@ -1,10 +1,12 @@
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
+import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
+import { Account, AccountLike } from "@ledgerhq/types-live";
+import invariant from "invariant";
 import React, { memo } from "react";
 import Box from "~/renderer/components/Box";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { Account, AccountLike } from "@ledgerhq/types-live";
 import EditOperationPanel from "~/renderer/components/OperationsList/EditOperationPanel";
-import { getStuckAccountAndOperation } from "@ledgerhq/live-common/operation";
-import invariant from "invariant";
 
 type Props = {
   account: AccountLike;
@@ -12,11 +14,16 @@ type Props = {
 };
 
 const EditStuckTransactionPanelBodyHeader = ({ account, parentAccount }: Props) => {
-  const editEthTx = useFeature("editEthTx");
-  if (!editEthTx?.enabled) {
+  invariant(account, "account required");
+
+  const mainAccount = getMainAccount(account, parentAccount);
+  const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
+  const isCurrencySupported =
+    params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) || false;
+
+  if (!isEditEvmTxEnabled || !isCurrencySupported) {
     return null;
   }
-  invariant(account, "account required");
   // check if there is a stuck transaction. If so, display a warning panel with "speed up or cancel" button
   const stuckAccountAndOperation = getStuckAccountAndOperation(account, parentAccount);
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/steps/StepMethod.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/steps/StepMethod.tsx
@@ -90,7 +90,7 @@ const StepMethod = ({
   }, [canCancel, setEditType]);
 
   const handleLearnMoreClick = useCallback(() => {
-    openURL(urls.editEthTx.learnMore);
+    openURL(urls.editEvmTx.learnMore);
   }, []);
 
   return (

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditOperationPanel.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditOperationPanel.tsx
@@ -1,11 +1,12 @@
+import { getMainAccount } from "@ledgerhq/coin-framework/account/helpers";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { Box, Flex } from "@ledgerhq/native-ui";
+import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
+import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
+import { useNavigation } from "@react-navigation/core";
 import React, { memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Box, Flex } from "@ledgerhq/native-ui";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { useNavigation } from "@react-navigation/core";
-import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { useTheme } from "styled-components/native";
-
 import LText from "../../../components/LText";
 import Link from "../../../components/wrappedUi/Link";
 import { NavigatorName, ScreenName } from "../../../const";
@@ -13,7 +14,7 @@ import { NavigatorName, ScreenName } from "../../../const";
 type EditOperationPanelProps = {
   isOperationStuck: boolean;
   operation: Operation;
-  account: AccountLike | null | undefined;
+  account: AccountLike;
   parentAccount: Account | null | undefined;
   onPress?: () => void;
 };
@@ -26,9 +27,13 @@ const EditOperationPanelComponent = ({
   onPress,
 }: EditOperationPanelProps) => {
   const { t } = useTranslation();
-  const editEthTxFeature = useFeature("editEthTx");
   const navigation = useNavigation();
   const { colors } = useTheme();
+
+  const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
+  const mainAccount = getMainAccount(account, parentAccount);
+  const isCurrencySupported =
+    params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) || false;
 
   const onLinkPress = useCallback(() => {
     onPress && onPress();
@@ -41,7 +46,7 @@ const EditOperationPanelComponent = ({
     }
   }, [account, parentAccount, operation, navigation, onPress]);
 
-  if (!editEthTxFeature?.enabled) {
+  if (!isEditEvmTxEnabled || !isCurrencySupported) {
     return null;
   }
 

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -231,7 +231,7 @@ function MethodSelectionComponent({ navigation, route }: Props) {
         </SelectableList>
         <LText
           style={{ marginTop: 8, textDecorationLine: "underline" }}
-          onPress={() => Linking.openURL(urls.editEthTx.learnMore)}
+          onPress={() => Linking.openURL(urls.editEvmTx.learnMore)}
         >
           {t("editTransaction.learnMore")}
         </LText>

--- a/apps/ledger-live-mobile/src/utils/urls.tsx
+++ b/apps/ledger-live-mobile/src/utils/urls.tsx
@@ -219,7 +219,7 @@ export const urls = {
     myLedger: "ledgerlive://myledger",
   },
   domainService: "https://support.ledger.com/hc/articles/9710787581469?docs=true",
-  editEthTx: {
+  editEvmTx: {
     learnMore: "https://support.ledger.com/hc/articles/9756122596765?support=true",
   },
   genuineCheck: {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -86,7 +86,6 @@ export const DEFAULT_FEATURES: Features = {
   ptxServiceCtaScreens: DEFAULT_FEATURE,
   customImage: DEFAULT_FEATURE,
   referralProgramDesktopBanner: DEFAULT_FEATURE,
-  editEthTx: DEFAULT_FEATURE,
   disableNftLedgerMarket: DEFAULT_FEATURE,
   disableNftRaribleOpensea: DEFAULT_FEATURE,
   disableNftSend: DEFAULT_FEATURE,
@@ -133,6 +132,11 @@ export const DEFAULT_FEATURES: Features = {
   },
 
   domainInputResolution: {
+    enabled: false,
+    params: { supportedCurrencyIds: ["ethereum"] },
+  },
+
+  editEvmTx: {
     enabled: false,
     params: { supportedCurrencyIds: ["ethereum"] },
   },

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -169,7 +169,7 @@ export type Features = CurrencyFeatures & {
   stakePrograms: Feature_StakePrograms;
   portfolioExchangeBanner: Feature_PortfolioExchangeBanner;
   objkt: Feature_Objkt;
-  editEthTx: Feature_EditEthTx;
+  editEvmTx: Feature_EditEvmTx;
   stakeAccountBanner: Feature_StakeAccountBanner;
   newsfeedPage: Feature_NewsfeedPage;
   domainInputResolution: Feature_DomainInputResolution;
@@ -382,6 +382,10 @@ export type Feature_DomainInputResolution = Feature<{
   supportedCurrencyIds: string[];
 }>;
 
+export type Feature_EditEvmTx = Feature<{
+  supportedCurrencyIds: string[];
+}>;
+
 export type Feature_FirebaseEnvironmentReadOnly = Feature<{
   comment: string;
   project: string;
@@ -482,7 +486,6 @@ export type Feature_PtxServiceCtaExchangeDrawer = DefaultFeature;
 export type Feature_PtxServiceCtaScreens = DefaultFeature;
 export type Feature_PortfolioExchangeBanner = DefaultFeature;
 export type Feature_Objkt = DefaultFeature;
-export type Feature_EditEthTx = DefaultFeature;
 export type Feature_ProtectServicesDiscoverDesktop = DefaultFeature;
 export type Feature_ListAppsV2minor1 = DefaultFeature;
 export type Feature_BrazeLearn = DefaultFeature;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In order to fine tune control of the rollout of the edit evm tx feature, replace the default global (enable / disable) feature flag with a more granular one allowing to specify for which currencies this feature is enabled.

- rename `editEthTx` to `editEvmTx` in urls configs
- rename `editEthTx` to `editEvmTx` in feature flag configs
- update the type of `editEvmTx` feature flag to add `supportedCurrencyId` param

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10138
- https://github.com/LedgerHQ/ledger-live/pull/4886

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] ~`npx changeset` was attached.~ Not needed here since done in main PR
- [x] ~**Covered by automatic tests.**~ Not relevant here
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Feature flag renamed affecting LLD and LLM
  - The feature can now be enabled for a subset of EVM currencies

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
