### PR TITLE
LIVE-10155/Chore: mocking RxJS timer in unit tests

### DIFF
--- a/.changeset/cool-lemons-develop.md
+++ b/.changeset/cool-lemons-develop.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+chore: mocking RxJS timer in unit tests
+
+In order to not depend on real time during tests

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
@@ -5,6 +5,18 @@ import { concatMap } from "rxjs/operators";
 import { TransportRef } from "../transports/core";
 import { aTransportRefBuilder } from "../mocks/aTransportRef";
 
+// Needs to mock the timer from rxjs used in the retry mechanism
+jest.mock("rxjs", () => {
+  const originalModule = jest.requireActual("rxjs");
+
+  return {
+    ...originalModule,
+    timer: jest.fn(() => {
+      return of(1);
+    }),
+  };
+});
+
 describe("sharedLogicTaskWrapper", () => {
   const task = jest.fn();
   const wrappedTask = sharedLogicTaskWrapper<void, { type: "data" }>(task);
@@ -278,7 +290,10 @@ describe("retryOnErrorsCommandWrapper", () => {
   describe("When the command throws an error that is set to be handled by the wrapper, and this error can be retried an infinite number of times", () => {
     it("should retry infinitely, without throwing an error, until a correct event is emitted", done => {
       let counter = 0;
-      const randomNumberOfRetries = Math.floor(Math.random() * 10 + 5);
+
+      // The default retry time is 500ms: testing a total time higher than the 5000ms that triggers a Jest timeout
+      // as the time should be mocked/faked
+      const randomNumberOfRetries = Math.floor(Math.random() * 5) + 11;
 
       command.mockReturnValue(
         of({ type: "data" }).pipe(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Support: fixing flaky tests
We wanted to randomly test a number of retries, but this was taking more time than the allowed Jest timeout (5000ms)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10155](https://ledgerhq.atlassian.net/browse/LIVE-10155)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10155]: https://ledgerhq.atlassian.net/browse/LIVE-10155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ