### PR TITLE
LIVE-10155/Chore: refactoring deprecated retryWhen

### DIFF
--- a/.changeset/ten-cheetahs-allow.md
+++ b/.changeset/ten-cheetahs-allow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+chore: refactoring deprecated retryWhen

--- a/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
@@ -14,7 +14,7 @@ import { sharedLogicTaskWrapper } from "../tasks/core";
 
 // Needed for rxjs timeout
 jest.useFakeTimers();
-// Needs to mock the timer from rxjs used in the task retry mechanism (`retryWhen` with `timer`)
+// Needs to mock the timer from rxjs used in the task retry mechanism (`retry` with `timer`)
 jest.mock("rxjs", () => {
   const originalModule = jest.requireActual("rxjs");
 

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
@@ -212,7 +212,7 @@ describe("retryOnErrorsCommandWrapper", () => {
           concatMap(_event => {
             counter++;
 
-            // Throws an error even after the limit is reached
+            // Always throws an error, exceeding the set max retry
             return throwError(
               () => new DisconnectedDevice(`Handled error max ${disconnectedDeviceMaxRetries}`),
             );

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -7,7 +7,7 @@ import {
   createCustomErrorClass,
 } from "@ledgerhq/errors";
 import { Observable, from, of, throwError, timer } from "rxjs";
-import { catchError, concatMap, retryWhen, switchMap, timeout } from "rxjs/operators";
+import { catchError, concatMap, retry, switchMap, timeout } from "rxjs/operators";
 import { Transport, TransportRef } from "../transports/core";
 
 export type SharedTaskEvent = { type: "error"; error: Error; retrying: boolean };
@@ -35,38 +35,33 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
       return task(args)
         .pipe(
           timeout(defaultTimeoutOverride ?? NO_RESPONSE_TIMEOUT_MS),
-          retryWhen(attempts =>
-            attempts.pipe(
-              // concatMap to sequentially handle errors
-              concatMap(error => {
-                let acceptedError = false;
+          retry({
+            delay: error => {
+              let acceptedError = false;
 
-                // - LockedDeviceError and UnresponsiveDeviceError: on every transport if there is a device but it is locked
-                // - CantOpenDevice: it can come from hw-transport-node-hid-singleton/TransportNodeHid
-                //   or react-native-hw-transport-ble/BleTransport when no device is found
-                // - DisconnectedDevice: it can come from TransportNodeHid while switching app
-                if (
-                  error instanceof LockedDeviceError ||
-                  error instanceof UnresponsiveDeviceError ||
-                  error instanceof CantOpenDevice ||
-                  error instanceof DisconnectedDevice ||
-                  error instanceof TransportRaceCondition
-                ) {
-                  // Emits to the action an error event so it is aware of it (for ex locked device) before retrying
-                  const event: SharedTaskEvent = {
-                    type: "error",
-                    error,
-                    retrying: true,
-                  };
-                  subscriber.next(event);
-                  acceptedError = true;
-                }
-
-                return acceptedError ? timer(RETRY_ON_ERROR_DELAY_MS) : throwError(() => error);
-              }),
-            ),
-          ),
-
+              // - LockedDeviceError and UnresponsiveDeviceError: on every transport if there is a device but it is locked
+              // - CantOpenDevice: it can come from hw-transport-node-hid-singleton/TransportNodeHid
+              //   or react-native-hw-transport-ble/BleTransport when no device is found
+              // - DisconnectedDevice: it can come from TransportNodeHid while switching app
+              if (
+                error instanceof LockedDeviceError ||
+                error instanceof UnresponsiveDeviceError ||
+                error instanceof CantOpenDevice ||
+                error instanceof DisconnectedDevice ||
+                error instanceof TransportRaceCondition
+              ) {
+                // Emits to the action an error event so it is aware of it (for ex locked device) before retrying
+                const event: SharedTaskEvent = {
+                  type: "error",
+                  error,
+                  retrying: true,
+                };
+                subscriber.next(event);
+                acceptedError = true;
+              }
+              return acceptedError ? timer(RETRY_ON_ERROR_DELAY_MS) : throwError(() => error);
+            },
+          }),
           catchError((error: Error) => {
             // Emits the error to the action, without throwing
             return of<SharedTaskEvent>({ type: "error", error, retrying: false });
@@ -138,40 +133,37 @@ export function retryOnErrorsCommandWrapper<CommandArgsWithoutTransportType, Com
           transport: transportRef.current,
         });
       }),
-      retryWhen(attempts =>
-        attempts.pipe(
-          // concatMap to sequentially handle errors
-          concatMap(error => {
-            let isAllowedError = false;
+      retry({
+        delay: error => {
+          let isAllowedError = false;
 
-            if (latestErrorName !== error.name) {
-              sameErrorInARowCount = 0;
-            } else {
-              sameErrorInARowCount++;
-            }
+          if (latestErrorName !== error.name) {
+            sameErrorInARowCount = 0;
+          } else {
+            sameErrorInARowCount++;
+          }
 
-            latestErrorName = error.name;
+          latestErrorName = error.name;
 
-            for (const { errorClass, maxRetries } of allowedErrors) {
-              if (error instanceof errorClass) {
-                if (maxRetries === "infinite" || sameErrorInARowCount < maxRetries) {
-                  isAllowedError = true;
-                }
-
-                break;
+          for (const { errorClass, maxRetries } of allowedErrors) {
+            if (error instanceof errorClass) {
+              if (maxRetries === "infinite" || sameErrorInARowCount < maxRetries) {
+                isAllowedError = true;
               }
-            }
 
-            if (isAllowedError) {
-              // Retries the whole pipe chain after the delay
-              return timer(RETRY_ON_ERROR_DELAY_MS);
+              break;
             }
+          }
 
-            // If the error is not part of the allowed errors, it is thrown
-            return throwError(() => error);
-          }),
-        ),
-      ),
+          if (isAllowedError) {
+            // Retries the whole pipe chain after the delay
+            return timer(RETRY_ON_ERROR_DELAY_MS);
+          }
+
+          // If the error is not part of the allowed errors, it is thrown
+          return throwError(() => error);
+        },
+      }),
     );
   };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Part of https://github.com/LedgerHQ/ledger-live/pull/5413

Chore: refactoring deprecated `retryWhen` in `libs/ledger-live-common/src/deviceSDK/tasks/core.ts`

<details>
  <summary>Demo Android - FW update success</summary>


https://github.com/LedgerHQ/ledger-live/assets/15096913/cfb8f1f2-a377-4a6d-b974-791a9440cc74



</details>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10155](https://ledgerhq.atlassian.net/browse/LIVE-10155)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** Normally none, but we need to check LLD and LLM firmware update



---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10155]: https://ledgerhq.atlassian.net/browse/LIVE-10155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ