### PR TITLE
[FEATURE] Polkadot network upgrade: sunset of stash/controller feature 

### DIFF
--- a/.changeset/gentle-tips-turn.md
+++ b/.changeset/gentle-tips-turn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-polkadot": minor
+---
+
+Polkadot network upgrade: sunset of stash/controller feature

--- a/libs/coin-polkadot/src/deviceTransactionConfig.ts
+++ b/libs/coin-polkadot/src/deviceTransactionConfig.ts
@@ -49,7 +49,7 @@ function getDeviceTransactionConfig({
   transaction: Transaction;
   status: TransactionStatus;
 }): Array<DeviceTransactionField> {
-  const { mode, recipient, rewardDestination } = transaction;
+  const { mode, rewardDestination } = transaction;
   const { amount } = status;
   const mainAccount = getMainAccount(account, parentAccount) as PolkadotAccount;
   let fields: { type: string; label: string; value?: string }[] = [];
@@ -80,11 +80,6 @@ function getDeviceTransactionConfig({
           type: "text",
           label: "Staking",
           value: "Bond",
-        });
-        fields.push({
-          type: "text",
-          label: "Controller",
-          value: recipient,
         });
         fields.push({
           type: "text",
@@ -170,14 +165,6 @@ function getDeviceTransactionConfig({
         type: "text",
         label: "Staking",
         value: "Set controller",
-      });
-      fields.push({
-        type: "text",
-        label: "Controller",
-        value:
-          // NOTE: I added this here as TokenAccount and ChildAccount
-          // both don't have freshAddress
-          account.type === "Account" ? account.freshAddress : mainAccount.freshAddress,
       });
       break;
 

--- a/libs/coin-polkadot/src/js-buildTransaction.ts
+++ b/libs/coin-polkadot/src/js-buildTransaction.ts
@@ -36,8 +36,6 @@ const getExtrinsicParams = (a: PolkadotAccount, t: Transaction): ExtrinsicParams
           pallet: "staking",
           name: "bond",
           args: {
-            // Spec choice: we always set the account as both the stash and its controller
-            controller: a.freshAddress,
             value: t.amount.toString(),
             // The rewards destination. Can be "Stash", "Staked", "Controller" or "{ Account: accountId }"".
             payee: t.rewardDestination || "Stash",
@@ -93,7 +91,7 @@ const getExtrinsicParams = (a: PolkadotAccount, t: Transaction): ExtrinsicParams
       return {
         pallet: "staking",
         name: "setController",
-        args: { controller: a.freshAddress },
+        args: {},
       };
 
     case "nominate":


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Following an update of the Polkadot protocol, this PR removes the `controller` arg from the calls in our Polkadot integration.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-8064
- https://github.com/paritytech/substrate/pull/14039

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Polkadot integration on LLD and LLC
  - The staking feature of the Polkadot coin should still work fine

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
