### PR TITLE
[BUGFIX][LIVE-10206] App crash on LLM when viewing non evm operations details

### DIFF
--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Content.tsx
@@ -144,7 +144,7 @@ export default function Content({
   const { EditOperationPanel: SpecificEditOperationPanel = undefined } =
     byFamiliesEditOperationPanel[
       mainAccount.currency.family as keyof typeof byFamiliesEditOperationPanel
-    ];
+    ] || {};
 
   const urlFeesInfo =
     specificOperationDetails &&


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix _Cannot read property 'EditOperationPanel' of undefined_ error causing a crash on LLM

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10206

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] ~`npx changeset` was attached.~ *Not relevant*
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM, when opening a non evm tx operation details, the app does not crash

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
