### PR TITLE
test(BridgeSync): add a test that confirm LIVE-3221 is already fixed

### DIFF
--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.test.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.test.tsx
@@ -8,6 +8,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { genAccount } from "../../mock/account";
 import { BridgeSync } from "./BridgeSync";
 import { setSupportedCurrencies } from "../../currencies";
+import { getAccountBridge } from "..";
 
 jest.setTimeout(30000);
 
@@ -32,12 +33,26 @@ describe("BridgeSync", () => {
   test("executes a sync at start tracked as reason=initial", async () => {
     await new Promise(resolve => {
       const BTC = getCryptoCurrencyById("bitcoin");
-      const accounts = [genAccount("btc1", { currency: BTC })];
+      const account = genAccount("btc1", { currency: BTC });
+      const futureOpLength = account.operations.length;
+      // we remove the first operation to feed it back as a broadcasted one, the mock impl will make it go back to operations
+      const lastOp = account.operations.splice(0, 1)[0];
+      getAccountBridge(account).broadcast({
+        account,
+        signedOperation: {
+          operation: lastOp,
+          signature: "",
+        },
+      });
+      const accounts = [account];
+      expect(accounts[0].operations.length).toBe(futureOpLength - 1);
+
       function track(type, opts) {
         if (type === "SyncSuccess") {
           expect(opts).toMatchObject({
             reason: "initial",
             currencyName: "Bitcoin",
+            operationsLength: futureOpLength,
           });
           resolve(null);
         }


### PR DESCRIPTION


### 📝 Description

we like bugfixes that are already fixed. I added a test that confirm it is fixed.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-3221 <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no changes

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
