### PR TITLE
test: fix live-app flaky test [LIVE-10145]

### DIFF
--- a/apps/ledger-live-desktop/index-types.d.ts
+++ b/apps/ledger-live-desktop/index-types.d.ts
@@ -15,7 +15,7 @@ declare module "*.mp4";
 
 type Store = import("redux").Store;
 type Device = import("@ledgerhq/live-common/hw/actions/types").Device;
-type ReplaySubject = import("rxjs").ReplaySubject;
+type ReplaySubject = import("rxjs").ReplaySubject<unknown>;
 type ListAppResult = import("@ledgerhq/live-common/apps/types").ListAppsResult;
 type TransactionRaw = import("@ledgerhq/live-common/generated/types").TransactionRaw;
 type Transaction = import("@ledgerhq/live-common/generated/types").Transaction;

--- a/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
@@ -82,9 +82,11 @@ const VerifyOnDevice = ({
     if (!device || skipDevice) return null;
     try {
       if (getEnv("MOCK")) {
-        setTimeout(() => {
-          onAddressVerified(true);
-        }, 3000);
+        window.mock.events.subject.subscribe({
+          complete() {
+            onAddressVerified(true);
+          },
+        });
       } else {
         await firstValueFrom(
           getAccountBridge(mainAccount).receive(mainAccount, {

--- a/apps/ledger-live-desktop/tests/specs/services/liveapp-sdk.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/liveapp-sdk.spec.ts
@@ -86,6 +86,7 @@ test("Live App SDK methods @smoke", async ({ page }) => {
   });
 
   await test.step("Verify Address - address output", async () => {
+    await deviceAction.complete();
     await modal.waitForModalToDisappear();
     await liveAppWebview.waitForCorrectTextInWebview("1xey");
   });

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -249,6 +249,7 @@ test("Wallet API methods @smoke", async ({ page }) => {
     });
 
     await deviceAction.openApp();
+    await deviceAction.complete();
     await modal.waitForModalToDisappear();
     await expect(response).resolves.toStrictEqual({
       id,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixing some flakiness in the live-app sdk test, it was using a timeout to close the modal and imitate a validation on the device.
Here we instead use the complete mocked event to wait on the test to be finish with the screenshot.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10145](https://ledgerhq.atlassian.net/browse/LIVE-10145)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached. No need for test stuff
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10145]: https://ledgerhq.atlassian.net/browse/LIVE-10145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ