### PR TITLE
Bugfix/live 10201 pairing secure channel

### DIFF
--- a/.changeset/metal-lamps-explain.md
+++ b/.changeset/metal-lamps-explain.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+fix: race condition on exchange issue in PairDevices
+
+- Due to an incorrect usage of RxJS firstValueFrom
+- Also improve observability with tracing

--- a/apps/ledger-live-mobile/src/screens/PairDevices/RenderError.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/RenderError.tsx
@@ -21,6 +21,7 @@ import IconArrowRight from "../../icons/ArrowRight";
 import { urls } from "@utils/urls";
 import LocationDisabled from "../../components/RequiresLocation/LocationDisabled";
 import LocationPermissionDenied from "../../components/RequiresLocation/LocationPermissionDenied";
+import { trace } from "@ledgerhq/logs";
 
 type Props = {
   error: HwTransportError | DeprecatedError | Error;
@@ -80,6 +81,21 @@ function RenderError({ error, status, onBypassGenuine, onRetry }: Props) {
       : isGenuineCheckSkippableError
       ? new GenuineCheckFailed()
       : null;
+
+  trace({
+    type: "hw",
+    message: `Rendering error: ${error}`,
+    data: {
+      error,
+      outerError,
+      isPairingStatus,
+      isBrokenPairing,
+      isGenuineCheckSkippableError,
+      isGenuineCheckStatus,
+      isFirmwareNotRecognized,
+    },
+    context: { component: "PairDevices/RenderError" },
+  });
 
   return (
     <Flex flex={1}>

--- a/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PairDevices/index.tsx
@@ -1,8 +1,9 @@
-import React, { useReducer, useCallback, useEffect, useRef } from "react";
+import React, { useReducer, useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useDispatch, useSelector } from "react-redux";
 import { timeout, tap } from "rxjs/operators";
+import { v4 as uuid } from "uuid";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
 import getDeviceName from "@ledgerhq/live-common/hw/getDeviceName";
 import { listApps } from "@ledgerhq/live-common/apps/hw";
@@ -31,7 +32,8 @@ import { RootComposite, StackNavigatorProps } from "../../components/RootNavigat
 import { BaseNavigatorStackParamList } from "../../components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "../../const";
 import { BaseOnboardingNavigatorParamList } from "../../components/RootNavigator/types/BaseOnboardingNavigator";
-import { firstValueFrom } from "rxjs";
+import { lastValueFrom } from "rxjs";
+import { LocalTracer } from "@ledgerhq/logs";
 
 type NavigationProps = RootComposite<
   | StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.PairDevices>
@@ -75,9 +77,11 @@ const initialState: State = {
 };
 
 function PairDevicesInner({ navigation, route }: NavigationProps) {
+  const [tracer] = useState(() => new LocalTracer("ble-ui", { component: "PairDevicesInner" }));
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const dispatchRedux = useDispatch();
   const [{ error, status, device, skipCheck, name }, dispatch] = useReducer(reducer, initialState);
+
   const unmounted = useRef(false);
   useEffect(
     () => () => {
@@ -126,16 +130,15 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
       });
 
       try {
-        const transport = await TransportBLE.open(bleDevice.id);
+        const transport = await TransportBLE.open(bleDevice.id, undefined, {
+          correlationId: uuid(),
+          origin: tracer.getContext(),
+        });
         if (unmounted.current) return;
 
         try {
           const deviceInfo = await getDeviceInfo(transport);
-          if (__DEV__)
-            // eslint-disable-next-line no-console
-            console.log({
-              deviceInfo,
-            });
+          tracer.trace("Device info", { deviceInfo });
 
           if (unmounted.current) return;
           dispatch({
@@ -143,10 +146,14 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
             payload: device,
           });
           let appsInstalled;
-          await firstValueFrom(
+
+          // Waits until listApps completes or emits and error
+          await lastValueFrom(
             listApps(transport, deviceInfo).pipe(
               timeout(GENUINE_CHECK_TIMEOUT),
               tap(e => {
+                tracer.trace("Event from listApps", { eventType: e.type });
+
                 if (e.type === "result") {
                   appsInstalled = e.result && e.result.installed.length;
 
@@ -157,19 +164,23 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
                       dispatchRedux(setHasInstalledAnyApp(false));
                     }
                   }
-
-                  return;
                 }
 
                 dispatch({
                   type: "allowManager",
-                  payload: e.type === "allow-manager-requested",
+                  payload:
+                    e.type === "allow-manager-requested" ||
+                    e.type === "device-permission-requested",
                 });
               }),
             ),
           );
           if (unmounted.current) return;
+
+          // listApps has completed, a new APDU can be sent
           const name = (await getDeviceName(transport)) || device.deviceName || "";
+          tracer.trace("Fetched device name", { name });
+
           if (unmounted.current) return;
           dispatchRedux(
             addKnownDevice({
@@ -205,7 +216,7 @@ function PairDevicesInner({ navigation, route }: NavigationProps) {
         onError(error as Error);
       }
     },
-    [dispatch, dispatchRedux, hasCompletedOnboarding, onError],
+    [dispatchRedux, hasCompletedOnboarding, onError, tracer],
   );
   const onBypassGenuine = useCallback(() => {
     navigation.setParams({
@@ -306,6 +317,7 @@ function reducer(
         device: action.payload as Device,
       };
 
+    // Currently allowManager is not used to display any UI component
     case "allowManager":
       return { ...state, genuineAskedOnDevice: !!action.payload };
 

--- a/libs/ledger-live-common/src/hw/getDeviceName.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceName.test.ts
@@ -1,38 +1,37 @@
+import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import getDeviceName from "./getDeviceName";
 
-const mockTransportGenerator = out => ({ send: async () => out });
+const mockedSend = jest.fn();
+const mockedTransport = aTransportBuilder({ send: mockedSend });
 
 describe("getDeviceName", () => {
   test("should return name if available", async () => {
-    const mockedTransport = mockTransportGenerator(
-      Buffer.from("646576696365206e616d659000", "hex"),
-    );
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore next-line
+    mockedSend.mockResolvedValue(Buffer.from("646576696365206e616d659000", "hex"));
+
     const res = await getDeviceName(mockedTransport);
+
     expect(res).toMatch("device name");
   });
 
   test("should return empty name when the device is not onboarded", async () => {
-    const mockedTransport = mockTransportGenerator(Buffer.from("bababababababa6d07", "hex"));
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore next-line
+    mockedSend.mockResolvedValue(Buffer.from("bababababababa6d07", "hex"));
+
     const res = await getDeviceName(mockedTransport);
-    await expect(res).toMatch("");
+
+    expect(res).toMatch("");
   });
 
   test("should return empty name when the device is not onboarded #2", async () => {
-    const mockedTransport = mockTransportGenerator(Buffer.from("bababababababa6611", "hex"));
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore next-line
+    mockedSend.mockResolvedValue(Buffer.from("bababababababa6611", "hex"));
+
     const res = await getDeviceName(mockedTransport);
-    await expect(res).toMatch("");
+
+    expect(res).toMatch("");
   });
 
   test("unexpected bootloader or any other code, should throw", async () => {
-    const mockedTransport = mockTransportGenerator(Buffer.from("662d", "hex"));
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore next-line
+    mockedSend.mockResolvedValue(Buffer.from("662d", "hex"));
+
     await expect(getDeviceName(mockedTransport)).rejects.toThrow(Error);
   });
 });

--- a/libs/ledger-live-common/src/hw/getDeviceName.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceName.ts
@@ -1,8 +1,20 @@
 import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { LocalTracer } from "@ledgerhq/logs";
 
 export default async (transport: Transport): Promise<string> => {
-  // NB Prevents bad apdu response for LNX
-  await transport.send(0xe0, 0x50, 0x00, 0x00).catch(() => {});
+  const tracer = new LocalTracer("hw", {
+    transport: transport.getTraceContext(),
+    function: "getDeviceName",
+  });
+  tracer.trace("Start");
+
+  try {
+    // Legacy: prevents bad apdu response for LNX
+    await transport.send(0xe0, 0x50, 0x00, 0x00);
+  } catch (error) {
+    tracer.trace(`Error on 0xe0500000: ${error}`, { error });
+  }
+  tracer.trace("Sent cleaning 0xe0500000");
 
   const res = await transport.send(0xe0, 0xd2, 0x00, 0x00, Buffer.from([]), [
     StatusCodes.OK,
@@ -11,6 +23,7 @@ export default async (transport: Transport): Promise<string> => {
   ]);
 
   const status = res.readUInt16BE(res.length - 2);
+  tracer.trace("Result status from 0xe0d20000", { status });
 
   switch (status) {
     case StatusCodes.OK:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In the PR [Update to RxJS 7](https://github.com/LedgerHQ/ledger-live/pull/4546) the `toPromise` method got deprecated and replaced everywhere by `firstValueFrom`. 
But [firstValueFrom](https://rxjs.dev/api/index/function/firstValueFrom) creates a Promise that resolves as soon as the **first value** is emitted by the observable.
Because of this, we are not waiting for the `listApps` to complete, and if a secure channel need to be created, we don't wait and go directly to the next code block. The next code block in this old component would send an APDU to get the name of the device, which would create a "race condition" because an exchange was already ongoing.

It was not the case for [toPromise](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/topromise.md): it would create a Promise which contains the last value from the Observable.

Solution:
- Replace it by [lastValueFrom](https://rxjs.dev/api/index/function/lastValueFrom) as in our case we want `listApps` to complete (or emit an error).
- More logs

Demo:

<details>
  <summary>Demo Android</summary>


https://github.com/LedgerHQ/ledger-live/assets/15096913/32e3f0c5-0f15-459b-894d-7e0868801977



</details>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10201](https://ledgerhq.atlassian.net/browse/LIVE-10201)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->


### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10201]: https://ledgerhq.atlassian.net/browse/LIVE-10201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ