### PR TITLE
[SUPPORT] use currencies createTransaction in walletApiAdapter

### DIFF
--- a/.changeset/gentle-cups-remember.md
+++ b/.changeset/gentle-cups-remember.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+use-create-tx-in-wallet-api-adapter

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -39,6 +39,15 @@ const defaultConfig = {
   testRegex,
   transformIgnorePatterns: ["/node_modules/(?!|@babel/runtime/helpers/esm/)"],
   moduleDirectories: ["node_modules", "cli/node_modules"],
+  /**
+   * Added because of this error happening when using toMatchInlineSnapshot:
+   *     TypeError: prettier.resolveConfig.sync is not a function
+
+      at runPrettier (../../node_modules/.pnpm/jest-snapshot@28.1.3/node_modules/jest-snapshot/build/InlineSnapshots.js:319:30)
+   * 
+   * See: https://github.com/jestjs/jest/issues/14305#issuecomment-1627346697   
+   */
+  prettierPath: null,
 };
 
 export default {

--- a/libs/ledger-live-common/src/families/bitcoin/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/walletApiAdapter.test.ts
@@ -1,7 +1,7 @@
-import btc from "./walletApiAdapter";
+import { Account } from "@ledgerhq/types-live";
 import { BitcoinTransaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
 import BigNumber from "bignumber.js";
-import { Transaction } from "./types";
+import btc from "./walletApiAdapter";
 
 describe("getPlatformTransactionSignFlowInfos", () => {
   describe("should properly get infos for BTC platform tx", () => {
@@ -12,20 +12,31 @@ describe("getPlatformTransactionSignFlowInfos", () => {
         recipient: "0xABCDEF",
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: btcPlatformTx.family,
-        amount: btcPlatformTx.amount,
-        recipient: btcPlatformTx.recipient,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        btc.getWalletAPITransactionSignFlowInfos(btcPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = btc.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: btcPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(false);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "family": "bitcoin",
+  "feePerByte": null,
+  "feesStrategy": "medium",
+  "networkInfo": null,
+  "rbf": false,
+  "recipient": "0xABCDEF",
+  "useAllAmount": false,
+  "utxoStrategy": Object {
+    "excludeUTXOs": Array [],
+    "strategy": 0,
+  },
+}
+`);
     });
 
     test("with fees provided", () => {
@@ -36,22 +47,82 @@ describe("getPlatformTransactionSignFlowInfos", () => {
         feePerByte: new BigNumber(300),
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: btcPlatformTx.family,
-        amount: btcPlatformTx.amount,
-        recipient: btcPlatformTx.recipient,
-        feePerByte: btcPlatformTx.feePerByte,
-        feesStrategy: null,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        btc.getWalletAPITransactionSignFlowInfos(btcPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = btc.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: btcPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(true);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "family": "bitcoin",
+  "feePerByte": "300",
+  "feesStrategy": null,
+  "networkInfo": null,
+  "rbf": false,
+  "recipient": "0xABCDEF",
+  "useAllAmount": false,
+  "utxoStrategy": Object {
+    "excludeUTXOs": Array [],
+    "strategy": 0,
+  },
+}
+`);
+    });
+
+    test("with opReturnData provided", () => {
+      const btcPlatformTx: WalletAPITransaction = {
+        family: "bitcoin",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        opReturnData: Buffer.from("hello world"),
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = btc.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: btcPlatformTx,
+        account: {} as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "family": "bitcoin",
+  "feePerByte": null,
+  "feesStrategy": "medium",
+  "networkInfo": null,
+  "opReturnData": Object {
+    "data": Array [
+      104,
+      101,
+      108,
+      108,
+      111,
+      32,
+      119,
+      111,
+      114,
+      108,
+      100,
+    ],
+    "type": "Buffer",
+  },
+  "rbf": false,
+  "recipient": "0xABCDEF",
+  "useAllAmount": false,
+  "utxoStrategy": Object {
+    "excludeUTXOs": Array [],
+    "strategy": 0,
+  },
+}
+`);
     });
   });
 });

--- a/libs/ledger-live-common/src/families/bitcoin/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/walletApiAdapter.ts
@@ -4,6 +4,7 @@ import {
   ConvertToLiveTransaction,
   GetWalletAPITransactionSignFlowInfos,
 } from "../../wallet-api/types";
+import createTransaction from "./js-createTransaction";
 import { Transaction } from "./types";
 
 const CAN_EDIT_FEES = true;
@@ -13,27 +14,42 @@ const areFeesProvided: AreFeesProvided<WalletAPIBitcoinTransaction> = tx => !!tx
 const convertToLiveTransaction: ConvertToLiveTransaction<
   WalletAPIBitcoinTransaction,
   Transaction
-> = tx => {
-  const hasFeesProvided = areFeesProvided(tx);
+> = ({ walletApiTransaction }) => {
+  const hasFeesProvided = areFeesProvided(walletApiTransaction);
 
-  const liveTx: Partial<Transaction> = {
-    ...tx,
-    amount: tx.amount,
-    recipient: tx.recipient,
-    feePerByte: tx.feePerByte,
-  };
+  const liveTx: Transaction = createTransaction();
 
-  return hasFeesProvided ? { ...liveTx, feesStrategy: null } : liveTx;
+  if (walletApiTransaction.amount) {
+    liveTx.amount = walletApiTransaction.amount;
+  }
+
+  if (walletApiTransaction.recipient) {
+    liveTx.recipient = walletApiTransaction.recipient;
+  }
+
+  if (walletApiTransaction.feePerByte) {
+    liveTx.feePerByte = walletApiTransaction.feePerByte;
+  }
+
+  if (walletApiTransaction.opReturnData) {
+    liveTx.opReturnData = walletApiTransaction.opReturnData;
+  }
+
+  if (hasFeesProvided) {
+    liveTx.feesStrategy = null;
+  }
+
+  return liveTx;
 };
 
 const getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<
   WalletAPIBitcoinTransaction,
   Transaction
-> = tx => {
+> = ({ walletApiTransaction, account }) => {
   return {
     canEditFees: CAN_EDIT_FEES,
-    liveTx: convertToLiveTransaction(tx),
-    hasFeesProvided: areFeesProvided(tx),
+    liveTx: convertToLiveTransaction({ walletApiTransaction, account }),
+    hasFeesProvided: areFeesProvided(walletApiTransaction),
   };
 };
 

--- a/libs/ledger-live-common/src/families/evm/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/evm/walletApiAdapter.test.ts
@@ -1,5 +1,4 @@
-import { DEFAULT_NONCE } from "@ledgerhq/coin-evm/createTransaction";
-import { Transaction } from "@ledgerhq/coin-evm/types/index";
+import { Account } from "@ledgerhq/types-live";
 import { EthereumTransaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
 import BigNumber from "bignumber.js";
 import evm from "./walletApiAdapter";
@@ -13,28 +12,32 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         recipient: "0xABCDEF",
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: "evm",
-        amount: ethPlatformTx.amount,
-        recipient: ethPlatformTx.recipient,
-        data: undefined,
-        gasLimit: undefined,
-        nonce: DEFAULT_NONCE,
-        customGasLimit: undefined,
-        feesStrategy: "medium",
-        maxFeePerGas: undefined,
-        maxPriorityFeePerGas: undefined,
-        type: 2,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        evm.getWalletAPITransactionSignFlowInfos(ethPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(false);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 0,
+  "family": "evm",
+  "feesStrategy": "medium",
+  "gasLimit": "21000",
+  "gasPrice": undefined,
+  "maxFeePerGas": undefined,
+  "maxPriorityFeePerGas": undefined,
+  "mode": "send",
+  "nonce": -1,
+  "recipient": "0xABCDEF",
+  "type": 2,
+  "useAllAmount": false,
+}
+`);
     });
 
     test("with fees provided for legacy tx", () => {
@@ -46,27 +49,33 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         gasLimit: new BigNumber(21000),
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: "evm",
-        amount: ethPlatformTx.amount,
-        recipient: ethPlatformTx.recipient,
-        gasPrice: ethPlatformTx.gasPrice,
-        gasLimit: ethPlatformTx.gasLimit,
-        customGasLimit: ethPlatformTx.gasLimit,
-        nonce: DEFAULT_NONCE,
-        data: undefined,
-        feesStrategy: "custom",
-        type: 0,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        evm.getWalletAPITransactionSignFlowInfos(ethPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(true);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 0,
+  "customGasLimit": "21000",
+  "family": "evm",
+  "feesStrategy": "custom",
+  "gasLimit": "21000",
+  "gasPrice": "300",
+  "maxFeePerGas": undefined,
+  "maxPriorityFeePerGas": undefined,
+  "mode": "send",
+  "nonce": -1,
+  "recipient": "0xABCDEF",
+  "type": 0,
+  "useAllAmount": false,
+}
+`);
     });
 
     test("with fees provided for eip1559 tx", () => {
@@ -79,28 +88,33 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         maxPriorityFeePerGas: new BigNumber(200),
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: "evm",
-        amount: ethPlatformTx.amount,
-        recipient: ethPlatformTx.recipient,
-        gasLimit: ethPlatformTx.gasLimit,
-        customGasLimit: ethPlatformTx.gasLimit,
-        maxFeePerGas: ethPlatformTx.maxFeePerGas,
-        maxPriorityFeePerGas: ethPlatformTx.maxPriorityFeePerGas,
-        nonce: DEFAULT_NONCE,
-        data: undefined,
-        feesStrategy: "custom",
-        type: 2,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        evm.getWalletAPITransactionSignFlowInfos(ethPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(true);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 0,
+  "customGasLimit": "21000",
+  "family": "evm",
+  "feesStrategy": "custom",
+  "gasLimit": "21000",
+  "gasPrice": undefined,
+  "maxFeePerGas": "300",
+  "maxPriorityFeePerGas": "200",
+  "mode": "send",
+  "nonce": -1,
+  "recipient": "0xABCDEF",
+  "type": 2,
+  "useAllAmount": false,
+}
+`);
     });
 
     test("with only gasLimit provided", () => {
@@ -111,28 +125,33 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         gasLimit: new BigNumber(21000),
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: "evm",
-        amount: ethPlatformTx.amount,
-        recipient: ethPlatformTx.recipient,
-        gasLimit: ethPlatformTx.gasLimit,
-        customGasLimit: ethPlatformTx.gasLimit,
-        feesStrategy: "medium",
-        maxFeePerGas: undefined,
-        maxPriorityFeePerGas: undefined,
-        nonce: DEFAULT_NONCE,
-        data: undefined,
-        type: 2,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        evm.getWalletAPITransactionSignFlowInfos(ethPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(false);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 0,
+  "customGasLimit": "21000",
+  "family": "evm",
+  "feesStrategy": "medium",
+  "gasLimit": "21000",
+  "gasPrice": undefined,
+  "maxFeePerGas": undefined,
+  "maxPriorityFeePerGas": undefined,
+  "mode": "send",
+  "nonce": -1,
+  "recipient": "0xABCDEF",
+  "type": 2,
+  "useAllAmount": false,
+}
+`);
     });
 
     test("with nonce provided", () => {
@@ -143,28 +162,124 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         nonce: 1,
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: "evm",
-        amount: ethPlatformTx.amount,
-        recipient: ethPlatformTx.recipient,
-        data: undefined,
-        gasLimit: undefined,
-        nonce: 1,
-        customGasLimit: undefined,
-        feesStrategy: "medium",
-        maxFeePerGas: undefined,
-        maxPriorityFeePerGas: undefined,
-        type: 2,
-      };
-
-      const { canEditFees, hasFeesProvided, liveTx } =
-        evm.getWalletAPITransactionSignFlowInfos(ethPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(false);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 0,
+  "family": "evm",
+  "feesStrategy": "medium",
+  "gasLimit": "21000",
+  "gasPrice": undefined,
+  "maxFeePerGas": undefined,
+  "maxPriorityFeePerGas": undefined,
+  "mode": "send",
+  "nonce": 1,
+  "recipient": "0xABCDEF",
+  "type": 2,
+  "useAllAmount": false,
+}
+`);
+    });
+
+    test("with data provided", () => {
+      const ethPlatformTx: WalletAPITransaction = {
+        family: "ethereum",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        data: Buffer.from("testBufferString"),
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: {} as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 0,
+  "data": Object {
+    "data": Array [
+      116,
+      101,
+      115,
+      116,
+      66,
+      117,
+      102,
+      102,
+      101,
+      114,
+      83,
+      116,
+      114,
+      105,
+      110,
+      103,
+    ],
+    "type": "Buffer",
+  },
+  "family": "evm",
+  "feesStrategy": "medium",
+  "gasLimit": "21000",
+  "gasPrice": undefined,
+  "maxFeePerGas": undefined,
+  "maxPriorityFeePerGas": undefined,
+  "mode": "send",
+  "nonce": -1,
+  "recipient": "0xABCDEF",
+  "type": 2,
+  "useAllAmount": false,
+}
+`);
+    });
+
+    test("with account (chainId) provided", () => {
+      const ethPlatformTx: WalletAPITransaction = {
+        family: "ethereum",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = evm.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: ethPlatformTx,
+        account: { currency: { ethereumLikeInfo: { chainId: 1 } } } as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "chainId": 1,
+  "family": "evm",
+  "feesStrategy": "medium",
+  "gasLimit": "21000",
+  "gasPrice": undefined,
+  "maxFeePerGas": undefined,
+  "maxPriorityFeePerGas": undefined,
+  "mode": "send",
+  "nonce": -1,
+  "recipient": "0xABCDEF",
+  "type": 2,
+  "useAllAmount": false,
+}
+`);
     });
   });
 });

--- a/libs/ledger-live-common/src/families/evm/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/evm/walletApiAdapter.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_NONCE } from "@ledgerhq/coin-evm/createTransaction";
+import { createTransaction } from "@ledgerhq/coin-evm/createTransaction";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
 import { EthereumTransaction as WalletAPIEthereumTransaction } from "@ledgerhq/wallet-api-core";
 import {
@@ -15,21 +15,36 @@ const areFeesProvided: AreFeesProvided<WalletAPIEthereumTransaction> = tx =>
 const convertToLiveTransaction: ConvertToLiveTransaction<
   WalletAPIEthereumTransaction,
   Transaction
-> = tx => {
-  const hasFeesProvided = areFeesProvided(tx);
-
-  const params: Partial<Transaction> = {
-    family: "evm" as const,
-    nonce: tx.nonce === undefined ? DEFAULT_NONCE : tx.nonce,
-    amount: tx.amount,
-    recipient: tx.recipient,
-    data: tx.data,
-    gasLimit: tx.gasLimit,
-    feesStrategy: hasFeesProvided ? ("custom" as const) : ("medium" as const),
-    customGasLimit: tx.gasLimit,
-  };
+> = ({ walletApiTransaction, account }) => {
+  const hasFeesProvided = areFeesProvided(walletApiTransaction);
 
   // We create a type 2 tx by default, and fallback to type 0 if gasPrice is provided
+  const liveTx: Transaction = createTransaction(account);
+
+  if (walletApiTransaction.nonce !== undefined) {
+    liveTx.nonce = walletApiTransaction.nonce;
+  }
+
+  if (walletApiTransaction.amount) {
+    liveTx.amount = walletApiTransaction.amount;
+  }
+
+  if (walletApiTransaction.recipient) {
+    liveTx.recipient = walletApiTransaction.recipient;
+  }
+
+  if (walletApiTransaction.data) {
+    liveTx.data = walletApiTransaction.data;
+  }
+
+  if (walletApiTransaction.gasLimit) {
+    liveTx.gasLimit = walletApiTransaction.gasLimit;
+    liveTx.customGasLimit = walletApiTransaction.gasLimit;
+  }
+
+  if (hasFeesProvided) {
+    liveTx.feesStrategy = "custom";
+  }
 
   /**
    * We explicitly set unrelated type specific fields to undefined to avoid transaction
@@ -46,22 +61,17 @@ const convertToLiveTransaction: ConvertToLiveTransaction<
       // `transaction` will be of type 2 here if `maxFeePerGas` and `maxPriorityFeePerGas` are not undefined
       const transaction = bridge.updateTransaction(tx2, txData);
    */
-
-  const liveTx: Partial<Transaction> = tx.gasPrice
-    ? {
-        ...params,
-        gasPrice: tx.gasPrice,
-        maxFeePerGas: undefined,
-        maxPriorityFeePerGas: undefined,
-        type: 0,
-      }
-    : {
-        ...params,
-        gasPrice: undefined,
-        maxFeePerGas: tx.maxFeePerGas,
-        maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-        type: 2,
-      };
+  if (walletApiTransaction.gasPrice) {
+    liveTx.maxFeePerGas = undefined;
+    liveTx.maxPriorityFeePerGas = undefined;
+    liveTx.gasPrice = walletApiTransaction.gasPrice;
+    liveTx.type = 0;
+  } else {
+    liveTx.gasPrice = undefined;
+    liveTx.maxFeePerGas = walletApiTransaction.maxFeePerGas;
+    liveTx.maxPriorityFeePerGas = walletApiTransaction.maxPriorityFeePerGas;
+    liveTx.type = 2;
+  }
 
   return liveTx;
 };
@@ -69,11 +79,11 @@ const convertToLiveTransaction: ConvertToLiveTransaction<
 const getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<
   WalletAPIEthereumTransaction,
   Transaction
-> = tx => {
+> = ({ walletApiTransaction, account }) => {
   return {
     canEditFees: CAN_EDIT_FEES,
-    liveTx: convertToLiveTransaction(tx),
-    hasFeesProvided: areFeesProvided(tx),
+    liveTx: convertToLiveTransaction({ walletApiTransaction, account }),
+    hasFeesProvided: areFeesProvided(walletApiTransaction),
   };
 };
 

--- a/libs/ledger-live-common/src/families/polkadot/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/polkadot/walletApiAdapter.test.ts
@@ -1,5 +1,5 @@
+import { Account } from "@ledgerhq/types-live";
 import { PolkadotTransaction as PlatformTransaction } from "@ledgerhq/wallet-api-core";
-import { Transaction } from "@ledgerhq/coin-polkadot/types";
 import BigNumber from "bignumber.js";
 import dot from "./walletApiAdapter";
 
@@ -13,21 +13,29 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         mode: "send",
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: dotPlatformTx.family,
-        amount: dotPlatformTx.amount,
-        recipient: dotPlatformTx.recipient,
-        mode: dotPlatformTx.mode,
-      };
+      const { canEditFees, hasFeesProvided, liveTx } = dot.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: dotPlatformTx,
+        account: {} as Account,
+      });
 
-      const { canEditFees, hasFeesProvided, liveTx } =
-        dot.getWalletAPITransactionSignFlowInfos(dotPlatformTx);
-
-      expect(canEditFees).toBe(false);
+      expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(false);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "era": null,
+  "family": "polkadot",
+  "fees": null,
+  "mode": "send",
+  "numSlashingSpans": 0,
+  "recipient": "0xABCDEF",
+  "rewardDestination": null,
+  "useAllAmount": false,
+  "validators": Array [],
+}
+`);
     });
 
     it("with era provided", () => {
@@ -39,22 +47,97 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         era: 1,
       };
 
-      const expectedLiveTx: Partial<Transaction> = {
-        family: dotPlatformTx.family,
-        amount: dotPlatformTx.amount,
-        recipient: dotPlatformTx.recipient,
-        mode: dotPlatformTx.mode,
-        era: `${dotPlatformTx.era}`,
-      };
+      const { canEditFees, hasFeesProvided, liveTx } = dot.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: dotPlatformTx,
+        account: {} as Account,
+      });
 
-      const { canEditFees, hasFeesProvided, liveTx } =
-        dot.getWalletAPITransactionSignFlowInfos(dotPlatformTx);
-
-      expect(canEditFees).toBe(false);
+      expect(canEditFees).toBe(true);
 
       expect(hasFeesProvided).toBe(false);
 
-      expect(liveTx).toEqual(expectedLiveTx);
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "era": "1",
+  "family": "polkadot",
+  "fees": null,
+  "mode": "send",
+  "numSlashingSpans": 0,
+  "recipient": "0xABCDEF",
+  "rewardDestination": null,
+  "useAllAmount": false,
+  "validators": Array [],
+}
+`);
+    });
+
+    it("with mode provided", () => {
+      const dotPlatformTx: PlatformTransaction = {
+        family: "polkadot",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        mode: "bond",
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = dot.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: dotPlatformTx,
+        account: {} as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "era": null,
+  "family": "polkadot",
+  "fees": null,
+  "mode": "bond",
+  "numSlashingSpans": 0,
+  "recipient": "0xABCDEF",
+  "rewardDestination": null,
+  "useAllAmount": false,
+  "validators": Array [],
+}
+`);
+    });
+
+    it("with fees provided", () => {
+      const dotPlatformTx: PlatformTransaction = {
+        family: "polkadot",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        mode: "send",
+        fee: new BigNumber(300),
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = dot.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: dotPlatformTx,
+        account: {} as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(true);
+
+      expect(liveTx).toMatchInlineSnapshot(`
+Object {
+  "amount": "100000",
+  "era": null,
+  "family": "polkadot",
+  "fees": "300",
+  "feesStrategy": null,
+  "mode": "send",
+  "numSlashingSpans": 0,
+  "recipient": "0xABCDEF",
+  "rewardDestination": null,
+  "useAllAmount": false,
+  "validators": Array [],
+}
+`);
     });
   });
 });

--- a/libs/ledger-live-common/src/families/polkadot/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/polkadot/walletApiAdapter.ts
@@ -1,29 +1,59 @@
+import createTransaction from "@ledgerhq/coin-polkadot/js-createTransaction";
+import { Transaction } from "@ledgerhq/coin-polkadot/types";
 import { PolkadotTransaction as WalletAPIPolkadotTransaction } from "@ledgerhq/wallet-api-core";
 import {
+  AreFeesProvided,
   ConvertToLiveTransaction,
   GetWalletAPITransactionSignFlowInfos,
 } from "../../wallet-api/types";
 
-import { Transaction } from "@ledgerhq/coin-polkadot/types";
+const CAN_EDIT_FEES = true;
 
-const CAN_EDIT_FEES = false;
+const areFeesProvided: AreFeesProvided<WalletAPIPolkadotTransaction> = tx => !!tx.fee;
 
 const convertToLiveTransaction: ConvertToLiveTransaction<
   WalletAPIPolkadotTransaction,
   Transaction
-> = tx => ({
-  ...tx,
-  era: tx.era ? `${tx.era}` : undefined,
-});
+> = ({ walletApiTransaction }) => {
+  const hasFeesProvided = areFeesProvided(walletApiTransaction);
+
+  const liveTx: Transaction = createTransaction();
+
+  if (walletApiTransaction.amount) {
+    liveTx.amount = walletApiTransaction.amount;
+  }
+
+  if (walletApiTransaction.recipient) {
+    liveTx.recipient = walletApiTransaction.recipient;
+  }
+
+  if (walletApiTransaction.mode) {
+    liveTx.mode = walletApiTransaction.mode;
+  }
+
+  if (walletApiTransaction.fee) {
+    liveTx.fees = walletApiTransaction.fee;
+  }
+
+  if (walletApiTransaction.era) {
+    liveTx.era = `${walletApiTransaction.era}`;
+  }
+
+  if (hasFeesProvided) {
+    liveTx.feesStrategy = null;
+  }
+
+  return liveTx;
+};
 
 const getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<
   WalletAPIPolkadotTransaction,
   Transaction
-> = tx => {
+> = ({ walletApiTransaction, account }) => {
   return {
     canEditFees: CAN_EDIT_FEES,
-    liveTx: convertToLiveTransaction(tx),
-    hasFeesProvided: false,
+    liveTx: convertToLiveTransaction({ walletApiTransaction, account }),
+    hasFeesProvided: areFeesProvided(walletApiTransaction),
   };
 };
 

--- a/libs/ledger-live-common/src/families/ripple/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/ripple/walletApiAdapter.test.ts
@@ -1,7 +1,8 @@
+import { Account } from "@ledgerhq/types-live";
 import { RippleTransaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
 import BigNumber from "bignumber.js";
-import xrp from "./walletApiAdapter";
 import { Transaction } from "./types";
+import xrp from "./walletApiAdapter";
 
 describe("getWalletAPITransactionSignFlowInfos", () => {
   describe("should properly get infos for XRP platform tx", () => {
@@ -17,8 +18,10 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         ...xrpPlatformTx,
       };
 
-      const { canEditFees, hasFeesProvided, liveTx } =
-        xrp.getWalletAPITransactionSignFlowInfos(xrpPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = xrp.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: xrpPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 
@@ -40,8 +43,10 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         ...xrpPlatformTx,
       };
 
-      const { canEditFees, hasFeesProvided, liveTx } =
-        xrp.getWalletAPITransactionSignFlowInfos(xrpPlatformTx);
+      const { canEditFees, hasFeesProvided, liveTx } = xrp.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: xrpPlatformTx,
+        account: {} as Account,
+      });
 
       expect(canEditFees).toBe(true);
 

--- a/libs/ledger-live-common/src/families/ripple/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/ripple/walletApiAdapter.ts
@@ -10,11 +10,11 @@ const areFeesProvided: AreFeesProvided<WalletAPIRippleTransaction> = tx => !!tx.
 const getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<
   WalletAPIRippleTransaction,
   Transaction
-> = tx => {
+> = ({ walletApiTransaction }) => {
   return {
     canEditFees: CAN_EDIT_FEES,
-    liveTx: tx,
-    hasFeesProvided: areFeesProvided(tx),
+    liveTx: walletApiTransaction,
+    hasFeesProvided: areFeesProvided(walletApiTransaction),
   };
 };
 

--- a/libs/ledger-live-common/src/wallet-api/converters.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.test.ts
@@ -1,8 +1,8 @@
+import { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import "../__tests__/test-helpers/setup";
-
-import { getWalletAPITransactionSignFlowInfos } from "./converters";
 import type { Transaction } from "../generated/types";
+import { getWalletAPITransactionSignFlowInfos } from "./converters";
 import type { WalletAPITransaction } from "./types";
 
 const evmBridge = jest.fn();
@@ -37,7 +37,7 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
     };
 
     // When
-    getWalletAPITransactionSignFlowInfos(tx);
+    getWalletAPITransactionSignFlowInfos({ walletApiTransaction: tx, account: {} as Account });
 
     // Then
     expect(bitcoinBridge).toBeCalledTimes(1);
@@ -53,7 +53,7 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
     };
 
     // When
-    getWalletAPITransactionSignFlowInfos(tx);
+    getWalletAPITransactionSignFlowInfos({ walletApiTransaction: tx, account: {} as Account });
 
     // Then
     expect(evmBridge).toBeCalledTimes(1);
@@ -77,7 +77,10 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
     };
 
     // When
-    const { canEditFees, hasFeesProvided, liveTx } = getWalletAPITransactionSignFlowInfos(tx);
+    const { canEditFees, hasFeesProvided, liveTx } = getWalletAPITransactionSignFlowInfos({
+      walletApiTransaction: tx,
+      account: {} as Account,
+    });
 
     // Then
     expect(evmBridge).toBeCalledTimes(0);

--- a/libs/ledger-live-common/src/wallet-api/logic.ts
+++ b/libs/ledger-live-common/src/wallet-api/logic.ts
@@ -99,8 +99,12 @@ export function signTransactionLogic(
     ? parentAccount?.currency.family
     : account.currency.family;
 
-  const { canEditFees, liveTx, hasFeesProvided } =
-    getWalletAPITransactionSignFlowInfos(transaction);
+  const mainAccount = getMainAccount(account, parentAccount);
+
+  const { canEditFees, liveTx, hasFeesProvided } = getWalletAPITransactionSignFlowInfos({
+    walletApiTransaction: transaction,
+    account: mainAccount,
+  });
 
   if (accountFamily !== liveTx.family) {
     return Promise.reject(
@@ -311,7 +315,10 @@ export function completeExchangeLogic(
   const mainFromAccount = getMainAccount(fromAccount, fromParentAccount);
   const mainFromAccountFamily = mainFromAccount.currency.family;
 
-  const { liveTx } = getWalletAPITransactionSignFlowInfos(transaction);
+  const { liveTx } = getWalletAPITransactionSignFlowInfos({
+    walletApiTransaction: transaction,
+    account: mainFromAccount,
+  });
 
   if (liveTx.family !== mainFromAccountFamily) {
     return Promise.reject(

--- a/libs/ledger-live-common/src/wallet-api/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/types.ts
@@ -1,4 +1,4 @@
-import type { SignedOperation } from "@ledgerhq/types-live";
+import type { Account, SignedOperation } from "@ledgerhq/types-live";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Transaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
 import type { CustomHandlers as WalletAPICustomHandlers } from "@ledgerhq/wallet-api-server";
@@ -44,7 +44,7 @@ export type WalletAPISupportedCurrency = CryptoCurrency | TokenCurrency;
 export type GetWalletAPITransactionSignFlowInfos<
   T extends WalletAPITransaction,
   U extends Transaction,
-> = (tx: T) => {
+> = ({ walletApiTransaction, account }: { walletApiTransaction: T; account: Account }) => {
   canEditFees: boolean;
   hasFeesProvided: boolean;
   liveTx: Partial<U>;
@@ -52,9 +52,13 @@ export type GetWalletAPITransactionSignFlowInfos<
 
 export type AreFeesProvided<T extends WalletAPITransaction> = (tx: T) => boolean;
 
-export type ConvertToLiveTransaction<T extends WalletAPITransaction, U extends Transaction> = (
-  tx: T,
-) => Partial<U>;
+export type ConvertToLiveTransaction<T extends WalletAPITransaction, U extends Transaction> = ({
+  walletApiTransaction,
+  account,
+}: {
+  walletApiTransaction: T;
+  account: Account;
+}) => Partial<U>;
 
 export type DiscoverDB = {
   recentlyUsed: RecentlyUsed[];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Use the currencies createTransaction function in their walletApiAdapter implementation instead of creating tx by hand
	- in order to improve consistency across the Ledger Live codebase and properly convert incoming tx (in this case from wallet-api) to the appropriate Ledger Live data model
- Update tests and add missing test cases

Seems relevant to avoid unexpected side effects like the one introduced by this commit (4cce42dfceff3170faac78ee0810cdbf11f7bb35) and fixed [here](https://github.com/LedgerHQ/ledger-live/pull/5482) 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10233
- https://github.com/LedgerHQ/ledger-live/pull/5482

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - wallet-api related flows, mainly using the `evm`, `bitcoin` and `polkadot` families.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
