### PR TITLE
chore: link to doc to manage duplicates

### DIFF
--- a/tools/actions/desktop-build-checks/build/main.js
+++ b/tools/actions/desktop-build-checks/build/main.js
@@ -40545,7 +40545,9 @@ function checksAgainstReference(reporter, metafiles, reference) {
   for (const lib in newDuplicates) {
     const bundles = newDuplicates[lib];
     reporter.warning(
-      `\`${lib}\` library is now duplicated in ${formatMarkdownBoldList(bundles)} (regression)`
+      `\`${lib}\` dependency is now duplicated in ${formatMarkdownBoldList(
+        bundles
+      )}. [Read more](https://github.com/LedgerHQ/ledger-live/wiki/Dependencies-duplicates-management)`
     );
   }
   for (const lib in removedDuplicates) {

--- a/tools/actions/desktop-build-checks/src/main.ts
+++ b/tools/actions/desktop-build-checks/src/main.ts
@@ -148,7 +148,9 @@ function checksAgainstReference(reporter: Reporter, metafiles: Metafiles, refere
   for (const lib in newDuplicates) {
     const bundles = newDuplicates[lib];
     reporter.warning(
-      `\`${lib}\` library is now duplicated in ${formatMarkdownBoldList(bundles)} (regression)`,
+      `\`${lib}\` dependency is now duplicated in ${formatMarkdownBoldList(
+        bundles,
+      )}. [Read more](https://github.com/LedgerHQ/ledger-live/wiki/Dependencies-duplicates-management)`,
     );
   }
   for (const lib in removedDuplicates) {


### PR DESCRIPTION


### 📝 Description

when Ledger Live Builds report some lib duplicates, it will now link to the documentation in order to guide to fix it.

### ❓ Context

- **JIRA or GitHub link**: na <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - only CI impact

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
