### PR TITLE
set empty token account id to the parentid

### DIFF
--- a/.changeset/brave-turtles-begin.md
+++ b/.changeset/brave-turtles-begin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": patch
+---
+
+empty token accounts ids set from their parent token account id

--- a/libs/coin-framework/src/account/helpers.ts
+++ b/libs/coin-framework/src/account/helpers.ts
@@ -246,21 +246,23 @@ export const isUpToDateAccount = (account: Account | null | undefined) => {
   return !outdated;
 };
 
-export const makeEmptyTokenAccount = (account: Account, token: TokenCurrency): TokenAccount => ({
-  type: "TokenAccount",
-  id: account.id + "+" + token.contractAddress,
-  parentId: account.id,
-  token,
-  balance: new BigNumber(0),
-  spendableBalance: new BigNumber(0),
-  operationsCount: 0,
-  creationDate: new Date(),
-  operations: [],
-  pendingOperations: [],
-  starred: false,
-  swapHistory: [],
-  balanceHistoryCache: emptyHistoryCache,
-});
+export const makeEmptyTokenAccount = (account: Account, token: TokenCurrency): TokenAccount => {
+  return {
+    type: "TokenAccount",
+    id: account.id,
+    parentId: account.id,
+    token,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operationsCount: 0,
+    creationDate: new Date(),
+    operations: [],
+    pendingOperations: [],
+    starred: false,
+    swapHistory: [],
+    balanceHistoryCache: emptyHistoryCache,
+  }
+};
 
 /**
  * Enhance an account to force token accounts presence


### PR DESCRIPTION
### 📝 Description

`makeEmptyTokenAccount` (in libs/coin-framework/src/account/helpers.ts) is called when we need to create temporary accounts for them to be displayed and chosen from. 
For instance, here we are triggering the `makeEmptyTokenAccount` function to display two USDT accounts: 


https://github.com/LedgerHQ/ledger-live/assets/5050709/56a8171e-d9bb-4caf-ba2e-47038ba4da99

Those token have a parent account (USDT parent is ethereum). 
The problem is, that function creates an id that doesn't match any existing account, and subsequent wallet api calls to `account.receive` with that ID expectedly fail. 
Assigning to the empty token account id its parent ID value solves that problem.


### ❓ Context

- **JIRA or GitHub link**: [JIRA-9888](https://ledgerhq.atlassian.net/browse/LIVE-9888) [JIRA-10041](https://ledgerhq.atlassian.net/browse/LIVE-10041)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** 
- [ ] **Impact of the changes:**

---

### 🧐 Checklist for the PR Reviewers


- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
