### PR TITLE
fix: earn app not found earn live-9844

### DIFF
--- a/.changeset/real-rockets-join.md
+++ b/.changeset/real-rockets-join.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+remove state update in earn screen that was causing App Not Found screen to display when app state was not loading but the manifest was also not yet found.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description


| Before        | After         |
| ------------- | ------------- |
|        Navigating to Earn dashboard shows App Not Found error page briefly before the app manifest was updated. This seemed to be caused by the re-render of the component when updating state, as the live app state was loaded but the manifest was not yet set.        |        Navigating no longer shows the App Not Found. The screen is now memoised, so should not re-render as often, minimising risk of re-setting the manifest.        |

### ❓ Context

- **JIRA or GitHub link**: LIVE-9844 https://ledgerhq.atlassian.net/browse/LIVE-9844

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) --> It's not yet clear how to test this as it is really dependent on whether useRemoteLiveAppManifest("earn") returns a manifest. 
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Navigating to Earn should no longer briefly show the App Not Found error page
  - Navigating to other pages from earn, such as the Buy flow, or the Stake Now flow, should no longer briefly show the App Not Found page before showing the Earn dashboard again 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
