### PR TITLE
feat(live-9396): recover llm banner subscription notification portfolio

### DIFF
--- a/.changeset/big-seahorses-mate.md
+++ b/.changeset/big-seahorses-mate.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Add recover banner for subscribtion informations

--- a/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
@@ -1,0 +1,136 @@
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { Button, Flex, ProgressLoader, Text } from "@ledgerhq/native-ui";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useCustomURI } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { useTheme } from "styled-components/native";
+import { RecoverBannerType } from "./types";
+import { Linking } from "react-native";
+import { getStoreValue, setStoreValue } from "~/store";
+
+function RecoverBanner() {
+  const [storageData, setStorageData] = useState<string>();
+  const [displayBannerData, setDisplayBannerData] = useState<boolean>();
+  const [stepNumber, setStepNumber] = useState<number>(0);
+
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const recoverServices = useFeature("protectServicesMobile");
+
+  const bannerIsEnabled = recoverServices?.params?.bannerSubscriptionNotification;
+  const protectID = recoverServices?.params?.protectId ?? "";
+  const maxStepNumber = 5;
+
+  const recoverUnfinishedOnboardingPath = useCustomURI(
+    recoverServices,
+    "activate",
+    "llm-banner-unfinished-onboarding",
+    "recover-launch",
+  );
+
+  const getStorageSubscriptionState = useCallback(async () => {
+    const storage = await getStoreValue("SUBSCRIPTION_STATE", protectID);
+    const displayBanner = await getStoreValue("DISPLAY_BANNER", protectID);
+    setStorageData(storage as string);
+    setDisplayBannerData(displayBanner === "true");
+  }, [protectID]);
+
+  const recoverBannerSelected: RecoverBannerType | undefined = useMemo(() => {
+    let recoverBannerWording: RecoverBannerType;
+
+    switch (storageData) {
+      case "NO_SUBSCRIPTION":
+        setStepNumber(1);
+        return undefined;
+      case "STARGATE_SUBSCRIBE":
+        setStepNumber(2);
+        recoverBannerWording = t("portfolio.recoverBanner.subscribeDone", { returnObjects: true });
+        break;
+      case "BACKUP_VERIFY_IDENTITY":
+        setStepNumber(3);
+        recoverBannerWording = t("portfolio.recoverBanner.verifyIdentity", { returnObjects: true });
+        break;
+      case "BACKUP_DEVICE_CONNECTION":
+        setStepNumber(4);
+        recoverBannerWording = t("portfolio.recoverBanner.connectDevice", { returnObjects: true });
+        break;
+      case "BACKUP_DONE":
+        setStepNumber(5);
+        return undefined;
+      default:
+        setStepNumber(0);
+        return undefined;
+    }
+
+    if (recoverBannerWording) {
+      recoverBannerWording.title = t("portfolio.recoverBanner.title");
+      return recoverBannerWording;
+    }
+  }, [storageData, t]);
+
+  const onRedirectRecover = () => {
+    if (recoverUnfinishedOnboardingPath)
+      Linking.canOpenURL(recoverUnfinishedOnboardingPath).then(() =>
+        Linking.openURL(recoverUnfinishedOnboardingPath),
+      );
+  };
+
+  const onCloseBanner = () => {
+    setStoreValue("DISPLAY_BANNER", "false", protectID);
+    setDisplayBannerData(false);
+  };
+
+  useEffect(() => {
+    getStorageSubscriptionState();
+  }, [getStorageSubscriptionState]);
+
+  if (!bannerIsEnabled || !recoverBannerSelected || !displayBannerData) return null;
+
+  return (
+    <Flex justifyContent="center" p={6}>
+      <Flex
+        position="relative"
+        columnGap={3}
+        bg={colors.opacityPurple.c10}
+        flexDirection="row"
+        justifyContent="space-between"
+        borderRadius="8px"
+        overflow="hidden"
+        width="100%"
+      >
+        <Flex alignItems="center" justifyContent="center" p={3} width={68}>
+          <ProgressLoader progress={stepNumber / maxStepNumber} radius={20}>
+            <Text display="block" flex={1} textAlign="center" fontSize="12px" lineHeight="15px">
+              {`${stepNumber}/${maxStepNumber}`}
+            </Text>
+          </ProgressLoader>
+        </Flex>
+        <Flex flex={1} flexDirection="column" py={3} overflow="hidden">
+          <Text fontSize="13px" lineHeight="16px" width="100%" overflow="hidden">
+            {recoverBannerSelected.title}
+          </Text>
+          <Text
+            mt={1}
+            fontSize="12px"
+            lineHeight="15px"
+            fontWeight="medium"
+            width="100%"
+            overflow="hidden"
+          >
+            {recoverBannerSelected.description}
+          </Text>
+        </Flex>
+        <Flex alignItems="center" p={3} pl={0} columnGap={3}>
+          <Button size="small" outline={false} onPress={onCloseBanner}>
+            {recoverBannerSelected.secondaryCta}
+          </Button>
+          <Button type="main" size="small" outline={false} onPress={onRedirectRecover}>
+            {recoverBannerSelected.primaryCta}
+          </Button>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+export default memo(RecoverBanner);

--- a/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
@@ -1,11 +1,11 @@
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { Button, Flex, ProgressLoader, Text } from "@ledgerhq/native-ui";
+import { Box, Flex, Icon, ProgressLoader, Text } from "@ledgerhq/native-ui";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCustomURI } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { useTheme } from "styled-components/native";
 import { RecoverBannerType } from "./types";
-import { Linking } from "react-native";
+import { GestureResponderEvent, Linking } from "react-native";
 import { getStoreValue, setStoreValue } from "~/store";
 
 function RecoverBanner() {
@@ -62,10 +62,7 @@ function RecoverBanner() {
         return undefined;
     }
 
-    if (recoverBannerWording) {
-      recoverBannerWording.title = t("portfolio.recoverBanner.title");
-      return recoverBannerWording;
-    }
+    return recoverBannerWording;
   }, [storageData, t]);
 
   const onRedirectRecover = () => {
@@ -75,7 +72,9 @@ function RecoverBanner() {
       );
   };
 
-  const onCloseBanner = () => {
+  const onCloseBanner = (event: GestureResponderEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
     setStoreValue("DISPLAY_BANNER", "false", protectID);
     setDisplayBannerData(false);
   };
@@ -87,47 +86,45 @@ function RecoverBanner() {
   if (!bannerIsEnabled || !recoverBannerSelected || !displayBannerData) return null;
 
   return (
-    <Flex justifyContent="center" p={6}>
+    <Flex justifyContent="center" position="relative">
       <Flex
         position="relative"
-        columnGap={3}
-        bg={colors.opacityPurple.c10}
+        columnGap={6}
+        bg={colors.opacityDefault.c05}
         flexDirection="row"
         justifyContent="space-between"
-        borderRadius="8px"
+        alignItems="center"
+        borderRadius={12}
         overflow="hidden"
         width="100%"
+        onTouchEnd={onRedirectRecover}
+        p={3}
       >
-        <Flex alignItems="center" justifyContent="center" p={3} width={68}>
+        <Flex alignItems="center" justifyContent="center" width={45}>
           <ProgressLoader progress={stepNumber / maxStepNumber} radius={20}>
             <Text display="block" flex={1} textAlign="center" fontSize="12px" lineHeight="15px">
-              {`${stepNumber}/${maxStepNumber}`}
+              {`${stepNumber}/${maxStepNumber - 1}`}
             </Text>
           </ProgressLoader>
         </Flex>
         <Flex flex={1} flexDirection="column" py={3} overflow="hidden">
-          <Text fontSize="13px" lineHeight="16px" width="100%" overflow="hidden">
+          <Text variant={"body"} fontWeight={"medium"} width="100%" overflow="hidden">
             {recoverBannerSelected.title}
           </Text>
           <Text
             mt={1}
-            fontSize="12px"
-            lineHeight="15px"
-            fontWeight="medium"
+            variant={"paragraph"}
+            fontWeight={"medium"}
             width="100%"
             overflow="hidden"
+            color={colors.neutral.c80}
           >
             {recoverBannerSelected.description}
           </Text>
         </Flex>
-        <Flex alignItems="center" p={3} pl={0} columnGap={3}>
-          <Button size="small" outline={false} onPress={onCloseBanner}>
-            {recoverBannerSelected.secondaryCta}
-          </Button>
-          <Button type="main" size="small" outline={false} onPress={onRedirectRecover}>
-            {recoverBannerSelected.primaryCta}
-          </Button>
-        </Flex>
+        <Box position="absolute" top={0} right={0} p={3} onTouchEnd={onCloseBanner}>
+          <Icon name="Close" size={16} color={colors.neutral.c100} />
+        </Box>
       </Flex>
     </Flex>
   );

--- a/apps/ledger-live-mobile/src/components/RecoverBanner/types.ts
+++ b/apps/ledger-live-mobile/src/components/RecoverBanner/types.ts
@@ -1,0 +1,6 @@
+export type RecoverBannerType = {
+  title: string;
+  description: string;
+  primaryCta: string;
+  secondaryCta?: string;
+};

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2224,21 +2224,17 @@
       "stake": "Stake"
     },
     "recoverBanner": {
-      "title": "You're almost there!",
       "subscribeDone": {
-        "description":"Add your credit or debit card to continue subscribing to Ledger Recover.",
-        "primaryCta": "Add my card",
-        "secondaryCta": "Maybe later"
+        "title": "Add credit or debit card",
+        "description":"Add your payment method to get your backup secure."
       },
       "verifyIdentity": {
-        "description":"Verify your identity to get your backup secure",
-        "primaryCta": "Verify now",
-        "secondaryCta": "Maybe later"
+        "title": "Verify my identity",
+        "description":"Verify your identity to get your backup secure."
       },
       "connectDevice": {
-        "description":"Connect and confirm your details on your Ledger.",
-        "primaryCta": "Connecting your Ledger",
-        "secondaryCta": "Maybe later"
+        "title": "Connect Ledger",
+        "description":"Connect your Ledger to get your backup secure."
       }
     }
   },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2222,6 +2222,24 @@
       "send": "Send",
       "deposit": "Receive",
       "stake": "Stake"
+    },
+    "recoverBanner": {
+      "title": "You're almost there!",
+      "subscribeDone": {
+        "description":"Add your credit or debit card to continue subscribing to Ledger Recover.",
+        "primaryCta": "Add my card",
+        "secondaryCta": "Maybe later"
+      },
+      "verifyIdentity": {
+        "description":"Verify your identity to get your backup secure",
+        "primaryCta": "Verify now",
+        "secondaryCta": "Maybe later"
+      },
+      "connectDevice": {
+        "description":"Connect and confirm your details on your Ledger.",
+        "primaryCta": "Connecting your Ledger",
+        "secondaryCta": "Maybe later"
+      }
     }
   },
   "addAccountsModal": {

--- a/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
@@ -26,7 +26,6 @@ import CheckLanguageAvailability from "../../../components/CheckLanguageAvailabi
 import CheckTermOfUseUpdate from "../../../components/CheckTermOfUseUpdate";
 import { TAB_BAR_SAFE_HEIGHT } from "../../../components/TabBar/TabBarSafeAreaView";
 import SetupDeviceBanner from "../../../components/SetupDeviceBanner";
-import RecoverBanner from "../../../components/RecoverBanner";
 import BuyDeviceBanner, { IMAGE_PROPS_BIG_NANO } from "../../../components/BuyDeviceBanner";
 import Assets from "../Assets";
 import { AnalyticsContext } from "../../../analytics/AnalyticsContext";
@@ -97,7 +96,6 @@ function ReadOnlyPortfolio({ navigation }: NavigationProps) {
 
   const data = useMemo(
     () => [
-      <RecoverBanner key="RecoverBanner" />,
       <Box onLayout={onPortfolioCardLayout} key="GraphCardContainer">
         <GraphCardContainer
           counterValueCurrency={counterValueCurrency}

--- a/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/ReadOnly/index.tsx
@@ -26,6 +26,7 @@ import CheckLanguageAvailability from "../../../components/CheckLanguageAvailabi
 import CheckTermOfUseUpdate from "../../../components/CheckTermOfUseUpdate";
 import { TAB_BAR_SAFE_HEIGHT } from "../../../components/TabBar/TabBarSafeAreaView";
 import SetupDeviceBanner from "../../../components/SetupDeviceBanner";
+import RecoverBanner from "../../../components/RecoverBanner";
 import BuyDeviceBanner, { IMAGE_PROPS_BIG_NANO } from "../../../components/BuyDeviceBanner";
 import Assets from "../Assets";
 import { AnalyticsContext } from "../../../analytics/AnalyticsContext";
@@ -96,6 +97,7 @@ function ReadOnlyPortfolio({ navigation }: NavigationProps) {
 
   const data = useMemo(
     () => [
+      <RecoverBanner key="RecoverBanner" />,
       <Box onLayout={onPortfolioCardLayout} key="GraphCardContainer">
         <GraphCardContainer
           counterValueCurrency={counterValueCurrency}

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -142,13 +142,13 @@ function PortfolioScreen({ navigation }: NavigationProps) {
 
   const data = useMemo(
     () => [
-      <RecoverBanner key="RecoverBanner" />,
       <Flex px={6} py={4} key="FirmwareUpdateBanner">
         <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
       </Flex>,
       <PortfolioGraphCard showAssets={showAssets} key="PortfolioGraphCard" />,
       showAssets ? (
         <Box background={colors.background.main} px={6} mt={6} key="PortfolioAssets">
+          <RecoverBanner />
           <PortfolioAssets
             hideEmptyTokenAccount={hideEmptyTokenAccount}
             openAddModal={openAddModal}
@@ -183,9 +183,10 @@ function PortfolioScreen({ navigation }: NavigationProps) {
           ]
         : [
             // If the user has no accounts we display an empty state
-            <Box mx={6} mt={12} key="PortfolioEmptyState">
+            <Flex flexDirection="column" rowGap={30} mx={6} key="PortfolioEmptyState">
+              <RecoverBanner />
               <PortfolioEmptyState openAddAccountModal={openAddModal} />
-            </Box>,
+            </Flex>,
           ]),
     ],
     [

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -28,6 +28,7 @@ import { ScreenName } from "../../const";
 import FirmwareUpdateBanner from "../../components/FirmwareUpdateBanner";
 import CheckLanguageAvailability from "../../components/CheckLanguageAvailability";
 import CheckTermOfUseUpdate from "../../components/CheckTermOfUseUpdate";
+import RecoverBanner from "../../components/RecoverBanner";
 import PortfolioEmptyState from "./PortfolioEmptyState";
 import SectionTitle from "../WalletCentricSections/SectionTitle";
 import SectionContainer from "../WalletCentricSections/SectionContainer";
@@ -141,6 +142,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
 
   const data = useMemo(
     () => [
+      <RecoverBanner key="RecoverBanner" />,
       <Flex px={6} py={4} key="FirmwareUpdateBanner">
         <FirmwareUpdateBanner onBackFromUpdate={onBackFromUpdate} />
       </Flex>,

--- a/apps/ledger-live-mobile/src/store.ts
+++ b/apps/ledger-live-mobile/src/store.ts
@@ -1,0 +1,11 @@
+import store from "~/logic/storeWrapper";
+import isEmpty from "lodash/isEmpty";
+
+export function getStoreValue<T>(key: string, storeId: string): T | undefined {
+  const value = store.get(`${storeId}-${key}`);
+  return isEmpty(value) ? undefined : (value as T);
+}
+
+export function setStoreValue<T>(key: string, value: T, storeId: string) {
+  return store.update(`${storeId}-${key}`, value);
+}

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -295,6 +295,8 @@ export const DEFAULT_FEATURES: Features = {
   protectServicesMobile: {
     enabled: false,
     params: {
+      ledgerliveStorageState: false,
+      bannerSubscriptionNotification: false,
       deeplink: "",
       compatibleDevices: [],
       account: {

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
@@ -156,7 +156,7 @@ export function useAlreadySeededDevicePath(
   return usePath(servicesConfig, uri);
 }
 
-export function useCustomPath(
+export function useCustomURI(
   servicesConfig: Feature_ProtectServicesDesktop | Feature_ProtectServicesMobile | null,
   page?: string,
   source?: string,
@@ -177,5 +177,16 @@ export function useCustomPath(
     return uri;
   }, [deeplinkCampaign, page, servicesConfig?.params?.protectId, source]);
 
-  return usePath(servicesConfig, customUri.toString());
+  return customUri.toString();
+}
+
+export function useCustomPath(
+  servicesConfig: Feature_ProtectServicesDesktop | Feature_ProtectServicesMobile | null,
+  page?: string,
+  source?: string,
+  deeplinkCampaign?: string,
+): string | undefined {
+  const uri = useCustomURI(servicesConfig, page, source, deeplinkCampaign);
+
+  return usePath(servicesConfig, uri);
 }

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -304,6 +304,8 @@ export type CompatibleDevice = {
 
 export type Feature_ProtectServicesMobile = Feature<{
   deeplink: string;
+  ledgerliveStorageState: boolean;
+  bannerSubscriptionNotification: boolean;
   compatibleDevices: CompatibleDevice[];
   onboardingRestore: {
     restoreInfoDrawer: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Manage banner of ledger recover subscription flow.
I use walletApi storage to set values on liveApp and get it on LLD.
This banner is displayed only if some values are defined on liveApp.
You can enable or disable banner with protectServiceDesktop featureFlags with `bannerSubscriptionNotification`

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
