### PR TITLE
[LIVE-10215] BUGFIX - Fix legacy derivation paths missing for Ethereum & Classic

### DIFF
--- a/.changeset/wicked-actors-sleep.md
+++ b/.changeset/wicked-actors-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": patch
+---
+
+Clean derivation.ts & add missing EthM EthMM & EtcM missing derivation path after ETH > EVM merge

--- a/libs/coin-framework/src/derivation.test.ts
+++ b/libs/coin-framework/src/derivation.test.ts
@@ -1,32 +1,110 @@
+import { getEnv, setEnv } from "@ledgerhq/live-env";
 import { getCryptoCurrencyById } from "./currencies";
-import { getPreferredNewAccountScheme, getDefaultPreferredNewAccountScheme } from "./derivation";
-describe("derivation", () => {
-  test("getPreferredNewAccountScheme should return a list of schemes for a given currency", () => {
-    const testData = [
-      ["bitcoin", ["native_segwit", "taproot", "segwit", ""]],
-      ["ethereum", null],
-      ["cosmos", null],
-      ["litecoin", ["native_segwit", "segwit", ""]],
-      ["qtum", ["segwit", ""]],
-    ];
-    testData.forEach(([currencyId, derivationModes]) => {
-      const currency = getCryptoCurrencyById(<string>currencyId);
-      const p = getPreferredNewAccountScheme(currency);
-      expect(p).toEqual(derivationModes);
+import {
+  getPreferredNewAccountScheme,
+  getDefaultPreferredNewAccountScheme,
+  getDerivationModesForCurrency,
+  isInvalidDerivationMode,
+  DerivationMode,
+} from "./derivation";
+
+describe("derivation.ts", () => {
+  describe("getPreferredNewAccountScheme", () => {
+    it("should return a list of schemes for a given currency", () => {
+      const testData: [string, string[] | null][] = [
+        ["bitcoin", ["native_segwit", "taproot", "segwit", ""]],
+        ["ethereum", null],
+        ["cosmos", null],
+        ["litecoin", ["native_segwit", "segwit", ""]],
+        ["qtum", ["segwit", ""]],
+      ];
+      testData.forEach(([currencyId, derivationModes]) => {
+        if (!currencyId) return;
+        const currency = getCryptoCurrencyById(currencyId);
+        const p = getPreferredNewAccountScheme(currency);
+        expect(p).toEqual(derivationModes);
+      });
     });
   });
-  test("getDefaultPreferredNewAccountScheme should return a default scheme for a given currency", () => {
-    const testData = [
-      ["bitcoin", "native_segwit"],
-      ["ethereum", null],
-      ["cosmos", null],
-      ["litecoin", "native_segwit"],
-      ["qtum", "segwit"],
-    ];
-    testData.forEach(([currencyId, derivationMode]) => {
-      const currency = getCryptoCurrencyById(<string>currencyId);
-      const defaultP = getDefaultPreferredNewAccountScheme(currency);
-      expect(defaultP).toEqual(derivationMode);
+
+  describe("getDefaultPreferredNewAccountScheme", () => {
+    it("should return a default scheme for a given currency", () => {
+      const testData = [
+        ["bitcoin", "native_segwit"],
+        ["ethereum", null],
+        ["cosmos", null],
+        ["litecoin", "native_segwit"],
+        ["qtum", "segwit"],
+      ];
+      testData.forEach(([currencyId, derivationMode]) => {
+        if (!currencyId) return;
+        const currency = getCryptoCurrencyById(currencyId);
+        const defaultP = getDefaultPreferredNewAccountScheme(currency);
+        expect(defaultP).toEqual(derivationMode);
+      });
     });
+  });
+
+  describe("getDerivationModesForCurrency", () => {
+    const expectations: [string, DerivationMode[]][] = [
+      ["ethereum", ["ethM", "ethMM", ""]], // test for fixing missing legacy derivation
+      ["ethereum_classic", ["ethM", "ethMM", "etcM", ""]], // test for fixing missing legacy derivation
+      ["polygon", [""]], // test absence of impact on other EVMs
+      [
+        "bitcoin",
+        [
+          "legacy_on_bch",
+          "segwit_on_legacy",
+          "legacy_on_segwit",
+          "legacy_on_native_segwit",
+          "native_segwit",
+          "taproot",
+          "segwit",
+          "",
+        ],
+      ], // supportsSegwit + supportsNativeSegwit + taproot + segwit
+      ["bitcoin_cash", ["unsplit", ""]], // forkedFrom
+      [
+        "bitcoin_gold",
+        [
+          "unsplit",
+          "segwit_unsplit",
+          "segwit_on_legacy",
+          "legacy_on_segwit",
+          "legacy_on_native_segwit",
+          "segwit",
+          "",
+        ],
+      ], // forkedFrom + supportsSegwit
+      ["tezos", ["galleonL", "tezboxL", "tezosbip44h", "tezbox"]], // disableBIP44
+      ["solana", ["solanaMain", "solanaSub"]], // backward compatible change in getDerivationModesForCurrency
+    ];
+
+    let envBackup: boolean;
+    beforeAll(() => {
+      envBackup = getEnv("SCAN_FOR_INVALID_PATHS");
+    });
+
+    afterEach(() => {
+      setEnv("SCAN_FOR_INVALID_PATHS", envBackup);
+    });
+
+    it.each(expectations)(
+      "should return the expected derivation paths for %s with SCAN_FOR_INVALID_PATHS false",
+      (currency, paths) => {
+        setEnv("SCAN_FOR_INVALID_PATHS", false);
+        expect(getDerivationModesForCurrency(getCryptoCurrencyById(currency))).toEqual(
+          paths.filter(path => !isInvalidDerivationMode(path)),
+        );
+      },
+    );
+
+    it.each(expectations)(
+      "should return the expected derivation paths for %s with SCAN_FOR_INVALID_PATHS true",
+      (currency, paths) => {
+        setEnv("SCAN_FOR_INVALID_PATHS", true);
+        expect(getDerivationModesForCurrency(getCryptoCurrencyById(currency))).toEqual(paths);
+      },
+    );
   });
 });

--- a/libs/coin-framework/src/derivation.ts
+++ b/libs/coin-framework/src/derivation.ts
@@ -6,7 +6,7 @@ import { TransportStatusError, UserRefusedAddress } from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "./currencies";
 import { getEnv } from "@ledgerhq/live-env";
-import type { CryptoCurrencyIds } from "@ledgerhq/types-live";
+
 export type ModeSpec = {
   mandatoryEmptyAccountSkip?: number;
   isNonIterable?: boolean;
@@ -212,14 +212,11 @@ const modes = Object.freeze({
 });
 modes as Record<DerivationMode, ModeSpec>; // eslint-disable-line
 
-// FIXME: CryptoCurrencyConfig was a flowtype we could not easily convert to ts so it has been deleted
-// previous types: Partial<CryptoCurrencyConfig<DerivationMode[]>>
-const legacyDerivations: Record<CryptoCurrencyIds, DerivationMode[]> = {
+const legacyDerivations: Partial<Record<CryptoCurrency["id"], DerivationMode[]>> = {
   aeternity: ["aeternity"],
   bitcoin_cash: [],
   bitcoin: ["legacy_on_bch"],
   vertcoin: ["vertcoin_128", "vertcoin_128_segwit"],
-  ethereum_classic: ["etcM"],
   tezos: ["galleonL", "tezboxL", "tezosbip44h", "tezbox"],
   stellar: ["sep5"],
   polkadot: ["polkadotbip44"],
@@ -232,10 +229,11 @@ const legacyDerivations: Record<CryptoCurrencyIds, DerivationMode[]> = {
   near: ["nearbip44h"],
   vechain: ["vechain"],
   stacks: ["stacks_wallet"],
-};
-
-const legacyDerivationsPerFamily: Record<string, DerivationMode[]> = {
   ethereum: ["ethM", "ethMM"],
+  ethereum_classic: ["ethM", "ethMM", "etcM"],
+  solana: ["solanaMain", "solanaSub"],
+  solana_devnet: ["solanaMain", "solanaSub"],
+  solana_testnet: ["solanaMain", "solanaSub"],
 };
 
 export const asDerivationMode = (derivationMode: string): DerivationMode => {
@@ -407,11 +405,8 @@ export const getSeedIdentifierDerivation = (
 // return an array of ways to derivate, by convention the latest is the standard one.
 export const getDerivationModesForCurrency = (currency: CryptoCurrency): DerivationMode[] => {
   let all: DerivationMode[] = [];
-  if (currency.family in legacyDerivationsPerFamily) {
-    all = all.concat(legacyDerivationsPerFamily[currency.family]);
-  }
   if (currency.id in legacyDerivations) {
-    all = all.concat(legacyDerivations[currency.id]);
+    all = all.concat(legacyDerivations[currency.id] || []);
   }
   if (currency.forkedFrom) {
     all.push("unsplit");
@@ -422,9 +417,7 @@ export const getDerivationModesForCurrency = (currency: CryptoCurrency): Derivat
   }
 
   if (currency.supportsSegwit) {
-    all.push("segwit_on_legacy");
-    all.push("legacy_on_segwit");
-    all.push("legacy_on_native_segwit");
+    all.push("segwit_on_legacy", "legacy_on_segwit", "legacy_on_native_segwit");
   }
 
   if (currency.supportsNativeSegwit) {
@@ -438,16 +431,13 @@ export const getDerivationModesForCurrency = (currency: CryptoCurrency): Derivat
     }
   }
 
+  // Can't this be concatenated with the first `supportsSegwit` condition ?
   if (currency.supportsSegwit) {
     all.push("segwit");
   }
 
   if (!disableBIP44[currency.id]) {
     all.push("");
-  }
-
-  if (currency.family === "solana") {
-    all.push("solanaMain", "solanaSub");
   }
 
   if (!getEnv("SCAN_FOR_INVALID_PATHS")) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

After the Ethereum to EVM merge, we forgot to do the migration of legacy derivation paths which was based on "family" name. 
This PR cleans a little bit the `getDerivationModesForCurrency` method and adds the missing `ethM` `ethMM` & `etcM` derivations paths for Ethereum & Ethereum Classic

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10215
### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Ethereum & Ethereum classic can now "discover" legacy accounts

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
