### PR TITLE
[BUGFIX][DEVELOP] use DEFAULT_NONCE when wallet-api evm tx nonce not provided

### DIFF
--- a/libs/ledger-live-common/src/families/evm/platformAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/evm/platformAdapter.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_NONCE } from "@ledgerhq/coin-evm/createTransaction";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
 import { FAMILIES, EthereumTransaction as PlatformTransaction } from "@ledgerhq/live-app-sdk";
 import BigNumber from "bignumber.js";
@@ -18,7 +19,7 @@ describe("getPlatformTransactionSignFlowInfos", () => {
         recipient: ethPlatformTx.recipient,
         data: undefined,
         gasLimit: undefined,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         customGasLimit: undefined,
         feesStrategy: undefined,
         type: 2,
@@ -51,7 +52,7 @@ describe("getPlatformTransactionSignFlowInfos", () => {
         gasPrice: ethPlatformTx.gasPrice,
         gasLimit: ethPlatformTx.gasLimit,
         customGasLimit: ethPlatformTx.gasLimit,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         data: undefined,
         feesStrategy: "custom",
         type: 0,
@@ -81,8 +82,38 @@ describe("getPlatformTransactionSignFlowInfos", () => {
         recipient: ethPlatformTx.recipient,
         gasLimit: ethPlatformTx.gasLimit,
         customGasLimit: ethPlatformTx.gasLimit,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         data: undefined,
+        type: 2,
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } =
+        evm.getPlatformTransactionSignFlowInfos(ethPlatformTx);
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toEqual(expectedLiveTx);
+    });
+
+    test("with nonce provided", () => {
+      const ethPlatformTx: PlatformTransaction = {
+        family: FAMILIES.ETHEREUM,
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        nonce: 1,
+      };
+
+      const expectedLiveTx: Partial<Transaction> = {
+        family: "evm",
+        amount: ethPlatformTx.amount,
+        recipient: ethPlatformTx.recipient,
+        data: undefined,
+        gasLimit: undefined,
+        nonce: 1,
+        customGasLimit: undefined,
+        feesStrategy: undefined,
         type: 2,
       };
 

--- a/libs/ledger-live-common/src/families/evm/platformAdapter.ts
+++ b/libs/ledger-live-common/src/families/evm/platformAdapter.ts
@@ -1,7 +1,8 @@
 // TODO: to remove once live-app-sdk is depreciated and removed from LL
 
-import { EthereumTransaction as PlatformTransaction } from "@ledgerhq/live-app-sdk";
+import { DEFAULT_NONCE } from "@ledgerhq/coin-evm/createTransaction";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
+import { EthereumTransaction as PlatformTransaction } from "@ledgerhq/live-app-sdk";
 
 const CAN_EDIT_FEES = true;
 
@@ -12,7 +13,7 @@ const convertToLiveTransaction = (tx: PlatformTransaction): Partial<Transaction>
 
   const params = {
     family: "evm" as const,
-    nonce: tx.nonce,
+    nonce: tx.nonce === undefined ? DEFAULT_NONCE : tx.nonce,
     amount: tx.amount,
     recipient: tx.recipient,
     data: tx.data,

--- a/libs/ledger-live-common/src/families/evm/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/evm/walletApiAdapter.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_NONCE } from "@ledgerhq/coin-evm/createTransaction";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
 import { EthereumTransaction as WalletAPITransaction } from "@ledgerhq/wallet-api-core";
 import BigNumber from "bignumber.js";
@@ -18,7 +19,7 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         recipient: ethPlatformTx.recipient,
         data: undefined,
         gasLimit: undefined,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         customGasLimit: undefined,
         feesStrategy: "medium",
         maxFeePerGas: undefined,
@@ -52,7 +53,7 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         gasPrice: ethPlatformTx.gasPrice,
         gasLimit: ethPlatformTx.gasLimit,
         customGasLimit: ethPlatformTx.gasLimit,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         data: undefined,
         feesStrategy: "custom",
         type: 0,
@@ -86,7 +87,7 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         customGasLimit: ethPlatformTx.gasLimit,
         maxFeePerGas: ethPlatformTx.maxFeePerGas,
         maxPriorityFeePerGas: ethPlatformTx.maxPriorityFeePerGas,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         data: undefined,
         feesStrategy: "custom",
         type: 2,
@@ -119,8 +120,40 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
         feesStrategy: "medium",
         maxFeePerGas: undefined,
         maxPriorityFeePerGas: undefined,
-        nonce: undefined,
+        nonce: DEFAULT_NONCE,
         data: undefined,
+        type: 2,
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } =
+        evm.getWalletAPITransactionSignFlowInfos(ethPlatformTx);
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toEqual(expectedLiveTx);
+    });
+
+    test("with nonce provided", () => {
+      const ethPlatformTx: WalletAPITransaction = {
+        family: "ethereum",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        nonce: 1,
+      };
+
+      const expectedLiveTx: Partial<Transaction> = {
+        family: "evm",
+        amount: ethPlatformTx.amount,
+        recipient: ethPlatformTx.recipient,
+        data: undefined,
+        gasLimit: undefined,
+        nonce: 1,
+        customGasLimit: undefined,
+        feesStrategy: "medium",
+        maxFeePerGas: undefined,
+        maxPriorityFeePerGas: undefined,
         type: 2,
       };
 

--- a/libs/ledger-live-common/src/families/evm/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/evm/walletApiAdapter.ts
@@ -1,5 +1,6 @@
-import { EthereumTransaction as WalletAPIEthereumTransaction } from "@ledgerhq/wallet-api-core";
+import { DEFAULT_NONCE } from "@ledgerhq/coin-evm/createTransaction";
 import { Transaction } from "@ledgerhq/coin-evm/types/index";
+import { EthereumTransaction as WalletAPIEthereumTransaction } from "@ledgerhq/wallet-api-core";
 import {
   AreFeesProvided,
   ConvertToLiveTransaction,
@@ -17,9 +18,9 @@ const convertToLiveTransaction: ConvertToLiveTransaction<
 > = tx => {
   const hasFeesProvided = areFeesProvided(tx);
 
-  const params = {
+  const params: Partial<Transaction> = {
     family: "evm" as const,
-    nonce: tx.nonce,
+    nonce: tx.nonce === undefined ? DEFAULT_NONCE : tx.nonce,
     amount: tx.amount,
     recipient: tx.recipient,
     data: tx.data,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Cherry-pick of [this PR's](https://github.com/LedgerHQ/ledger-live/pull/5482) fix on develop to not block related developments while release is in progress

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://github.com/LedgerHQ/ledger-live/pull/5482

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] ~`npx changeset` was attached.~ N/A (changeset present in original PR on release, should be backported once merged, not re-created to avoid duplication) 
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - wallet-api sign methods (with our without nonce provided) should work fine
  	- for example this one walletAPI.transaction.signAndBroadcast( ... ) // without nonce

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
