### PR TITLE
fix: move swap-web-app cacheKey from input to hash

### DIFF
--- a/.changeset/funny-terms-collect.md
+++ b/.changeset/funny-terms-collect.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Move swap-web-app cacheKey from input to hash

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -162,16 +162,20 @@ const SwapWebView = ({ swapState, redirectToProviderApp }: SwapWebProps) => {
   };
 
   const isDevelopment = process.env.NODE_ENV === "development";
+  // TODO: remove hash logic after complete swap migration manifest={manifest}
   return (
     <>
       {isDevelopment && (
-        <TopBar manifest={manifest} webviewAPIRef={webviewAPIRef} webviewState={webviewState} />
+        <TopBar
+          manifest={{ ...manifest, url: `${manifest.url}#${swapState.cacheKey}` }}
+          webviewAPIRef={webviewAPIRef}
+          webviewState={webviewState}
+        />
       )}
       <SwapWebAppWrapper isDevelopment={isDevelopment}>
         <Web3AppWebview
-          manifest={manifest}
+          manifest={{ ...manifest, url: `${manifest.url}#${swapState.cacheKey}` }}
           inputs={{
-            cacheKey: swapState.cacheKey,
             theme: themeType,
             lang: locale,
             currencyTicker: fiatCurrency.ticker,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Move swap-web-app cacheKey from input to hash to avoid refresh swap-web-app with any change in params.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-10073

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
