### PR TITLE
fix cardano send max and spendable balance

### DIFF
--- a/.changeset/sharp-pandas-dance.md
+++ b/.changeset/sharp-pandas-dance.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Fix cardano spendable balance and sendmax amount on confirm screen

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/Delegation/Row.tsx
@@ -48,7 +48,6 @@ const Row = ({ account, delegation }: Props) => {
       ? delegation.ticker + " - " + delegation.name
       : shortAddressPreview(delegation.poolId);
   }
-  const totalStaked = account.balance.plus(delegation.rewards);
   return (
     <Wrapper>
       <Value>
@@ -59,7 +58,7 @@ const Row = ({ account, delegation }: Props) => {
       <Value>
         <FormattedVal
           ff="Inter|SemiBold"
-          val={totalStaked}
+          val={account.balance}
           unit={unit}
           showCode
           fontSize={3}

--- a/libs/ledger-live-common/src/families/cardano/deviceTransactionConfig.ts
+++ b/libs/ledger-live-common/src/families/cardano/deviceTransactionConfig.ts
@@ -80,11 +80,10 @@ function getDeviceTransactionConfig({
         }),
       });
     } else if (account.type === "Account") {
-      const transactionAmount = transaction.useAllAmount ? account.balance : transaction.amount;
       fields.push({
         type: "text",
         label: "Amount",
-        value: formatCurrencyUnit(getAccountUnit(account), transactionAmount, {
+        value: formatCurrencyUnit(getAccountUnit(account), transaction.amount, {
           showCode: true,
           disableRounding: true,
         }),

--- a/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
@@ -295,7 +295,7 @@ export const makeGetAccountShape =
     );
 
     const utxos = prepareUtxos(newTransactions, stableUtxos, accountCredentialsMap);
-    let utxosSum = utxos.reduce((total, u) => total.plus(u.amount), new BigNumber(0));
+    const utxosSum = utxos.reduce((total, u) => total.plus(u.amount), new BigNumber(0));
     const tokenBalance = mergeTokens(utxos.map(u => u.tokens).flat());
     const subAccounts = buildSubAccounts({
       initialAccount,
@@ -321,11 +321,7 @@ export const makeGetAccountShape =
     const cardanoNetworkInfo = await getNetworkInfo(initialAccount as CardanoAccount, currency);
     const delegationInfo = await getDelegationInfo(currency, stakeCredential.key);
 
-    let totalBalance = utxosSum;
-
-    if (delegationInfo?.rewards) {
-      totalBalance = utxosSum.plus(delegationInfo.rewards);
-    }
+    const totalBalance = delegationInfo?.rewards ? utxosSum.plus(delegationInfo.rewards) : utxosSum;
 
     const minAdaBalanceForTokens = tokenBalance.length
       ? calculateMinUtxoAmount(

--- a/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
@@ -295,7 +295,7 @@ const makeGetAccountShape =
     );
 
     const utxos = prepareUtxos(newTransactions, stableUtxos, accountCredentialsMap);
-    let accountBalance = utxos.reduce((total, u) => total.plus(u.amount), new BigNumber(0));
+    let utxosSum = utxos.reduce((total, u) => total.plus(u.amount), new BigNumber(0));
     const tokenBalance = mergeTokens(utxos.map(u => u.tokens).flat());
     const subAccounts = buildSubAccounts({
       initialAccount,
@@ -320,8 +320,11 @@ const makeGetAccountShape =
       }));
     const cardanoNetworkInfo = await getNetworkInfo(initialAccount as CardanoAccount, currency);
     const delegationInfo = await getDelegationInfo(currency, stakeCredential.key);
+
+    let totalBalance = utxosSum;
+
     if (delegationInfo?.rewards) {
-      accountBalance = accountBalance.plus(delegationInfo.rewards);
+      totalBalance = utxosSum.plus(delegationInfo.rewards);
     }
 
     const minAdaBalanceForTokens = tokenBalance.length
@@ -349,8 +352,8 @@ const makeGetAccountShape =
     return {
       id: accountId,
       xpub,
-      balance: accountBalance,
-      spendableBalance: accountBalance.minus(minAdaBalanceForTokens),
+      balance: totalBalance,
+      spendableBalance: utxosSum.minus(minAdaBalanceForTokens),
       operations: operations,
       syncHash,
       subAccounts,

--- a/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
+++ b/libs/ledger-live-common/src/families/cardano/js-synchronisation.ts
@@ -205,7 +205,7 @@ export type SignerContext = (
   fn: (signer: Ada) => Promise<ExtendedPublicKey>,
 ) => Promise<ExtendedPublicKey>;
 
-const makeGetAccountShape =
+export const makeGetAccountShape =
   (signerContext: SignerContext): GetAccountShape =>
   async (info, { blacklistedTokenIds }) => {
     const {

--- a/libs/ledger-live-common/src/families/cardano/js-synchronisation.unit.test.ts
+++ b/libs/ledger-live-common/src/families/cardano/js-synchronisation.unit.test.ts
@@ -1,0 +1,125 @@
+import BigNumber from "bignumber.js";
+import { AccountShapeInfo, GetAccountShape } from "../../bridge/jsHelpers";
+import { APINetworkInfo, APITransaction } from "./api/api-types";
+import { getDelegationInfo } from "./api/getDelegationInfo";
+import { getNetworkInfo } from "./api/getNetworkInfo";
+import { getTransactions } from "./api/getTransactions";
+import { buildSubAccounts } from "./buildSubAccounts";
+import { makeGetAccountShape, SignerContext } from "./js-synchronisation";
+import { BipPath, CardanoAccount, CardanoDelegation } from "./types";
+jest.mock("./buildSubAccounts");
+jest.mock("./api/getTransactions");
+jest.mock("./api/getNetworkInfo");
+jest.mock("./api/getDelegationInfo");
+
+describe("makeGetAccountShape", () => {
+  let signerContext: SignerContext;
+  let shape: GetAccountShape;
+  let accountShapeInfo: AccountShapeInfo;
+  let getTransactionsMock;
+
+  beforeEach(() => {
+    const pubKeyMock = {
+      extendedPubKeyHex: "extendedPubKeyHex",
+      chainCodeHex: "chainCodeHex",
+      publicKeyHex: "publicKeyHex",
+    };
+    signerContext = () => Promise.resolve(pubKeyMock);
+    shape = makeGetAccountShape(signerContext);
+    accountShapeInfo = {
+      currency: { id: "cardano" } as any,
+      address: "add",
+      index: 0,
+      initialAccount: {
+        cardanoResources: {
+          utxos: [
+            {
+              hash: "hash",
+              index: 0,
+              address: "addr",
+              amount: new BigNumber(1),
+              tokens: [],
+              paymentCredential: {
+                key: "key",
+                path: {
+                  purpose: 1852,
+                  coin: 1815,
+                  account: 0,
+                  chain: 0,
+                  index: 0,
+                },
+              },
+            },
+          ],
+        },
+      } as unknown as CardanoAccount,
+      derivationPath: "",
+      derivationMode: "cardano",
+      deviceId: "id",
+    };
+    const buildSubAccountsMock = jest.mocked(buildSubAccounts);
+    buildSubAccountsMock.mockReturnValue([]);
+    getTransactionsMock = jest.mocked(getTransactions);
+    const getNetworkInfoMock = jest.mocked(getNetworkInfo);
+    getNetworkInfoMock.mockReturnValue(
+      Promise.resolve({ protocolParams: { lovelacePerUtxoWord: "1" } } as APINetworkInfo),
+    );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("balance", () => {
+    it("should return 0 balance when there is no utxos", async () => {
+      getTransactionsMock.mockReturnValue(
+        Promise.resolve({
+          transactions: [],
+          externalCredentials: [
+            { path: { index: 0 } as BipPath, networkId: "id", isUsed: false, key: "" },
+          ],
+          internalCredentials: [],
+          blockHeight: 0,
+        }),
+      );
+      const result = await shape(accountShapeInfo, { paginationConfig: {} });
+      expect(result.balance).toEqual(new BigNumber(0));
+    });
+
+    it("should return the sum of utxos with delegation reward value", async () => {
+      getTransactionsMock.mockReturnValue(
+        Promise.resolve({
+          transactions: [],
+          externalCredentials: [
+            { path: { index: 0 } as BipPath, networkId: "id", isUsed: false, key: "" },
+          ],
+          internalCredentials: ["cred"],
+          blockHeight: 0,
+        }),
+      );
+      const getDelegationInfoMock = jest.mocked(getDelegationInfo);
+      getDelegationInfoMock.mockReturnValue(
+        Promise.resolve({ rewards: new BigNumber(42) } as CardanoDelegation),
+      );
+      const result = await shape(accountShapeInfo, { paginationConfig: {} });
+      expect(result.balance).toEqual(new BigNumber(42));
+    });
+  });
+
+  describe("spendableBalance", () => {
+    it("should return 0 spendable balance when there is no utxos", async () => {
+      const getTransactionsMock = jest.mocked(getTransactions);
+      getTransactionsMock.mockReturnValue(
+        Promise.resolve({
+          transactions: [],
+          externalCredentials: [{ path: "p", networkId: "id" }],
+          internalCredentials: [],
+        } as any),
+      );
+      const result = await shape(accountShapeInfo, { paginationConfig: {} });
+      expect(result.spendableBalance).toEqual(new BigNumber(0));
+    });
+
+    // it("should return the sum of utxos minus ada minimum for tokens", async () => {});
+  });
+});

--- a/libs/ledger-live-common/src/families/cardano/js-synchronisation.unit.test.ts
+++ b/libs/ledger-live-common/src/families/cardano/js-synchronisation.unit.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { AccountShapeInfo, GetAccountShape } from "../../bridge/jsHelpers";
-import { APINetworkInfo, APITransaction } from "./api/api-types";
+import { APINetworkInfo } from "./api/api-types";
 import { getDelegationInfo } from "./api/getDelegationInfo";
 import { getNetworkInfo } from "./api/getNetworkInfo";
 import { getTransactions } from "./api/getTransactions";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix cardano spendable balance on LLD as it included twice the reward
Fix cardano amount on last step before signing

Integration tests fail the same way on develop : https://github.com/LedgerHQ/ledger-live/actions/runs/6967769829/job/18960305105

Adding unit test for the utxo sum is really difficult as I don't know the specifics on utxos/internalcredential/paymentCred thing

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [https://ledgerhq.atlassian.net/browse/LIVE-9913](https://ledgerhq.atlassian.net/browse/LIVE-9913), [https://ledgerhq.atlassian.net/browse/LIVE-10253](https://ledgerhq.atlassian.net/browse/LIVE-10253)
### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Send max amount on confirmation with device screen
  - Available balance

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [] **Any new dependencies** have been justified and documented.
- [] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
