### PR TITLE
fix(stax): loading multiple invalid pictures and going back will navigate on correct page

### DIFF
--- a/.changeset/pretty-poems-lie.md
+++ b/.changeset/pretty-poems-lie.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Loading multiple invalid picture for stax and using the back arrow navigate to the correct page

--- a/apps/ledger-live-mobile/src/components/RootNavigator/CustomImageNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/CustomImageNavigator.tsx
@@ -12,6 +12,7 @@ import Step0Welcome from "../../screens/CustomImage/Step0Welcome";
 import PreviewPreEdit from "../../screens/CustomImage/PreviewPreEdit";
 import PreviewPostEdit from "../../screens/CustomImage/PreviewPostEdit";
 import NFTGallerySelector from "../../screens/CustomImage/NFTGallerySelector";
+import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import { CustomImageNavigatorParamList } from "./types/CustomImageNavigator";
 
 export default function CustomImageNavigator() {
@@ -47,11 +48,11 @@ export default function CustomImageNavigator() {
       <Stack.Screen
         name={ScreenName.CustomImageErrorScreen}
         component={ErrorScreen}
-        options={{
+        options={({ navigation }) => ({
           title: "",
-          headerLeft: undefined,
+          headerLeft: () => <NavigationHeaderBackButton onPress={() => navigation.popToTop()} />,
           gestureEnabled: false,
-        }}
+        })}
       />
       <Stack.Screen
         name={ScreenName.CustomImagePreviewPreEdit}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/CustomImageNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/CustomImageNavigator.tsx
@@ -12,7 +12,6 @@ import Step0Welcome from "../../screens/CustomImage/Step0Welcome";
 import PreviewPreEdit from "../../screens/CustomImage/PreviewPreEdit";
 import PreviewPostEdit from "../../screens/CustomImage/PreviewPostEdit";
 import NFTGallerySelector from "../../screens/CustomImage/NFTGallerySelector";
-import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 import { CustomImageNavigatorParamList } from "./types/CustomImageNavigator";
 
 export default function CustomImageNavigator() {
@@ -48,11 +47,11 @@ export default function CustomImageNavigator() {
       <Stack.Screen
         name={ScreenName.CustomImageErrorScreen}
         component={ErrorScreen}
-        options={({ navigation }) => ({
+        options={{
           title: "",
-          headerLeft: () => <NavigationHeaderBackButton onPress={() => navigation.popToTop()} />,
+          headerLeft: undefined,
           gestureEnabled: false,
-        })}
+        }}
       />
       <Stack.Screen
         name={ScreenName.CustomImagePreviewPreEdit}

--- a/apps/ledger-live-mobile/src/screens/CustomImage/ErrorScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/ErrorScreen.tsx
@@ -1,5 +1,5 @@
 import { Flex } from "@ledgerhq/native-ui";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
@@ -25,10 +25,30 @@ const buttonClickedEventProperties = {
   button: "upload another image",
 };
 
-const ErrorScreen = ({ route }: NavigationProps) => {
+const ErrorScreen = ({ route, navigation }: NavigationProps) => {
   const [isModalOpened, setIsModalOpened] = useState(false);
   const { params } = route;
   const { error, device } = params;
+
+  // Only keep 1 instance of error page in the navigation
+  useEffect(() => {
+    const navigationState = navigation.getState();
+    const { index, routes } = navigationState;
+    const firstErrorPageIndex = routes.findIndex(
+      (route: { name: string }, id: number) =>
+        route.name === ScreenName.CustomImageErrorScreen && index !== id,
+    );
+
+    if (firstErrorPageIndex !== -1) {
+      const filteredRoutes = routes.filter((route, id) => id !== firstErrorPageIndex);
+
+      navigation.reset({
+        ...navigationState,
+        index: filteredRoutes.length - 1,
+        routes: filteredRoutes,
+      });
+    }
+  }, [navigation]);
 
   const { t } = useTranslation();
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Only allow one error page in navigation so going back return to the previous page.

Before

https://github.com/LedgerHQ/ledger-live/assets/146743014/974e9a79-eace-498b-a4d9-88f6bc6f6f49

After

https://github.com/LedgerHQ/ledger-live/assets/146743014/95089369-8154-41e9-9d90-818dc898e2e1


### ❓ Context

LLM
[LIVE-7703](https://ledgerhq.atlassian.net/browse/LIVE-7703?filter=13654)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Reforge the navigation history to only keep the last error page

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-7703]: https://ledgerhq.atlassian.net/browse/LIVE-7703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ