### PR TITLE
[BUGFIX] : 2 X icons to close when scanning QR code on Send

### DIFF
--- a/.changeset/nasty-needles-sell.md
+++ b/.changeset/nasty-needles-sell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix 2 "X" icons to close when scanning QR code on Send

--- a/apps/ledger-live-mobile/src/components/CameraScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/components/CameraScreen/index.tsx
@@ -1,13 +1,10 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { View } from "react-native";
 import { rgba } from "../../colors";
 import QRCodeBottomLayer from "./QRCodeBottomLayer";
-import { Box, Flex, IconsLegacy } from "@ledgerhq/native-ui";
+import { Box, Flex } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import ScanTargetSvg from "./ScanTargetSvg";
-import { TouchableOpacity } from "react-native";
-import { useNavigation } from "@react-navigation/native";
-import { track } from "../../analytics";
 
 type Props = {
   width: number;
@@ -18,14 +15,6 @@ type Props = {
 };
 export default function CameraScreen({ width, height, progress, liveQrCode, instruction }: Props) {
   const { colors } = useTheme();
-  const { goBack } = useNavigation();
-
-  const onClose = useCallback(() => {
-    track("button_clicked", {
-      button: "Close",
-    });
-    goBack();
-  }, [goBack]);
 
   // Make the viewfinder borders 2/3 of the screen shortest border
   const wrapperStyle =
@@ -40,38 +29,14 @@ export default function CameraScreen({ width, height, progress, liveQrCode, inst
         };
   return (
     <View style={wrapperStyle}>
-      <Flex
-        height={height * 0.15}
-        backgroundColor={rgba(colors.constant.black, 0.8)}
-        alignItems={"flex-end"}
-        px={6}
-        pt={9}
-        zIndex={1}
-      >
-        <TouchableOpacity onPress={onClose}>
-          <Flex
-            bg={"neutral.c100"}
-            width={"32px"}
-            height={"32px"}
-            alignItems={"center"}
-            justifyContent={"center"}
-            borderRadius={32}
-          >
-            <IconsLegacy.CloseMedium size={20} color={"neutral.c00"} />
-          </Flex>
-        </TouchableOpacity>
-      </Flex>
+      <Flex height={height * 0.15} px={6} pt={9} zIndex={1} />
       <Flex flexDirection={"row"} justifyContent={"space-evenly"} alignItems={"center"}>
         <Box flexGrow={1} backgroundColor={rgba(colors.constant.black, 0.8)} height={"100%"} />
         <ScanTargetSvg />
         <Box flexGrow={1} backgroundColor={rgba(colors.constant.black, 0.8)} height={"100%"} />
       </Flex>
       <Box backgroundColor={rgba(colors.constant.black, 0.8)} flex={1}>
-        <QRCodeBottomLayer
-          liveQrCode={liveQrCode}
-          progress={progress}
-          instruction={instruction}
-        ></QRCodeBottomLayer>
+        <QRCodeBottomLayer liveQrCode={liveQrCode} progress={progress} instruction={instruction} />
       </Box>
     </View>
   );

--- a/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
@@ -46,6 +46,29 @@ export const NavigationHeaderCloseButton: React.FC<Props> = React.memo(({ onPres
   );
 });
 
+export const NavigationHeaderCloseButtonRounded: React.FC<Props> = React.memo(({ onPress }) => {
+  const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
+  return (
+    <Touchable
+      onPress={() => (onPress ? onPress() : navigation.popToTop())}
+      touchableTestID="NavigationHeaderCloseButton"
+      event="HeaderRightClose"
+    >
+      <Flex
+        bg="neutral.c100"
+        width="32px"
+        height="32px"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius={32}
+        mr={6}
+      >
+        <IconsLegacy.CloseMedium size={20} color="neutral.c00" />
+      </Flex>
+    </Touchable>
+  );
+});
+
 type AdvancedProps = {
   preferDismiss?: boolean;
   skipNavigation?: boolean;
@@ -54,6 +77,7 @@ type AdvancedProps = {
   confirmationTitle?: React.ReactNode;
   confirmationDesc?: React.ReactNode;
   onClose?: () => void;
+  rounded?: boolean;
 };
 
 /**
@@ -71,6 +95,7 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
     confirmationTitle,
     confirmationDesc,
     onClose = emptyFunction,
+    rounded = false,
   }) => {
     const navigation = useNavigation();
     const [isConfirmationModalOpened, setIsConfirmationModalOpened] = useState(false);
@@ -134,7 +159,12 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
 
     return (
       <>
-        <NavigationHeaderCloseButton onPress={onPress} color={color} />
+        {rounded ? (
+          <NavigationHeaderCloseButtonRounded onPress={onPress} color={color} />
+        ) : (
+          <NavigationHeaderCloseButton onPress={onPress} color={color} />
+        )}
+
         {withConfirmation && (
           <ConfirmationModal
             isOpened={isConfirmationModalOpened}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -421,6 +421,7 @@ export default function BaseNavigator() {
               <NavigationHeaderCloseButtonAdvanced
                 color={colors.constant.white}
                 preferDismiss={false}
+                rounded
               />
             ),
             headerLeft: () => null,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ImportAccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ImportAccountsNavigator.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTranslation } from "react-i18next";
-import { Text } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "../../const";
 import ScanAccounts from "../../screens/ImportAccounts/Scan";
@@ -22,13 +21,15 @@ export default function ImportAccountsNavigator() {
         component={ScanAccounts}
         options={{
           ...TransparentHeaderNavigationOptions,
-          headerShown: false,
-          headerTitle: () => (
-            <Text variant="h3" uppercase>
-              {t("account.import.scan.title")}
-            </Text>
+          headerShown: true,
+          headerTitle: () => null,
+          headerRight: () => (
+            <NavigationHeaderCloseButtonAdvanced
+              color={colors.constant.white}
+              preferDismiss={false}
+              rounded
+            />
           ),
-          headerRight: props => <NavigationHeaderCloseButtonAdvanced {...props} color={"#fff"} />,
           headerLeft: () => null,
         }}
       />

--- a/apps/ledger-live-mobile/src/components/Scanner.tsx
+++ b/apps/ledger-live-mobile/src/components/Scanner.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useContext } from "react";
+import React, { useContext } from "react";
 import { StyleSheet, View } from "react-native";
 import { BarCodeScanningResult, Camera, CameraType } from "expo-camera";
 import { BarCodeScanner } from "expo-barcode-scanner";
-import { useTheme } from "styled-components/native";
-import { useNavigation } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
 import StyledStatusBar from "./StyledStatusBar";
 import CameraScreen from "./CameraScreen";
-import { NavigationHeaderCloseButtonAdvanced } from "./NavigationHeaderCloseButton";
 import getWindowDimensions from "../logic/getWindowDimensions";
 import RequiresCameraPermissions from "./RequiresCameraPermissions";
 import CameraPermissionContext from "./RequiresCameraPermissions/CameraPermissionContext";
@@ -23,21 +20,6 @@ type Props = {
 const Scanner = ({ onResult, liveQrCode, progress, instruction }: Props) => {
   const hasPermission = useContext(CameraPermissionContext).permissionGranted;
   const { width, height } = getWindowDimensions();
-  const navigation = useNavigation();
-  const { colors } = useTheme();
-
-  useEffect(() => {
-    if (hasPermission) {
-      navigation.setOptions({
-        headerRight: () => (
-          <NavigationHeaderCloseButtonAdvanced
-            color={colors.constant.white}
-            preferDismiss={false}
-          />
-        ),
-      });
-    }
-  }, [colors, hasPermission, navigation]);
 
   if (!hasPermission) return <View />;
 
@@ -68,16 +50,6 @@ const Scanner = ({ onResult, liveQrCode, progress, instruction }: Props) => {
 };
 
 const ScannerWrappedInRequiresCameraPermission: React.FC<Props> = props => {
-  const navigation = useNavigation();
-  const { colors } = useTheme();
-  useEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <NavigationHeaderCloseButtonAdvanced color={colors.neutral.c100} preferDismiss={false} />
-      ),
-    });
-  }, [colors.neutral.c100, navigation]);
-
   return (
     <RequiresCameraPermissions optimisticallyMountChildren>
       <Scanner {...props} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

There was  2 X icons to close when scanning QR code on Send

![Simulator Screenshot - iPhone 14 Pro - 2023-11-27 at 17 22 34](https://github.com/LedgerHQ/ledger-live/assets/112866305/1e2eb4b1-8a27-48b0-85de-3bc5fdbca3d0)
![Simulator Screenshot - iPhone 14 Pro - 2023-11-27 at 17 22 27](https://github.com/LedgerHQ/ledger-live/assets/112866305/aca38752-49de-413e-bdc7-0b5783e04b47)


### ❓ Context

- **JIRA or GitHub link**: [LIVE-10250]<!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10250]: https://ledgerhq.atlassian.net/browse/LIVE-10250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ