### PR TITLE
[BUGFIX] : LLD was showing an error page : TypeError Cannot destructure property ‘Component’ of ‘n[Y]’ as it is undefined

### DIFF
--- a/.changeset/cyan-students-visit.md
+++ b/.changeset/cyan-students-visit.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+LLD was showing an error page : TypeError Cannot destructure property ‘Component’ of ‘n[Y]’ as it is undefined

--- a/apps/ledger-live-desktop/src/renderer/components/Carousel/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Carousel/index.tsx
@@ -272,6 +272,8 @@ const Carousel = ({
       ) : null}
       <Slides>
         {transitions.map(({ item, props, key }) => {
+          if (!slides?.[item]) return null;
+
           const { Component } = slides[item];
           return (
             <animated.div key={key} style={{ ...props }}>


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

TypeError Cannot destructure property ‘Component’ of ‘n[Y]’ as it is undefined was showing up on some times in Carousel

Related to this error 
<img width="917" alt="Screenshot 2023-11-28 at 11 35 37" src="https://github.com/LedgerHQ/ledger-live/assets/112866305/3d1835b5-5bc7-44a1-9e56-6d9088ba5efa">


### ❓ Context

- **JIRA or GitHub link**: [LIVE-10306] <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10306]: https://ledgerhq.atlassian.net/browse/LIVE-10306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ