### PR TITLE
[LIVE-5499] Replace 'Allow Manager' Lottie's by 'Validate' Lottie's 

### DIFF
--- a/.changeset/mighty-comics-suffer.md
+++ b/.changeset/mighty-comics-suffer.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Replace "Allow Manager" Lottie by "Validate" Lottie's

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/animations.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/animations.ts
@@ -17,9 +17,9 @@ import NANO_S_LIGHT_quitApp from "~/renderer/animations/nanoS/4QuitApp/light.jso
 // @ts-ignore
 import NANO_S_DARK_quitApp from "~/renderer/animations/nanoS/4QuitApp/dark.json";
 // @ts-ignore
-import NANO_S_LIGHT_allowManager from "~/renderer/animations/nanoS/5AllowManager/light.json";
+import NANO_S_LIGHT_allowManager from "~/renderer/animations/nanoS/7Validate/light.json";
 // @ts-ignore
-import NANO_S_DARK_allowManager from "~/renderer/animations/nanoS/5AllowManager/dark.json";
+import NANO_S_DARK_allowManager from "~/renderer/animations/nanoS/7Validate/dark.json";
 // @ts-ignore
 import NANO_S_LIGHT_openApp from "~/renderer/animations/nanoS/6OpenApp/light.json";
 // @ts-ignore
@@ -51,9 +51,9 @@ import NANO_X_LIGHT_quitApp from "~/renderer/animations/nanoX/4QuitApp/light.jso
 // @ts-ignore
 import NANO_X_DARK_quitApp from "~/renderer/animations/nanoX/4QuitApp/dark.json";
 // @ts-ignore
-import NANO_X_LIGHT_allowManager from "~/renderer/animations/nanoX/5AllowManager/light.json";
+import NANO_X_LIGHT_allowManager from "~/renderer/animations/nanoX/7Validate/light.json";
 // @ts-ignore
-import NANO_X_DARK_allowManager from "~/renderer/animations/nanoX/5AllowManager/dark.json";
+import NANO_X_DARK_allowManager from "~/renderer/animations/nanoX/7Validate/dark.json";
 // @ts-ignore
 import NANO_X_LIGHT_openApp from "~/renderer/animations/nanoX/6OpenApp/light.json";
 // @ts-ignore
@@ -88,9 +88,9 @@ import NANO_SP_LIGHT_quitApp from "~/renderer/animations/nanoSP/4QuitApp/light.j
 // @ts-ignore
 import NANO_SP_DARK_quitApp from "~/renderer/animations/nanoSP/4QuitApp/dark.json";
 // @ts-ignore
-import NANO_SP_LIGHT_allowManager from "~/renderer/animations/nanoSP/5AllowManager/light.json";
+import NANO_SP_LIGHT_allowManager from "~/renderer/animations/nanoSP/7Validate/light.json";
 // @ts-ignore
-import NANO_SP_DARK_allowManager from "~/renderer/animations/nanoSP/5AllowManager/dark.json";
+import NANO_SP_DARK_allowManager from "~/renderer/animations/nanoSP/7Validate/dark.json";
 // @ts-ignore
 import NANO_SP_LIGHT_openApp from "~/renderer/animations/nanoSP/6OpenApp/light.json";
 // @ts-ignore

--- a/apps/ledger-live-mobile/src/helpers/getDeviceAnimation.ts
+++ b/apps/ledger-live-mobile/src/helpers/getDeviceAnimation.ts
@@ -28,8 +28,8 @@ const animations: Animations = {
       dark: require("../animations/nanoS/4QuitApp/dark.json"),
     },
     allowManager: {
-      light: require("../animations/nanoS/5AllowManager/light.json"),
-      dark: require("../animations/nanoS/5AllowManager/dark.json"),
+      light: require("../animations/nanoS/7Validate/light.json"),
+      dark: require("../animations/nanoS/7Validate/dark.json"),
     },
     openApp: {
       light: require("../animations/nanoS/6OpenApp/light.json"),
@@ -62,8 +62,8 @@ const animations: Animations = {
       dark: require("../animations/nanoSP/4QuitApp/dark.json"),
     },
     allowManager: {
-      light: require("../animations/nanoSP/5AllowManager/light.json"),
-      dark: require("../animations/nanoSP/5AllowManager/dark.json"),
+      light: require("../animations/nanoSP/7Validate/light.json"),
+      dark: require("../animations/nanoSP/7Validate/dark.json"),
     },
     openApp: {
       light: require("../animations/nanoSP/6OpenApp/light.json"),
@@ -131,8 +131,8 @@ const animations: Animations = {
         dark: require("../animations/nanoX/wired/4QuitApp/dark.json"),
       },
       allowManager: {
-        light: require("../animations/nanoX/wired/5AllowManager/light.json"),
-        dark: require("../animations/nanoX/wired/5AllowManager/dark.json"),
+        light: require("../animations/nanoX/wired/7Validate/light.json"),
+        dark: require("../animations/nanoX/wired/7Validate/dark.json"),
       },
       openApp: {
         light: require("../animations/nanoX/wired/6OpenApp/light.json"),
@@ -165,8 +165,8 @@ const animations: Animations = {
         dark: require("../animations/nanoX/bluetooth/4QuitApp/dark.json"),
       },
       allowManager: {
-        light: require("../animations/nanoX/bluetooth/5AllowManager/light.json"),
-        dark: require("../animations/nanoX/bluetooth/5AllowManager/dark.json"),
+        light: require("../animations/nanoX/bluetooth/7Validate/light.json"),
+        dark: require("../animations/nanoX/bluetooth/7Validate/dark.json"),
       },
       openApp: {
         light: require("../animations/nanoX/bluetooth/6OpenApp/light.json"),


### PR DESCRIPTION
📝 Description
Replace localize lottie for "Allow Manager" by "validate" which just show a checkmark on the device screen (NanoS, NanoSP, NanoX)

❓ Context
[LIVE-5499](https://ledgerhq.atlassian.net/browse/LIVE-5499)
✅ Checklist
Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

 npx changeset was attached.
 Covered by automatic tests. <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression)
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-5499]: https://ledgerhq.atlassian.net/browse/LIVE-5499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ