### PR TITLE
[FEAT][LIVE-10320] update near explorer views urls

### DIFF
--- a/.changeset/hungry-countries-compare.md
+++ b/.changeset/hungry-countries-compare.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/cryptoassets": patch
+"@ledgerhq/live-common": patch
+---
+
+update near explorer views urls

--- a/libs/ledger-live-common/src/currencies/mock.ts
+++ b/libs/ledger-live-common/src/currencies/mock.ts
@@ -482,8 +482,8 @@ export const CURRENCIES_LIST: CryptoCurrency[] = [
     ],
     explorerViews: [
       {
-        address: "https://explorer.near.org/accounts/$address",
-        tx: "https://explorer.near.org/transactions/$hash",
+        address: "https://nearblocks.io/address/$address",
+        tx: "https://nearblocks.io/txns/$hash",
       },
     ],
     keywords: ["near"],

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -104,8 +104,8 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ],
     explorerViews: [
       {
-        address: "https://explorer.near.org/accounts/$address",
-        tx: "https://explorer.near.org/transactions/$hash",
+        address: "https://nearblocks.io/address/$address",
+        tx: "https://nearblocks.io/txns/$hash",
       },
     ],
     keywords: ["near"],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Update the NEAR explorer view to https://nearblocks.io/ since the originally used one will be deprecated early 2024.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10320

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] ~**Covered by automatic tests.**~ N/A <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - On LLD and LLM, in the transaction details screen, the CTA to view the transaction in block explorer should now redirect to https://nearblocks.io/ instead of https://explorer.near.org

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
