### PR TITLE
[BUGFIX] : LL Welcome Page Partially in EN when a PWD is set and you are in other language

### DIFF
--- a/.changeset/lucky-buttons-rush.md
+++ b/.changeset/lucky-buttons-rush.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LL Welcome Page Partially in EN when a PWD is set and you were is French or any other language

--- a/apps/ledger-live-mobile/src/context/AuthPass/AuthScreen.tsx
+++ b/apps/ledger-live-mobile/src/context/AuthPass/AuthScreen.tsx
@@ -1,5 +1,5 @@
 import React, { PureComponent } from "react";
-import { withTranslation, Trans } from "react-i18next";
+import { withTranslation, useTranslation } from "react-i18next";
 import {
   TouchableWithoutFeedback,
   View,
@@ -53,14 +53,17 @@ type Props = OwnProps & {
 
 function NormalHeader() {
   const { colors } = useTheme();
+
+  const { t } = useTranslation();
+
   return (
     <Flex alignItems="center" justifyContent="center">
       <Logos.LedgerLiveAltRegular color={colors.neutral.c100} width={50} height={50} />
       <LText semiBold secondary style={styles.title}>
-        <Trans i18nKey="auth.unlock.title" />
+        {t("auth.unlock.title")}
       </LText>
       <LText style={styles.description} color="grey">
-        <Trans i18nKey="auth.unlock.desc" />
+        {t("auth.unlock.desc")}
       </LText>
     </Flex>
   );
@@ -82,11 +85,12 @@ const FormFooter = ({
   passwordError,
   onPress,
 }: FormFooterProps) => {
+  const { t } = useTranslation();
   return inputFocused ? (
     <TouchableWithoutFeedback>
       <BaseButton
         event="SubmitUnlock"
-        title={<Trans i18nKey="auth.unlock.login" />}
+        title={t("auth.unlock.login")}
         type="primary"
         onPress={onSubmit}
         containerStyle={styles.buttonContainer}
@@ -98,7 +102,7 @@ const FormFooter = ({
   ) : (
     <Touchable event="ForgetPassword" onPress={onPress}>
       <LText semiBold style={styles.link} color="live">
-        <Trans i18nKey="auth.unlock.forgotPassword" />
+        {t("auth.unlock.forgotPassword")}
       </LText>
     </Touchable>
   );

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -291,9 +291,9 @@ export default class Root extends Component {
                           <StylesProvider>
                             <StyledStatusBar />
                             <NavBarColorHandler />
-                            <AuthPass>
-                              <I18nextProvider i18n={i18n}>
-                                <LocaleProvider>
+                            <I18nextProvider i18n={i18n}>
+                              <LocaleProvider>
+                                <AuthPass>
                                   <BridgeSyncProvider>
                                     <CounterValuesProvider initialState={initialCountervalues}>
                                       <ButtonUseTouchableContext.Provider value={true}>
@@ -314,9 +314,9 @@ export default class Root extends Component {
                                       </ButtonUseTouchableContext.Provider>
                                     </CounterValuesProvider>
                                   </BridgeSyncProvider>
-                                </LocaleProvider>
-                              </I18nextProvider>
-                            </AuthPass>
+                                </AuthPass>
+                              </LocaleProvider>
+                            </I18nextProvider>
                           </StylesProvider>
                         </PerformanceProvider>
                       </SafeAreaProvider>


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

LL Welcome Page Partially in EN when a PWD is set and you are in other language 
- you needed to focus input to have translations updated


https://github.com/LedgerHQ/ledger-live/assets/112866305/756bd346-1dea-44ba-ba02-85a369bb42b1



### ❓ Context

- **JIRA or GitHub link**: [LIVE-10334] <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10334]: https://ledgerhq.atlassian.net/browse/LIVE-10334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ