### PR TITLE
Fix: max amount swap failed transaction when stop auto refresh

### DIFF
--- a/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.ts
@@ -63,8 +63,11 @@ export const useUpdateMaxAmount = ({
           transaction,
         });
         setIsMaxLoading(false);
-        // todo check amount before reducing it
-        if (isAccount(account) && ["evm", "bitcoin", "dot"].includes(transaction?.family || "")) {
+        if (
+          isAccount(account) && // only apply fix to native currencies account
+          ["evm"].includes(transaction?.family || "") && // Only apply fix to EVM families
+          amount.shiftedBy(account.unit.magnitude).gt(0.02) // prevent going below 0 with max amount
+        ) {
           setFromAmount(amount.minus(new BigNumber(0.01).shiftedBy(account.unit.magnitude)));
         } else {
           setFromAmount(amount);

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useUpdateMaxAmount.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { getAccountBridge } from "../../../bridge";
 import { Result as UseBridgeTransactionResult } from "../../../bridge/useBridgeTransaction";
 import { SwapDataType, SwapSelectorStateType, SwapTransactionType } from "../types";
+import { isAccount } from "@ledgerhq/coin-framework/account/helpers";
 
 export const ZERO = new BigNumber(0);
 
@@ -62,7 +63,12 @@ export const useUpdateMaxAmount = ({
           transaction,
         });
         setIsMaxLoading(false);
-        setFromAmount(amount);
+        // todo check amount before reducing it
+        if (isAccount(account) && ["evm", "bitcoin", "dot"].includes(transaction?.family || "")) {
+          setFromAmount(amount.minus(new BigNumber(0.01).shiftedBy(account.unit.magnitude)));
+        } else {
+          setFromAmount(amount);
+        }
       };
 
       if (isMaxEnabled) {


### PR DESCRIPTION
### 📝 Description

Fix: max amount swap failed transaction when stop auto refresh. 
Bug that could happen with #5583  

Only applying on EVM as other networks might work differently 

PS: not an ideal fix but feature will be deprecated once migrated to swap-web-app in a few months.

### ❓ Context

JIRA-9064 and #5583

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
