### PR TITLE
fix big transactions cosmos

### DIFF
--- a/.changeset/tame-schools-float.md
+++ b/.changeset/tame-schools-float.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Fix big number transactions on cosmos family

--- a/libs/ledger-live-common/src/families/cosmos/js-buildTransaction.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-buildTransaction.test.ts
@@ -34,7 +34,7 @@ describe("txToMessages", () => {
         expect(aminoMsg.type).toContain("MsgSend");
         expect(aminoMsg.value.to_address).toEqual(transaction.recipient);
         expect(aminoMsg.value.from_address).toEqual(account.freshAddress);
-        expect(aminoMsg.value.amount[0].amount).toEqual(transaction.amount.toString());
+        expect(aminoMsg.value.amount[0].amount).toEqual(transaction.amount.toFixed());
         expect(aminoMsg.value.amount[0].denom).toEqual(account.currency.units[1].code);
       });
 
@@ -75,7 +75,7 @@ describe("txToMessages", () => {
         expect(protoMsg.typeUrl).toContain("MsgSend");
         expect(value.toAddress).toEqual(transaction.recipient);
         expect(value.fromAddress).toEqual(account.freshAddress);
-        expect(value.amount[0].amount).toEqual(transaction.amount.toString());
+        expect(value.amount[0].amount).toEqual(transaction.amount.toFixed());
         expect(value.amount[0].denom).toEqual(account.currency.units[1].code);
       });
 
@@ -120,7 +120,7 @@ describe("txToMessages", () => {
         expect(message.type).toContain("MsgDelegate");
         expect(message.value.validator_address).toEqual(transaction.validators[0].address);
         expect(message.value.delegator_address).toEqual(account.freshAddress);
-        expect(message.value.amount?.amount).toEqual(transaction.amount.toString());
+        expect(message.value.amount?.amount).toEqual(transaction.amount.toFixed());
         expect(message.value.amount?.denom).toEqual(account.currency.units[1].code);
       });
 
@@ -167,7 +167,7 @@ describe("txToMessages", () => {
         const value = MsgDelegate.decode(message.value);
         expect(value.validatorAddress).toEqual(transaction.validators[0].address);
         expect(value.delegatorAddress).toEqual(account.freshAddress);
-        expect(value.amount?.amount).toEqual(transaction.amount.toString());
+        expect(value.amount?.amount).toEqual(transaction.amount.toFixed());
         expect(value.amount?.denom).toEqual(account.currency.units[1].code);
       });
 
@@ -219,7 +219,7 @@ describe("txToMessages", () => {
         expect(message.type).toContain("MsgUndelegate");
         expect(message.value.validator_address).toEqual(transaction.validators[0].address);
         expect(message.value.delegator_address).toEqual(account.freshAddress);
-        expect(message.value.amount?.amount).toEqual(transaction.validators[0].amount.toString());
+        expect(message.value.amount?.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(message.value.amount?.denom).toEqual(account.currency.units[1].code);
       });
 
@@ -279,7 +279,7 @@ describe("txToMessages", () => {
         const value = MsgUndelegate.decode(message.value);
         expect(value.validatorAddress).toEqual(transaction.validators[0].address);
         expect(value.delegatorAddress).toEqual(account.freshAddress);
-        expect(value.amount?.amount).toEqual(transaction.validators[0].amount.toString());
+        expect(value.amount?.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(value.amount?.denom).toEqual(account.currency.units[1].code);
       });
 
@@ -345,7 +345,7 @@ describe("txToMessages", () => {
         expect(message.value.validator_src_address).toEqual(transaction.sourceValidator);
         expect(message.value.validator_dst_address).toEqual(transaction.validators[0].address);
         expect(message.value.delegator_address).toEqual(account.freshAddress);
-        expect(message.value.amount.amount).toEqual(transaction.validators[0].amount.toString());
+        expect(message.value.amount.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(message.value.amount.denom).toEqual(account.currency.units[1].code);
       });
 
@@ -410,7 +410,7 @@ describe("txToMessages", () => {
         expect(value.validatorSrcAddress).toEqual(transaction.sourceValidator);
         expect(value.validatorDstAddress).toEqual(transaction.validators[0].address);
         expect(value.delegatorAddress).toEqual(account.freshAddress);
-        expect(value.amount?.amount).toEqual(transaction.validators[0].amount.toString());
+        expect(value.amount?.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(value.amount?.denom).toEqual(account.currency.units[1].code);
       });
 
@@ -558,7 +558,7 @@ describe("txToMessages", () => {
         expect(delegateMessage.value.validator_address).toEqual(transaction.validators[0].address);
         expect(delegateMessage.value.delegator_address).toEqual(account.freshAddress);
         expect(delegateMessage.value.amount.amount).toEqual(
-          transaction.validators[0].amount.toString(),
+          transaction.validators[0].amount.toFixed(),
         );
         expect(delegateMessage.value.amount.denom).toEqual(account.currency.units[1].code);
       });
@@ -585,7 +585,7 @@ describe("txToMessages", () => {
         expect(delegateMessageValue.validatorAddress).toEqual(transaction.validators[0].address);
         expect(delegateMessageValue.delegatorAddress).toEqual(account.freshAddress);
         expect(delegateMessageValue.amount?.amount).toEqual(
-          transaction.validators[0].amount.toString(),
+          transaction.validators[0].amount.toFixed(),
         );
         expect(delegateMessageValue.amount?.denom).toEqual(account.currency.units[1].code);
       });

--- a/libs/ledger-live-common/src/families/cosmos/js-buildTransaction.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-buildTransaction.test.ts
@@ -12,6 +12,8 @@ import { MsgWithdrawDelegatorReward } from "cosmjs-types/cosmos/distribution/v1b
 import { TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import { Fee } from "@keplr-wallet/proto-types/cosmos/tx/v1beta1/tx";
 
+const veryBigNumber = new BigNumber(3333300000000000000000);
+
 describe("txToMessages", () => {
   const transaction: Transaction = {} as Transaction;
   const account: CosmosAccount = {
@@ -36,6 +38,14 @@ describe("txToMessages", () => {
         expect(aminoMsg.value.from_address).toEqual(account.freshAddress);
         expect(aminoMsg.value.amount[0].amount).toEqual(transaction.amount.toFixed());
         expect(aminoMsg.value.amount[0].denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.recipient = "address";
+        transaction.amount = veryBigNumber;
+        const { aminoMsgs } = txToMessages(account, transaction);
+        const [aminoMsg] = aminoMsgs;
+        expect(aminoMsg.value.amount[0].amount.includes("e")).toEqual(false);
       });
 
       it("should return no message if recipient isn't defined", () => {
@@ -77,6 +87,15 @@ describe("txToMessages", () => {
         expect(value.fromAddress).toEqual(account.freshAddress);
         expect(value.amount[0].amount).toEqual(transaction.amount.toFixed());
         expect(value.amount[0].denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.recipient = "address";
+        transaction.amount = veryBigNumber;
+        const { protoMsgs } = txToMessages(account, transaction);
+        const [protoMsg] = protoMsgs;
+        const value = cosmos.bank.v1beta1.MsgSend.decode(protoMsg.value);
+        expect(value.amount[0].amount?.includes("e")).toEqual(false);
       });
 
       it("should return no message if recipient isn't defined", () => {
@@ -124,6 +143,20 @@ describe("txToMessages", () => {
         expect(message.value.amount?.denom).toEqual(account.currency.units[1].code);
       });
 
+      it("should not include exponential part on big numbers", () => {
+        transaction.recipient = "address";
+        transaction.amount = veryBigNumber;
+        transaction.validators = [
+          {
+            address: "realAddressTrustMe",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { aminoMsgs } = txToMessages(account, transaction);
+        const [message] = aminoMsgs;
+        expect(message.value.amount?.amount.includes("e")).toEqual(false);
+      });
+
       it("should return no message if tx has a 0 amount", () => {
         transaction.amount = new BigNumber(0);
         transaction.validators = [{ address: "realAddressTrustMe" } as CosmosDelegationInfo];
@@ -169,6 +202,20 @@ describe("txToMessages", () => {
         expect(value.delegatorAddress).toEqual(account.freshAddress);
         expect(value.amount?.amount).toEqual(transaction.amount.toFixed());
         expect(value.amount?.denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.amount = veryBigNumber;
+        transaction.validators = [
+          {
+            address: "realAddressTrustMe",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { protoMsgs } = txToMessages(account, transaction);
+        const [message] = protoMsgs;
+        const value = MsgDelegate.decode(message.value);
+        expect(value.amount?.amount.includes("e")).toEqual(false);
       });
 
       it("should return no message if tx has a 0 amount", () => {
@@ -221,6 +268,19 @@ describe("txToMessages", () => {
         expect(message.value.delegator_address).toEqual(account.freshAddress);
         expect(message.value.amount?.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(message.value.amount?.denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.amount = veryBigNumber;
+        transaction.validators = [
+          {
+            address: "realAddressTrustMe",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { aminoMsgs } = txToMessages(account, transaction);
+        const [message] = aminoMsgs;
+        expect(message.value.amount?.amount.includes("e")).toEqual(false);
       });
 
       it("should return no message if validators aren't defined", () => {
@@ -281,6 +341,20 @@ describe("txToMessages", () => {
         expect(value.delegatorAddress).toEqual(account.freshAddress);
         expect(value.amount?.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(value.amount?.denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.amount = veryBigNumber;
+        transaction.validators = [
+          {
+            address: "realAddressTrustMe",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { protoMsgs } = txToMessages(account, transaction);
+        const [message] = protoMsgs;
+        const value = MsgUndelegate.decode(message.value);
+        expect(value.amount?.amount.includes("e")).toEqual(false);
       });
 
       it("should return no message if validators aren't defined", () => {
@@ -349,6 +423,19 @@ describe("txToMessages", () => {
         expect(message.value.amount.denom).toEqual(account.currency.units[1].code);
       });
 
+      it("should not include exponential part on big numbers", () => {
+        transaction.sourceValidator = "source";
+        transaction.validators = [
+          {
+            address: "realAddressTrustMe",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { aminoMsgs } = txToMessages(account, transaction);
+        const [message] = aminoMsgs;
+        expect(message.value.amount.amount.includes("e")).toEqual(false);
+      });
+
       it("should return no message if sourceValidator isn't defined", () => {
         transaction.sourceValidator = "";
         transaction.validators = [
@@ -412,6 +499,21 @@ describe("txToMessages", () => {
         expect(value.delegatorAddress).toEqual(account.freshAddress);
         expect(value.amount?.amount).toEqual(transaction.validators[0].amount.toFixed());
         expect(value.amount?.denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.sourceValidator = "source";
+        transaction.validators = [
+          {
+            address: "realAddressTrustMe",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { protoMsgs } = txToMessages(account, transaction);
+        const [message] = protoMsgs;
+        expect(message).toBeTruthy();
+        const value = MsgBeginRedelegate.decode(message.value);
+        expect(value.amount?.amount.includes("e")).toEqual(false);
       });
 
       it("should return no message if sourceValidator isn't defined", () => {
@@ -562,6 +664,18 @@ describe("txToMessages", () => {
         );
         expect(delegateMessage.value.amount.denom).toEqual(account.currency.units[1].code);
       });
+
+      it("should not include exponential part on big numbers", () => {
+        transaction.validators = [
+          {
+            address: "iAmAValidatorAddress",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { aminoMsgs } = txToMessages(account, transaction);
+        const [, delegateMessage] = aminoMsgs;
+        expect(delegateMessage.value.amount.amount.includes("e")).toEqual(false);
+      });
     });
 
     describe("Proto", () => {
@@ -588,6 +702,19 @@ describe("txToMessages", () => {
           transaction.validators[0].amount.toFixed(),
         );
         expect(delegateMessageValue.amount?.denom).toEqual(account.currency.units[1].code);
+      });
+
+      it("should return a MsgWithdrawDelegatorReward message and a MsgDelegate if transaction is complete", () => {
+        transaction.validators = [
+          {
+            address: "iAmAValidatorAddress",
+            amount: veryBigNumber,
+          } as CosmosDelegationInfo,
+        ];
+        const { protoMsgs } = txToMessages(account, transaction);
+        const [, delegateMessage] = protoMsgs;
+        const delegateMessageValue = MsgDelegate.decode(delegateMessage.value);
+        expect(delegateMessageValue.amount?.amount.includes("e")).toEqual(false);
       });
     });
   });

--- a/libs/ledger-live-common/src/families/cosmos/js-buildTransaction.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-buildTransaction.ts
@@ -48,7 +48,7 @@ export const txToMessages = (
             amount: [
               {
                 denom: account.currency.units[1].code,
-                amount: transaction.amount.toString(),
+                amount: transaction.amount.toFixed(),
               },
             ],
           },
@@ -64,7 +64,7 @@ export const txToMessages = (
             amount: [
               {
                 denom: account.currency.units[1].code,
-                amount: transaction.amount.toString(),
+                amount: transaction.amount.toFixed(),
               },
             ],
           }).finish(),
@@ -82,7 +82,7 @@ export const txToMessages = (
               validator_address: validator.address,
               amount: {
                 denom: account.currency.units[1].code,
-                amount: transaction.amount.toString(),
+                amount: transaction.amount.toFixed(),
               },
             },
           };
@@ -96,7 +96,7 @@ export const txToMessages = (
               validatorAddress: validator.address,
               amount: {
                 denom: account.currency.units[1].code,
-                amount: transaction.amount.toString(),
+                amount: transaction.amount.toFixed(),
               },
             }).finish(),
           });
@@ -121,7 +121,7 @@ export const txToMessages = (
             validator_dst_address: validator.address,
             amount: {
               denom: account.currency.units[1].code,
-              amount: validator.amount.toString(),
+              amount: validator.amount.toFixed(),
             },
           },
         };
@@ -136,7 +136,7 @@ export const txToMessages = (
             validatorDstAddress: validator.address,
             amount: {
               denom: account.currency.units[1].code,
-              amount: validator.amount.toString(),
+              amount: validator.amount.toFixed(),
             },
           }).finish(),
         });
@@ -154,7 +154,7 @@ export const txToMessages = (
               validator_address: validator.address,
               amount: {
                 denom: account.currency.units[1].code,
-                amount: validator.amount.toString(),
+                amount: validator.amount.toFixed(),
               },
             },
           };
@@ -168,7 +168,7 @@ export const txToMessages = (
               validatorAddress: validator.address,
               amount: {
                 denom: account.currency.units[1].code,
-                amount: validator.amount.toString(),
+                amount: validator.amount.toFixed(),
               },
             }).finish(),
           });
@@ -224,7 +224,7 @@ export const txToMessages = (
             validator_address: validator.address,
             amount: {
               denom: account.currency.units[1].code,
-              amount: validator.amount.toString(),
+              amount: validator.amount.toFixed(),
             },
           },
         };
@@ -245,7 +245,7 @@ export const txToMessages = (
             validatorAddress: validator.address,
             amount: {
               denom: account.currency.units[1].code,
-              amount: validator.amount.toString(),
+              amount: validator.amount.toFixed(),
             },
           }).finish(),
         });

--- a/libs/ledger-live-common/src/families/cosmos/js-prepareTransaction.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-prepareTransaction.ts
@@ -29,7 +29,7 @@ export const calculateFees: CacheRes<
     return await getEstimatedFees(account as CosmosAccount, transaction);
   },
   ({ account, transaction }) =>
-    `${account.id}_${account.currency.id}_${transaction.amount.toString()}_${
+    `${account.id}_${account.currency.id}_${transaction.amount.toFixed()}_${
       transaction.recipient
     }_${String(transaction.useAllAmount)}_${transaction.mode}_${
       transaction.validators

--- a/libs/ledger-live-common/src/families/cosmos/js-signOperation.ts
+++ b/libs/ledger-live-common/src/families/cosmos/js-signOperation.ts
@@ -34,10 +34,10 @@ const signOperation: SignOperationFnSignature<Transaction> = ({ account, deviceI
             amount: [
               {
                 denom: account.currency.units[1].code,
-                amount: transaction.fees.toString(),
+                amount: transaction.fees.toFixed(),
               },
             ],
-            gas: transaction.gas.toString(),
+            gas: transaction.gas.toFixed(),
           };
           // Note:
           // Cosmos Nano App sign data in Amino way only, not Protobuf.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Replace toString by toFixed method on transaction amounts, on a coin with 18 magnitude, it causes problem by adding the exponential part to numbers as string. It starts being a problem with atleast 1000 value

![image](https://github.com/LedgerHQ/ledger-live/assets/19901996/df8ea6f5-654a-4622-9789-3526007f3928)
![image](https://github.com/LedgerHQ/ledger-live/assets/19901996/eea4d918-fc0d-4e6b-bdd0-a5d560cac17b)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10287 , https://ledgerhq.atlassian.net/browse/LIVE-10354

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
