### PR TITLE
Fix: Genuine check is skipped over USB

### DIFF
--- a/.changeset/late-apples-complain.md
+++ b/.changeset/late-apples-complain.md
@@ -1,0 +1,9 @@
+---
+"live-mobile": patch
+---
+
+fix: Genuine check not skipped during onboarding with Nano X via USB
+
+During the last step of the onboarding, filters USB device by their id and
+not their device model, using the same flows for Nano X, Nano SP, Nano S
+and Blue when connected via USB OTG.

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
@@ -37,7 +37,7 @@ const ConnectNanoScene = ({
   const requestToSetHeaderOptions = useCallback(() => undefined, []);
 
   const onSelectDevice = useCallback(
-    async (device: Device) => {
+    (device: Device) => {
       const isUsbDevice = device.deviceId.startsWith("usb|");
       trace({ type: "onboarding", message: "Selected device", data: { isUsbDevice } });
 
@@ -46,15 +46,15 @@ const ConnectNanoScene = ({
       dispatch(setHasOrderedNano(false));
 
       // Goes through an "allow secure connection"/genuine check device action
-      if (isUsbDevice) {
+      if (isUsbDevice || newDeviceSelectionFeatureFlag?.enabled) {
         setDevice(device);
       }
-      // The BLE pairing flow will handle the "allow secure connection"/genuine check device action step
+      // The BLE pairing flow on the old device selection will handle the "allow secure connection"/genuine check device action step
       else {
         onNext();
       }
     },
-    [dispatch, onNext],
+    [dispatch, newDeviceSelectionFeatureFlag?.enabled, onNext],
   );
 
   const onResult = useCallback(

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "react-redux";
+import { trace } from "@ledgerhq/logs";
 import { Flex } from "@ledgerhq/native-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useFeature } from "@ledgerhq/live-config/featureFlags/index";
@@ -35,22 +36,23 @@ const ConnectNanoScene = ({
   // Keeping the header (back arrow and information button) from the onboarding.
   const requestToSetHeaderOptions = useCallback(() => undefined, []);
 
-  const onSetDevice = useCallback(
+  const onSelectDevice = useCallback(
     async (device: Device) => {
-      dispatch(setLastConnectedDevice(device));
-      setDevice(device);
-      dispatch(setReadOnlyMode(false));
-      dispatch(setHasOrderedNano(false));
-    },
-    [dispatch],
-  );
+      const isUsbDevice = device.deviceId.startsWith("usb|");
+      trace({ type: "onboarding", message: "Selected device", data: { isUsbDevice } });
 
-  const directNext = useCallback(
-    async (device: Device) => {
       dispatch(setLastConnectedDevice(device));
       dispatch(setReadOnlyMode(false));
       dispatch(setHasOrderedNano(false));
-      onNext();
+
+      // Goes through an "allow secure connection"/genuine check device action
+      if (isUsbDevice) {
+        setDevice(device);
+      }
+      // The BLE pairing flow will handle the "allow secure connection"/genuine check device action step
+      else {
+        onNext();
+      }
     },
     [dispatch, onNext],
   );
@@ -75,7 +77,8 @@ const ConnectNanoScene = ({
     [dispatch, onNext],
   );
 
-  const usbOnly = ["nanoS", "nanoSP", "blue"].includes(deviceModelId);
+  // Other models can be connected via BLE or USB
+  const modelIsUsbOnly = ["nanoS", "nanoSP", "blue"].includes(deviceModelId);
 
   return (
     <>
@@ -83,7 +86,7 @@ const ConnectNanoScene = ({
       <Flex flex={1}>
         {newDeviceSelectionFeatureFlag?.enabled ? (
           <SelectDevice2
-            onSelect={onSetDevice}
+            onSelect={onSelectDevice}
             stopBleScanning={!!device}
             requestToSetHeaderOptions={requestToSetHeaderOptions}
             isChoiceDrawerDisplayedOnAddDevice={false}
@@ -92,8 +95,8 @@ const ConnectNanoScene = ({
         ) : (
           <SelectDevice
             withArrows
-            usbOnly={usbOnly}
-            onSelect={usbOnly ? onSetDevice : directNext}
+            usbOnly={modelIsUsbOnly}
+            onSelect={onSelectDevice}
             autoSelectOnAdd
             hideAnimation
           />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The problem is only happening for Nano X when connected via USB. 
And it was due to a bad naming, and probably a wrong strategy to detect if the device is connected via USB or BLE and what to do with it (we were just looking at which device model was selected on the app, and not how the device was actually connected).

The fix: filtering USB device by their id and not according to their model 

<details>
  <summary>Quick win with Nano X + Android + USB</summary>


https://github.com/LedgerHQ/ledger-live/assets/15096913/a901effd-3099-4cf9-8b30-778e62d84f2e



</details>

Other videos (of different scenarios) can be found starting at [this comment](https://ledgerhq.atlassian.net/browse/LIVE-4618?focusedCommentId=382942)


### ❓ Context

- **JIRA or GitHub link**: [LIVE-4618](https://ledgerhq.atlassian.net/browse/LIVE-4618)
### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** Onboarding on LLM (Android) with a USB cable
  

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-4618]: https://ledgerhq.atlassian.net/browse/LIVE-4618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ