### PR TITLE
[BUGIX][LLM][LIVE-8086] add missing i18n for solana

### DIFF
--- a/.changeset/rare-beds-marry.md
+++ b/.changeset/rare-beds-marry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+add missing solana i18n

--- a/apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/Delegations/index.tsx
@@ -156,12 +156,12 @@ function Delegations({ account }: Props) {
             style={[styles.valueText]}
             color="live"
           >
-            {stake.activation.state}
+            {t(`solana.delegation.states.${stake.activation.state}`)}
           </Text>
         ),
       },
       {
-        label: "Active",
+        label: t("solana.delegation.stakeActivePercent"),
         Component: (
           <Text
             numberOfLines={1}
@@ -175,7 +175,7 @@ function Delegations({ account }: Props) {
         ),
       },
       {
-        label: "Available balance",
+        label: t("solana.delegation.stakeAvailableBalance"),
         Component: (
           <Text
             numberOfLines={1}
@@ -211,7 +211,7 @@ function Delegations({ account }: Props) {
         withdraw: rgba(colors.yellow, 0.2),
       });
       const drawerAction: DelegationDrawerActions[number] = {
-        label: capitalize(action),
+        label: t(`solana.delegation.actions.${action}`),
         Icon: (props: IconProps) => (
           <Circle {...props} bg={actionEnabled ? enabledActionCircleBgColor : colors.lightFog}>
             <DrawerStakeActionIcon stakeAction={action} enabled={actionEnabled} />
@@ -235,7 +235,15 @@ function Delegations({ account }: Props) {
       };
       return drawerAction;
     });
-  }, [selectedStakeWithMeta, colors.fog, colors.alert, colors.yellow, colors.lightFog, onNavigate]);
+  }, [
+    selectedStakeWithMeta,
+    colors.fog,
+    colors.alert,
+    colors.yellow,
+    colors.lightFog,
+    onNavigate,
+    t,
+  ]);
 
   const onDelegate = () => {
     onNavigate({

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5706,6 +5706,20 @@
       "totalStake": "Total stake",
       "commission": "Commission",
       "stakeActivationState": "State",
+      "stakeActivePercent": "Active",
+      "stakeAvailableBalance": "Available balance",
+      "actions": {
+        "activate": "Activate",
+        "deactivate": "Deactivate",
+        "reactivate": "Reactivate",
+        "withdraw": "Withdraw"
+      },
+      "states": {
+        "active": "Active",
+        "inactive": "Inactive",
+        "activating": "Activating",
+        "deactivating": "Deactivating"
+      },
       "delegationEarn": "You can earn SOL rewards by delegating your assets.",
       "info": "How Delegation works",
       "broadcastSuccessTitle": "Operation sent",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add missing i18n pairs for Solana delegation feature.
It only impacts LLM which, for some reason, was only partially internationalized. LLD is not affected since the related key/value pairs were already defined and used there.


![photo_2023-06-21 19 19 46](https://github.com/LedgerHQ/ledger-live/assets/9203826/9ca297dc-6479-455c-bc3f-82a1e6ce6bf1)
![IMG_9716](https://github.com/LedgerHQ/ledger-live/assets/9203826/7f7e2777-4980-4c9b-8f50-00bf8ec8d272)

PS: can't provide screenshots of the updated version since I don't have Solana funds to test.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-8086

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM (iOS and Android) in the Solana delegation flow

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
