### PR TITLE
Feat Live 10310 live config lib timer fetch

### DIFF
--- a/.changeset/proud-dragons-tan.md
+++ b/.changeset/proud-dragons-tan.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+fetch config from firebase every 12 hours

--- a/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
@@ -29,21 +29,17 @@ export const FirebaseRemoteConfigProvider = ({ children }: Props): JSX.Element |
     const fetchConfig = async () => {
       try {
         const remoteConfig = getRemoteConfig();
-
-        if (__DEV__) {
-          remoteConfig.settings.minimumFetchIntervalMillis = 0;
-        }
-
+        remoteConfig.settings.minimumFetchIntervalMillis = 0;
         remoteConfig.defaultConfig = {
           ...formatDefaultFeatures(DEFAULT_FEATURES),
         };
-        await fetchAndActivate(remoteConfig);
         setConfig(remoteConfig);
         LiveConfig.setProviderGetValueMethod({
           firebaseRemoteConfig: (key: string) => {
             return getValue(remoteConfig, key);
           },
         });
+        await fetchAndActivate(remoteConfig);
       } catch (error) {
         console.error(`Failed to fetch Firebase remote config with error: ${error}`);
       }

--- a/apps/ledger-live-mobile/src/components/FirebaseRemoteConfig.tsx
+++ b/apps/ledger-live-mobile/src/components/FirebaseRemoteConfig.tsx
@@ -11,18 +11,16 @@ export const FirebaseRemoteConfigProvider = ({ children }: Props): JSX.Element |
     let unmounted = false;
     const fetchConfig = async () => {
       try {
-        if (__DEV__) {
-          remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 0 });
-        }
+        remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 0 });
         await remoteConfig().setDefaults({
           ...formatDefaultFeatures(DEFAULT_FEATURES),
         });
-        await remoteConfig().fetchAndActivate();
         LiveConfig.setProviderGetValueMethod({
           firebaseRemoteConfig: (key: string) => {
             return remoteConfig().getValue(key);
           },
         });
+        await remoteConfig().fetchAndActivate();
       } catch (error) {
         if (!unmounted) {
           console.error(`Failed to fetch Firebase remote config with error: ${error}`);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Feature flag improvement : 
1. Before this PR, Config is retrieved from firebase only once when LLD/LLM is started. After this PR, config will be retrieved from firebase every 12 hours. 
2. Before this PR, if firebase server is down and there is no local cache, all the config are disabled. After this PR, if firebase server is down and there is no local cache, default values will be taken into account.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** Very hard to write test as we need the mock the firebase service.
- [X] **Impact of the changes:** Config will be retrieved from firebase every 12 hours. If firebase server is not available, use the config from local cache. If the local cache is not available, use the default values.
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
