### PR TITLE
fix(protect-2846): allow restore on lns+

### DIFF
--- a/.changeset/long-grapes-serve.md
+++ b/.changeset/long-grapes-serve.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+allow onboarding restore previous version lns+

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -6,7 +6,6 @@ import { Action } from "@ledgerhq/live-common/hw/actions/types";
 import {
   OutdatedApp,
   LatestFirmwareVersionRequired,
-  DeviceNotOnboarded,
   NoSuchAppOnProvider,
   EConnResetError,
   LanguageInstallRefusedOnDevice,
@@ -27,7 +26,6 @@ import useTheme from "~/renderer/hooks/useTheme";
 import {
   ManagerNotEnoughSpaceError,
   UpdateYourApp,
-  TransportStatusError,
   UserRefusedAddress,
   UserRefusedAllowManager,
   UserRefusedFirmwareUpdate,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -69,6 +69,7 @@ import { AppAndVersion } from "@ledgerhq/live-common/hw/connectApp";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/lib/helpers";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { isDeviceNotOnboardedError } from "./utils";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
 
@@ -433,11 +434,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
 
     // NB Until we find a better way, remap the error if it's 6d06 (LNS, LNSP, LNX) or 6d07 (Stax) and we haven't fallen
     // into another handled case.
-    if (
-      e instanceof DeviceNotOnboarded ||
-      (e instanceof TransportStatusError &&
-        (error.message.includes("0x6d06") || error.message.includes("0x6d07")))
-    ) {
+    if (isDeviceNotOnboardedError(e)) {
       return <RenderDeviceNotOnboardedError t={t} device={device} />;
     }
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/utils.ts
@@ -1,9 +1,13 @@
-// NB Until we find a better way, remap the error if it's 6d06 (LNS, LNSP, LNX) or 6d07 (Stax) and we haven't fallen
+import { TransportStatusError } from "@ledgerhq/errors";
+import { DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
+
+// NB Until we find a better way,
+// remap the error if it's 6d06 (LNS, LNSP, LNX) or 6d07 (Stax) and we haven't fallen
 // into another handled case.
 export function isDeviceNotOnboardedError(e: unknown) {
   return (
     e instanceof DeviceNotOnboarded ||
     (e instanceof TransportStatusError &&
-      (error.message.includes("0x6d06") || error.message.includes("0x6d07")))
+      (e.message.includes("0x6d06") || e.message.includes("0x6d07")))
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/utils.ts
@@ -1,0 +1,9 @@
+// NB Until we find a better way, remap the error if it's 6d06 (LNS, LNSP, LNX) or 6d07 (Stax) and we haven't fallen
+// into another handled case.
+export function isDeviceNotOnboardedError(e: unknown) {
+  return (
+    e instanceof DeviceNotOnboarded ||
+    (e instanceof TransportStatusError &&
+      (error.message.includes("0x6d06") || error.message.includes("0x6d07")))
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { Flex, Text } from "@ledgerhq/react-ui";
-import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
+import { DeviceAlreadySetup, DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import OnboardingNavHeader from "../Onboarding/OnboardingNavHeader";
@@ -55,7 +55,10 @@ const RecoverRestore = () => {
         }
       },
       error: (error: Error) => {
-        if (error instanceof TransportStatusError && error.message.includes("0x6d06")) {
+        if (
+          (error instanceof TransportStatusError && error.message.includes("0x6d06")) ||
+          error instanceof DeviceNotOnboarded
+        ) {
           setState({
             isOnboarded: false,
             isInRecoveryMode: false,

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { Flex, Text } from "@ledgerhq/react-ui";
-import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
+import { DeviceAlreadySetup, DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import OnboardingNavHeader from "../Onboarding/OnboardingNavHeader";
@@ -17,9 +17,10 @@ import { first } from "rxjs/operators";
 import { Subscription, from } from "rxjs";
 import {
   OnboardingState,
+  OnboardingStep,
   extractOnboardingState,
 } from "@ledgerhq/live-common/hw/extractOnboardingState";
-import { FirmwareInfo } from "@ledgerhq/types-live";
+import { FirmwareInfo, SeedPhraseType } from "@ledgerhq/types-live";
 import { renderError } from "../DeviceAction/rendering";
 import { useDynamicUrl } from "~/renderer/terms";
 
@@ -53,6 +54,15 @@ const RecoverRestore = () => {
         }
       },
       error: (error: Error) => {
+        if (error instanceof DeviceNotOnboarded) {
+          setState({
+            isOnboarded: false,
+            isInRecoveryMode: false,
+            seedPhraseType: SeedPhraseType.TwentyFour,
+            currentOnboardingStep: OnboardingStep.NewDevice,
+            currentSeedWordIndex: 0,
+          });
+        }
         setError(error);
       },
     });

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { Flex, Text } from "@ledgerhq/react-ui";
-import { DeviceAlreadySetup, DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
+import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import OnboardingNavHeader from "../Onboarding/OnboardingNavHeader";
@@ -49,15 +49,7 @@ const RecoverRestore = () => {
         try {
           setState(extractOnboardingState(firmware.flags));
         } catch (error: unknown) {
-          if (error instanceof TransportStatusError && error.message.includes("0x6d06")) {
-            setState({
-              isOnboarded: false,
-              isInRecoveryMode: false,
-              seedPhraseType: SeedPhraseType.TwentyFour,
-              currentOnboardingStep: OnboardingStep.NewDevice,
-              currentSeedWordIndex: 0,
-            });
-          } else if (error instanceof Error) {
+          if (error instanceof Error) {
             setError(error);
           }
         }

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -62,8 +62,9 @@ const RecoverRestore = () => {
             currentOnboardingStep: OnboardingStep.NewDevice,
             currentSeedWordIndex: 0,
           });
+        } else {
+          setError(error);
         }
-        setError(error);
       },
     });
   }, []);

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -55,10 +55,7 @@ const RecoverRestore = () => {
         }
       },
       error: (error: Error) => {
-        if (
-          (error instanceof TransportStatusError && error.message.includes("0x6d06")) ||
-          error instanceof DeviceNotOnboarded
-        ) {
+        if (isDeviceNotOnboardedError(error)) {
           setState({
             isOnboarded: false,
             isInRecoveryMode: false,

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -23,6 +23,7 @@ import {
 import { FirmwareInfo, SeedPhraseType } from "@ledgerhq/types-live";
 import { renderError } from "../DeviceAction/rendering";
 import { useDynamicUrl } from "~/renderer/terms";
+import { TransportStatusError } from "@ledgerhq/errors";
 
 const RecoverRestore = () => {
   const { t } = useTranslation();
@@ -48,7 +49,7 @@ const RecoverRestore = () => {
         try {
           setState(extractOnboardingState(firmware.flags));
         } catch (error: unknown) {
-          if (error instanceof DeviceNotOnboarded) {
+          if (error instanceof TransportStatusError && error.message.includes("0x6d06")) {
             setState({
               isOnboarded: false,
               isInRecoveryMode: false,
@@ -62,7 +63,7 @@ const RecoverRestore = () => {
         }
       },
       error: (error: Error) => {
-        if (error instanceof DeviceNotOnboarded) {
+        if (error instanceof TransportStatusError && error.message.includes("0x6d06")) {
           setState({
             isOnboarded: false,
             isInRecoveryMode: false,

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -48,7 +48,15 @@ const RecoverRestore = () => {
         try {
           setState(extractOnboardingState(firmware.flags));
         } catch (error: unknown) {
-          if (error instanceof Error) {
+          if (error instanceof DeviceNotOnboarded) {
+            setState({
+              isOnboarded: false,
+              isInRecoveryMode: false,
+              seedPhraseType: SeedPhraseType.TwentyFour,
+              currentOnboardingStep: OnboardingStep.NewDevice,
+              currentSeedWordIndex: 0,
+            });
+          } else if (error instanceof Error) {
             setError(error);
           }
         }

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverRestore/index.tsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useHistory } from "react-router-dom";
 import { Flex, Text } from "@ledgerhq/react-ui";
-import { DeviceAlreadySetup, DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
+import { DeviceAlreadySetup } from "@ledgerhq/live-common/errors";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import OnboardingNavHeader from "../Onboarding/OnboardingNavHeader";
@@ -23,7 +23,7 @@ import {
 import { FirmwareInfo, SeedPhraseType } from "@ledgerhq/types-live";
 import { renderError } from "../DeviceAction/rendering";
 import { useDynamicUrl } from "~/renderer/terms";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { isDeviceNotOnboardedError } from "../DeviceAction/utils";
 
 const RecoverRestore = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Allow restore flow recover with LNS+ previous version

### ❓ Context

- [JIRA PROTECT-2846](https://ledgerhq.atlassian.net/browse/PROTECT-2846)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
