### PR TITLE
[FEATURE][LIVE-10220] make Qtum work with old and new nano app interfaces

### DIFF
--- a/.changeset/nice-bobcats-drop.md
+++ b/.changeset/nice-bobcats-drop.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-btc": minor
+---
+
+make Qtum work with old and new nano app interfaces

--- a/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
@@ -1,3 +1,4 @@
+import semver from "semver";
 import type Transport from "@ledgerhq/hw-transport";
 import BtcNew from "./BtcNew";
 import BtcOld from "./BtcOld";
@@ -49,9 +50,10 @@ export default class Btc {
       ],
       scrambleKey,
     );
-    // new APDU (nano app API) for bitcoin and old APDU for altcoin
-    if (currency === "bitcoin" || currency === "bitcoin_testnet") {
+    // new APDU (nano app API) for currencies using app-bitcoin-new implementation
+    if (currency === "bitcoin" || currency === "bitcoin_testnet" || currency === "qtum") {
       this._impl = new BtcNew(new AppClient(this._transport));
+      // old APDU (legacy API) for currencies using legacy bitcoin app implementation
     } else {
       this._impl = new BtcOld(this._transport);
     }
@@ -281,6 +283,9 @@ export default class Btc {
       // therefore, we use a workaround to distinguish legacy and new versions.
       // This can be removed once Ledger Live enforces minimum bitcoin version >= 2.1.0.
       isBtcLegacy = await checkIsBtcLegacy(this._transport);
+    } else if (appAndVersion.name === "Qtum") {
+      // we use the legacy protocol for versions below 2.1.6 of the Qtum app.
+      isBtcLegacy = semver.lt(appAndVersion.version, "2.1.6");
     }
 
     if (isBtcLegacy) {

--- a/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
@@ -50,13 +50,19 @@ export default class Btc {
       ],
       scrambleKey,
     );
-    // new APDU (nano app API) for currencies using app-bitcoin-new implementation
-    if (currency === "bitcoin" || currency === "bitcoin_testnet" || currency === "qtum") {
-      this._impl = new BtcNew(new AppClient(this._transport));
-      // old APDU (legacy API) for currencies using legacy bitcoin app implementation
-    } else {
-      this._impl = new BtcOld(this._transport);
-    }
+
+    this._impl = (() => {
+      switch (currency) {
+        case "bitcoin":
+        case "bitcoin_testnet":
+        case "qtum":
+          // new APDU (nano app API) for currencies using app-bitcoin-new implementation
+          return new BtcNew(new AppClient(this._transport));
+        default:
+          // old APDU (legacy API) for currencies using legacy bitcoin app implementation
+          return new BtcOld(this._transport);
+      }
+    })();
   }
 
   /**
@@ -265,28 +271,31 @@ export default class Btc {
     // if BtcOld was instantiated, stick with it
     if (this._impl instanceof BtcOld) return this._impl;
 
-    const appAndVersion = await getAppAndVersion(this._transport);
-    let isBtcLegacy = true; // default for all altcoins
+    const { name, version } = await getAppAndVersion(this._transport);
 
-    if (appAndVersion.name === "Bitcoin" || appAndVersion.name === "Bitcoin Test") {
-      const [major, minor] = appAndVersion.version.split(".");
-      // we use the legacy protocol for versions below 2.1.0 of the Bitcoin app.
-      isBtcLegacy = parseInt(major) <= 1 || (parseInt(major) == 2 && parseInt(minor) == 0);
-    } else if (
-      appAndVersion.name === "Bitcoin Legacy" ||
-      appAndVersion.name === "Bitcoin Test Legacy"
-    ) {
-      // the "Bitcoin Legacy" and "Bitcoin Testnet Legacy" app use the legacy protocol, regardless of the version
-      isBtcLegacy = true;
-    } else if (appAndVersion.name === "Exchange") {
-      // We can't query the version of the Bitcoin app if we're coming from Exchange;
-      // therefore, we use a workaround to distinguish legacy and new versions.
-      // This can be removed once Ledger Live enforces minimum bitcoin version >= 2.1.0.
-      isBtcLegacy = await checkIsBtcLegacy(this._transport);
-    } else if (appAndVersion.name === "Qtum") {
-      // we use the legacy protocol for versions below 2.1.6 of the Qtum app.
-      isBtcLegacy = semver.lt(appAndVersion.version, "2.1.6");
-    }
+    const isBtcLegacy = await (async () => {
+      switch (name) {
+        case "Bitcoin":
+        case "Bitcoin Test": {
+          // we use the legacy protocol for versions below 2.1.0 of the Bitcoin app.
+          return semver.lt(version, "2.1.0");
+        }
+        case "Bitcoin Legacy":
+        case "Bitcoin Test Legacy":
+          // the "Bitcoin Legacy" and "Bitcoin Testnet Legacy" app use the legacy protocol, regardless of the version
+          return true;
+        case "Exchange":
+          // We can't query the version of the Bitcoin app if we're coming from Exchange;
+          // therefore, we use a workaround to distinguish legacy and new versions.
+          // This can be removed once Ledger Live enforces minimum bitcoin version >= 2.1.0.
+          return await checkIsBtcLegacy(this._transport);
+        case "Qtum":
+          // we use the legacy protocol for versions below 2.1.6 of the Qtum app.
+          return semver.lt(version, "2.1.6");
+        default:
+          return true;
+      }
+    })();
 
     if (isBtcLegacy) {
       this._impl = new BtcOld(this._transport);

--- a/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/Btc.ts
@@ -290,8 +290,8 @@ export default class Btc {
           // This can be removed once Ledger Live enforces minimum bitcoin version >= 2.1.0.
           return await checkIsBtcLegacy(this._transport);
         case "Qtum":
-          // we use the legacy protocol for versions below 2.1.6 of the Qtum app.
-          return semver.lt(version, "2.1.6");
+          // we use the legacy protocol for versions below 3.0.0 of the Qtum app.
+          return semver.lt(version, "3.0.0");
         default:
           return true;
       }

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
@@ -460,32 +460,60 @@ function accountTypeFromArg(
   M/48'/0'/99'/7'/1/17/2 // Too many non-hardened derivation steps
   M/199'/0'/1'/0/88      // Not a known purpose 199
   M/86'/1'/99'/2         // Change path item must be 0 or 1
+
+  Useful resource on derivation paths: https://learnmeabitcoin.com/technical/derivation-paths
 */
+
+//path is not deepest hardened node of a standard path or deeper, use BtcOld
+const H = 0x80000000; //HARDENED from bip32
+
+const VALID_COIN_TYPES = [
+  0, // Bitcoin
+  1, // Bitcoin (Testnet)
+  88, // Qtum
+];
+
+const VALID_SINGLE_SIG_PURPOSES = [
+  44, // BIP44 - https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+  49, // BIP49 - https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
+  84, // BIP84 - https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
+  86, // BIP86 - https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
+];
+
+const VALID_MULTISIG_PURPOSES = [
+  48, // BIP48 - https://github.com/bitcoin/bips/blob/master/bip-0048.mediawiki
+];
+
+const hard = (n: number) => n >= H;
+const soft = (n: number | undefined) => n === undefined || n < H;
+const change = (n: number | undefined) => n === undefined || n === 0 || n === 1;
+
+const validCoinPathPartsSet = new Set(VALID_COIN_TYPES.map(t => t + H));
+const validSingleSigPurposePathPartsSet = new Set(VALID_SINGLE_SIG_PURPOSES.map(t => t + H));
+const validMultiSigPurposePathPartsSet = new Set(VALID_MULTISIG_PURPOSES.map(t => t + H));
+
 export function isPathNormal(path: string): boolean {
-  //path is not deepest hardened node of a standard path or deeper, use BtcOld
-  const h = 0x80000000; //HARDENED from bip32
   const pathElems = pathStringToArray(path);
 
-  const hard = (n: number) => n >= h;
-  const soft = (n: number | undefined) => n === undefined || n < h;
-  const change = (n: number | undefined) => n === undefined || n === 0 || n === 1;
-
+  // Single sig
   if (
     pathElems.length >= 3 &&
     pathElems.length <= 5 &&
-    [44 + h, 49 + h, 84 + h, 86 + h].some(v => v == pathElems[0]) &&
-    [0 + h, 1 + h, 88 + h].some(v => v == pathElems[1]) &&
+    validSingleSigPurposePathPartsSet.has(pathElems[0]) &&
+    validCoinPathPartsSet.has(pathElems[1]) &&
     hard(pathElems[2]) &&
     change(pathElems[3]) &&
     soft(pathElems[4])
   ) {
     return true;
   }
+
+  // Multi sig
   if (
     pathElems.length >= 4 &&
     pathElems.length <= 6 &&
-    48 + h == pathElems[0] &&
-    [0 + h, 1 + h, 88 + h].some(v => v == pathElems[1]) &&
+    validMultiSigPurposePathPartsSet.has(pathElems[0]) &&
+    validCoinPathPartsSet.has(pathElems[1]) &&
     hard(pathElems[2]) &&
     hard(pathElems[3]) &&
     change(pathElems[4]) &&

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
@@ -445,11 +445,11 @@ function accountTypeFromArg(
 /*
   The new protocol only allows standard path.
   Standard paths are (currently):
-  M/44'/(1|0)'/X'
-  M/49'/(1|0)'/X'
-  M/84'/(1|0)'/X'
-  M/86'/(1|0)'/X'
-  M/48'/(1|0)'/X'/Y'
+  M/44'/(1|0|88)'/X'
+  M/49'/(1|0|88)'/X'
+  M/84'/(1|0|88)'/X'
+  M/86'/(1|0|88)'/X'
+  M/48'/(1|0|88)'/X'/Y'
   followed by "", "(0|1)", or "(0|1)/b", where a and b are 
   non-hardened. For example, the following paths are standard
   M/48'/1'/99'/7'
@@ -474,7 +474,7 @@ function isPathNormal(path: string): boolean {
     pathElems.length >= 3 &&
     pathElems.length <= 5 &&
     [44 + h, 49 + h, 84 + h, 86 + h].some(v => v == pathElems[0]) &&
-    [0 + h, 1 + h].some(v => v == pathElems[1]) &&
+    [0 + h, 1 + h, 88 + h].some(v => v == pathElems[1]) &&
     hard(pathElems[2]) &&
     change(pathElems[3]) &&
     soft(pathElems[4])
@@ -485,7 +485,7 @@ function isPathNormal(path: string): boolean {
     pathElems.length >= 4 &&
     pathElems.length <= 6 &&
     48 + h == pathElems[0] &&
-    [0 + h, 1 + h].some(v => v == pathElems[1]) &&
+    [0 + h, 1 + h, 88 + h].some(v => v == pathElems[1]) &&
     hard(pathElems[2]) &&
     hard(pathElems[3]) &&
     change(pathElems[4]) &&

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts
@@ -461,7 +461,7 @@ function accountTypeFromArg(
   M/199'/0'/1'/0/88      // Not a known purpose 199
   M/86'/1'/99'/2         // Change path item must be 0 or 1
 */
-function isPathNormal(path: string): boolean {
+export function isPathNormal(path: string): boolean {
   //path is not deepest hardened node of a standard path or deeper, use BtcOld
   const h = 0x80000000; //HARDENED from bip32
   const pathElems = pathStringToArray(path);

--- a/libs/ledgerjs/packages/hw-app-btc/tests/newops/isPathNormal.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/newops/isPathNormal.test.ts
@@ -1,0 +1,30 @@
+import { isPathNormal } from "../../src/BtcNew";
+
+describe("isPathNormal", () => {
+  describe("should return true for normal and supported paths", () => {
+    test.each([
+      "44'/0'/0'",
+      "44'/0'/0'/0/0",
+      "84'/0'/0'",
+      "84'/0'/0'/0/0",
+      "86'/0'/0'",
+      "86'/0'/0'/0/0",
+      "49'/0'/0'",
+      "49'/0'/0'/0/0",
+      "48'/1'/99'/7'",
+      "86'/1'/99'/0",
+      "48'/0'/99'/7'/1/17",
+    ])("%s", path => {
+      expect(isPathNormal(path)).toEqual(true);
+    });
+  });
+
+  describe("should return false for non-normal or non supported paths", () => {
+    test.each(["48'/0'/99'", "48'/0'/99'/7'/1/17/2", "199'/0'/1'/0/88", "86'/1'/99'/2"])(
+      "%s",
+      path => {
+        expect(isPathNormal(path)).toEqual(false);
+      },
+    );
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-btc/tests/semver.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/semver.test.ts
@@ -1,0 +1,37 @@
+import semver from "semver";
+
+/**
+ * To detect any semver regression that could impact the behavior of the package
+ * implementation when working with versions having prefix.
+ * One might say this is not necessary since it should already be covered by the
+ * semver package own testsuite, but better be safe than sorry.
+ *
+ * Following this comment:
+ * Are you 100% sure this does the same as the current implem?
+ * Just being paranoid, because app versions can be different from a clean
+ * major.minor.patch
+ * e.g they can have -rc0 -next0 or such additional stuff at the end,
+ * and it happened in the past that semver doesn't behave as we think it does.
+ * cf. https://github.com/LedgerHQ/ledger-live/pull/5675/files#r1417174514
+ */
+
+describe("semver", () => {
+  describe("should be able to properly compare version with prefix", () => {
+    it("2.0.0-rc0 should be lower than 2.1.0", () => {
+      const version = "2.0.0-rc1";
+      expect(semver.lt(version, "2.1.0"));
+    });
+    it("2.0.0-next0 should be lower than 2.1.0", () => {
+      const version = "2.0.0-next0";
+      expect(semver.lt(version, "2.1.0"));
+    });
+    it("2.1.0-rc0 should be greater than 2.1.0", () => {
+      const version = "2.1.0-rc0";
+      expect(semver.gt(version, "2.1.0"));
+    });
+    it("2.1.0-next0 should be greater than 2.1.0", () => {
+      const version = "2.1.0-next0";
+      expect(semver.gt(version, "2.1.0"));
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- 9669119dbbac40e8c82532c9308da8babdb43fa8 makes qtum work with old and new nano app interfaces
- dd9dba41f598d1f8813f8d23d57a24b3f8087f82 adds some code improvements:
	- use switch instead of if else cascade
	- use [semver](https://www.npmjs.com/package/semver) for nano apps versions related tests

-----

All Bitcoin altcoins use the `BtcOld` implementation of the [`hw-app-btc` package](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledgerjs/packages/hw-app-btc) today, including Qtum. But Qtum is being updated to use the [app-bitcoin-new](https://github.com/LedgerHQ/app-bitcoin-new) and should therefore now use the `BtcNew` implementation.

This will imply a version check in the codebase to make sure the correct version of the implementation is used depending on the app version.

The current version of the Qtum app is 2.1.0, and the new version currently on P4 is 2.1.6.
The new Qtum nano app migrating from the old implem to the new one (cf. using the [app-bitcoin-new repo](https://github.com/LedgerHQ/app-bitcoin-new)) is a breaking change.
To properly follow [semver](https://semver.org/) the major version of the app should be updated and the new Qtum app version should therefore be 3.X.X

But making the Qtum nano app use the `BtcNew` implementation of `hw-app-btc` results in a new error:
`non-standard path: 44'/88'/0'/0/0"`

From what I see, this error originates from the `getWalletPublicKey` here:
https://github.com/LedgerHQ/ledger-live/blob/01fdeb3b75cba3d9a4ce0a40c9cc749cfa67ce8a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts#L111-L113

It looks like as of today, the `BtcNew` implementation only allows a standard path. Probably because it was originally done only for Bitcoin.

However, after removing this normal path check, I’m able to properly add a Qtum account using their new nano app version currently on P4.

~The question is then to know what proper update is needed on the `BtcNew` implementation and the related (maybe unintended) consequences.
Should we just get rid of this `isPathNormal` [check](https://github.com/LedgerHQ/ledger-live/blob/01fdeb3b75cba3d9a4ce0a40c9cc749cfa67ce8a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts#L445-L497), or should the pathCheck specifications be extended to include non-standard paths as well (and if yes, how)?~
The `isPathNormal` [function](https://github.com/LedgerHQ/ledger-live/blob/01fdeb3b75cba3d9a4ce0a40c9cc749cfa67ce8a/libs/ledgerjs/packages/hw-app-btc/src/BtcNew.ts#L445-L497) has been updated to allow Qtum coin type (88)



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10220

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - One can now add qtum accounts, and use the currency normally, with app version implemented using the legacy bitcoin app framework (version `2.1.0` of the app) and the version using the new bitcoin app framework (version currently available on P4, with version number ~either `2.1.6` or~ `3.x.x`)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
