### PR TITLE
Bugfix - Add missing loadConfig in signMessage context

### DIFF
--- a/.changeset/violet-suns-thank.md
+++ b/.changeset/violet-suns-thank.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Add `loadConfig` to `signerContext` for `signMessage`

--- a/libs/coin-evm/src/__tests__/unit/hw-signMessage.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/hw-signMessage.unit.test.ts
@@ -18,12 +18,14 @@ const signEIP712HashedMessage = jest.fn(async () => ({
   s: "08",
   v: 9,
 }));
+const setLoadConfig = jest.fn();
 
 const signerContextMock: any = async (deviceId: string, fn: any) => {
   return fn({
     signPersonalMessage,
     signEIP712Message,
     signEIP712HashedMessage,
+    setLoadConfig,
   });
 };
 

--- a/libs/coin-evm/src/hw-signMessage.ts
+++ b/libs/coin-evm/src/hw-signMessage.ts
@@ -1,5 +1,7 @@
 import { ethers } from "ethers";
+import { getEnv } from "@ledgerhq/live-env";
 import { SignerContext } from "@ledgerhq/coin-framework/signer";
+import { LoadConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
 import { isEIP712Message } from "@ledgerhq/evm-tools/message/EIP712/index";
 import { Account, AnyMessage, DeviceId, TypedEvmMessage } from "@ledgerhq/types-live";
 import { EvmSignature, EvmSigner } from "./signer";
@@ -46,8 +48,14 @@ export const signMessage =
     rsv: { r: string; s: string; v: string | number };
     signature: string;
   }> => {
+    const loadConfig: LoadConfig = {
+      cryptoassetsBaseURL: getEnv("DYNAMIC_CAL_BASE_URL"),
+      nftExplorerBaseURL: getEnv("NFT_ETH_METADATA_SERVICE") + "/v1/ethereum",
+    };
+
     if (messageOpts.standard === "EIP191") {
       const { r, s, v } = await signerContext(deviceId, signer => {
+        signer.setLoadConfig(loadConfig);
         return signer.signPersonalMessage(
           account.freshAddressPath,
           Buffer.from(messageOpts.message).toString("hex"),
@@ -65,6 +73,8 @@ export const signMessage =
 
     if (messageOpts.standard === "EIP712") {
       const { r, s, v } = await signerContext(deviceId, async signer => {
+        signer.setLoadConfig(loadConfig);
+
         try {
           return await signer.signEIP712Message(account.freshAddressPath, messageOpts.message);
         } catch (e) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adding missing `loadConfig` to signer for the `hw-signMessage` context

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., JIRA-123 or #123) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** // unecessary
- [x] **Impact of the changes:** // no impact

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
