### PR TITLE
fix(LLM): chunk the preloaded data in the mobile app to support Android limits of 2MB per sqlite window cursor

### DIFF
--- a/.changeset/healthy-windows-perform.md
+++ b/.changeset/healthy-windows-perform.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixes Android limits of 2MB per sqlite window cursor silently crashing for many users.

--- a/apps/ledger-live-mobile/src/bridge/cache.ts
+++ b/apps/ledger-live-mobile/src/bridge/cache.ts
@@ -1,11 +1,11 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
+import deviceStorage from "../logic/storeWrapper";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
 import { log } from "@ledgerhq/logs";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 
 export async function clearBridgeCache() {
-  const keys = await AsyncStorage.getAllKeys();
-  await AsyncStorage.multiRemove(keys.filter(k => k.startsWith("bridgeproxypreload")));
+  const keys = await deviceStorage.keys();
+  await deviceStorage.delete(keys.filter(k => k.startsWith("bridgeproxypreload")));
 }
 
 function currencyCacheId(currency: CryptoCurrency) {
@@ -13,7 +13,7 @@ function currencyCacheId(currency: CryptoCurrency) {
 }
 
 export async function listCachedCurrencyIds() {
-  const keys = await AsyncStorage.getAllKeys();
+  const keys = await deviceStorage.keys();
   return keys
     .filter(k => k.startsWith("bridgeproxypreload"))
     .map(k => k.replace("bridgeproxypreload_", ""));
@@ -21,26 +21,20 @@ export async function listCachedCurrencyIds() {
 
 export async function setCurrencyCache(currency: CryptoCurrency, data: unknown) {
   if (data) {
-    const serialized = JSON.stringify(data);
-
-    if (serialized) {
-      await AsyncStorage.setItem(currencyCacheId(currency), serialized);
-    }
+    await deviceStorage.save(currencyCacheId(currency), data);
   }
 }
+
 export async function getCurrencyCache(currency: CryptoCurrency): Promise<unknown> {
-  const res = await AsyncStorage.getItem(currencyCacheId(currency));
-
-  if (res) {
-    try {
-      return JSON.parse(res);
-    } catch (e) {
-      log("bridge/cache", `failure to retrieve cache ${String(e)}`);
-    }
+  try {
+    const res = await deviceStorage.get(currencyCacheId(currency));
+    return res;
+  } catch (e) {
+    log("bridge/cache", `failure to retrieve cache ${String(e)}`);
   }
-
   return undefined;
 }
+
 export const bridgeCache = makeBridgeCacheSystem({
   saveData: setCurrencyCache,
   getData: getCurrencyCache,


### PR DESCRIPTION
### 📝 Description

Switch the storage implementation of `CurrencyBridge#preload` data using the storeWrapper instead of a direct usage, in order to handle data bigger than 2MB. The ethereum preloaded data recently exceeded 2MB which created a crash for many users (on most Android phone that have [this default manufacturer limit](https://react-native-async-storage.github.io/async-storage/docs/limits/))

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10386](https://ledgerhq.atlassian.net/browse/LIVE-10386)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** this won't be covered by test, we'll consider better storage db in future however (see tech debt discussion in confluence) <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM storage of coin preloaded data (delegator lists, tokens)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10386]: https://ledgerhq.atlassian.net/browse/LIVE-10386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ