### PR TITLE
[BUGFIX][LIVE-10725] infinite rerender on live apps sign eth tx summary

### DIFF
--- a/.changeset/bright-insects-allow.md
+++ b/.changeset/bright-insects-allow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove infinite rerender on live apps sign eth tx summary

--- a/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EvmFeesStrategy.tsx
@@ -81,44 +81,51 @@ export default function EvmFeesStrategy({
   const [customStrategyTransactionPatch, setCustomStrategyTransactionPatch] =
     useState<Partial<Transaction>>();
 
-  useEffect(() => {
-    if (!customStrategyTransactionPatch) {
-      return;
-    }
-    const bridge = getAccountBridge<Transaction>(account, parentAccount);
+  /**
+   * Commenting out this useEffect because it is causing an infinite
+   * rerender of the summary screen in the swap flow.
+   * This hook has been added originally to have the custom fees strategy
+   * selected by default when the user comes back to the summary screen after having
+   * customized the fees in the custom fees screen.
+   */
+  /**
+   * If the customStrategyTransactionPatch is present, this means the custom
+   * fee has been edited by the user. In this case, we need to update the
+   * transaction with the new fee data.
+   * This also selects the new "custom" strategy in the fees strategy list.
+   */
+  // useEffect(() => {
+  //   if (!customStrategyTransactionPatch) {
+  //     return;
+  //   }
 
-    /**
-     * If the customStrategyTransactionPatch is present, this means the custom
-     * fee has been edited by the user. In this case, we need to update the
-     * transaction with the new fee data.
-     * This also selects the new "custom" strategy in the fees strategy list.
-     */
-    const updatedTransaction = bridge.updateTransaction(transaction, {
-      ...customStrategyTransactionPatch,
-    });
+  //   const updatedTransaction = bridge.updateTransaction(transaction, {
+  //     ...customStrategyTransactionPatch,
+  //   });
 
-    setTransaction(updatedTransaction);
-  }, [
-    setTransaction,
-    account,
-    parentAccount,
-    transaction,
-    customStrategyTransactionPatch,
-    gasOptions,
-  ]);
+  //   setTransaction(updatedTransaction);
+  // }, [
+  //   setTransaction,
+  //   account,
+  //   parentAccount,
+  //   transaction,
+  //   customStrategyTransactionPatch,
+  //   gasOptions,
+  //   bridge,
+  // ]);
 
+  /**
+   * If the feesStrategy is "custom" but no customStrategyTransactionPatch is
+   * present, this means the custom fee has been selected by default ahead in
+   * the flow (e.g. if the tx comes from a live-app or from the edit tx flow).
+   * In this case, we need to create the customStrategyTransactionPatch from
+   * the transaction fee data.
+   */
   useEffect(() => {
     if (customStrategyTransactionPatch || transaction.feesStrategy !== "custom") {
       return;
     }
 
-    /**
-     * If the feesStrategy is "custom" but no customStrategyTransactionPatch is
-     * present, this means the custom fee has been selected by default ahead in
-     * the flow (e.g. if the tx comes from a live-app or from the edit tx flow).
-     * In this case, we need to create the customStrategyTransactionPatch from
-     * the transaction fee data.
-     */
     const patchCommon: Partial<Transaction> = {
       feesStrategy: "custom",
       gasLimit: transaction.gasLimit,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -51,6 +51,18 @@ type Props = Navigation;
 
 const WARN_FROM_UTXO_COUNT = 50;
 
+const shouldDispayBuyCta = (error?: unknown): boolean => {
+  if (!error) {
+    return false;
+  }
+
+  if (error instanceof NotEnoughGas || error instanceof NotEnoughBalance) {
+    return true;
+  }
+
+  return false;
+};
+
 function SendSummary({ navigation, route }: Props) {
   const { colors } = useTheme();
   const { nextNavigation, overrideAmountLabel, hideTotal } = route.params;
@@ -260,7 +272,7 @@ function SendSummary({ navigation, route }: Props) {
         <LText style={styles.error} color="alert">
           <TranslatedError error={transactionError} />
         </LText>
-        {error && (error instanceof NotEnoughGas || error instanceof NotEnoughBalance) ? (
+        {shouldDispayBuyCta(error) ? (
           // If the user does not enough funds for gas, he needs to buy
           // the main account currency (which is not necessarily ETH depending
           // on the EVM network used)

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -8,7 +8,7 @@ import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/accoun
 import type { Account } from "@ledgerhq/types-live";
 import type { TransactionStatus as BitcoinTransactionStatus } from "@ledgerhq/live-common/families/bitcoin/types";
 import { isNftTransaction } from "@ledgerhq/live-common/nft/index";
-import { NotEnoughGas } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughGas } from "@ledgerhq/errors";
 import { useTheme } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import invariant from "invariant";
@@ -260,7 +260,7 @@ function SendSummary({ navigation, route }: Props) {
         <LText style={styles.error} color="alert">
           <TranslatedError error={transactionError} />
         </LText>
-        {error && error instanceof NotEnoughGas ? (
+        {error && (error instanceof NotEnoughGas || error instanceof NotEnoughBalance) ? (
           // If the user does not enough funds for gas, he needs to buy
           // the main account currency (which is not necessarily ETH depending
           // on the EVM network used)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Remove the `useEffect` hook triggering infinite rerender in the case of live app sign flow
- Make the `NotEnoughBalance` error display buy CTA alongside the `NotEnoughGas` one
	- Why transaction error is a `NotEnoughBalance` one in case of custom fees and not a `NotEnoughGas` one like for other default options?

The goal and scope of this PR is to unblock the current LLM pre-release.

This hook has only been commented out for now as it was originally added to automatically select the custom fee option after a user updates custom fees.

This hook does not trigger an infinite rerender in the normal send flow.
TBD if the fact that the custom fees option is not automatically selected once the user comes back from the "Customize fees" screen is a prio or not. I think this has always been here, and this was part of what the [related PR](https://github.com/LedgerHQ/ledger-live/pull/5409) was trying to fix in the first place.

It could make sense to investigate what is actually invalidating the removed hook dependency to further understand how to properly mitigate it. It could be due to how the parent component handles `transaction` and `setTransaction` since these are both props of the impacted component.

Feel free to update this PR as you see fit, either to remove the related code altogether instead of commenting it if you don't intend to work on this topic in the near future, or add any related changes relevant to this issue.

https://github.com/LedgerHQ/ledger-live/assets/9203826/7daf9ec1-fa03-474a-9c0a-f1c8bd1dd8fd



### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10725
- https://github.com/LedgerHQ/ledger-live/pull/5789

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - User can continue in the sign transaction flow when interacting with a dapp (for example a dapp swap provider)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
