### PR TITLE
fix: bot formatter to display mutation details properly

### DIFF
--- a/.changeset/silly-vans-taste.md
+++ b/.changeset/silly-vans-taste.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix bot formatter to display mutation details properly

--- a/libs/ledger-live-common/src/bot/formatters.ts
+++ b/libs/ledger-live-common/src/bot/formatters.ts
@@ -76,7 +76,7 @@ export function formatReportForConsole<T extends Transaction>({
     if (account && !account.used) {
       detail = "account is empty";
     } else {
-      const byErrorMessage = groupBy(unavailableMutationReasons, "message");
+      const byErrorMessage = groupBy(unavailableMutationReasons, r => r.error.message);
       const keys = Object.keys(byErrorMessage);
 
       if (keys.length === 1) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The change is trivial, it seems that some time ago `unavailableMutationReasons` was change and `groupBy` usage was made the way, that typecheck didn't help.

Before:
```
🤷‍♂️ couldn't find a mutation to do! (undefined)
```

After
```
🤷‍♂️ couldn't find a mutation to do! (Transfer ~50%: balance is 0, Transfer Max: balance is 0, Delegate: not enough balance, Deactivate Activating Delegation: not enough balance, Deactivate Active Delegation: not enough balance, Reactivate Deactivating Delegation: not enough balance, Activate Inactive Delegation: not enough balance, Withdraw Delegation: not enough balance)
```

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  N/A

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) --> n/a. the tests were fixed
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on --> proper bot test details
 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
