### PR TITLE
[support] Change vechain's bot spec to use NanoS+ app instead of NanoX

### DIFF
--- a/libs/ledger-live-common/src/families/vechain/specs.ts
+++ b/libs/ledger-live-common/src/families/vechain/specs.ts
@@ -20,7 +20,7 @@ const MAX_VTHO_FEE_FOR_VET_TRANSACTION = 420000000000000000;
 const vechainTest = {
   currency: getCryptoCurrencyById("vechain"),
   appQuery: {
-    model: DeviceModelId.nanoX,
+    model: DeviceModelId.nanoSP,
     appName: "VeChain",
     appVersion: "1.1.1",
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

For some reason the bot spec for Vechain has been set to use the NanoX app.
While this works, it makes it mandatory to checkout NanoX apps for every single run of the bot in the CI.
Vechain is the only spec using the NanoX app, so this PR makes it use the NanoS+ app instead, which is the reference device that all of our integrations should be gradually migrated to.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: N/A <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
