### PR TITLE
guards against previous apps trying to send messages to the one that was navigated into

### DIFF
--- a/.changeset/tough-fishes-hang.md
+++ b/.changeset/tough-fishes-hang.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+guards against live apps trying to send message to other live apps

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -273,7 +273,10 @@ function useWebView(
         const manifestUrl = new URL(manifest.url).origin;
         const webviewUrl = new URL(webviewRef.current?.src).origin;
         if (manifestUrl !== webviewUrl) {
-          console.warn(`event fired from ${manifestUrl}, ignored as webview is ${webviewUrl}`);
+          track("event fired from liveapp would target another liveapp", {
+            manifestUrl,
+            webviewUrl,
+          });
           return;
         }
         onMessage(event.args[0]);
@@ -314,8 +317,9 @@ function useWebView(
         webview.removeEventListener("dom-ready", handleDomReady);
       }
     };
+    // NOTE: server in deps to avoid this error https://github.com/LedgerHQ/ledger-live/pull/5835#issue-2064329250
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleDomReady, handleMessage, onLoad]);
+  }, [handleDomReady, handleMessage, onLoad, server]);
 
   const webviewStyle = useMemo(() => {
     return {

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -277,7 +277,6 @@ function useWebView(
             manifestUrl,
             webviewUrl,
           });
-          return;
         }
         onMessage(event.args[0]);
       }

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -267,10 +267,19 @@ function useWebView(
   const handleMessage = useCallback(
     (event: Electron.IpcMessageEvent) => {
       if (event.channel === "webviewToParent") {
+        if (!webviewRef.current) {
+          return;
+        }
+        const manifestUrl = new URL(manifest.url).origin;
+        const webviewUrl = new URL(webviewRef.current?.src).origin;
+        if (manifestUrl !== webviewUrl) {
+          console.warn(`event fired from ${manifestUrl}, ignored as webview is ${webviewUrl}`);
+          return;
+        }
         onMessage(event.args[0]);
       }
     },
-    [onMessage],
+    [onMessage, manifest, webviewRef],
   );
 
   const handleDomReady = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

#### The error

A “wallet.userId” request is made from the buy-sell-live-app when landing on the buy / sell page.
(Sometimes) when clicking on buy again with moonpay, another “wallet.userId” request is made, as the moonpay liveapp finished loading, it is that liveapp that then has to handle the “wallet.userId” request. 



##### Replication steps: 

- launch buy process with moonpay to have it as your “precedent buying option”at launch of LL (or sometimes even after refreshing the app)

- open dev tools

- go to buy/sell

- quickly click on buy again with moonpay (the “shouldn’t happen” error is logged in the video below),


https://github.com/LedgerHQ/ledger-live/assets/5050709/25b47491-2297-4df7-b872-190678325590



#### Notes: 

- It doesn’t happen 100% of the time. I’d say the rate is ~50% of the time. It seems to vary for reasons Im not sure of right now (see points below)

- It can happen when the app was running for a while, but only happens when you’re first launching the buy/sell app (it won’t happen again once you’ve been on that page)

- It seems to happen more when clicking quicker on “buy with moonpay again”.

- Lowering the network speed / clicking the synchronize button seem to impact the occurence rate of the error. 

- When the bug happens, the transport’s `onMessage` still has closure over the previous server (of the multibuy-v2 app) : 


![SCR-20240103-pjxl](https://github.com/LedgerHQ/ledger-live/assets/5050709/913e2605-3968-452b-acc8-f57a7b8cf4ea)

#### Fix:

`handleMessage` should check if the webview corresponds to the manifest. 

It could check against the `webview.src` and the `manifest.url`, but since those sometimes differ (added query params), we should check against  their origin (in this way `URL(webview.src.origin)`  )

We’ll return early if the webview differs from what the manifes that triggered the event expects, and log the error as such: 

_event fired from https://buy.moonpay.com,/ ignored as webview is https://buy-sell-v2.apps.ledger.com/_


To make that check, `handleMessage` dependency array must include the manifest and the webviewRef. 

Only having those in the dependency array makes the error go away.

The issue was that `handleMessage` wasn’t properly updated, as its only dependecy (`onMessag`e) didn’t change at all. This isn’t a problem most of the time, only triggering errors when a message is sent from a liveapp whilst another liveapp takes its place inside the same webview. 

Here’s a quick recap of the flow of information.


1. _In ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx_
`webviewHook` is created (_useMemo with no dependency_)

2. sent to `useWalletAPIServer` (_in libs/ledger-live-common/src/wallet-api/react.ts_)


3. there, used by `useTransport` (_useMemo with depency over webviewHook_) to create transport


4. transport sent to _WalletApiServer.useWalletAPIServer_


5. there, we have 
6. 
```js
  const onMessage = useCallback(
    (event: string) => {
      transport.onMessage?.(event);
    },
    [transport],
  );
```

7. `onMessage` is returned and used in _WalletAPIWebview.tsx_ inside the `handleMessage` callback. This is here that a guard was added, to avoid any edge cases that might occur when loading another live app.



### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/623?selectedIssue=LIVE-10764

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
