### PR TITLE
Bugfix/live 10292 handle usb disconnect open app

### DIFF
--- a/.changeset/khaki-schools-hide.md
+++ b/.changeset/khaki-schools-hide.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Fix the disconnected device drawer behavior when a device is disconnected during action

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/Item.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/Item.tsx
@@ -61,16 +61,18 @@ const Item = ({ device, onPress }: Props) => {
         </Flex>
 
         {!wired ? (
-          <Touchable event="ItemForget" onPress={onItemContextPress}>
-            <OthersMedium size={24} color={"neutral.c100"} />
-          </Touchable>
+          <>
+            <Touchable event="ItemForget" onPress={onItemContextPress}>
+              <OthersMedium size={24} color={"neutral.c100"} />
+            </Touchable>
+            <RemoveDeviceMenu
+              open={isRemoveDeviceMenuOpen}
+              device={device}
+              onHideMenu={() => setIsRemoveDeviceMenuOpen(false)}
+            />
+          </>
         ) : null}
       </Flex>
-      <RemoveDeviceMenu
-        open={isRemoveDeviceMenuOpen}
-        device={device}
-        onHideMenu={() => setIsRemoveDeviceMenuOpen(false)}
-      />
     </Touchable>
   );
 };

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -161,6 +161,7 @@ const getInitialState = (device?: Device | null | undefined, request?: AppReques
   listedApps: false, // Nb maybe expose the result
   skippedAppOps: [],
   itemProgress: 0,
+  progress: undefined,
 });
 
 const reducer = (state: State, e: Event): State => {
@@ -208,26 +209,17 @@ const reducer = (state: State, e: Event): State => {
       };
     case "inline-install":
       return {
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        requestQuitApp: false,
-        requiresAppInstallation: null,
-        allowOpeningRequestedWording: null,
         allowOpeningGranted: true,
         allowManagerRequested: false,
         allowManagerGranted: true,
         device: state.device,
-        opened: false,
-        appAndVersion: null,
-        error: null,
-        derivation: null,
-        displayUpgradeWarning: false,
-        unresponsive: false,
-        isLocked: false,
         installingApp: true,
         progress: e.progress || 0,
-        requestOpenApp: null,
-        listingApps: false,
+
+        deviceInfo: undefined,
+        latestFirmware: undefined,
 
         request: state.request,
         skippedAppOps: state.skippedAppOps,
@@ -264,98 +256,70 @@ const reducer = (state: State, e: Event): State => {
 
     case "ask-open-app":
       return {
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        requestQuitApp: false,
-        requiresAppInstallation: null,
-        allowOpeningRequestedWording: null,
-        allowOpeningGranted: false,
-        allowManagerRequested: false,
-        allowManagerGranted: false,
         device: state.device,
-        opened: false,
-        appAndVersion: null,
-        error: null,
-        derivation: null,
-        displayUpgradeWarning: false,
-        unresponsive: false,
-        isLocked: false,
         requestOpenApp: e.appName,
 
-        request: state.request,
+        deviceInfo: undefined,
+        latestFirmware: undefined,
+        installingApp: undefined,
+        listingApps: undefined,
+        installQueue: undefined,
+        listedApps: undefined,
+        itemProgress: undefined,
+
         skippedAppOps: state.skippedAppOps,
       };
 
     case "ask-quit-app":
       return {
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        requestOpenApp: null,
-        requiresAppInstallation: null,
-        allowOpeningRequestedWording: null,
-        allowOpeningGranted: false,
-        allowManagerRequested: false,
-        allowManagerGranted: false,
         device: state.device,
-        opened: false,
-        appAndVersion: null,
-        error: null,
-        derivation: null,
-        displayUpgradeWarning: false,
-        unresponsive: false,
-        isLocked: false,
         requestQuitApp: true,
 
-        request: state.request,
+        installingApp: undefined,
+        listingApps: undefined,
+        installQueue: undefined,
+        listedApps: undefined,
+        itemProgress: undefined,
+
         skippedAppOps: state.skippedAppOps,
       };
 
     case "device-permission-requested":
       return {
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        requestQuitApp: false,
-        requestOpenApp: null,
-        requiresAppInstallation: null,
         device: state.device,
-        opened: false,
-        appAndVersion: null,
-        error: null,
-        derivation: null,
-        displayUpgradeWarning: false,
-        unresponsive: false,
-        isLocked: false,
-        allowOpeningGranted: false,
-        allowOpeningRequestedWording: null,
-        allowManagerGranted: false,
         allowManagerRequested: true,
 
-        request: state.request,
+        deviceInfo: undefined,
+        latestFirmware: undefined,
+        installingApp: undefined,
+        listingApps: undefined,
+        listedApps: undefined,
+        itemProgress: undefined,
+
         skippedAppOps: state.skippedAppOps,
         installQueue: state.installQueue,
       };
 
     case "device-permission-granted":
       return {
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        requestQuitApp: false,
-        requestOpenApp: null,
-        requiresAppInstallation: null,
         device: state.device,
-        opened: false,
-        appAndVersion: null,
-        error: null,
-        derivation: null,
-        displayUpgradeWarning: false,
-        unresponsive: false,
-        isLocked: false,
         allowOpeningGranted: true,
-        allowOpeningRequestedWording: null,
         allowManagerGranted: true,
-        allowManagerRequested: false,
 
-        request: state.request,
+        deviceInfo: undefined,
+        latestFirmware: undefined,
+        installingApp: undefined,
+        listingApps: undefined,
+        itemProgress: undefined,
+
         skippedAppOps: state.skippedAppOps,
         installQueue: state.installQueue,
         listedApps: state.listedApps,
@@ -363,28 +327,22 @@ const reducer = (state: State, e: Event): State => {
 
     case "app-not-installed":
       return {
-        requestQuitApp: false,
-        requestOpenApp: null,
-        device: state.device,
-        opened: false,
-        appAndVersion: null,
-        error: null,
-        derivation: null,
-        displayUpgradeWarning: false,
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        unresponsive: false,
-        isLocked: false,
-        allowOpeningGranted: false,
-        allowOpeningRequestedWording: null,
-        allowManagerGranted: false,
-        allowManagerRequested: false,
+        device: state.device,
         requiresAppInstallation: {
           appNames: e.appNames,
           appName: e.appName,
         },
 
-        request: state.request,
+        deviceInfo: undefined,
+        latestFirmware: undefined,
+        installingApp: undefined,
+        listingApps: undefined,
+        installQueue: undefined,
+        listedApps: undefined,
+        itemProgress: undefined,
+
         skippedAppOps: state.skippedAppOps,
       };
 
@@ -397,22 +355,19 @@ const reducer = (state: State, e: Event): State => {
 
     case "opened":
       return {
-        requestQuitApp: false,
-        requestOpenApp: null,
-        requiresAppInstallation: null,
-        allowOpeningGranted: false,
-        allowOpeningRequestedWording: null,
-        allowManagerGranted: false,
-        allowManagerRequested: false,
-        device: state.device,
-        error: null,
+        ...getInitialState(state.device, state.request),
         isLoading: false,
-        isDisconnected: false,
-        unresponsive: false,
-        isLocked: false,
+        device: state.device,
         opened: true,
         appAndVersion: e.app,
         derivation: e.derivation,
+
+        deviceInfo: undefined,
+        latestFirmware: undefined,
+        installingApp: undefined,
+        listingApps: undefined,
+        installQueue: undefined,
+        itemProgress: undefined,
 
         request: state.request,
         skippedAppOps: state.skippedAppOps,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

Fix the disconnected device drawer behavior when a device is disconnected during action.

Before:

https://github.com/LedgerHQ/ledger-live/assets/35492518/3cb5480f-f2c7-4b6c-bd80-ba6129812137

After:

https://github.com/LedgerHQ/ledger-live/assets/35492518/69b2f9ca-4a0f-4d8e-a40b-1d75d2765ec6


### 📝 Description

When a user unplug a device during the open app action, the disconnected error drawer close automatically after few seconds. With this fix, the drawer remains open until the user close it.

<!--
| Before        | After         |
| ------------- | ------------- |
|  Drawer close automatically    |  Drawer is still opened   |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10292]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** Changes are on behavior of the open app action.
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10292]: https://ledgerhq.atlassian.net/browse/LIVE-10292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ