### PR TITLE
Bugfix/live-10863

### DIFF
--- a/.changeset/rich-pans-exercise.md
+++ b/.changeset/rich-pans-exercise.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+error message when searching quotes instead of loading message

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Rates/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Rates/index.tsx
@@ -7,7 +7,7 @@ import Text from "~/renderer/components/Text";
 import NoQuoteSwapRate from "./NoQuoteSwapRate";
 import SwapRate from "./SwapRate";
 import Countdown from "./Countdown";
-import EmptyState from "./EmptyState";
+import LoadingState from "./LoadingState";
 import Filter from "./Filter";
 import {
   SwapSelectorStateType,
@@ -247,7 +247,7 @@ export default function ProviderRate({
           );
         })}
       </Box>
-      {!filteredRates.length && <EmptyState />}
+      {!filteredRates.length && <LoadingState />}
     </Box>
   );
 }


### PR DESCRIPTION
### 📝 Description

When second search of quotes error message was displayed instead of loading message

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-10863

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
