### PR TITLE
[B2CQA-1804]: add test for access wallet screen by sync with Ledger Live Desktop

### DIFF
--- a/apps/ledger-live-mobile/e2e/models/onboarding/onboardingSteps.ts
+++ b/apps/ledger-live-mobile/e2e/models/onboarding/onboardingSteps.ts
@@ -15,6 +15,8 @@ export default class OnboardingSteps {
   getStartedButtonId = "onboarding-getStarted-button";
   devicePairedContinueButtonId = "onboarding-paired-continue";
   exploreWithoutDeviceButtonId = "discoverLive-exploreWithoutADevice";
+  readyToScanButtonID = "onboarding-scan-button";
+  scanAndImportAccountsPageID = "onboarding-import-accounts-title";
   discoverLiveTitle = (index: number) => `onboarding-discoverLive-${index}-title`;
   onboardingGetStartedButton = () => getElementById(this.getStartedButtonId);
   accessWalletButton = () => getElementById("onboarding-accessWallet");
@@ -23,6 +25,8 @@ export default class OnboardingSteps {
   buyLedgerButton = () => getElementById("onboarding-noLedgerYetModal-buy");
   exploreWithoutDeviceButton = () => getElementById(this.exploreWithoutDeviceButtonId);
   connectLedgerButton = () => getElementById("Existing Wallet | Connect");
+  syncWithLedgerLiveDesktop = () => getElementById("Existing Wallet | Sync");
+  readyToScanButton = () => getElementById(this.readyToScanButtonID);
   continueButton = () => getElementById(this.devicePairedContinueButtonId);
   pairDeviceButton = () => getElementById("pair-device");
   pairNanoButton = () => getElementById("Onboarding-PairNewNano");
@@ -94,6 +98,18 @@ export default class OnboardingSteps {
 
   async chooseToConnectYourLedger() {
     await tapByElement(this.connectLedgerButton());
+  }
+
+  async chooseToSyncWithLedgerLiveDesktop() {
+    await tapByElement(this.syncWithLedgerLiveDesktop());
+  }
+
+  async goesThroughLedgerLiveDesktopScanning() {
+    await tapByElement(this.readyToScanButton());
+  }
+
+  async waitForScanningPage() {
+    await waitForElementById(this.scanAndImportAccountsPageID);
   }
 
   // Setup new Ledger

--- a/apps/ledger-live-mobile/e2e/setup.ts
+++ b/apps/ledger-live-mobile/e2e/setup.ts
@@ -21,6 +21,9 @@ export async function launchApp() {
       language: "en-US",
       locale: "en-US",
     },
+    permissions: {
+      camera: "YES", // Give iOS permissions for the camera
+    },
   });
 }
 

--- a/apps/ledger-live-mobile/e2e/specs/onboarding.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/onboarding.spec.ts
@@ -74,4 +74,12 @@ describe("Onboarding", () => {
     await onboardingSteps.openLedgerLive();
     await portfolioPage.waitForPortfolioPageToLoad();
   });
+
+  it("does the Onboarding and choose to synchronize with Ledger Live Desktop", async () => {
+    await onboardingSteps.startOnboarding();
+    await onboardingSteps.chooseToAccessYourWallet();
+    await onboardingSteps.chooseToSyncWithLedgerLiveDesktop();
+    await onboardingSteps.goesThroughLedgerLiveDesktopScanning();
+    await onboardingSteps.waitForScanningPage();
+  });
 });

--- a/apps/ledger-live-mobile/src/components/CameraScreen/QRCodeBottomLayer.tsx
+++ b/apps/ledger-live-mobile/src/components/CameraScreen/QRCodeBottomLayer.tsx
@@ -24,7 +24,7 @@ function QrCodeBottomLayer({ progress, liveQrCode, instruction }: Props) {
       mx={6}
       mb={7}
     >
-      <Text variant={"h5"} fontWeight={"semiBold"} mb={6}>
+      <Text variant={"h5"} fontWeight={"semiBold"} mb={6} testID="onboarding-import-accounts-title">
         {instruction || (
           <Trans i18nKey={liveQrCode ? "account.import.newScan.title" : "send.scan.descBottom"} />
         )}

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/SyncDesktop.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/SyncDesktop.tsx
@@ -58,7 +58,7 @@ SyncDesktopScene.id = "SyncDesktopScene";
 const Next = ({ onNext }: { onNext: () => void }) => {
   const { t } = useTranslation();
   return (
-    <Button type="main" size="large" onPress={onNext}>
+    <Button type="main" size="large" onPress={onNext} testID="onboarding-scan-button">
       {t("onboarding.stepImportAccounts.cta")}
     </Button>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Add Detox test for [B2CQA-1804] Access Wallet screen - Sync with Ledger Live Desktop option
- Add test id for Sync Desktop and Scanning page
- Add camera permissions for iOS

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/B2CQA-1804

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on --> No impact

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[B2CQA-1804]: https://ledgerhq.atlassian.net/browse/B2CQA-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ