### PR TITLE
refactor: simplify receive staking flow json stringify hash

### DIFF
--- a/.changeset/eight-beds-glow.md
+++ b/.changeset/eight-beds-glow.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove bad usage of JSON.stringify as a hash function, remove unused actions in StepReceiveStakingFlow, replace state with constants, and fix a url string type.

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveStakingFlow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveStakingFlow.tsx
@@ -35,41 +35,13 @@ export const CheckBoxContainer: typeof Flex = styled(Flex)`
 const StepReceiveStakingFlow = (props: StepProps) => {
   const { t } = useTranslation();
   const receiveStakingFlowConfig = useFeature("receiveStakingFlowConfigDesktop");
+  const { account } = props;
   const [doNotShowAgain, setDoNotShowAgain] = useState<boolean>(false);
-  // FIXME action is not used?
-  const [action, setAction] = useState<ManageAction | undefined>();
-  const [title, setTitle] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
-  const { account, parentAccount } = props;
 
   const id = account && "currency" in account ? account.currency?.id : undefined;
   const supportLink = id ? receiveStakingFlowConfig?.params?.[id]?.supportLink : undefined;
-
-  const manage =
-    account && account.type === "Account"
-      ? getLLDCoinFamily(account.currency.family).accountHeaderManageActions
-      : null;
-
-  const familyManageActions =
-    account && manage ? manage({ account: account as Account, parentAccount }) : undefined;
-
-  useEffect(() => {
-    const manageList =
-      familyManageActions && familyManageActions.length > 0 ? familyManageActions : [];
-    const newAction = manageList && manageList.find(item => item.key === "Stake");
-    const newTitle = t(`receive.steps.staking.${id}.title`);
-    const newDescription = t(`receive.steps.staking.${id}.description`);
-    // FIXME fix this code. https://ledgerhq.atlassian.net/browse/LIVE-7343
-    if (JSON.stringify(title) !== JSON.stringify(newTitle)) {
-      setTitle(newTitle);
-    }
-    if (JSON.stringify(description) !== JSON.stringify(newDescription)) {
-      setDescription(newDescription);
-    }
-    if (JSON.stringify(action) !== JSON.stringify(newAction)) {
-      setAction(newAction);
-    }
-  }, [action, description, familyManageActions, id, t, title]);
+  const title = t(`receive.steps.staking.${id}.title`);
+  const description = t(`receive.steps.staking.${id}.description`);
 
   const getTrackProperties = useCallback(() => {
     return {
@@ -88,8 +60,10 @@ const StepReceiveStakingFlow = (props: StepProps) => {
       ...getTrackProperties(),
       link: supportLink,
     });
-    // @ts-expect-error TYPINGS
-    openURL(supportLink, "OpenURL", getTrackProperties());
+
+    if (supportLink) {
+      openURL(supportLink, "OpenURL", getTrackProperties());
+    }
   }, [getTrackProperties, supportLink]);
 
   const onChange = useCallback(() => {
@@ -140,7 +114,8 @@ export const StepReceiveStakingFooter = (props: StepProps) => {
     const manageList =
       familyManageActions && familyManageActions.length > 0 ? familyManageActions : [];
     const newAction = manageList && manageList.find(item => item.key === "Stake");
-    if (JSON.stringify(newAction) !== JSON.stringify(action)) {
+
+    if (newAction?.key !== action?.key || newAction?.label !== action?.label) {
       setAction(newAction);
     }
   }, [action, familyManageActions]);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Simplify component using JSON.stringify as a hash function to only update based on the relevant currency ID prop. Remove unused actions, replace state with consts, and add a type check instead of a ts expect errror. 

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/7c5661c0-01b7-42f0-a37e-e31fbb2c3614)


### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-7343

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** 
  - StakingModal that appears at the end of the Receive flow for Solana, Celo, Cosmos and Osmo. Behaviour should remain the same

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
