### PR TITLE
feat: display fees even if there no edit available

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
@@ -166,6 +166,16 @@ const SectionFees = ({
         alwaysShowValue
       />
     </>
+  ) : estimatedFees ? (
+    <FormattedVal
+      color="palette.text.shade100"
+      val={estimatedFees}
+      unit={mainAccountUnit}
+      fontSize={3}
+      ff="Inter|SemiBold"
+      showCode
+      alwaysShowValue
+    />
   ) : (
     <NoValuePlaceholder />
   );


### PR DESCRIPTION
### 📝 Description

Display fees is they are estimated even if there is no drawer to edit them. 

### ❓ Context
fixes hidden tezos fees 
[relevant ticket](https://ledgerhq.atlassian.net/browse/LIVE-10851)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
