### PR TITLE
fix(lld/deviceaction/rendering): FirmwareNotRecognized rendering polish

### DIFF
--- a/.changeset/eight-rockets-drop.md
+++ b/.changeset/eight-rockets-drop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Device actions errors: new rendering component for FirmwareNotRecognized/"InvalidProvider" error

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect } from "react";
 import { BigNumber } from "bignumber.js";
 import map from "lodash/map";
 import { TFunction } from "i18next";
-import { Trans } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { connect, useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
@@ -11,7 +11,12 @@ import ProviderIcon from "~/renderer/components/ProviderIcon";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, Exchange } from "@ledgerhq/live-common/exchange/swap/types";
 import { getProviderName, getNoticeType } from "@ledgerhq/live-common/exchange/swap/utils/index";
-import { WrongDeviceForAccount, UpdateYourApp, LockedDeviceError } from "@ledgerhq/errors";
+import {
+  WrongDeviceForAccount,
+  UpdateYourApp,
+  LockedDeviceError,
+  FirmwareNotRecognized,
+} from "@ledgerhq/errors";
 import { LatestFirmwareVersionRequired, DeviceNotOnboarded } from "@ledgerhq/live-common/errors";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -41,7 +46,7 @@ import { Rotating } from "~/renderer/components/Spinner";
 import ProgressCircle from "~/renderer/components/ProgressCircle";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
-import { context } from "~/renderer/drawers/Provider";
+import { context, setDrawer } from "~/renderer/drawers/Provider";
 import { track } from "~/renderer/analytics/segment";
 import { DrawerFooter } from "~/renderer/screens/exchange/Swap2/Form/DrawerFooter";
 import {
@@ -58,10 +63,10 @@ import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import DeviceIllustration from "~/renderer/components/DeviceIllustration";
 import FramedImage from "../CustomImage/FramedImage";
 import { Account } from "@ledgerhq/types-live";
-import LinkWithExternalIcon from "../LinkWithExternalIcon";
 import { openURL } from "~/renderer/linking";
 import Installing from "~/renderer/modals/UpdateFirmwareModal/Installing";
 import { ErrorBody } from "../ErrorBody";
+import LinkWithExternalIcon from "../LinkWithExternalIcon";
 
 export const AnimationWrapper = styled.div`
   width: 600px;
@@ -589,14 +594,14 @@ export const renderLockedDeviceError = ({
               })
             : t("errors.LockedDeviceError.description")
         }
+        buttons={
+          onRetry && inlineRetry ? (
+            <ButtonV3 size="large" variant="main" onClick={onRetry} borderRadius={"9999px"}>
+              {t("common.retry")}
+            </ButtonV3>
+          ) : null
+        }
       />
-      <ButtonContainer>
-        {onRetry && inlineRetry ? (
-          <ButtonV3 size="large" variant="main" onClick={onRetry} borderRadius={"9999px"}>
-            {t("common.retry")}
-          </ButtonV3>
-        ) : null}
-      </ButtonContainer>
     </Wrapper>
   );
 };
@@ -621,25 +626,59 @@ export const DeviceNotOnboardedErrorComponent = withV3StyleProvider(
           top={device ? <DeviceIllustration size={120} deviceId={device.modelId} /> : null}
           title={t("errors.DeviceNotOnboardedError.title")}
           description={t("errors.DeviceNotOnboardedError.description")}
+          buttons={
+            <ButtonV3
+              variant="main"
+              size="large"
+              borderRadius="9999px"
+              onClick={redirectToOnboarding}
+              Icon={IconsLegacy.ArrowRightMedium}
+            >
+              {productName
+                ? t("errors.DeviceNotOnboardedError.goToOnboardingButtonWithProductName", {
+                    productName,
+                  })
+                : t("errors.DeviceNotOnboardedError.goToOnboardingButton")}
+            </ButtonV3>
+          }
         />
-        <ButtonV3
-          variant="main"
-          size="large"
-          borderRadius="9999px"
-          mt={10}
-          onClick={redirectToOnboarding}
-          Icon={IconsLegacy.ArrowRightMedium}
-        >
-          {productName
-            ? t("errors.DeviceNotOnboardedError.goToOnboardingButtonWithProductName", {
-                productName,
-              })
-            : t("errors.DeviceNotOnboardedError.goToOnboardingButton")}
-        </ButtonV3>
       </Wrapper>
     );
   },
 );
+
+const FirmwareNotRecognizedErrorComponent: React.FC<{
+  onRetry?: (() => void) | null | undefined;
+}> = ({ onRetry }) => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const goToExperimentalSettings = () => {
+    setDrawer();
+    history.push("/settings/experimental");
+  };
+  return (
+    <Wrapper>
+      <ErrorBody
+        Icon={IconsLegacy.InfoAltFillMedium}
+        iconColor="primary.c80"
+        title={t("errors.FirmwareNotRecognized.title")}
+        description={t("errors.FirmwareNotRecognized.description")}
+        buttons={
+          <>
+            <ButtonV3 size="large" variant="main" onClick={goToExperimentalSettings}>
+              {t("errors.FirmwareNotRecognized.goToSettingsCTA")}
+            </ButtonV3>
+            {onRetry ? (
+              <ButtonV3 size="large" variant="shade" onClick={onRetry}>
+                {t("common.retry")}
+              </ButtonV3>
+            ) : null}
+          </>
+        }
+      />
+    </Wrapper>
+  );
+};
 
 export const renderError = ({
   error,
@@ -684,6 +723,8 @@ export const renderError = ({
     return renderLockedDeviceError({ t, onRetry, device, inlineRetry });
   } else if (error instanceof DeviceNotOnboarded) {
     return <DeviceNotOnboardedErrorComponent t={t} device={device} />;
+  } else if (error instanceof FirmwareNotRecognized) {
+    return <FirmwareNotRecognizedErrorComponent onRetry={onRetry} />;
   }
 
   // if no supportLink is provided, we fallback on the related url linked to

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -596,7 +596,7 @@ export const renderLockedDeviceError = ({
         }
         buttons={
           onRetry && inlineRetry ? (
-            <ButtonV3 size="large" variant="main" onClick={onRetry} borderRadius={"9999px"}>
+            <ButtonV3 size="large" variant="main" onClick={onRetry}>
               {t("common.retry")}
             </ButtonV3>
           ) : null
@@ -630,7 +630,6 @@ export const DeviceNotOnboardedErrorComponent = withV3StyleProvider(
             <ButtonV3
               variant="main"
               size="large"
-              borderRadius="9999px"
               onClick={redirectToOnboarding}
               Icon={IconsLegacy.ArrowRightMedium}
             >

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorBody.tsx
@@ -1,17 +1,21 @@
 import React from "react";
-import { BoxedIcon, Text } from "@ledgerhq/react-ui";
+import { Box, BoxedIcon, Flex, Text } from "@ledgerhq/react-ui";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import styled from "styled-components";
 
 export const ErrorTitle = styled(Text)`
   color: ${p => p.theme.colors.neutral.c100};
   text-align: center;
+  max-width: 400px;
+  user-select: text;
 `;
 
 export const ErrorDescription = styled(Text)`
   color: ${p => p.theme.colors.neutral.c80};
   white-space: pre-wrap;
   text-align: center;
+  max-width: 400px;
+  user-select: text;
 `;
 
 /** Renders an error icon, title and description */
@@ -27,14 +31,18 @@ export const ErrorBody: React.FC<{
    * icon to render inside a box
    */
   Icon?: React.ComponentType<{ color?: string | undefined; size?: number | undefined }> | undefined;
-}> = withV3StyleProvider(({ top, Icon, title, description, list }) => {
+  iconColor?: string;
+  buttons?: React.ReactNode;
+}> = withV3StyleProvider(({ top, Icon, iconColor, title, description, list, buttons }) => {
   return (
     <>
-      {top ? (
-        top
-      ) : Icon ? (
-        <BoxedIcon Icon={Icon} size={64} iconSize={24} iconColor="neutral.c100" />
-      ) : null}
+      <Box alignSelf="center">
+        {top ? (
+          top
+        ) : Icon ? (
+          <BoxedIcon Icon={Icon} size={64} iconSize={24} iconColor={iconColor || "neutral.c100"} />
+        ) : null}
+      </Box>
       <ErrorTitle variant="h5Inter" fontWeight="semiBold" mt={top || Icon ? 10 : 0}>
         {title}
       </ErrorTitle>
@@ -44,6 +52,11 @@ export const ErrorBody: React.FC<{
         </ErrorDescription>
       ) : null}
       {list ? <ErrorDescription>{list}</ErrorDescription> : null}
+      {buttons ? (
+        <Flex alignSelf="center" mt={10} flexDirection="row" columnGap={6}>
+          {buttons}
+        </Flex>
+      ) : null}
     </>
   );
 });

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5231,7 +5231,8 @@
     },
     "FirmwareNotRecognized": {
       "title": "Invalid Provider",
-      "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Live \"Settings\", select \"Experimental features\", and then select a different provider."
+      "description": "You have to change \"My Ledger provider\" setting. To change it, open Ledger Live \"Settings\", select \"Experimental features\", and then select a different provider.",
+      "goToSettingsCTA": "Go to settings"
     },
     "HardResetFail": {
       "title": "Sorry, could not reset",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- New rendering component for `FirmwareNotRecognized`/"InvalidProvider" error:
<img width="1136" alt="Screenshot 2023-12-21 at 13 26 28" src="https://github.com/LedgerHQ/ledger-live/assets/91890529/a5b9d92b-e08f-4df9-aec9-614f46168001">

- Added a `buttons` prop to `ErrorBody` component and used it for `DeviceNotOnboardedErrorComponent` and `renderLockedDeviceError`

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10338] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - cf. description above

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10338]: https://ledgerhq.atlassian.net/browse/LIVE-10338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ