### PR TITLE
fix(Dynamic Counter Values): Bugfixes

### DIFF
--- a/.changeset/nasty-peas-love.md
+++ b/.changeset/nasty-peas-love.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/coin-framework": patch
+---
+
+Supported Counter Values : fallback to local list if call fails + fixed call to the API retriggered on LLD causing UI bugs

--- a/apps/ledger-live-desktop/src/renderer/hooks/useInitSupportedCounterValues.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useInitSupportedCounterValues.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { getsupportedCountervalues } from "~/renderer/reducers/settings";
 import { setSupportedCounterValues } from "~/renderer/actions/settings";
@@ -5,6 +6,11 @@ import { setSupportedCounterValues } from "~/renderer/actions/settings";
 export const useInitSupportedCounterValues = async () => {
   const dispatch = useDispatch();
 
-  const supportedCounterValues = await getsupportedCountervalues();
-  dispatch(setSupportedCounterValues(supportedCounterValues));
+  useEffect(() => {
+    const fetchData = async () => {
+      const supportedCounterValues = await getsupportedCountervalues();
+      dispatch(setSupportedCounterValues(supportedCounterValues));
+    };
+    fetchData();
+  }, [dispatch]);
 };

--- a/libs/coin-framework/src/currencies/support.ts
+++ b/libs/coin-framework/src/currencies/support.ts
@@ -12,34 +12,26 @@ let userSupportedCurrencies: CryptoCurrency[] = [];
 let userSupportedFiats: FiatCurrency[] | null = null;
 
 // The API returns Coingeko countervalues tickers, but getFiatCurrencyByTicker might not support each of those.
-const locallySupportedFiats = [
+export const locallySupportedFiats = [
   "AED",
   "AUD",
-  "BGN",
   "BHD",
   "BRL",
   "CAD",
   "CHF",
   "CLP",
   "CNY",
-  "CRC",
   "CZK",
   "DKK",
   "EUR",
   "GBP",
-  "GHS",
   "HKD",
-  "HRK",
   "HUF",
   "IDR",
   "ILS",
   "INR",
-  "IRR",
   "JPY",
-  "KES",
-  "KHR",
   "KRW",
-  "MUR",
   "MXN",
   "MYR",
   "NGN",
@@ -48,29 +40,28 @@ const locallySupportedFiats = [
   "PHP",
   "PKR",
   "PLN",
-  "RON",
   "RUB",
   "SEK",
   "SGD",
   "THB",
   "TRY",
-  "TZS",
   "UAH",
-  "UGX",
   "USD",
-  "VES",
   "VND",
-  "VUV",
   "ZAR",
 ];
 
 async function initializeUserSupportedFiats() {
   try {
     const ids = await fetchSupportedFiatsTokens();
-    const idsToUpper = ids.map(id => id.toUpperCase());
+    let supportedTokens = locallySupportedFiats;
 
-    // This makes sure we only keep the elements supported in our API and that are available for getFiatCurrencyByTicker
-    const supportedTokens = idsToUpper.filter(token => locallySupportedFiats.includes(token));
+    if (ids.length) {
+      const idsToUpper = ids?.map(id => id.toUpperCase());
+
+      // This makes sure we only keep the elements supported in our API and that are available for getFiatCurrencyByTicker
+      supportedTokens = idsToUpper.filter(token => locallySupportedFiats.includes(token));
+    }
     userSupportedFiats = supportedTokens.map(id => {
       return getFiatCurrencyByTicker(id);
     });
@@ -95,8 +86,7 @@ export async function fetchSupportedFiatsTokens(): Promise<string[]> {
     const data: string[] = await response.json();
     return data;
   } catch (error) {
-    // Handle any network or parsing errors here
-    console.error("Error:", error);
+    log("debug", `Failed to fetch supported fiat tokens. Error Message: ${error}`);
     throw error;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR aims to fix two bugs :
- Users only having 2 default CV if the API call fails.
- API call retriggered at each re-render on LLD, making the select list unusable in poor network conditions (auto scroll once data is updated)
Here's how those are fixed :
- fallback to (updated) local list if API call fails.
- fixed hook call to the API retriggered on LLD.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-10577] [PROD-5432]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10577]: https://ledgerhq.atlassian.net/browse/LIVE-10577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROD-5432]: https://ledgerhq.atlassian.net/browse/PROD-5432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ