### PR TITLE
fix: lower stale timeout of fetch rates

### DIFF
--- a/.changeset/real-suns-compete.md
+++ b/.changeset/real-suns-compete.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+lower stale timeout on fetch rates

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchRates.ts
@@ -38,7 +38,7 @@ export function useFetchRates({
       toCurrencyId,
       fromCurrencyAmount: formattedCurrencyAmount,
     },
-    staleTimeout: 50000,
+    staleTimeout: 20000,
     enabled: !!toCurrencyId && !!currencyFrom && fromCurrencyAmount.gt(0) && !!unitFrom && !!unitTo,
     onSuccess,
   });


### PR DESCRIPTION
### 📝 Description

- lower stale timeout from 50s to 20s in conjunction with the lowering of the refresh rate of rates.



### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
