### PR TITLE
[LIVE-6541] [LLD]: Improve "connect" screen during sync onboarding via USB

### DIFF
--- a/.changeset/metal-lemons-perform.md
+++ b/.changeset/metal-lemons-perform.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Improve stax connect screen before ESC by polling device onboarding state

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/DeviceConnection/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/DeviceConnection/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
 import { DeviceModelId } from "@ledgerhq/types-devices";
@@ -6,28 +6,80 @@ import { stringToDeviceModelId } from "@ledgerhq/devices/helpers";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import Success from "./Success";
 import Searching from "./Searching";
+import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
+import LockedDeviceDrawer, {
+  Props as LockedDeviceDrawerProps,
+} from "~/renderer/components/SyncOnboarding/Manual/LockedDeviceDrawer";
+import { setDrawer } from "~/renderer/drawers/Provider";
 
 export type SyncOnboardingDeviceConnectionProps = {
   deviceModelId: string; // Should be DeviceModelId. react-router 5 seems to only handle [K in keyof Params]?: string props
 };
 
 const SUCCESS_TIMEOUT_MS = 2500;
+const POLLING_PERIOD_MS = 1000;
 
 const SyncOnboardingDeviceConnection = ({
   deviceModelId: strDeviceModelId,
 }: SyncOnboardingDeviceConnectionProps) => {
+  const navTimeout = useRef<ReturnType<typeof setTimeout>>();
   const history = useHistory();
   const currentDevice = useSelector(getCurrentDevice);
-
+  const [stopPolling, setStopPolling] = useState(false);
+  const { lockedDevice } = useOnboardingStatePolling({
+    device: currentDevice,
+    pollingPeriodMs: POLLING_PERIOD_MS,
+    stopPolling,
+  });
   const deviceModelId = stringToDeviceModelId(strDeviceModelId, DeviceModelId.stax);
+  const [shouldNavigate, setShouldNavigate] = useState(
+    currentDevice && currentDevice.modelId === deviceModelId,
+  );
 
-  if (currentDevice && currentDevice.modelId === deviceModelId) {
-    setTimeout(
-      () =>
-        // Uses the modelId from the newly connected device, in case the route prop strDeviceModelId is different
-        history.push(`/onboarding/sync/manual/${currentDevice.modelId}`),
-      SUCCESS_TIMEOUT_MS,
+  useEffect(() => {
+    return () => setStopPolling(true);
+  }, []);
+
+  useEffect(() => {
+    setShouldNavigate(
+      Boolean(currentDevice && currentDevice.modelId === deviceModelId && !lockedDevice),
     );
+  }, [currentDevice, deviceModelId, lockedDevice]);
+
+  useEffect(() => {
+    if (lockedDevice && currentDevice) {
+      const props: LockedDeviceDrawerProps = {
+        deviceModelId,
+      };
+      setDrawer(LockedDeviceDrawer, props, {
+        forceDisableFocusTrap: true,
+        preventBackdropClick: true,
+      });
+    } else {
+      setDrawer();
+    }
+    return () => setDrawer();
+  }, [lockedDevice, currentDevice, deviceModelId]);
+
+  useEffect(() => {
+    // if current device is set and unlocked (pin) we start a timeout of 2500ms to navigate on success screen
+    if (shouldNavigate && !navTimeout.current && currentDevice?.modelId) {
+      navTimeout.current = setTimeout(
+        () =>
+          // Uses the modelId from the newly connected device, in case the route prop strDeviceModelId is different
+          history.push(`/onboarding/sync/manual/${currentDevice?.modelId}`),
+        SUCCESS_TIMEOUT_MS,
+      );
+    }
+    // else we cancel the timeout
+    else if (navTimeout.current && !shouldNavigate) {
+      clearTimeout(navTimeout.current);
+      navTimeout.current = undefined;
+    }
+    return () => clearTimeout(navTimeout.current);
+  }, [shouldNavigate, currentDevice, history]);
+
+  if (currentDevice && shouldNavigate) {
     return <Success device={currentDevice} />;
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
Improve stax connect screen before ESC by polling device onboarding state

https://github.com/LedgerHQ/ledger-live/assets/145363160/4522dc25-aeba-4682-83fe-2c5d45e44761


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-6541] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Lock stax in connect screen before/after lottie animation change
  - Unplug stax in connect screen before/after lottie animation change

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [x] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [x] **Any new dependencies** have been justified and documented.
- [x] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-6541]: https://ledgerhq.atlassian.net/browse/LIVE-6541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ