### PR TITLE
Bugfix/live 8799 storage available

### DIFF
--- a/.changeset/slow-mugs-attack.md
+++ b/.changeset/slow-mugs-attack.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Fix the free storage available for all devices

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/StorageBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/StorageBar.tsx
@@ -182,7 +182,7 @@ const StorageBar = ({
                   name,
                   currency,
                 })}
-                ratio={blocks / (distribution.totalBlocks - distribution.osBlocks)}
+                ratio={blocks / distribution.appsSpaceBlocks}
               >
                 <Tooltip
                   hideOnClick={false}

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -437,12 +437,13 @@ export function getBlockSize(state: State): number {
 export const isIncompleteState = (state: State): boolean => state.installed.some(a => !a.name);
 // calculate if a given state (typically a predicted one) is out of memory (meaning impossible to reach with a device)
 export const isOutOfMemoryState = (state: State): boolean => {
+  const { customImageBlocks } = state;
   const blockSize = getBlockSize(state);
   const totalBytes = state.deviceModel.memorySize;
   const totalBlocks = Math.floor(totalBytes / blockSize);
   const osBytes = (state.firmware && state.firmware.bytes) || 0;
   const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks;
+  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
   const totalAppsBlocks = state.installed.reduce((sum, app) => sum + app.blocks, 0);
   return totalAppsBlocks > appsSpaceBlocks;
 };

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -437,14 +437,7 @@ export function getBlockSize(state: State): number {
 export const isIncompleteState = (state: State): boolean => state.installed.some(a => !a.name);
 // calculate if a given state (typically a predicted one) is out of memory (meaning impossible to reach with a device)
 export const isOutOfMemoryState = (state: State): boolean => {
-  const { customImageBlocks } = state;
-  const blockSize = getBlockSize(state);
-  const totalBytes = state.deviceModel.memorySize;
-  const totalBlocks = Math.floor(totalBytes / blockSize);
-  const osBytes = (state.firmware && state.firmware.bytes) || 0;
-  const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
-  const totalAppsBlocks = state.installed.reduce((sum, app) => sum + app.blocks, 0);
+  const { totalAppsBlocks, appsSpaceBlocks } = distribute(state);
   return totalAppsBlocks > appsSpaceBlocks;
 };
 export const isLiveSupportedApp = (app: App): boolean => {

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -386,7 +386,9 @@ export const distribute = (
   const totalBlocks = Math.floor(totalBytes / blockSize);
   const osBytes = (state.firmware && state.firmware.bytes) || 0;
   const osBlocks = Math.ceil(osBytes / blockSize);
-  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks;
+  const languagePackBytes = state.installedLanguagePack?.bytes || 0;
+  const languagePackBlocks = Math.ceil(languagePackBytes / blockSize);
+  const appsSpaceBlocks = totalBlocks - osBlocks - customImageBlocks - languagePackBlocks;
   const appsSpaceBytes = appsSpaceBlocks * blockSize;
   let totalAppsBlocks = 0;
   const apps = state.installed.map(app => {
@@ -423,6 +425,7 @@ export const distribute = (
     appsSpaceBytes,
     totalAppsBlocks,
     customImageBlocks,
+    languagePackBlocks,
     totalAppsBytes,
     freeSpaceBlocks,
     freeSpaceBytes,

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -186,6 +186,7 @@ export function mockListAppsResult(
     installed,
     installedAvailable: true,
     customImageBlocks: 0,
+    installedLanguagePack: undefined,
   };
 }
 

--- a/libs/ledger-live-common/src/apps/types.ts
+++ b/libs/ledger-live-common/src/apps/types.ts
@@ -1,6 +1,6 @@
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { DeviceModel, DeviceModelId } from "@ledgerhq/devices";
-import { App, DeviceInfo, FinalFirmware } from "@ledgerhq/types-live";
+import { App, DeviceInfo, FinalFirmware, LanguagePackage } from "@ledgerhq/types-live";
 import type { Observable, Subject } from "rxjs";
 export type Exec = (
   appOp: AppOp,
@@ -75,6 +75,7 @@ export type ListAppsResult = {
   appsListNames: string[];
   installedAvailable: boolean;
   installed: InstalledItem[];
+  installedLanguagePack: LanguagePackage | undefined;
   deviceInfo: DeviceInfo;
   deviceModelId: DeviceModelId;
   deviceName: string;
@@ -90,6 +91,7 @@ export type State = {
   customImageBlocks: number;
   installedAvailable: boolean;
   installed: InstalledItem[];
+  installedLanguagePack: LanguagePackage | undefined;
   recentlyInstalledApps: string[];
   installQueue: string[];
   uninstallQueue: string[];
@@ -209,4 +211,5 @@ export type AppsDistribution = {
   freeSpaceBytes: number;
   shouldWarnMemory: boolean;
   customImageBlocks: number;
+  languagePackBlocks: number;
 };

--- a/libs/ledgerjs/packages/devices/src/index.ts
+++ b/libs/ledgerjs/packages/devices/src/index.ts
@@ -57,7 +57,7 @@ const devices: { [key in DeviceModelId]: DeviceModel } = {
     productIdMM: 0x50,
     legacyUsbProductId: 0x0005,
     usbOnly: true,
-    memorySize: 1536 * 1024,
+    memorySize: 1533 * 1024,
     masks: [0x33100000],
     getBlockSize: (_firmwareVersion: string): number => 32,
   },
@@ -85,7 +85,7 @@ const devices: { [key in DeviceModelId]: DeviceModel } = {
     productIdMM: 0x60,
     legacyUsbProductId: 0x0006,
     usbOnly: false,
-    memorySize: 1536 * 1024,
+    memorySize: 1533 * 1024,
     masks: [0x33200000],
     getBlockSize: (_firmwareVersion: string): number => 32,
     bluetoothSpec: [


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

The storage information was inaccurately represented due to the previous system's behavior. 
- Custom lock screen image was missing for Stax
- Current installed language pack not taken into account
- Size of storage for Stax and LNS+ too large

With this patch, the storage left is displayed correctly for all devices on LLD and LLM.

<!--
| Before        | After         |
| ------------- | ------------- |
| Unable to install apps because no storage left | No errors because storage left is calculated correctly |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-8799]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [x] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-8799]: https://ledgerhq.atlassian.net/browse/LIVE-8799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ