### PR TITLE
Fix close cta on SideDrawer when it overlaps AppRegionDrag

### DIFF
--- a/.changeset/spotty-ants-deny.md
+++ b/.changeset/spotty-ants-deny.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix close cta on Side Drawer when it overlaps AppRegionDrag

--- a/apps/ledger-live-desktop/src/renderer/components/SideDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SideDrawer.tsx
@@ -87,6 +87,7 @@ const DrawerContainer = styled.div.attrs(({ state }: { state: TransitionStatus }
   bottom: 0;
   right: 0;
   overflow: hidden;
+  -webkit-app-region: no-drag;
   z-index: 50;
 `;
 export type DrawerProps = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Today on some Side Drawers we can't close them using the close cta. The reason is that we have the AppRegionDrag that is positioned in the same area and takes over for a drag event.

<img width="1355" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/31533861/f73ed9ae-a660-43aa-8737-88e123824b7f">

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10500
### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
