### PR TITLE
Feat/revert live 10717 usage of description for search manifest

### DIFF
--- a/.changeset/grumpy-donuts-dress.md
+++ b/.changeset/grumpy-donuts-dress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+revert usage-of-description-for-search-manifest

--- a/libs/ledger-live-common/src/wallet-api/constants.ts
+++ b/libs/ledger-live-common/src/wallet-api/constants.ts
@@ -13,14 +13,7 @@ export const WALLET_API_FAMILIES = [...FAMILIES, "evm"];
 export const WALLET_API_VERSION = "2.0.0";
 
 export const BROWSE_SEARCH_OPTIONS: Fuse.IFuseOptions<AppManifest> = {
-  keys: [
-    "name",
-    "categories",
-    {
-      name: "mergedDescriptions",
-      getFn: item => Object.values(item.content.description).join(" "),
-    },
-  ],
+  keys: ["name", "categories"],
   threshold: 0.1,
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Revert usage of description into search apps

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
