### PR TITLE
Fix: LIVE-10969 Fix inline install app while another app is opened

### DIFF
--- a/.changeset/great-horses-marry.md
+++ b/.changeset/great-horses-marry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix: inline install app while another app is opened

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -26,7 +26,6 @@ import { getImplementation, ImplementationType } from "./implementations";
 
 export type State = {
   isLoading: boolean;
-  isDisconnected: boolean;
   requestQuitApp: boolean;
   requestOpenApp: string | null | undefined;
   requiresAppInstallation:
@@ -134,7 +133,6 @@ const mapResult = ({
 
 const getInitialState = (device?: Device | null | undefined, request?: AppRequest): State => ({
   isLoading: !!device,
-  isDisconnected: false,
   requestQuitApp: false,
   requestOpenApp: null,
   unresponsive: false,
@@ -188,18 +186,10 @@ const reducer = (state: State, e: Event): State => {
       return {
         ...getInitialState(null, state.request),
         isLoading: !!e.expected,
-        isDisconnected: true,
       };
 
     case "deviceChange":
-      // Preserve the current state when the device is disconnected to avoid displaying
-      // the loader drawer above the disconnected one.
-      if (state.isDisconnected) return state;
-
-      return {
-        ...getInitialState(e.device, state.request),
-        device: e.device,
-      };
+      return { ...getInitialState(e.device, state.request), device: e.device };
 
     case "some-apps-skipped":
       return {
@@ -239,10 +229,6 @@ const reducer = (state: State, e: Event): State => {
       };
 
     case "error":
-      // Preserve the current state when the device is disconnected to avoid displaying
-      // an additional error message above the disconnected one.
-      if (state.isDisconnected) return state;
-
       return {
         ...getInitialState(state.device, state.request),
         device: state.device || null,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When another app B is already opened while launching an action that needs an app A, which triggers the inline installation of the app A, a wrong component telling the user their device was disconnected was being displayed.

The issue was the event `deviceChange` not processed correctly after an event `disconnected`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10969](https://ledgerhq.atlassian.net/browse/LIVE-10969)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10969]: https://ledgerhq.atlassian.net/browse/LIVE-10969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ