### PR TITLE
[LIVE-10904][LLM][BLE][Android] When using an open app"Switch on and unlock your device" drawer blocks the action

### DIFF
--- a/.changeset/giant-sloths-switch.md
+++ b/.changeset/giant-sloths-switch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix deviceChange reducer

--- a/.changeset/giant-sloths-switch.md
+++ b/.changeset/giant-sloths-switch.md
@@ -1,5 +1,7 @@
 ---
 "@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
 ---
 
-fix deviceChange reducer
+Open app device action: fix reducer for "deviceChange" and "error" events types, causing issues when the app changes on the device

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -26,7 +26,6 @@ import { getImplementation, ImplementationType } from "./implementations";
 
 export type State = {
   isLoading: boolean;
-  isDisconnected: boolean;
   requestQuitApp: boolean;
   requestOpenApp: string | null | undefined;
   requiresAppInstallation:
@@ -134,7 +133,6 @@ const mapResult = ({
 
 const getInitialState = (device?: Device | null | undefined, request?: AppRequest): State => ({
   isLoading: !!device,
-  isDisconnected: false,
   requestQuitApp: false,
   requestOpenApp: null,
   unresponsive: false,
@@ -188,20 +186,10 @@ const reducer = (state: State, e: Event): State => {
       return {
         ...getInitialState(null, state.request),
         isLoading: !!e.expected,
-        isDisconnected: true,
       };
 
     case "deviceChange":
-      // Preserve the current state when the device is disconnected to avoid displaying
-      // the loader drawer above the disconnected one.
-      if (state.isDisconnected) {
-        return { ...state, device: e.device };
-      }
-
-      return {
-        ...getInitialState(e.device, state.request),
-        device: e.device,
-      };
+      return { ...getInitialState(e.device, state.request), device: e.device };
 
     case "some-apps-skipped":
       return {
@@ -241,10 +229,6 @@ const reducer = (state: State, e: Event): State => {
       };
 
     case "error":
-      // Preserve the current state when the device is disconnected to avoid displaying
-      // an additional error message above the disconnected one.
-      if (state.isDisconnected) return state;
-
       return {
         ...getInitialState(state.device, state.request),
         device: state.device || null,

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -194,7 +194,9 @@ const reducer = (state: State, e: Event): State => {
     case "deviceChange":
       // Preserve the current state when the device is disconnected to avoid displaying
       // the loader drawer above the disconnected one.
-      if (state.isDisconnected) return state;
+      if (state.isDisconnected) {
+        return { ...state, device: e.device };
+      }
 
       return {
         ...getInitialState(e.device, state.request),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Some breaking changes had been added to the open app device action reducer in #5902. The actual fix made in that PR was not those changes so they were unnecessary.

Thanks to @Wozacosta for the initial fix proposal 🙏

**Demo of the fix:**
LLM Android: The device going from one app to another during a device action should not cause any issue and the device action should go on normally. The issue was that the "switch on and unlock your device" drawer was getting displayed and never disappearing.

https://github.com/LedgerHQ/ledger-live/assets/91890529/3f357374-fff0-4f79-8769-ef830bd120aa



**Demo of what had been fixed in #5902 and is still working:**
LLM Android: Unplugging the USB during a device action should not result in the drawer getting dismissed, it should show an error message.

https://github.com/LedgerHQ/ledger-live/assets/91890529/1faa24c1-07c4-4bd4-85b2-6e462fa7bc9c



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10904]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10904]: https://ledgerhq.atlassian.net/browse/LIVE-10904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ