### PR TITLE
bugfix(solana): Use fallback TX fee amount in case of failed retries

### DIFF
--- a/.changeset/odd-chefs-sell.md
+++ b/.changeset/odd-chefs-sell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+use fallback tx fee amount in case of failed retries

--- a/libs/ledger-live-common/src/families/solana/tx-fees.ts
+++ b/libs/ledger-live-common/src/families/solana/tx-fees.ts
@@ -5,9 +5,9 @@ import { Transaction, TransactionModel } from "./types";
 import { assertUnreachable } from "./utils";
 import { VersionedTransaction as OnChainTransaction } from "@solana/web3.js";
 import { log } from "@ledgerhq/logs";
-import { NetworkError } from "@ledgerhq/errors";
 
 const MAX_RETRIES = 10; // TODO Candidate to put in coin config
+const DEFAULT_TX_FEE = 5000;
 
 export async function estimateTxFee(
   api: ChainAPI,
@@ -27,8 +27,11 @@ export async function estimateTxFee(
   }
 
   if (typeof fee !== "number") {
-    log("error", `unexpected fee: <${fee}>, after retry with a new blockhash`);
-    throw new NetworkError();
+    log(
+      "error",
+      `unexpected fee: <${fee}>, after retry with a new blockhash. Fallback to the default.`,
+    );
+    fee = DEFAULT_TX_FEE;
   }
   return fee;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

An addition to #5913. In case of a failure after retries, use hardcoded value for a basic TX fee with one signature.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: #5913

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:** Best effort to calculate fees in case of a systematic failures to get fee from RPC nodes.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
