### PR TITLE
bugfix: triggering error only after having quotes (cherryPick from develop)

### DIFF
--- a/libs/ledger-live-common/src/exchange/swap/maybeTezosAccountUnrevealedAccount.ts
+++ b/libs/ledger-live-common/src/exchange/swap/maybeTezosAccountUnrevealedAccount.ts
@@ -4,6 +4,7 @@ export const maybeTezosAccountUnrevealedAccount = (
   swapTransaction: SwapTransactionType,
 ): Error | undefined => {
   if (
+    swapTransaction.swap?.rates.status == "success" &&
     swapTransaction?.transaction?.family == "tezos" &&
     swapTransaction?.transaction?.estimatedFees &&
     swapTransaction?.transaction?.fees !== swapTransaction?.transaction?.estimatedFees


### PR DESCRIPTION
### 📝 Description

Tezos error for unreavealed account could crash. 
This is a test PR to see if triggering the error after receiving rates solves the issue

### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-10967)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
