### PR TITLE
Chore: add DisconnectedDeviceDuringOperation to the allowed errors of the sync onboarding polling

### DIFF
--- a/.changeset/selfish-files-trade.md
+++ b/.changeset/selfish-files-trade.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Chore: add DisconnectedDeviceDuringOperation to allowed error during sync onboarding polling

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -12,6 +12,7 @@ import {
   LockedDeviceError,
   UnexpectedBootloader,
   TransportExchangeTimeoutError,
+  DisconnectedDeviceDuringOperation,
 } from "@ledgerhq/errors";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { extractOnboardingState, OnboardingState } from "./extractOnboardingState";
@@ -136,6 +137,7 @@ export const isAllowedOnboardingStatePollingError = (error: unknown): boolean =>
     (error instanceof TimeoutError ||
       error instanceof TransportExchangeTimeoutError ||
       error instanceof DisconnectedDevice ||
+      error instanceof DisconnectedDeviceDuringOperation ||
       error instanceof CantOpenDevice ||
       error instanceof TransportRaceCondition ||
       error instanceof TransportStatusError ||


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

On LLD, depending at what time the device is unplugged, we would not get the same behavior: sometimes the banner would be displayed, sometimes it would directly be the USB troubleshooting drawer.

What we want: we always want the same behavior: banner first when unplugging because we know the user can reconnect their device, and after 60 secs the troubleshooting drawer, we can:

The simple fix: update the list in `isAllowedOnboardingStatePollingError` to add the error `DisconnectedDeviceDuringOperation`

<details>
  <summary>LLD demo</summary>


https://github.com/LedgerHQ/ledger-live/assets/15096913/29da3280-ffce-46f0-9866-aa9995984426



</details>

<details>
  <summary>LLM demo - still working</summary>


https://github.com/LedgerHQ/ledger-live/assets/15096913/7e5f28d2-b518-4fd2-baa5-9a36ea45883e



</details>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-9044](https://ledgerhq.atlassian.net/browse/LIVE-9044)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-9044]: https://ledgerhq.atlassian.net/browse/LIVE-9044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ