### PR TITLE
[bugfix] Revert increase of nb retries for solana fees

### DIFF
--- a/libs/ledger-live-common/src/families/solana/tx-fees.ts
+++ b/libs/ledger-live-common/src/families/solana/tx-fees.ts
@@ -6,7 +6,6 @@ import { assertUnreachable } from "./utils";
 import { VersionedTransaction as OnChainTransaction } from "@solana/web3.js";
 import { log } from "@ledgerhq/logs";
 
-const MAX_RETRIES = 10; // TODO Candidate to put in coin config
 const DEFAULT_TX_FEE = 5000;
 
 export async function estimateTxFee(
@@ -18,19 +17,20 @@ export async function estimateTxFee(
   const [onChainTx] = await buildTransactionWithAPI(address, tx, api);
 
   let fee = await api.getFeeForMessage(onChainTx.message);
-  let retries = 0;
 
-  while (typeof fee !== "number" && retries++ < MAX_RETRIES) {
-    // FIXME HACK: sometimes fee is not a number, retrying with a next blockhash
-    log("debug", `api.getFeeForMessage returned invalid fee: <${fee}>`);
+  if (typeof fee !== "number") {
+    // Sometimes getFeeForMessage doesn't return valid fees, because onChainTx.message.recentBlockhash
+    // is outdated --> retrying with a next blockhash
+    log("debug", `Solana api.getFeeForMessage returned invalid fee: <${fee}>`);
     fee = await retryWithNewBlockhash(api, onChainTx);
   }
 
   if (typeof fee !== "number") {
     log(
       "error",
-      `unexpected fee: <${fee}>, after retry with a new blockhash. Fallback to the default.`,
+      `Solana unexpected fee: <${fee}>, after retry with a new blockhash. Fallback to the default.`,
     );
+    // If still failing, fallback to a default fees value
     fee = DEFAULT_TX_FEE;
   }
   return fee;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

1) https://github.com/LedgerHQ/ledger-live/pull/5913 added a retry x10 mechanism, as a mitigation for https://ledgerhq.atlassian.net/browse/LIVE-10945
2) https://github.com/LedgerHQ/ledger-live/pull/5946 then provided a better fix, by falling back on default fees
3) This PR removes the retry x10 mechanism, since now with the proper fallback only a 1x retry is enough

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10945

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached. --> no need as it's basically a revert of unreleased changes
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
