### PR TITLE
[Tron] - tronResource not mandatory in accountActions component

### DIFF
--- a/.changeset/smooth-mails-love.md
+++ b/.changeset/smooth-mails-love.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+tronResource not mandatory in accountActions

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -6,7 +6,7 @@ import { getLastVotedDate } from "@ledgerhq/live-common/families/tron/react";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent } from "~/components/FabActions";
-import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { isSubAccount } from "@ledgerhq/live-common/account/index";
 
 const getSecondaryActions = ({
   account,
@@ -20,10 +20,10 @@ const getSecondaryActions = ({
   const accountId = account.id;
   const canVote = tronPower > 0;
   const lastVotedDate = getLastVotedDate(account as TronAccount);
-  const mainAccount = getMainAccount(account);
 
-  return mainAccount.id === accountId
-    ? [
+  return isSubAccount(account)
+    ? []
+    : [
         {
           id: "freeze",
           disabled: true,
@@ -80,8 +80,7 @@ const getSecondaryActions = ({
             outline: false,
           },
         },
-      ]
-    : [];
+      ];
 };
 
 export default {

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -6,6 +6,7 @@ import { getLastVotedDate } from "@ledgerhq/live-common/families/tron/react";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent } from "~/components/FabActions";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 
 const getSecondaryActions = ({
   account,
@@ -19,65 +20,68 @@ const getSecondaryActions = ({
   const accountId = account.id;
   const canVote = tronPower > 0;
   const lastVotedDate = getLastVotedDate(account as TronAccount);
+  const mainAccount = getMainAccount(account);
 
-  return [
-    {
-      id: "freeze",
-      disabled: true,
-      navigationParams: [
-        NavigatorName.Freeze,
+  return mainAccount.id === accountId
+    ? [
         {
-          screen: canVote ? ScreenName.FreezeAmount : ScreenName.FreezeInfo,
-          params: {
-            accountId,
+          id: "freeze",
+          disabled: true,
+          navigationParams: [
+            NavigatorName.Freeze,
+            {
+              screen: canVote ? ScreenName.FreezeAmount : ScreenName.FreezeInfo,
+              params: {
+                accountId,
+              },
+            },
+          ],
+          label: <Trans i18nKey="tron.manage.freeze.title" />,
+          description: <Trans i18nKey="tron.manage.freeze.description" />,
+          Icon: IconsLegacy.FreezeMedium,
+        },
+        {
+          id: "unfreeze",
+          disabled: true,
+          navigationParams: [
+            NavigatorName.Unfreeze,
+            {
+              screen: ScreenName.UnfreezeAmount,
+              params: {
+                accountId,
+              },
+            },
+          ],
+          label: <Trans i18nKey="tron.manage.unfreeze.title" />,
+          description: <Trans i18nKey="tron.manage.unfreeze.description" />,
+          Icon: IconsLegacy.UnfreezeMedium,
+          buttonProps: {
+            type: "main",
+            outline: false,
           },
         },
-      ],
-      label: <Trans i18nKey="tron.manage.freeze.title" />,
-      description: <Trans i18nKey="tron.manage.freeze.description" />,
-      Icon: IconsLegacy.FreezeMedium,
-    },
-    {
-      id: "unfreeze",
-      disabled: true,
-      navigationParams: [
-        NavigatorName.Unfreeze,
         {
-          screen: ScreenName.UnfreezeAmount,
-          params: {
-            accountId,
+          id: "vote",
+          disabled: true,
+          navigationParams: [
+            NavigatorName.TronVoteFlow,
+            {
+              screen: lastVotedDate ? "VoteSelectValidator" : "VoteStarted",
+              params: {
+                accountId,
+              },
+            },
+          ],
+          label: <Trans i18nKey="tron.manage.vote.title" />,
+          description: <Trans i18nKey="tron.manage.vote.description" />,
+          Icon: IconsLegacy.VoteMedium,
+          buttonProps: {
+            type: "main",
+            outline: false,
           },
         },
-      ],
-      label: <Trans i18nKey="tron.manage.unfreeze.title" />,
-      description: <Trans i18nKey="tron.manage.unfreeze.description" />,
-      Icon: IconsLegacy.UnfreezeMedium,
-      buttonProps: {
-        type: "main",
-        outline: false,
-      },
-    },
-    {
-      id: "vote",
-      disabled: true,
-      navigationParams: [
-        NavigatorName.TronVoteFlow,
-        {
-          screen: lastVotedDate ? "VoteSelectValidator" : "VoteStarted",
-          params: {
-            accountId,
-          },
-        },
-      ],
-      label: <Trans i18nKey="tron.manage.vote.title" />,
-      description: <Trans i18nKey="tron.manage.vote.description" />,
-      Icon: IconsLegacy.VoteMedium,
-      buttonProps: {
-        type: "main",
-        outline: false,
-      },
-    },
-  ];
+      ]
+    : [];
 };
 
 export default {

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Trans } from "react-i18next";
-import invariant from "invariant";
 import type { Account } from "@ledgerhq/types-live";
 import type { TronAccount } from "@ledgerhq/live-common/families/tron/types";
 import { getLastVotedDate } from "@ledgerhq/live-common/families/tron/react";
@@ -15,11 +14,10 @@ const getSecondaryActions = ({
   parentAccount: Account;
 }): ActionButtonEvent[] => {
   const { tronResources } = account;
-  invariant(tronResources, "tron resources required");
-  const { tronPower } = tronResources;
+  const tronPower = tronResources?.tronPower || 0;
 
   const accountId = account.id;
-  const canVote = (tronPower || 0) > 0;
+  const canVote = tronPower > 0;
   const lastVotedDate = getLastVotedDate(account as TronAccount);
 
   return [


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

accountActions had an invariant for `tronResources`, when there were no `tronResources` the app would crash. However they were not mandatory for the component.
In this PR the choice is made to remove the invariant and propose a fallback in case the `tronResources`

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10972

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
