### PR TITLE
[LIVE-10934][BUGFIX] Close button on USB troubleshooting drawer during Sync Onboarding is misleading

### DIFF
--- a/.changeset/cool-falcons-wave.md
+++ b/.changeset/cool-falcons-wave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Return to device selection screen after clicking the cross button

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -139,7 +139,12 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
           setDrawer();
         },
       };
-      setDrawer(TroubleshootingDrawer, props, { forceDisableFocusTrap: true });
+      setDrawer(TroubleshootingDrawer, props, {
+        forceDisableFocusTrap: true,
+        onRequestClose: () => {
+          history.push("/onboarding/select-device");
+        },
+      });
     }
     return () => setDrawer();
   }, [deviceModelId, history, isTroubleshootingDrawerOpen, lockedDevice]);

--- a/apps/ledger-live-desktop/src/renderer/drawers/Drawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/Drawer.tsx
@@ -63,8 +63,11 @@ export const Drawer = () => {
   const track = useTrack();
   const onRequestClose = useCallback(() => {
     track("button_clicked", { button: "Close" });
+    if (state?.props?.onRequestClose) {
+      onRequestClose();
+    }
     setDrawer();
-  }, [setDrawer, track]);
+  }, [setDrawer, state?.props?.onRequestClose, track]);
   return (
     <SideDrawer
       isOpen={!!state.open}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Disconnect device when onboarding a Stax, waiting for the 'troubleshooting' modal shows, then click on the cross button. Now this action will return to the device selection page, which is the same with the 'close' button at the bottom of the modal.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10934](https://ledgerhq.atlassian.net/browse/LIVE-10934)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10934]: https://ledgerhq.atlassian.net/browse/LIVE-10934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ