### PR TITLE
fix(lld): reset app position when changing monitors

### DIFF
--- a/apps/ledger-live-desktop/src/main/window-lifecycle.ts
+++ b/apps/ledger-live-desktop/src/main/window-lifecycle.ts
@@ -83,6 +83,49 @@ export const loadWindow = async () => {
   }
 };
 
+function restorePosition(
+  previousPosition?: { x: number; y: number },
+  previousDimensions?: { width: number; height: number },
+) {
+  let width = DEFAULT_WINDOW_WIDTH;
+  let height = DEFAULT_WINDOW_HEIGHT;
+  let x, y;
+  if (previousDimensions) {
+    width = previousDimensions.width;
+    height = previousDimensions.height;
+  }
+  if (previousPosition) {
+    x = previousPosition.x;
+    y = previousPosition.y;
+  } else {
+    const windowPosition = getWindowPosition(width, height);
+    x = windowPosition.x;
+    y = windowPosition.y;
+  }
+
+  const bounds = { x, y, width, height };
+
+  const area = screen.getDisplayMatching(bounds).workArea;
+
+  // If the saved position still valid (the window is entirely inside the display area), use it.
+  if (
+    bounds.x >= area.x &&
+    bounds.y >= area.y &&
+    bounds.x + bounds.width <= area.x + area.width &&
+    bounds.y + bounds.height <= area.y + area.height
+  ) {
+    x = bounds.x;
+    y = bounds.y;
+  }
+  // If the saved size is still valid, use it.
+  if (bounds.width <= area.width || bounds.height <= area.height) {
+    width = bounds.width;
+    height = bounds.height;
+  }
+
+  return { x, y, width, height };
+}
+
 export async function createMainWindow(
   {
     dimensions,
@@ -95,22 +138,15 @@ export async function createMainWindow(
       ? settings.theme
       : "null";
 
-  // TODO renderer should provide the saved window rectangle
-  const width = dimensions ? dimensions.width : DEFAULT_WINDOW_WIDTH;
-  const height = dimensions ? dimensions.height : DEFAULT_WINDOW_HEIGHT;
-  const windowPosition = positions || getWindowPosition(width, height);
   const windowOptions = {
     ...defaultWindowOptions,
-    x: windowPosition.x,
-    y: windowPosition.y,
+    ...restorePosition(positions, dimensions),
     ...(process.platform === "darwin"
       ? {
           frame: false,
           titleBarStyle: "hiddenInset" as const,
         }
       : {}),
-    width,
-    height,
     minWidth: MIN_WIDTH,
     minHeight: MIN_HEIGHT,
     show: false,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

this should fix a bug where LLD is running but you can’t see it if you have unplugged a second screen on which you had the Ledger Live app opened before.

used this tip: https://github.com/electron/electron/issues/526#issuecomment-563010533

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10371](https://ledgerhq.atlassian.net/browse/LIVE-10371)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - position of the live app when restarted

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10371]: https://ledgerhq.atlassian.net/browse/LIVE-10371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ