### PR TITLE
[LLM] - [LIVE-9808] - Add Hero Content Card

### DIFF
--- a/.changeset/swift-socks-complain.md
+++ b/.changeset/swift-socks-complain.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add Hero Content Card to LLM

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/elements.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/elements.tsx
@@ -1,0 +1,58 @@
+import { Flex, Icons, Text } from "@ledgerhq/native-ui";
+import React from "react";
+import { Image as NativeImage, Pressable, View } from "react-native";
+import { useTheme } from "styled-components/native";
+import { ButtonAction } from "~/contentCards/cards/types";
+
+export const Image = ({ uri }: { uri: string }) => {
+  return (
+    <NativeImage
+      source={{ uri }}
+      resizeMode="cover"
+      borderRadius={12}
+      style={{ width: "100%", height: 134 }}
+    />
+  );
+};
+
+export const Close = ({ onPress }: { onPress: ButtonAction }) => {
+  return (
+    <Pressable onPress={onPress} hitSlop={11}>
+      <Icons.Close size="XS" />
+    </Pressable>
+  );
+};
+
+type LabelProps = {
+  label: string;
+};
+
+export const Tag = ({ label }: LabelProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <Flex
+      position="absolute"
+      backgroundColor={colors.opacityReverse.c70}
+      style={{ top: 12, left: 12 }}
+      borderRadius={4}
+      px={"6px"}
+      pt={"4px"}
+      pb={"5px"}
+    >
+      <Text fontWeight="bold" color={colors.neutral.c100} variant="small">
+        {label}
+      </Text>
+    </Flex>
+  );
+};
+
+export const Subtitle = ({ label }: LabelProps) => {
+  const { colors } = useTheme();
+
+  return (
+    <Text variant="body" fontWeight="medium" color={colors.neutral.c80} lineHeight={"18px"}>
+      {label}
+    </Text>
+  );
+};

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/elements.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/elements.tsx
@@ -1,6 +1,6 @@
 import { Flex, Icons, Text } from "@ledgerhq/native-ui";
 import React from "react";
-import { Image as NativeImage, Pressable, View } from "react-native";
+import { Image as NativeImage, Pressable } from "react-native";
 import { useTheme } from "styled-components/native";
 import { ButtonAction } from "~/contentCards/cards/types";
 

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/elements.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/elements.tsx
@@ -47,7 +47,7 @@ export const Tag = ({ label }: LabelProps) => {
   );
 };
 
-export const Subtitle = ({ label }: LabelProps) => {
+export const Title = ({ label }: LabelProps) => {
   const { colors } = useTheme();
 
   return (

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
@@ -1,0 +1,32 @@
+import { Button, Flex } from "@ledgerhq/native-ui";
+import React, { useEffect } from "react";
+import { TouchableOpacity } from "react-native";
+import { ContentCardBuilder } from "~/contentCards/cards/utils";
+import { Image, Subtitle, Tag } from "./elements";
+
+type Props = {
+  description: string;
+  image: string;
+  cta: {
+    label: string;
+    fct: Function;
+  };
+  tag?: string;
+};
+
+const HeroCard = ContentCardBuilder<Props>(({ description, image, cta, tag, metadata }) => {
+  useEffect(() => metadata.actions?.onView?.());
+
+  return (
+    <TouchableOpacity onPress={metadata.actions?.onClick} key={metadata.id}>
+      <Flex alignItems="start" rowGap={16} position="relative">
+        <Image uri={image} />
+        {tag && <Tag label={tag} />}
+        <Subtitle label={description} />
+        <Button type="main">{cta.label}</Button>
+      </Flex>
+    </TouchableOpacity>
+  );
+});
+
+export default HeroCard;

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
@@ -5,12 +5,9 @@ import { ContentCardBuilder } from "~/contentCards/cards/utils";
 import { Image, Subtitle, Tag } from "./elements";
 
 type Props = {
-  description: string;
   image: string;
-  cta: {
-    label: string;
-    fct: Function;
-  };
+  description: string;
+  cta: string;
   tag?: string;
 };
 
@@ -23,7 +20,7 @@ const HeroCard = ContentCardBuilder<Props>(({ description, image, cta, tag, meta
         <Image uri={image} />
         {tag && <Tag label={tag} />}
         <Subtitle label={description} />
-        <Button type="main">{cta.label}</Button>
+        <Button type="main">{cta}</Button>
       </Flex>
     </TouchableOpacity>
   );

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
@@ -2,16 +2,16 @@ import { Button, Flex } from "@ledgerhq/native-ui";
 import React, { useEffect } from "react";
 import { TouchableOpacity } from "react-native";
 import { ContentCardBuilder } from "~/contentCards/cards/utils";
-import { Image, Subtitle, Tag } from "./elements";
+import { Image, Title, Tag } from "./elements";
 
 type Props = {
   image: string;
-  description: string;
+  title: string;
   cta: string;
   tag?: string;
 };
 
-const HeroCard = ContentCardBuilder<Props>(({ description, image, cta, tag, metadata }) => {
+const HeroCard = ContentCardBuilder<Props>(({ title, image, cta, tag, metadata }) => {
   useEffect(() => metadata.actions?.onView?.());
 
   return (
@@ -19,7 +19,7 @@ const HeroCard = ContentCardBuilder<Props>(({ description, image, cta, tag, meta
       <Flex alignItems="start" rowGap={16} position="relative">
         <Image uri={image} />
         {tag && <Tag label={tag} />}
-        <Subtitle label={description} />
+        <Title label={title} />
         <Button type="main">{cta}</Button>
       </Flex>
     </TouchableOpacity>

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -16,12 +16,14 @@ import {
   mapAsSmallSquareContentCard,
   mapAsMediumSquareContentCard,
   mapAsBigSquareContentCard,
+  mapAsHeroContentCard,
 } from "~/dynamicContent/utils";
 import Carousel, { WidthFactor } from "../../contentCards/layouts/carousel";
 import useDynamicContent from "../useDynamicContent";
 import { ContentCardsType } from "../types";
 import Grid from "~/contentCards/layouts/grid";
 import VerticalCard from "~/contentCards/cards/vertical";
+import HeroCard from "~/contentCards/cards/hero";
 
 // TODO : Better type to remove any (maybe use AnyContentCard)
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -46,6 +48,10 @@ const contentCardsTypes: {
   [ContentCardsType.action]: {
     contentCardComponent: HorizontalCard,
     mappingFunction: mapAsHorizontalContentCard,
+  },
+  [ContentCardsType.hero]: {
+    contentCardComponent: HeroCard,
+    mappingFunction: mapAsHeroContentCard,
   },
   // TODO : To remove once we extract category from ContentCardsType
   [ContentCardsType.category]: {

--- a/apps/ledger-live-mobile/src/dynamicContent/types.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/types.ts
@@ -8,6 +8,7 @@ enum ContentCardsType {
   bigSquare = "big_square",
   action = "action",
   category = "category",
+  hero = "hero",
 }
 
 enum ContentCardsLayout {
@@ -92,6 +93,15 @@ type HorizontalContentCard = ContentCardCommonProperties & {
   image?: string;
 };
 
+type HeroContentCard = ContentCardCommonProperties & {
+  title?: string; // Unused but still need to be provided to log the content card title
+  image?: string;
+  tag?: string;
+  description?: string;
+  cta: string;
+  link?: string;
+};
+
 type VerticalContentCard = ContentCardCommonProperties & {
   tag?: string;
   title?: string;
@@ -108,6 +118,7 @@ type AnyContentCard =
   | AssetContentCard
   | LearnContentCard
   | NotificationContentCard
+  | HeroContentCard
   | HorizontalContentCard
   | VerticalContentCard;
 
@@ -119,6 +130,7 @@ export type {
   LearnContentCard,
   CategoryContentCard,
   HorizontalContentCard,
+  HeroContentCard,
   VerticalContentCard,
   BrazeContentCard,
   AnyContentCard,

--- a/apps/ledger-live-mobile/src/dynamicContent/types.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/types.ts
@@ -94,10 +94,9 @@ type HorizontalContentCard = ContentCardCommonProperties & {
 };
 
 type HeroContentCard = ContentCardCommonProperties & {
-  title?: string; // Unused but still need to be provided to log the content card title
+  title?: string;
   image?: string;
   tag?: string;
-  description?: string;
   cta: string;
   link?: string;
 };

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -14,6 +14,7 @@ import {
   HorizontalContentCard,
   ContentCardsLayout,
   VerticalContentCard,
+  HeroContentCard,
 } from "~/dynamicContent/types";
 
 export const getMobileContentCards = (array: BrazeContentCard[]) =>
@@ -162,6 +163,18 @@ const mapAsSquareContentCard = (
   viewed: card.viewed,
   order: parseInt(card.extras.order) ? parseInt(card.extras.order) : undefined,
   carouselWidthFactor: widthFactor,
+});
+
+export const mapAsHeroContentCard = (card: BrazeContentCard): HeroContentCard => ({
+  id: card.id,
+  tag: card.extras.tag,
+  description: card.extras.description,
+  image: card.extras.image,
+  cta: card.extras.cta,
+  link: card.extras.link,
+  createdAt: card.created,
+  viewed: card.viewed,
+  order: parseInt(card.extras.order) ? parseInt(card.extras.order) : undefined,
 });
 
 export const mapAsSmallSquareContentCard = (card: BrazeContentCard): VerticalContentCard =>

--- a/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/utils.tsx
@@ -168,7 +168,7 @@ const mapAsSquareContentCard = (
 export const mapAsHeroContentCard = (card: BrazeContentCard): HeroContentCard => ({
   id: card.id,
   tag: card.extras.tag,
-  description: card.extras.description,
+  title: card.extras.title,
   image: card.extras.image,
   cta: card.extras.cta,
   link: card.extras.link,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add Hero Content Card and linked it to the Dynamic Content system.

<img width="413" alt="image" src="https://github.com/LedgerHQ/ledger-live/assets/25589782/ff17aa1f-9107-4c00-8dd1-b609a830de89">

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-9808]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-9808]: https://ledgerhq.atlassian.net/browse/LIVE-9808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ