### PR TITLE
fix: check starts with to catch ppd and stg envs

### DIFF
--- a/.changeset/silly-ears-cry.md
+++ b/.changeset/silly-ears-cry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+check starts with to catch ppd and stg in swap live app

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Migrations/SwapMigrationUI.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/Migrations/SwapMigrationUI.tsx
@@ -79,19 +79,20 @@ export const SwapMigrationUI = (props: SwapMigrationUIProps) => {
     return allNativeUI;
   }
 
-  switch (manifestID) {
-    /**
-     * Demo 0 live app should only contain Exchange Button
-     * Rest should be in native UI (e.g quotes)
-     */
-    case SwapWebManifestIDs.Demo0:
+  switch (true) {
+    case manifestID?.startsWith(SwapWebManifestIDs.Demo0):
+      /**
+       * Demo 0 live app should only contain Exchange Button
+       * Rest should be in native UI (e.g quotes)
+       */
       return (
         <>
           {nativeQuotesUI}
           {liveApp}
         </>
       );
-    case SwapWebManifestIDs.Demo1:
+
+    case manifestID?.startsWith(SwapWebManifestIDs.Demo1):
       /**
        * Demo 1 live app should contain:
        *  - Exchange Button


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
Check the startsWith for stg and ppd.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
