### PR TITLE
[BUGFIX]: Fix display of texts in empty state NFT Gallery

### DIFF
--- a/.changeset/wicked-socks-relate.md
+++ b/.changeset/wicked-socks-relate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix link display in French

--- a/apps/ledger-live-mobile/src/screens/Nft/NftGallery/NftGalleryEmptyState.tsx
+++ b/apps/ledger-live-mobile/src/screens/Nft/NftGallery/NftGalleryEmptyState.tsx
@@ -52,7 +52,9 @@ const NftGalleryEmptyState = () => {
         Icon={IconsLegacy.ExternalLinkMedium}
         iconPosition="right"
       >
-        {t("wallet.nftGallery.empty.supportLink")}
+        <Text fontWeight="semiBold" variant="paragraph">
+          {t("wallet.nftGallery.empty.supportLink")}
+        </Text>
       </Link>
 
       <ReceiveNFTsModal isOpened={isModalOpened} onClose={closeModal} />


### PR DESCRIPTION
### 📝 Description

Fix Empty state display in NFT Gallery in French

BEFORE / AFTER

https://github.com/LedgerHQ/ledger-live/assets/112866305/dadd2279-b418-4687-8b3d-5cb60688f499



-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
