### PR TITLE
[LIVE-6441][BUGFIX] Discrepencies between app size when update available

### DIFF
--- a/.changeset/bright-books-join.md
+++ b/.changeset/bright-books-join.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Show installed app capacity correctly and update version number.

--- a/apps/ledger-live-mobile/src/screens/Manager/Modals/UpdateAllModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/Manager/Modals/UpdateAllModal.tsx
@@ -76,7 +76,14 @@ const FlatListContainer = styled(FlatList).attrs({
   marginBottom: 20,
 })`` as unknown as typeof FlatList;
 
-const UpdateAllModal = ({ isOpened, onClose, onConfirm, apps, installed, state }: Props) => {
+export default memo(function UpdateAllModal({
+  isOpened,
+  onClose,
+  onConfirm,
+  apps,
+  installed,
+  state,
+}: Props) {
   const { deviceInfo } = state;
 
   const data = apps.map(app => ({
@@ -91,7 +98,7 @@ const UpdateAllModal = ({ isOpened, onClose, onConfirm, apps, installed, state }
     }: {
       item: App & { installed: InstalledItem | null | undefined };
     }) => {
-      const version = (installed && installed.version) || appVersion;
+      const version = installed?.availableVersion || appVersion;
 
       return (
         <AppLine>
@@ -159,6 +166,4 @@ const UpdateAllModal = ({ isOpened, onClose, onConfirm, apps, installed, state }
       </Flex>
     </QueuedDrawer>
   );
-};
-
-export default memo(UpdateAllModal);
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description
1. When an installed app has an update, the displayed capacity is not the one installed, but it should be.
2. When opening the update app modal, the list displays the installed versions of apps instead of the to update ones, but it should be. The bug is described in this [LIVE-9586](https://ledgerhq.atlassian.net/browse/LIVE-9586) ticket.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-6441](https://ledgerhq.atlassian.net/browse/LIVE-6441)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-9586]: https://ledgerhq.atlassian.net/browse/LIVE-9586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-6441]: https://ledgerhq.atlassian.net/browse/LIVE-6441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ