### PR TITLE
[bugfix] Solana: display spinner in staking workflows

### DIFF
--- a/.changeset/six-ways-hope.md
+++ b/.changeset/six-ways-hope.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+display spinner in solana staking workflows

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/steps/StepValidator.tsx
@@ -80,6 +80,7 @@ export function StepValidatorFooter({
         <Button
           id="delegate-continue-button"
           disabled={!canNext}
+          isLoading={bridgePending}
           primary
           onClick={() => transitionTo("connectDevice")}
         >

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
@@ -79,6 +79,7 @@ export function StepValidatorFooter({
         <Button
           id="delegate-continue-button"
           disabled={!canNext}
+          isLoading={bridgePending}
           primary
           onClick={() => transitionTo("connectDevice")}
         >

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/steps/StepValidator.tsx
@@ -86,6 +86,7 @@ export function StepValidatorFooter({
         <Button
           id="delegate-continue-button"
           disabled={!canNext}
+          isLoading={bridgePending}
           primary
           onClick={() => transitionTo("amount")}
         >

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/steps/StepValidator.tsx
@@ -80,6 +80,7 @@ export function StepValidatorFooter({
         <Button
           id="delegate-continue-button"
           disabled={!canNext}
+          isLoading={bridgePending}
           primary
           onClick={() => transitionTo("connectDevice")}
         >

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/steps/StepAmount.tsx
@@ -50,7 +50,12 @@ export function StepAmountFooter({
         <Button mr={1} secondary onClick={onClose}>
           {t("common.cancel")}
         </Button>
-        <Button disabled={!canNext} primary onClick={() => transitionTo("connectDevice")}>
+        <Button
+          disabled={!canNext}
+          isLoading={bridgePending}
+          primary
+          onClick={() => transitionTo("connectDevice")}
+        >
           {t("common.continue")}
         </Button>
       </Box>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Display spinner inside "continue" button in solana staking workflows (Delegate/Activate/Deactivate/Reactivate/Withdraw modals).

![image](https://github.com/LedgerHQ/ledger-live/assets/3897859/bdd7f443-9365-4b3f-ad1b-ecd89cb72288)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10980

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - "Continue" button in Solana "Delegate/Activate/Deactivate" staking modals should now display correct loading Spinner

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
