### PR TITLE
[LLM] - [LIVE-11091] - Fix UI/functional bug on Hero Content Card

### DIFF
--- a/.changeset/lemon-mugs-poke.md
+++ b/.changeset/lemon-mugs-poke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixing UI bug on Hero Content Card CTA

--- a/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/cards/hero/index.tsx
@@ -20,7 +20,11 @@ const HeroCard = ContentCardBuilder<Props>(({ title, image, cta, tag, metadata }
         <Image uri={image} />
         {tag && <Tag label={tag} />}
         <Title label={title} />
-        <Button type="main">{cta}</Button>
+        <Flex flexDirection="row">
+          <Button onPress={metadata.actions?.onClick} type="main">
+            {cta}
+          </Button>
+        </Flex>
       </Flex>
     </TouchableOpacity>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR aims at fixing a UI/functional bug on the Hero Content Card CTA.

**Expected behaviour:**

- On android the CTA button must not take up the entire width of the screen
- CTA should redirect to the mentioned link

**Actual behaviour:**

- Nothing happens when clicking on the CTA
- Large CTA width on Android

This PR fixes that.

https://github.com/LedgerHQ/ledger-live/assets/25589782/8be2af92-c6ba-45e7-bf74-4693b1ab180d


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11091] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11091]: https://ledgerhq.atlassian.net/browse/LIVE-11091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ