### PR TITLE
[LIVE 11108] Handle LockedDeviceError correctly

### DIFF
--- a/.changeset/cool-kiwis-film.md
+++ b/.changeset/cool-kiwis-film.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/errors": patch
+---
+
+Set prototype of locked device error in order to fix 'instanceof' check of an error

--- a/.changeset/nervous-cobras-jog.md
+++ b/.changeset/nervous-cobras-jog.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Update stax display correct error on locking it

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
@@ -67,7 +67,9 @@ const DeviceCancel = ({
       <ErrorDisplay
         error={error}
         warning={isUserRefusedFirmwareUpdate}
-        withExportLogs={!isUserRefusedFirmwareUpdate && !isRestoreStepRefusedOnDevice}
+        withExportLogs={
+          !isUserRefusedFirmwareUpdate && !isRestoreStepRefusedOnDevice && !isDeviceLockedError
+        }
       />
     </UpdateFirmwareError>
   );

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -318,6 +318,8 @@ export class TransportStatusError extends Error {
     this.statusCode = statusCode;
     this.statusText = statusText;
 
+    Object.setPrototypeOf(this, TransportStatusError.prototype);
+
     // Maps to a LockedDeviceError
     if (canBeMappedToChildError && statusCode === StatusCodes.LOCKED_DEVICE) {
       return new LockedDeviceError(message);
@@ -332,6 +334,7 @@ export class LockedDeviceError extends TransportStatusError {
       this.message = message;
     }
     this.name = "LockedDeviceError";
+    Object.setPrototypeOf(this, LockedDeviceError.prototype);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- Update stax display correct error on locking it
- Set prototype of locked device error in order to fix 'instanceof' check of an error


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11108] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11108]: https://ledgerhq.atlassian.net/browse/LIVE-11108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ