### PR TITLE
fix: exclude ethereum classic from accounts with stake button

### DIFF
--- a/.changeset/tame-ants-build.md
+++ b/.changeset/tame-ants-build.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Exclude Ethereum Classic from list of EVM accounts that can be staked.

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -32,7 +32,12 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
     }
   }, [account, dispatch, parentAccount]);
 
-  if (account.type === "Account" && account.currency.id.includes("ethereum")) {
+  if (
+    account.type === "Account" &&
+    // Ethereum Classic is still on proof of work
+    account.currency.id !== "ethereum_classic" &&
+    account.currency.id.includes("ethereum")
+  ) {
     return [
       {
         key: "Stake",

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -15,7 +15,9 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const onClick = useCallback(() => {
+  const isEthereumAccount = account.type === "Account" && account.currency.id === "ethereum";
+
+  const onClickStake = useCallback(() => {
     if (isAccountEmpty(account)) {
       dispatch(
         openModal("MODAL_NO_FUNDS_STAKE", {
@@ -32,16 +34,11 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
     }
   }, [account, dispatch, parentAccount]);
 
-  if (
-    account.type === "Account" &&
-    // Ethereum Classic is still on proof of work
-    account.currency.id !== "ethereum_classic" &&
-    account.currency.id.includes("ethereum")
-  ) {
+  if (isEthereumAccount) {
     return [
       {
         key: "Stake",
-        onClick,
+        onClick: onClickStake,
         event: "button_clicked2",
         eventProperties: {
           button: "stake",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR  prevents erroneously including a staking button on `ethereum classic`accounts, as well as other accounts with "ethereum" in the currency ID that are not Ethereum accounts.

The issue does not occur on mobile because only Ethereum is included. On mobile, the logic is just: 
```
// apps/ledger-live-mobile/src/families/evm/accountActions.tsx

if (account.type === "Account" && account.currency.id === "ethereum") {
    // show option to stake 
```

But on desktop we checked for the string `ethereum`, and therefore included all test nets:
  "ethereum_ropsten",
  "ethereum_goerli",
  "ethereum_sepolia",
  "ethereum_holesky",

This accidentally also includes `ethereum_classic`.

This PR puts the desktop in line with the mobile app, to exclude every account currency except Ethereum (for EVM staking).

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/873?selectedIssue=LIVE-10712

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ... Ethereum Classic will no longer erroneously appear in the staking flow. i.e the "Stake" button does not appearr on Ethereum Classic accounts, nor on ethereum test net accounts

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
