### PR TITLE
fix: only open EVM staking modal if the user receives ethereum

### DIFF
--- a/.changeset/afraid-taxis-tease.md
+++ b/.changeset/afraid-taxis-tease.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: only open EVM staking modal at the end of the Receive Currency flow if the user receives ethereum

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -45,7 +45,7 @@ const ProviderItem = ({ provider, stakeOnClick, redirectIfOnlyProvider }: Props)
 
   const manifest = useMemo(() => remoteManifest || localManifest, [localManifest, remoteManifest]);
 
-  const hasTag = i18n.exists(`ethereum.stake.${provider.id}.tag`);
+  const hasTag = !!provider?.min && i18n.exists(`ethereum.stake.${provider.id}.tag`);
 
   useEffect(() => {
     if (manifest) redirectIfOnlyProvider({ provider, manifest });

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -135,6 +135,7 @@ const Receive2Device = ({ name, device }: { name: string; device: Device }) => {
     </>
   );
 };
+
 const StepReceiveFunds = (props: StepProps) => {
   const {
     isAddressVerified,
@@ -154,6 +155,14 @@ const StepReceiveFunds = (props: StepProps) => {
   } = props;
   const dispatch = useDispatch();
   const receiveStakingFlowConfig = useFeature("receiveStakingFlowConfigDesktop");
+  const receivedCurrencyId: string | undefined = account?.currency?.id;
+  const isStakingEnabledForAccount =
+    !!receivedCurrencyId &&
+    receiveStakingFlowConfig?.enabled &&
+    receiveStakingFlowConfig?.params?.[receivedCurrencyId]?.enabled;
+  const isDirectStakingEnabledForAccount =
+    !!receivedCurrencyId && receiveStakingFlowConfig?.params?.[receivedCurrencyId]?.direct;
+
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   invariant(account && mainAccount, "No account given");
   const name = token ? token.name : getAccountName(account);
@@ -188,6 +197,7 @@ const StepReceiveFunds = (props: StepProps) => {
       hideQRCodeModal();
     }
   }, [device, mainAccount, transitionTo, onChangeAddressVerified, hideQRCodeModal]);
+
   const onVerify = useCallback(() => {
     // if device has changed since the beginning, we need to re-entry device
     if (device !== initialDevice.current || !isAddressVerified) {
@@ -196,16 +206,11 @@ const StepReceiveFunds = (props: StepProps) => {
     onChangeAddressVerified(null);
     onResetSkip();
   }, [device, onChangeAddressVerified, onResetSkip, transitionTo, isAddressVerified]);
+
   const onFinishReceiveFlow = useCallback(() => {
-    const id = mainAccount?.currency?.id;
-    const dismissModal = global.localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${id}`) === "true";
-    if (
-      !dismissModal &&
-      !receiveNFTMode &&
-      !receiveTokenMode &&
-      receiveStakingFlowConfig?.enabled &&
-      receiveStakingFlowConfig?.params?.[id]?.enabled
-    ) {
+    const dismissModal =
+      global.localStorage.getItem(`${LOCAL_STORAGE_KEY_PREFIX}${receivedCurrencyId}`) === "true";
+    if (!dismissModal && !receiveNFTMode && !receiveTokenMode && isStakingEnabledForAccount) {
       track("button_clicked2", {
         button: "continue",
         page: window.location.hash
@@ -216,7 +221,8 @@ const StepReceiveFunds = (props: StepProps) => {
         modal: "receive",
         account: name,
       });
-      if (receiveStakingFlowConfig?.params?.[id]?.direct) {
+      // Only open EVM staking modal if the user received ETH or an EVM currency supported by the providers
+      if (isDirectStakingEnabledForAccount) {
         dispatch(
           openModal("MODAL_EVM_STAKE", {
             account: mainAccount,
@@ -233,15 +239,16 @@ const StepReceiveFunds = (props: StepProps) => {
       onClose();
     }
   }, [
-    mainAccount,
-    currencyName,
-    dispatch,
-    name,
-    onClose,
-    receiveStakingFlowConfig?.enabled,
-    receiveStakingFlowConfig?.params,
+    receivedCurrencyId,
     receiveNFTMode,
     receiveTokenMode,
+    isStakingEnabledForAccount,
+    isDirectStakingEnabledForAccount,
+    currencyName,
+    name,
+    dispatch,
+    mainAccount,
+    onClose,
     transitionTo,
   ]);
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -155,7 +155,8 @@ const StepReceiveFunds = (props: StepProps) => {
   } = props;
   const dispatch = useDispatch();
   const receiveStakingFlowConfig = useFeature("receiveStakingFlowConfigDesktop");
-  const receivedCurrencyId: string | undefined = account?.currency?.id;
+  const receivedCurrencyId: string | undefined =
+    account && account.type !== "TokenAccount" ? account?.currency?.id : undefined;
   const isStakingEnabledForAccount =
     !!receivedCurrencyId &&
     receiveStakingFlowConfig?.enabled &&

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3609,6 +3609,7 @@
     "stake": {
       "title": "Grow your ETH holdings",
       "subTitle": "Stake your ETH and grow your holdings by receiving daily rewards directly into your Ledger Live.",
+      "tagMinimum": "Requires {{min}} ETH",
       "kiln_pooling": {
         "title": "Kiln staking pool",
         "description": "Stake with no minimum. Earn auto-compounded rewards with no lock-up period.",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3615,7 +3615,7 @@
         "supportLink": "Learn more about Kiln pooling"
       },
       "lido": {
-        "title": "Earn with Lido",
+        "title": "Lido",
         "description": "Stake any amount of ETH for instant liquidity and daily rewards.",
         "supportLink": "Learn more about Lido"
       },

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerProvider.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerProvider.tsx
@@ -34,7 +34,7 @@ export function EvmStakingDrawerProvider({
 }: Props) {
   const { t, i18n } = useTranslation();
   const manifest = useManifest(provider.liveAppId);
-  const hasTag = i18n.exists(`stake.ethereum.providers.${provider.id}.tag`);
+  const hasTag = provider?.min && i18n.exists(`stake.ethereum.providers.${provider.id}.tag`);
 
   const providerPress = useCallback(() => {
     if (manifest) {

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/types.ts
@@ -1,3 +1,13 @@
-import { EthStakingProviders } from "~/types/featureFlags";
+export type EthStakingProviders = {
+  listProvider: Array<{
+    id: string;
+    name: string;
+    liveAppId: string;
+    min?: number; // min required amount to stake in ETH
+    supportLink?: string;
+    icon?: string;
+    queryParams?: Record<string, string>;
+  }>;
+};
 
 export type ListProvider = EthStakingProviders["listProvider"][number];

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/types.ts
@@ -1,13 +1,3 @@
-export type EthStakingProviders = {
-  listProvider: Array<{
-    id: string;
-    name: string;
-    liveAppId: string;
-    min?: number;
-    supportLink?: string;
-    icon?: string;
-    queryParams?: Record<string, string>;
-  }>;
-};
+import { EthStakingProviders } from "~/types/featureFlags";
 
 export type ListProvider = EthStakingProviders["listProvider"][number];

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6540,6 +6540,7 @@
     "ethereum": {
       "title": "Grow your ETH holdings",
       "subTitle": "Stake your ETH and grow your holdings by earning daily rewards directly into your Ledger Live.",
+      "tagMinimum": "Requires {{min}} ETH",
       "close": "Close",
       "providers": {
         "kiln_pooling": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6553,7 +6553,7 @@
           "supportLink": "Learn more about Stader"
         },
         "lido": {
-          "title": "Earn with Lido",
+          "title": "Lido",
           "description": "Stake any amount of ETH for instant liquidity and daily rewards.",
           "supportLink": "Learn more about Lido"
         },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Receive flow for NFTs and ERC 20 tokens was showing the ETH staking modal. Instead we only want it to display if the currency that was received was a full ETH account.

Also:

-  minor updates to translations for providers list
- only show the "requires 32 ETH" tag if the provider has a "min" set in Firebase config

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-10059](https://ledgerhq.atlassian.net/browse/LIVE-10059)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ... Receive ETH --> full list of providers should show
  - Receive an NFT or Token - even from an ETH account --> no eth staking model
  - Receive another supported currency: i.e. celo, cosmos, osmo, solana then we want the generic "stake with ledger" modal to appear, and not the full ETH providers list.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10059]: https://ledgerhq.atlassian.net/browse/LIVE-10059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ