### PR TITLE
chore(lodash): all lodash imports must use the fp import style

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,14 @@ module.exports = {
     "no-inner-declarations": "off",
     // Enables no-unused-vars only from TypeScript
     "no-unused-vars": "off",
+    "no-restricted-imports": [
+      2,
+      {
+        paths: [
+          "lodash", // you must use the lodash/fp module import style to avoid importing the entire library
+        ],
+      },
+    ],
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -58,7 +58,6 @@
     "express": "^4.17.2",
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
-    "lodash.product": "^18.9.19",
     "pako": "^2.0.4",
     "qrcode-terminal": "^0.12.0",
     "qrloop": "^1.2.0",

--- a/apps/cli/src/commands/countervalues.ts
+++ b/apps/cli/src/commands/countervalues.ts
@@ -1,6 +1,3 @@
-import "lodash.product";
-// @ts-expect-error product is not inferred we need to extend lodash type
-import { product } from "lodash";
 import uniq from "lodash/uniq";
 import { BigNumber } from "bignumber.js";
 import asciichart from "asciichart";
@@ -162,7 +159,7 @@ export default {
         const currencies = await getCurrencies(opts);
         const countervalues = getCountervalues(opts);
         const format = histoFormatters[opts.format || "default"];
-        const startDate = getStartDate(opts);
+        const startDate = getStartDate(opts) || new Date();
         const dates = getDatesWithOpts(opts);
         const cvs = await loadCountervalues(initialState, {
           trackingPairs: resolveTrackingPairs(
@@ -257,4 +254,14 @@ function getDatesWithOpts(opts: Opts): Date[] {
   const range = asPortfolioRange(opts.period || "month");
   const count = getPortfolioCountByDate(startDate, range);
   return getDates(range, count);
+}
+
+function product<A, B>(arr1: A[], arr2: B[]): [A, B][] {
+  const result: [A, B][] = [];
+  arr1.forEach(item1 => {
+    arr2.forEach(item2 => {
+      result.push([item1, item2]);
+    });
+  });
+  return result;
 }

--- a/apps/cli/src/transaction.ts
+++ b/apps/cli/src/transaction.ts
@@ -1,6 +1,3 @@
-import "lodash.product";
-// @ts-expect-error we imported lodash.product but not recognized by TS in lodash
-import { product } from "lodash";
 import uniqBy from "lodash/uniqBy";
 import shuffle from "lodash/shuffle";
 import flatMap from "lodash/flatMap";
@@ -169,4 +166,14 @@ export async function inferTransactions(
   );
 
   return transactions;
+}
+
+function product<A, B>(arr1: A[], arr2: B[]): [A, B][] {
+  const result: [A, B][] = [];
+  arr1.forEach(item1 => {
+    arr2.forEach(item2 => {
+      result.push([item1, item2]);
+    });
+  });
+  return result;
 }

--- a/apps/ledger-live-desktop/.eslintrc.js
+++ b/apps/ledger-live-desktop/.eslintrc.js
@@ -29,6 +29,10 @@ const livecommonRules = {
             message: "Please remove the /lib import from live-common import.",
           },
         ],
+
+        paths: [
+          "lodash", // you must use the lodash/fp module import style to avoid importing the entire library
+        ],
       },
     ],
   },

--- a/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/FirebaseRemoteConfig.tsx
@@ -12,7 +12,7 @@ import { FirebaseRemoteConfigProvider as FirebaseProvider } from "@ledgerhq/live
 import { DEFAULT_FEATURES, formatDefaultFeatures } from "@ledgerhq/live-common/featureFlags/index";
 import type { FirebaseFeatureFlagsProviderProps as Props } from "@ledgerhq/live-common/featureFlags/index";
 import { getFirebaseConfig } from "~/firebase-setup";
-import { isMatch } from "lodash";
+import isMatch from "lodash/isMatch";
 import * as fs from "fs";
 
 export const FirebaseRemoteConfigContext = React.createContext<RemoteConfig | null>(null);

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/useChangeLanguagePrompt.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/useChangeLanguagePrompt.tsx
@@ -4,7 +4,7 @@ import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
 import { useAvailableLanguagesForDevice } from "@ledgerhq/live-common/manager/hooks";
 import { DeviceInfo, DeviceModelInfo, idsToLanguage } from "@ledgerhq/types-live";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { firstValueFrom, from } from "rxjs";

--- a/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
@@ -203,7 +203,7 @@ export const flattenAccountsSelector = createSelector(accountsSelector, flattenA
  *
  * Example:
  * ```
- * import { isEqual } from "lodash";
+ * import isEqual from "lodash/isEqual";
  * // ...
  * const orderedVisibleNfts = useSelector(orderedVisibleNftsSelector, isEqual)
  * ```

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/Item.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/Item.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, memo, useCallback } from "react";
-import { camelCase } from "lodash";
+import camelCase from "lodash/camelCase";
 import { useNotEnoughMemoryToInstall } from "@ledgerhq/live-common/apps/react";
 import { getCryptoCurrencyById, isCurrencySupported } from "@ledgerhq/live-common/currencies/index";
 import { App, FeatureId } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/.eslintrc.js
+++ b/apps/ledger-live-mobile/.eslintrc.js
@@ -48,6 +48,9 @@ module.exports = {
             message: "Please remove the /lib import from live-common import.",
           },
         ],
+        paths: [
+          "lodash", // you must use the lodash/fp module import style to avoid importing the entire library
+        ],
       },
     ],
     "i18next/no-literal-string": [

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -14,7 +14,7 @@ import {
   RouteProp,
   useRoute,
 } from "@react-navigation/native";
-import { snakeCase } from "lodash";
+import snakeCase from "lodash/snakeCase";
 import React, { MutableRefObject, useCallback } from "react";
 import { FeatureId, Features, idsToLanguage } from "@ledgerhq/types-live";
 import {

--- a/apps/ledger-live-mobile/src/components/AssetRowLayout.tsx
+++ b/apps/ledger-live-mobile/src/components/AssetRowLayout.tsx
@@ -4,7 +4,7 @@ import { BigNumber } from "bignumber.js";
 import { Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import { Flex, Text, Tag } from "@ledgerhq/native-ui";
 import { ValueChange } from "@ledgerhq/types-live";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { TouchableOpacity, TouchableOpacityProps } from "react-native";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import CounterValue from "./CounterValue";

--- a/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
+++ b/apps/ledger-live-mobile/src/components/OperationRow/index.tsx
@@ -19,7 +19,7 @@ import { Account, Operation, AccountLike } from "@ledgerhq/types-live";
 import { Box, Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import { WarningMedium } from "@ledgerhq/native-ui/assets/icons";
 import debounce from "lodash/debounce";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { useSelector } from "react-redux";
 import CurrencyUnitValue from "../CurrencyUnitValue";
 import CounterValue from "../CounterValue";

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -2,6 +2,7 @@ import type { Operation, AccountLike, Account, DeviceInfo } from "@ledgerhq/type
 import type { NavigatorScreenParams, ParamListBase } from "@react-navigation/native";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+// eslint-disable-next-line no-restricted-imports
 import type { PropertyPath } from "lodash";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { MappedSwapOperation } from "@ledgerhq/live-common/exchange/swap/types";

--- a/apps/ledger-live-mobile/src/components/SectionHeader.tsx
+++ b/apps/ledger-live-mobile/src/components/SectionHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components/native";
 import { Flex, Text } from "@ledgerhq/native-ui";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import FormatDay from "./DateFormat/FormatDay";
 
 type Props = {

--- a/apps/ledger-live-mobile/src/components/StorylyStories/index.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from "@ledgerhq/native-ui";
 import { FlexBoxProps } from "@ledgerhq/native-ui/components/Layout/Flex/index";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { Linking } from "react-native";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { ScrollView, StyleProp, ViewStyle } from "react-native";

--- a/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/TabBar/TransferDrawer.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { ScrollView } from "react-native-gesture-handler";
 import { Flex, Text, Box } from "@ledgerhq/native-ui";
 import { Linking, StyleProp, ViewStyle } from "react-native";
-import { snakeCase } from "lodash";
+import snakeCase from "lodash/snakeCase";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -16,7 +16,7 @@ import { NftMetadataProvider } from "@ledgerhq/live-nft-react";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { ToastProvider } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import "./config/configInit";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { postOnboardingSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import Config from "react-native-config";
 import { LogLevel, PerformanceProfiler, RenderPassReport } from "@shopify/react-native-performance";

--- a/apps/ledger-live-mobile/src/logic/storeWrapper.ts
+++ b/apps/ledger-live-mobile/src/logic/storeWrapper.ts
@@ -6,7 +6,7 @@
 // with the new React-native-async-store package
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { KeyValuePair } from "@react-native-async-storage/async-storage/lib/typescript/types";
-import { merge } from "lodash";
+import merge from "lodash/merge";
 
 const CHUNKED_KEY = "_-_CHUNKED";
 const CHUNK_SIZE = 1000000;

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -461,7 +461,7 @@ export const orderedNftsSelector = createSelector(
  *
  * Example:
  * ```
- * import { isEqual } from "lodash";
+ * import isEqual from "lodash/isEqual";
  * // ...
  * const orderedVisibleNfts = useSelector(orderedVisibleNftsSelector, isEqual)
  * ```

--- a/apps/ledger-live-mobile/src/screens/CustomImage/NFTGallerySelector.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/NFTGallerySelector.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useSelector } from "react-redux";
 import { ProtoNFT } from "@ledgerhq/types-live";
 import { FlatList } from "react-native";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 import { orderedVisibleNftsSelector } from "~/reducers/accounts";
 import NftListItem from "~/components/Nft/NftGallery/NftListItem";

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -19,7 +19,9 @@ import {
   Button,
   Switch,
 } from "@ledgerhq/native-ui";
-import { includes, lowerCase, trim } from "lodash";
+import includes from "lodash/includes";
+import lowerCase from "lodash/lowerCase";
+import trim from "lodash/trim";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Keyboard } from "react-native";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/ledger-live-mobile/src/screens/Nft/WalletNftGallery/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Nft/WalletNftGallery/index.tsx
@@ -7,7 +7,7 @@ import NftGalleryEmptyState from "../NftGallery/NftGalleryEmptyState";
 import CollapsibleHeaderScrollView from "~/components/WalletTab/CollapsibleHeaderScrollView";
 import { accountsSelector, filteredNftsSelector, hasNftsSelector } from "~/reducers/accounts";
 
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { galleryChainFiltersSelector } from "~/reducers/nft";
 import { useNftGalleryFilter } from "@ledgerhq/live-nft-react";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";

--- a/apps/ledger-live-mobile/src/screens/Portfolio/Assets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/Assets.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { FlatList } from "react-native";
 import { useNavigation } from "@react-navigation/native";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import AssetRow, { NavigationProp } from "../WalletCentricAsset/AssetRow";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import { Asset } from "~/types/asset";

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Node.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Node.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "@react-navigation/native";
 import { StyleSheet, View } from "react-native";
 import { Text, IconsLegacy, Flex } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { State } from "~/reducers/types";
 import Touchable from "~/components/Touchable";
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Store.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable no-console */
 import React, { useCallback, useState } from "react";
 import styled from "styled-components/native";
-import { get, set, cloneDeep } from "lodash";
+import get from "lodash/get";
+import set from "lodash/set";
+import cloneDeep from "lodash/cloneDeep";
 import { BigNumber } from "bignumber.js";
 import { StyleSheet, SafeAreaView, ScrollView } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
@@ -32,7 +34,7 @@ export default function Store() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [targetPath, setTargetPath] = useState("");
   const [targetType, setTargetType] = useState("string");
-  const [modifiedState, setModifiedState] = useState<State>(cloneDeep(state));
+  const [modifiedState, setModifiedState] = useState<State>(() => cloneDeep(state));
   const currentValue = get(modifiedState, targetPath);
 
   const dispatch = useDispatch();

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/AssetRow.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { BigNumber } from "bignumber.js";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { GestureResponderEvent } from "react-native";
 import { useStartProfiler } from "@shopify/react-native-performance";
 import { NavigatorName, ScreenName } from "~/const";

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
@@ -10,7 +10,7 @@ import { isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
 import { useTheme } from "styled-components/native";
 import { useNavigation } from "@react-navigation/native";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import BigNumber from "bignumber.js";
 import { ReactNavigationPerformanceView } from "@shopify/react-native-performance-navigation";
 import accountSyncRefreshControl from "~/components/accountSyncRefreshControl";

--- a/apps/ledger-live-mobile/src/screens/WalletCentricSections/Allocations.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricSections/Allocations.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { DefaultTheme, useTheme } from "styled-components/native";
 import { useNavigation } from "@react-navigation/native";
 import { useSelector } from "react-redux";
-import { chunk } from "lodash";
+import chunk from "lodash/chunk";
 import { ensureContrast } from "../../colors";
 import { ScreenName } from "~/const";
 import { useDistribution } from "~/actions/general";

--- a/apps/web-tools/repl/components/LiveEnvEditor.tsx
+++ b/apps/web-tools/repl/components/LiveEnvEditor.tsx
@@ -3,7 +3,8 @@ import React, { useCallback, useEffect, useState } from "react";
 import { changes, setEnvUnsafe } from "@ledgerhq/live-env";
 import { setDefaultEnv, updateEnv, getEnv } from "../helpers/env";
 import { Resizable } from "re-resizable";
-import { map, get } from "lodash";
+import map from "lodash/map";
+import get from "lodash/get";
 import ReactTable from "react-table";
 import { SmallButton } from "./Smallbutton";
 

--- a/apps/web-tools/repl/helpers/env.ts
+++ b/apps/web-tools/repl/helpers/env.ts
@@ -1,5 +1,7 @@
 import { getAllEnvs, setEnvUnsafe, getEnvDefault, EnvName } from "@ledgerhq/live-env";
-import { each, reduce, pick } from "lodash";
+import each from "lodash/each";
+import reduce from "lodash/reduce";
+import pick from "lodash/pick";
 
 const whitelist: EnvName[] = [
   "FORCE_PROVIDER",

--- a/libs/coin-algorand/src/js-prepareTransaction.ts
+++ b/libs/coin-algorand/src/js-prepareTransaction.ts
@@ -1,4 +1,4 @@
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { BigNumber } from "bignumber.js";
 import { AlgorandAPI } from "./api";
 import { estimateMaxSpendable } from "./js-estimateMaxSpendable";

--- a/libs/coin-evm/src/prepareTransaction.ts
+++ b/libs/coin-evm/src/prepareTransaction.ts
@@ -1,7 +1,7 @@
 import { findSubAccountById } from "@ledgerhq/coin-framework/account/index";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import { getNftCollectionMetadata } from "./api/nft";
 import { getNodeApi } from "./api/node/index";
 import { DEFAULT_NONCE } from "./createTransaction";

--- a/libs/coin-framework/src/transaction/common.ts
+++ b/libs/coin-framework/src/transaction/common.ts
@@ -7,8 +7,7 @@ import type {
   TransactionStatusCommonRaw,
 } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import { mapValues } from "lodash";
-
+import mapValues from "lodash/mapValues";
 import { getAccountUnit } from "../account";
 import { formatCurrencyUnit } from "../currencies";
 

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/__tests__/xpub.synced.integration.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/__tests__/xpub.synced.integration.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import coininfo from "coininfo";
-import { zipObject } from "lodash";
+import zipObject from "lodash/zipObject";
 import { DerivationModes } from "../types";
 import BitcoinLikeStorage from "../storage";
 import BitcoinLikeExplorer from "../explorer";

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/pickingstrategies/CoinSelect.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/pickingstrategies/CoinSelect.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
-import { flatten, sortBy } from "lodash";
+import flatten from "lodash/flatten";
+import sortBy from "lodash/sortBy";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/pickingstrategies/DeepFirst.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/pickingstrategies/DeepFirst.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
-import { flatten, sortBy } from "lodash";
+import flatten from "lodash/flatten";
+import sortBy from "lodash/sortBy";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/pickingstrategies/Merge.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/pickingstrategies/Merge.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
-import { flatten, sortBy } from "lodash";
+import flatten from "lodash/flatten";
+import sortBy from "lodash/sortBy";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -1,4 +1,7 @@
-import { findLast, filter, uniqBy, findIndex } from "lodash";
+import findLast from "lodash/findLast";
+import filter from "lodash/filter";
+import uniqBy from "lodash/uniqBy";
+import findIndex from "lodash/findIndex";
 import Base from "../crypto/base";
 import { Input, IStorage, Output, TX, Address, Block } from "./types";
 

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/wallet.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/wallet.ts
@@ -1,4 +1,4 @@
-import { flatten } from "lodash";
+import flatten from "lodash/flatten";
 import BigNumber from "bignumber.js";
 import Btc from "@ledgerhq/hw-app-btc";
 import { log } from "@ledgerhq/logs";

--- a/libs/ledger-live-common/src/families/bitcoin/wallet-btc/xpub.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/wallet-btc/xpub.ts
@@ -1,4 +1,6 @@
-import { maxBy, range, some } from "lodash";
+import maxBy from "lodash/maxBy";
+import range from "lodash/range";
+import some from "lodash/some";
 import BigNumber from "bignumber.js";
 import { TX, Address, IStorage } from "./storage/types";
 import { IExplorer } from "./explorer/types";

--- a/libs/ledger-live-common/src/families/cardano/buildSubAccounts.ts
+++ b/libs/ledger-live-common/src/families/cardano/buildSubAccounts.ts
@@ -6,7 +6,8 @@ import { CardanoOperation, CardanoOperationExtra, PaymentCredential, Token } fro
 import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import { findTokenById } from "@ledgerhq/cryptoassets";
 import { decodeTokenAccountId, emptyHistoryCache, encodeTokenAccountId } from "../../account";
-import { groupBy, keyBy } from "lodash";
+import groupBy from "lodash/groupBy";
+import keyBy from "lodash/keyBy";
 import { mergeOps } from "../../bridge/jsHelpers";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/families/casper/bridge/bridgeHelpers/accountShape.ts
+++ b/libs/ledger-live-common/src/families/casper/bridge/bridgeHelpers/accountShape.ts
@@ -1,4 +1,4 @@
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import { encodeAccountId } from "../../../../account";

--- a/libs/ledger-live-common/src/families/elrond/specs.ts
+++ b/libs/ledger-live-common/src/families/elrond/specs.ts
@@ -21,7 +21,7 @@ import {
 import BigNumber from "bignumber.js";
 import { MIN_DELEGATION_AMOUNT } from "./constants";
 import { SubAccount } from "@ledgerhq/types-live";
-import { sample } from "lodash";
+import sample from "lodash/sample";
 
 const currency = getCryptoCurrencyById("elrond");
 const minimalAmount = parseCurrencyUnit(currency.units[0], "0.001");

--- a/libs/ledger-live-common/src/families/internet_computer/bridge/bridgeHelpers/account.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/bridge/bridgeHelpers/account.ts
@@ -2,7 +2,7 @@ import { GetAccountShape } from "../../../../bridge/jsHelpers";
 import { decodeAccountId, encodeAccountId } from "../../../../account";
 import { log } from "@ledgerhq/logs";
 import { fetchBalances, fetchBlockHeight, fetchTxns } from "./api";
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 import { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { ICPRosettaGetTxnsHistoryResponse } from "./icpRosetta/types";

--- a/libs/ledger-live-common/src/families/solana/api/chain/web3.ts
+++ b/libs/ledger-live-common/src/families/solana/api/chain/web3.ts
@@ -12,7 +12,7 @@ import {
   SystemProgram,
   TransactionInstruction,
 } from "@solana/web3.js";
-import { chunk } from "lodash";
+import chunk from "lodash/chunk";
 import { ChainAPI } from ".";
 import { Awaited } from "../../logic";
 import {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -5,7 +5,7 @@ import {
   FeatureMap,
   ABTestingVariants,
 } from "@ledgerhq/types-live";
-import { reduce } from "lodash";
+import reduce from "lodash/reduce";
 import { formatToFirebaseFeatureId } from "./firebaseFeatureFlags";
 
 /**

--- a/libs/ledger-live-common/src/featureFlags/firebaseFeatureFlags.ts
+++ b/libs/ledger-live-common/src/featureFlags/firebaseFeatureFlags.ts
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "react";
-import { snakeCase } from "lodash";
+import snakeCase from "lodash/snakeCase";
 import semver from "semver";
 import { Feature, FeatureId } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";

--- a/libs/ledger-live-common/src/onboarding/hooks/useOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/onboarding/hooks/useOnboardingStatePolling.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Subscription } from "rxjs";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import type { Device } from "../../hw/actions/types";
 import { DeviceOnboardingStatePollingError } from "@ledgerhq/errors";
 

--- a/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/helpers.ts
+++ b/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/helpers.ts
@@ -1,4 +1,5 @@
-import { uniq, isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
+import uniq from "lodash/uniq";
 import { CurrenciesPerProvider, RampCatalog } from "./types";
 import { CryptoCurrency } from "@ledgerhq/wallet-api-core/lib/currencies/types";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,9 +179,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      lodash.product:
-        specifier: ^18.9.19
-        version: 18.9.19(lodash@4.17.21)
       pako:
         specifier: ^2.0.4
         version: 2.0.4
@@ -42597,14 +42594,6 @@ packages:
 
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
-    dev: false
-
-  /lodash.product@18.9.19(lodash@4.17.21):
-    resolution: {integrity: sha512-yPX6KO0jveBR/DjSngqvUEynWTb4oJwB8g5WseShPzX0CO8pjX1gxlR5Fo7V3E81uPDc9mEuNVw3Ah6df9uy0g==}
-    peerDependencies:
-      lodash: ^4.17.11
-    dependencies:
-      lodash: 4.17.21
     dev: false
 
   /lodash.pullall@4.2.0:


### PR DESCRIPTION

### 📝 Description

- migrate all `{ foo } from "lodash"` to `foo from "lodash/foo"`as it was the convention of ledger-live that was forgotten over time ( see also https://stackoverflow.com/questions/35250500/correct-way-to-import-lodash )
- eslint rules to enforce this rule
- remove lodash.product dep in CLI
- minor optim in Debug LLM component that was always recreating a cloneDeep due to `useState<State>(cloneDeep(state));` – it was changed to `useState<State>(() => cloneDeep(state));` and useState will only call this initializer once

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-11142

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
