### PR TITLE
[LLM] pass account to ScreenName.SignTransactionSummary

### DIFF
--- a/.changeset/itchy-walls-begin.md
+++ b/.changeset/itchy-walls-begin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+pass account to SignTransactionSummary

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
@@ -32,7 +32,7 @@ import type { Transaction as StellarTransaction } from "@ledgerhq/live-common/fa
 import type { Transaction as StacksTransaction } from "@ledgerhq/live-common/families/stacks/types";
 import type { Transaction as CasperTransaction } from "@ledgerhq/live-common/families/casper/types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { Account, Operation, SignedOperation } from "@ledgerhq/types-live";
+import { Account, AccountLike, Operation, SignedOperation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { ScreenName } from "~/const";
 
@@ -43,7 +43,7 @@ type ListenersParams = {
 
 export type SignTransactionNavigatorParamList = {
   [ScreenName.SignTransactionSummary]: {
-    account?: Account;
+    account?: AccountLike;
     accountId: string;
     parentId?: string;
     deviceId?: string;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SignTransactionNavigator.ts
@@ -43,6 +43,7 @@ type ListenersParams = {
 
 export type SignTransactionNavigatorParamList = {
   [ScreenName.SignTransactionSummary]: {
+    account?: Account;
     accountId: string;
     parentId?: string;
     deviceId?: string;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -249,6 +249,7 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
               navigation.navigate(NavigatorName.SignTransaction, {
                 screen: ScreenName.SignTransactionSummary,
                 params: {
+                  account,
                   currentNavigation: ScreenName.SignTransactionSummary,
                   nextNavigation: ScreenName.SignTransactionSelectDevice,
                   transaction: tx as Transaction,

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -369,6 +369,7 @@ function useUiHook(): Partial<UiHook> {
             currentNavigation: ScreenName.SignTransactionSummary,
             nextNavigation: ScreenName.SignTransactionSelectDevice,
             transaction: tx as Transaction,
+            account,
             accountId: account.id,
             parentId: parentAccount ? parentAccount.id : undefined,
             appName: options?.hwAppId,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When need the account to be passed to the SendSummary function (apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx)
Because there, when we call `accountScreenSelector` function, it checks in the route params for the presence of an `account`. 

<img width="601" alt="SCR-20240208-ppya" src="https://github.com/LedgerHQ/ledger-live/assets/5050709/9226b814-b22f-4d72-8a10-8a981c2ff290">

`account` was never passed to that screen, and we ended up with invariant checks failing in `SendSummary`

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/623?selectedIssue=LIVE-11191

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
