### PR TITLE
LLM - Removed recommendations toggle from the notifications settings

### DIFF
--- a/.changeset/rich-dogs-peel.md
+++ b/.changeset/rich-dogs-peel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Removed Recommendations toggle from the notifications settings

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -120,7 +120,6 @@ const extraProperties = async (store: AppStore) => {
   const notificationsOptedIn = {
     notificationsAllowed: notifications.areNotificationsAllowed,
     optInAnnouncements: notifications.announcementsCategory,
-    optInRecommendations: notifications.recommendationsCategory,
     optInLargeMovers: notifications.largeMoverCategory,
     optInTxAlerts: notifications.transactionsAlertsCategory,
   };

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2843,10 +2843,6 @@
         "title": "Announcements",
         "desc": "Receive important Ledger Live updates"
       },
-      "recommendations": {
-        "title": "Recommendations",
-        "desc": "Enrich your experience with personalized recommendations and special offers"
-      },
       "largeMover": {
         "title": "Large Mover",
         "desc": "You'll be notified of important price movements for BTC and ETH"

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -8,10 +8,20 @@ export const start = async () => {
 };
 
 export const updateUserPreferences = (notificationsPreferences: NotificationsSettings) => {
-  const notificationsAllowed = notificationsPreferences.areNotificationsAllowed;
+  const notificationsOptedIn = {
+    optInAnnouncements: notificationsPreferences.announcementsCategory,
+    optInLargeMovers: notificationsPreferences.largeMoverCategory,
+    optInTxAlerts: notificationsPreferences.transactionsAlertsCategory,
+  };
   const notificationsBlacklisted = Object.entries(notificationsPreferences)
     .filter(([key, value]) => key !== "areNotificationsAllowed" && value === false)
     .map(([key]) => key);
-  Braze.setCustomUserAttribute("notificationsAllowed", notificationsAllowed);
+  Braze.setCustomUserAttribute(
+    "notificationsAllowed",
+    notificationsPreferences.areNotificationsAllowed,
+  );
   Braze.setCustomUserAttribute("notificationsBlacklisted", notificationsBlacklisted);
+  for (const [key, value] of Object.entries(notificationsOptedIn)) {
+    Braze.setCustomUserAttribute(key, value);
+  }
 };

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -162,7 +162,6 @@ export const INITIAL_STATE: SettingsState = {
   notifications: {
     areNotificationsAllowed: true,
     announcementsCategory: true,
-    recommendationsCategory: true,
     largeMoverCategory: true,
     transactionsAlertsCategory: false,
   },

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -261,7 +261,6 @@ export type SettingsState = {
 export type NotificationsSettings = {
   areNotificationsAllowed: boolean;
   announcementsCategory: boolean;
-  recommendationsCategory: boolean;
   largeMoverCategory: boolean;
   transactionsAlertsCategory: boolean;
 };

--- a/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
@@ -16,7 +16,6 @@ import { updateUserPreferences } from "~/notifications/braze";
 const notificationsMapping = {
   areNotificationsAllowed: "allowed",
   announcementsCategory: "announcements",
-  recommendationsCategory: "recommendations",
   largeMoverCategory: "largeMover",
   transactionsAlertsCategory: "transactionsAlerts",
 };
@@ -162,13 +161,6 @@ function NotificationsSettings() {
             !notificationsCategoriesHidden.includes("announcementsCategory") ? (
               <NotificationSettingsRow
                 notificationKey={"announcementsCategory"}
-                disabled={disableSubSettings}
-              />
-            ) : null}
-            {!notificationsCategoriesHidden ||
-            !notificationsCategoriesHidden.includes("recommendationsCategory") ? (
-              <NotificationSettingsRow
-                notificationKey={"recommendationsCategory"}
                 disabled={disableSubSettings}
               />
             ) : null}


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Removed recommendations toggle from the notifications settings
Call the braze.setCustomUserAttributes for the optInAnnouncements, optInLargeMovers and optInTxAlerts attributes to update them in braze directly when the user modifies his preferences

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11228] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11228]: https://ledgerhq.atlassian.net/browse/LIVE-11228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ