### PR TITLE
[Bugfix/Stacks] Fix Account sync error for imported accounts 

### DIFF
--- a/.changeset/dry-birds-learn.md
+++ b/.changeset/dry-birds-learn.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Possible fix for account sync errors on stacks when user imports account from accountId string

--- a/libs/ledger-live-common/src/families/stacks/bridge.integration.test.ts
+++ b/libs/ledger-live-common/src/families/stacks/bridge.integration.test.ts
@@ -14,7 +14,7 @@ import { fromTransactionRaw } from "./transaction";
 import { testBridge } from "../../__tests__/test-helpers/bridge";
 
 const SEED_IDENTIFIER = "SP3KS7VMY2ZNE6SB88PHR4SKRK2EEPHS8N8MCCBR9";
-const DUMMY_PUBKEY = "022d82baea2d041ac281bebafab11571f45db4f163a9e3f8640b1c804a4ac6f662";
+const SEED_IDENTIFIER_PUBKEY = "022a460decc9dba8c452927fecb33d7ae25a8d79dc5442b84feaf8f3aa0e2b575d";
 const ACCOUNT_1 = "SP2DV2RVZP1A69Q6VAG5PHEQ6ZHQHZPCV84TMYNGN";
 
 const stacks: CurrenciesData<Transaction> = {
@@ -36,16 +36,17 @@ const stacks: CurrenciesData<Transaction> = {
   accounts: [
     {
       raw: {
-        id: `js:2:stacks:${DUMMY_PUBKEY}:`,
+        id: `js:2:stacks:${SEED_IDENTIFIER_PUBKEY}:`,
         seedIdentifier: SEED_IDENTIFIER,
         name: "Stacks 1",
         derivationMode: "",
         index: 0,
         freshAddress: SEED_IDENTIFIER,
-        freshAddressPath: "44'/5757'/0'/0/0",
+        freshAddressPath: "",
         freshAddresses: [],
         blockHeight: 0,
         operations: [],
+        xpub: SEED_IDENTIFIER_PUBKEY,
         pendingOperations: [],
         currencyId: "stacks",
         unitMagnitude: 6,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix for account sync error on stacks caused by import of accounts on ledger live using `accountId` string. The address is now derived from pubkey which is always stored in the accountId string and acts as seedId. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10786

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
