### PR TITLE
[BUGFIX] : Continue button was greyed out in step 1 of Send flow if the Account to debit is changed

### DIFF
--- a/.changeset/polite-papayas-fold.md
+++ b/.changeset/polite-papayas-fold.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Continue button greyed out in step 1 of Send flow if the "Account to debit" is changed

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
@@ -46,7 +46,7 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
       onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));
       resetInitValue && resetInitValue();
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [bridge, onChangeTransaction, resetInitValue, transaction, value]);
 
   const onChange = useCallback(
     async (recipient: string, maybeExtra?: OnChangeExtra | null) => {


### PR DESCRIPTION




### 📝 Description

Continue button was greyed out in step 1 of Send flow if the Account to debit is changed

BEFORE 
![image-20240108-144755](https://github.com/LedgerHQ/ledger-live/assets/112866305/fc283fc5-9b37-4a88-86cb-8c84079b3470)


AFTER

https://github.com/LedgerHQ/ledger-live/assets/112866305/7f3f067f-ec2f-48d2-9ae2-3b76fb068cd8



### ❓ Context

- **JIRA or GitHub link**: [LIVE-10876]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10876]: https://ledgerhq.atlassian.net/browse/LIVE-10876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ