### PR TITLE
feat: add providers AB test trait to analytics identify for eth staking modal

### DIFF
--- a/.changeset/fast-bananas-study.md
+++ b/.changeset/fast-bananas-study.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add stakingProvidersEnabled A/B test trait to analytics identify for eth staking modal on both llm and lld.

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -99,6 +99,9 @@ const extraProperties = (store: ReduxStore) => {
   const device = lastSeenDeviceSelector(state);
   const devices = devicesModelListSelector(state);
   const accounts = accountsSelector(state);
+  const stakingProviders =
+    analyticsFeatureFlagMethod &&
+    analyticsFeatureFlagMethod("ethStakingProviders")?.params?.listProvider;
 
   const deviceInfo = device
     ? {
@@ -149,6 +152,7 @@ const extraProperties = (store: ReduxStore) => {
     hasGenesisPass,
     hasInfinityPass,
     modelIdList: devices,
+    stakingProvidersEnabled: stakingProviders?.length || "flag not loaded",
     ...deviceInfo,
   };
 };
@@ -218,7 +222,7 @@ const confidentialityFilter = (properties?: Record<string, unknown> | null) => {
   };
 };
 
-export const updateIdentify = async (customTraits?: Record<string, boolean | string | number>) => {
+export const updateIdentify = async () => {
   if (!storeInstance || !shareAnalyticsSelector(storeInstance.getState())) return;
 
   const analytics = getAnalytics();
@@ -226,7 +230,6 @@ export const updateIdentify = async (customTraits?: Record<string, boolean | str
 
   const allProperties = {
     ...extraProperties(storeInstance),
-    ...customTraits, // Needed for A/B tests to study historical data to make sure test groups are unbiased. See: https://segment.com/docs/unify/traits/custom-traits/
     braze_external_id: id, // Needed for braze with this exact name
   };
   analytics.identify(id, allProperties, {

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -62,6 +62,7 @@ const getFeatureFlagProperties = () => {
     const analytics = getAnalytics();
     const ptxEarnFeatureFlag = analyticsFeatureFlagMethod("ptxEarn");
     const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
+    const stakingProviders = analyticsFeatureFlagMethod("ethStakingProviders");
 
     const isBatch1Enabled =
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;
@@ -69,6 +70,8 @@ const getFeatureFlagProperties = () => {
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 2;
     const isBatch3Enabled =
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 3;
+    const stakingProvidersEnabled =
+      stakingProviders?.enabled && stakingProviders?.params?.listProvider.length;
 
     analytics.identify(
       id,
@@ -77,6 +80,7 @@ const getFeatureFlagProperties = () => {
         isBatch1Enabled,
         isBatch2Enabled,
         isBatch3Enabled,
+        stakingProvidersEnabled,
       },
       {
         context: getContext(),
@@ -214,7 +218,7 @@ const confidentialityFilter = (properties?: Record<string, unknown> | null) => {
   };
 };
 
-export const updateIdentify = async () => {
+export const updateIdentify = async (customTraits?: Record<string, boolean | string | number>) => {
   if (!storeInstance || !shareAnalyticsSelector(storeInstance.getState())) return;
 
   const analytics = getAnalytics();
@@ -222,6 +226,7 @@ export const updateIdentify = async () => {
 
   const allProperties = {
     ...extraProperties(storeInstance),
+    ...customTraits, // Needed for A/B tests to study historical data to make sure test groups are unbiased. See: https://segment.com/docs/unify/traits/custom-traits/
     braze_external_id: id, // Needed for braze with this exact name
   };
   analytics.identify(id, allProperties, {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Account } from "@ledgerhq/types-live";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { Flex } from "@ledgerhq/react-ui";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { EthStakingModalBody } from "./EthStakingModalBody";
+import { updateIdentify } from "~/renderer/analytics/segment";
 
 type Props = {
   account: Account;
@@ -16,6 +17,14 @@ type Props = {
 
 const StakingModal = ({ account, hasCheckbox, singleProviderRedirectMode, source }: Props) => {
   const ethStakingProviders = useFeature("ethStakingProviders");
+  const providers = ethStakingProviders?.params?.listProvider;
+  const stakingProvidersEnabled = providers && providers.length;
+
+  useEffect(() => {
+    if (stakingProvidersEnabled) {
+      updateIdentify({ stakingProvidersEnabled });
+    }
+  }, [stakingProvidersEnabled]);
 
   if (!ethStakingProviders?.enabled) {
     return null;
@@ -39,7 +48,7 @@ const StakingModal = ({ account, hasCheckbox, singleProviderRedirectMode, source
                 hasCheckbox={hasCheckbox}
                 singleProviderRedirectMode={singleProviderRedirectMode}
                 source={source}
-                listProviders={ethStakingProviders.params?.listProvider}
+                listProviders={providers}
               />
             </Flex>
           )}

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Account } from "@ledgerhq/types-live";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { Flex } from "@ledgerhq/react-ui";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { EthStakingModalBody } from "./EthStakingModalBody";
-import { updateIdentify } from "~/renderer/analytics/segment";
 
 type Props = {
   account: Account;
@@ -18,13 +17,6 @@ type Props = {
 const StakingModal = ({ account, hasCheckbox, singleProviderRedirectMode, source }: Props) => {
   const ethStakingProviders = useFeature("ethStakingProviders");
   const providers = ethStakingProviders?.params?.listProvider;
-  const stakingProvidersEnabled = providers && providers.length;
-
-  useEffect(() => {
-    if (stakingProvidersEnabled) {
-      updateIdentify({ stakingProvidersEnabled });
-    }
-  }, [stakingProvidersEnabled]);
 
   if (!ethStakingProviders?.enabled) {
     return null;

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -71,6 +71,7 @@ const getFeatureFlagProperties = () => {
   (async () => {
     const ptxEarnFeatureFlag = analyticsFeatureFlagMethod("ptxEarn");
     const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
+    const stakingProviders = analyticsFeatureFlagMethod("ethStakingProviders");
 
     const isBatch1Enabled =
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;
@@ -78,12 +79,15 @@ const getFeatureFlagProperties = () => {
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 2;
     const isBatch3Enabled =
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 3;
+    const stakingProvidersEnabled =
+      stakingProviders?.enabled && stakingProviders?.params?.listProvider.length;
 
     updateIdentify({
       ptxEarnEnabled: !!ptxEarnFeatureFlag?.enabled,
       isBatch1Enabled,
       isBatch2Enabled,
       isBatch3Enabled,
+      stakingProvidersEnabled,
     });
   })();
 };
@@ -220,6 +224,7 @@ export const start = async (store: AppStore): Promise<SegmentClient | undefined>
   return segmentClient;
 };
 
+// TODO: use this to update the user traits
 export const updateIdentify = async (additionalProperties?: UserTraits) => {
   Sentry.addBreadcrumb({
     category: "identify",

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -155,6 +155,11 @@ const extraProperties = async (store: AppStore) => {
   const personalizedRecommendationsEnabled: boolean =
     personalizedRecommendationsEnabledSelector(state);
 
+  const stakingProviders =
+    analyticsFeatureFlagMethod && analyticsFeatureFlagMethod("ethStakingProviders");
+  const stakingProvidersCount =
+    stakingProviders?.enabled && stakingProviders?.params?.listProvider.length;
+
   return {
     appVersion,
     androidVersionCode: getAndroidVersionCode(VersionNumber.buildVersion),
@@ -191,6 +196,7 @@ const extraProperties = async (store: AppStore) => {
     nps,
     optInAnalytics: analyticsEnabled,
     optInPersonalRecommendations: personalizedRecommendationsEnabled,
+    stakingProvidersEnabled: stakingProvidersCount || "flag not loaded",
   };
 };
 

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -224,7 +224,6 @@ export const start = async (store: AppStore): Promise<SegmentClient | undefined>
   return segmentClient;
 };
 
-// TODO: use this to update the user traits
 export const updateIdentify = async (additionalProperties?: UserTraits) => {
   Sentry.addBreadcrumb({
     category: "identify",

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "styled-components/native";
 
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Flex, ScrollListContainer } from "@ledgerhq/native-ui";
-import { Track } from "~/analytics";
+import { Track, updateIdentify } from "~/analytics";
 import { useRootDrawerContext } from "~/context/RootDrawerContext";
 import { EvmStakingDrawerBody } from "./EvmStakingDrawerBody";
 import QueuedDrawer from "~/components/QueuedDrawer";
@@ -17,16 +17,17 @@ const descending = (a: ListProvider, b: ListProvider) => (b?.min || 0) - (a?.min
 export function EvmStakingDrawer() {
   const { isOpen, onModalHide, openDrawer, onClose, drawer } = useRootDrawerContext();
   const ethStakingProviders = useFeature("ethStakingProviders");
+  const providers = ethStakingProviders?.params?.listProvider;
+  const stakingProvidersEnabled = providers && providers.length;
+
   const { theme: themeName } = useTheme();
 
   useEffect(() => {
-    if (
-      ethStakingProviders?.enabled ||
-      (ethStakingProviders?.params?.listProvider ?? []).length > 0
-    ) {
+    if (ethStakingProviders?.enabled || (providers ?? []).length > 0) {
+      updateIdentify({ stakingProvidersEnabled });
       openDrawer();
     }
-  }, [ethStakingProviders, openDrawer]);
+  }, [ethStakingProviders, openDrawer, providers, stakingProvidersEnabled]);
 
   if (!ethStakingProviders || drawer.id !== "EvmStakingDrawer") return null;
 

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "styled-components/native";
 
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Flex, ScrollListContainer } from "@ledgerhq/native-ui";
-import { Track, updateIdentify } from "~/analytics";
+import { Track } from "~/analytics";
 import { useRootDrawerContext } from "~/context/RootDrawerContext";
 import { EvmStakingDrawerBody } from "./EvmStakingDrawerBody";
 import QueuedDrawer from "~/components/QueuedDrawer";
@@ -17,25 +17,22 @@ const descending = (a: ListProvider, b: ListProvider) => (b?.min || 0) - (a?.min
 export function EvmStakingDrawer() {
   const { isOpen, onModalHide, openDrawer, onClose, drawer } = useRootDrawerContext();
   const ethStakingProviders = useFeature("ethStakingProviders");
+  const isStakingProvidersEnabled = ethStakingProviders?.enabled;
   const providers = ethStakingProviders?.params?.listProvider;
-  const stakingProvidersEnabled = providers && providers.length;
 
   const { theme: themeName } = useTheme();
 
   useEffect(() => {
-    if (ethStakingProviders?.enabled || (providers ?? []).length > 0) {
-      updateIdentify({ stakingProvidersEnabled });
+    if (isStakingProvidersEnabled || (providers ?? []).length > 0) {
       openDrawer();
     }
-  }, [ethStakingProviders, openDrawer, providers, stakingProvidersEnabled]);
+  }, [isStakingProvidersEnabled, openDrawer, providers]);
 
   if (!ethStakingProviders || drawer.id !== "EvmStakingDrawer") return null;
 
   const has32Eth = drawer.props.has32Eth ?? false;
 
-  const listProvidersSorted = ethStakingProviders.params!.listProvider.sort(
-    has32Eth ? descending : ascending,
-  );
+  const listProvidersSorted = providers.sort(has32Eth ? descending : ascending);
 
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose} onModalHide={onModalHide}>

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
@@ -32,7 +32,9 @@ export function EvmStakingDrawer() {
 
   const has32Eth = drawer.props.has32Eth ?? false;
 
-  const listProvidersSorted = providers.sort(has32Eth ? descending : ascending);
+  const listProvidersSorted = ethStakingProviders.params!.listProvider.sort(
+    has32Eth ? descending : ascending,
+  );
 
   return (
     <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={onClose} onModalHide={onModalHide}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- We have a new stakingProvidersEnabled user trait in Segment to capture historical data on user activity on the eth staking drawer
- To measure the success of the new providers in the list, the new trait should show on Segment whether the user is displayed e.g. `5` or `3` providers.
- Captured on every event

 
![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/9770a860-7fcb-42e8-bd73-4c18f22c3bea)


### ❓ Context

- **JIRA or GitHub link**: [LIVE-11189](https://ledgerhq.atlassian.net/browse/LIVE-11189)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) --> Only analytics updated
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ... No behaviour change when using the modal
  - Only Segment analytics should update with the new trait

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11189]: https://ledgerhq.atlassian.net/browse/LIVE-11189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ