### PR TITLE
fix: live 11256 - eth account stake modal conditional render

### DIFF
--- a/.changeset/big-dodos-burn.md
+++ b/.changeset/big-dodos-burn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Ensure hasTag is boolean, add some type safety checks

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerProvider.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerProvider.tsx
@@ -34,7 +34,8 @@ export function EvmStakingDrawerProvider({
 }: Props) {
   const { t, i18n } = useTranslation();
   const manifest = useManifest(provider.liveAppId);
-  const hasTag = provider?.min && i18n.exists(`stake.ethereum.providers.${provider.id}.tag`);
+  const hasTag: boolean =
+    !!provider?.min && i18n.exists(`stake.ethereum.providers.${provider.id}.tag`);
 
   const providerPress = useCallback(() => {
     if (manifest) {

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
@@ -18,7 +18,7 @@ export function EvmStakingDrawer() {
   const { isOpen, onModalHide, openDrawer, onClose, drawer } = useRootDrawerContext();
   const ethStakingProviders = useFeature("ethStakingProviders");
   const isStakingProvidersEnabled = ethStakingProviders?.enabled;
-  const providers = ethStakingProviders?.params?.listProvider;
+  const providers: ListProvider[] | undefined = ethStakingProviders?.params?.listProvider;
 
   const { theme: themeName } = useTheme();
 
@@ -32,7 +32,7 @@ export function EvmStakingDrawer() {
 
   const has32Eth = drawer.props.has32Eth ?? false;
 
-  const listProvidersSorted = ethStakingProviders.params!.listProvider.sort(
+  const listProvidersSorted: ListProvider[] = ethStakingProviders.params!.listProvider.sort(
     has32Eth ? descending : ascending,
   );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Eth modal conditional render logic did not check for type safety of `hasTag`, so it was throwing "Strings must be rendered inside a Text tag" error. 

 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-11256

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - The ETH account > stake button opens the EVM staking modal without throwing an error.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
