### PR TITLE
fix: LLD wallet connect deep link handling for requests [LIVE-11270]

### DIFF
--- a/.changeset/fair-adults-marry.md
+++ b/.changeset/fair-adults-marry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: LLD wallet connect deeplink handling for requests [LIVE-11270]

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
@@ -306,6 +306,17 @@ export function useDeepLinkHandler() {
           }
           break;
         case "wc": {
+          // Only prevent requests if already on the wallet connect live-app
+          if (location.pathname === "/platform/ledger-wallet-connect") {
+            try {
+              // Prevent a request from updating the live-app url and reloading it
+              if (query.uri && new URL(query.uri).searchParams.get("requestId")) {
+                return;
+              }
+            } catch {
+              // Fall back on navigation to the live-app in case of an invalid URL
+            }
+          }
           setTrackingSource("deeplink");
           navigate("/platform/ledger-wallet-connect", query);
 
@@ -329,7 +340,7 @@ export function useDeepLinkHandler() {
           break;
       }
     },
-    [accounts, dispatch, navigate, setUrl],
+    [accounts, dispatch, location.pathname, navigate, setUrl],
   );
   return {
     handler,


### PR DESCRIPTION
### 📝 Description

Prevents a deep link for wallet connect to go through if only coming from a request and we're already on the live-app page, aligning LLD behavior with LLM

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11270]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** We don't auto test deeplinks <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - [ ] wallet connect deep link handling on LLD (can be tested with wc demo app https://react-app.walletconnect.com/)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11270]: https://ledgerhq.atlassian.net/browse/LIVE-11270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ