### PR TITLE
[LIVE-10515] Bugfix: Update `DEFAULT_NONCE` behaviour, preventing OP Stack chains to work correctly

### DIFF
--- a/.changeset/clean-buses-accept.md
+++ b/.changeset/clean-buses-accept.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Update `DEFAULT_NONCE` (-1) behaviour when converting a Ledger Live transaction to an `ethers` transaction, because using an invalid nonce (like a negative value here) will make `ethers` throw with some of its methods, like `serializeTransaction`

--- a/libs/coin-evm/src/__tests__/unit/adapters/ethers.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/adapters/ethers.unit.test.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
+import { DEFAULT_NONCE } from "../../../createTransaction";
 import { transactionToEthersTransaction } from "../../../adapters";
 import { EvmTransactionEIP1559, EvmTransactionLegacy } from "../../../types";
 
@@ -90,6 +91,39 @@ describe("EVM Family", () => {
           };
 
           expect(transactionToEthersTransaction(txWithFloatingPoint)).toEqual(ethers1559Tx);
+        });
+
+        it("should replace the usage of DEFAULT_NONCE by a valid nonce (but unrealistic) instead", () => {
+          const createdTransactionWithDefaultNonce: EvmTransactionLegacy = {
+            amount: new BigNumber(100),
+            useAllAmount: false,
+            subAccountId: "id",
+            recipient: "0xkvn",
+            feesStrategy: "custom",
+            family: "evm",
+            mode: "send",
+            nonce: DEFAULT_NONCE,
+            gasLimit: new BigNumber(21000),
+            chainId: 1,
+            data: Buffer.from(testData, "hex"),
+            gasPrice: new BigNumber(10000),
+            type: 0,
+          };
+
+          const ethersTxWithUnrealisticNonce: ethers.Transaction = {
+            to: "0xkvn",
+            nonce: Number.MAX_SAFE_INTEGER - 1,
+            gasLimit: ethers.BigNumber.from(21000),
+            data: "0x" + testData,
+            value: ethers.BigNumber.from(100),
+            chainId: 1,
+            type: 0,
+            gasPrice: ethers.BigNumber.from(10000),
+          };
+
+          expect(transactionToEthersTransaction(createdTransactionWithDefaultNonce)).toEqual(
+            ethersTxWithUnrealisticNonce,
+          );
         });
       });
     });

--- a/libs/coin-evm/src/__tests__/unit/prepareTransaction.unit.test.ts
+++ b/libs/coin-evm/src/__tests__/unit/prepareTransaction.unit.test.ts
@@ -1,5 +1,9 @@
+import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { prepareForSignOperation, prepareTransaction } from "../../prepareTransaction";
+import { DEFAULT_NONCE, createTransaction } from "../../createTransaction";
+import { makeAccount } from "../fixtures/common.fixtures";
 import * as nodeApi from "../../api/node/rpc.common";
 import {
   account,
@@ -11,7 +15,6 @@ import {
 } from "../fixtures/prepareTransaction.fixtures";
 import { GasOptions } from "../../types";
 import * as nftAPI from "../../api/nft";
-import { DEFAULT_NONCE } from "../../createTransaction";
 
 describe("EVM Family", () => {
   describe("prepareTransaction.ts", () => {
@@ -199,6 +202,34 @@ describe("EVM Family", () => {
             maxFeePerGas: new BigNumber(1),
             maxPriorityFeePerGas: new BigNumber(1),
             gasLimit: new BigNumber(12),
+            type: 2,
+          });
+        });
+
+        it("should prepare an optimism transaction and return proper additionalFees", async () => {
+          const optimism = getCryptoCurrencyById("optimism");
+          const opAccount = makeAccount("0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d", optimism);
+          const opTransaction = {
+            ...createTransaction(opAccount),
+            recipient: ethers.constants.AddressZero,
+          };
+
+          jest.spyOn(ethers, "Contract").mockImplementationOnce(() => {
+            return {
+              getL1Fee: (): ethers.BigNumber => {
+                return ethers.BigNumber.from(1234);
+              },
+            } as any;
+          });
+
+          const tx = await prepareTransaction(opAccount, { ...opTransaction });
+
+          expect(tx).toEqual({
+            ...opTransaction,
+            additionalFees: new BigNumber(1234),
+            gasPrice: undefined,
+            maxFeePerGas: new BigNumber(1),
+            maxPriorityFeePerGas: new BigNumber(1),
             type: 2,
           });
         });

--- a/libs/coin-evm/src/adapters/ethers.ts
+++ b/libs/coin-evm/src/adapters/ethers.ts
@@ -1,6 +1,7 @@
 import { ethers } from "ethers";
 import { Transaction as EvmTransaction } from "../types";
 import { getGasLimit } from "../logic";
+import { DEFAULT_NONCE } from "../createTransaction";
 
 /**
  * Adapter to convert a Ledger Live transaction to an Ethers transaction
@@ -19,7 +20,10 @@ export const transactionToEthersTransaction = (tx: EvmTransaction): ethers.Trans
     value: ethers.BigNumber.from(tx.amount.toFixed(0)),
     data: tx.data ? `0x${tx.data.toString("hex")}` : undefined,
     gasLimit: ethers.BigNumber.from(gasLimit.toFixed(0)),
-    nonce: tx.nonce,
+    // When using DEFAULT_NONCE (-1) ethers might break on some methods,
+    // therefore we replace this by an unrealisticly high nonce
+    // to prevent any valid signature being crafted here
+    nonce: tx.nonce === DEFAULT_NONCE ? Number.MAX_SAFE_INTEGER - 1 : tx.nonce,
     chainId: tx.chainId,
     type: tx.type,
   } as Partial<ethers.Transaction>;

--- a/libs/coin-evm/src/api/node/rpc.common.ts
+++ b/libs/coin-evm/src/api/node/rpc.common.ts
@@ -257,10 +257,12 @@ export const getOptimismAdditionalFees: NodeApi["getOptimismAdditionalFees"] = m
             s: "0xffffffffffffffffffffffffffffffffffffffff",
             v: 0,
           });
-        } catch (e) {
+        } catch (error) {
+          log("coin-evm", "getOptimismAdditionalFees: Transaction serializing failed", { error });
           return null;
         }
       })();
+
       if (!serializedTransaction) {
         return new BigNumber(0);
       }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR update the `DEFAULT_NONCE` (-1) behaviour put in place for the "Edit Ethereum Transaction" feature, preventing the serialization of a transaction when using it with `ethers`.
It leads to not being able to get the L1 fees for OP Stack transactions, preventing the usage of the `useMax` feature by not being able to predict a correct maximum amount spendable.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-10515

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
