### PR TITLE
[BUGFIX] : Wrong icon when hovering over 'Refresh' CTA when synchronisation error 🐛

### DIFF
--- a/.changeset/loud-moons-compare.md
+++ b/.changeset/loud-moons-compare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Wrong icon when hovering over 'Refresh" CTA when synchronisation error and add pointer cursor when it's clickable"

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/ActivityIndicator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/ActivityIndicator.tsx
@@ -45,6 +45,7 @@ export default function ActivityIndicatorInner() {
       data-test-id="topbar-synchronize-button"
       disabled={isDisabled}
       onClick={isDisabled ? undefined : onClick}
+      isInteractive
     >
       <Rotating
         size={16}
@@ -89,6 +90,7 @@ export default function ActivityIndicatorInner() {
               style={{
                 textDecoration: "underline",
                 pointerEvents: "all",
+                cursor: "pointer",
               }}
               onClick={onClick}
             >

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/shared.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/shared.ts
@@ -23,7 +23,7 @@ export const ItemContainer = styled(Tabbable).attrs<ItemProps>(p => ({
   height: 40px;
   position: relative;
   pointer-events: ${p => (p.disabled ? "none" : "unset")};
-
+  cursor: ${p => (p.isInteractive ? "pointer" : "initial")};
   &:hover {
     color: ${p => (p.disabled ? "" : p.theme.colors.palette.text.shade100)};
     background: ${p => (p.disabled ? "" : rgba(p.theme.colors.palette.action.active, 0.05))};


### PR DESCRIPTION
### 📝 Description

- Fix disabled cursor on "Refresh" label when sync error
- Add pointer cursor when it's interactive


After/Before

*Synchronizing...* will not be red it was just on test purpose

https://github.com/LedgerHQ/ledger-live/assets/112866305/6f697953-fb95-44a7-8f15-2f96f2e2bda0



### ❓ Context

- **JIRA or GitHub link**:[LIVE-10962] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10962]: https://ledgerhq.atlassian.net/browse/LIVE-10962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ