### PR TITLE
[LIVE-11289][Common] Error “not found entity” when using a firmware that requires a “My Ledger provider”

### DIFF
--- a/.changeset/tough-books-lick.md
+++ b/.changeset/tough-books-lick.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+- Fixed bad conditional branching for `listAppsUseCase`: list apps v1 and v2 were switched
+  - Added unit tests for that.
+- Fixed `forceProvider` parameter missing in `listAppsV2` call in `listAppsUseCase`. It was resulting in "not found entity" errors regardless of the selected "My Ledger" provider in Ledger Live.
+  - Added a stricter typing (the parameter is now always required)
+- Fixed bad error remapping for `HttpManagerApiRepository.getCurrentFirmware` which should throw a `FirmwareNotRecognized` in case of a `404`.
+  - Added a unit test for that.
+- Added full unit testing coverage of `HttpManagerApiRepository`.

--- a/libs/ledger-live-common/src/apps/listApps/v2.test.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.test.ts
@@ -36,6 +36,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       error: err => {
         expect(err).toBeInstanceOf(UnexpectedBootloader);
@@ -57,6 +58,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       error: err => {
         expect(err).toBeInstanceOf(UnexpectedBootloader);
@@ -78,6 +80,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       error: err => {
         expect(err.message).toBe("Bad usage of listAppsV2: missing deviceModelId");
@@ -109,6 +112,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       complete: () => {
         done();
@@ -142,6 +146,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe();
     jest.advanceTimersByTime(1);
 
@@ -167,6 +172,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       error: err => {
         expect(err.message).toBe("getDeviceVersion failed");
@@ -198,6 +204,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       error: err => {
         expect(err.message).toBe("catalogForDevice failed");
@@ -231,6 +238,7 @@ describe("listApps v2", () => {
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
+      forceProvider: 1,
     }).subscribe({
       error: err => {
         expect(err.message).toBe("getLanguagePackagesForDevice failed");

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -32,7 +32,7 @@ type ListAppsParams = {
   deviceInfo: DeviceInfo;
   deviceProxyModel?: DeviceModelId;
   managerDevModeEnabled?: boolean;
-  forceProvider?: number;
+  forceProvider: number;
   managerApiRepository: ManagerApiRepository;
 };
 

--- a/libs/ledger-live-common/src/device-core/managerApi/repositories/HttpManagerApiRepository.test.ts
+++ b/libs/ledger-live-common/src/device-core/managerApi/repositories/HttpManagerApiRepository.test.ts
@@ -1,0 +1,432 @@
+import network from "@ledgerhq/live-network/network";
+import { HttpManagerApiRepository } from "./HttpManagerApiRepository";
+import { FirmwareNotRecognized, ManagerDeviceLockedError, NetworkDown } from "@ledgerhq/errors";
+import mock from "../../../generated/mock";
+import { DeviceInfoEntity } from "../entities/DeviceInfoEntity";
+import { DeviceVersionEntity } from "../entities/DeviceVersionEntity";
+
+const getUserHashesModule = jest.requireActual("../../../user");
+const networkModule = jest.requireActual("@ledgerhq/live-network/network");
+
+describe("HttpManagerApiRepository", () => {
+  let httpManagerApiRepository: HttpManagerApiRepository;
+  let getUserHashesSpy: jest.SpyInstance;
+  let networkSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    httpManagerApiRepository = new HttpManagerApiRepository("http://managerApiBase.com", "1.2.3");
+    getUserHashesSpy = jest.spyOn(getUserHashesModule, "getUserHashes");
+    networkSpy = jest.spyOn(networkModule, "default");
+    networkSpy.mockImplementation(jest.fn());
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("fetchLatestFirmware should call network() with the correct parameters", async () => {
+    getUserHashesSpy.mockReturnValue({
+      firmwareSalt: "mockedFirmwareSalt",
+    });
+    const params: Parameters<typeof httpManagerApiRepository.fetchLatestFirmware>[0] = {
+      current_se_firmware_final_version: 888,
+      device_version: 123,
+      providerId: 12,
+      userId: "userId",
+    };
+
+    await httpManagerApiRepository.fetchLatestFirmware(params).catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "POST",
+      url: "http://managerApiBase.com/get_latest_firmware?livecommonversion=1.2.3&salt=mockedFirmwareSalt",
+      data: {
+        current_se_firmware_final_version: 888,
+        device_version: 123,
+        provider: 12,
+      },
+    });
+  });
+
+  test("fetchLatestFirmware should return null if data.result is null", async () => {
+    getUserHashesSpy.mockReturnValue({
+      firmwareSalt: "mockedFirmwareSalt",
+    });
+    const params: Parameters<typeof httpManagerApiRepository.fetchLatestFirmware>[0] = {
+      current_se_firmware_final_version: 888,
+      device_version: 123,
+      providerId: 12,
+      userId: "userId",
+    };
+    networkSpy.mockResolvedValue({
+      data: {
+        result: "null",
+      },
+    });
+
+    const result = await httpManagerApiRepository.fetchLatestFirmware(params);
+
+    expect(result).toBeNull();
+  });
+
+  test("fetchLatestFirmware should return data.se_firmware_osu_version", async () => {
+    getUserHashesSpy.mockReturnValue({
+      firmwareSalt: "mockedFirmwareSalt",
+    });
+    const params: Parameters<typeof httpManagerApiRepository.fetchLatestFirmware>[0] = {
+      current_se_firmware_final_version: 888,
+      device_version: 123,
+      providerId: 12,
+      userId: "userId",
+    };
+    networkSpy.mockResolvedValue({
+      data: {
+        result: "mockedResult",
+        se_firmware_osu_version: "mockedOsuFirmware",
+      },
+    });
+
+    const result = await httpManagerApiRepository.fetchLatestFirmware(params);
+
+    expect(result).toBe("mockedOsuFirmware");
+  });
+
+  test("fetchMcus should call network() with the correct parameters", async () => {
+    await httpManagerApiRepository.fetchMcus().catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "GET",
+      url: "http://managerApiBase.com/mcu_versions?livecommonversion=1.2.3",
+    });
+  });
+
+  test("fetchMcus should return data", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    const result = await httpManagerApiRepository.fetchMcus();
+
+    expect(result).toBe("mockedData");
+  });
+
+  test("getDeviceVersion should call network() with the correct parameters", async () => {
+    const params: Parameters<typeof httpManagerApiRepository.getDeviceVersion>[0] = {
+      targetId: 123,
+      providerId: 12,
+    };
+
+    await httpManagerApiRepository.getDeviceVersion(params).catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "POST",
+      url: "http://managerApiBase.com/get_device_version?livecommonversion=1.2.3",
+      data: {
+        target_id: 123,
+        provider: 12,
+      },
+    });
+  });
+
+  test("getDeviceVersion should throw a FirmwareNotRecognized error if status is 404", async () => {
+    networkSpy.mockRejectedValue({
+      status: 404,
+    });
+
+    await expect(
+      httpManagerApiRepository.getDeviceVersion({
+        targetId: 123,
+        providerId: 12,
+      }),
+    ).rejects.toThrow(FirmwareNotRecognized);
+  });
+
+  test("getDeviceVersion should throw a FirmwareNotRecognized error if response.status is 404", async () => {
+    networkSpy.mockRejectedValue({
+      response: {
+        status: 404,
+      },
+    });
+
+    await expect(
+      httpManagerApiRepository.getDeviceVersion({
+        targetId: 123,
+        providerId: 12,
+      }),
+    ).rejects.toThrow(FirmwareNotRecognized);
+  });
+
+  test("getDeviceVersion should return data", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    const result = await httpManagerApiRepository.getDeviceVersion({
+      targetId: 123,
+      providerId: 12,
+    });
+
+    expect(result).toBe("mockedData");
+  });
+
+  test("getCurrentOSU should call network() with the correct parameters", async () => {
+    const params: Parameters<typeof httpManagerApiRepository.getCurrentOSU>[0] = {
+      deviceId: 123,
+      providerId: 12,
+      version: "mockedVersion",
+    };
+
+    await httpManagerApiRepository.getCurrentOSU(params).catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "POST",
+      url: "http://managerApiBase.com/get_osu_version?livecommonversion=1.2.3",
+      data: {
+        device_version: 123,
+        provider: 12,
+        version_name: "mockedVersion-osu",
+      },
+    });
+  });
+
+  test("getCurrentOSU should return data", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    const result = await httpManagerApiRepository.getCurrentOSU({
+      deviceId: 123,
+      providerId: 12,
+      version: "mockedVersion",
+    });
+
+    expect(result).toBe("mockedData");
+  });
+
+  test("getCurrentFirmware should call network() with the correct parameters", async () => {
+    const params: Parameters<typeof httpManagerApiRepository.getCurrentFirmware>[0] = {
+      deviceId: 123,
+      providerId: 12,
+      version: "mockedVersion",
+    };
+
+    await httpManagerApiRepository.getCurrentFirmware(params).catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "POST",
+      url: "http://managerApiBase.com/get_firmware_version?livecommonversion=1.2.3",
+      data: {
+        device_version: 123,
+        provider: 12,
+        version_name: "mockedVersion",
+      },
+    });
+  });
+
+  test("getCurrentFirmware should throw a FirmwareNotRecognized error if status is 404", async () => {
+    networkSpy.mockRejectedValue({
+      status: 404,
+    });
+
+    await expect(
+      httpManagerApiRepository.getCurrentFirmware({
+        deviceId: 123,
+        providerId: 12,
+        version: "mockedVersion",
+      }),
+    ).rejects.toThrow(FirmwareNotRecognized);
+  });
+
+  test("getCurrentFirmware should throw a FirmwareNotRecognized error if response.status is 404", async () => {
+    networkSpy.mockRejectedValue({
+      response: {
+        status: 404,
+      },
+    });
+
+    await expect(
+      httpManagerApiRepository.getCurrentFirmware({
+        deviceId: 123,
+        providerId: 12,
+        version: "mockedVersion",
+      }),
+    ).rejects.toThrow(FirmwareNotRecognized);
+  });
+
+  test("getCurrentFirmware should return data", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    const result = await httpManagerApiRepository.getCurrentFirmware({
+      deviceId: 123,
+      providerId: 12,
+      version: "mockedVersion",
+    });
+
+    expect(result).toBe("mockedData");
+  });
+
+  test("getFinalFirmwareById should call network() with the correct parameters", async () => {
+    await httpManagerApiRepository.getFinalFirmwareById(123).catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "GET",
+      url: "http://managerApiBase.com/firmware_final_versions/123?livecommonversion=1.2.3",
+    });
+  });
+
+  test("getFinalFirmwareById should return data", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    const result = await httpManagerApiRepository.getFinalFirmwareById(123);
+
+    expect(result).toBe("mockedData");
+  });
+
+  test("getAppsByHash should call network() with the correct parameters", async () => {
+    const mockHashes = ["mockedHash1", "mockedHash2"];
+    await httpManagerApiRepository.getAppsByHash(mockHashes).catch(() => {
+      // ignore the error in this test case
+    });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "POST",
+      url: "http://managerApiBase.com/v2/apps/hash?livecommonversion=1.2.3",
+      data: mockHashes,
+    });
+  });
+
+  test("getAppsByHash should throw a NetworkDown error if data is null", async () => {
+    networkSpy.mockResolvedValue({
+      data: null,
+    });
+
+    await expect(httpManagerApiRepository.getAppsByHash(["mockedHash"])).rejects.toThrow(
+      NetworkDown,
+    );
+  });
+
+  test("getAppsByHash should throw a NetworkDown error if data is not an array", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    await expect(httpManagerApiRepository.getAppsByHash(["mockedHash"])).rejects.toThrow(
+      NetworkDown,
+    );
+  });
+
+  test("getAppsByHash should return data if it's an array", async () => {
+    networkSpy.mockResolvedValue({
+      data: ["mockedData"],
+    });
+
+    const result = await httpManagerApiRepository.getAppsByHash(["mockedHash"]);
+
+    expect(result).toEqual(["mockedData"]);
+  });
+
+  test("catalogForDevice should call network() with the correct parameters", async () => {
+    await httpManagerApiRepository
+      .catalogForDevice({
+        targetId: 123,
+        provider: 12,
+        firmwareVersion: "mockedFirmwareVersion",
+      })
+      .catch(() => {
+        // ignore the error in this test case
+      });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "GET",
+      url: "http://managerApiBase.com/v2/apps/by-target?livecommonversion=1.2.3&provider=12&target_id=123&firmware_version_name=mockedFirmwareVersion",
+    });
+  });
+
+  test("catalogForDevice should throw a NetworkDown error if data is null", async () => {
+    networkSpy.mockResolvedValue({
+      data: null,
+    });
+
+    await expect(
+      httpManagerApiRepository.catalogForDevice({
+        targetId: 123,
+        provider: 12,
+        firmwareVersion: "mockedFirmwareVersion",
+      }),
+    ).rejects.toThrow(NetworkDown);
+  });
+
+  test("catalogForDevice should throw a NetworkDown error if data is not an array", async () => {
+    networkSpy.mockResolvedValue({
+      data: "mockedData",
+    });
+
+    await expect(
+      httpManagerApiRepository.catalogForDevice({
+        targetId: 123,
+        provider: 12,
+        firmwareVersion: "mockedFirmwareVersion",
+      }),
+    ).rejects.toThrow(NetworkDown);
+  });
+
+  test("catalogForDevice should return data if it's an array", async () => {
+    networkSpy.mockResolvedValue({
+      data: ["mockedData"],
+    });
+
+    const result = await httpManagerApiRepository.catalogForDevice({
+      targetId: 123,
+      provider: 12,
+      firmwareVersion: "mockedFirmwareVersion",
+    });
+
+    expect(result).toEqual(["mockedData"]);
+  });
+
+  test("getLanguagePackagesForDevice should call network() and other methods with the correct parameters", async () => {
+    const getDeviceVersionSpy = jest
+      .spyOn(httpManagerApiRepository, "getDeviceVersion")
+      .mockReturnValue(Promise.resolve({ id: 4 } as DeviceVersionEntity));
+    const getCurrentFirmwareSpy = jest
+      .spyOn(httpManagerApiRepository, "getCurrentFirmware")
+      .mockImplementation(jest.fn());
+
+    await httpManagerApiRepository
+      .getLanguagePackagesForDevice(
+        {
+          version: 1,
+          targetId: 2,
+          id: 3,
+        } as unknown as DeviceInfoEntity,
+        12,
+      )
+      .catch(() => {
+        // ignore the error in this test case
+      });
+
+    expect(getDeviceVersionSpy).toHaveBeenCalledWith({ targetId: 2, providerId: 12 });
+    expect(getCurrentFirmwareSpy).toHaveBeenCalledWith({ deviceId: 4, providerId: 12, version: 1 });
+
+    expect(networkSpy).toHaveBeenCalledWith({
+      method: "GET",
+      url: "http://managerApiBase.com/language-package?livecommonversion=1.2.3",
+    });
+  });
+});

--- a/libs/ledger-live-common/src/device-core/managerApi/repositories/HttpManagerApiRepository.ts
+++ b/libs/ledger-live-common/src/device-core/managerApi/repositories/HttpManagerApiRepository.ts
@@ -96,13 +96,12 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
           target_id: targetId,
         },
       }).catch(error => {
-        const status = error && (error.status || (error.response && error.response.status)); // FIXME LLD is doing error remapping already. we probably need to move the remapping in live-common
+        const status = error?.status || error?.response?.status;
 
-        if (status === 404) {
+        if (status === 404)
           throw new FirmwareNotRecognized("manager api did not recognize targetId=" + targetId, {
             targetId,
           });
-        }
 
         throw error;
       });
@@ -151,6 +150,12 @@ export class HttpManagerApiRepository implements ManagerApiRepository {
           version_name: input.version,
           provider: input.providerId,
         },
+      }).catch(error => {
+        const status = error?.status || error?.response?.status;
+
+        if (status === 404) throw new FirmwareNotRecognized();
+
+        throw error;
       });
       return data;
     },

--- a/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.test.ts
@@ -1,0 +1,35 @@
+import { enableListAppsV2, listAppsUseCase } from "./listAppsUseCase";
+import Transport from "@ledgerhq/hw-transport";
+import { DeviceInfo } from "@ledgerhq/types-live";
+
+const listAppsV2Module = jest.requireActual("../../apps/listApps/v2");
+const listAppsV1Module = jest.requireActual("../../apps/listApps/v1");
+
+describe("listAppsUseCase", () => {
+  let listAppsV1Spy: jest.SpyInstance;
+  let listAppsV2Spy: jest.SpyInstance;
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    enableListAppsV2(false);
+    listAppsV1Spy = jest.spyOn(listAppsV1Module, "listApps").mockImplementation(jest.fn());
+    listAppsV2Spy = jest.spyOn(listAppsV2Module, "listApps").mockImplementation(jest.fn());
+  });
+
+  it("should call listAppsV2 when enableListAppsV2 is called with true", () => {
+    enableListAppsV2(true);
+
+    listAppsUseCase({} as Transport, {} as DeviceInfo);
+
+    expect(listAppsV1Spy).not.toHaveBeenCalled();
+    expect(listAppsV2Spy).toHaveBeenCalled();
+  });
+
+  it("should call listAppsV1 when enableListAppsV2 is called with false", () => {
+    enableListAppsV2(false);
+
+    listAppsUseCase({} as Transport, {} as DeviceInfo);
+
+    expect(listAppsV1Spy).toHaveBeenCalled();
+    expect(listAppsV2Spy).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.ts
+++ b/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.ts
@@ -38,11 +38,12 @@ export function listAppsUseCase(
   managerApiRepository: ManagerApiRepository = HttpManagerApiRepositoryFactory.getInstance(),
 ): Observable<ListAppsEvent> {
   return listAppsV2Enabled
-    ? listAppsV1(transport, deviceInfo, managerApiRepository)
-    : listAppsV2({
+    ? listAppsV2({
         transport,
         deviceInfo,
         deviceProxyModel: getEnv("DEVICE_PROXY_MODEL") as DeviceModelId,
         managerApiRepository,
-      });
+        forceProvider: getEnv("FORCE_PROVIDER"),
+      })
+    : listAppsV1(transport, deviceInfo, managerApiRepository);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

When the `listAppsV2minor1` feature flag was disabled, it was in fact using v2, and v2 had an issue with the "My Ledger provider ID" not being properly passed to the underlying logic. It was causing an "not found entity" error on some firmware versions. Also there was an issue with error remapping of the "not found entity error".

- Fixed bad conditional branching for `listAppsUseCase`: list apps v1 and v2 were switched
  - Added unit tests for that.
- Fixed `forceProvider` parameter missing in `listAppsV2` call in `listAppsUseCase`. It was resulting in "not found entity" errors regardless of the selected "My Ledger" provider in Ledger Live.
  - Added a stricter typing (the parameter is now always required)
- Fixed bad error remapping for `HttpManagerApiRepository.getCurrentFirmware` which should throw a `FirmwareNotRecognized` in case of a `404`.
  - Added a unit test for that.
- Added full unit testing coverage of `HttpManagerApiRepository`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11289] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Access to "My Ledger", with the `listAppsV2minor1` feature flag either enabled or disabled.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11289]: https://ledgerhq.atlassian.net/browse/LIVE-11289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ