### PR TITLE
[Bugfix/LIVE-11132]: add ptxSwapMoonpayProviderEnabled as an identity and tracker analytics property

### DIFF
--- a/.changeset/cyan-pens-prove.md
+++ b/.changeset/cyan-pens-prove.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+add ptxSwapMoonpayProviderEnabled as an identity and tracker analytics property

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -60,6 +60,7 @@ const getPtxAttributes = () => {
   const ptxEarnFeatureFlag = analyticsFeatureFlagMethod("ptxEarn");
   const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
   const stakingProviders = analyticsFeatureFlagMethod("ethStakingProviders");
+  const ptxSwapMoonpayProviderFlag = analyticsFeatureFlagMethod("ptxSwapMoonpayProvider");
 
   const ptxEarnEnabled: boolean = !!ptxEarnFeatureFlag?.enabled;
   const isBatch1Enabled: boolean =
@@ -74,12 +75,14 @@ const getPtxAttributes = () => {
     stakingProviders?.params?.listProvider?.length > 0
       ? stakingProviders?.params?.listProvider.length
       : "flag not loaded";
+  const ptxSwapMoonpayProviderEnabled: boolean = !!ptxSwapMoonpayProviderFlag?.enabled;
   return {
     ptxEarnEnabled,
     isBatch1Enabled,
     isBatch2Enabled,
     isBatch3Enabled,
     stakingProvidersEnabled,
+    ptxSwapMoonpayProviderEnabled,
   };
 };
 
@@ -97,6 +100,7 @@ const extraProperties = (store: ReduxStore) => {
     isBatch2Enabled,
     isBatch3Enabled,
     stakingProvidersEnabled,
+    ptxSwapMoonpayProviderEnabled,
   } = getPtxAttributes();
 
   const deviceInfo = device
@@ -153,6 +157,7 @@ const extraProperties = (store: ReduxStore) => {
     isBatch2Enabled,
     isBatch3Enabled,
     ptxEarnEnabled,
+    ptxSwapMoonpayProviderEnabled,
     ...deviceInfo,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/utils/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/utils/index.ts
@@ -3,19 +3,16 @@ import { useHistory } from "react-router-dom";
 import { SwapExchangeRateAmountTooLow } from "@ledgerhq/live-common/errors";
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { track } from "~/renderer/analytics/segment";
-import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 export const SWAP_VERSION = "2.35";
 
 export const useGetSwapTrackingProperties = () => {
-  const ptxSwapMoonpayProviderFlag = useFeature("ptxSwapMoonpayProvider");
   return useMemo(
     () => ({
       swapVersion: SWAP_VERSION,
       flow: "swap",
-      ptxSwapMoonpayProviderEnabled: !!ptxSwapMoonpayProviderFlag?.enabled,
     }),
-    [ptxSwapMoonpayProviderFlag?.enabled],
+    [],
   );
 };
 

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/utils/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/utils/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useHistory } from "react-router-dom";
 import { SwapExchangeRateAmountTooLow } from "@ledgerhq/live-common/errors";
 import { NotEnoughBalance } from "@ledgerhq/errors";
@@ -6,14 +6,13 @@ import { track } from "~/renderer/analytics/segment";
 
 export const SWAP_VERSION = "2.35";
 
+const SWAP_TRACKING_PROPERTIES = {
+  swapVersion: SWAP_VERSION,
+  flow: "swap",
+};
+
 export const useGetSwapTrackingProperties = () => {
-  return useMemo(
-    () => ({
-      swapVersion: SWAP_VERSION,
-      flow: "swap",
-    }),
-    [],
-  );
+  return SWAP_TRACKING_PROPERTIES;
 };
 
 export const useRedirectToSwapHistory = () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

- add ptxSwapMoonpayProviderEnabled as an identity and tracker analytics property.
- remove from swap page since it is now an extra property for all events.


### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-11132

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
