### PR TITLE
fix: make sure mouse is hovering nano S on onboarding e2e tests

### DIFF
--- a/apps/ledger-live-desktop/tests/models/OnboardingPage.ts
+++ b/apps/ledger-live-desktop/tests/models/OnboardingPage.ts
@@ -82,8 +82,12 @@ export class OnboardingPage {
     await this.getStartedButton.click();
   }
 
-  async selectDevice(device: "nanoS" | "nanoX" | "nanoSP" | "stax") {
+  async hoverDevice(device: "nanoS" | "nanoX" | "nanoSP" | "stax") {
     await this.page.hover(`[data-test-id=v3-container-device-${device}]`);
+  }
+
+  async selectDevice(device: "nanoS" | "nanoX" | "nanoSP" | "stax") {
+    await this.hoverDevice(device);
     await this.selectDeviceButton(device).click();
   }
 

--- a/apps/ledger-live-desktop/tests/specs/onboarding/connect-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/connect-device.spec.ts
@@ -24,6 +24,7 @@ test.describe.parallel("Onboarding", () => {
 
       await test.step("Get started", async () => {
         await onboardingPage.getStarted();
+        await onboardingPage.hoverDevice(Nano.nanoS);
         await expect(page).toHaveScreenshot("v3-device-selection.png");
       });
 

--- a/apps/ledger-live-desktop/tests/specs/onboarding/restore-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/restore-device.spec.ts
@@ -24,6 +24,7 @@ test.describe.parallel("Onboarding", () => {
 
       await test.step("Get started", async () => {
         await onboardingPage.getStarted();
+        await onboardingPage.hoverDevice(Nano.nanoS);
         await expect(page).toHaveScreenshot("v3-device-selection.png", {
           mask: [page.locator("video")],
         });

--- a/apps/ledger-live-desktop/tests/specs/onboarding/setup-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/setup-device.spec.ts
@@ -24,6 +24,7 @@ test.describe.parallel("Onboarding", () => {
 
       await test.step("Get started", async () => {
         await onboardingPage.getStarted();
+        await onboardingPage.hoverDevice(Nano.nanoS);
         await expect(page).toHaveScreenshot("v3-device-selection.png");
       });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Today those tests are unstable because we don't make sure that we're hovering the Nano S card on the onboarding when we take the screenshot.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-11337
### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
