### PR TITLE
[LLM] - [LIVE-11362] - Fix QR code UI issue on scan

### DIFF
--- a/apps/ledger-live-mobile/src/components/CameraScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/components/CameraScreen/index.tsx
@@ -29,7 +29,13 @@ export default function CameraScreen({ width, height, progress, liveQrCode, inst
         };
   return (
     <View style={wrapperStyle}>
-      <Flex height={height * 0.15} px={6} pt={9} zIndex={1} />
+      <Flex
+        height={height * 0.15}
+        px={6}
+        pt={9}
+        zIndex={1}
+        backgroundColor={rgba(colors.constant.black, 0.8)}
+      />
       <Flex flexDirection={"row"} justifyContent={"space-evenly"} alignItems={"center"}>
         <Box flexGrow={1} backgroundColor={rgba(colors.constant.black, 0.8)} height={"100%"} />
         <ScanTargetSvg />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This PR includes a fix that solves a known UI issue on QR code scanning.

![Screenshot_20240220-101422](https://github.com/LedgerHQ/ledger-live/assets/25589782/dc39d4ff-1d8c-4c7e-8609-279cbb726ad2)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11362] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11362]: https://ledgerhq.atlassian.net/browse/LIVE-11362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ