### PR TITLE
chore: live-hub only owns the /src of live-common, not package.json's

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,7 +15,7 @@ libs/**/errors/                                          @ledgerhq/live-hub
 libs/**/logs/                                            @ledgerhq/live-hub
 libs/**/types-live/                                      @ledgerhq/live-hub
 libs/env/                                                @ledgerhq/live-hub
-libs/ledger-live-common/                                 @ledgerhq/live-hub
+libs/ledger-live-common/src/                             @ledgerhq/live-hub
 libs/live-countervalues-react/                           @ledgerhq/live-hub
 libs/live-countervalues/                                 @ledgerhq/live-hub
 libs/live-hooks/                                         @ledgerhq/live-hub


### PR DESCRIPTION


### 📝 Description

ledger live common still being that monolithic library that we are progressively dismantling into smaller libraries, we don't want live-hub to be pinged on each single modification of package.json, therefore we only make hub owning the /src not the whole live-common package. (Note that specific teams already specialize part of live-common src/* sub paths and that live-hub is a catch all fallback case)


### ❓ Context

- **JIRA or GitHub link**: na

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
