### PR TITLE
[LIVE-8852] Bugfix: Prevent error message on NFT send if bridge pending

### DIFF
--- a/.changeset/eighty-jars-smell.md
+++ b/.changeset/eighty-jars-smell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Prevent error displayed when sending an ERC1155 NFT and bridge is still pending

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03b-AmountNft.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03b-AmountNft.tsx
@@ -83,6 +83,8 @@ const SendAmountNFT = ({ route }: Props) => {
   const blur = useCallback(() => Keyboard.dismiss(), []);
 
   const error = useMemo(() => {
+    if (bridgePending) return <LText style={styles.error} numberOfLines={2} />;
+
     if (quantity?.isFinite()) {
       if (status?.warnings?.amount) {
         return (
@@ -102,7 +104,7 @@ const SendAmountNFT = ({ route }: Props) => {
     }
 
     return <LText style={styles.error} numberOfLines={2} />;
-  }, [quantity, status?.errors?.amount, status?.warnings?.amount]);
+  }, [quantity, status?.errors?.amount, status?.warnings?.amount, bridgePending]);
 
   return (
     <>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Removes blinking error on ERC1155 NFT send

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-8852

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
