### PR TITLE
[bugfix] Solana: Update staking operations to fix balances history in graph

### DIFF
--- a/.changeset/cyan-socks-taste.md
+++ b/.changeset/cyan-socks-taste.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Update solana delegate operation values and extra data to fix graph history numbers

--- a/apps/ledger-live-desktop/src/renderer/families/solana/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/index.ts
@@ -5,6 +5,7 @@ import sendRecipientFields from "./SendRecipientFields";
 import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
 import StakeBanner from "./StakeBanner";
 import { SolanaFamily } from "./types";
+import operationDetails from "./operationDetails";
 
 const family: SolanaFamily = {
   accountHeaderManageActions,
@@ -13,6 +14,7 @@ const family: SolanaFamily = {
   sendRecipientFields,
   AccountBalanceSummaryFooter,
   StakeBanner,
+  operationDetails,
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/solana/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/operationDetails.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { useSelector } from "react-redux";
+import BigNumber from "bignumber.js";
+import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
+import { CryptoCurrency, Unit } from "@ledgerhq/types-cryptoassets";
+import { getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { SolanaAccount, SolanaOperation } from "@ledgerhq/live-common/families/solana/types";
+import { useSolanaPreloadData } from "@ledgerhq/live-common/families/solana/react";
+import Box from "~/renderer/components/Box/Box";
+import { useDiscreetMode } from "~/renderer/components/Discreet";
+import Text from "~/renderer/components/Text";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import {
+  Address,
+  OpDetailsData,
+  OpDetailsSection,
+  OpDetailsTitle,
+  OpDetailsVoteData,
+} from "~/renderer/drawers/OperationDetails/styledComponents";
+import { localeSelector } from "~/renderer/reducers/settings";
+import { openURL } from "~/renderer/linking";
+import { OperationDetailsExtraProps } from "../types";
+
+export const redirectAddress = (currency: CryptoCurrency, address: string) => () => {
+  const url = getAddressExplorer(getDefaultExplorerView(currency), address);
+  if (url) openURL(url);
+};
+
+function useFormatAmount() {
+  const discreet = useDiscreetMode();
+  const locale = useSelector(localeSelector);
+  const formatConfig = {
+    disableRounding: true,
+    alwaysShowSign: false,
+    showCode: true,
+    discreet,
+    locale,
+  };
+
+  return (unit: Unit, amount: BigNumber) => {
+    return formatCurrencyUnit(unit, amount, formatConfig);
+  };
+}
+
+type SolanaOperationDetailsExtraProps = OperationDetailsExtraProps<SolanaAccount, SolanaOperation>;
+type DelegateExtraFieldsProps = {
+  account: SolanaAccount;
+  voteAddress: string;
+  amount: BigNumber;
+};
+
+const DelegateExtraFields = ({ account, voteAddress, amount }: DelegateExtraFieldsProps) => {
+  const unit = getAccountUnit(account);
+  const formatAmount = useFormatAmount();
+  const preloadData = useSolanaPreloadData(account.currency);
+  const validator = preloadData?.validators.find(v => v.voteAccount === voteAddress);
+
+  return (
+    <OpDetailsSection gap="80px">
+      <OpDetailsTitle>
+        <Trans i18nKey={"operationDetails.extra.validators"} />
+      </OpDetailsTitle>
+      <OpDetailsData>
+        <OpDetailsVoteData>
+          <Box>
+            <Ellipsis>
+              <Trans
+                i18nKey="operationDetails.extra.votesAddress"
+                values={{
+                  votes: formatAmount(unit, amount),
+                  name: validator?.name || voteAddress,
+                }}
+              >
+                <Text ff="Inter|SemiBold">{""}</Text>
+                {""}
+                <Text ff="Inter|SemiBold">{""}</Text>
+              </Trans>
+            </Ellipsis>
+          </Box>
+          <Address
+            style={{ maxWidth: "95%" }}
+            onClick={redirectAddress(account.currency, voteAddress)}
+          >
+            <Ellipsis>{voteAddress}</Ellipsis>
+          </Address>
+        </OpDetailsVoteData>
+      </OpDetailsData>
+    </OpDetailsSection>
+  );
+};
+
+type WithdrawExtraFieldsProps = {
+  account: SolanaAccount;
+  fromAddress: string;
+  amount: BigNumber;
+};
+const WithdrawExtraFields = ({ account, fromAddress, amount }: WithdrawExtraFieldsProps) => {
+  const unit = getAccountUnit(account);
+  const formatAmount = useFormatAmount();
+
+  return (
+    <>
+      <OpDetailsSection>
+        <OpDetailsTitle>
+          <Trans i18nKey={"operationDetails.extra.withdrawnFrom"} />
+        </OpDetailsTitle>
+        <OpDetailsData>
+          <Ellipsis>{fromAddress}</Ellipsis>
+        </OpDetailsData>
+      </OpDetailsSection>
+
+      <OpDetailsSection>
+        <OpDetailsTitle>
+          <Trans i18nKey="operationDetails.extra.withdrawnAmount" />
+        </OpDetailsTitle>
+        <OpDetailsData>{formatAmount(unit, amount)}</OpDetailsData>
+      </OpDetailsSection>
+    </>
+  );
+};
+
+const OperationStakeDetails = ({ account, operation, type }: SolanaOperationDetailsExtraProps) => {
+  if (!operation.extra.stake) return null;
+  const { address, amount } = operation.extra.stake;
+  switch (type) {
+    case "DELEGATE": {
+      return <DelegateExtraFields account={account} voteAddress={address} amount={amount} />;
+    }
+    case "WITHDRAW_UNBONDED": {
+      return <WithdrawExtraFields account={account} fromAddress={address} amount={amount} />;
+    }
+    default:
+      return null;
+  }
+};
+
+const OperationDetailsMemo = ({ memo }: { memo: string }) => {
+  return (
+    <OpDetailsSection>
+      <OpDetailsTitle>
+        <Trans i18nKey={"operationDetails.extra.memo"} />
+      </OpDetailsTitle>
+      <OpDetailsData>
+        <Ellipsis ml={2}>{memo}</Ellipsis>
+      </OpDetailsData>
+    </OpDetailsSection>
+  );
+};
+
+const OperationDetailsExtra = ({ type, account, operation }: SolanaOperationDetailsExtraProps) => {
+  return (
+    <>
+      {!!operation.extra.memo && <OperationDetailsMemo memo={operation.extra.memo} />}
+      <OperationStakeDetails type={type} account={account} operation={operation} />
+    </>
+  );
+};
+
+export default {
+  OperationDetailsExtra,
+};

--- a/apps/ledger-live-mobile/src/families/solana/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/operationDetails.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { Linking, View } from "react-native";
+import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { BigNumber } from "bignumber.js";
+import { OperationType } from "@ledgerhq/types-live";
+import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
+import { getAccountUnit } from "@ledgerhq/live-common/account/helpers";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { CryptoCurrency, Unit } from "@ledgerhq/types-cryptoassets";
+import { useSolanaPreloadData } from "@ledgerhq/live-common/families/solana/react";
+import { SolanaAccount, SolanaOperation } from "@ledgerhq/live-common/families/solana/types";
+import Section from "~/screens/OperationDetails/Section";
+import { discreetModeSelector } from "~/reducers/settings";
+import { useSettings } from "~/hooks";
+
+export const openAddressUrl = (currency: CryptoCurrency, address: string) => () => {
+  const url = getAddressExplorer(getDefaultExplorerView(currency), address);
+  if (url) {
+    Linking.openURL(url);
+  }
+};
+
+function useFormatAmount() {
+  const discreet = useSelector(discreetModeSelector);
+  const { locale } = useSettings();
+  const formatConfig = {
+    disableRounding: true,
+    alwaysShowSign: false,
+    showCode: true,
+    discreet,
+    locale,
+  };
+
+  return (unit: Unit, amount: BigNumber) => {
+    return formatCurrencyUnit(unit, amount, formatConfig);
+  };
+}
+
+type WithdrawExtraFieldsProps = {
+  account: SolanaAccount;
+  fromAddress: string;
+  amount: BigNumber;
+};
+
+const WithdrawExtraFields = ({ account, fromAddress, amount }: WithdrawExtraFieldsProps) => {
+  const { t } = useTranslation();
+  const unit = getAccountUnit(account);
+  const formatAmount = useFormatAmount();
+
+  return (
+    <View>
+      <Section title={t("operationDetails.extra.withdrawnFrom")} value={fromAddress} />
+      <Section
+        title={t("operationDetails.extra.withdrawnAmount")}
+        value={formatAmount(unit, amount)}
+      />
+    </View>
+  );
+};
+
+type DelegateExtraFieldsProps = {
+  account: SolanaAccount;
+  voteAddress: string;
+  amount: BigNumber;
+};
+
+const DelegateExtraFields = ({ account, voteAddress, amount }: DelegateExtraFieldsProps) => {
+  const { t } = useTranslation();
+  const unit = getAccountUnit(account);
+  const formatAmount = useFormatAmount();
+  const preloadData = useSolanaPreloadData(account.currency);
+  const validator = preloadData?.validators.find(v => v.voteAccount === voteAddress);
+  const nameOrAddress = validator ? validator.name : voteAddress;
+
+  return (
+    <View>
+      <Section
+        title={t("operationDetails.extra.delegatedTo")}
+        value={nameOrAddress}
+        onPress={() => openAddressUrl(account.currency, voteAddress)}
+      />
+      <Section
+        title={t("operationDetails.extra.delegatedAmount")}
+        value={formatAmount(unit, amount)}
+      />
+    </View>
+  );
+};
+
+const OperationDetailsStake = ({ account, operation, type }: SolanaOperationDetailsExtraProps) => {
+  if (!operation.extra.stake) return null;
+  const { address, amount } = operation.extra.stake;
+  switch (type) {
+    case "DELEGATE": {
+      return <DelegateExtraFields account={account} voteAddress={address} amount={amount} />;
+    }
+    case "WITHDRAW_UNBONDED": {
+      return <WithdrawExtraFields account={account} fromAddress={address} amount={amount} />;
+    }
+    default:
+      return null;
+  }
+};
+
+const OperationDetailsMemo = ({ memo }: { memo: string }) => {
+  const { t } = useTranslation();
+  return <Section title={t("operationDetails.extra.memo")} value={memo} />;
+};
+
+type SolanaOperationDetailsExtraProps = {
+  operation: SolanaOperation;
+  type: OperationType;
+  account: SolanaAccount;
+};
+
+const OperationDetailsExtra = ({ type, account, operation }: SolanaOperationDetailsExtraProps) => {
+  return (
+    <>
+      {!!operation.extra.memo && <OperationDetailsMemo memo={operation.extra.memo} />}
+      <OperationDetailsStake type={type} account={account} operation={operation} />
+    </>
+  );
+};
+
+export default {
+  OperationDetailsExtra,
+};

--- a/libs/ledger-live-common/src/families/solana/bridge/bridge.ts
+++ b/libs/ledger-live-common/src/families/solana/bridge/bridge.ts
@@ -25,7 +25,12 @@ import { PRELOAD_MAX_AGE, hydrate, preloadWithAPI } from "../js-preload";
 import { prepareTransaction as prepareTransactionWithAPI } from "../js-prepareTransaction";
 import { signOperationWithAPI } from "../js-signOperation";
 import { getAccountShapeWithAPI } from "../js-synchronization";
-import { assignFromAccountRaw, assignToAccountRaw } from "../serialization";
+import {
+  assignFromAccountRaw,
+  assignToAccountRaw,
+  fromOperationExtraRaw,
+  toOperationExtraRaw,
+} from "../serialization";
 import type { SolanaAccount, SolanaPreloadDataV1, Transaction } from "../types";
 import { endpointByCurrencyId } from "../utils";
 
@@ -164,6 +169,8 @@ export function makeBridges({
     signOperation: makeSign(getAPI),
     assignFromAccountRaw,
     assignToAccountRaw,
+    toOperationExtraRaw,
+    fromOperationExtraRaw,
   };
 
   const currencyBridge: CurrencyBridge = {

--- a/libs/ledger-live-common/src/families/solana/js-synchronization.ts
+++ b/libs/ledger-live-common/src/families/solana/js-synchronization.ts
@@ -51,6 +51,7 @@ import { drainSeq } from "./utils";
 import { estimateTxFee } from "./tx-fees";
 import { SolanaAccount, SolanaOperationExtra, SolanaStake } from "./types";
 import { Account, Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
+import { DelegateInfo, WithdrawInfo } from "./api/chain/instruction/stake/types";
 
 type OnChainTokenAccount = Awaited<ReturnType<typeof getAccount>>["tokenAccounts"][number];
 
@@ -382,9 +383,7 @@ function txToMainAccOperation(
   const txDate = new Date(tx.info.blockTime * 1000);
 
   const opFee = isFeePayer ? txFee : new BigNumber(0);
-
-  const value = balanceDelta.abs();
-  const opValue = opType === "OPT_OUT" ? value.negated() : value;
+  const opValue = getOpValue(balanceDelta, opFee, opType);
 
   return {
     id: encodeOperationId(accountId, txHash, opType),
@@ -393,7 +392,7 @@ function txToMainAccOperation(
     hasFailed: !!tx.info.err,
     blockHeight: tx.info.slot,
     blockHash: message.recentBlockhash,
-    extra: getOpExtra(tx),
+    extra: getOpExtra(tx, balanceDelta, opType),
     type: opType,
     senders,
     recipients,
@@ -404,10 +403,56 @@ function txToMainAccOperation(
   };
 }
 
-function getOpExtra(tx: TransactionDescriptor): SolanaOperationExtra {
+function getOpValue(balanceDelta: BigNumber, opFee: BigNumber, opType: OperationType): BigNumber {
+  const value = balanceDelta.abs();
+  switch (opType) {
+    case "DELEGATE":
+    case "WITHDRAW_UNBONDED":
+      return opFee;
+    case "OPT_OUT":
+      return value.negated();
+    default:
+      return value;
+  }
+}
+
+function getOpExtra(
+  tx: TransactionDescriptor,
+  balanceDelta: BigNumber,
+  opType: OperationType,
+): SolanaOperationExtra {
   const extra: SolanaOperationExtra = {};
+  const { instructions } = tx.parsed.transaction.message;
+  const parsedIxs = instructions
+    .map(ix => parseQuiet(ix))
+    .filter(({ program }) => program !== "spl-memo");
+
   if (tx.info.memo !== null) {
     extra.memo = dropMemoLengthPrefixIfAny(tx.info.memo);
+  }
+
+  if (opType === "DELEGATE") {
+    const delegateInfo = parsedIxs.find(
+      ix => ix.program === "stake" && ix.instruction?.type === "delegate",
+    )?.instruction?.info as DelegateInfo;
+    if (!delegateInfo) return extra;
+
+    extra.stake = {
+      address: delegateInfo.voteAccount.toBase58(),
+      amount: balanceDelta.abs(),
+    };
+  }
+
+  if (opType === "WITHDRAW_UNBONDED") {
+    const withdrawInfo = parsedIxs.find(
+      ix => ix.program === "stake" && ix.instruction?.type === "withdraw",
+    )?.instruction?.info as WithdrawInfo;
+    if (!withdrawInfo) return extra;
+
+    extra.stake = {
+      address: withdrawInfo.stakeAccount.toBase58(),
+      amount: new BigNumber(withdrawInfo.lamports),
+    };
   }
 
   return extra;
@@ -461,7 +506,7 @@ function txToTokenAccOperation(
     senders,
     value: delta.abs(),
     hasFailed: !!tx.info.err,
-    extra: getOpExtra(tx),
+    extra: getOpExtra(tx, delta, opType),
     blockHash: tx.parsed.transaction.message.recentBlockhash,
   };
 }
@@ -538,7 +583,7 @@ function getMainAccOperationTypeFromTx(tx: ParsedTransaction): OperationType | u
           case "deactivate":
             return "UNDELEGATE";
           case "withdraw":
-            return "IN";
+            return "WITHDRAW_UNBONDED";
         }
         break;
       default:

--- a/libs/ledger-live-common/src/families/solana/serialization.ts
+++ b/libs/ledger-live-common/src/families/solana/serialization.ts
@@ -1,5 +1,12 @@
-import { SolanaAccount, SolanaAccountRaw, SolanaResources, SolanaResourcesRaw } from "./types";
-import { Account, AccountRaw } from "@ledgerhq/types-live";
+import {
+  SolanaAccount,
+  SolanaAccountRaw,
+  SolanaOperationExtra,
+  SolanaOperationExtraRaw,
+  SolanaResources,
+  SolanaResourcesRaw,
+} from "./types";
+import { Account, AccountRaw, OperationExtra, OperationExtraRaw } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 
 export function toSolanaResourcesRaw(resources: SolanaResources): SolanaResourcesRaw {
@@ -29,4 +36,46 @@ export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account) {
   const solanaResourcesRaw = (accountRaw as SolanaAccountRaw).solanaResources;
   if (solanaResourcesRaw)
     (account as SolanaAccount).solanaResources = fromSolanaResourcesRaw(solanaResourcesRaw);
+}
+
+export function fromOperationExtraRaw(extraRaw: OperationExtraRaw): OperationExtra {
+  const extra: SolanaOperationExtra = {};
+  if (!isExtraValid(extraRaw)) return extra;
+  const solanaExtraRaw = extraRaw as SolanaOperationExtraRaw;
+
+  if (solanaExtraRaw.memo) {
+    extra.memo = solanaExtraRaw.memo;
+  }
+
+  if (solanaExtraRaw.stake) {
+    extra.stake = {
+      address: solanaExtraRaw.stake.address,
+      amount: new BigNumber(solanaExtraRaw.stake.amount),
+    };
+  }
+
+  return extra;
+}
+
+export function toOperationExtraRaw(extra: OperationExtra): OperationExtraRaw {
+  const extraRaw: SolanaOperationExtraRaw = {};
+  if (!isExtraValid(extra)) return extraRaw;
+  const solanaExtra = extra as SolanaOperationExtra;
+
+  if (solanaExtra.memo) {
+    extraRaw.memo = solanaExtra.memo;
+  }
+
+  if (solanaExtra.stake) {
+    extraRaw.stake = {
+      address: solanaExtra.stake.address,
+      amount: solanaExtra.stake.amount.toJSON(),
+    };
+  }
+
+  return extraRaw;
+}
+
+function isExtraValid(extra: OperationExtra | OperationExtraRaw): boolean {
+  return !!extra && typeof extra === "object";
 }

--- a/libs/ledger-live-common/src/families/solana/types.ts
+++ b/libs/ledger-live-common/src/families/solana/types.ts
@@ -261,7 +261,24 @@ export type TransactionStatus = TransactionStatusCommon;
 export type TransactionStatusRaw = TransactionStatusCommonRaw;
 
 export type SolanaOperation = Operation<SolanaOperationExtra>;
+export type SolanaOperationRaw = Operation<SolanaOperationExtraRaw>;
+
+export type ExtraStakeInfo = {
+  address: string;
+  amount: BigNumber;
+};
+
+export type ExtraStakeInfoRaw = {
+  address: string;
+  amount: string;
+};
 
 export type SolanaOperationExtra = {
   memo?: string;
+  stake?: ExtraStakeInfo;
+};
+
+export type SolanaOperationExtraRaw = {
+  memo?: string;
+  stake?: ExtraStakeInfoRaw;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

**Issue:**
After staking SOL, the initial balance increases and balances history on the graph becomes incorrect.

Having research this, we found that this is connected to staking operations containing delegated SOL in their `value` field.
Balances history in graph is calculated from now to past, starting from the current account balance, by applying operations values on the account balance for a given period of time.
Since account balance already contains staked SOL, when delegate/withdraw operation values are applied to the balance, the graph history becomes incorrect, increasing its amount by delegated `Operation.value`.

**Fix:**
Elrond and Cosmos were used as examples for this fix.
- [LLC] Updated delegate/withdraw operations `value` to keep fee instead of delegated amount.
- [LLC] Added delegated amount and address to `OperationExtra` fields for delegate/withdraw operations
- [LLD & LLM] Render additional `OperationExtra` fields (validators, withdrawn from, etc.) in OperationDetails drawer (withdraw,delegate ops).

#### LLD
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/41d227aa-149e-45b8-81b5-7c870951b0dd" height="500" />
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/3f981b18-6b29-4b8d-82de-f3283a347cb1" height="500" />


#### LLM
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/15614926-01a1-4b7e-9bcb-ee05c16e1a7a" height="500" />
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/8ceda358-5ea4-4b78-9027-987da2763cef" height="500" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [https://ledgerhq.atlassian.net/browse/LIVE-11245](https://ledgerhq.atlassian.net/browse/LIVE-11245)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Check your balance then stake SOL. Balance and graph history should be correct.
  - Delegate operation details should display extra data: validator and amount being staked. 
  - Deactivate stake then withdraw stake. Withdraw operation details should display extra data: ATA address and withdrawn amount. Balance should be correct.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
