### PR TITLE
fix(LIVE-11282): close platform drawer

### DIFF
--- a/.changeset/heavy-wombats-confess.md
+++ b/.changeset/heavy-wombats-confess.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(LIVE-11282): close platform drawer from firmware update error state

--- a/apps/ledger-live-desktop/src/renderer/actions/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/modals.ts
@@ -1,5 +1,4 @@
-
-import { Action, ActionFunctionAny, createAction } from "redux-actions";
+import { createAction } from "redux-actions";
 import { ModalData } from "~/renderer/modals/types";
 
 function openModalF<Name extends keyof ModalData>(name: Name, data: ModalData[Name]) {

--- a/apps/ledger-live-desktop/src/renderer/actions/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/modals.ts
@@ -1,4 +1,5 @@
-import { createAction } from "redux-actions";
+
+import { Action, ActionFunctionAny, createAction } from "redux-actions";
 import { ModalData } from "~/renderer/modals/types";
 
 function openModalF<Name extends keyof ModalData>(name: Name, data: ModalData[Name]) {

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -222,7 +222,6 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
 
   const modelId = device ? device.modelId : overridesPreferredDeviceModel || preferredDeviceModel;
 
-
   useEffect(() => {
     if (modelId !== preferredDeviceModel) {
       dispatch(setPreferredDeviceModel(modelId));

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -213,7 +213,6 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     signMessageRequested,
   } = hookState;
 
-
   const dispatch = useDispatch();
   const preferredDeviceModel = useSelector(preferredDeviceModelSelector);
   const swapDefaultTrack = useGetSwapTrackingProperties();

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -213,6 +213,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     signMessageRequested,
   } = hookState;
 
+
   const dispatch = useDispatch();
   const preferredDeviceModel = useSelector(preferredDeviceModelSelector);
   const swapDefaultTrack = useGetSwapTrackingProperties();
@@ -220,6 +221,8 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   const type = useTheme().colors.palette.type;
 
   const modelId = device ? device.modelId : overridesPreferredDeviceModel || preferredDeviceModel;
+
+
   useEffect(() => {
     if (modelId !== preferredDeviceModel) {
       dispatch(setPreferredDeviceModel(modelId));

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -288,7 +288,15 @@ const OpenManagerBtn = ({
     closeAllModal();
     closePlatformAppDrawer();
     setDrawer(undefined);
-  }, [updateApp, firmwareUpdate, appName, history, closeAllModal, setDrawer]);
+  }, [
+    updateApp,
+    firmwareUpdate,
+    appName,
+    history,
+    closeAllModal,
+    closePlatformAppDrawer,
+    setDrawer,
+  ]);
 
   return (
     <Button mt={mt} ml={ml} primary onClick={onClick}>

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -67,6 +67,7 @@ import { openURL } from "~/renderer/linking";
 import Installing from "~/renderer/modals/UpdateFirmwareModal/Installing";
 import { ErrorBody } from "../ErrorBody";
 import LinkWithExternalIcon from "../LinkWithExternalIcon";
+import { closePlatformAppDrawer } from "~/renderer/actions/UI";
 
 export const AnimationWrapper = styled.div`
   width: 600px;
@@ -254,6 +255,7 @@ export const renderVerifyUnwrapped = ({
 
 const OpenManagerBtn = ({
   closeAllModal,
+  closePlatformAppDrawer,
   appName,
   updateApp,
   firmwareUpdate,
@@ -261,6 +263,7 @@ const OpenManagerBtn = ({
   ml = 0,
 }: {
   closeAllModal: () => void;
+  closePlatformAppDrawer: () => void;
   appName?: string;
   updateApp?: boolean;
   firmwareUpdate?: boolean;
@@ -283,6 +286,7 @@ const OpenManagerBtn = ({
       search: search ? `?${search}` : "",
     });
     closeAllModal();
+    closePlatformAppDrawer();
     setDrawer(undefined);
   }, [updateApp, firmwareUpdate, appName, history, closeAllModal, setDrawer]);
 
@@ -312,7 +316,10 @@ const OpenOnboardingBtn = () => {
   );
 };
 
-const OpenManagerButton = connect(null, { closeAllModal })(OpenManagerBtn);
+const OpenManagerButton = connect(null, {
+  closeAllModal,
+  closePlatformAppDrawer,
+})(OpenManagerBtn);
 
 export const renderRequiresAppInstallation = ({ appNames }: { appNames: string[] }) => {
   const appNamesCSV = appNames.join(", ");
@@ -777,13 +784,7 @@ export const renderError = ({
                 mx={1}
               />
             ) : null}
-            {withOpenManager ? (
-              <OpenManagerButton mt={0} ml={withExportLogs ? 4 : 0} />
-            ) : onRetry && inlineRetry ? (
-              <Button primary ml={withExportLogs ? 4 : 0} onClick={onRetry}>
-                {t("common.retry")}
-              </Button>
-            ) : null}
+
             {withOnboardingCTA ? <OpenOnboardingBtn /> : null}
             {buyLedger ? (
               <LinkWithExternalIcon

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -784,7 +784,13 @@ export const renderError = ({
                 mx={1}
               />
             ) : null}
-
+            {withOpenManager ? (
+              <OpenManagerButton mt={0} ml={withExportLogs ? 4 : 0} />
+            ) : onRetry && inlineRetry ? (
+              <Button primary ml={withExportLogs ? 4 : 0} onClick={onRetry}>
+                {t("common.retry")}
+              </Button>
+            ) : null}
             {withOnboardingCTA ? <OpenOnboardingBtn /> : null}
             {buyLedger ? (
               <LinkWithExternalIcon


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Prior to this PR, the drawer does not close. 

Although the main CTA dispatches the `MODAL_CLOSE_ALL` action, it does not effect this drawer. Because this drawer was triggered by `EXCHANGE_APP_DRAWER_OPEN`. 

Which needs to be closed by using the `PLATFORM_APP_DRAWER_CLOSE`.

I don't think this PR is a clean solution, I'm open to suggestions 

https://github.com/LedgerHQ/ledger-live/assets/138497251/8b0ec41f-e42f-49f7-937e-7b9635ca4546

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11282](https://ledgerhq.atlassian.net/browse/LIVE-11282)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11282]: https://ledgerhq.atlassian.net/browse/LIVE-11282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ