### PR TITLE
fix(llm): android preview when app is in background

### DIFF
--- a/.changeset/cuddly-rings-drive.md
+++ b/.changeset/cuddly-rings-drive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM ANDROID fix flag secure when app is background

--- a/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/apps/ledger-live-mobile/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -102,15 +102,19 @@ public class MainActivity extends ReactActivity {
     }
 
     @Override
-    protected void onPause() {
-        super.onPause();
+    public void onWindowFocusChanged(boolean hasFocus) {
+    super.onWindowFocusChanged(hasFocus);
+    if (!hasFocus && !BuildConfig.DEBUG) {
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+        } else {
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        }
     }
+
 
     @Override
     protected void onResume() {
         super.onResume();
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
 
         /*
          * Override the detected language to english if it's a RTL language. TODO if we


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fix secure_flag for android. 
Native secure_flag makes a white screen when app is in background. 
Switched onPause for onWindowFocusChanged ( https://issuetracker.google.com/issues/237190495 )

<!--
| Before        | After         |
| ------------- | ------------- |
|        
       |               |
-->
Before
![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/0461f079-4bc6-4383-a3ba-30bf7e41cdb1)
After
![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/81e9e6f0-c645-4a64-93ee-5c7c507842b2)

### ❓ Context

- **JIRA or GitHub link**:[LIVE-10673](https://ledgerhq.atlassian.net/browse/LIVE-10673) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10673]: https://ledgerhq.atlassian.net/browse/LIVE-10673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ