### PR TITLE
[LIVE-10057] Feature: Add support for `chainId` in @ledgerhq/hw-app-eth and @ledgerhq/coin-evm address retrieval

### DIFF
--- a/.changeset/pretty-cobras-carry.md
+++ b/.changeset/pretty-cobras-carry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Add `chainId` while using the `hw-getAddress` method to display the network name and logo on a Stax device

--- a/.changeset/warm-jobs-crash.md
+++ b/.changeset/warm-jobs-crash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-eth": minor
+---
+
+Add option to specificy the `chainId` during a `getAddress` which will display the network name and logo on a Stax device

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/hw-getAddress.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/hw-getAddress.unit.test.ts
@@ -1,26 +1,34 @@
 import eip55 from "eip55";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import type { EvmAddress, EvmSignature, EvmSigner } from "../../types/signer";
 import resolver from "../../hw-getAddress";
 
 const address = "0xc3f95102D5c8F2c83e49Ce3Acfb905eDfb7f37dE";
+const spy = jest.fn().mockImplementation(async () =>
+  Promise.resolve({
+    publicKey: "",
+    address: address.toLowerCase(),
+  }),
+);
 const mockSignerFactory = (
   _: string,
   fn: (signer: EvmSigner) => Promise<EvmAddress | EvmSignature>,
 ): Promise<EvmAddress | EvmSignature> =>
   fn({
-    getAddress: async () => ({
-      publicKey: "",
-      address: address.toLowerCase(),
-    }),
+    getAddress: spy,
   } as any);
 
 describe("EVM Family", () => {
   describe("hw-getAddress.ts", () => {
     it("should return an eip 55 encoded address", async () => {
       const getAddress = resolver(mockSignerFactory);
-      const response = await getAddress({} as any, {} as any);
+      const response = await getAddress(
+        {} as any,
+        { path: "44'/60'/0'/0/0", verify: true, currency: getCryptoCurrencyById("polygon") } as any,
+      );
       expect(response.address).toBe(address);
       expect(eip55.verify(response.address)).toBe(true);
+      expect(spy).toHaveBeenCalledWith("44'/60'/0'/0/0", true, false, "137");
     });
   });
 });

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/logic.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/logic.unit.test.ts
@@ -418,7 +418,13 @@ describe("EVM Family", () => {
       // you consider it an acceptable behaviour
       // especially while considering mobile
       // performances for this action
-      it("should have decent performances (10 syncHashes of each major EVM in less than 350ms on a computer)", () => {
+      //
+      // EDIT: Since the CAL went from ~9k to 14k+ tokens
+      // this test now takes longer to execute.
+      // Now changing to 550ms to hash
+      // when CI generally run it
+      // in under 450ms.
+      it("should have decent performances (10 syncHashes of each major EVM in less than 550ms on a computer)", () => {
         const start = performance.now();
         for (let i = 0; i < 10; i++) {
           getSyncHash(getCryptoCurrencyById("ethereum"));
@@ -426,7 +432,7 @@ describe("EVM Family", () => {
           getSyncHash(getCryptoCurrencyById("bsc"));
         }
         const now = performance.now();
-        expect(now - start).toBeLessThan(350);
+        expect(now - start).toBeLessThan(550);
       });
 
       it("should provide a hash not dependent on reference", () => {

--- a/libs/coin-modules/coin-evm/src/hw-getAddress.ts
+++ b/libs/coin-modules/coin-evm/src/hw-getAddress.ts
@@ -7,10 +7,11 @@ import { EvmAddress, EvmSignature, EvmSigner } from "./types/signer";
 const resolver = (
   signerContext: SignerContext<EvmSigner, EvmAddress | EvmSignature>,
 ): GetAddressFn => {
-  return async (deviceId: string, { path, verify }: GetAddressOptions) => {
+  return async (deviceId: string, { path, verify, currency }: GetAddressOptions) => {
     const { address, publicKey, chainCode } = (await signerContext(deviceId, signer =>
-      signer.getAddress(path, verify, false),
+      signer.getAddress(path, verify, false, currency?.ethereumLikeInfo?.chainId.toString()),
     )) as EvmAddress;
+
     return {
       address: eip55.encode(address),
       publicKey,

--- a/libs/ledgerjs/packages/hw-app-eth/README.md
+++ b/libs/ledgerjs/packages/hw-app-eth/README.md
@@ -120,6 +120,7 @@ get Ethereum address for a given BIP 32 path.
 *   `path` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** a path in BIP 32 format
 *   `boolDisplay` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**&#x20;
 *   `boolChaincode` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**&#x20;
+*   `chainId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
 
 ##### Examples
 

--- a/libs/ledgerjs/packages/hw-app-eth/src/Eth.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/Eth.ts
@@ -21,7 +21,14 @@ import { BigNumber } from "bignumber.js";
 // NB: these are temporary import for the deprecated fallback mechanism
 import { LedgerEthTransactionResolution, LoadConfig, ResolutionConfig } from "./services/types";
 import { log } from "@ledgerhq/logs";
-import { decodeTxInfo, hexBuffer, intAsHexBytes, maybeHexBuffer, splitPath } from "./utils";
+import {
+  decodeTxInfo,
+  hexBuffer,
+  intAsHexBytes,
+  maybeHexBuffer,
+  padHexString,
+  splitPath,
+} from "./utils";
 import { domainResolutionFlow } from "./modules/Domains";
 import ledgerService from "./services/ledger";
 import { EthAppNftNotSupported, EthAppPleaseEnableContractData } from "./errors";
@@ -106,6 +113,7 @@ export default class Eth {
    * @param path a path in BIP 32 format
    * @option boolDisplay optionally enable or not the display
    * @option boolChaincode optionally enable or not the chaincode request
+   * @option chainId optionally display the network clearly on a Stax device
    * @return an object with a publicKey, address and (optionally) chainCode
    * @example
    * eth.getAddress("44'/60'/0'/0/0").then(o => o.address)
@@ -114,17 +122,30 @@ export default class Eth {
     path: string,
     boolDisplay?: boolean,
     boolChaincode?: boolean,
+    chainId?: string,
   ): Promise<{
     publicKey: string;
     address: string;
     chainCode?: string;
   }> {
     const paths = splitPath(path);
-    const buffer = Buffer.alloc(1 + paths.length * 4);
+    let buffer = Buffer.alloc(1 + paths.length * 4);
     buffer[0] = paths.length;
     paths.forEach((element, index) => {
       buffer.writeUInt32BE(element, 1 + 4 * index);
     });
+
+    if (chainId) {
+      const chainIdBufferMask = Buffer.alloc(8, 0);
+      const chainIdBuffer = Buffer.from(padHexString(new BigNumber(chainId).toString(16)), "hex");
+      chainIdBufferMask.write(
+        chainIdBuffer.toString("hex"),
+        chainIdBufferMask.length - chainIdBuffer.length,
+        "hex",
+      );
+      buffer = Buffer.concat([buffer, chainIdBufferMask]);
+    }
+
     return this.transport
       .send(0xe0, 0x02, boolDisplay ? 0x01 : 0x00, boolChaincode ? 0x01 : 0x00, buffer)
       .then(response => {

--- a/libs/ledgerjs/packages/hw-app-eth/tests/Eth.unit.test.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/tests/Eth.unit.test.ts
@@ -466,6 +466,50 @@ describe("Eth app biding", () => {
       });
     });
 
+    test("getAddress with chain ID", async () => {
+      const transportHolesky = await openTransportReplayer(
+        RecordStore.fromString(`
+        => e00201001d058000002c8000003c8000000000000000000000000000000000004268
+        <= 41047d8d3c470d1cfd8525d9537efdb92319a13a9bc9e336b6621fa5a664d2591b60fcd4f7882b0ff07d5ea0697050c7d23428daa5beaf6268cbac1369c278c6d8ea28366342434437334344386538613432383434363632663041306537364437463739416664393333649000
+      `),
+      );
+      const ethHolesky = new Eth(transportHolesky);
+      const resultHolesky = await ethHolesky.getAddress("44'/60'/0'/0/0", true, false, "17000");
+      expect(resultHolesky).toEqual({
+        address: "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
+        publicKey:
+          "047d8d3c470d1cfd8525d9537efdb92319a13a9bc9e336b6621fa5a664d2591b60fcd4f7882b0ff07d5ea0697050c7d23428daa5beaf6268cbac1369c278c6d8ea",
+      });
+
+      const transportPolygon = await openTransportReplayer(
+        RecordStore.fromString(`
+        => e00201001d058000002c8000003c8000000000000000000000000000000000000089
+        <= 41047d8d3c470d1cfd8525d9537efdb92319a13a9bc9e336b6621fa5a664d2591b60fcd4f7882b0ff07d5ea0697050c7d23428daa5beaf6268cbac1369c278c6d8ea28366342434437334344386538613432383434363632663041306537364437463739416664393333649000
+      `),
+      );
+      const ethPolygon = new Eth(transportPolygon);
+      const resultPolygon = await ethPolygon.getAddress("44'/60'/0'/0/0", true, false, "137");
+      expect(resultPolygon).toEqual({
+        address: "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
+        publicKey:
+          "047d8d3c470d1cfd8525d9537efdb92319a13a9bc9e336b6621fa5a664d2591b60fcd4f7882b0ff07d5ea0697050c7d23428daa5beaf6268cbac1369c278c6d8ea",
+      });
+
+      const transportGoerli = await openTransportReplayer(
+        RecordStore.fromString(`
+        => e00201001d058000002c8000003c8000000000000000000000000000000000000005
+        <= 41047d8d3c470d1cfd8525d9537efdb92319a13a9bc9e336b6621fa5a664d2591b60fcd4f7882b0ff07d5ea0697050c7d23428daa5beaf6268cbac1369c278c6d8ea28366342434437334344386538613432383434363632663041306537364437463739416664393333649000
+      `),
+      );
+      const ethGoerli = new Eth(transportGoerli);
+      const resultGoerli = await ethGoerli.getAddress("44'/60'/0'/0/0", true, false, "5");
+      expect(resultGoerli).toEqual({
+        address: "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
+        publicKey:
+          "047d8d3c470d1cfd8525d9537efdb92319a13a9bc9e336b6621fa5a664d2591b60fcd4f7882b0ff07d5ea0697050c7d23428daa5beaf6268cbac1369c278c6d8ea",
+      });
+    });
+
     test("signTransaction", async () => {
       const transport = await openTransportReplayer(
         RecordStore.fromString(`


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Allows the `$@ledgerhq/hw-app-eth` and `@ledgerhq/coin-evm` to use the `chainId` parameter during address retrieval, displaying the network name and logo on a Stax device

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-10057

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - New APDU used during a `getAddress`

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
