### PR TITLE
[LIVE-10371] [LLD] 🐛 Ledger Live does not detect when moving from multi to single monitor

### DIFF
--- a/.changeset/brave-ducks-share.md
+++ b/.changeset/brave-ducks-share.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+This should fix a bug on Windows where LLD is running but you can’t see it if you have unplugged a second screen on which you had the Ledger Live app opened before


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

This should fix a bug on Windows where LLD is running but you can’t see it if you have unplugged a second screen on which you had the Ledger Live app opened before


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10371] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [x] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [x] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10371]: https://ledgerhq.atlassian.net/browse/LIVE-10371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ