### PR TITLE
[LIVE-11121] LLD - Fix Transaction details drawer empty when using third party app

### DIFF
--- a/.changeset/quiet-fireants-fry.md
+++ b/.changeset/quiet-fireants-fry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fixes display of operation details drawer

--- a/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/Toast.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/Toast.tsx
@@ -132,7 +132,7 @@ export function Toast({
     <>
       {transitions.map(({ key, props }) => (
         <Wrapper key={key} style={props} onClick={onClick}>
-          <Content>
+          <Content data-test-id="toaster">
             <IconContainer color={defaultIconColor}>
               <Icon size={19} />
             </IconContainer>

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -96,7 +96,9 @@ const mapStateToProps = (
         })
       : undefined;
   let account: AccountLike | undefined | null;
-  if (parentAccount) {
+  if (parentAccount && parentId === accountId) {
+    account = parentAccount;
+  } else if (parentAccount) {
     account = findSubAccountById(parentAccount, accountId);
   } else {
     account = accountSelector(state, {

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -458,18 +458,18 @@ test("Wallet API methods @smoke", async ({ page }) => {
     await modal.continueToSignTransaction();
 
     // Step Device
-    await page.waitForTimeout(3000);
     await deviceAction.silentSign();
-    await page.waitForTimeout(3000);
-    // NOTE: toaster not visible in scre
+
+    // Click on notification toaster
+    // NOTE: toaster not visible in output, need to find a better way to handle css animations
     // await page.waitForSelector('[data-test-id="toaster"][style="opacity: 1;"]');
     const toaster = page.locator("data-test-id=toaster");
     await toaster.scrollIntoViewIfNeeded();
     await expect(toaster).toBeVisible();
     await expect(toaster.getByText("Transaction sent !")).toBeVisible();
-    await toaster.click()
-    await page.waitForTimeout(3000);
 
+    // Display transaction drawer
+    await toaster.click();
     const drawer = page.locator("data-test-id=drawer-content");
     await expect(drawer).toBeVisible();
     await expect(drawer.getByText("View in explorer")).toBeVisible();

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -458,7 +458,22 @@ test("Wallet API methods @smoke", async ({ page }) => {
     await modal.continueToSignTransaction();
 
     // Step Device
+    await page.waitForTimeout(3000);
     await deviceAction.silentSign();
+    await page.waitForTimeout(3000);
+    // NOTE: toaster not visible in scre
+    // await page.waitForSelector('[data-test-id="toaster"][style="opacity: 1;"]');
+    const toaster = page.locator("data-test-id=toaster");
+    await toaster.scrollIntoViewIfNeeded();
+    await expect(toaster).toBeVisible();
+    await expect(toaster.getByText("Transaction sent !")).toBeVisible();
+    await toaster.click()
+    await page.waitForTimeout(3000);
+
+    const drawer = page.locator("data-test-id=drawer-content");
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByText("View in explorer")).toBeVisible();
+    await expect(drawer.getByText("Confirmed")).toBeVisible();
 
     await expect(response).resolves.toStrictEqual({
       id,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->


### 📝 Description

- Set account to parent account if same id in `operationdetails` drawer

### How we end up with parentAccountId being the same value of accountId 

<img width="400" alt="SCR-20240227-lsqr" src="https://github.com/LedgerHQ/ledger-live/assets/5050709/68e92a13-4027-4e29-81fe-6f250df201ed">  <img width="400" alt="SCR-20240227-lpkb" src="https://github.com/LedgerHQ/ledger-live/assets/5050709/0ce90b35-9a8d-4711-8ac0-e4ebf59f4b9b">

0.  In [wallet-api/logic.ts](https://github.com/LedgerHQ/ledger-live/blob/9098224d29ff811c286e51c2179354dde22a08f4/libs/ledger-live-common/src/wallet-api/logic.ts#L101), we set parentAccount to getParentAccount(account, accounts)

In [getParentAccount](https://github.com/LedgerHQ/ledger-live/blob/9098224d29ff811c286e51c2179354dde22a08f4/libs/coin-framework/src/account/helpers.ts#L374), we return the account passed if it is of type `Account`. 

**Thus if selected a non-child / token account, parent account will be set to the same account.** 

1. Here, if a parentAccount is passed, account was searched on that parentAccount subaccounts, which ended up being undefined.


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/623?selectedIssue=LIVE-11121

### Final result 

<img width="1265" alt="SCR-20240227-lvji" src="https://github.com/LedgerHQ/ledger-live/assets/5050709/8621e64d-4ed9-49fb-9d90-b75ca0507410">


### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** Fixes display of data in transaction details drawer when using wallet-api.
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
