### PR TITLE
Safer solana hydrate

### DIFF
--- a/.changeset/unlucky-bottles-dress.md
+++ b/.changeset/unlucky-bottles-dress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Safer solana hydrate

--- a/libs/ledger-live-common/src/families/solana/js-preload.test.ts
+++ b/libs/ledger-live-common/src/families/solana/js-preload.test.ts
@@ -1,0 +1,14 @@
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { hydrate } from "./js-preload";
+import { SolanaPreloadData } from "./types";
+
+describe("hydrate", () => {
+  it.each([undefined, null, {}, { version: null }, { version: undefined }, {}])(
+    "should return undefined if data is corrupted (%p value)",
+    value => {
+      expect(hydrate(value as unknown as SolanaPreloadData, {} as CryptoCurrency)).toEqual(
+        undefined,
+      );
+    },
+  );
+});

--- a/libs/ledger-live-common/src/families/solana/js-preload.ts
+++ b/libs/ledger-live-common/src/families/solana/js-preload.ts
@@ -53,6 +53,7 @@ async function loadDevnetValidators(api: ChainAPI) {
 }
 
 export function hydrate(data: SolanaPreloadData | undefined, currency: CryptoCurrency): void {
+  // https://ledgerhq.atlassian.net/browse/LIVE-11568 covers unknown case where version is undefined
   if (data == null || data.version == null) {
     return;
   }

--- a/libs/ledger-live-common/src/families/solana/js-preload.ts
+++ b/libs/ledger-live-common/src/families/solana/js-preload.ts
@@ -53,7 +53,7 @@ async function loadDevnetValidators(api: ChainAPI) {
 }
 
 export function hydrate(data: SolanaPreloadData | undefined, currency: CryptoCurrency): void {
-  if (data === undefined) {
+  if (data == null || data.version == null) {
     return;
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Solana preloaded data somehow ends up with a data without version, this PR adds a safer check before hydrate

I cannot reproduce so it looks like it is not consistent, anyway hydrate data field should be treated as unsafe, if data is corrupted we have to return; directly.

```
// reinject the preloaded data (typically if it was cached)
// method need to treat the data object as unsafe and validate all fields / be backward compatible.
hydrate(data: unknown, currency: CryptoCurrency): void;
```

If it's unsafe we drop it and rely on fresh data. It looks like in the sentry issue case the user somehow ended up with preload data without version which should not happen as you can see on linked screenshot

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [https://ledgerhq.atlassian.net/browse/LIVE-11568](https://ledgerhq.atlassian.net/browse/LIVE-11568)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** Solana hydrate
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
