### PR TITLE
bugfix/LIVE 11546 llm swap text overlap when user doesnt have enough eth in parent account for fees

### DIFF
--- a/.changeset/yellow-geese-trade.md
+++ b/.changeset/yellow-geese-trade.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix(11546): extra right margin to prevent unreadable warning message in LLM swap form input

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/TxForm/From.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/TxForm/From.tsx
@@ -130,6 +130,7 @@ export function From({ swapTx, provider, swapError, swapWarning, isSendMaxLoadin
             <WarningSolidMedium size={20} color={swapError ? "error.c50" : "orange"} />
             <Text
               marginY={4}
+              marginRight={8}
               color={swapError ? "error.c50" : "orange"}
               textAlign="left"
               fontWeight="medium"


### PR DESCRIPTION
### 📝 Description

Extra right margin on error / warning text to prevent text from overlapping


| Before        | After         |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-28 at 13 51 21](https://github.com/LedgerHQ/ledger-live/assets/138497251/d6540537-2313-44e0-879b-14c705f94e1f)               |             ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-02-28 at 13 51 16](https://github.com/LedgerHQ/ledger-live/assets/138497251/ec79a43b-95e0-4785-a0fc-312b52bb7339)  |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11547](https://ledgerhq.atlassian.net/browse/LIVE-11547)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11547]: https://ledgerhq.atlassian.net/browse/LIVE-11547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ