### PR TITLE
bugfix: check for disableSlowStrategy in ethFee drawer

### DIFF
--- a/.changeset/hip-peaches-retire.md
+++ b/.changeset/hip-peaches-retire.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+bugfix: desktop eth drawer accept disabledSlowFee

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
@@ -7,7 +7,7 @@ import {
   Strategy,
 } from "@ledgerhq/coin-evm/types/index";
 import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
-import { Account, FeeStrategy } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/types-live";
 import React, { memo, useMemo } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
@@ -20,7 +20,6 @@ import TachometerHigh from "~/renderer/icons/TachometerHigh";
 import TachometerLow from "~/renderer/icons/TachometerLow";
 import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import BigNumber from "bignumber.js";
 
 type Props = {
   onClick: (_: { feesStrategy: Strategy }) => void;
@@ -215,7 +214,16 @@ const SelectFeeStrategy = ({
           </FeesWrapper>
         );
       }),
-    [accountUnit, feesCurrency, gasOptions, messageGas, onClick, transaction, transactionToUpdate],
+    [
+      accountUnit,
+      feesCurrency,
+      gasOptions,
+      messageGas,
+      onClick,
+      transaction,
+      disableSlowStrategy,
+      transactionToUpdate,
+    ],
   );
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
@@ -114,12 +114,6 @@ const SelectFeeStrategy = ({
               feeData: gasOption,
             })) ||
           (strategy === "slow" && disableSlowStrategy);
-        console.log(
-          "%capps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx:118 disabled, ",
-          "color: #007acc;",
-          disabled,
-          disableSlowStrategy,
-        );
         const selected = !disabled && transaction.feesStrategy === strategy;
 
         return (

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
@@ -7,7 +7,7 @@ import {
   Strategy,
 } from "@ledgerhq/coin-evm/types/index";
 import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
-import { Account } from "@ledgerhq/types-live";
+import { Account, FeeStrategy } from "@ledgerhq/types-live";
 import React, { memo, useMemo } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
@@ -20,6 +20,7 @@ import TachometerHigh from "~/renderer/icons/TachometerHigh";
 import TachometerLow from "~/renderer/icons/TachometerLow";
 import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import BigNumber from "bignumber.js";
 
 type Props = {
   onClick: (_: { feesStrategy: Strategy }) => void;
@@ -28,6 +29,7 @@ type Props = {
   gasOptions: GasOptions;
   transactionToUpdate?: EvmTransaction;
   status: TransactionStatus;
+  disableSlowStrategy?: boolean;
 };
 
 const FeesWrapper = styled(Tabbable)<{ error?: boolean }>`
@@ -91,6 +93,7 @@ const SelectFeeStrategy = ({
   account,
   onClick,
   gasOptions,
+  disableSlowStrategy,
   transactionToUpdate,
   status,
 }: Props) => {
@@ -106,11 +109,18 @@ const SelectFeeStrategy = ({
         const estimatedFees = getEstimatedFees(getTypedTransaction(transaction, gasOption));
 
         const disabled =
-          !!transactionToUpdate &&
-          isStrategyDisabled({
-            transaction: transactionToUpdate,
-            feeData: gasOption,
-          });
+          (!!transactionToUpdate &&
+            isStrategyDisabled({
+              transaction: transactionToUpdate,
+              feeData: gasOption,
+            })) ||
+          (strategy === "slow" && disableSlowStrategy);
+        console.log(
+          "%capps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx:118 disabled, ",
+          "color: #007acc;",
+          disabled,
+          disableSlowStrategy,
+        );
         const selected = !disabled && transaction.feesStrategy === strategy;
 
         return (

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/SendAmountFields.tsx
@@ -14,6 +14,7 @@ export type SendAmountFieldsProps = {
   bridgePending?: boolean;
   trackProperties?: Record<string, unknown>;
   transactionToUpdate?: Transaction;
+  disableSlowStrategy?: boolean;
 };
 
 const AmountRelatedField = (props: SendAmountFieldsProps) => {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.tsx
@@ -65,6 +65,7 @@ export default function FeesDrawer({
             onChange={setTransaction}
             updateTransaction={updateTransaction}
             mapStrategies={mapStrategies}
+            disableSlowStrategy={disableSlowStrategy}
             trackProperties={{
               page: "Swap quotes",
               ...swapDefaultTrack,


### PR DESCRIPTION

### 📝 Description

Check for disableSlowStrategy in the ETH fee drawer. I did not reuse this mapStrategy function as it is specific to bitcoin. 

video shows disabled for fixed rate

https://github.com/LedgerHQ/ledger-live/assets/5360522/bfb1d09d-f1df-4bd1-b576-08a53b7fd519



### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-11585

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
