### PR TITLE
Revert "[BUGFIX] : Continue button was greyed out in step 1 of Send flow if the Account to debit is changed"

### DIFF
--- a/.changeset/polite-papayas-fold.md
+++ b/.changeset/polite-papayas-fold.md
@@ -1,5 +1,0 @@
----
-"ledger-live-desktop": patch
----
-
-Fix Continue button greyed out in step 1 of Send flow if the "Account to debit" is changed

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
@@ -46,7 +46,7 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
       onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));
       resetInitValue && resetInitValue();
     }
-  }, [bridge, onChangeTransaction, resetInitValue, transaction, value]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onChange = useCallback(
     async (recipient: string, maybeExtra?: OnChangeExtra | null) => {


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#6139