### PR TITLE
bugfix(LIVE-11608): llm swap wrong behaviour with the drawer

### DIFF
--- a/.changeset/chilly-hornets-smoke.md
+++ b/.changeset/chilly-hornets-smoke.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+fix(LIVE-11608): longer quote refresh rate for LLM to prevent frequent flow restart

--- a/apps/ledger-live-mobile/src/reducers/swap.ts
+++ b/apps/ledger-live-mobile/src/reducers/swap.ts
@@ -1,5 +1,5 @@
 import { Action, handleActions, ReducerMap } from "redux-actions";
-import { DEFAULT_SWAP_RATES_INTERVAL_MS } from "@ledgerhq/live-common/exchange/swap/const/timeout";
+import { DEFAULT_SWAP_RATES_LLM_INTERVAL_MS } from "@ledgerhq/live-common/exchange/swap/const/timeout";
 import { AvailableProviderV3, Pair } from "@ledgerhq/live-common/exchange/swap/types";
 import { SwapStateType } from "./types";
 import {
@@ -49,7 +49,7 @@ const handlers: ReducerMap<SwapStateType, SwapPayload> = {
       exchangeRate: payload,
       exchangeRateExpiration:
         payload?.tradeMethod === "fixed"
-          ? new Date(new Date().getTime() + DEFAULT_SWAP_RATES_INTERVAL_MS)
+          ? new Date(new Date().getTime() + DEFAULT_SWAP_RATES_LLM_INTERVAL_MS)
           : undefined,
     };
   },

--- a/libs/ledger-live-common/src/exchange/swap/const/timeout.ts
+++ b/libs/ledger-live-common/src/exchange/swap/const/timeout.ts
@@ -4,3 +4,8 @@ export const DEFAULT_SWAP_TIMEOUT_MS = 10000;
  * Default to 20 seconds for quotes refresh interval in millisecond
  */
 export const DEFAULT_SWAP_RATES_INTERVAL_MS = 20 * 1000;
+
+/**
+ * Default to 30 seconds LLM
+ */
+export const DEFAULT_SWAP_RATES_LLM_INTERVAL_MS = 30 * 1000;

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -88,6 +88,17 @@ export const useFromAmountStatusMessage = (
   }, [statusEntries, currency, estimatedFees, transaction?.amount, account?.id, parentAccount?.id]);
 };
 
+type UseSwapTransactionProps = {
+  accounts?: Account[];
+  setExchangeRate?: SetExchangeRateCallback;
+  defaultCurrency?: SwapSelectorStateType["currency"];
+  defaultAccount?: SwapSelectorStateType["account"];
+  defaultParentAccount?: SwapSelectorStateType["parentAccount"];
+  onNoRates?: OnNoRatesCallback;
+  excludeFixedRates?: boolean;
+  refreshRate?: number;
+};
+
 export const useSwapTransaction = ({
   accounts,
   setExchangeRate,
@@ -96,17 +107,8 @@ export const useSwapTransaction = ({
   defaultParentAccount = selectorStateDefaultValues.parentAccount,
   onNoRates,
   excludeFixedRates,
-}: {
-  accounts?: Account[];
-  setExchangeRate?: SetExchangeRateCallback;
-  defaultCurrency?: SwapSelectorStateType["currency"];
-  defaultAccount?: SwapSelectorStateType["account"];
-  defaultParentAccount?: SwapSelectorStateType["parentAccount"];
-  onNoRates?: OnNoRatesCallback;
-  excludeFixedRates?: boolean;
-  timeout?: number;
-  timeoutErrorMessage?: string;
-} = {}): SwapTransactionType => {
+  refreshRate,
+}: UseSwapTransactionProps = {}): SwapTransactionType => {
   const bridgeTransaction = useBridgeTransaction(() => ({
     account: defaultAccount,
     parentAccount: defaultParentAccount,
@@ -159,6 +161,7 @@ export const useSwapTransaction = ({
     toState,
     onNoRates,
     setExchangeRate,
+    countdown: refreshRate,
   });
 
   return {

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useProviderRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useProviderRates.ts
@@ -12,6 +12,7 @@ type Props = {
   toState: SwapSelectorStateType;
   onNoRates?: OnNoRatesCallback;
   setExchangeRate?: SetExchangeRateCallback | null | undefined;
+  countdown?: number;
 };
 
 export type UseProviderRatesResponse = {
@@ -26,9 +27,10 @@ export function useProviderRates({
   toState,
   onNoRates,
   setExchangeRate,
+  ...props
 }: Props): UseProviderRatesResponse {
   const [countdown, { startCountdown, resetCountdown, stopCountdown }] = useCountdown({
-    countStart: DEFAULT_SWAP_RATES_INTERVAL_MS / 1000,
+    countStart: props.countdown ?? DEFAULT_SWAP_RATES_INTERVAL_MS / 1000,
     countStop: 0,
   });
   const ptxSwapMoonpayProviderFlag = useFeature("ptxSwapMoonpayProvider");


### PR DESCRIPTION
### 📝 Description

Longer quote refresh rate to prevent swap confirmation flow restarting frequently 

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11608](https://ledgerhq.atlassian.net/browse/LIVE-11608)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11608]: https://ledgerhq.atlassian.net/browse/LIVE-11608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ