### PR TITLE
bugfix/LIVE 11608 llm swap wrong behaviour with the drawer

### DIFF
--- a/.changeset/good-pillows-kiss.md
+++ b/.changeset/good-pillows-kiss.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+fix(LIVE-11382): disable quote refresh during confirmation for LLM

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -41,6 +41,7 @@ import { SwapFormNavigatorParamList } from "~/components/RootNavigator/types/Swa
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import type { DetailsSwapParamList } from "../types";
 import { getAvailableProviders } from "@ledgerhq/live-common/exchange/swap/index";
+import { DEFAULT_SWAP_RATES_LLM_INTERVAL_MS } from "@ledgerhq/live-common/exchange/swap/const/timeout";
 
 type Navigation = StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.Account>;
 
@@ -84,6 +85,9 @@ export function SwapForm({
     setExchangeRate,
     onNoRates,
     excludeFixedRates: true,
+    refreshRate: DEFAULT_SWAP_RATES_LLM_INTERVAL_MS / 1000,
+    // Disable refresh when modal is shown
+    allowRefresh: !confirmed,
   });
 
   // @TODO: Try to check if we can directly have the right state from `useSwapTransaction`

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -109,7 +109,7 @@ export const useSwapTransaction = ({
   onNoRates,
   excludeFixedRates,
   refreshRate,
-  allowRefresh
+  allowRefresh,
 }: UseSwapTransactionProps = {}): SwapTransactionType => {
   const bridgeTransaction = useBridgeTransaction(() => ({
     account: defaultAccount,
@@ -164,7 +164,7 @@ export const useSwapTransaction = ({
     onNoRates,
     setExchangeRate,
     countdown: refreshRate,
-    allowRefresh
+    allowRefresh,
   });
 
   return {

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -97,6 +97,7 @@ type UseSwapTransactionProps = {
   onNoRates?: OnNoRatesCallback;
   excludeFixedRates?: boolean;
   refreshRate?: number;
+  allowRefresh?: boolean;
 };
 
 export const useSwapTransaction = ({
@@ -108,6 +109,7 @@ export const useSwapTransaction = ({
   onNoRates,
   excludeFixedRates,
   refreshRate,
+  allowRefresh
 }: UseSwapTransactionProps = {}): SwapTransactionType => {
   const bridgeTransaction = useBridgeTransaction(() => ({
     account: defaultAccount,
@@ -162,6 +164,7 @@ export const useSwapTransaction = ({
     onNoRates,
     setExchangeRate,
     countdown: refreshRate,
+    allowRefresh
   });
 
   return {

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useProviderRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useProviderRates.ts
@@ -13,6 +13,7 @@ type Props = {
   onNoRates?: OnNoRatesCallback;
   setExchangeRate?: SetExchangeRateCallback | null | undefined;
   countdown?: number;
+  allowRefresh?: boolean;
 };
 
 export type UseProviderRatesResponse = {
@@ -27,6 +28,7 @@ export function useProviderRates({
   toState,
   onNoRates,
   setExchangeRate,
+  allowRefresh = true,
   ...props
 }: Props): UseProviderRatesResponse {
   const [countdown, { startCountdown, resetCountdown, stopCountdown }] = useCountdown({
@@ -60,10 +62,10 @@ export function useProviderRates({
   });
 
   useEffect(() => {
-    if (countdown <= 0) {
+    if (countdown <= 0 && allowRefresh) {
       refetch();
     }
-  }, [countdown, refetch]);
+  }, [countdown, refetch, allowRefresh]);
 
   if (!fromState.amount || fromState.amount.lte(0)) {
     setExchangeRate?.(undefined);


### PR DESCRIPTION
### 📝 Description

- Make sure LLM quote refresh rate is 60 seconds
- Disable quote refresh during modal shown for confirmation

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10923]: https://ledgerhq.atlassian.net/browse/LIVE-10923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ