### PR TITLE
Bugfix/live 9301 infinite loader

### DIFF
--- a/.changeset/silly-ads-work.md
+++ b/.changeset/silly-ads-work.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Handle unresponsive event correctly in LLD

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -32,7 +32,7 @@ import {
   UserRefusedOnDevice,
   UserRefusedDeviceNameChange,
   UnresponsiveDeviceError,
-  TransportRaceCondition,
+  TransportPendingOperation,
 } from "@ledgerhq/errors";
 import {
   InstallingApp,
@@ -415,7 +415,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     });
   }
 
-  if (unresponsive || error instanceof TransportRaceCondition) {
+  if (unresponsive || error instanceof TransportPendingOperation) {
     return renderError({
       t,
       error: new UnresponsiveDeviceError(),

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -31,6 +31,8 @@ import {
   UserRefusedFirmwareUpdate,
   UserRefusedOnDevice,
   UserRefusedDeviceNameChange,
+  UnresponsiveDeviceError,
+  TransportRaceCondition,
 } from "@ledgerhq/errors";
 import {
   InstallingApp,
@@ -413,6 +415,15 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     });
   }
 
+  if (unresponsive || error instanceof TransportRaceCondition) {
+    return renderError({
+      t,
+      error: new UnresponsiveDeviceError(),
+      onRetry,
+      withExportLogs: false,
+    });
+  }
+
   if (!isLoading && error) {
     const e = error as unknown;
     if (
@@ -499,7 +510,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     return renderLockedDeviceError({ t, device, onRetry, inlineRetry });
   }
 
-  if ((!isLoading && !device) || unresponsive) {
+  if (!isLoading && !device) {
     return renderConnectYourDevice({
       modelId,
       type,

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -434,7 +434,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       return renderError({
         t,
         error,
-        managerAppName: error.managerAppName,
+        managerAppName: (error as { managerAppName: string }).managerAppName,
       });
     }
 
@@ -462,7 +462,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     }
 
     // workaround to catch ECONNRESET error and show better message
-    if (error?.message?.includes("ECONNRESET")) {
+    if ((error as Error)?.message?.includes("ECONNRESET")) {
       return renderError({
         t,
         error: new EConnResetError(),
@@ -478,7 +478,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     // All the error rendering needs to be unified, the same way we do for ErrorIcon
     // not handled here.
     if (
-      error instanceof UserRefusedFirmwareUpdate ||
+      (error as unknown) instanceof UserRefusedFirmwareUpdate ||
       (error as unknown) instanceof UserRefusedAllowManager ||
       (error as unknown) instanceof UserRefusedOnDevice ||
       (error as unknown) instanceof UserRefusedAddress ||

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5482,6 +5482,10 @@
       "title": "Something went wrong. Please reconnect your device",
       "description": "An action was already pending on the Ledger device. Please deny or reconnect."
     },
+    "UnresponsiveDeviceError": {
+      "title": "Something went wrong.",
+      "description": "Unable to access your device.\nAn action may be pending, please deny or try to reconnect."
+    },
     "TransportStatusError": {
       "title": "Something went wrong. Please reconnect your device",
       "description": "{{message}}"

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5478,7 +5478,7 @@
       "title": "Something went wrong. Please reconnect your device",
       "description": "{{message}}"
     },
-    "TransportRaceCondition": {
+    "TransportPendingOperation": {
       "title": "Something went wrong. Please reconnect your device",
       "description": "An action was already pending on the Ledger device. Please deny or reconnect."
     },

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -366,7 +366,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
    * then either: this current fw update step is skipped or this error is ignored
    * And in both cases: nothing should be displayed to the user (logs are saved).
    *
-   * Especially: a `TransportRaceCondition` error is to be expected since we chain multiple
+   * Especially: a `TransportPendingOperation` error is to be expected since we chain multiple
    * device actions that use different transport acquisition paradigms the action should,
    * however, retry to execute and resolve the error by itself.
    * There is no need to present the error to the user.

--- a/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
@@ -1,5 +1,5 @@
 import { Observable, of } from "rxjs";
-import { LockedDeviceError, TransportRaceCondition } from "@ledgerhq/errors";
+import { LockedDeviceError, TransportPendingOperation } from "@ledgerhq/errors";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 
 import { getDeviceInfoTask, internalGetDeviceInfoTask } from "../tasks/getDeviceInfo";
@@ -249,9 +249,9 @@ describe("getLatestAvailableFirmwareAction", () => {
         new Observable(o => {
           if (count < 1) {
             count++;
-            // Mocks the internal task, some shared error are thrown (like `TransportRaceCondition`)
+            // Mocks the internal task, some shared error are thrown (like `TransportPendingOperation`)
             // and caught by the `sharedLogicTaskWrapper`
-            o.error(new TransportRaceCondition());
+            o.error(new TransportPendingOperation());
           } else {
             o.next({ type: "data", deviceInfo: aDeviceInfo });
           }
@@ -291,7 +291,7 @@ describe("getLatestAvailableFirmwareAction", () => {
                 expect(error).toEqual(
                   expect.objectContaining({
                     type: "SharedError",
-                    name: "TransportRaceCondition",
+                    name: "TransportPendingOperation",
                     retrying: true,
                   }),
                 );

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -2,7 +2,7 @@ import {
   CantOpenDevice,
   DisconnectedDevice,
   LockedDeviceError,
-  TransportRaceCondition,
+  TransportPendingOperation,
   UnresponsiveDeviceError,
   TransportStatusErrorClassType,
   CustomErrorClassType,
@@ -49,7 +49,7 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
                 error instanceof UnresponsiveDeviceError ||
                 error instanceof CantOpenDevice ||
                 error instanceof DisconnectedDevice ||
-                error instanceof TransportRaceCondition
+                error instanceof TransportPendingOperation
               ) {
                 // Emits to the action an error event so it is aware of it (for ex locked device) before retrying
                 const event: SharedTaskEvent = {

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -229,14 +229,7 @@ const eventImplementation: Implementation = <SpecificType, GenericRequestType>(
 
             return concat(
               initialEvent,
-              !device
-                ? EMPTY
-                : task({ deviceId: device.deviceId, request }).pipe(
-                    filter(
-                      // unresponsiveDevice are for polling.
-                      event => (event as ImplementationEvent).type !== "unresponsiveDevice",
-                    ),
-                  ),
+              !device ? EMPTY : task({ deviceId: device.deviceId, request }),
             );
           }),
           catchError((error: Error) =>

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -8,7 +8,7 @@ import {
   DeviceExtractOnboardingStateError,
   DisconnectedDevice,
   CantOpenDevice,
-  TransportRaceCondition,
+  TransportPendingOperation,
   LockedDeviceError,
   UnexpectedBootloader,
   TransportExchangeTimeoutError,
@@ -139,7 +139,7 @@ export const isAllowedOnboardingStatePollingError = (error: unknown): boolean =>
       error instanceof DisconnectedDevice ||
       error instanceof DisconnectedDeviceDuringOperation ||
       error instanceof CantOpenDevice ||
-      error instanceof TransportRaceCondition ||
+      error instanceof TransportPendingOperation ||
       error instanceof TransportStatusError ||
       // A locked device is handled as an allowed error
       error instanceof LockedDeviceError)

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -124,7 +124,7 @@ export const TransportOpenUserCancelled = createCustomErrorClass("TransportOpenU
 export const TransportInterfaceNotAvailable = createCustomErrorClass(
   "TransportInterfaceNotAvailable",
 );
-export const TransportRaceCondition = createCustomErrorClass("TransportRaceCondition");
+export const TransportPendingOperation = createCustomErrorClass("TransportPendingOperation");
 export const TransportWebUSBGestureRequired = createCustomErrorClass(
   "TransportWebUSBGestureRequired",
 );

--- a/libs/ledgerjs/packages/hw-transport/src/Transport.ts
+++ b/libs/ledgerjs/packages/hw-transport/src/Transport.ts
@@ -1,7 +1,7 @@
 import EventEmitter from "events";
 import type { DeviceModel } from "@ledgerhq/devices";
 import {
-  TransportRaceCondition,
+  TransportPendingOperation,
   TransportError,
   StatusCodes,
   getAltStatusMessage,
@@ -339,7 +339,7 @@ export default class Transport {
 
     if (this.exchangeBusyPromise) {
       tracer.trace("Atomic exchange is already busy");
-      throw new TransportRaceCondition(
+      throw new TransportPendingOperation(
         "An action was already pending on the Ledger device. Please deny or reconnect.",
       );
     }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

In a case where the device is waiting for a user prompt (for example open Ethereum app)
The device action can result in an infinite loader because the unresponsive state of the device is not handled correctly.

- Fix the event implementation to don't filter out the unresponsive event
- Improve the displayed error in case of unresponsive event

Before:


https://github.com/LedgerHQ/ledger-live/assets/35492518/f0e7683a-a8e9-4caa-a42e-bbc0f2df9c25


After:

https://github.com/LedgerHQ/ledger-live/assets/35492518/0bf21772-45e8-46c2-ae90-563eed9e3fd2


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-9301]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** A new Error display is added in case of unresponsive event for LLD. Some changes are made in LLC, that impact LLD and LLM.
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-9301]: https://ledgerhq.atlassian.net/browse/LIVE-9301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ