### PR TITLE
fix(LIVE-11708): add check to useEffect to avoid multiple broadcasts

### DIFF
--- a/.changeset/perfect-crabs-arrive.md
+++ b/.changeset/perfect-crabs-arrive.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add check to useEffect

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Operation, SignedOperation } from "@ledgerhq/types-live";
 import { Exchange } from "@ledgerhq/live-common/exchange/platform/types";
@@ -106,6 +106,7 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
   }, [exchange, getCurrencyByAccount]);
 
   const broadcast = useBroadcast({ account, parentAccount });
+  const broadcastRef = useRef(false);
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();
   const [error, setError] = useState<Error>();
@@ -200,9 +201,13 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
   }, [onCancel, error, onClose]);
 
   useEffect(() => {
-    if (!signedOperation) return;
+    if (broadcastRef.current || !signedOperation) return;
     console.log("[moonpay] about to broadcast");
-    broadcast(signedOperation).then(onBroadcastSuccess, setError);
+    broadcast(signedOperation)
+      .then(onBroadcastSuccess, setError)
+      .finally(() => {
+        broadcastRef.current = true;
+      });
   }, [signedOperation, broadcast, onBroadcastSuccess, setError]);
 
   return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add check to useEffect to avoid multiple broadcast on success

### ❓ Context
https://ledgerhq.atlassian.net/browse/LIVE-11708

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
