### PR TITLE
fix(live-11468): prevent duplicate backend calls on swap cancellation or acceptance

### DIFF
--- a/.changeset/eight-mails-crash.md
+++ b/.changeset/eight-mails-crash.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+remove duplicate back-end call from LLD onBroadcastSuccess


### PR DESCRIPTION
### 📝 Description
 
This fix addresses an issue where two backend calls were made from Ledger Live Desktop (LLD) and the exchange SDK when a swap was canceled or accepted.

Changes:
- There is check in the `onBroadcastSuccess` function to determine if the `swapId` exists. If it does, this indicates that the swap was initiated from the exchange SDK, and there is no need to call `setBroadcastTransaction` in LLD.
- Replicated the old logic where, if `DISABLE_TRANSACTION_BROADCAST` is true, the 'canceled' API from the exchange SDK is called to maintain backward compatibility.

Before
<img width="1414" alt="SCR-20240314-kibc" src="https://github.com/LedgerHQ/ledger-live/assets/11476482/196a23a1-5179-4250-9b40-724af22f87a9">
 
After
<img width="1442" alt="SCR-20240311-sems" src="https://github.com/LedgerHQ/ledger-live/assets/11476482/68fc50d4-ace6-4814-82cd-9cb248b80504">
 
### ❓ Context
https://ledgerhq.atlassian.net/browse/LIVE-11468

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
