### PR TITLE
[LIVE-11614] Bugfix - Update Operation amount on failed transaction

### DIFF
--- a/.changeset/weak-frogs-flow.md
+++ b/.changeset/weak-frogs-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Fix Operations' amount depending if failure and remove internal operations from a failed coin operation

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/etherscan.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/etherscan.unit.test.ts
@@ -385,6 +385,118 @@ describe("EVM Family", () => {
             expectedOperations,
           );
         });
+
+        it("should return an operation with the expected amount", () => {
+          const accountId = encodeAccountId({
+            type: "js",
+            version: "2",
+            currencyId: "ethereum",
+            xpubOrAddress: "0x9aa99c23f67c81701c772b106b4f83f6e858dd2e",
+            derivationMode: "",
+          });
+
+          const etherscanOpFees: EtherscanOperation = {
+            blockNumber: "14923692",
+            timeStamp: "1654646570",
+            hash: "0xaa45b4858ba44230a5fce5a29570a5dec2bf1f0ba95bacdec4fe8f2c4fa99338",
+            nonce: "7",
+            blockHash: "0x8df71a12a8c06b36c06c26bf6248857dd2a2b75b6edbb4e33e9477078897b282",
+            transactionIndex: "27",
+            from: "0x9aa99c23f67c81701c772b106b4f83f6e858dd2e",
+            to: "",
+            value: "0",
+            gas: "6000000",
+            gasPrice: "125521409858",
+            isError: "0",
+            txreceipt_status: "1",
+            input:
+              "0xa9059cbb000000000000000000000000313143c4088a47c469d06fe3fa5fd4196be6a4d600000000000000000000000000000000000000000003b8e97d229a2d54800000",
+            contractAddress: "0x4969d9fd2542e71e6b3ea87be54ea9a736bcc4e9",
+            cumulativeGasUsed: "1977481",
+            gasUsed: "57168",
+            confirmations: "122471",
+            methodId: "0xa9059cbb",
+            functionName: "transfer(address _to, uint256 _value)",
+          };
+
+          // Successful Op
+          expect(etherscanOperationToOperations(accountId, etherscanOpFees)[0].value).toEqual(
+            new BigNumber(etherscanOpFees.value).plus(
+              new BigNumber(etherscanOpFees.gasPrice).times(etherscanOpFees.gasUsed),
+            ),
+          );
+          // Failing Op
+          expect(
+            etherscanOperationToOperations(accountId, { ...etherscanOpFees, isError: "1" })[0]
+              .value,
+          ).toEqual(new BigNumber(etherscanOpFees.gasPrice).times(etherscanOpFees.gasUsed));
+
+          const etherscanOpOut: EtherscanOperation = {
+            blockNumber: "13807766",
+            timeStamp: "1639544926",
+            hash: "0x8d3e871469ce549c5a80b8c8beaae0d502ecea85bb43eb84703cebeea7d25944",
+            nonce: "11898499",
+            blockHash: "0xad04a8ed598c9c270f7ffd9a113224bc16fc285af814a2dc735c261620bad669",
+            transactionIndex: "394",
+            from: "0x9aa99c23f67c81701c772b106b4f83f6e858dd2e",
+            to: "0x26e3fd2dec89bf645ba7b41c4ddfad8454ee6245",
+            value: "143141441418750645",
+            gas: "210000",
+            gasPrice: "68363841693",
+            isError: "0",
+            txreceipt_status: "1",
+            input: "0x",
+            contractAddress: "",
+            cumulativeGasUsed: "14788393",
+            gasUsed: "21000",
+            confirmations: "2582470",
+            methodId: "0x",
+            functionName: "",
+          };
+
+          // Successful Op
+          expect(etherscanOperationToOperations(accountId, etherscanOpOut)[0].value).toEqual(
+            new BigNumber(etherscanOpOut.value).plus(
+              new BigNumber(etherscanOpOut.gasPrice).times(etherscanOpOut.gasUsed),
+            ),
+          );
+          // Failing Op
+          expect(
+            etherscanOperationToOperations(accountId, { ...etherscanOpOut, isError: "1" })[0].value,
+          ).toEqual(new BigNumber(etherscanOpOut.gasPrice).times(etherscanOpOut.gasUsed));
+
+          const etherscanOpIn: EtherscanOperation = {
+            blockNumber: "13807766",
+            timeStamp: "1639544926",
+            hash: "0x8d3e871469ce549c5a80b8c8beaae0d502ecea85bb43eb84703cebeea7d25944",
+            nonce: "11898499",
+            blockHash: "0xad04a8ed598c9c270f7ffd9a113224bc16fc285af814a2dc735c261620bad669",
+            transactionIndex: "394",
+            from: "0x26e3fd2dec89bf645ba7b41c4ddfad8454ee6245",
+            to: "0x9aa99c23f67c81701c772b106b4f83f6e858dd2e",
+            value: "143141441418750645",
+            gas: "210000",
+            gasPrice: "68363841693",
+            isError: "0",
+            txreceipt_status: "1",
+            input: "0x",
+            contractAddress: "",
+            cumulativeGasUsed: "14788393",
+            gasUsed: "21000",
+            confirmations: "2582470",
+            methodId: "0x",
+            functionName: "",
+          };
+
+          // Successful Op
+          expect(etherscanOperationToOperations(accountId, etherscanOpIn)[0].value).toEqual(
+            new BigNumber(etherscanOpIn.value),
+          );
+          // Failing Op
+          expect(
+            etherscanOperationToOperations(accountId, { ...etherscanOpIn, isError: "1" })[0].value,
+          ).toEqual(new BigNumber(etherscanOpIn.value));
+        });
       });
 
       describe("etherscanERC20EventToOperations", () => {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/ledger.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/ledger.unit.test.ts
@@ -522,6 +522,209 @@ describe("EVM Family", () => {
             expectedOperation2,
           ]);
         });
+
+        it("should return an operation with the expected amount", () => {
+          const randomAccountId = encodeAccountId({
+            type: "js",
+            version: "2",
+            currencyId: "ethereum",
+            xpubOrAddress: "0x9aa99c23f67c81701c772b106b4f83f6e858dd2e",
+            derivationMode: "",
+          });
+
+          const ledgerExplorerNoneOp: LedgerExplorerOperation = {
+            hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",
+            transaction_type: 2,
+            nonce: "0x4b",
+            nonce_value: 75,
+            value: "0",
+            gas: "62350",
+            gas_price: "81876963401",
+            max_fee_per_gas: "125263305914",
+            max_priority_fee_per_gas: "33000000000",
+            from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            to: "",
+            transfer_events: [
+              {
+                contract: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+                from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+                to: "0xc2907efcce4011c491bbeda8a0fa63ba7aab596c",
+                count: "100000000000000",
+              },
+            ],
+            erc721_transfer_events: [],
+            erc1155_transfer_events: [],
+            approval_events: [],
+            actions: [],
+            confirmations: 5968364,
+            input:
+              "0xa9059cbb000000000000000000000000313143c4088a47c469d06fe3fa5fd4196be6a4d600000000000000000000000000000000000000000003b8e97d229a2d54800000",
+            gas_used: "51958",
+            cumulative_gas_used: "16087064",
+            status: 1,
+            received_at: "2023-01-24T17:11:45Z",
+            block: {
+              hash: "0xcbd52de09904fd89a94b0638a8e39107e247d761e92411fd5b7b7d8b88641ddd",
+              height: 38476740,
+              time: "2023-01-24T17:11:45Z",
+            },
+          };
+
+          // Successful Op
+          expect(
+            ledgerOperationToOperations(randomAccountId, ledgerExplorerNoneOp)[0].value,
+          ).toEqual(new BigNumber(ledgerExplorerNoneOp.value));
+          // Failing Op
+          expect(
+            ledgerOperationToOperations(randomAccountId, { ...ledgerExplorerNoneOp, status: 0 })[0]
+              .value,
+          ).toEqual(new BigNumber(ledgerExplorerNoneOp.value));
+
+          const ledgerExplorerFeesOp: LedgerExplorerOperation = {
+            hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",
+            transaction_type: 2,
+            nonce: "0x4b",
+            nonce_value: 75,
+            value: "0",
+            gas: "62350",
+            gas_price: "81876963401",
+            max_fee_per_gas: "125263305914",
+            max_priority_fee_per_gas: "33000000000",
+            from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            to: "",
+            transfer_events: [
+              {
+                contract: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+                from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+                to: "0xc2907efcce4011c491bbeda8a0fa63ba7aab596c",
+                count: "100000000000000",
+              },
+            ],
+            erc721_transfer_events: [],
+            erc1155_transfer_events: [],
+            approval_events: [],
+            actions: [],
+            confirmations: 5968364,
+            input:
+              "0xa9059cbb000000000000000000000000313143c4088a47c469d06fe3fa5fd4196be6a4d600000000000000000000000000000000000000000003b8e97d229a2d54800000",
+            gas_used: "51958",
+            cumulative_gas_used: "16087064",
+            status: 1,
+            received_at: "2023-01-24T17:11:45Z",
+            block: {
+              hash: "0xcbd52de09904fd89a94b0638a8e39107e247d761e92411fd5b7b7d8b88641ddd",
+              height: 38476740,
+              time: "2023-01-24T17:11:45Z",
+            },
+          };
+
+          // Successful Op
+          expect(ledgerOperationToOperations(accountId, ledgerExplorerFeesOp)[0].value).toEqual(
+            new BigNumber(ledgerExplorerFeesOp.value).plus(
+              new BigNumber(ledgerExplorerFeesOp.gas_price).times(ledgerExplorerFeesOp.gas_used),
+            ),
+          );
+          // Failing Op
+          expect(
+            ledgerOperationToOperations(accountId, { ...ledgerExplorerFeesOp, status: 0 })[0].value,
+          ).toEqual(
+            new BigNumber(ledgerExplorerFeesOp.gas_price).times(ledgerExplorerFeesOp.gas_used),
+          );
+
+          const ledgerOperationOut: LedgerExplorerOperation = {
+            hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",
+            transaction_type: 2,
+            nonce: "0x4b",
+            nonce_value: 75,
+            value: "1",
+            gas: "62350",
+            gas_price: "81876963401",
+            max_fee_per_gas: "125263305914",
+            max_priority_fee_per_gas: "33000000000",
+            from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            to: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+            transfer_events: [
+              {
+                contract: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+                from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+                to: "0xc2907efcce4011c491bbeda8a0fa63ba7aab596c",
+                count: "100000000000000",
+              },
+            ],
+            erc721_transfer_events: [],
+            erc1155_transfer_events: [],
+            approval_events: [],
+            actions: [],
+            confirmations: 5968364,
+            input: null,
+            gas_used: "51958",
+            cumulative_gas_used: "16087064",
+            status: 1,
+            received_at: "2023-01-24T17:11:45Z",
+            block: {
+              hash: "0xcbd52de09904fd89a94b0638a8e39107e247d761e92411fd5b7b7d8b88641ddd",
+              height: 38476740,
+              time: "2023-01-24T17:11:45Z",
+            },
+          };
+
+          // Successful Op
+          expect(ledgerOperationToOperations(accountId, ledgerOperationOut)[0].value).toEqual(
+            new BigNumber(ledgerOperationOut.value).plus(
+              new BigNumber(ledgerOperationOut.gas_price).times(ledgerOperationOut.gas_used),
+            ),
+          );
+          // Failing Op
+          expect(
+            ledgerOperationToOperations(accountId, { ...ledgerOperationOut, status: 0 })[0].value,
+          ).toEqual(new BigNumber(ledgerOperationOut.gas_price).times(ledgerOperationOut.gas_used));
+
+          const ledgerOperationIn: LedgerExplorerOperation = {
+            hash: "0xf350d4f8e910419e2d5cec294d44e69af8c6185b7089061d33bb4fc246cefb79",
+            transaction_type: 2,
+            nonce: "0x4b",
+            nonce_value: 75,
+            value: "1",
+            gas: "62350",
+            gas_price: "81876963401",
+            max_fee_per_gas: "125263305914",
+            max_priority_fee_per_gas: "33000000000",
+            from: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+            to: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            transfer_events: [
+              {
+                contract: "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+                from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+                to: "0xc2907efcce4011c491bbeda8a0fa63ba7aab596c",
+                count: "100000000000000",
+              },
+            ],
+            erc721_transfer_events: [],
+            erc1155_transfer_events: [],
+            approval_events: [],
+            actions: [],
+            confirmations: 5968364,
+            input: null,
+            gas_used: "51958",
+            cumulative_gas_used: "16087064",
+            status: 1,
+            received_at: "2023-01-24T17:11:45Z",
+            block: {
+              hash: "0xcbd52de09904fd89a94b0638a8e39107e247d761e92411fd5b7b7d8b88641ddd",
+              height: 38476740,
+              time: "2023-01-24T17:11:45Z",
+            },
+          };
+
+          // Successful Op
+          expect(ledgerOperationToOperations(accountId, ledgerOperationIn)[0].value).toEqual(
+            new BigNumber(ledgerOperationOut.value),
+          );
+          // Failing Op
+          expect(
+            ledgerOperationToOperations(accountId, { ...ledgerOperationIn, status: 0 })[0].value,
+          ).toEqual(new BigNumber(ledgerOperationOut.value));
+        });
       });
 
       describe("ledgerERC20EventToOperations", () => {
@@ -1046,6 +1249,25 @@ describe("EVM Family", () => {
       });
 
       describe("ledgerInternalTransactionToOperations", () => {
+        it("should ignore explorer actions for a if the coin operation has failed", () => {
+          const ledgerAction: LedgerExplorerInternalTransaction = {
+            from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",
+            to: "0x49048044d57e1c92a77f79988d21fa8faf74e97e",
+            input: null,
+            value: "10000000000000000",
+            gas: "57090",
+            gas_used: "27485",
+            error: null,
+          };
+
+          expect(
+            ledgerInternalTransactionToOperations(
+              { ...coinOperation, hasFailed: true },
+              ledgerAction,
+            ),
+          ).toEqual([]);
+        });
+
         it("should convert a ledger explorer out action to a Ledger Live Operation", () => {
           const ledgerAction: LedgerExplorerInternalTransaction = {
             from: "0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d",

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -52,7 +52,7 @@ export const etherscanOperationToOperations = (
         id: encodeOperationId(accountId, etherscanOp.hash, type),
         hash: etherscanOp.hash,
         type,
-        value: type === "OUT" || type === "FEES" ? value.plus(fee) : hasFailed ? fee : value,
+        value: type === "OUT" || type === "FEES" ? (hasFailed ? fee : value.plus(fee)) : value,
         fee,
         senders: [from],
         recipients: [to],

--- a/libs/coin-modules/coin-evm/src/adapters/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/ledger.ts
@@ -52,7 +52,7 @@ export const ledgerOperationToOperations = (
         id: encodeOperationId(accountId, ledgerOp.hash, type),
         hash: ledgerOp.hash,
         type: type,
-        value: type === "OUT" || type === "FEES" ? value.plus(fee) : hasFailed ? fee : value,
+        value: type === "OUT" || type === "FEES" ? (hasFailed ? fee : value.plus(fee)) : value,
         fee,
         senders: [from],
         recipients: [to],
@@ -234,6 +234,8 @@ export const ledgerInternalTransactionToOperations = (
   action: LedgerExplorerInternalTransaction,
   index = 0,
 ): Operation[] => {
+  if (coinOperation.hasFailed) return [];
+
   const { hash, blockHeight, blockHash, date, accountId } = coinOperation;
   const { xpubOrAddress: address } = decodeAccountId(accountId);
   const from = safeEncodeEIP55(action.from);

--- a/libs/coin-modules/coin-evm/src/logic.ts
+++ b/libs/coin-modules/coin-evm/src/logic.ts
@@ -199,22 +199,9 @@ export const getSyncHash = (
     .join("");
   const isNftSupported = isNFTActive(currency);
   const { node = {}, explorer = {} } = currency.ethereumLikeInfo || {};
-  // Did the migration of token accounts IDs
-  // e.g. binance-peg_bsc-usd to binance#!dash!#peg#!underscore!#bsc#!dash!#usd
-  //
-  // This could theorically be removed after a decent amount of releases (~3/4),
-  // just the time necessary for every user to have a different
-  // hash at least once to avoid duplicated TokenAccounts.
-  // For a user with duplicates, a "clear cache"
-  // shoud be enough to fix everything.
-  const hasSafeTokenIdAccount = true;
 
   const stringToHash =
-    basicTokensListString +
-    isNftSupported +
-    JSON.stringify(node) +
-    JSON.stringify(explorer) +
-    hasSafeTokenIdAccount;
+    basicTokensListString + isNftSupported + JSON.stringify(node) + JSON.stringify(explorer);
 
   if (!simpleSyncHashMemoize[stringToHash]) {
     simpleSyncHashMemoize[stringToHash] = `0x${murmurhash(stringToHash).result().toString(16)}`;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Updates Operation behaviour regarding amount displayed on failed transaction and removes internal operations from a failed main operation to prevent errors in graph

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-11614

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Graph is now not displaying failed transaction (except for fees)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
