### PR TITLE
chore: unify rendering of Recover Banner

### DIFF
--- a/.changeset/silent-apricots-work.md
+++ b/.changeset/silent-apricots-work.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Unify rendering of Recover Banner.

--- a/apps/ledger-live-desktop/src/renderer/components/ContentCards/ActionCard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ContentCards/ActionCard/index.tsx
@@ -6,6 +6,7 @@ import { useInView } from "react-intersection-observer";
 
 type Props = {
   img?: string;
+  leftContent?: React.ReactNode;
 
   title: string;
   description: string;
@@ -24,7 +25,7 @@ type Props = {
   onView?: Function;
 };
 
-const ActionCard = ({ img, title, description, actions, onView }: Props) => {
+const ActionCard = ({ img, leftContent, title, description, actions, onView }: Props) => {
   const { ref, inView } = useInView({ threshold: 0.5, triggerOnce: true });
 
   useEffect(() => {
@@ -33,7 +34,7 @@ const ActionCard = ({ img, title, description, actions, onView }: Props) => {
 
   return (
     <CardContainer ref={ref}>
-      {img && <Header src={img} />}
+      {(img && <Header src={img} />) || leftContent}
       <Body>
         <Title>{title}</Title>
         <Description>{description}</Description>

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverBanner/RecoverBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverBanner/RecoverBanner.tsx
@@ -12,6 +12,7 @@ import styled from "styled-components";
 
 const Wrapper = styled(Card)`
   background-color: ${p => p.theme.colors.opacityPurple.c10};
+  margin: 20px 0px;
 `;
 
 /**

--- a/apps/ledger-live-desktop/src/renderer/components/RecoverBanner/RecoverBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/RecoverBanner/RecoverBanner.tsx
@@ -1,20 +1,23 @@
-import { Flex, Link, ProgressLoader, Text } from "@ledgerhq/react-ui";
+import { Flex, ProgressLoader, Text } from "@ledgerhq/react-ui";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { getStoreValue, setStoreValue } from "~/renderer/store";
 import { useCustomPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { useTranslation } from "react-i18next";
-import styled from "styled-components";
 import { RecoverBannerType } from "./types";
-import { Card } from "~/renderer/components/Box";
-import ButtonV3 from "~/renderer/components/ButtonV3";
+import ActionCard from "../ContentCards/ActionCard";
+import { Card } from "../Box";
+import styled from "styled-components";
 
-const BannerContainer = styled(Card)`
+const Wrapper = styled(Card)`
   background-color: ${p => p.theme.colors.opacityPurple.c10};
 `;
 
-export default function RecoverBanner() {
+/**
+ * @prop children: if a child is passed, it will be rendered instead of the default banner. this allows to do a passthrough to have first the recover banner, then the rest of the content.
+ */
+export default function RecoverBanner({ children }: { children?: React.ReactNode }) {
   const [storageData, setStorageData] = useState<string>();
   const [displayBannerData, setDisplayBannerData] = useState<boolean>();
   const [stepNumber, setStepNumber] = useState<number>(0);
@@ -23,6 +26,7 @@ export default function RecoverBanner() {
   const history = useHistory();
 
   const recoverServices = useFeature("protectServicesDesktop");
+
   const recoverBannerIsEnabled = recoverServices?.params?.bannerSubscriptionNotification;
   const protectID = recoverServices?.params?.protectId ?? "";
   const recoverUnfinishedOnboardingPath = useCustomPath(
@@ -84,72 +88,45 @@ export default function RecoverBanner() {
     getStorageSubscriptionState();
   }, [getStorageSubscriptionState]);
 
-  if (!recoverBannerIsEnabled || !recoverBannerSelected || !displayBannerData) return null;
+  const passthrough = children || null;
+  if (!recoverBannerIsEnabled || !recoverBannerSelected || !displayBannerData) return passthrough;
 
   return (
-    <BannerContainer>
-      <Flex
-        position="relative"
-        columnGap={12}
-        justifyContent="space-between"
-        alignItems="center"
-        borderRadius="8px"
-        overflow="hidden"
-        width="100%"
-      >
-        <Flex alignItems="center" justifyContent="center" ml={3} width={40}>
-          <ProgressLoader
-            progress={(stepNumber * 100) / maxStepNumber}
-            radius={20}
-            stroke={4}
-            showPercentage={false}
-          />
-          <Text
-            display="block"
-            flex={1}
-            textAlign="center"
-            fontSize="12px"
-            lineHeight="15px"
-            fontWeight="medium"
-          >
-            {`${stepNumber}/${maxStepNumber - 1}`}
-          </Text>
-        </Flex>
-        <Flex flex={1} flexDirection="column" py={3} overflow="hidden">
-          <Text
-            fontWeight="semiBold"
-            fontSize="14px"
-            lineHeight="16px"
-            whiteSpace="nowrap"
-            textOverflow="ellipsis"
-            width="100%"
-            overflow="hidden"
-          >
-            {recoverBannerSelected.title}
-          </Text>
-          <Text
-            mt={1}
-            fontSize="13px"
-            lineHeight="15px"
-            fontWeight="medium"
-            whiteSpace="nowrap"
-            textOverflow="ellipsis"
-            width="100%"
-            overflow="hidden"
-            color="pallette.neutral.c80"
-          >
-            {recoverBannerSelected.description}
-          </Text>
-        </Flex>
-        <Flex alignItems="center" p={3} pl={0} columnGap={3}>
-          <Link size="small" onClick={onCloseBanner}>
-            {recoverBannerSelected.secondaryCta}
-          </Link>
-          <ButtonV3 big variant="main" onClick={onRedirectRecover}>
-            {recoverBannerSelected.primaryCta}
-          </ButtonV3>
-        </Flex>
-      </Flex>
-    </BannerContainer>
+    <Wrapper>
+      <ActionCard
+        leftContent={
+          <Flex alignItems="center" justifyContent="center" ml={3} width={40}>
+            <ProgressLoader
+              progress={(stepNumber * 100) / maxStepNumber}
+              radius={20}
+              stroke={4}
+              showPercentage={false}
+            />
+            <Text
+              display="block"
+              flex={1}
+              textAlign="center"
+              fontSize="12px"
+              lineHeight="15px"
+              fontWeight="medium"
+            >
+              {`${stepNumber}/${maxStepNumber - 1}`}
+            </Text>
+          </Flex>
+        }
+        title={recoverBannerSelected.title}
+        description={recoverBannerSelected.description}
+        actions={{
+          primary: {
+            label: recoverBannerSelected.primaryCta,
+            action: onRedirectRecover,
+          },
+          dismiss: {
+            label: recoverBannerSelected.secondaryCta,
+            action: onCloseBanner,
+          },
+        }}
+      />
+    </Wrapper>
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/ActionContentCards.tsx
@@ -2,13 +2,10 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Carousel } from "@ledgerhq/react-ui";
 import { ABTestingVariants } from "@ledgerhq/types-live";
 import React, { PropsWithChildren } from "react";
-import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { useRefreshAccountsOrderingEffect } from "~/renderer/actions/general";
 import { Card } from "~/renderer/components/Box";
 import useActionCards from "~/renderer/hooks/useActionCards";
-import { accountsSelector } from "~/renderer/reducers/accounts";
-import { hasInstalledAppsSelector } from "~/renderer/reducers/settings";
 
 const ActionVariantA = styled(Card)`
   background-color: ${p => p.theme.colors.opacityPurple.c10};
@@ -39,15 +36,12 @@ const ActionVariantB = ({ children }: PropsWithChildren) => (
 const ActionContentCards = ({ variant }: { variant: ABTestingVariants }) => {
   const slides = useActionCards();
   const lldActionCarousel = useFeature("lldActionCarousel");
-  const totalAccounts = useSelector(accountsSelector).length;
-  const hasInstalledApps = useSelector(hasInstalledAppsSelector);
 
-  const showCarousel = lldActionCarousel?.enabled && hasInstalledApps && totalAccounts >= 0;
   useRefreshAccountsOrderingEffect({
     onMount: true,
   });
 
-  if (!showCarousel || slides.length === 0) return null;
+  if (!lldActionCarousel?.enabled || slides.length === 0) return null;
 
   if (
     lldActionCarousel?.params?.variant === ABTestingVariants.variantB &&

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
@@ -55,6 +55,7 @@ export default function DashboardPage() {
   const hasInstalledApps = useSelector(hasInstalledAppsSelector);
   const totalAccounts = accounts.length;
   const portfolioExchangeBanner = useFeature("portfolioExchangeBanner");
+  const lldActionCarousel = useFeature("lldActionCarousel");
   const totalCurrencies = useMemo(() => uniq(accounts.map(a => a.currency.id)).length, [accounts]);
   const totalOperations = useMemo(
     () => accounts.reduce((sum, a) => sum + a.operations.length, 0),
@@ -93,7 +94,7 @@ export default function DashboardPage() {
       </TopBannerContainer>
       <Box>
         <RecoverBanner>
-          {isActionCardsCampainRunning ? (
+          {isActionCardsCampainRunning && lldActionCarousel?.enabled ? (
             <ActionContentCards variant={ABTestingVariants.variantA} />
           ) : (
             <Carousel />

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
@@ -91,13 +91,14 @@ export default function DashboardPage() {
         <ClearCacheBanner />
         <CurrencyDownStatusAlert currencies={currencies} hideStatusIncidents />
       </TopBannerContainer>
-      <Box gap={"20px"}>
-        <RecoverBanner />
-        {isActionCardsCampainRunning ? (
-          <ActionContentCards variant={ABTestingVariants.variantA} />
-        ) : (
-          <Carousel />
-        )}
+      <Box>
+        <RecoverBanner>
+          {isActionCardsCampainRunning ? (
+            <ActionContentCards variant={ABTestingVariants.variantA} />
+          ) : (
+            <Carousel />
+          )}
+        </RecoverBanner>
       </Box>
       {isPostOnboardingBannerVisible && <PostOnboardingHubBanner />}
       <FeaturedButtons />


### PR DESCRIPTION
### 📝 Description

This makes sure that only one banner at a time is displayed, before this fix, the recover banner could appear on top of the content card banner, instead we have made it so the recover banner is first displayed before the second. This is implemented with a "passthrough" pattern (the RecoverBanner will render any children that is passed if it doesn't need to render anything, that way RecoverBanner remains decoupled from ContentCards)

On top of this, we have fixed inconsistencies in the UI of the Recover Banner that was fixed on this PR by making RecoverBanner renders an ActionCard. a leftContent generic prop was introduced to allow to inject custom left content instead of an image.

⚠️  I have only tested by modifying directly into the code to force enable recover banner because I couldn't properly access the dev environment of recover. Another QA / dev will need to take over to confirm the banner still works as attended, and notably in combination with Braze banners.

```
    //const storage = await getStoreValue("SUBSCRIPTION_STATE", protectID);
    //const displayBanner = await getStoreValue("DISPLAY_BANNER", protectID);
    const storage = "STARGATE_SUBSCRIBE";
    const displayBanner = "true";
```

https://github.com/LedgerHQ/ledger-live/assets/211411/12ed9ec6-b2f6-424b-bf09-d118dddb9953




### ❓ Context

- **JIRA or GitHub link**: [LIVE-11239]

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** we are far from being able to automate test for this unfortunately. but we should plan this – cc @KVNLS  <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - the Recover Banner and its behaviour when there is also content cards banner

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11239]: https://ledgerhq.atlassian.net/browse/LIVE-11239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ