### PR TITLE
fix: use payload as unique source of true swap native

### DIFF
--- a/apps/ledger-live-desktop/protocol.proto
+++ b/apps/ledger-live-desktop/protocol.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+package ledger_swap;
+
+message NewTransactionResponse {
+    string payin_address = 1;
+    string payin_extra_id = 2;
+    string refund_address = 3;
+    string refund_extra_id = 4;
+    string payout_address = 5;
+    string payout_extra_id = 6;
+    string currency_from = 7;
+    string currency_to = 8;
+    bytes  amount_to_provider = 9;
+    bytes  amount_to_wallet = 10;
+    string device_transaction_id = 11;
+    bytes device_transaction_id_ng = 12;
+}
+
+// (coefficient) * 10^(- exponent)
+message UDecimal {
+    bytes  coefficient = 1;
+    uint32 exponent = 2;
+}
+
+message NewSellResponse {
+    string   trader_email = 1;           // traderEmail
+    string   in_currency = 2;            // inCurrency
+    bytes    in_amount = 3;              // inAmount
+    string   in_address = 4;             // account
+    string   out_currency = 5;           // outCurrency
+    UDecimal out_amount = 6;             // outAmount
+    bytes    device_transaction_id = 7;  // nonce
+}
+
+message NewFundResponse {
+    string   user_id = 1;                // user ID
+    string   account_name = 2;           // funded account name ex: Card 1234
+    string   in_currency = 3;            // inCurrency
+    bytes    in_amount = 4;              // inAmount
+    string   in_address = 5;             // account
+    bytes    device_transaction_id = 6;  // nonce
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/SwapAction.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/SwapAction.tsx
@@ -22,6 +22,7 @@ import { getCurrentDevice } from "~/renderer/reducers/devices";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import initSwap from "@ledgerhq/live-common/exchange/swap/initSwap";
 import { Device } from "@ledgerhq/types-devices";
+import { BigNumber } from "bignumber.js";
 
 const transactionAction = transactionCreateAction(getEnv("MOCK") ? mockedEventEmitter : connectApp);
 const initAction = initSwapCreateAction(
@@ -55,7 +56,11 @@ const TransactionResult = (
 type Props = {
   swapTransaction: SwapTransactionType;
   exchangeRate: ExchangeRate;
-  onCompletion: (a: { operation: Operation; swapId: string }) => void;
+  onCompletion: (a: {
+    operation: Operation;
+    swapId: string;
+    magnitudeAwareRate: BigNumber;
+  }) => void;
   onError: (a: { error: Error; swapId?: string }) => void;
 };
 
@@ -92,12 +97,13 @@ export default function SwapAction({
 
   useEffect(() => {
     if (initData && signedOperation) {
-      const { swapId } = initData;
+      const { swapId, magnitudeAwareRate } = initData;
       broadcast(signedOperation).then(
         operation => {
           onCompletion({
             operation,
             swapId,
+            magnitudeAwareRate,
           });
         },
         error => {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/index.tsx
@@ -27,6 +27,7 @@ import { Separator } from "../Separator";
 import SwapAction from "./SwapAction";
 import SwapCompleted from "./SwapCompleted";
 import { Operation } from "@ledgerhq/types-live";
+import { BigNumber } from "bignumber.js";
 
 const ContentBox = styled(Box)`
   ${DeviceActionHeader} {
@@ -91,8 +92,16 @@ export default function ExchangeDrawer({ swapTransaction, exchangeRate, onComple
   );
 
   const onCompletion = useCallback(
-    (result: { operation: Operation; swapId: string }) => {
-      const { magnitudeAwareRate, provider } = exchangeRate;
+    ({
+      magnitudeAwareRate,
+      ...result
+    }: {
+      operation: Operation;
+      swapId: string;
+      magnitudeAwareRate: BigNumber;
+    }) => {
+      const { provider } = exchangeRate;
+
       setBroadcastTransaction({
         result,
         provider,

--- a/apps/ledger-live-desktop/tests/models/DeviceAction.ts
+++ b/apps/ledger-live-desktop/tests/models/DeviceAction.ts
@@ -299,6 +299,7 @@ export class DeviceAction {
           initSwapResult: {
             transaction,
             swapId: "12345",
+            magnitudeAwareRate: 1.397e11,
           },
         },
         {

--- a/apps/ledger-live-desktop/tests/specs/services/swap.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/swap.spec.ts
@@ -242,7 +242,7 @@ test.describe.parallel("Swap", () => {
       await swapPage.waitForExchangeDetails();
       await expect.soft(swapPage.detailsSwapId).toHaveText("12345");
       await expect.soft(drawer.swapAmountFrom).toContainText("-1.280"); // regex /-1.280\d+ BTC/ not working with toHaveText() and value can change after the first 3 decimals so this will have to do for now - see LIVE-8642
-      await expect.soft(drawer.swapAmountTo).toContainText("+17.898");
+      await expect.soft(drawer.swapAmountTo).toContainText("+17.8943438531 ETH");
       await expect.soft(drawer.swapAccountFrom).toHaveText("Bitcoin 2 (legacy)");
       await expect.soft(drawer.swapAccountTo).toHaveText("Ethereum 2");
 

--- a/apps/ledger-live-mobile/e2e/models/DeviceAction.ts
+++ b/apps/ledger-live-mobile/e2e/models/DeviceAction.ts
@@ -203,6 +203,7 @@ export default class DeviceAction {
         initSwapResult: {
           transaction,
           swapId: "12345",
+          magnitudeAwareRate: new BigNumber(50000),
         },
       },
       {

--- a/apps/ledger-live-mobile/protocol.proto
+++ b/apps/ledger-live-mobile/protocol.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+package ledger_swap;
+
+message NewTransactionResponse {
+    string payin_address = 1;
+    string payin_extra_id = 2;
+    string refund_address = 3;
+    string refund_extra_id = 4;
+    string payout_address = 5;
+    string payout_extra_id = 6;
+    string currency_from = 7;
+    string currency_to = 8;
+    bytes  amount_to_provider = 9;
+    bytes  amount_to_wallet = 10;
+    string device_transaction_id = 11;
+    bytes device_transaction_id_ng = 12;
+}
+
+// (coefficient) * 10^(- exponent)
+message UDecimal {
+    bytes  coefficient = 1;
+    uint32 exponent = 2;
+}
+
+message NewSellResponse {
+    string   trader_email = 1;           // traderEmail
+    string   in_currency = 2;            // inCurrency
+    bytes    in_amount = 3;              // inAmount
+    string   in_address = 4;             // account
+    string   out_currency = 5;           // outCurrency
+    UDecimal out_amount = 6;             // outAmount
+    bytes    device_transaction_id = 7;  // nonce
+}
+
+message NewFundResponse {
+    string   user_id = 1;                // user ID
+    string   account_name = 2;           // funded account name ex: Card 1234
+    string   in_currency = 3;            // inCurrency
+    bytes    in_amount = 4;              // inAmount
+    string   in_address = 5;             // account
+    bytes    device_transaction_id = 6;  // nonce
+}

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
@@ -30,6 +30,7 @@ import type { StackNavigatorNavigation } from "~/components/RootNavigator/types/
 import { ScreenName } from "~/const";
 import type { SwapNavigatorParamList } from "~/components/RootNavigator/types/SwapNavigator";
 import { useInitSwapDeviceAction, useTransactionDeviceAction } from "~/hooks/deviceActions";
+import { BigNumber } from "bignumber.js";
 
 export type DeviceMeta = {
   result: { installed: InstalledItem[] } | null | undefined;
@@ -88,7 +89,14 @@ export function Confirmation({
   const navigation = useNavigation<NavigationProp>();
 
   const onComplete = useCallback(
-    (result: { operation: Operation; swapId: string }) => {
+    ({
+      magnitudeAwareRate,
+      ...result
+    }: {
+      operation: Operation;
+      swapId: string;
+      magnitudeAwareRate: BigNumber;
+    }) => {
       const { operation, swapId } = result;
       /**
        * If transaction broadcast are disabled, consider the swap as cancelled
@@ -118,7 +126,10 @@ export function Confirmation({
                 transaction: swapTx.current.transaction as Transaction,
                 swap: {
                   exchange,
-                  exchangeRate: exchangeRate.current,
+                  exchangeRate: {
+                    ...exchangeRate.current,
+                    magnitudeAwareRate,
+                  },
                 },
                 swapId,
               }),
@@ -159,10 +170,10 @@ export function Confirmation({
 
   useEffect(() => {
     if (swapData && signedOperation) {
-      const { swapId } = swapData;
+      const { swapId, magnitudeAwareRate } = swapData;
       broadcast(signedOperation).then(
         operation => {
-          onComplete({ operation, swapId });
+          onComplete({ operation, swapId, magnitudeAwareRate });
         },
         error => {
           onError(error);

--- a/libs/ledger-live-common/src/exchange/swap/initSwap.ts
+++ b/libs/ledger-live-common/src/exchange/swap/initSwap.ts
@@ -18,6 +18,7 @@ import { delay } from "../../promise";
 import { getProviderConfig, getSwapAPIBaseURL } from "./";
 import { mockInitSwap } from "./mock";
 import type { InitSwapInput, SwapRequestEvent } from "./types";
+import { decodePayloadProtobuf } from "@ledgerhq/hw-app-exchange";
 
 const withDevicePromise = (deviceId, fn) =>
   firstValueFrom(withDevice(deviceId)(transport => from(fn(transport))));
@@ -36,6 +37,7 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
 
     const confirmSwap = async () => {
       let ignoreTransportError;
+      let magnitudeAwareRate;
       log("swap", `attempt to connect to ${deviceId}`);
       await withDevicePromise(deviceId, async transport => {
         const ratesFlag =
@@ -46,12 +48,11 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         const deviceTransactionId = await swap.startNewTransaction();
         if (unsubscribed) return;
 
-        const { provider, rateId, payoutNetworkFees } = exchangeRate;
+        const { provider, rateId } = exchangeRate;
         const { fromParentAccount, fromAccount, toParentAccount, toAccount } = exchange;
         const { amount } = transaction;
         const refundCurrency = getAccountCurrency(fromAccount);
         const unitFrom = getAccountUnit(exchange.fromAccount);
-        const unitTo = getAccountUnit(exchange.toAccount);
         const payoutCurrency = getAccountCurrency(toAccount);
         const refundAccount = getMainAccount(fromAccount, fromParentAccount);
         const payoutAccount = getMainAccount(toAccount, toParentAccount);
@@ -218,14 +219,15 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         // to properly render the amount on the device confirmation steps. Although changelly
         // made the calculation inside the binary payload, we still have to deal with it here
         // to not break their other clients.
-        let amountExpectedTo;
 
-        if (swapResult?.amountExpectedTo) {
-          amountExpectedTo = new BigNumber(swapResult.amountExpectedTo)
-            .times(new BigNumber(10).pow(unitTo.magnitude))
-            .minus(new BigNumber(payoutNetworkFees || 0))
-            .toString();
+        let amountExpectedTo;
+        if (swapResult.binaryPayload) {
+          const decodePayload = await decodePayloadProtobuf(swapResult.binaryPayload);
+          amountExpectedTo = new BigNumber(decodePayload.amountToWallet.toString());
         }
+
+        magnitudeAwareRate =
+          amountExpectedTo && transaction.amount && amountExpectedTo.dividedBy(transaction.amount);
 
         o.next({
           type: "init-swap-requested",
@@ -270,6 +272,7 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         initSwapResult: {
           transaction,
           swapId,
+          magnitudeAwareRate,
         },
       });
     };

--- a/libs/ledger-live-common/src/exchange/swap/mock.ts
+++ b/libs/ledger-live-common/src/exchange/swap/mock.ts
@@ -118,6 +118,7 @@ export const mockInitSwap = (
     initSwapResult: {
       transaction,
       swapId: "mockedSwapId",
+      magnitudeAwareRate: new BigNumber(50000),
     },
   });
 };

--- a/libs/ledger-live-common/src/exchange/swap/types.ts
+++ b/libs/ledger-live-common/src/exchange/swap/types.ts
@@ -163,6 +163,7 @@ export type GetExchangeRates = (
 export type InitSwapResult = {
   transaction: Transaction;
   swapId: string;
+  magnitudeAwareRate: BigNumber;
 };
 
 type ValidSwapStatus = "pending" | "onhold" | "expired" | "finished" | "refunded";

--- a/libs/ledgerjs/packages/hw-app-exchange/package.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/package.json
@@ -28,7 +28,8 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:^",
     "bignumber.js": "^9.1.2",
-    "invariant": "^2.2.2"
+    "invariant": "^2.2.2",
+    "protobufjs": "7.2.5"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-mocker": "workspace:^",
@@ -37,7 +38,6 @@
     "@types/node": "^20.8.10",
     "documentation": "14.0.2",
     "jest": "^29.7.0",
-    "protobufjs": "7.2.5",
     "secp256k1": "5.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.4.0"

--- a/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.test.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.test.ts
@@ -1,0 +1,56 @@
+import { decodePayloadProtobuf } from "./SwapUtils"; // Asegúrate de proporcionar la ruta correcta
+
+describe("decodePayloadProtobuf function", () => {
+  test("should decode NewTransactionResponse correctly with device transaction id", async () => {
+    const binaryPayload =
+      "0a2a3078393736633339353463356462626633396135393135313064623332643266386363323235323830371a2a3078636361454263423338373661373561623945393639373530353861413735343633373733303239632a2a626331717164796b647738753336796864736c657477737976347865393573333735716a6a7934676b303a0345544842034254434a10000000000000000001118f178fb48000521000000000000000000000000000080e355a0a5552554f4b5149424f42";
+    const decodedPayload = await decodePayloadProtobuf(binaryPayload);
+    expect(decodedPayload).toBeDefined();
+    expect(decodedPayload).toHaveProperty(
+      "payinAddress",
+      "0x976c3954c5dbbf39a591510db32d2f8cc2252807",
+    );
+    expect(decodedPayload).toHaveProperty(
+      "payoutAddress",
+      "bc1qqdykdw8u36yhdsletwsyv4xe95s375qjjy4gk0",
+    );
+    expect(decodedPayload).toHaveProperty(
+      "refundAddress",
+      "0xccaEBcB3876a75ab9E96975058aA75463773029c",
+    );
+    expect(decodedPayload).toHaveProperty("currencyFrom", "ETH");
+    expect(decodedPayload).toHaveProperty("currencyTo", "BTC");
+    expect(decodedPayload).toHaveProperty("deviceTransactionId", "URUOKQIBOB");
+    expect(decodedPayload).toHaveProperty("deviceTransactionIdNg", undefined);
+    expect(decodedPayload).toHaveProperty("amountToProvider", BigInt(77000000000000000));
+    expect(decodedPayload).toHaveProperty("amountToWallet", BigInt(527925));
+  });
+
+  test("should decode NewTransactionResponse correctly with device transaction id ng", async () => {
+    const binaryPayload =
+      "0a2a3078433945463730363132373141633234633533323933393134633842353932453844363130336642651a2a3078393437453537363639663843386332623136334234323035423844394542333138336130373841622a2a3078393437453537363639663843386332623136334234323035423844394542333138336130373841623a0362746342036274634a10000000000018911000000000000000005210c8f34b481ba8000000000000000000005a0131621000000000000000010000000000000000";
+    const decodedPayload = await decodePayloadProtobuf(binaryPayload);
+    expect(decodedPayload).toBeDefined();
+    expect(decodedPayload).toHaveProperty(
+      "payinAddress",
+      "0xC9EF7061271Ac24c53293914c8B592E8D6103fBe",
+    );
+    expect(decodedPayload).toHaveProperty(
+      "payoutAddress",
+      "0x947E57669f8C8c2b163B4205B8D9EB3183a078Ab",
+    );
+    expect(decodedPayload).toHaveProperty(
+      "refundAddress",
+      "0x947E57669f8C8c2b163B4205B8D9EB3183a078Ab",
+    );
+    expect(decodedPayload).toHaveProperty("currencyFrom", "btc");
+    expect(decodedPayload).toHaveProperty("currencyTo", "btc");
+    expect(decodedPayload).toHaveProperty("deviceTransactionId", "1");
+    expect(decodedPayload).toHaveProperty(
+      "deviceTransactionIdNg",
+      "00000000000000010000000000000000",
+    );
+    expect(decodedPayload).toHaveProperty("amountToProvider", BigInt(2.969925795867238e25));
+    expect(decodedPayload).toHaveProperty("amountToWallet", BigInt(2.671088541873143e38));
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/SwapUtils.ts
@@ -1,0 +1,59 @@
+import { loadSync } from "protobufjs";
+
+type SwapProtobufPayload = {
+  payinAddress: string;
+  payinExtraId?: string;
+  refundAddress: string;
+  refundExtraId?: string;
+  payoutAddress: string;
+  payoutExtraId?: string;
+  currencyFrom: string;
+  currencyTo: string;
+  amountToProvider: Buffer;
+  amountToWallet: Buffer;
+  message?: string;
+  deviceTransactionId?: string;
+  deviceTransactionIdNg?: Buffer;
+};
+
+export type SwapPayload = {
+  payinAddress: string;
+  payinExtraId?: string;
+  refundAddress: string;
+  refundExtraId?: string;
+  payoutAddress: string;
+  payoutExtraId?: string;
+  currencyFrom: string;
+  currencyTo: string;
+  amountToProvider: bigint;
+  amountToWallet: bigint;
+  message?: string;
+  deviceTransactionId?: string;
+  deviceTransactionIdNg?: string;
+};
+
+export async function decodePayloadProtobuf(hexBinaryPayload: string): Promise<SwapPayload> {
+  const buffer = Buffer.from(hexBinaryPayload, "hex");
+  const protoFilePath = "protocol.proto";
+  const root = loadSync(protoFilePath);
+  const TransactionResponse = root.lookupType("ledger_swap.NewTransactionResponse");
+  const err = TransactionResponse.verify(buffer);
+  if (err) {
+    throw Error(err);
+  }
+  const decodePayload = TransactionResponse.decode(buffer) as unknown as SwapProtobufPayload;
+  const {
+    amountToWallet: amountToWalletBuffer,
+    amountToProvider: amountToProviderBuffer,
+    deviceTransactionIdNg: deviceTransactionIdNgBuffer,
+  } = decodePayload;
+  const amountToWalletHexString = amountToWalletBuffer.toString("hex"); // Gets the hexadecimal representation from the Buffer
+  const amountToWallet = BigInt("0x" + amountToWalletHexString); // Convert hexadecimal representation to a big integer
+
+  const amountToProviderHexString = amountToProviderBuffer.toString("hex"); // Gets the hexadecimal representation from the Buffer
+  const amountToProvider = BigInt("0x" + amountToProviderHexString); // Convert hexadecimal representation to a big integer
+
+  const deviceTransactionIdNg = deviceTransactionIdNgBuffer?.toString("hex") || undefined;
+
+  return { ...decodePayload, amountToWallet, amountToProvider, deviceTransactionIdNg };
+}

--- a/libs/ledgerjs/packages/hw-app-exchange/src/index.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/index.ts
@@ -7,9 +7,11 @@ import Exchange, {
   isExchangeTypeNg,
   PayloadSignatureComputedFormat,
 } from "./Exchange";
+import { decodePayloadProtobuf } from "./SwapUtils";
 
 export {
   createExchange,
+  decodePayloadProtobuf,
   getExchangeErrorMessage,
   ExchangeTypes,
   RateTypes,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2977,6 +2977,9 @@ importers:
       invariant:
         specifier: ^2.2.2
         version: 2.2.4
+      protobufjs:
+        specifier: 7.2.5
+        version: 7.2.5
     devDependencies:
       '@ledgerhq/hw-transport-mocker':
         specifier: workspace:^
@@ -2996,9 +2999,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.8.10)(ts-node@10.9.1)
-      protobufjs:
-        specifier: 7.2.5
-        version: 7.2.5
       secp256k1:
         specifier: 5.0.0
         version: 5.0.0
@@ -18081,36 +18081,46 @@ packages:
 
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+    dev: false
 
   /@protobufjs/base64@1.1.2:
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+    dev: false
 
   /@protobufjs/codegen@2.0.4:
     resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+    dev: false
 
   /@protobufjs/eventemitter@1.1.0:
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+    dev: false
 
   /@protobufjs/fetch@1.1.0:
     resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
+    dev: false
 
   /@protobufjs/float@1.0.2:
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+    dev: false
 
   /@protobufjs/inquire@1.1.0:
     resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+    dev: false
 
   /@protobufjs/path@1.1.2:
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+    dev: false
 
   /@protobufjs/pool@1.1.0:
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+    dev: false
 
   /@protobufjs/utf8@1.1.0:
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+    dev: false
 
   /@radix-ui/number@1.0.1:
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -42965,6 +42975,7 @@ packages:
 
   /long@5.2.0:
     resolution: {integrity: sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==}
+    dev: false
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -48749,7 +48760,7 @@ packages:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 20.8.10
       long: 5.2.0
-    dev: true
+    dev: false
 
   /protocols@2.0.1:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->
Use payload as unique source of true

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-11513

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
