### PR TITLE
LLD - Help buttons redirect to chatbot instead of faq

### DIFF
--- a/.changeset/bright-pans-punch.md
+++ b/.changeset/bright-pans-punch.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+LLD - Help buttons redirect to the chatbot instead of the faq

--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -46,6 +46,8 @@ export const urls = {
     "https://www.ledger.com/pages/ledger-nano-x#utm_source=Ledger%20Live%20Desktop%20App&utm_medium=Ledger%20Live&utm_campaign=Ledger%20Live%20Desktop%20-%20Banner%20LNX",
   // Ledger support
   faq: "https://support.ledger.com/hc/categories/4404369571601-Support?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=faq",
+  chatbot:
+    "https://live-chat-static.sprinklr.com/test-html/index.html?appId=633307d2cd91267be7d0eea7_app_300078095&env=prod3&skin=MODERN&variant=PAGE&scope=CONVERSATION",
   ledgerStatus: "https://status.ledger.com/",
   syncErrors:
     "https://support.ledger.com/hc/articles/360012207759?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=error_syncerror",

--- a/apps/ledger-live-desktop/src/renderer/modals/Help/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Help/index.tsx
@@ -17,6 +17,8 @@ import { SideDrawer } from "~/renderer/components/SideDrawer";
 import Box from "~/renderer/components/Box";
 import { urls } from "~/config/urls";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+
 const ItemContainer = styled.a`
   flex: 1;
   display: flex;
@@ -75,6 +77,7 @@ const Item = ({
 };
 const HelpSideDrawer = ({ isOpened, onClose }: { isOpened: boolean; onClose: () => void }) => {
   const { t } = useTranslation();
+  const chatbotSupportFeature = useFeature("lldChatbotSupport");
 
   const gettingStartedUrl = useLocalizedUrl(urls.helpModal.gettingStarted);
   const helpCenterUrl = useLocalizedUrl(urls.helpModal.helpCenter);
@@ -95,12 +98,21 @@ const HelpSideDrawer = ({ isOpened, onClose }: { isOpened: boolean; onClose: () 
             url={gettingStartedUrl}
             Icon={IconNano}
           />
-          <Item
-            title={t("help.helpCenter.title")}
-            desc={t("help.helpCenter.desc")}
-            url={helpCenterUrl}
-            Icon={IconHelp}
-          />
+          {chatbotSupportFeature?.enabled ? (
+            <Item
+              title={t("settings.help.chatbot")}
+              desc={t("help.helpCenter.desc")}
+              url={urls.chatbot}
+              Icon={IconHelp}
+            />
+          ) : (
+            <Item
+              title={t("help.helpCenter.title")}
+              desc={t("help.helpCenter.desc")}
+              url={helpCenterUrl}
+              Icon={IconHelp}
+            />
+          )}
           <Item
             title={t("help.ledgerAcademy.title")}
             desc={t("help.ledgerAcademy.desc")}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/index.tsx
@@ -12,17 +12,27 @@ import RepairDeviceButton from "./RepairDeviceButton";
 import LaunchOnboardingBtn from "./LaunchOnboardingBtn";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { urls } from "~/config/urls";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 const SectionHelp = () => {
   const { t } = useTranslation();
 
   const urlFaq = useLocalizedUrl(urls.faq);
+  const chatbotSupportFeature = useFeature("lldChatbotSupport");
 
   return (
     <>
       <TrackPage category="Settings" name="Help" />
       <Body>
-        <RowItem title={t("settings.help.faq")} desc={t("settings.help.faqDesc")} url={urlFaq} />
+        {chatbotSupportFeature?.enabled ? (
+          <RowItem
+            title={t("settings.help.chatbot")}
+            desc={t("settings.help.faqDesc")}
+            url={urls.chatbot}
+          />
+        ) : (
+          <RowItem title={t("settings.help.faq")} desc={t("settings.help.faqDesc")} url={urlFaq} />
+        )}
         <Row
           title={t("settings.profile.softResetTitle")}
           desc={t("settings.profile.softResetDesc")}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4030,6 +4030,7 @@
       "releaseNotesBtn": "Details",
       "termsBtn": "Read",
       "faq": "Ledger Support",
+      "chatbot": "Ledger Chatbot",
       "faqDesc": "If you have a problem, get help using Ledger Live with your hardware wallet.",
       "terms": "Terms of Use",
       "termsDesc": "By using Ledger Live you are deemed to have accepted our Terms of Use.",

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -435,6 +435,8 @@ export const DEFAULT_FEATURES: Features = {
       variant: ABTestingVariants.variantA,
     },
   },
+
+  lldChatbotSupport: DEFAULT_FEATURE,
   supportDeviceStax: DEFAULT_FEATURE,
   supportDeviceEuropa: DEFAULT_FEATURE,
 };

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -167,6 +167,7 @@ export type Features = CurrencyFeatures & {
   flexibleContentCards: Feature_FlexibleContentCards;
   llmAnalyticsOptInPrompt: Feature_LlmAnalyticsOptInPrompt;
   lldAnalyticsOptInPrompt: Feature_LldAnalyticsOptInPrompt;
+  lldChatbotSupport: Feature_LldChatbotSupport;
   myLedgerDisplayAppDeveloperName: Feature_MyLedgerDisplayAppDeveloperName;
   nftsFromSimplehash: Feature_NftsFromSimpleHash;
   lldActionCarousel: Feature_lldActionCarousel;
@@ -473,6 +474,8 @@ export type Feature_FlexibleContentCards = DefaultFeature;
 export type Feature_MyLedgerDisplayAppDeveloperName = DefaultFeature;
 export type Feature_SupportDeviceStax = DefaultFeature;
 export type Feature_SupportDeviceEuropa = DefaultFeature;
+export type Feature_LldChatbotSupport = DefaultFeature;
+
 /**
  * Utils types.
  */


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Added the `lldChatbotSupport` feature flag to redirect to the chabot instead of the faq when enabled
The buttons impacted for now are the `Ledger Support` button in the `Help & Support` drawer and the `Ledger Support` button in the `Help` settings screen.

### 📸 Demo

https://github.com/LedgerHQ/ledger-live/assets/17146928/6c631621-e68f-44f9-a9e7-ac292febda0d


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11554] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11554]: https://ledgerhq.atlassian.net/browse/LIVE-11554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ