### PR TITLE
fix: groupAccountsOperationsByDay bug

### DIFF
--- a/.changeset/sharp-queens-lick.md
+++ b/.changeset/sharp-queens-lick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": patch
+---
+
+fix groupAccountsOperationsByDay edge case

--- a/libs/coin-framework/src/account.test.ts
+++ b/libs/coin-framework/src/account.test.ts
@@ -37,6 +37,14 @@ describe("groupAccountOperationsByDay", () => {
       // $FlowFixMe
       flatMap(res1.sections, s => s.data),
     );
+    const res3 = groupAccountOperationsByDay(account, {
+      count: 20,
+    });
+    expect(res3.completed).toBe(true);
+    const res4 = groupAccountOperationsByDay(account, {
+      count: 16,
+    });
+    expect(res4.completed).toBe(false);
   });
   test("basic 2", () => {
     const accounts = Array(10)

--- a/libs/coin-framework/src/account/groupOperations.ts
+++ b/libs/coin-framework/src/account/groupOperations.ts
@@ -152,11 +152,11 @@ export function groupAccountsOperationsByDay(
       day,
       data,
     });
+    data = [];
   }
-
   return {
     sections,
-    completed: !next,
+    completed: !next && data.length === 0,
   };
 }
 


### PR DESCRIPTION
### 📝 Description

Fix an edge case in groupAccountsOperationsByDay method.
When getNext() returns no more operation but there is still operations in data array(the last section we should add as history operation but since totalOperations = count and we don't want to display them unless user click "see more" button)
In this case, the return variable of "completed" should be false, so that we display the "see more" button in UI.

### ❓ Context

- **JIRA or GitHub link**: [https://ledgerhq.atlassian.net/browse/LIVE-10778](https://ledgerhq.atlassian.net/browse/LIVE-10778)

### ✅ Checklist

Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready.

- [X] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes:** No impact
  - ...

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- [ ] **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- [ ] **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- [ ] **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- [ ] **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- [ ] **Any new dependencies** have been justified and documented.
- [ ] **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
