### PR TITLE
[LIVE-11685]Remove hard coded mention to Stax in Settings restored step

### DIFF
--- a/.changeset/tender-lamps-guess.md
+++ b/.changeset/tender-lamps-guess.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix a device name bug in restoring Apps

--- a/apps/ledger-live-desktop/static/i18n/ar/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ar/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "اضغط مع الاستمرار على الزر على الأقل لمدة 5 ثوانٍ حتى يتم عرض خيارات التمهيد. انقر على وضع Bootloader",
       "successTitle" : "نظام تشغيل جهازك {{deviceName}}\nمُحدَّث إلى آخر إصدار.",
       "successTitleApps" : "نظام تشغيل جهازك {{deviceName}}\nمُحدَّث إلى آخر إصدار. شيء أخير...",
-      "successSubtitleApps" : "لبدء استعادة التطبيق على جهازك Ledger Stax، اختر\nزر ”Restore apps (استعادة التطبيقات)“ أدناه.",
+      "successSubtitleApps" : "لبدء استعادة التطبيق على جهازك {{deviceName}}، اختر\nزر ”Restore apps (استعادة التطبيقات)“ أدناه.",
       "sucessCTAApps" : "استعادة التطبيقات",
       "SuccessCTANoApps" : "إتمام",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/de/app.json
+++ b/apps/ledger-live-desktop/static/i18n/de/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "Halten Sie die Taste für mindestens 5 Sekunden gedrückt, bis die Boot-Optionen angezeigt werden. Tippen Sie auf Bootloader-Modus",
       "successTitle" : "Das Betriebssystem Ihres {{deviceName}}-Geräts ist auf dem neuesten Stand.",
       "successTitleApps" : "Das Betriebssystem Ihres {{deviceName}}-Geräts ist\nauf dem neuesten Stand. Noch eine letzte Sache ...",
-      "successSubtitleApps" : "Um die App-Wiederherstellung auf Ihrem Ledger Stax zu starten, wählen Sie\nunten den Button „Restore apps“ (Apps wiederherstellen).",
+      "successSubtitleApps" : "Um die App-Wiederherstellung auf Ihrem {{deviceName}} zu starten, wählen Sie\nunten den Button „Restore apps“ (Apps wiederherstellen).",
       "sucessCTAApps" : "Apps wiederherstellen",
       "SuccessCTANoApps" : "Beenden",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2004,7 +2004,7 @@
       "mcuBlueSecond": "Press and hold the button for at least 5 seconds until the Boot Options are displayed. Tap Bootloader Mode",
       "successTitle": "Your {{deviceName}} OS is\nup to date.",
       "successTitleApps": "Your {{deviceName}} OS is\nup to date. One last thing...",
-      "successSubtitleApps": "To initiate app restore on your Ledger Stax, select\nthe “Restore apps“ button below.",
+      "successSubtitleApps": "To initiate app restore on your {{deviceName}}, select\nthe “Restore apps“ button below.",
       "sucessCTAApps": "Restore apps",
       "SuccessCTANoApps": "Finish",
       "resetSteps": {

--- a/apps/ledger-live-desktop/static/i18n/es/app.json
+++ b/apps/ledger-live-desktop/static/i18n/es/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "Mantén presionado el botón durante al menos 5 segundos hasta que se muestren las “Boot Options” (\"Opciones de arranque\"). Toca en Bootloader Mode",
       "successTitle" : "El SO de tu {{deviceName}} está actualizado.",
       "successTitleApps" : "El SO de tu {{deviceName}}\nestá actualizado. Una última cosa...",
-      "successSubtitleApps" : "Para iniciar la restauración de la aplicación en tu Ledger Stax, selecciona\nel botón “Restaurar aplicaciones” a continuación.",
+      "successSubtitleApps" : "Para iniciar la restauración de la aplicación en tu {{deviceName}}, selecciona\nel botón “Restaurar aplicaciones” a continuación.",
       "sucessCTAApps" : "Restaurando aplicaciones",
       "SuccessCTANoApps" : "Finalizar",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/fr/app.json
+++ b/apps/ledger-live-desktop/static/i18n/fr/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "Faites un appui long sur le bouton pendant au moins 5 secondes jusqu’à ce que les options de Boot apparaissent. Sélectionnez le mode Bootloader.",
       "successTitle" : "Votre {{deviceName}}\nest à jour.",
       "successTitleApps" : "Le système d’exploitation de votre {{deviceName}} est à jour. Dernière étape...",
-      "successSubtitleApps" : "Pour lancer la restauration des apps sur votre Ledger Stax, cliquez sur Restaurer les apps.",
+      "successSubtitleApps" : "Pour lancer la restauration des apps sur votre {{deviceName}}, cliquez sur Restaurer les apps.",
       "sucessCTAApps" : "Restaurer les apps",
       "SuccessCTANoApps" : "Terminer",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/ja/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ja/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "ブートオプションが表示されるまで、少なくとも5秒間ボタンを押し続けます。Bootloaderモードをタップしてください。",
       "successTitle" : "{{deviceName}} のOSは\n最新の状態です",
       "successTitleApps" : "{{deviceName}}のOSは\n最新の状態です。最後に...",
-      "successSubtitleApps" : "Ledger Staxでアプリの復元を開始するには、\n下の「Restore apps（アプリを復元）」ボタンを選択します。",
+      "successSubtitleApps" : "{{deviceName}}でアプリの復元を開始するには、\n下の「Restore apps（アプリを復元）」ボタンを選択します。",
       "sucessCTAApps" : "アプリを復元",
       "SuccessCTANoApps" : "終了する",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/ko/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ko/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "부팅 옵션이 표시될 때까지 버튼을 5초 이상 누르세요. Bootloader 모드 탭",
       "successTitle" : "사용 중인 {{deviceName}} OS가 최신 상태입니다.",
       "successTitleApps" : "사용 중인 {{deviceName}} OS가\n최신 상태입니다. 마지막으로...",
-      "successSubtitleApps" : "Ledger Stax에서 앱 복구를 시작하려면, 아래\n\"앱 복구\" 버튼을 선택하세요.",
+      "successSubtitleApps" : "{{deviceName}}에서 앱 복구를 시작하려면, 아래\n\"앱 복구\" 버튼을 선택하세요.",
       "sucessCTAApps" : "앱 복원",
       "SuccessCTANoApps" : "완료",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/pt-BR/app.json
+++ b/apps/ledger-live-desktop/static/i18n/pt-BR/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "Pressione e segure o botão por pelo menos 5 segundos até que as opções de inicialização sejam exibidas. Selecione o modo bootloader",
       "successTitle" : "O sistema operacional da sua {{deviceName}} está atualizado.",
       "successTitleApps" : "O sistema operacional da sua {{deviceName}} está\natualizado. Só mais uma coisa…",
-      "successSubtitleApps" : "Para iniciar a restauração de aplicativos em sua Ledger Stax, selecione\no botão \"Restaurar aplicativos\" abaixo.",
+      "successSubtitleApps" : "Para iniciar a restauração de aplicativos em sua {{deviceName}}, selecione\no botão \"Restaurar aplicativos\" abaixo.",
       "sucessCTAApps" : "Restaurar aplicativos",
       "SuccessCTANoApps" : "Finalizar",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/ru/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ru/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "Нажмите и удерживайте кнопку в течение нескольких секунд, пока не увидите опции загрузки. Выберите режим Bootloader",
       "successTitle" : "ОС {{deviceName}}\nактуальна.",
       "successTitleApps" : "ОС {{deviceName}}\nактуальна Осталось совсем немного.",
-      "successSubtitleApps" : "Нажмите «Переустановить приложения», чтобы\nвосстановить приложения на Ledger Stax",
+      "successSubtitleApps" : "Нажмите «Переустановить приложения», чтобы\nвосстановить приложения на {{deviceName}}",
       "sucessCTAApps" : "Переустановка приложений",
       "SuccessCTANoApps" : "Завершить",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/tr/app.json
+++ b/apps/ledger-live-desktop/static/i18n/tr/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "Başlatma Seçenekleri görüntülenene kadar tuşu en az 5 saniye basılı tutun. Bootlader Moduna dokunun",
       "successTitle" : "{{deviceName}} işletim sisteminiz\ngüncel.",
       "successTitleApps" : "{{deviceName}} cihazınızdaki işletim sisteminiz\ngüncel. Son bir şey daha var...",
-      "successSubtitleApps" : "Ledger Stax cihazınızda uygulamayı geri yüklemeyi başlatmak için\naşağıdaki \"Uygulamaları geri yükle\" düğmesini seçin.",
+      "successSubtitleApps" : "{{deviceName}} cihazınızda uygulamayı geri yüklemeyi başlatmak için\naşağıdaki \"Uygulamaları geri yükle\" düğmesini seçin.",
       "sucessCTAApps" : "Uygulamaları geri yükleyin",
       "SuccessCTANoApps" : "Tamamla",
       "resetSteps" : {

--- a/apps/ledger-live-desktop/static/i18n/zh/app.json
+++ b/apps/ledger-live-desktop/static/i18n/zh/app.json
@@ -1982,7 +1982,7 @@
       "mcuBlueSecond" : "持续按住设备侧面按钮至少5秒直至设备显示 Boot Options（启动选项）。轻击 Bootloader Mode（启动装载模式）。",
       "successTitle" : "您的 {{deviceName}} 操作系统\n是最新的。",
       "successTitleApps" : "您的 {{deviceName}} 操作系统\n是最新的。最后一点……",
-      "successSubtitleApps" : "要在您的 Ledger Stax 上开始恢复应用程序，请选择\n下方的“Restore apps”（恢复应用程序）按钮。",
+      "successSubtitleApps" : "要在您的 {{deviceName}} 上开始恢复应用程序，请选择\n下方的“Restore apps”（恢复应用程序）按钮。",
       "sucessCTAApps" : "恢复应用程序",
       "SuccessCTANoApps" : "完成",
       "resetSteps" : {


### PR DESCRIPTION
* Remove hard coded Ledger Stax device name in translation.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11685]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11685]: https://ledgerhq.atlassian.net/browse/LIVE-11685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ