### PR TITLE
fix: nanoapp minVersion check

### DIFF
--- a/.changeset/silent-windows-train.md
+++ b/.changeset/silent-windows-train.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix nanoapp minVersion check

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -31,7 +31,7 @@ export function mustUpgrade(appName: string, appVersion: string): boolean {
   // we should convert the app name to camel case and replace spaces with underscores to match the config convention in firebase
   const minVersion = LiveConfig.getValueByKey(
     `config_nanoapp_${appName.toLowerCase().replace(/ /g, "_")}`,
-  ).minVersion;
+  )?.minVersion;
   if (minVersion) {
     return !semver.gte(appVersion || "", minVersion, {
       includePrerelease: true, // this will allow pre-release tags for higher versions than the minimum one


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes: No impact.
  - ...

### 📝 Description

If the "LiveConfig.getValueByKey" method returns undefined, it means that we don't have the corresponding config key. The Ledger live should return a value instead of throwing an error.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
