### PR TITLE
[SUPPORT]: Remove .unit usage from account.unit

### DIFF
--- a/.changeset/wet-apes-rest.md
+++ b/.changeset/wet-apes-rest.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove .unit usage from account.unit

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -20,6 +20,7 @@ import {
   SettingsState,
   VaultSigner,
   SupportedCountervaluesData,
+  CurrencySettings,
 } from "~/renderer/reducers/settings";
 import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 import { Language, Locale } from "~/config/languages";
@@ -375,7 +376,13 @@ export const addStarredMarketCoins = (payload: string) => ({
   type: "ADD_STARRED_MARKET_COINS",
   payload,
 });
+
 export const removeStarredMarketCoins = (payload: string) => ({
   type: "REMOVE_STARRED_MARKET_COINS",
+  payload,
+});
+
+export const setCurrencySettings = (payload: { key: string; value: CurrencySettings }) => ({
+  type: "SET_CURRENCY_SETTINGS",
   payload,
 });

--- a/apps/ledger-live-desktop/src/renderer/components/AccountsList/AccountRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/AccountsList/AccountRow.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import styled from "styled-components";
 import { Account } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";
@@ -9,6 +9,7 @@ import CryptoCurrencyIconWithCount from "~/renderer/components/CryptoCurrencyIco
 import FormattedVal from "~/renderer/components/FormattedVal";
 import Input from "~/renderer/components/Input";
 import AccountTagDerivationMode from "../AccountTagDerivationMode";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const InputWrapper = styled.div`
   margin-left: 4px;
   width: 100%;
@@ -24,38 +25,45 @@ type Props = {
   onEditName?: (b: Account, a: string) => void;
   hideAmount?: boolean;
 };
-export default class AccountRow extends PureComponent<Props> {
-  handlePreventSubmit = (e: React.SyntheticEvent<HTMLInputElement>) => {
+export default function AccountRow(props: Props) {
+  const {
+    account,
+    isChecked,
+    onEditName,
+    onToggleAccount,
+    accountName,
+    isDisabled,
+    isReadonly,
+    autoFocusInput,
+    hideAmount,
+  } = props;
+
+  const unit = useAccountUnit(account);
+
+  const handlePreventSubmit = (e: React.SyntheticEvent<HTMLInputElement>) => {
     e.preventDefault();
     e.stopPropagation();
   };
 
-  handleKeyPress = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  const handleKeyPress = (e: React.SyntheticEvent<HTMLInputElement>) => {
     // this fixes a bug with the event propagating to the Tabbable
     e.stopPropagation();
   };
 
-  onToggleAccount = () => {
-    const { onToggleAccount, account, isChecked } = this.props;
-    if (onToggleAccount) onToggleAccount(account, !isChecked);
-  };
+  const onClickToggleAccount = () => onToggleAccount?.(account, !isChecked);
 
-  handleChangeName = (name: string) => {
-    const { onEditName, account } = this.props;
-    if (onEditName) onEditName(account, name);
-  };
+  const handleChangeName = (name: string) => onEditName?.(account, name);
 
-  onClickInput = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  const onClickInput = (e: React.SyntheticEvent<HTMLInputElement>) => {
     e.preventDefault();
     e.stopPropagation();
   };
 
-  onFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+  const onFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     e.target.select();
   };
 
-  onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const { onEditName, account } = this.props;
+  const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const { value } = e.target;
     if (!value && onEditName) {
       // don't leave an empty input on blur
@@ -63,92 +71,80 @@ export default class AccountRow extends PureComponent<Props> {
     }
   };
 
-  _input = null;
-  overflowStyles: React.CSSProperties = {
+  const overflowStyles: React.CSSProperties = {
     textOverflow: "ellipsis",
     overflow: "hidden",
     whiteSpace: "nowrap",
   };
 
-  render() {
-    const {
-      account,
-      isChecked,
-      onEditName,
-      accountName,
-      isDisabled,
-      isReadonly,
-      autoFocusInput,
-      hideAmount,
-    } = this.props;
-    const tokenCount = (account.subAccounts && account.subAccounts.length) || 0;
-    const tag = <AccountTagDerivationMode account={account} />;
-    return (
-      <AccountRowContainer
-        className="account-row"
-        isDisabled={isDisabled}
-        onClick={isDisabled ? undefined : this.onToggleAccount}
+  const tokenCount = (account.subAccounts && account.subAccounts.length) || 0;
+  const tag = <AccountTagDerivationMode account={account} />;
+  return (
+    <AccountRowContainer
+      className="account-row"
+      isDisabled={isDisabled}
+      onClick={isDisabled ? undefined : onClickToggleAccount}
+    >
+      <CryptoCurrencyIconWithCount currency={account.currency} count={tokenCount} withTooltip />
+      <Box
+        shrink
+        grow
+        ff="Inter|SemiBold"
+        color="palette.text.shade100"
+        horizontal
+        alignItems="center"
+        fontSize={4}
       >
-        <CryptoCurrencyIconWithCount currency={account.currency} count={tokenCount} withTooltip />
-        <Box
-          shrink
-          grow
-          ff="Inter|SemiBold"
-          color="palette.text.shade100"
-          horizontal
-          alignItems="center"
-          fontSize={4}
-        >
-          {onEditName ? (
-            <InputWrapper>
-              <Input
-                style={this.overflowStyles}
-                value={accountName}
-                onChange={this.handleChangeName}
-                onClick={this.onClickInput}
-                onEnter={this.handlePreventSubmit}
-                onFocus={this.onFocus}
-                onBlur={this.onBlur}
-                onKeyPress={this.handleKeyPress}
-                maxLength={getEnv("MAX_ACCOUNT_NAME_SIZE")}
-                editInPlace
-                autoFocus={autoFocusInput}
-                renderRight={tag}
-              />
-            </InputWrapper>
-          ) : (
-            <div
-              style={{
-                ...this.overflowStyles,
-                paddingLeft: 15,
-                marginLeft: 4,
-                width: "100%",
-              }}
-            >
-              {accountName}
-              {tag}
-            </div>
-          )}
-        </Box>
-        {!hideAmount ? (
-          <FormattedVal
-            val={account.balance}
-            unit={account.unit}
+        {onEditName ? (
+          <InputWrapper>
+            <Input
+              style={overflowStyles}
+              value={accountName}
+              onChange={handleChangeName}
+              onClick={onClickInput}
+              onEnter={handlePreventSubmit}
+              onFocus={onFocus}
+              onBlur={onBlur}
+              onKeyPress={handleKeyPress}
+              maxLength={getEnv("MAX_ACCOUNT_NAME_SIZE")}
+              editInPlace
+              autoFocus={autoFocusInput}
+              renderRight={tag}
+            />
+          </InputWrapper>
+        ) : (
+          <div
             style={{
-              textAlign: "right",
-              width: "auto",
-              minWidth: 120,
+              ...overflowStyles,
+              paddingLeft: 15,
+              marginLeft: 4,
+              width: "100%",
             }}
-            showCode
-            fontSize={4}
-            color="palette.text.shade60"
-          />
-        ) : null}
-        {!isDisabled && !isReadonly && <CheckBox disabled isChecked={isChecked || !!isDisabled} />}
-      </AccountRowContainer>
-    );
-  }
+          >
+            {accountName}
+            {tag}
+          </div>
+        )}
+      </Box>
+      {!hideAmount ? (
+        <FormattedVal
+          val={account.balance}
+          unit={unit}
+          style={{
+            textAlign: "right",
+            width: "auto",
+            minWidth: 120,
+          }}
+          showCode
+          fontSize={4}
+          color="palette.text.shade60"
+        />
+      ) : null}
+      {!isDisabled && !isReadonly && <CheckBox disabled isChecked={isChecked || !!isDisabled} />}
+    </AccountRowContainer>
+  );
 }
+
 const AccountRowContainer = styled(Tabbable).attrs(() => ({
   horizontal: true,
   alignItems: "center",

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -18,8 +18,7 @@ import {
   addNewDeviceModel,
 } from "~/renderer/actions/settings";
 import {
-  CurrencySettings,
-  currencySettingsLocaleSelector,
+  storeSelector as settingsSelector,
   preferredDeviceModelSelector,
 } from "~/renderer/reducers/settings";
 import { DeviceModelId } from "@ledgerhq/devices";
@@ -76,10 +75,9 @@ import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/
 import { AppAndVersion } from "@ledgerhq/live-common/hw/connectApp";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/lib/helpers";
-import { Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { isDeviceNotOnboardedError } from "./utils";
 import { useKeepScreenAwake } from "~/renderer/hooks/useKeepScreenAwake";
-import { State } from "~/renderer/reducers";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
 
@@ -232,14 +230,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   const dispatch = useDispatch();
   const preferredDeviceModel = useSelector(preferredDeviceModelSelector);
   const swapDefaultTrack = useGetSwapTrackingProperties();
-
-  const useCurrencySettingsSelector = (currency: Currency): CurrencySettings => {
-    const currencySettings = useSelector((state: State) =>
-      currencySettingsLocaleSelector(state.settings, currency),
-    );
-
-    return currencySettings;
-  };
+  const stateSettings = useSelector(settingsSelector);
 
   const type = useTheme().colors.palette.type;
 
@@ -376,7 +367,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
           swapDefaultTrack,
           amountExpectedTo: amountExpectedTo.toString() ?? undefined,
           estimatedFees: estimatedFees?.toString() ?? undefined,
-          getCurrencySettings: useCurrencySettingsSelector,
+          stateSettings,
         });
       }
 
@@ -409,7 +400,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       amountExpectedTo: amountExpectedTo ?? undefined,
       estimatedFees: estimatedFees ?? undefined,
       swapDefaultTrack,
-      getCurrencySettings: useCurrencySettingsSelector,
+      stateSettings,
     });
   }
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -17,7 +17,11 @@ import {
   setLastSeenDeviceInfo,
   addNewDeviceModel,
 } from "~/renderer/actions/settings";
-import { preferredDeviceModelSelector } from "~/renderer/reducers/settings";
+import {
+  CurrencySettings,
+  currencySettingsLocaleSelector,
+  preferredDeviceModelSelector,
+} from "~/renderer/reducers/settings";
 import { DeviceModelId } from "@ledgerhq/devices";
 import AutoRepair from "~/renderer/components/AutoRepair";
 import TransactionConfirm from "~/renderer/components/TransactionConfirm";
@@ -72,9 +76,10 @@ import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/
 import { AppAndVersion } from "@ledgerhq/live-common/hw/connectApp";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/lib/helpers";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { isDeviceNotOnboardedError } from "./utils";
 import { useKeepScreenAwake } from "~/renderer/hooks/useKeepScreenAwake";
+import { State } from "~/renderer/reducers";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
 
@@ -228,6 +233,14 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   const preferredDeviceModel = useSelector(preferredDeviceModelSelector);
   const swapDefaultTrack = useGetSwapTrackingProperties();
 
+  const useCurrencySettingsSelector = (currency: Currency): CurrencySettings => {
+    const currencySettings = useSelector((state: State) =>
+      currencySettingsLocaleSelector(state.settings, currency),
+    );
+
+    return currencySettings;
+  };
+
   const type = useTheme().colors.palette.type;
 
   const modelId = device ? device.modelId : overridesPreferredDeviceModel || preferredDeviceModel;
@@ -363,6 +376,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
           swapDefaultTrack,
           amountExpectedTo: amountExpectedTo.toString() ?? undefined,
           estimatedFees: estimatedFees?.toString() ?? undefined,
+          getCurrencySettings: useCurrencySettingsSelector,
         });
       }
 
@@ -395,6 +409,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       amountExpectedTo: amountExpectedTo ?? undefined,
       estimatedFees: estimatedFees ?? undefined,
       swapDefaultTrack,
+      getCurrencySettings: useCurrencySettingsSelector,
     });
   }
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { connect, useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
-import { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import ProviderIcon from "~/renderer/components/ProviderIcon";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -980,6 +980,7 @@ export const renderSwapDeviceConfirmation = ({
 
   const unitMainAccount =
     currenciesSettings[getMainAccount(exchange.fromAccount, exchange.fromParentAccount).id].unit;
+
   return (
     <>
       <ConfirmWrapper>

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -71,7 +71,7 @@ import { ErrorBody } from "../ErrorBody";
 import LinkWithExternalIcon from "../LinkWithExternalIcon";
 import { closePlatformAppDrawer } from "~/renderer/actions/UI";
 import { CompleteExchangeError } from "@ledgerhq/live-common/exchange/error";
-import { CurrencySettings } from "~/renderer/reducers/settings";
+import { SettingsState, currencySettingsLocaleSelector } from "~/renderer/reducers/settings";
 
 export const AnimationWrapper = styled.div`
   width: 600px;
@@ -950,7 +950,7 @@ export const renderSwapDeviceConfirmation = ({
   amountExpectedTo,
   estimatedFees,
   swapDefaultTrack,
-  getCurrencySettings,
+  stateSettings,
 }: {
   modelId: DeviceModelId;
   type: Theme["theme"];
@@ -960,7 +960,7 @@ export const renderSwapDeviceConfirmation = ({
   amountExpectedTo?: string;
   estimatedFees?: string;
   swapDefaultTrack: Record<string, string | boolean>;
-  getCurrencySettings: (currency: Currency) => CurrencySettings;
+  stateSettings: SettingsState;
 }) => {
   const fromAccountCurrency = getAccountCurrency(exchange.fromAccount);
   const toAccountCurrency = getAccountCurrency(exchange.toAccount);
@@ -978,9 +978,10 @@ export const renderSwapDeviceConfirmation = ({
   const noticeType = getNoticeType(exchangeRate.provider);
   const alertProperties = noticeType.learnMore ? { learnMoreUrl: urls.swap.learnMore } : {};
 
-  const unitFromExchange = getCurrencySettings(fromAccountCurrency).unit;
-  const unitToExchange = getCurrencySettings(toAccountCurrency).unit;
-  const unitMainAccount = getCurrencySettings(
+  const unitFromExchange = currencySettingsLocaleSelector(stateSettings, fromAccountCurrency).unit;
+  const unitToExchange = currencySettingsLocaleSelector(stateSettings, toAccountCurrency).unit;
+  const unitMainAccount = currencySettingsLocaleSelector(
+    stateSettings,
     getMainAccount(exchange.fromAccount, exchange.fromParentAccount).currency,
   ).unit;
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { connect, useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
-import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import ProviderIcon from "~/renderer/components/ProviderIcon";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
@@ -950,7 +950,7 @@ export const renderSwapDeviceConfirmation = ({
   amountExpectedTo,
   estimatedFees,
   swapDefaultTrack,
-  currenciesSettings,
+  getCurrencySettings,
 }: {
   modelId: DeviceModelId;
   type: Theme["theme"];
@@ -960,26 +960,29 @@ export const renderSwapDeviceConfirmation = ({
   amountExpectedTo?: string;
   estimatedFees?: string;
   swapDefaultTrack: Record<string, string | boolean>;
-  currenciesSettings: Record<string, CurrencySettings>;
+  getCurrencySettings: (currency: Currency) => CurrencySettings;
 }) => {
+  const fromAccountCurrency = getAccountCurrency(exchange.fromAccount);
+  const toAccountCurrency = getAccountCurrency(exchange.toAccount);
+
   const [sourceAccountName, sourceAccountCurrency] = [
     getAccountName(exchange.fromAccount),
-    getAccountCurrency(exchange.fromAccount),
+    fromAccountCurrency,
   ];
   const [targetAccountName, targetAccountCurrency] = [
     getAccountName(exchange.toAccount),
-    getAccountCurrency(exchange.toAccount),
+    toAccountCurrency,
   ];
+
   const providerName = getProviderName(exchangeRate.provider);
   const noticeType = getNoticeType(exchangeRate.provider);
   const alertProperties = noticeType.learnMore ? { learnMoreUrl: urls.swap.learnMore } : {};
 
-  const unitFromExchange = currenciesSettings[exchange.fromAccount.id].unit;
-
-  const unitToExchange = currenciesSettings[exchange.toAccount.id].unit;
-
-  const unitMainAccount =
-    currenciesSettings[getMainAccount(exchange.fromAccount, exchange.fromParentAccount).id].unit;
+  const unitFromExchange = getCurrencySettings(fromAccountCurrency).unit;
+  const unitToExchange = getCurrencySettings(toAccountCurrency).unit;
+  const unitMainAccount = getCurrencySettings(
+    getMainAccount(exchange.fromAccount, exchange.fromParentAccount).currency,
+  ).unit;
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -25,7 +25,6 @@ import {
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import {
-  getAccountUnit,
   getMainAccount,
   getAccountName,
   getAccountCurrency,
@@ -72,6 +71,7 @@ import { ErrorBody } from "../ErrorBody";
 import LinkWithExternalIcon from "../LinkWithExternalIcon";
 import { closePlatformAppDrawer } from "~/renderer/actions/UI";
 import { CompleteExchangeError } from "@ledgerhq/live-common/exchange/error";
+import { CurrencySettings } from "~/renderer/reducers/settings";
 
 export const AnimationWrapper = styled.div`
   width: 600px;
@@ -950,6 +950,7 @@ export const renderSwapDeviceConfirmation = ({
   amountExpectedTo,
   estimatedFees,
   swapDefaultTrack,
+  currenciesSettings,
 }: {
   modelId: DeviceModelId;
   type: Theme["theme"];
@@ -959,6 +960,7 @@ export const renderSwapDeviceConfirmation = ({
   amountExpectedTo?: string;
   estimatedFees?: string;
   swapDefaultTrack: Record<string, string | boolean>;
+  currenciesSettings: Record<string, CurrencySettings>;
 }) => {
   const [sourceAccountName, sourceAccountCurrency] = [
     getAccountName(exchange.fromAccount),
@@ -971,6 +973,13 @@ export const renderSwapDeviceConfirmation = ({
   const providerName = getProviderName(exchangeRate.provider);
   const noticeType = getNoticeType(exchangeRate.provider);
   const alertProperties = noticeType.learnMore ? { learnMoreUrl: urls.swap.learnMore } : {};
+
+  const unitFromExchange = currenciesSettings[exchange.fromAccount.id].unit;
+
+  const unitToExchange = currenciesSettings[exchange.toAccount.id].unit;
+
+  const unitMainAccount =
+    currenciesSettings[getMainAccount(exchange.fromAccount, exchange.fromParentAccount).id].unit;
   return (
     <>
       <ConfirmWrapper>
@@ -995,7 +1004,7 @@ export const renderSwapDeviceConfirmation = ({
             {
               amountSent: (
                 <CurrencyUnitValue
-                  unit={getAccountUnit(exchange.fromAccount)}
+                  unit={unitFromExchange}
                   value={transaction.amount}
                   disableRounding
                   showCode
@@ -1003,7 +1012,7 @@ export const renderSwapDeviceConfirmation = ({
               ),
               amountReceived: (
                 <CurrencyUnitValue
-                  unit={getAccountUnit(exchange.toAccount)}
+                  unit={unitToExchange}
                   value={amountExpectedTo ? BigNumber(amountExpectedTo) : exchangeRate.toAmount}
                   disableRounding
                   showCode
@@ -1017,9 +1026,7 @@ export const renderSwapDeviceConfirmation = ({
               ),
               fees: (
                 <CurrencyUnitValue
-                  unit={getAccountUnit(
-                    getMainAccount(exchange.fromAccount, exchange.fromParentAccount),
-                  )}
+                  unit={unitMainAccount}
                   value={BigNumber(estimatedFees || 0)}
                   disableRounding
                   showCode

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
@@ -97,5 +97,4 @@ function OperationComponent({
     </OperationRow>
   );
 }
-const ConnectedOperationComponent: React.ComponentType<OwnProps> = OperationComponent;
-export default ConnectedOperationComponent;
+export default React.memo(OperationComponent);

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/Operation.tsx
@@ -1,15 +1,13 @@
-import React, { PureComponent } from "react";
-import { connect } from "react-redux";
+import React from "react";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { rgba } from "~/renderer/styles/helpers";
 import Box from "~/renderer/components/Box";
-import { createStructuredSelector } from "reselect";
 import { TFunction } from "i18next";
 import { AccountLike, Account, Operation } from "@ledgerhq/types-live";
 import {
   getAccountCurrency,
   getAccountName,
-  getAccountUnit,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
 import ConfirmationCell from "./ConfirmationCell";
@@ -19,12 +17,9 @@ import AddressCell from "./AddressCell";
 import AmountCell from "./AmountCell";
 import { confirmationsNbForCurrencySelector } from "~/renderer/reducers/settings";
 import { isConfirmedOperation } from "@ledgerhq/live-common/operation";
-const mapStateToProps = createStructuredSelector({
-  confirmationsNb: (state, { account, parentAccount }) =>
-    confirmationsNbForCurrencySelector(state, {
-      currency: getMainAccount(account, parentAccount).currency,
-    }),
-});
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { State } from "~/renderer/reducers";
+
 const OperationRow = styled(Box).attrs(() => ({
   horizontal: true,
   alignItems: "center",
@@ -49,69 +44,58 @@ type OwnProps = {
   text?: string;
   editable?: boolean;
 };
-type Props = {
-  confirmationsNb: number;
-} & OwnProps;
-class OperationComponent extends PureComponent<Props> {
-  static defaultProps = {
-    withAccount: false,
-    withAddress: true,
-  };
+type Props = OwnProps;
 
-  onOperationClick = () => {
-    const { account, parentAccount, onOperationClick, operation } = this.props;
+function OperationComponent({
+  operation,
+  account,
+  parentAccount,
+  onOperationClick,
+  t,
+  text,
+  editable,
+  withAddress = true,
+  withAccount = false,
+}: Props) {
+  const mainAccount = getMainAccount(account, parentAccount);
+  const confirmationsNb = useSelector((state: State) =>
+    confirmationsNbForCurrencySelector(state, mainAccount),
+  );
+  const unit = useAccountUnit(mainAccount);
+
+  const onClickOnOperation = () => {
     onOperationClick(operation, account, parentAccount);
   };
 
-  render() {
-    const {
-      account,
-      parentAccount,
-      t,
-      operation,
-      withAccount,
-      text,
-      withAddress,
-      confirmationsNb,
-      editable,
-    } = this.props;
-    const isOptimistic = operation.blockHeight === null;
-    const currency = getAccountCurrency(account);
-    const unit = getAccountUnit(account);
-    const mainAccount = getMainAccount(account, parentAccount);
-    const isConfirmed = isConfirmedOperation(operation, mainAccount, confirmationsNb);
-    return (
-      <OperationRow
-        className="operation-row"
-        isOptimistic={isOptimistic}
-        onClick={this.onOperationClick}
-      >
-        <ConfirmationCell
-          operation={operation}
-          parentAccount={parentAccount}
-          account={account}
-          t={t}
-          isConfirmed={isConfirmed}
-        />
-        <DateCell
-          family={mainAccount.currency.family}
-          text={text}
-          operation={operation}
-          editable={editable}
-          t={t}
-        />
-        {withAccount && <AccountCell accountName={getAccountName(account)} currency={currency} />}
-        {withAddress ? <AddressCell operation={operation} /> : <Box flex="1" />}
-        <AmountCell
-          operation={operation}
-          currency={currency}
-          unit={unit}
-          isConfirmed={isConfirmed}
-        />
-      </OperationRow>
-    );
-  }
+  const isOptimistic = operation.blockHeight === null;
+  const currency = getAccountCurrency(account);
+
+  const isConfirmed = isConfirmedOperation(operation, mainAccount, confirmationsNb);
+  return (
+    <OperationRow
+      className="operation-row"
+      isOptimistic={isOptimistic}
+      onClick={onClickOnOperation}
+    >
+      <ConfirmationCell
+        operation={operation}
+        parentAccount={parentAccount}
+        account={account}
+        t={t}
+        isConfirmed={isConfirmed}
+      />
+      <DateCell
+        family={mainAccount.currency.family}
+        text={text}
+        operation={operation}
+        editable={editable}
+        t={t}
+      />
+      {withAccount && <AccountCell accountName={getAccountName(account)} currency={currency} />}
+      {withAddress ? <AddressCell operation={operation} /> : <Box flex="1" />}
+      <AmountCell operation={operation} currency={currency} unit={unit} isConfirmed={isConfirmed} />
+    </OperationRow>
+  );
 }
-const ConnectedOperationComponent: React.ComponentType<OwnProps> =
-  connect(mapStateToProps)(OperationComponent);
+const ConnectedOperationComponent: React.ComponentType<OwnProps> = OperationComponent;
 export default ConnectedOperationComponent;

--- a/apps/ledger-live-desktop/src/renderer/components/SelectAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SelectAccount.tsx
@@ -1,7 +1,6 @@
 import {
   flattenAccounts,
   getAccountCurrency,
-  getAccountUnit,
   getAccountName,
   listSubAccounts,
 } from "@ledgerhq/live-common/account/index";
@@ -25,6 +24,7 @@ import Button from "~/renderer/components/Button";
 import Plus from "~/renderer/icons/Plus";
 import Text from "./Text";
 import { openModal } from "../actions/modals";
+import { useAccountUnit } from "../hooks/useAccountUnit";
 
 const mapStateToProps = createStructuredSelector({
   accounts: shallowAccountsSelector,
@@ -104,7 +104,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
   singleLineLayout = true,
 }: AccountOptionProps) {
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const name = getAccountName(account);
   const nested = "TokenAccount" === account.type;
   const balance = account.spendableBalance || account.balance;

--- a/apps/ledger-live-desktop/src/renderer/components/SpendableAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SpendableAmount.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { Account, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
 import { useDebounce } from "@ledgerhq/live-common//hooks/useDebounce";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import BigNumber from "bignumber.js";
+import { useAccountUnit } from "../hooks/useAccountUnit";
 
 type Props<T extends TransactionCommon> = {
   account: AccountLike;
@@ -25,6 +25,7 @@ const SpendableAmount = <T extends TransactionCommon>({
 }: Props<T>) => {
   const [maxSpendable, setMaxSpendable] = useState<BigNumber | null>(null);
   const debouncedTransaction = useDebounce(transaction, 500);
+  const accountUnit = useAccountUnit(account);
   useEffect(() => {
     if (!account) return;
     let cancelled = false;
@@ -42,7 +43,7 @@ const SpendableAmount = <T extends TransactionCommon>({
       cancelled = true;
     };
   }, [account, parentAccount, debouncedTransaction]);
-  const accountUnit = getAccountUnit(account);
+
   return maxSpendable ? (
     <FormattedVal
       style={{

--- a/apps/ledger-live-desktop/src/renderer/components/Stars/Item.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Stars/Item.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback } from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
-import {
-  getAccountCurrency,
-  getAccountUnit,
-  getAccountName,
-} from "@ledgerhq/live-common/account/helpers";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/account/helpers";
 import { AccountLike } from "@ledgerhq/types-live";
 import Hide from "~/renderer/components/MainSideBar/Hide";
 import FormattedVal from "~/renderer/components/FormattedVal";
@@ -13,6 +9,7 @@ import Box from "~/renderer/components/Box";
 import Ellipsis from "~/renderer/components/Ellipsis";
 import ParentCryptoCurrencyIcon from "~/renderer/components/ParentCryptoCurrencyIcon";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const ParentCryptoCurrencyIconWrapper = styled.div`
   width: 20px;
 `;
@@ -61,7 +58,7 @@ const Item = ({ account, pathname, collapsed }: Props) => {
         : `/account/${account.id}`,
     });
   }, [account, history]);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   return (
     <ItemWrapper className="bookmarked-account-item" active={active} onClick={onAccountClick}>
       <Box horizontal ff="Inter|SemiBold" flex={1} flow={3} alignItems="center">

--- a/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import Box from "~/renderer/components/Box";
 import { Account, AccountLike, PortfolioRange } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
@@ -38,29 +38,26 @@ const NestedRow = styled(Box)`
   }
 `;
 
-class TokenRow extends PureComponent<Props> {
-  onClick = () => {
-    const { account, parentAccount, onClick } = this.props;
+function TokenRow(props: Props) {
+  const { account, parentAccount, onClick, range, nested, disableRounding } = props;
+  const onClickRow = () => {
     onClick(account, parentAccount);
   };
 
-  render() {
-    const { account, range, nested, disableRounding } = this.props;
-    const currency = getAccountCurrency(account);
-    const unit = currency.units[0];
-    const Row = nested ? NestedRow : TableRow;
-    return (
-      <Row className="token-row" onClick={this.onClick} tabIndex={-1}>
-        <Header nested={nested} account={account} />
-        <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
-        <Countervalue account={account} currency={currency} range={range} />
-        <Delta account={account} range={range} />
-        <Star
-          accountId={account.id}
-          parentId={account.type !== "Account" ? account.parentId : undefined}
-        />
-      </Row>
-    );
-  }
+  const currency = getAccountCurrency(account);
+  const unit = currency.units[0];
+  const Row = nested ? NestedRow : TableRow;
+  return (
+    <Row className="token-row" onClick={onClickRow} tabIndex={-1}>
+      <Header nested={nested} account={account} />
+      <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
+      <Countervalue account={account} currency={currency} range={range} />
+      <Delta account={account} range={range} />
+      <Star
+        accountId={account.id}
+        parentId={account.type !== "Account" ? account.parentId : undefined}
+      />
+    </Row>
+  );
 }
 export default TokenRow;

--- a/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Box from "~/renderer/components/Box";
 import { Account, AccountLike, PortfolioRange } from "@ledgerhq/types-live";
-import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import styled from "styled-components";
 import Header from "~/renderer/screens/accounts/AccountRowItem/Header";
 import Balance from "~/renderer/screens/accounts/AccountRowItem/Balance";
@@ -9,6 +9,7 @@ import Delta from "~/renderer/screens/accounts/AccountRowItem/Delta";
 import Countervalue from "~/renderer/screens/accounts/AccountRowItem/Countervalue";
 import Star from "~/renderer/components/Stars/Star";
 import { TableRow } from "./TableContainer";
+import { useAccountUnit } from "../hooks/useAccountUnit";
 
 type Props = {
   account: AccountLike;
@@ -43,9 +44,9 @@ function TokenRow(props: Props) {
   const onClickRow = () => {
     onClick(account, parentAccount);
   };
-
-  const currency = getAccountCurrency(account);
-  const unit = currency.units[0];
+  const mainAccount = getMainAccount(account, parentAccount);
+  const unit = useAccountUnit(mainAccount);
+  const currency = mainAccount.currency;
   const Row = nested ? NestedRow : TableRow;
   return (
     <Row className="token-row" onClick={onClickRow} tabIndex={-1}>

--- a/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TokenRow.tsx
@@ -41,13 +41,14 @@ const NestedRow = styled(Box)`
 
 function TokenRow(props: Props) {
   const { account, parentAccount, onClick, range, nested, disableRounding } = props;
-  const onClickRow = () => {
-    onClick(account, parentAccount);
-  };
+
+  const onClickRow = () => onClick(account, parentAccount);
+
   const mainAccount = getMainAccount(account, parentAccount);
   const unit = useAccountUnit(mainAccount);
   const currency = mainAccount.currency;
   const Row = nested ? NestedRow : TableRow;
+
   return (
     <Row className="token-row" onClick={onClickRow} tabIndex={-1}>
       <Header nested={nested} account={account} />
@@ -61,4 +62,5 @@ function TokenRow(props: Props) {
     </Row>
   );
 }
-export default TokenRow;
+
+export default React.memo(TokenRow);

--- a/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TransactionConfirm/index.tsx
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import React, { useMemo } from "react";
 import styled from "styled-components";
 import { Account, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
-import { getAccountUnit, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getDeviceTransactionConfig } from "@ledgerhq/live-common/transaction/index";
@@ -19,6 +19,7 @@ import { getDeviceAnimation } from "../DeviceAction/animations";
 import { DeviceBlocker } from "../DeviceAction/DeviceBlocker";
 import ConfirmAlert from "./ConfirmAlert";
 import ConfirmTitle from "./ConfirmTitle";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FieldText = styled(Text).attrs(() => ({
   ml: 1,
@@ -34,24 +35,27 @@ const FieldText = styled(Text).attrs(() => ({
 export type FieldComponentProps = FCPGeneric<Account, TransactionCommon, TransactionStatus>;
 export type FieldComponent = React.ComponentType<FieldComponentProps>;
 
-const AmountField = ({ account, status: { amount }, field }: FieldComponentProps) => (
-  <TransactionConfirmField label={field.label}>
-    <FormattedVal
-      color={"palette.text.shade80"}
-      unit={getAccountUnit(account)}
-      val={amount}
-      fontSize={3}
-      inline
-      showCode
-      alwaysShowValue
-      disableRounding
-    />
-  </TransactionConfirmField>
-);
+const AmountField = ({ account, status: { amount }, field }: FieldComponentProps) => {
+  const unit = useAccountUnit(account);
+  return (
+    <TransactionConfirmField label={field.label}>
+      <FormattedVal
+        color={"palette.text.shade80"}
+        unit={unit}
+        val={amount}
+        fontSize={3}
+        inline
+        showCode
+        alwaysShowValue
+        disableRounding
+      />
+    </TransactionConfirmField>
+  );
+};
 const FeesField = ({ account, parentAccount, status, field }: FieldComponentProps) => {
   const mainAccount = getMainAccount(account, parentAccount);
   const { estimatedFees } = status;
-  const feesUnit = getAccountUnit(mainAccount);
+  const feesUnit = useAccountUnit(mainAccount);
   return (
     <TransactionConfirmField label={field.label}>
       <FormattedVal

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
@@ -19,7 +19,8 @@ import { darken } from "~/renderer/styles/helpers";
 import { Observable } from "rxjs";
 import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
 import { useTranslation } from "react-i18next";
-import { currenciesSettingsSelector } from "~/renderer/reducers/settings";
+import { currencySettingsLocaleSelector } from "~/renderer/reducers/settings";
+import { State } from "~/renderer/reducers";
 
 const AddIconContainer = styled.div`
   border-radius: 50%;
@@ -44,7 +45,9 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
   const accountIds = useGetAccountIds(accounts$);
   const nestedAccounts = useSelector(accountsSelector);
 
-  const currenciesSettings = useSelector(currenciesSettingsSelector);
+  const currencySettings = useSelector((state: State) =>
+    currencySettingsLocaleSelector(state.settings, currency),
+  );
 
   const accountTuples = useMemo(() => {
     return getAccountTuplesForCurrency(currency, nestedAccounts, false, accountIds);
@@ -82,7 +85,7 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
       {accountTuples.map((accountTuple, index) => {
         const { account, subAccount } = accountTuple;
         const accountCurrency = getAccountCurrency(subAccount || account);
-        const unit = currenciesSettings[accountCurrency.id].unit;
+        const unit = currencySettings.unit;
 
         return (
           <RowContainer

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
@@ -19,7 +19,10 @@ import { darken } from "~/renderer/styles/helpers";
 import { Observable } from "rxjs";
 import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
 import { useTranslation } from "react-i18next";
-import { currencySettingsLocaleSelector } from "~/renderer/reducers/settings";
+import {
+  currenciesSettingsSelector,
+  currencySettingsLocaleSelector,
+} from "~/renderer/reducers/settings";
 import { State } from "~/renderer/reducers";
 
 const AddIconContainer = styled.div`
@@ -45,6 +48,7 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
   const accountIds = useGetAccountIds(accounts$);
   const nestedAccounts = useSelector(accountsSelector);
 
+  const currenciesSettings = useSelector(currenciesSettingsSelector);
   const currencySettings = useSelector((state: State) =>
     currencySettingsLocaleSelector(state.settings, currency),
   );
@@ -85,7 +89,7 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
       {accountTuples.map((accountTuple, index) => {
         const { account, subAccount } = accountTuple;
         const accountCurrency = getAccountCurrency(subAccount || account);
-        const unit = currencySettings.unit;
+        const unit = currenciesSettings[accountCurrency.ticker]?.unit || currencySettings.unit;
 
         return (
           <RowContainer

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
@@ -5,7 +5,7 @@ import { Account, AccountLike } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useGetAccountIds } from "@ledgerhq/live-common/wallet-api/react";
 import { useSelector, useDispatch } from "react-redux";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { getAccountTuplesForCurrency } from "~/renderer/components/PerCurrencySelectAccount/state";
 import { openModal } from "~/renderer/actions/modals";
@@ -19,6 +19,7 @@ import { darken } from "~/renderer/styles/helpers";
 import { Observable } from "rxjs";
 import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
 import { useTranslation } from "react-i18next";
+import { currenciesSettingsSelector } from "~/renderer/reducers/settings";
 
 const AddIconContainer = styled.div`
   border-radius: 50%;
@@ -42,6 +43,9 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
   const { t } = useTranslation();
   const accountIds = useGetAccountIds(accounts$);
   const nestedAccounts = useSelector(accountsSelector);
+
+  const currenciesSettings = useSelector(currenciesSettingsSelector);
+
   const accountTuples = useMemo(() => {
     return getAccountTuplesForCurrency(currency, nestedAccounts, false, accountIds);
   }, [nestedAccounts, currency, accountIds]);
@@ -78,6 +82,8 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
       {accountTuples.map((accountTuple, index) => {
         const { account, subAccount } = accountTuple;
         const accountCurrency = getAccountCurrency(subAccount || account);
+        const unit = currenciesSettings[accountCurrency.id].unit;
+
         return (
           <RowContainer
             key={account.id}
@@ -120,7 +126,7 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
                 <FormattedVal
                   color="palette.text.shade50"
                   val={subAccount ? subAccount.balance : account.balance}
-                  unit={getAccountUnit(subAccount || account)}
+                  unit={unit}
                   showCode
                 />
               </Box>

--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -1,7 +1,6 @@
 import {
   findSubAccountById,
   getAccountCurrency,
-  getAccountUnit,
   getFeesCurrency,
   getFeesUnit,
   getMainAccount,
@@ -79,6 +78,7 @@ import {
   TextEllipsis,
 } from "./styledComponents";
 import { dayAndHourFormat, useDateFormatted } from "~/renderer/hooks/useDateFormatter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const mapStateToProps = (
   state: State,
@@ -156,7 +156,7 @@ const OperationD = (props: Props) => {
   const mainCurrency = getAccountCurrency(mainAccount);
   const { status, metadata } = useNftMetadata(contract, tokenId, currency.id);
   const show = useMemo(() => status === "loading", [status]);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const amount = getOperationAmountNumber(operation);
   const isNegative = amount.isNegative();
   const marketColor = getMarketColor({

--- a/apps/ledger-live-desktop/src/renderer/drawers/SwapOperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/SwapOperationDetails/index.tsx
@@ -1,7 +1,6 @@
 import {
   getAccountCurrency,
   getAccountName,
-  getAccountUnit,
   getMainAccount,
 } from "@ledgerhq/live-common/account/index";
 import { isSwapOperationPending } from "@ledgerhq/live-common/exchange/swap/index";
@@ -34,6 +33,7 @@ import {
   OpDetailsSection,
   OpDetailsTitle,
 } from "~/renderer/drawers/OperationDetails/styledComponents";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { dayFormat, useDateFormatted } from "~/renderer/hooks/useDateFormatter";
 import useTheme from "~/renderer/hooks/useTheme";
 import IconArrowDown from "~/renderer/icons/ArrowDown";
@@ -116,9 +116,9 @@ const SwapOperationDetails = ({
   const dateFormatted = useDateFormatted(operation.date, dayFormat);
   const language = useSelector(languageSelector);
   const history = useHistory();
-  const fromUnit = getAccountUnit(fromAccount);
+  const fromUnit = useAccountUnit(fromAccount);
   const fromCurrency = getAccountCurrency(fromAccount);
-  const toUnit = getAccountUnit(toAccount);
+  const toUnit = useAccountUnit(toAccount);
   const toCurrency = getAccountCurrency(toAccount);
   const accounts = useSelector(shallowAccountsSelector);
   const normalisedFromAmount = fromAmount.times(-1);

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/AccountHeaderManageActions.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { getAccountUnit } from "@ledgerhq/live-common/account/helpers";
 import { openModal } from "~/renderer/actions/modals";
 import IconCoins from "~/renderer/icons/Coins";
 import { AlgorandFamily } from "./types";

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/AccountHeaderManageActions.ts
@@ -5,6 +5,7 @@ import { getAccountUnit } from "@ledgerhq/live-common/account/helpers";
 import { openModal } from "~/renderer/actions/modals";
 import IconCoins from "~/renderer/icons/Coins";
 import { AlgorandFamily } from "./types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const AccountHeaderActions: AlgorandFamily["accountHeaderManageActions"] = ({
   account,
@@ -13,7 +14,7 @@ const AccountHeaderActions: AlgorandFamily["accountHeaderManageActions"] = ({
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const balance = account.balance;
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const minRewardsBalance = 10 ** unit.magnitude;
 
   const onClick = useCallback(() => {

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/steps/StepInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/steps/StepInfo.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { StepProps } from "../types";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/steps/StepInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/steps/StepInfo.tsx
@@ -15,9 +15,10 @@ import Text from "~/renderer/components/Text";
 import ClaimRewardsIllu from "~/renderer/images/rewards.svg";
 import Image from "~/renderer/components/Image";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 export default function StepInfo({ account, warning, error }: StepProps) {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const locale = useSelector(localeSelector);
   const { algorandResources } = account;
   const { rewards } = algorandResources || {};

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/index.tsx
@@ -1,8 +1,4 @@
-import {
-  getAccountCurrency,
-  getAccountUnit,
-  getMainAccount,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { AlgorandAccount } from "@ledgerhq/live-common/families/algorand/types";
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
@@ -17,6 +13,7 @@ import ToolTip from "~/renderer/components/Tooltip";
 import ClaimRewards from "~/renderer/icons/ClaimReward";
 import { AlgorandFamily } from "../types";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type AccountBodyHeader = NonNullable<AlgorandFamily["AccountBodyHeader"]>;
 
@@ -30,7 +27,7 @@ const RewardsSection = ({
   const mainAccount = getMainAccount(account, parentAccount);
   const { rewards } = mainAccount.algorandResources || {};
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const dispatch = useDispatch();
   const onRewardsClick = useCallback(() => {
     dispatch(

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/operationDetails.tsx
@@ -1,4 +1,4 @@
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { AlgorandAccount, AlgorandOperation } from "@ledgerhq/live-common/families/algorand/types";
 import { BigNumber } from "bignumber.js";

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/operationDetails.tsx
@@ -27,6 +27,7 @@ import {
   ConfirmationCellProps,
   OperationDetailsExtraProps,
 } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const CellIcon = styled(Box)<{ index: number }>`
   flex: 1 0 50%;
@@ -57,7 +58,7 @@ const OperationDetailsExtra = ({
   account,
   operation,
 }: OperationDetailsExtraProps<AlgorandAccount, AlgorandOperation>) => {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const currency = getAccountCurrency(account);
   const { rewards, memo, assetId } = operation.extra;
   return (

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/CoinControlModal.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/CoinControlModal.tsx
@@ -19,6 +19,7 @@ import {
   Transaction,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/bitcoin/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   isOpened?: boolean;
@@ -45,6 +46,8 @@ const CoinControlModal = ({
   updateTransaction,
 }: Props) => {
   const onClickLink = useCallback(() => openURL(urls.coinControl), []);
+
+  const unit = useAccountUnit(account);
   if (!account.bitcoinResources) return null;
   const { bitcoinResources } = account;
   const { utxoStrategy } = transaction;
@@ -85,7 +88,7 @@ const CoinControlModal = ({
                   <FormattedVal
                     disableRounding
                     val={status.totalSpent}
-                    unit={account.unit}
+                    unit={unit}
                     showCode
                     fontSize={4}
                     color="palette.text.shade100"
@@ -135,7 +138,7 @@ const CoinControlModal = ({
                     <FormattedVal
                       disableRounding
                       val={status.totalSpent}
-                      unit={account.unit}
+                      unit={unit}
                       showCode
                       fontSize={4}
                       ff="Inter|SemiBold"
@@ -155,7 +158,7 @@ const CoinControlModal = ({
                     <FormattedVal
                       disableRounding
                       val={returning ? returning.value : 0}
-                      unit={account.unit}
+                      unit={unit}
                       showCode
                       fontSize={4}
                       ff="Inter|SemiBold"

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/CoinControlRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/CoinControlRow.tsx
@@ -17,6 +17,7 @@ import {
   TransactionStatus,
   UtxoStrategy,
 } from "@ledgerhq/live-common/families/bitcoin/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type CoinControlRowProps = {
   utxo: BitcoinOutput;
@@ -64,6 +65,7 @@ export const CoinControlRow = ({
   updateTransaction,
   bridge,
 }: CoinControlRowProps) => {
+  const unit = useAccountUnit(account);
   const s = getUTXOStatus(utxo, utxoStrategy);
   const utxoStatus = s.excluded ? s.reason || "" : "";
   const input = (status.txInputs || []).find(
@@ -128,7 +130,7 @@ export const CoinControlRow = ({
         <FormattedVal
           disableRounding
           val={utxo.value}
-          unit={account.unit}
+          unit={unit}
           showCode
           fontSize={4}
           color="palette.text.shade100"

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepAccounts.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepAccounts.tsx
@@ -15,7 +15,7 @@ import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
 import { FullNodeSteps } from "..";
 import styled from "styled-components";
-import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Row = styled(Box).attrs(() => ({
   horizontal: true,
   alignItems: "center",
@@ -39,8 +39,8 @@ const Accounts = ({
   const currency = getCryptoCurrencyById("bitcoin");
 
   const bitcoinAccounts = accounts.filter(a => getAccountCurrency(a) === currency);
-
-  const unit = useAccountUnit(bitcoinAccounts[0]);
+  const firstNonFalsyAccount = bitcoinAccounts.find(account => !!account);
+  const unit = useMaybeAccountUnit(firstNonFalsyAccount);
 
   const onUpdateNumberOfAccountsToScan = useCallback(
     (value: string) => {

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepAccounts.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/FullNode/steps/StepAccounts.tsx
@@ -15,6 +15,7 @@ import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
 import { FullNodeSteps } from "..";
 import styled from "styled-components";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Row = styled(Box).attrs(() => ({
   horizontal: true,
   alignItems: "center",
@@ -36,7 +37,11 @@ const Accounts = ({
   // FIXME Not using the AccountList component because styles differ quite a bit, we should unify.
   const accounts = useSelector(accountsSelector);
   const currency = getCryptoCurrencyById("bitcoin");
+
   const bitcoinAccounts = accounts.filter(a => getAccountCurrency(a) === currency);
+
+  const unit = useAccountUnit(bitcoinAccounts[0]);
+
   const onUpdateNumberOfAccountsToScan = useCallback(
     (value: string) => {
       if (value) {
@@ -122,7 +127,7 @@ const Accounts = ({
                 <FormattedVal
                   ff="Inter|Regular"
                   val={account.balance}
-                  unit={account.unit}
+                  unit={unit}
                   style={{
                     textAlign: "right",
                     width: "auto",

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/AccountBalanceSummaryFooter.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/AccountBalanceSummaryFooter.tsx
@@ -11,6 +11,7 @@ import Text from "~/renderer/components/Text";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
 import { CardanoFamily } from "./types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -51,7 +52,7 @@ const AccountBalanceSummaryFooter: CardanoFamily["AccountBalanceSummaryFooter"] 
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
   const _spendableBalance = account.spendableBalance;
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/Delegation/Row.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import styled from "styled-components";
-import { getAccountUnit, shortAddressPreview } from "@ledgerhq/live-common/account/index";
+import { shortAddressPreview } from "@ledgerhq/live-common/account/index";
 import { CardanoAccount, CardanoDelegation } from "@ledgerhq/live-common/families/cardano/types";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import Text from "~/renderer/components/Text";
 import Ellipsis from "~/renderer/components/Ellipsis";
 import ContextMenu from "./ContextMenu";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   delegation: CardanoDelegation;
@@ -41,7 +42,7 @@ const Value = styled.div`
 `;
 
 const Row = ({ account, delegation }: Props) => {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   let name = "";
   if (delegation && delegation.poolId) {
     name = delegation.ticker

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorField.tsx
@@ -17,6 +17,7 @@ import ValidatorSearchInput from "~/renderer/components/Delegation/ValidatorSear
 import { LEDGER_POOL_IDS } from "@ledgerhq/live-common/families/cardano/utils";
 import { CardanoDelegation } from "@ledgerhq/live-common/families/cardano/types";
 import BigSpinner from "~/renderer/components/BigSpinner";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   t: TFunction;
@@ -29,7 +30,7 @@ type Props = {
 
 const ValidatorField = ({ account, delegation, onChangeValidator, selectedPoolId }: Props) => {
   const [ledgerPools, setLedgerPools] = useState<Array<StakePool>>([]);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
 
   const [showAll, setShowAll] = useState(
     LEDGER_POOL_IDS.length === 0 ||

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorField.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepSummary.tsx
@@ -1,7 +1,7 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import Ellipsis from "~/renderer/components/Ellipsis";
@@ -11,6 +11,7 @@ import CounterValue from "~/renderer/components/CounterValue";
 import { StepProps } from "../types";
 import CardanoLedgerPoolIcon from "../LedgerPoolIcon";
 import BigNumber from "bignumber.js";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FromToWrapper = styled.div``;
 const Separator = styled.div`
@@ -20,86 +21,69 @@ const Separator = styled.div`
   margin: 15px 0;
 `;
 
-export default class StepSummary extends PureComponent<StepProps> {
-  render() {
-    const { account, transaction, status, selectedPool } = this.props;
-    if (!account) return null;
-    if (!transaction) return null;
-    const { estimatedFees } = status;
-    const feesUnit = getAccountUnit(account);
-    const feesCurrency = getAccountCurrency(account);
-    const showDeposit = !account.cardanoResources?.delegation?.status;
-    const stakeKeyDeposit = account.cardanoResources?.protocolParams.stakeKeyDeposit;
-    return (
-      <Box flow={4} mx={40}>
-        <FromToWrapper>
-          <Box>
-            <Box horizontal alignItems="center">
-              <Box flex={1}>
-                <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-                  <Trans i18nKey="cardano.delegation.delegatingTo" />
-                </Text>
-                <Ellipsis mt={2}>
-                  <Box horizontal alignItems="center">
-                    <CardanoLedgerPoolIcon validator={selectedPool} />
-                    <Text ff="Inter" color="palette.text.shade100" fontSize={4} ml={2}>
-                      {`${selectedPool.name} [${selectedPool.ticker}]`}
-                    </Text>
-                  </Box>
-                </Ellipsis>
-              </Box>
-            </Box>
-          </Box>
-          <Box horizontal justifyContent="space-between" mt={1}>
-            <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-              <Trans i18nKey="cardano.delegation.cost" />
-            </Text>
-            <Box>
-              <FormattedVal
-                color={"palette.text.shade80"}
-                disableRounding
-                unit={feesUnit}
-                alwaysShowValue
-                val={new BigNumber(selectedPool.cost)}
-                fontSize={4}
-                inline
-                showCode
-              />
-            </Box>
-          </Box>
-          <Box horizontal justifyContent="space-between" mt={1}>
-            <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-              <Trans i18nKey="cardano.delegation.commission" />
-            </Text>
-            <Box>
-              <Text ff="Inter|Medium" color="palette.text.shade80" fontSize={4}>
-                {selectedPool.margin} %
-              </Text>
-            </Box>
-          </Box>
-          <Separator />
-          {showDeposit ? (
-            <Box horizontal justifyContent="space-between">
+export default function StepSummary(props: StepProps) {
+  const { account, transaction, status, selectedPool } = props;
+
+  const feesUnit = useMaybeAccountUnit(account);
+  if (!account || !transaction) return null;
+
+  const { estimatedFees } = status;
+
+  const feesCurrency = getAccountCurrency(account);
+  const showDeposit = !account.cardanoResources?.delegation?.status;
+  const stakeKeyDeposit = account.cardanoResources?.protocolParams.stakeKeyDeposit;
+  return (
+    <Box flow={4} mx={40}>
+      <FromToWrapper>
+        <Box>
+          <Box horizontal alignItems="center">
+            <Box flex={1}>
               <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-                <Trans i18nKey="cardano.delegation.stakeKeyRegistrationDeposit" />
+                <Trans i18nKey="cardano.delegation.delegatingTo" />
               </Text>
-              <Box>
-                <FormattedVal
-                  color={"palette.text.shade80"}
-                  disableRounding
-                  unit={feesUnit}
-                  alwaysShowValue
-                  val={new BigNumber(stakeKeyDeposit)}
-                  fontSize={4}
-                  inline
-                  showCode
-                />
-              </Box>
+              <Ellipsis mt={2}>
+                <Box horizontal alignItems="center">
+                  <CardanoLedgerPoolIcon validator={selectedPool} />
+                  <Text ff="Inter" color="palette.text.shade100" fontSize={4} ml={2}>
+                    {`${selectedPool.name} [${selectedPool.ticker}]`}
+                  </Text>
+                </Box>
+              </Ellipsis>
             </Box>
-          ) : null}
+          </Box>
+        </Box>
+        <Box horizontal justifyContent="space-between" mt={1}>
+          <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+            <Trans i18nKey="cardano.delegation.cost" />
+          </Text>
+          <Box>
+            <FormattedVal
+              color={"palette.text.shade80"}
+              disableRounding
+              unit={feesUnit}
+              alwaysShowValue
+              val={new BigNumber(selectedPool.cost)}
+              fontSize={4}
+              inline
+              showCode
+            />
+          </Box>
+        </Box>
+        <Box horizontal justifyContent="space-between" mt={1}>
+          <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+            <Trans i18nKey="cardano.delegation.commission" />
+          </Text>
+          <Box>
+            <Text ff="Inter|Medium" color="palette.text.shade80" fontSize={4}>
+              {selectedPool.margin} %
+            </Text>
+          </Box>
+        </Box>
+        <Separator />
+        {showDeposit ? (
           <Box horizontal justifyContent="space-between">
             <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-              <Trans i18nKey="send.steps.details.fees" />
+              <Trans i18nKey="cardano.delegation.stakeKeyRegistrationDeposit" />
             </Text>
             <Box>
               <FormattedVal
@@ -107,27 +91,44 @@ export default class StepSummary extends PureComponent<StepProps> {
                 disableRounding
                 unit={feesUnit}
                 alwaysShowValue
-                val={estimatedFees}
+                val={new BigNumber(stakeKeyDeposit)}
                 fontSize={4}
                 inline
                 showCode
               />
-              <Box textAlign="right">
-                <CounterValue
-                  color={"palette.text.shade60"}
-                  fontSize={3}
-                  currency={feesCurrency}
-                  value={estimatedFees}
-                  alwaysShowSign={false}
-                  alwaysShowValue
-                />
-              </Box>
             </Box>
           </Box>
-        </FromToWrapper>
-      </Box>
-    );
-  }
+        ) : null}
+        <Box horizontal justifyContent="space-between">
+          <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+            <Trans i18nKey="send.steps.details.fees" />
+          </Text>
+          <Box>
+            <FormattedVal
+              color={"palette.text.shade80"}
+              disableRounding
+              unit={feesUnit}
+              alwaysShowValue
+              val={estimatedFees}
+              fontSize={4}
+              inline
+              showCode
+            />
+            <Box textAlign="right">
+              <CounterValue
+                color={"palette.text.shade60"}
+                fontSize={3}
+                currency={feesCurrency}
+                value={estimatedFees}
+                alwaysShowSign={false}
+                alwaysShowValue
+              />
+            </Box>
+          </Box>
+        </Box>
+      </FromToWrapper>
+    </Box>
+  );
 }
 
 export function StepSummaryFooter({ transitionTo }: StepProps) {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -1,7 +1,7 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
-import { getAccountUnit, getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import FormattedVal from "~/renderer/components/FormattedVal";
@@ -12,6 +12,7 @@ import TranslatedError from "~/renderer/components/TranslatedError";
 import { StepProps } from "../types";
 import BigNumber from "bignumber.js";
 import Alert from "~/renderer/components/Alert";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FromToWrapper = styled.div``;
 const Separator = styled.div`
@@ -21,88 +22,87 @@ const Separator = styled.div`
   margin: 15px 0;
 `;
 
-export default class StepSummary extends PureComponent<StepProps> {
-  render() {
-    const { account, transaction, status, error } = this.props;
-    const { estimatedFees, errors } = status;
-    if (!account) return null;
-    if (!transaction) return null;
-    const accountUnit = getAccountUnit(account);
-    const feesCurrency = getAccountCurrency(account);
-    const stakeKeyDeposit = account.cardanoResources?.protocolParams.stakeKeyDeposit;
-    const displayError = errors.amount?.message ? errors.amount : "";
-    return (
-      <Box flow={4} mx={40}>
-        {error && <ErrorBanner error={error} />}
+export default function StepSummary(props: StepProps) {
+  const { account, transaction, status, error } = props;
+  const { estimatedFees, errors } = status;
+  const displayError = errors.amount?.message ? errors.amount : "";
 
-        <FromToWrapper>
+  const accountUnit = useMaybeAccountUnit(account);
+  if (!account || !transaction) return null;
+
+  const feesCurrency = getAccountCurrency(account);
+  const stakeKeyDeposit = account.cardanoResources?.protocolParams.stakeKeyDeposit;
+  return (
+    <Box flow={4} mx={40}>
+      {error && <ErrorBanner error={error} />}
+
+      <FromToWrapper>
+        <Box>
+          <Box horizontal alignItems="center">
+            <Box flex={1}>
+              <Text ff="Inter" color="palette.text.shade100" fontSize={4} ml={2}>
+                <Trans i18nKey="cardano.unDelegation.message" />
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+        <Separator />
+
+        <Box horizontal justifyContent="space-between" mt={1}>
+          <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+            <Trans i18nKey="cardano.unDelegation.refund" />
+          </Text>
           <Box>
-            <Box horizontal alignItems="center">
-              <Box flex={1}>
-                <Text ff="Inter" color="palette.text.shade100" fontSize={4} ml={2}>
-                  <Trans i18nKey="cardano.unDelegation.message" />
-                </Text>
-              </Box>
-            </Box>
+            <FormattedVal
+              color={"palette.text.shade80"}
+              disableRounding
+              unit={accountUnit}
+              alwaysShowValue
+              val={new BigNumber(stakeKeyDeposit)}
+              fontSize={4}
+              inline
+              showCode
+            />
           </Box>
-          <Separator />
-
-          <Box horizontal justifyContent="space-between" mt={1}>
-            <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-              <Trans i18nKey="cardano.unDelegation.refund" />
-            </Text>
-            <Box>
-              <FormattedVal
-                color={"palette.text.shade80"}
-                disableRounding
-                unit={accountUnit}
+        </Box>
+        <Separator />
+        <Box horizontal justifyContent="space-between">
+          <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+            <Trans i18nKey="send.steps.details.fees" />
+          </Text>
+          <Box>
+            <FormattedVal
+              color={"palette.text.shade80"}
+              disableRounding
+              unit={accountUnit}
+              alwaysShowValue
+              val={estimatedFees}
+              fontSize={4}
+              inline
+              showCode
+            />
+            <Box textAlign="right">
+              <CounterValue
+                color={"palette.text.shade60"}
+                fontSize={3}
+                currency={feesCurrency}
+                value={estimatedFees}
+                alwaysShowSign={false}
                 alwaysShowValue
-                val={new BigNumber(stakeKeyDeposit)}
-                fontSize={4}
-                inline
-                showCode
               />
             </Box>
           </Box>
-          <Separator />
-          <Box horizontal justifyContent="space-between">
-            <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
-              <Trans i18nKey="send.steps.details.fees" />
-            </Text>
-            <Box>
-              <FormattedVal
-                color={"palette.text.shade80"}
-                disableRounding
-                unit={accountUnit}
-                alwaysShowValue
-                val={estimatedFees}
-                fontSize={4}
-                inline
-                showCode
-              />
-              <Box textAlign="right">
-                <CounterValue
-                  color={"palette.text.shade60"}
-                  fontSize={3}
-                  currency={feesCurrency}
-                  value={estimatedFees}
-                  alwaysShowSign={false}
-                  alwaysShowValue
-                />
-              </Box>
-            </Box>
-          </Box>
-        </FromToWrapper>
-        {displayError ? (
-          <Box grow>
-            <Alert type="error">
-              <TranslatedError error={displayError} field="title" />
-            </Alert>
-          </Box>
-        ) : null}
-      </Box>
-    );
-  }
+        </Box>
+      </FromToWrapper>
+      {displayError ? (
+        <Box grow>
+          <Alert type="error">
+            <TranslatedError error={displayError} field="title" />
+          </Alert>
+        </Box>
+      ) : null}
+    </Box>
+  );
 }
 export function StepSummaryFooter({
   transitionTo,

--- a/apps/ledger-live-desktop/src/renderer/families/casper/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/TransactionConfirmFields.tsx
@@ -1,11 +1,12 @@
 import invariant from "invariant";
 import React from "react";
 import TransactionConfirmField from "~/renderer/components/TransactionConfirm/TransactionConfirmField";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import { CasperFieldComponentProps } from "./types";
 import { ExtraDeviceTransactionField } from "@ledgerhq/live-common/families/casper/deviceTransactionConfig";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const CasperExtendedAmountField = ({
   account,
@@ -15,7 +16,7 @@ const CasperExtendedAmountField = ({
 }: CasperFieldComponentProps) => {
   invariant(transaction.family === "casper", "casper transaction");
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const specifiedAmount = (field as ExtraDeviceTransactionField).value;
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/families/celo/AccountBalanceSummaryFooter/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/AccountBalanceSummaryFooter/AccountBalanceSummaryFooter.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
@@ -10,15 +9,17 @@ import ToolTip from "~/renderer/components/Tooltip";
 import { withdrawableBalance } from "@ledgerhq/live-common/families/celo/logic";
 import * as S from "./AccountBalanceSummaryFooter.styles";
 import { CeloFamily } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const AccountBalanceSummaryFooter: CeloFamily["AccountBalanceSummaryFooter"] = ({ account }) => {
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
   if (account.type !== "Account") return null;
   const { spendableBalance, celoResources } = account;
   const { lockedBalance, nonvotingLockedBalance } = celoResources;
   const withdrawableBalanceAmount = withdrawableBalance(account);
-  const unit = getAccountUnit(account);
+
   const formatConfig = {
     disableRounding: false,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/AccountBodyHeader/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/AccountBodyHeader/Row.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
@@ -24,6 +23,7 @@ import ManageDropDown from "./ManageDropDown";
 import { ModalActions } from "../modals";
 import { DropDownItemType } from "~/renderer/components/DropDownSelector";
 import Discreet from "~/renderer/components/Discreet";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const voteActions = (vote: CeloVote): Array<{ key: ModalActions; label: React.ReactNode }> => {
   const actions: Array<{ key: ModalActions; label: React.ReactNode }> = [];
   if (vote.activatable)
@@ -53,6 +53,9 @@ export const Row = ({ account, vote, onManageAction, onExternalLink }: Props) =>
   );
   const onExternalLinkClick = () => onExternalLink(vote);
   const actions = voteActions(vote);
+
+  const unit = useAccountUnit(account);
+
   const { validatorGroups } = useCeloPreloadData();
   const validatorGroup = useMemo(
     () =>
@@ -62,7 +65,6 @@ export const Row = ({ account, vote, onManageAction, onExternalLink }: Props) =>
   );
   const status = voteStatus(vote);
   const formatAmount = (amount: number) => {
-    const unit = getAccountUnit(account);
     return formatCurrencyUnit(unit, new BigNumber(amount), {
       disableRounding: false,
       alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/steps/StepVote.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/steps/StepVote.tsx
@@ -12,9 +12,9 @@ import Button from "~/renderer/components/Button";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { useCeloPreloadData } from "@ledgerhq/live-common/families/celo/react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import ActivateValidatorGroupRow from "~/renderer/families/celo/ActivateFlowModal/components/ActivateValidatorGroupRow";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export const StepVoteFooter = ({
   transitionTo,
   account,
@@ -58,6 +58,8 @@ const StepVote = ({
     "account with votes and transaction required",
   );
   const bridge = getAccountBridge(account, parentAccount);
+  const unit = useAccountUnit(account);
+
   const onChange = useCallback(
     (recipient: string) => {
       onChangeTransaction(
@@ -81,7 +83,7 @@ const StepVote = ({
       })) || [],
     [votes, validatorGroups],
   );
-  const unit = getAccountUnit(account);
+
   return (
     <Box flow={1}>
       <TrackPage

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/fields/AmountField.tsx
@@ -4,7 +4,6 @@ import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   CeloAccount,
   Transaction,
@@ -17,6 +16,7 @@ import InputCurrency from "~/renderer/components/InputCurrency";
 import Switch from "~/renderer/components/Switch";
 import Text from "~/renderer/components/Text";
 import * as S from "./AmountField.styles";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 type Props = {
   t: TFunction;
   account: CeloAccount | undefined | null;
@@ -35,7 +35,7 @@ const AmountField = ({
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
   const bridge = getAccountBridge(account, parentAccount);
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/fields/AmountField.tsx
@@ -4,7 +4,6 @@ import { Trans } from "react-i18next";
 import { TFunction } from "i18next";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import SpendableAmount from "~/renderer/components/SpendableAmount";
 import Label from "~/renderer/components/Label";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/fields/AmountField.tsx
@@ -17,6 +17,7 @@ import {
   TransactionStatus,
   CeloAccount,
 } from "@ledgerhq/live-common/families/celo/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   t: TFunction;
@@ -36,7 +37,7 @@ const AmountField = ({
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
   const bridge = getAccountBridge(account, parentAccount);
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/steps/StepVote.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/steps/StepVote.tsx
@@ -14,6 +14,7 @@ import Alert from "~/renderer/components/Alert";
 import { urls } from "~/config/urls";
 import * as S from "./StepVote.styles";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export const StepVoteFooter = ({
   transitionTo,
   account,
@@ -53,6 +54,7 @@ const StepVote = ({
     account && account.celoResources && transaction,
     "celo account, resources and transaction required",
   );
+  const unit = useAccountUnit(account);
   const bridge = getAccountBridge(account, parentAccount);
   const onChange = useCallback(
     (recipient: string, index: number) => {
@@ -78,7 +80,7 @@ const StepVote = ({
       })) || [],
     [votes, validatorGroups],
   );
-  const unit = getAccountUnit(account);
+
   return (
     <Box flow={1}>
       <TrackPage

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/steps/StepVote.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/steps/StepVote.tsx
@@ -8,7 +8,6 @@ import Button from "~/renderer/components/Button";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import RevokeVoteRow from "../components/RevokeVoteRow";
 import { useCeloPreloadData } from "@ledgerhq/live-common/families/celo/react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { revokableVotes, fallbackValidatorGroup } from "@ledgerhq/live-common/families/celo/logic";
 import Alert from "~/renderer/components/Alert";
 import { urls } from "~/config/urls";

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/fields/AmountField.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import {
   CeloAccount,

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/fields/AmountField.tsx
@@ -17,6 +17,7 @@ import SpendableAmount from "~/renderer/components/SpendableAmount";
 import Switch from "~/renderer/components/Switch";
 import Text from "~/renderer/components/Text";
 import * as S from "./AmountField.styles";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   t: TFunction;
@@ -36,7 +37,7 @@ const AmountField = ({
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
   const bridge = getAccountBridge(account, parentAccount);
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/fields/ValidatorGroupsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/fields/ValidatorGroupsField.tsx
@@ -17,6 +17,7 @@ import {
   CeloAccount,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/celo/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 type Props = {
   account: CeloAccount;
   status: TransactionStatus;
@@ -32,7 +33,7 @@ const ValidatorGroupsField = ({
   invariant(account && account.celoResources, "celo account and resources required");
   const [search, setSearch] = useState("");
   const [showAll, setShowAll] = useState(false);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const validatorGroups = useValidatorGroups(search);
   const onSearch = useCallback(
     (evt: React.ChangeEvent<HTMLInputElement>) => setSearch(evt.target.value),

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/fields/ValidatorGroupsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/fields/ValidatorGroupsField.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import invariant from "invariant";
 import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Trans } from "react-i18next";

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
@@ -16,6 +16,7 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import * as S from "./StepAmount.styles";
 import { StepProps } from "../types";
 import { fromNow } from "~/renderer/hooks/useDateFormatter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export const StepAmountFooter = ({
   transitionTo,
   account,
@@ -65,6 +66,8 @@ const StepAmount = ({
     account && transaction && account.celoResources && account.celoResources.pendingWithdrawals,
     "account with pending withdrawals and transaction required",
   );
+
+  const unit = useAccountUnit(account);
   const bridge = getAccountBridge(account, parentAccount);
   const onChange = useCallback(
     (index: number) => {
@@ -105,7 +108,7 @@ const StepAmount = ({
                 )}
                 <FormattedVal
                   val={value}
-                  unit={account.unit}
+                  unit={unit}
                   style={{
                     textAlign: "right",
                     width: "auto",

--- a/apps/ledger-live-desktop/src/renderer/families/celo/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/operationDetails.tsx
@@ -18,6 +18,7 @@ import {
 } from "~/renderer/drawers/OperationDetails/styledComponents";
 import { openURL } from "~/renderer/linking";
 import { OperationDetailsExtraProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const redirectAddress = (currency: CryptoCurrency, address: string) => () => {
   const url = getAddressExplorer(getDefaultExplorerView(currency), address);
@@ -30,6 +31,8 @@ const OperationDetailsExtra = ({
   account,
 }: OperationDetailsExtraProps<CeloAccount, CeloOperation>) => {
   const { currency } = account;
+
+  const unit = useAccountUnit(account);
   const { validatorGroups } = useCeloPreloadData();
   switch (type) {
     case "ACTIVATE":
@@ -52,7 +55,7 @@ const OperationDetailsExtra = ({
                 <Box>
                   <FormattedVal
                     val={operation.extra.celoOperationValue}
-                    unit={account.unit}
+                    unit={unit}
                     showCode
                     fontSize={4}
                     color="palette.text.shade60"
@@ -96,7 +99,7 @@ const OperationDetailsExtra = ({
                 <Box>
                   <FormattedVal
                     val={operation.extra.celoOperationValue}
-                    unit={account.unit}
+                    unit={unit}
                     showCode
                     fontSize={4}
                     color="palette.text.shade60"

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountBalanceSummaryFooter.tsx
@@ -15,6 +15,7 @@ import ToolTip from "~/renderer/components/Tooltip";
 import { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
 import { CosmosAPI } from "@ledgerhq/live-common/families/cosmos/api/Cosmos";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -81,11 +82,11 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
     });
   }, [account]);
 
+  const unit = useAccountUnit(account);
   if (account.type !== "Account") return null;
   const { spendableBalance: _spendableBalance, cosmosResources } = account;
   const { delegatedBalance: _delegatedBalance, unbondingBalance: _unbondingBalance } =
     cosmosResources;
-  const unit = getAccountUnit(account);
   const formatConfig = {
     disableRounding: false,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/AccountBalanceSummaryFooter.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
 import { Unit } from "@ledgerhq/types-cryptoassets";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
@@ -4,7 +4,6 @@ import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { StepProps } from "../types";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
@@ -19,6 +19,7 @@ import {
   CosmosLikeTransaction,
   CosmosMappedDelegation,
 } from "@ledgerhq/live-common/families/cosmos/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 export default function StepClaimRewards({
   account,
@@ -32,7 +33,7 @@ export default function StepClaimRewards({
   const locale = useSelector(localeSelector);
   invariant(account && account.cosmosResources && transaction, "account and transaction required");
   const bridge = getAccountBridge(account, parentAccount);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const updateClaimRewards = useCallback(
     (newTransaction: Partial<CosmosLikeTransaction>) => {
       onUpdateTransaction(transaction => bridge.updateTransaction(transaction, newTransaction));

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepConfirmation.tsx
@@ -17,6 +17,7 @@ import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { StepProps } from "../types";
 import { localeSelector } from "~/renderer/reducers/settings";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
   grow: true,
@@ -31,8 +32,8 @@ function StepConfirmation({ account, optimisticOperation, error, signed, transac
   const currencyId = account.currency.id;
   const { validators } = useCosmosFamilyPreloadData(currencyId);
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
   if (optimisticOperation) {
-    const unit = account && getAccountUnit(account);
     const validator = transaction && transaction.validators ? transaction.validators[0] : null;
     const v =
       validator &&

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepConfirmation.tsx
@@ -3,7 +3,6 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { useCosmosFamilyPreloadData } from "@ledgerhq/live-common/families/cosmos/react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
 import TrackPage from "~/renderer/analytics/TrackPage";

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/index.tsx
@@ -29,6 +29,7 @@ import { CosmosAccount } from "@ledgerhq/live-common/families/cosmos/types";
 import { DelegationActionsModalName } from "../modals";
 import cryptoFactory from "@ledgerhq/live-common/families/cosmos/chain/chain";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   p: 3,
@@ -53,7 +54,7 @@ const Delegation = ({ account }: { account: CosmosAccount }) => {
   const mappedDelegations = useCosmosFamilyMappedDelegations(account);
   const currencyId = account.currency.id;
   const { validators } = useCosmosFamilyPreloadData(currencyId);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const mappedUnbondings = mapUnbondings(unbondings, validators, unit);
   const onEarnRewards = useCallback(() => {
     dispatch(

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/index.tsx
@@ -3,7 +3,6 @@ import { useDispatch } from "react-redux";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { SubAccount } from "@ledgerhq/types-live";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   useCosmosFamilyPreloadData,
   useCosmosFamilyMappedDelegations,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
@@ -16,6 +16,7 @@ import ScrollLoadingList from "~/renderer/components/ScrollLoadingList";
 import Text from "~/renderer/components/Text";
 import ValidatorRow from "~/renderer/families/cosmos/shared/components/CosmosFamilyValidatorRow";
 import IconAngleDown from "~/renderer/icons/AngleDown";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 type Props = {
   t: TFunction;
   account: Account;
@@ -27,7 +28,7 @@ type Props = {
 const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props) => {
   const [showAll, setShowAll] = useState(false);
   const [search, setSearch] = useState("");
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const currencyId = account.currency.id;
   const validators = useLedgerFirstShuffledValidatorsCosmosFamily(currencyId, search);
   const onSearch = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { useLedgerFirstShuffledValidatorsCosmosFamily } from "@ledgerhq/live-common/families/cosmos/react";
 import {
   CosmosDelegation,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/fields/ValidatorField.tsx
@@ -2,7 +2,6 @@ import invariant from "invariant";
 import React, { useState, useCallback } from "react";
 import styled from "styled-components";
 import { useLedgerFirstShuffledValidatorsCosmosFamily } from "@ledgerhq/live-common/families/cosmos/react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import ValidatorSearchInput from "~/renderer/components/Delegation/ValidatorSearchInput";
 import ScrollLoadingList from "~/renderer/components/ScrollLoadingList";

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/fields/ValidatorField.tsx
@@ -14,6 +14,7 @@ import {
   CosmosValidatorItem,
   Transaction,
 } from "@ledgerhq/live-common/families/cosmos/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const ValidatorsSection = styled(Box)`
   width: 100%;
   height: 100%;
@@ -37,7 +38,7 @@ export default function ValidatorField({
     [setSearch],
   );
   invariant(cosmosResources, "cosmosResources required");
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const fromValidatorAddress = transaction.sourceValidator;
   const sortedFilteredValidators = validators.filter(
     v => v.validatorAddress !== fromValidatorAddress,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/TransactionConfirmFields.tsx
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import React, { useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { getAccountUnit, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TransactionConfirmField from "~/renderer/components/TransactionConfirm/TransactionConfirmField";
 import Text from "~/renderer/components/Text";
 import WarnBox from "~/renderer/components/WarnBox";
@@ -18,6 +18,7 @@ import {
 import FormattedVal from "~/renderer/components/FormattedVal";
 import { CosmosFieldComponentProps } from "./types";
 import { CosmosAccount, Transaction } from "@ledgerhq/live-common/families/cosmos/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Info = styled(Box).attrs(() => ({
   ff: "Inter|SemiBold",
   color: "palette.text.shade100",
@@ -68,7 +69,7 @@ export const CosmosDelegateValidatorsField = ({
   field,
 }: CosmosFieldComponentProps) => {
   const mainAccount = getMainAccount(account, parentAccount);
-  const unit = getAccountUnit(mainAccount);
+  const unit = useAccountUnit(mainAccount);
   const { validators } = transaction;
   const currencyId = mainAccount.currency.id;
   const { validators: cosmosValidators } = useCosmosFamilyPreloadData(currencyId);
@@ -145,7 +146,7 @@ export const CosmosValidatorAmountField = ({
 }: CosmosFieldComponentProps) => {
   const mainAccount = getMainAccount(account, parentAccount);
   invariant(transaction.family === "cosmos", "not a cosmos family transaction");
-  const unit = getAccountUnit(mainAccount);
+  const unit = useAccountUnit(mainAccount);
   const { validators } = transaction;
   return validators && validators.length > 0 ? (
     <TransactionConfirmField label={field.label}>

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/fields/Amount.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { BigNumber } from "bignumber.js";
 import styled from "styled-components";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { Account } from "@ledgerhq/types-live";
 import {
   CosmosDelegationInfo,

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/fields/Amount.tsx
@@ -10,6 +10,7 @@ import {
 import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Label from "~/renderer/components/Label";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   amount: BigNumber;
@@ -27,7 +28,7 @@ export default function AmountField({
   status: { errors, warnings },
   label,
 }: Props) {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const [currentValidator, setCurrentValidator] = useState(validator);
   const [focused, setFocused] = useState(false);
   const [initialAmount, setInitialAmount] = useState(validator ? validator.amount : BigNumber(0));

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Confirmation.tsx
@@ -17,6 +17,7 @@ import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export default function StepConfirmation({
   account,
   optimisticOperation,
@@ -28,8 +29,8 @@ export default function StepConfirmation({
   const currencyId = account.currency.id;
   const { validators } = useCosmosFamilyPreloadData(currencyId);
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
   if (optimisticOperation) {
-    const unit = account && getAccountUnit(account);
     const validator = transaction && transaction.validators ? transaction.validators[0] : null;
     const v =
       validator &&

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Confirmation.tsx
@@ -12,7 +12,6 @@ import RetryButton from "~/renderer/components/RetryButton";
 import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import { StepProps } from "../types";
 import { useCosmosFamilyPreloadData } from "@ledgerhq/live-common/families/cosmos/react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/operationDetails.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable consistent-return */
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
 import cryptoFactory from "@ledgerhq/live-common/families/cosmos/chain/chain";
@@ -34,6 +34,7 @@ import {
 import { openURL } from "~/renderer/linking";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { AmountCellExtraProps, OperationDetailsExtraProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 function getURLFeesInfo({
   op,
@@ -124,7 +125,7 @@ const OperationDetailsExtra = ({
   type,
   account,
 }: OperationDetailsExtraProps<CosmosAccount, CosmosOperation>) => {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const currency = getAccountCurrency(account);
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/AccountBalanceSummaryFooter.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { BigNumber } from "bignumber.js";
 import { useSelector } from "react-redux";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/AccountBalanceSummaryFooter.tsx
@@ -18,6 +18,7 @@ import {
 import { DelegationType } from "./types";
 import { ElrondAccount } from "@ledgerhq/live-common/families/elrond/types";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 interface BalanceType {
   tooltip: string;
@@ -34,7 +35,7 @@ const Summary = (props: { account: ElrondAccount }) => {
   );
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const fetchDelegations = useCallback(() => {
     setBalance(account.spendableBalance);
     setDelegationResources(account.elrondResources ? account.elrondResources.delegations : []);

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Delegations/components/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Delegations/components/Delegation/index.tsx
@@ -27,6 +27,7 @@ import {
 } from "@ledgerhq/live-common/families/elrond/types";
 import { ModalsData } from "~/renderer/families/elrond/modals";
 import Discreet from "~/renderer/components/Discreet";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 interface RenderDropdownItemType {
   isActive: boolean;
@@ -141,6 +142,8 @@ const Delegation = (props: Props) => {
       }),
     [claimableRewards],
   );
+
+  const unit = useAccountUnit(account);
   return (
     <Wrapper>
       <Column
@@ -168,11 +171,11 @@ const Delegation = (props: Props) => {
       </Column>
 
       <Column>
-        <Discreet>{amount}</Discreet> {getAccountUnit(account).code}
+        <Discreet>{amount}</Discreet> {unit.code}
       </Column>
 
       <Column>
-        <Discreet>{rewards}</Discreet> {getAccountUnit(account).code}
+        <Discreet>{rewards}</Discreet> {unit.code}
       </Column>
 
       <Column>

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Delegations/components/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Delegations/components/Delegation/index.tsx
@@ -3,7 +3,6 @@ import { BigNumber } from "bignumber.js";
 import { Trans } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box/Box";
 import CheckCircle from "~/renderer/icons/CheckCircle";
 import ToolTip from "~/renderer/components/Tooltip";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepClaimRewards.tsx
@@ -4,7 +4,6 @@ import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
 import invariant from "invariant";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepClaimRewards.tsx
@@ -15,6 +15,7 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import { ElrondTransactionMode, Transaction } from "@ledgerhq/live-common/families/elrond/types";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const StepClaimRewards = (props: StepProps) => {
   const {
@@ -57,6 +58,7 @@ const StepClaimRewards = (props: StepProps) => {
     },
     [updateClaimRewards, transaction],
   );
+  const unit = useAccountUnit(account);
   if (!transaction) return null;
   const key = transaction.mode === "claimRewards" ? "claimInfo" : "compoundInfo";
   return (
@@ -80,7 +82,7 @@ const StepClaimRewards = (props: StepProps) => {
               amount: `${denominate({
                 input: String(transaction.amount),
                 decimals: 4,
-              })} ${getAccountUnit(account).code}`,
+              })} ${unit.code}`,
             }}
           >
             <b></b>

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepConfirmation.tsx
@@ -14,6 +14,7 @@ import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDiscla
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -26,13 +27,15 @@ const Container = styled(Box).attrs(() => ({
 `;
 const StepConfirmation = (props: StepProps) => {
   const { optimisticOperation, error, signed, account, transaction, validators } = props;
+
+  const unit = useAccountUnit(account);
   if (optimisticOperation) {
     const provider: string | undefined = transaction && transaction.recipient;
     const v = provider ? validators?.find(validator => validator.contract === provider) : undefined;
     const amount = `${denominate({
       input: String(transaction?.amount),
       decimals: 4,
-    })} ${getAccountUnit(account).code || "EGLD"}`;
+    })} ${unit.code || "EGLD"}`;
     const titleKey = transaction?.mode === "claimRewards" ? "title" : "titleCompound";
     const textKey = transaction?.mode === "claimRewards" ? "text" : "textCompound";
     return (

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Claim/steps/StepConfirmation.tsx
@@ -3,7 +3,6 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Delegate/fields/ValidatorList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Delegate/fields/ValidatorList.tsx
@@ -15,6 +15,7 @@ import {
   ElrondProvider,
   Transaction,
 } from "@ledgerhq/live-common/families/elrond/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const ValidatorsFieldContainer = styled(Box)`
   border: 1px solid ${p => p.theme.colors.palette.divider};
@@ -50,7 +51,7 @@ const ValidatorList = (props: Props) => {
   const { account, validators, onSelectValidator, transaction } = props;
   const [showAll, setShowAll] = useState(false);
   const [search, setSearch] = useState("");
-  const unit = useMemo(() => getAccountUnit(account), [account]);
+  const unit = useAccountUnit(account);
   const providers = useSearchValidators(validators, search);
   const defaultValidator = useMemo(
     () =>

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Delegate/fields/ValidatorList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Delegate/fields/ValidatorList.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, Fragment, useCallback } from "react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/fields/Amount.tsx
@@ -8,6 +8,7 @@ import TranslatedError from "~/renderer/components/TranslatedError";
 import { Unit } from "@ledgerhq/types-cryptoassets";
 import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { ElrondAccount, TransactionStatus } from "@ledgerhq/live-common/families/elrond/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const InputLeft = styled(Box).attrs(() => ({
   ff: "Inter|Medium",
@@ -96,7 +97,7 @@ const AmountField = (props: Props) => {
     status: { errors, warnings },
     label,
   } = props;
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const [focused, setFocused] = useState(false);
   const onAmountChange = (amount: BigNumber, unit?: Unit) => {
     onChange(amount, unit);
@@ -142,7 +143,7 @@ const AmountField = (props: Props) => {
         value={amount}
         onChange={onAmountChange}
         onChangeFocus={() => setFocused(true)}
-        renderLeft={<InputLeft>{getAccountUnit(account).code}</InputLeft>}
+        renderLeft={<InputLeft>{unit.code}</InputLeft>}
         renderRight={
           <InputRight>
             {options.map(({ label, value }) => (

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/fields/Amount.tsx
@@ -6,7 +6,6 @@ import InputCurrency from "~/renderer/components/InputCurrency";
 import Label from "~/renderer/components/Label";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import { Unit } from "@ledgerhq/types-cryptoassets";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { ElrondAccount, TransactionStatus } from "@ledgerhq/live-common/families/elrond/types";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/steps/Confirmation.tsx
@@ -3,7 +3,6 @@ import { useTranslation, Trans } from "react-i18next";
 import styled from "styled-components";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Undelegate/steps/Confirmation.tsx
@@ -14,6 +14,7 @@ import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -27,13 +28,14 @@ const Container = styled(Box).attrs(() => ({
 const StepConfirmation = (props: StepProps) => {
   const { optimisticOperation, error, signed, account, transaction, validators } = props;
   const { t } = useTranslation();
+  const unit = useAccountUnit(account);
   if (optimisticOperation && transaction) {
     const provider: string | undefined = transaction && transaction.recipient;
     const v = provider ? validators.find(validator => validator.contract === provider) : undefined;
     const amount = `${denominate({
       input: String(transaction.amount),
       decimals: 4,
-    })} ${getAccountUnit(account).code || "EGLD"}`;
+    })} ${unit.code || "EGLD"}`;
     return (
       <Container>
         <TrackPage

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepConfirmation.tsx
@@ -14,6 +14,7 @@ import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDiscla
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
   grow: true,
@@ -25,11 +26,12 @@ const Container = styled(Box).attrs(() => ({
 `;
 const StepConfirmation = (props: StepProps) => {
   const { optimisticOperation, error, signed, account, transaction } = props;
+  const unit = useAccountUnit(account);
   if (optimisticOperation && account && transaction) {
     const amount = `${denominate({
       input: String(transaction.amount),
       decimals: 4,
-    })} ${getAccountUnit(account).code || "EGLD"}`;
+    })} ${unit.code || "EGLD"}`;
     return (
       <Container>
         <TrackPage

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepConfirmation.tsx
@@ -3,7 +3,6 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepWithdraw.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepWithdraw.tsx
@@ -14,6 +14,7 @@ import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { Transaction } from "@ledgerhq/live-common/families/elrond/types";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const StepWithdraw = (props: StepProps) => {
   const {
@@ -28,6 +29,7 @@ const StepWithdraw = (props: StepProps) => {
     amount,
     name,
   } = props;
+  const unit = useAccountUnit(account);
   const bridge: AccountBridge<Transaction> = getAccountBridge(account);
   const onDelegationChange = useCallback(
     // @ts-expect-error another TS puzzle for another day
@@ -63,7 +65,7 @@ const StepWithdraw = (props: StepProps) => {
               amount: `${denominate({
                 input: String(transaction.amount),
                 decimals: 4,
-              })} ${getAccountUnit(account).code}`,
+              })} ${unit.code}`,
             }}
           >
             <b></b>

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepWithdraw.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Modals/Withdraw/steps/StepWithdraw.tsx
@@ -1,7 +1,6 @@
 import React, { Fragment, useCallback } from "react";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { Trans } from "react-i18next";
 import { BigNumber } from "bignumber.js";
 import TrackPage from "~/renderer/analytics/TrackPage";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Unbondings/components/Unbonding/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Unbondings/components/Unbonding/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "@ledgerhq/live-common/families/elrond/constants";
 import { ElrondAccount } from "@ledgerhq/live-common/families/elrond/types";
 import Discreet from "~/renderer/components/Discreet";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 // FIXME spreading UnbondingType is a bad pattern
 const Unbonding = (
@@ -75,6 +76,9 @@ const Unbonding = (
       }),
     );
   }, [account, contract, unbondings, amount, validator, dispatch]);
+
+  const unit = useAccountUnit(account);
+
   useEffect(handleCounter, [seconds]);
   return (
     <Wrapper>
@@ -103,7 +107,7 @@ const Unbonding = (
       </Column>
 
       <Column>
-        <Discreet>{balance}</Discreet> {getAccountUnit(account).code}
+        <Discreet>{balance}</Discreet> {unit.code}
       </Column>
 
       <Column>

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/components/Unbondings/components/Unbonding/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/components/Unbondings/components/Unbonding/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useMemo, useEffect } from "react";
 import { Trans } from "react-i18next";
 import { denominate } from "@ledgerhq/live-common/families/elrond/helpers/denominate";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { useDispatch } from "react-redux";
 import Box from "~/renderer/components/Box/Box";
 import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/operationDetails.tsx
@@ -30,6 +30,7 @@ import {
 import { openURL } from "~/renderer/linking";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { AmountCellExtraProps, OperationDetailsExtraProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const getURLFeesInfo = ({ op }: { op: Operation; currencyId: string }): string | undefined => {
   if (op.fee.gt(200000)) {
@@ -61,6 +62,8 @@ const OperationDetailsDelegation = (props: OperationDetailsDelegationProps) => {
   const formattedValidator: ElrondProvider | undefined = validators.find(
     v => v.contract === operation.contract,
   );
+
+  const unit = useAccountUnit(account);
   return (
     <OpDetailsSection>
       {!isTransactionField && (
@@ -80,7 +83,7 @@ const OperationDetailsDelegation = (props: OperationDetailsDelegationProps) => {
                     votes: `${denominate({
                       input: operation.extra.amount?.toString() ?? "",
                       decimals: 4,
-                    })} ${getAccountUnit(account).code}`,
+                    })} ${unit.code}`,
                     name: formattedValidator?.identity.name || operation.contract,
                   }}
                 >
@@ -101,7 +104,7 @@ const OperationDetailsDelegation = (props: OperationDetailsDelegationProps) => {
 
 const OperationDetailsExtra = (props: OperationDetailsExtraProps<Account, ElrondOperation>) => {
   const { type, account, operation } = props;
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
   const { validators } = useElrondPreloadData();

--- a/apps/ledger-live-desktop/src/renderer/families/elrond/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/elrond/operationDetails.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable consistent-return */
 
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
   ELROND_EXPLORER_URL,

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
@@ -6,7 +6,7 @@ import {
   GasOptions,
   Strategy,
 } from "@ledgerhq/coin-evm/types/index";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { Account } from "@ledgerhq/types-live";
 import React, { memo, useMemo } from "react";
 import { Trans } from "react-i18next";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/SelectFeeStrategy.tsx
@@ -20,6 +20,7 @@ import TachometerHigh from "~/renderer/icons/TachometerHigh";
 import TachometerLow from "~/renderer/icons/TachometerLow";
 import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   onClick: (_: { feesStrategy: Strategy }) => void;
@@ -96,7 +97,7 @@ const SelectFeeStrategy = ({
   transactionToUpdate,
   status,
 }: Props) => {
-  const accountUnit = getAccountUnit(account);
+  const accountUnit = useAccountUnit(account);
   const feesCurrency = getAccountCurrency(account);
   const { errors } = status;
   const { gasPrice: messageGas } = errors;

--- a/apps/ledger-live-desktop/src/renderer/families/near/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/AccountBalanceSummaryFooter.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
@@ -51,7 +50,10 @@ const AmountValue = styled(Text).attrs(() => ({
 const AccountBalanceSummaryFooter: NearFamily["AccountBalanceSummaryFooter"] = ({ account }) => {
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
+
   if (account.type !== "Account") return null;
+
   const {
     spendableBalance: _spendableBalance,
     nearResources: {
@@ -61,7 +63,7 @@ const AccountBalanceSummaryFooter: NearFamily["AccountBalanceSummaryFooter"] = (
       pendingBalance: _pendingBalance,
     },
   } = account;
-  const unit = useAccountUnit(account);
+
   const formatConfig = {
     alwaysShowSign: false,
     showCode: true,

--- a/apps/ledger-live-desktop/src/renderer/families/near/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/AccountBalanceSummaryFooter.tsx
@@ -11,6 +11,7 @@ import Text from "~/renderer/components/Text";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import ToolTip from "~/renderer/components/Tooltip";
 import { NearFamily } from "./types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -60,7 +61,7 @@ const AccountBalanceSummaryFooter: NearFamily["AccountBalanceSummaryFooter"] = (
       pendingBalance: _pendingBalance,
     },
   } = account;
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formatConfig = {
     alwaysShowSign: false,
     showCode: true,

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/fields/ValidatorField.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from "react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { useLedgerFirstShuffledValidatorsNear } from "@ledgerhq/live-common/families/near/react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/fields/ValidatorField.tsx
@@ -14,6 +14,7 @@ import ValidatorRow from "~/renderer/families/near/shared/components/ValidatorRo
 import { Account } from "@ledgerhq/types-live";
 import { NearValidatorItem } from "@ledgerhq/live-common/families/near/types";
 import { FIGMENT_NEAR_VALIDATOR_ADDRESS } from "@ledgerhq/live-common/families/near/constants";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 type Props = {
   account: Account;
   onChangeValidator: (a: { address: string }) => void;
@@ -23,7 +24,7 @@ type Props = {
 const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props) => {
   const [search, setSearch] = useState("");
   const [showAll, setShowAll] = useState(false);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const validators = useLedgerFirstShuffledValidatorsNear(search);
   const renderItem = (validator: NearValidatorItem) => {
     return (

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/fields/Amount.tsx
@@ -7,6 +7,7 @@ import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Label from "~/renderer/components/Label";
 import { TransactionStatus } from "@ledgerhq/live-common/families/near/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   amount: BigNumber;
@@ -27,7 +28,7 @@ export default function AmountField({
   status: { errors, warnings },
   label,
 }: Props) {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const [currentValidator, setCurrentValidator] = useState(validator);
   const [focused, setFocused] = useState(false);
   const [initialAmount, setInitialAmount] = useState(validator ? validator.amount : BigNumber(0));

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/fields/Amount.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { BigNumber } from "bignumber.js";
 import styled from "styled-components";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { Account } from "@ledgerhq/types-live";
 import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Confirmation.tsx
@@ -11,7 +11,6 @@ import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import RetryButton from "~/renderer/components/RetryButton";
 import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import { StepProps } from "../types";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Confirmation.tsx
@@ -16,6 +16,7 @@ import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export default function StepConfirmation({
   account,
   optimisticOperation,
@@ -25,8 +26,8 @@ export default function StepConfirmation({
 }: StepProps) {
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
   if (optimisticOperation) {
-    const unit = account && getAccountUnit(account);
     const amount =
       unit &&
       transaction &&

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/fields/Amount.tsx
@@ -7,6 +7,7 @@ import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Label from "~/renderer/components/Label";
 import { TransactionStatus } from "@ledgerhq/live-common/families/near/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   amount: BigNumber;
@@ -27,7 +28,7 @@ export default function AmountField({
   status: { errors, warnings },
   label,
 }: Props) {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const [currentValidator, setCurrentValidator] = useState(validator);
   const [focused, setFocused] = useState(false);
   const [initialAmount, setInitialAmount] = useState(validator ? validator.amount : BigNumber(0));

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/fields/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/fields/Amount.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState, useEffect } from "react";
 import { BigNumber } from "bignumber.js";
 import styled from "styled-components";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { Account } from "@ledgerhq/types-live";
 import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/steps/Confirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/steps/Confirmation.tsx
@@ -11,11 +11,11 @@ import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import RetryButton from "~/renderer/components/RetryButton";
 import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import { StepProps } from "../types";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export default function StepConfirmation({
   account,
   optimisticOperation,
@@ -25,8 +25,8 @@ export default function StepConfirmation({
 }: StepProps) {
   const { t } = useTranslation();
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
   if (optimisticOperation) {
-    const unit = account && getAccountUnit(account);
     const amount =
       unit &&
       transaction &&

--- a/apps/ledger-live-desktop/src/renderer/families/near/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/operationDetails.tsx
@@ -11,6 +11,7 @@ import {
 import { AmountCellExtraProps, OperationDetailsExtraProps } from "../types";
 import { NearAccount } from "@ledgerhq/live-common/families/near/types";
 import { Operation } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const AmountCellExtra = ({ operation, currency, unit }: AmountCellExtraProps<Operation>) => {
   const amount = operation.value;
@@ -38,6 +39,7 @@ const OperationDetailsExtra = ({
   account,
 }: OperationDetailsExtraProps<NearAccount, Operation>) => {
   const amount = operation.value;
+  const unit = useAccountUnit(account);
   let i18nKey = "";
   if (type === "STAKE") {
     i18nKey = "near.operationDetails.extra.stakedAmount";
@@ -53,7 +55,7 @@ const OperationDetailsExtra = ({
       <OpDetailsData>
         <Box alignItems="flex-end">
           <Box horizontal alignItems="center">
-            <FormattedVal unit={account.unit} showCode val={amount} color="palette.text.shade80" />
+            <FormattedVal unit={unit} showCode val={amount} color="palette.text.shade80" />
           </Box>
           <Box horizontal justifyContent="flex-end">
             <CounterValue

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountBalanceSummaryFooter.tsx
@@ -16,6 +16,7 @@ import TriangleWarning from "~/renderer/icons/TriangleWarning";
 import ToolTip from "~/renderer/components/Tooltip";
 import { PolkadotAccount } from "@ledgerhq/live-common/families/polkadot/types";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -66,6 +67,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
   const preloaded = usePolkadotPreloadData();
+  const unit = useAccountUnit(account);
   if (account.type !== "Account") return null;
   const { spendableBalance: _spendableBalance, polkadotResources } = account;
   const {
@@ -75,7 +77,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   } = polkadotResources;
   const minimumBondBalance = BigNumber(preloaded.minimumBondBalance);
   const hasMinBondBalance = hasMinimumBondBalance(account);
-  const unit = getAccountUnit(account);
+
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/AccountBalanceSummaryFooter.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { usePolkadotPreloadData } from "@ledgerhq/live-common/families/polkadot/react";
 import { hasMinimumBondBalance } from "@ledgerhq/live-common/families/polkadot/logic";

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/fields/AmountField.tsx
@@ -13,6 +13,7 @@ import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Switch from "~/renderer/components/Switch";
 import Text from "~/renderer/components/Text";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const InputRight = styled(Box).attrs(() => ({
   ff: "Inter|Medium",
   color: "palette.text.shade60",
@@ -43,7 +44,7 @@ const AmountField = ({
 }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
   const bridge = getAccountBridge(account, parentAccount);
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/fields/AmountField.tsx
@@ -4,7 +4,6 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/polkadot/types";
 import SpendableAmount from "~/renderer/components/SpendableAmount";

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/Row.tsx
@@ -19,6 +19,7 @@ import ToolTip from "~/renderer/components/Tooltip";
 import ExternalLink from "~/renderer/icons/ExternalLink";
 import FirstLetterIcon from "~/renderer/components/FirstLetterIcon";
 import { useDateFromNow } from "~/renderer/hooks/useDateFormatter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled.div`
   display: flex;
@@ -91,7 +92,7 @@ export function Row({
   const name = validator?.identity || address;
   const total = validator?.totalBonded ?? null;
   const commission = validator?.commission ?? null;
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formattedAmount = useMemo(
     () =>
       value && (status === "active" || status === "inactive")
@@ -201,7 +202,7 @@ export function UnlockingRow({
     [completionDate],
   );
 
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formattedAmount = useMemo(
     () =>
       formatCurrencyUnit(unit, amount, {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/Row.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
   PolkadotValidator,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
@@ -3,7 +3,6 @@ import invariant from "invariant";
 import { useDispatch, useSelector } from "react-redux";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
   hasExternalController,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
@@ -44,6 +44,7 @@ import {
   PolkadotValidator,
 } from "@ledgerhq/live-common/families/polkadot/types";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   account: PolkadotAccount | SubAccount;
@@ -66,7 +67,7 @@ export type NominationValidator =
 const Nomination = ({ account }: { account: PolkadotAccount }) => {
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const dispatch = useDispatch();
   const { staking, validators } = usePolkadotPreloadData();
   const { polkadotResources } = account;

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useState, useRef, useEffect } from "react";
 import { TFunction } from "i18next";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getDefaultExplorerView, getAddressExplorer } from "@ledgerhq/live-common/explorers";
 import {

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
@@ -38,6 +38,7 @@ import Alert from "~/renderer/components/Alert";
 
 // Specific Validator Row
 import ValidatorRow from "./ValidatorRow";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const DrawerWrapper = styled(Box).attrs(() => ({
   horizontal: true,
   alignItems: "center",
@@ -114,7 +115,7 @@ const ValidatorField = ({
   const [search, setSearch] = useState("");
   const { polkadotResources } = account;
   invariant(polkadotResources && nominations, "polkadot transaction required");
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/fields/AmountField.tsx
@@ -5,7 +5,6 @@ import { TFunction } from "i18next";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   PolkadotAccount,
   Transaction,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/fields/AmountField.tsx
@@ -17,6 +17,7 @@ import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Switch from "~/renderer/components/Switch";
 import Text from "~/renderer/components/Text";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const InputRight = styled(Box).attrs(() => ({
   ff: "Inter|Medium",
@@ -43,7 +44,7 @@ type Props = {
 const AmountField = ({ account, onChangeTransaction, transaction, status }: Props) => {
   invariant(account && transaction && account.spendableBalance, "account and transaction required");
   const bridge = getAccountBridge(account);
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/fields/AmountField.tsx
@@ -16,6 +16,7 @@ import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Switch from "~/renderer/components/Switch";
 import Text from "~/renderer/components/Text";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const InputRight = styled(Box).attrs(() => ({
   ff: "Inter|Medium",
   color: "palette.text.shade60",
@@ -40,7 +41,7 @@ type Props = {
 };
 const AmountField = ({ account, onChangeTransaction, transaction, status }: Props) => {
   const bridge = getAccountBridge(account);
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   const onChange = useCallback(
     (value: BigNumber) => {
       onChangeTransaction(

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/fields/AmountField.tsx
@@ -4,7 +4,6 @@ import { TFunction } from "i18next";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   PolkadotAccount,
   Transaction,

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/operationDetails.tsx
@@ -24,6 +24,7 @@ import { useDiscreetMode } from "~/renderer/components/Discreet";
 import { urls } from "~/config/urls";
 import { SplitAddress } from "~/renderer/components/OperationsList/AddressCell";
 import { AmountCellExtraProps, OperationDetailsExtraProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 function getURLFeesInfo({
   op,
@@ -152,6 +153,8 @@ const OperationDetailsExtra = ({
   account,
 }: OperationDetailsExtraProps<PolkadotAccount, PolkadotOperation>) => {
   const { extra } = operation;
+
+  const unit = useAccountUnit(account);
   switch (type) {
     case "OUT":
     case "IN":
@@ -166,7 +169,7 @@ const OperationDetailsExtra = ({
               <Box>
                 <FormattedVal
                   val={extra.transferAmount ?? new BigNumber(0)}
-                  unit={account.unit}
+                  unit={unit}
                   disableRounding={true}
                   showCode
                   fontSize={4}
@@ -200,7 +203,7 @@ const OperationDetailsExtra = ({
                 <Box>
                   <FormattedVal
                     val={extra.bondedAmount}
-                    unit={account.unit}
+                    unit={unit}
                     disableRounding={true}
                     showCode
                     fontSize={4}
@@ -224,7 +227,7 @@ const OperationDetailsExtra = ({
               <Box>
                 <FormattedVal
                   val={extra.unbondedAmount ?? new BigNumber(0)}
-                  unit={account.unit}
+                  unit={unit}
                   disableRounding={true}
                   showCode
                   fontSize={4}
@@ -247,7 +250,7 @@ const OperationDetailsExtra = ({
               <Box>
                 <FormattedVal
                   val={BigNumber(extra.withdrawUnbondedAmount ?? new BigNumber(0))}
-                  unit={account.unit}
+                  unit={unit}
                   disableRounding={true}
                   showCode
                   fontSize={4}

--- a/apps/ledger-live-desktop/src/renderer/families/ripple/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/ripple/SendAmountFields.tsx
@@ -10,6 +10,7 @@ import Box from "~/renderer/components/Box";
 import GenericContainer from "~/renderer/components/FeesContainer";
 import { track } from "~/renderer/analytics/segment";
 import BigNumber from "bignumber.js";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   account: Account;
@@ -46,7 +47,7 @@ function FeesField({ account, transaction, onChange, status, trackProperties = {
   const { errors } = status;
   const { fee: feeError } = errors;
   const { fee } = transaction;
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   return (
     <GenericContainer>
       <InputCurrency

--- a/apps/ledger-live-desktop/src/renderer/families/ripple/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/ripple/SendAmountFields.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/ripple/types";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import Box from "~/renderer/components/Box";
 import GenericContainer from "~/renderer/components/FeesContainer";

--- a/apps/ledger-live-desktop/src/renderer/families/solana/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/AccountBalanceSummaryFooter.tsx
@@ -13,6 +13,7 @@ import { localeSelector } from "~/renderer/reducers/settings";
 import { BigNumber } from "bignumber.js";
 import { SolanaAccount } from "@ledgerhq/live-common/families/solana/types";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -64,7 +65,7 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const _delegatedWithdrawableBalance = new BigNumber(
     stakes.reduce((sum, s) => sum + s.withdrawable, 0),
   );
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/AccountBalanceSummaryFooter.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -56,7 +55,10 @@ type Props = {
 const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
+
   if (account.type !== "Account") return null;
+
   const { spendableBalance: _spendableBalance, solanaResources } = account;
   const { stakes } = solanaResources;
   const _delegatedBalance = new BigNumber(
@@ -65,7 +67,6 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const _delegatedWithdrawableBalance = new BigNumber(
     stakes.reduce((sum, s) => sum + s.withdrawable, 0),
   );
-  const unit = useAccountUnit(account);
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/Delegation/Row.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import {
   stakeActions as solanaStakeActions,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/Delegation/Row.tsx
@@ -23,6 +23,7 @@ import Loader from "~/renderer/icons/Loader";
 import { TableLine } from "./Header";
 import { DelegateModalName } from "../modals";
 import Discreet from "~/renderer/components/Discreet";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
@@ -95,7 +96,7 @@ type Props = {
 export function Row({ account, stakeWithMeta, onManageAction, onExternalLink }: Props) {
   const { stake, meta } = stakeWithMeta;
   const stakeActions = solanaStakeActions(stake).map(toStakeDropDownItem);
-
+  const unit = useAccountUnit(account);
   const onSelect = useCallback(
     (action: (typeof stakeActions)[number]) => {
       onManageAction(stakeWithMeta, action.key);
@@ -106,7 +107,6 @@ export function Row({ account, stakeWithMeta, onManageAction, onExternalLink }: 
   const validatorName = meta.validator?.name ?? stake.delegation?.voteAccAddr ?? "-";
   const onExternalLinkClick = () => onExternalLink(stakeWithMeta);
   const formatAmount = (amount: number) => {
-    const unit = getAccountUnit(account);
     return formatCurrencyUnit(unit, new BigNumber(amount), {
       disableRounding: true,
       alwaysShowSign: false,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   useValidators,
   useSolanaStakesWithMeta,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
@@ -14,9 +14,11 @@ import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import ErrorDisplay from "../../shared/components/ErrorDisplay";
 import ValidatorRow from "../../shared/components/ValidatorRow";
 import { StepProps } from "../types";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 export default function StepValidator({ account, transaction, status, error, t: _t }: StepProps) {
-  if (account === null || transaction === null || account?.solanaResources === undefined) {
+  const unit = useMaybeAccountUnit(account);
+  if (account === null || transaction === null || account?.solanaResources === undefined || !unit) {
     throw new Error("account, transaction and solana resouces required");
   }
   const { solanaResources } = account;
@@ -30,7 +32,6 @@ export default function StepValidator({ account, transaction, status, error, t: 
     throw new Error(`stake with account address <${stakeAccAddr}> not found`);
   }
   const { stake } = stakeWithMeta;
-  const unit = getAccountUnit(account);
   const validators = useValidators(account.currency);
   const validator = validators.find(v => v.voteAccount === stake.delegation?.voteAccAddr);
   if (validator === undefined) {
@@ -52,7 +53,7 @@ export default function StepValidator({ account, transaction, status, error, t: 
         currency={account.currency}
         validator={validator}
         unit={unit}
-      ></ValidatorRow>
+      />
       {status.errors.fee && <ErrorDisplay error={status.errors.fee} />}
     </Box>
   );

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/steps/StepValidator.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   useSolanaStakesWithMeta,
   useValidators,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/steps/StepValidator.tsx
@@ -14,9 +14,11 @@ import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import ErrorDisplay from "../../shared/components/ErrorDisplay";
 import { StepProps } from "../types";
 import ValidatorRow from "../../shared/components/ValidatorRow";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 export default function StepValidator({ account, transaction, status, error }: StepProps) {
-  if (account === null || transaction === null || account?.solanaResources === undefined) {
+  const unit = useMaybeAccountUnit(account);
+  if (account === null || transaction === null || account?.solanaResources === undefined || !unit) {
     throw new Error("account, transaction and solana resouces required");
   }
   const { solanaResources } = account;
@@ -30,7 +32,6 @@ export default function StepValidator({ account, transaction, status, error }: S
     throw new Error(`stake with account address <${stakeAccAddr}> not found`);
   }
   const { stake } = stakeWithMeta;
-  const unit = getAccountUnit(account);
   const validators = useValidators(account.currency);
   const validator = validators.find(v => v.voteAccount === stake.delegation?.voteAccAddr);
   if (validator === undefined) {

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/fields/AmountField.tsx
@@ -9,6 +9,7 @@ import React from "react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 type Props = {
   account: SolanaAccount;
   transaction: Transaction;
@@ -23,7 +24,7 @@ const InputRight = styled(Box).attrs(() => ({
 }))``;
 export default function AmountField({ account, transaction, status }: Props) {
   invariant(transaction.family === "solana", "AmountField: solana family expected");
-  const defaultUnit = getAccountUnit(account);
+  const defaultUnit = useAccountUnit(account);
   return (
     <InputCurrency
       disabled

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/fields/AmountField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/fields/AmountField.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import {
   SolanaAccount,
   Transaction,

--- a/apps/ledger-live-desktop/src/renderer/families/solana/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/operationDetails.tsx
@@ -22,6 +22,7 @@ import {
 import { localeSelector } from "~/renderer/reducers/settings";
 import { openURL } from "~/renderer/linking";
 import { OperationDetailsExtraProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 export const redirectAddress = (currency: CryptoCurrency, address: string) => () => {
   const url = getAddressExplorer(getDefaultExplorerView(currency), address);
@@ -52,7 +53,7 @@ type DelegateExtraFieldsProps = {
 };
 
 const DelegateExtraFields = ({ account, voteAddress, amount }: DelegateExtraFieldsProps) => {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formatAmount = useFormatAmount();
   const preloadData = useSolanaPreloadData(account.currency);
   const validator = preloadData?.validators.find(v => v.voteAccount === voteAddress);
@@ -97,7 +98,7 @@ type WithdrawExtraFieldsProps = {
   amount: BigNumber;
 };
 const WithdrawExtraFields = ({ account, fromAddress, amount }: WithdrawExtraFieldsProps) => {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const formatAmount = useFormatAmount();
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/families/solana/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/operationDetails.tsx
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux";
 import BigNumber from "bignumber.js";
 import { getAddressExplorer, getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
 import { CryptoCurrency, Unit } from "@ledgerhq/types-cryptoassets";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { SolanaAccount, SolanaOperation } from "@ledgerhq/live-common/families/solana/types";
 import { useSolanaPreloadData } from "@ledgerhq/live-common/families/solana/react";

--- a/apps/ledger-live-desktop/src/renderer/families/solana/shared/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/shared/fields/ValidatorsField.tsx
@@ -14,6 +14,7 @@ import ScrollLoadingList from "~/renderer/components/ScrollLoadingList";
 import Text from "~/renderer/components/Text";
 import IconAngleDown from "~/renderer/icons/AngleDown";
 import ValidatorRow from "../components/ValidatorRow";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   account: SolanaAccount;
@@ -23,7 +24,7 @@ type Props = {
 const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props) => {
   const [search, setSearch] = useState("");
   const [showAll, setShowAll] = useState(false);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const validators = useValidators(account.currency, search);
   const chosenValidator = useMemo(() => {
     if (chosenVoteAccAddr !== null) {

--- a/apps/ledger-live-desktop/src/renderer/families/solana/shared/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/shared/fields/ValidatorsField.tsx
@@ -1,4 +1,3 @@
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { useValidators } from "@ledgerhq/live-common/families/solana/react";
 import { ValidatorsAppValidator } from "@ledgerhq/live-common/families/solana/validator-app/index";
 import { SolanaAccount } from "@ledgerhq/live-common/families/solana/types";

--- a/apps/ledger-live-desktop/src/renderer/families/stacks/TransactionConfirmFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stacks/TransactionConfirmFields.tsx
@@ -4,9 +4,10 @@ import TransactionConfirmField from "~/renderer/components/TransactionConfirm/Tr
 import Text from "~/renderer/components/Text";
 import { DeviceTransactionField } from "@ledgerhq/live-common/transaction/index";
 import { FieldComponentProps } from "~/renderer/components/TransactionConfirm";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const addressStyle: React.CSSProperties = {
   wordBreak: "break-all",
@@ -17,7 +18,7 @@ const addressStyle: React.CSSProperties = {
 const StacksExtendedAmountField = ({ account, status: { amount }, field }: FieldComponentProps) => {
   invariant(field.type === "stacks.extendedAmount", "stacks.extendedAmount field expected");
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const specifiedAmount = field.value != null ? field.value : null;
   return (
     <TransactionConfirmField label={field.label}>

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/FeeField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/FeeField.tsx
@@ -11,6 +11,7 @@ import invariant from "invariant";
 import { Account } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/stellar/types";
 import BigNumber from "bignumber.js";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FeeField = ({
   onChange,
@@ -24,6 +25,8 @@ const FeeField = ({
   status: TransactionStatus;
 }) => {
   invariant(transaction.family === "stellar", "FeeField: stellar family expected");
+
+  const unit = useAccountUnit(account);
   const bridge = getAccountBridge(account);
   const onFeeValueChange = useCallback(
     (fees: BigNumber) => {
@@ -64,7 +67,7 @@ const FeeField = ({
           containerProps={{
             grow: true,
           }}
-          defaultUnit={account.unit}
+          defaultUnit={unit}
           value={transaction.fees}
           onChange={onFeeValueChange}
           renderRight={<InputRight>XLM</InputRight>}

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/steps/StepSummary.tsx
@@ -1,11 +1,7 @@
 import invariant from "invariant";
 import React from "react";
 import styled from "styled-components";
-import {
-  getAccountCurrency,
-  getAccountName,
-  getAccountUnit,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/account/index";
 import { useBaker, useDelegation } from "@ledgerhq/live-common/families/tezos/bakers";
 import { Baker } from "@ledgerhq/live-common/families/tezos/types";
 import { Trans } from "react-i18next";
@@ -24,6 +20,7 @@ import InfoCircle from "~/renderer/icons/InfoCircle";
 import BakerImage from "../../BakerImage";
 import DelegationContainer from "../DelegationContainer";
 import { StepProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const urlDelegationHelp = "https://support.ledger.com/hc/en-us/articles/360010653260";
 
@@ -57,7 +54,7 @@ const StepSummary = ({ account, transaction, eventType, transitionTo }: StepProp
   const delegation = useDelegation(account);
   const baker = useBaker(transaction.recipient);
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const getBakerName = (baker: Baker | undefined | null, fallback: string) =>
     baker ? baker.name : fallback;
 

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/Delegation/Row.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { Trans } from "react-i18next";
 import {
   getMainAccount,
-  getAccountUnit,
   getAccountCurrency,
   shortAddressPreview,
 } from "@ledgerhq/live-common/account/index";
@@ -22,6 +21,7 @@ import Ellipsis from "~/renderer/components/Ellipsis";
 import BakerImage from "../BakerImage";
 import ContextMenu from "./ContextMenu";
 import { TezosAccount } from "@ledgerhq/live-common/families/tezos/types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   delegation: Delegation;
@@ -77,7 +77,7 @@ const CTA = styled.div`
   justify-content: flex-end;
 `;
 const Row = ({ account, parentAccount, delegation }: Props) => {
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const currency = getAccountCurrency(account);
   const mainAccount = getMainAccount(account, parentAccount);
   const name = delegation.baker ? delegation.baker.name : shortAddressPreview(delegation.address);

--- a/apps/ledger-live-desktop/src/renderer/families/tron/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tron/AccountBalanceSummaryFooter.tsx
@@ -12,6 +12,7 @@ import ToolTip from "~/renderer/components/Tooltip";
 import { localeSelector } from "~/renderer/reducers/settings";
 import { TronAccount } from "@ledgerhq/live-common/families/tron/types";
 import { SubAccount } from "@ledgerhq/types-live";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
   mt: 4,
@@ -53,7 +54,9 @@ type Props = {
 const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
-  if (account.type !== "Account") return null;
+
+  const unit = useMaybeAccountUnit(account);
+  if (account.type !== "Account" || !unit) return null;
   const { tronResources } = account;
   const formatConfig = {
     disableRounding: true,
@@ -80,9 +83,9 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
 
   const { freeUsed, freeLimit, gainedUsed, gainedLimit } = tronResources.bandwidth;
 
-  const spendableBalance = formatCurrencyUnit(account.unit, account.spendableBalance, formatConfig);
+  const spendableBalance = formatCurrencyUnit(unit, account.spendableBalance, formatConfig);
   const frozenAmount = formatCurrencyUnit(
-    account.unit,
+    unit,
     BigNumber(frozenBandwidthAmount || 0)
       .plus(BigNumber(frozenEnergyAmount || 0))
       .plus(BigNumber(delegatedFrozenBandwidthAmount || 0))

--- a/apps/ledger-live-desktop/src/renderer/families/tron/Votes/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tron/Votes/index.tsx
@@ -9,7 +9,6 @@ import {
   formatVotes,
   getNextRewardDate,
 } from "@ledgerhq/live-common/families/tron/react";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { getDefaultExplorerView } from "@ledgerhq/live-common/explorers";
 import { openURL } from "~/renderer/linking";
@@ -35,6 +34,7 @@ import { useDateFromNow } from "~/renderer/hooks/useDateFormatter";
 import { useHistory } from "react-router";
 import { stakeDefaultTrack } from "~/renderer/screens/stake/constants";
 import { track } from "~/renderer/analytics/segment";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const Wrapper = styled(Box).attrs(() => ({
   p: 3,
@@ -55,7 +55,7 @@ const Delegation = ({ account }: { account: TronAccount }) => {
     const diff = new Date().getTime() - lastVoteDate.getTime();
     return Math.floor(diff / (1000 * 60 * 60 * 24));
   }, [lastVoteDate]);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const explorerView = getDefaultExplorerView(account.currency);
   const { tronResources } = account;
   const { votes, tronPower, unwithdrawnReward } = tronResources;

--- a/apps/ledger-live-desktop/src/renderer/families/tron/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tron/operationDetails.tsx
@@ -24,6 +24,7 @@ import FormattedVal from "~/renderer/components/FormattedVal";
 import CounterValue from "~/renderer/components/CounterValue";
 import { useDiscreetMode } from "~/renderer/components/Discreet";
 import { OperationDetailsExtraProps } from "../types";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 const helpURL = "https://support.ledger.com/hc/en-us/articles/360013062139";
 
 function getURLFeesInfo({ op }: { op: Operation; currencyId: string }): string | undefined {
@@ -106,6 +107,7 @@ const OperationDetailsExtra = ({
   type,
   account,
 }: OperationDetailsExtraProps<TronAccount, TronOperation>) => {
+  const unit = useAccountUnit(account);
   const frozenAmount = operation.extra?.frozenAmount
     ? (operation.extra.frozenAmount as BigNumber)
     : new BigNumber(0);
@@ -144,7 +146,7 @@ const OperationDetailsExtra = ({
             <Box>
               <FormattedVal
                 val={frozenAmount}
-                unit={account.unit}
+                unit={unit}
                 showCode
                 fontSize={4}
                 color="palette.text.shade60"
@@ -163,7 +165,7 @@ const OperationDetailsExtra = ({
             <Box>
               <FormattedVal
                 val={unfreezeAmount}
-                unit={account.unit}
+                unit={unit}
                 showCode
                 fontSize={4}
                 color="palette.text.shade60"
@@ -183,7 +185,7 @@ const OperationDetailsExtra = ({
               <Box>
                 <FormattedVal
                   val={unDelegatedAmount}
-                  unit={account.unit}
+                  unit={unit}
                   showCode
                   fontSize={4}
                   color="palette.text.shade60"
@@ -215,7 +217,7 @@ const OperationDetailsExtra = ({
             <Box>
               <FormattedVal
                 val={unfreezeAmount}
-                unit={account.unit}
+                unit={unit}
                 showCode
                 fontSize={4}
                 color="palette.text.shade60"

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAccountUnit.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAccountUnit.ts
@@ -1,0 +1,16 @@
+import { useSelector } from "react-redux";
+import { accountUnitSelector } from "../reducers/settings";
+import { AccountLike } from "@ledgerhq/types-live";
+import { State } from "../reducers";
+
+export function useAccountUnit(account: AccountLike) {
+  const unit = useSelector((state: State) => accountUnitSelector(state, account));
+  return unit;
+}
+
+export function useMaybeAccountUnit(account?: AccountLike | null) {
+  const unit = useSelector((state: State) =>
+    account ? accountUnitSelector(state, account) : undefined,
+  );
+  return unit;
+}

--- a/apps/ledger-live-desktop/src/renderer/modals/ExportOperations/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExportOperations/index.tsx
@@ -188,7 +188,6 @@ const LabelWrapper = styled(Box)`
   text-align: center;
   font-size: 13px;
   font-family: "Inter";
-  font-weight:;
 `;
 const IconWrapperCircle = styled(Box)<{ green?: boolean }>`
   width: 50px;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepSummary.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import {
   getAccountName,
   getAccountCurrency,
-  getAccountUnit,
   getFeesCurrency,
   getFeesUnit,
   getMainAccount,
@@ -27,6 +26,7 @@ import NFTSummary from "~/renderer/screens/nft/Send/Summary";
 import { StepProps } from "../types";
 import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
 import { getLLDCoinFamily } from "~/renderer/families";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FromToWrapper = styled.div``;
 const Circle = styled.div`
@@ -56,12 +56,8 @@ const WARN_FROM_UTXO_COUNT = 50;
 
 const StepSummary = (props: StepProps) => {
   const { account, parentAccount, transaction, status, currencyName, isNFTSend } = props;
-
-  if (!account) {
-    return null;
-  }
-
-  const mainAccount = getMainAccount(account, parentAccount);
+  const mainAccount = account && getMainAccount(account, parentAccount);
+  const unit = useMaybeAccountUnit(mainAccount);
 
   if (!mainAccount || !transaction) {
     return null;
@@ -73,7 +69,6 @@ const StepSummary = (props: StepProps) => {
   const currency = getAccountCurrency(account);
   const feesCurrency = getFeesCurrency(mainAccount);
   const feesUnit = getFeesUnit(feesCurrency);
-  const unit = getAccountUnit(account);
   const utxoLag = txInputs ? txInputs.length >= WARN_FROM_UTXO_COUNT : null;
   const hasNonEmptySubAccounts =
     account.type === "Account" &&

--- a/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
@@ -6,7 +6,6 @@ import { connect } from "react-redux";
 import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import type { Account, DerivationMode } from "@ledgerhq/types-live";
-import { Unit } from "@ledgerhq/types-cryptoassets";
 import { validateNameEdition } from "@ledgerhq/live-common/account/index";
 import { AccountNameRequiredError } from "@ledgerhq/errors";
 import { getEnv } from "@ledgerhq/live-env";
@@ -18,7 +17,6 @@ import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Alert from "~/renderer/components/Alert";
 import Input from "~/renderer/components/Input";
-import Select from "~/renderer/components/Select";
 import Spoiler from "~/renderer/components/Spoiler";
 import ConfirmModal from "~/renderer/modals/ConfirmModal";
 import Space from "~/renderer/components/Space";
@@ -26,7 +24,6 @@ import Button from "~/renderer/components/Button";
 import { getTagDerivationMode } from "@ledgerhq/coin-framework/derivation";
 type State = {
   accountName: string | undefined | null;
-  accountUnit: Unit | undefined | null;
   accountNameError: Error | undefined | null;
   isRemoveAccountModalOpen: boolean;
 };
@@ -40,8 +37,7 @@ type Props = {
   removeAccount: Function;
   t: TFunction;
 } & OwnProps;
-const unitGetOptionValue = (unit: Unit) => unit.magnitude + "";
-const renderUnitItemCode = (item: { data: Unit }) => item.data.code;
+
 const mapDispatchToProps = {
   setDataModal,
   updateAccount,
@@ -114,12 +110,6 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
     }
   };
 
-  handleChangeUnit = (value?: Unit | null) => {
-    this.setState({
-      accountUnit: value,
-    });
-  };
-
   handleOpenRemoveAccountModal = () =>
     this.setState({
       isRemoveAccountModalOpen: true,
@@ -140,7 +130,7 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
   };
 
   render() {
-    const { accountUnit, accountNameError, isRemoveAccountModalOpen } = this.state;
+    const { accountNameError, isRemoveAccountModalOpen } = this.state;
     const { t, onClose, data } = this.props;
     if (!data) return null;
     const account = this.getAccount(data);
@@ -185,27 +175,6 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
                   }
                   error={accountNameError}
                   id="input-edit-name"
-                />
-              </Box>
-            </Container>
-            <Container>
-              <Box>
-                <OptionRowTitle>{t("account.settings.unit.title")}</OptionRowTitle>
-                <OptionRowDesc>{t("account.settings.unit.desc")}</OptionRowDesc>
-              </Box>
-              <Box
-                style={{
-                  width: 230,
-                }}
-              >
-                <Select
-                  isSearchable={false}
-                  onChange={this.handleChangeUnit}
-                  getOptionValue={unitGetOptionValue}
-                  renderValue={renderUnitItemCode}
-                  renderOption={renderUnitItemCode}
-                  value={accountUnit || account.unit}
-                  options={account.currency.units}
                 />
               </Box>
             </Container>

--- a/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/index.tsx
@@ -14,7 +14,7 @@ export default class SettingsAccount extends PureComponent<Props> {
         name="MODAL_SETTINGS_ACCOUNT"
         centered
         render={({ data, onClose }) => (
-          <AccountSettingRenderBody {...this.props} data={data} onClose={onClose} />
+          <AccountSettingRenderBody {...this.props} account={data.account} onClose={onClose} />
         )}
       />
     );

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
@@ -27,7 +27,7 @@ import Alert from "~/renderer/components/Alert";
 import { StepProps } from "../types";
 import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
 import { getLLDCoinFamily } from "~/renderer/families";
-import { useAccountUnit, useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FromToWrapper = styled.div``;
 const Circle = styled.div`

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/steps/StepSummary.tsx
@@ -6,7 +6,6 @@ import styled from "styled-components";
 import {
   getAccountName,
   getAccountCurrency,
-  getAccountUnit,
   getFeesCurrency,
   getFeesUnit,
   getMainAccount,
@@ -28,6 +27,7 @@ import Alert from "~/renderer/components/Alert";
 import { StepProps } from "../types";
 import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
 import { getLLDCoinFamily } from "~/renderer/families";
+import { useAccountUnit, useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const FromToWrapper = styled.div``;
 const Circle = styled.div`
@@ -58,11 +58,8 @@ const WARN_FROM_UTXO_COUNT = 50;
 const StepSummary = (props: StepProps) => {
   const { account, parentAccount, transaction, status } = props;
 
-  if (!account) {
-    return null;
-  }
-
-  const mainAccount = getMainAccount(account, parentAccount);
+  const mainAccount = account && getMainAccount(account, parentAccount);
+  const unit = useMaybeAccountUnit(mainAccount);
 
   if (!mainAccount || !transaction) {
     return null;
@@ -74,7 +71,7 @@ const StepSummary = (props: StepProps) => {
   const currency = getAccountCurrency(account);
   const feesCurrency = getFeesCurrency(mainAccount);
   const feesUnit = getFeesUnit(feesCurrency);
-  const unit = getAccountUnit(account);
+
   const utxoLag = txInputs ? txInputs.length >= WARN_FROM_UTXO_COUNT : null;
   const hasNonEmptySubAccounts =
     account.type === "Account" &&

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -688,7 +688,7 @@ export const unitForCurrencySelector = (
   },
 ): Unit => {
   const obj = state.settings.currenciesSettings[currency.ticker];
-  if (obj) return obj.unit;
+  if (obj?.unit) return obj.unit;
   const defs = currencySettingsDefaults(currency);
   return defs.unit;
 };

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -13,8 +13,9 @@ import {
   Feature,
   PortfolioRange,
   FirmwareUpdateContext,
+  AccountLike,
 } from "@ledgerhq/types-live";
-import { CryptoCurrency, Currency } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, Currency, Unit } from "@ledgerhq/types-cryptoassets";
 import { getEnv } from "@ledgerhq/live-env";
 import {
   LanguageIds,
@@ -461,6 +462,7 @@ const pairHash = (from: Currency, to: Currency) => `${from.ticker}_${to.ticker}`
 
 export type CurrencySettings = {
   confirmationsNb: number;
+  unit: Unit;
 };
 
 type ConfirmationDefaults = {
@@ -474,7 +476,11 @@ type ConfirmationDefaults = {
     | null;
 };
 
-export const currencySettingsDefaults = (c: Currency): ConfirmationDefaults => {
+type UnitDefaults = {
+  unit: Unit;
+};
+
+export const currencySettingsDefaults = (c: Currency): ConfirmationDefaults & UnitDefaults => {
   let confirmationsNb;
   if (c.type === "CryptoCurrency") {
     const { blockAvgTime } = c;
@@ -489,6 +495,7 @@ export const currencySettingsDefaults = (c: Currency): ConfirmationDefaults => {
   }
   return {
     confirmationsNb,
+    unit: c.units[0],
   };
 };
 const bitcoin = getCryptoCurrencyById("bitcoin");
@@ -510,6 +517,7 @@ const defaultsForCurrency: (a: Currency) => CurrencySettings = crypto => {
   const defaults = currencySettingsDefaults(crypto);
   return {
     confirmationsNb: defaults.confirmationsNb ? defaults.confirmationsNb.def : 0,
+    unit: defaults.unit,
   };
 };
 
@@ -659,6 +667,29 @@ export const confirmationsNbForCurrencySelector = (
   const defs = currencySettingsDefaults(currency);
   return defs.confirmationsNb ? defs.confirmationsNb.def : 0;
 };
+
+export const unitForCurrencySelector = (
+  state: State,
+  {
+    currency,
+  }: {
+    currency: CryptoCurrency;
+  },
+): Unit => {
+  const obj = state.settings.currenciesSettings[currency.ticker];
+  if (obj) return obj.unit;
+  const defs = currencySettingsDefaults(currency);
+  return defs.unit;
+};
+
+export const accountUnitSelector = (state: State, account: AccountLike): Unit => {
+  if (account.type === "Account") {
+    return unitForCurrencySelector(state, account);
+  } else {
+    return account.token.units[0];
+  }
+};
+
 export const preferredDeviceModelSelector = (state: State) => state.settings.preferredDeviceModel;
 export const sidebarCollapsedSelector = (state: State) => state.settings.sidebarCollapsed;
 export const accountsViewModeSelector = (state: State) => state.settings.accountsViewMode;
@@ -757,6 +788,7 @@ export const hasSeenAnalyticsOptInPromptSelector = (state: State) =>
 export const dismissedContentCardsSelector = (state: State) => state.settings.dismissedContentCards;
 export const anonymousBrazeIdSelector = (state: State) => state.settings.anonymousBrazeId;
 
-//MARKET
+export const currenciesSettingsSelector = (state: State) => state.settings.currenciesSettings;
 
+//MARKET
 export const starredMarketCoinsSelector = (state: State) => state.settings.starredMarketCoins;

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -257,6 +257,7 @@ type HandlersPayloads = {
   SET_ANONYMOUS_BRAZE_ID: string;
   ADD_STARRED_MARKET_COINS: string;
   REMOVE_STARRED_MARKET_COINS: string;
+  SET_CURRENCY_SETTINGS: { key: string; value: CurrencySettings };
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
@@ -381,6 +382,13 @@ const handlers: SettingsHandlers = {
     lastSeenCustomImage: {
       size: payload.imageSize,
       hash: payload.imageHash,
+    },
+  }),
+  SET_CURRENCY_SETTINGS: (state: SettingsState, { payload }) => ({
+    ...state,
+    currenciesSettings: {
+      ...state.currenciesSettings,
+      [payload.key]: payload.value,
     },
   }),
   SET_OVERRIDDEN_FEATURE_FLAG: (state: SettingsState, { payload }) => ({

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -501,6 +501,7 @@ export const currencySettingsDefaults = (c: Currency): ConfirmationDefaults & Un
       };
     }
   }
+
   return {
     confirmationsNb,
     unit: c.units[0],
@@ -635,12 +636,14 @@ export const currencySettingsLocaleSelector = (
   settings: SettingsState,
   currency: Currency,
 ): CurrencySettings => {
-  const currencySettings = settings.currenciesSettings[currency.ticker];
-  const val = {
+  const currencySettings = Object.keys(settings.currenciesSettings)?.includes(currency.ticker)
+    ? settings.currenciesSettings[currency.ticker]
+    : {};
+
+  return {
     ...defaultsForCurrency(currency),
     ...currencySettings,
   };
-  return val;
 };
 
 export const currencyPropExtractor = (_: State, { currency }: { currency: CryptoCurrency }) =>

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountBalanceSummaryHeader.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountBalanceSummaryHeader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { AccountLike, BalanceHistoryWithCountervalue, ValueChange } from "@ledgerhq/types-live";
 import { Currency } from "@ledgerhq/types-cryptoassets";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { BalanceTotal, BalanceDiff } from "~/renderer/components/BalanceInfos";
 import Box, { Tabbable } from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
@@ -10,6 +10,7 @@ import Price from "~/renderer/components/Price";
 import PillsDaysCount from "~/renderer/components/PillsDaysCount";
 import Swap from "~/renderer/icons/Swap";
 import { NoCountervaluePlaceholder } from "~/renderer/components/CounterValue";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   isAvailable: boolean;
@@ -32,7 +33,7 @@ export default function AccountBalanceSummaryHeader({
   setCountervalueFirst,
 }: Props) {
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const cvUnit = counterValue.units[0];
   const data = [
     {

--- a/apps/ledger-live-desktop/src/renderer/screens/account/BalanceSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/BalanceSummary.tsx
@@ -4,7 +4,6 @@ import { useBalanceHistoryWithCountervalue, usePortfolio } from "~/renderer/acti
 import { BigNumber } from "bignumber.js";
 import { formatShort } from "@ledgerhq/live-common/currencies/index";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import { getAccountUnit } from "@ledgerhq/live-common/account/index";
 import { useTimeRange } from "~/renderer/actions/settings";
 import { counterValueCurrencySelector, discreetModeSelector } from "~/renderer/reducers/settings";
 import Chart from "~/renderer/components/Chart";
@@ -19,6 +18,7 @@ import Alert from "~/renderer/components/Alert";
 import { useTranslation } from "react-i18next";
 import { tokensWithUnsupportedGraph } from "~/helpers/tokensWithUnsupportedGraph";
 import { hourFormat, dayFormat, useDateFormatter } from "~/renderer/hooks/useDateFormatter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Props = {
   chartColor: string;
@@ -48,10 +48,13 @@ export default function AccountBalanceSummary({
   const discreetMode = useSelector(discreetModeSelector);
   const dayFormatter = useDateFormatter(dayFormat);
   const hourFormatter = useDateFormatter(hourFormat);
+
+  const unit = useAccountUnit(account);
+
   const renderTooltip = useCallback(
     (d: Item) => {
       const displayCountervalue = countervalueFirst && countervalueAvailable;
-      const unit = getAccountUnit(account);
+
       const data = [
         {
           val: d.value,
@@ -79,20 +82,19 @@ export default function AccountBalanceSummary({
       );
     },
     [
-      account,
       counterValue.units,
       countervalueAvailable,
       countervalueFirst,
       dayFormatter,
       hourFormatter,
+      unit,
     ],
   );
   const renderTickYCryptoValue = useCallback(
     (val: number | string) => {
-      const unit = getAccountUnit(account);
       return formatShort(unit, BigNumber(val));
     },
-    [account],
+    [unit],
   );
   const renderTickYCounterValue = useCallback(
     (val: number | string) => formatShort(counterValue.units[0], BigNumber(val)),
@@ -102,9 +104,7 @@ export default function AccountBalanceSummary({
   const AccountBalanceSummaryFooter = mainAccount
     ? getLLDCoinFamily(mainAccount.currency.family).AccountBalanceSummaryFooter
     : null;
-  const chartMagnitude = displayCountervalue
-    ? counterValue.units[0].magnitude
-    : getAccountUnit(account).magnitude;
+  const chartMagnitude = displayCountervalue ? counterValue.units[0].magnitude : unit.magnitude;
   return (
     <Card p={0} py={5}>
       <Box px={6}>

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountGridItem/Header.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountGridItem/Header.tsx
@@ -1,10 +1,6 @@
-import React, { PureComponent } from "react";
+import React from "react";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import {
-  getAccountCurrency,
-  getAccountUnit,
-  getAccountName,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import Ellipsis from "~/renderer/components/Ellipsis";
 import Bar from "~/renderer/components/Bar";
@@ -15,91 +11,81 @@ import Star from "~/renderer/components/Stars/Star";
 import Tooltip from "~/renderer/components/Tooltip";
 import AccountSyncStatusIndicator from "../AccountSyncStatusIndicator";
 import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
-class HeadText extends PureComponent<{
-  account: AccountLike;
-  title: string;
-  name: string;
-}> {
-  render() {
-    const { title, name, account } = this.props;
-    return (
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+function HeadText(props: { account: AccountLike; title: string; name: string }) {
+  const { title, name, account } = props;
+  return (
+    <Box
+      style={{
+        flex: 1,
+        alignItems: "flex-start",
+      }}
+    >
       <Box
         style={{
-          flex: 1,
-          alignItems: "flex-start",
+          textTransform: "uppercase",
         }}
+        horizontal
+        alignItems="center"
+        fontSize={10}
+        color="palette.text.shade80"
       >
-        <Box
-          style={{
-            textTransform: "uppercase",
-          }}
-          horizontal
-          alignItems="center"
-          fontSize={10}
-          color="palette.text.shade80"
-        >
-          {title}
-          <AccountTagDerivationMode account={account} />
-        </Box>
-        <Tooltip content={name} delay={1200}>
-          <Ellipsis>
-            <Text fontSize={13} color="palette.text.shade100">
-              {name}
-            </Text>
-          </Ellipsis>
-        </Tooltip>
+        {title}
+        <AccountTagDerivationMode account={account} />
       </Box>
-    );
-  }
+      <Tooltip content={name} delay={1200}>
+        <Ellipsis>
+          <Text fontSize={13} color="palette.text.shade100">
+            {name}
+          </Text>
+        </Ellipsis>
+      </Tooltip>
+    </Box>
+  );
 }
-class Header extends PureComponent<{
-  account: AccountLike;
-  parentAccount: Account | undefined | null;
-}> {
-  render() {
-    const { account, parentAccount } = this.props;
-    const currency = getAccountCurrency(account);
-    const unit = getAccountUnit(account);
-    const name = getAccountName(account);
-    let title;
-    switch (account.type) {
-      case "Account":
-        title = currency.name;
-        break;
-      case "TokenAccount":
-        title = "token";
-        break;
-      default:
-        title = "";
-    }
-    return (
-      <Box flow={4}>
-        <Box horizontal ff="Inter|SemiBold" flow={3} alignItems="center">
-          <ParentCryptoCurrencyIcon currency={currency} withTooltip />
-          <HeadText account={account} name={name} title={title} />
-          <AccountSyncStatusIndicator
-            accountId={(parentAccount && parentAccount.id) || account.id}
-            account={account}
-          />
-          <Star
-            accountId={account.id}
-            parentId={account.type !== "Account" ? account.parentId : undefined}
-          />
-        </Box>
-        <Bar size={1} color="palette.divider" />
-        <Box justifyContent="center">
-          <FormattedVal
-            alwaysShowSign={false}
-            animateTicker={false}
-            ellipsis
-            color="palette.text.shade100"
-            unit={unit}
-            showCode
-            val={account.balance}
-          />
-        </Box>
-      </Box>
-    );
+function Header(props: { account: AccountLike; parentAccount?: Account | null }) {
+  const { account, parentAccount } = props;
+  const currency = getAccountCurrency(account);
+  const unit = useAccountUnit(account);
+  const name = getAccountName(account);
+  let title;
+  switch (account.type) {
+    case "Account":
+      title = currency.name;
+      break;
+    case "TokenAccount":
+      title = "token";
+      break;
+    default:
+      title = "";
   }
+  return (
+    <Box flow={4}>
+      <Box horizontal ff="Inter|SemiBold" flow={3} alignItems="center">
+        <ParentCryptoCurrencyIcon currency={currency} withTooltip />
+        <HeadText account={account} name={name} title={title} />
+        <AccountSyncStatusIndicator
+          accountId={(parentAccount && parentAccount.id) || account.id}
+          account={account}
+        />
+        <Star
+          accountId={account.id}
+          parentId={account.type !== "Account" ? account.parentId : undefined}
+        />
+      </Box>
+      <Bar size={1} color="palette.divider" />
+      <Box justifyContent="center">
+        <FormattedVal
+          alwaysShowSign={false}
+          animateTicker={false}
+          ellipsis
+          color="palette.text.shade100"
+          unit={unit}
+          showCode
+          val={account.balance}
+        />
+      </Box>
+    </Box>
+  );
 }
 export default Header;

--- a/apps/ledger-live-desktop/src/renderer/screens/asset/AccountDistribution/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/asset/AccountDistribution/Row.tsx
@@ -20,6 +20,7 @@ import ToolTip from "~/renderer/components/Tooltip";
 import useTheme from "~/renderer/hooks/useTheme";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { IconsLegacy } from "@ledgerhq/react-ui";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 export type AccountDistributionItem = {
   account: AccountLike;
   distribution: number;
@@ -35,6 +36,7 @@ export default function Row({
   item: { currency, amount, distribution, account },
   isVisible,
 }: Props) {
+  const unit = useAccountUnit(account);
   const accounts = useSelector(accountsSelector);
   const theme = useTheme();
   const history = useHistory();
@@ -88,7 +90,7 @@ export default function Row({
           <Ellipsis>
             <FormattedVal
               color={"palette.text.shade80"}
-              unit={currency.units[0]}
+              unit={unit}
               val={amount}
               fontSize={3}
               showCode

--- a/apps/ledger-live-desktop/src/renderer/screens/asset/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/asset/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Redirect } from "react-router";
 import { Account } from "@ledgerhq/types-live";
-import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import Box from "~/renderer/components/Box";
 import OperationsList from "~/renderer/components/OperationsList";
@@ -19,6 +19,7 @@ import {
 import { useFlattenSortAccounts } from "~/renderer/actions/general";
 import AssetHeader from "./AssetHeader";
 import TrackPage from "~/renderer/analytics/TrackPage";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 type Props = {
   match: {
     params: {
@@ -44,12 +45,12 @@ export default function AssetPage({ match }: Props) {
     (id: string): Account | undefined | null => allAccounts.find(a => a.id === id) || null,
     [allAccounts],
   );
-
-  if (!accounts.length) return <Redirect to="/" />;
+  const unit = useMaybeAccountUnit(accounts[0]);
+  if (!accounts.length || !unit) return <Redirect to="/" />;
   const parentAccount =
     accounts[0].type !== "Account" ? lookupParentAccount(accounts[0].parentId) : null;
   const currency = getAccountCurrency(accounts[0]);
-  const unit = getAccountUnit(accounts[0]);
+
   const color = getCurrencyColor(currency, paperColor);
   return (
     <Box>

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import {
-  getAccountUnit,
-  getAccountCurrency,
-  getAccountName,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/account/index";
 import Box from "~/renderer/components/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import { ErrorContainer } from "~/renderer/components/Input";
@@ -30,6 +26,7 @@ import { WarningSolidMedium } from "@ledgerhq/react-ui/assets/icons";
 import { useSwapableAccounts } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { useSelector } from "react-redux";
 import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const SwapStatusContainer = styled.div<{ isError: boolean }>(
   ({ theme: { space, colors }, isError }) => `
@@ -125,9 +122,11 @@ function FromRow({
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const flattenedAccounts = useSelector(flattenAccountsSelector);
   const accounts = useSwapableAccounts({ accounts: flattenedAccounts });
-  const unit = fromAccount && getAccountUnit(fromAccount);
+  const unit = useMaybeAccountUnit(fromAccount);
   const { t } = useTranslation();
   usePickDefaultAccount(accounts, fromAccount, setFromAccount);
+
+  if (!fromAccount) return null;
 
   const trackEditAccount = () => {
     track("button_clicked2", {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { getAccountUnit, getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { context } from "~/renderer/drawers/Provider";
 import SummaryLabel from "./SummaryLabel";
 import SummaryValue, { NoValuePlaceholder } from "./SummaryValue";
@@ -22,6 +22,7 @@ import TachometerMedium from "~/renderer/icons/TachometerMedium";
 import styled from "styled-components";
 import { useGetSwapTrackingProperties } from "../../utils/index";
 import { EDITABLE_FEE_FAMILIES } from "@ledgerhq/live-common/exchange/swap/const/blockchain";
+import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 type Strategies = "slow" | "medium" | "fast" | "advanced";
 
@@ -74,7 +75,7 @@ const SectionFees = ({
   const { setDrawer } = React.useContext(context);
   const exchangeRate = useSelector(rateSelector);
   const mainFromAccount = account && getMainAccount(account, parentAccount);
-  const mainAccountUnit = mainFromAccount && getAccountUnit(mainFromAccount);
+  const mainAccountUnit = useMaybeAccountUnit(mainFromAccount);
   const estimatedFees = status?.estimatedFees;
   const showSummaryValue = mainFromAccount && estimatedFees && estimatedFees.gt(0);
   const family = mainFromAccount?.currency.family;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/TargetAccountDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/TargetAccountDrawer/index.tsx
@@ -7,11 +7,7 @@ import Text from "~/renderer/components/Text";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import { AccountLike } from "@ledgerhq/types-live";
-import {
-  getAccountCurrency,
-  getAccountUnit,
-  getAccountName,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/account/index";
 import Check from "~/renderer/icons/Check";
 import { SwapTransactionType } from "@ledgerhq/live-common/exchange/swap/types";
 import Tabbable from "~/renderer/components/Box/Tabbable";
@@ -23,6 +19,7 @@ import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import { context } from "~/renderer/drawers/Provider";
 import { track } from "~/renderer/analytics/segment";
 import { useGetSwapTrackingProperties } from "../../utils/index";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 const AccountWrapper = styled(Tabbable)<{ selected?: boolean }>`
   cursor: pointer;
@@ -66,7 +63,7 @@ const TargetAccount = memo(function TargetAccount({
   const allAccounts = useSelector(shallowAccountsSelector);
   const theme = useTheme();
   const currency = getAccountCurrency(account);
-  const unit = getAccountUnit(account);
+  const unit = useAccountUnit(account);
   const name = getAccountName(account);
   const parentAccount =
     account?.type !== "Account" ? allAccounts?.find(a => a.id === account?.parentId) : null;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/History/OperationRow.tsx
@@ -1,8 +1,4 @@
-import {
-  getAccountCurrency,
-  getAccountName,
-  getAccountUnit,
-} from "@ledgerhq/live-common/account/index";
+import { getAccountCurrency, getAccountName } from "@ledgerhq/live-common/account/index";
 import {
   isSwapOperationPending,
   operationStatusList,
@@ -23,6 +19,7 @@ import IconClock from "~/renderer/icons/Clock";
 import IconSwap from "~/renderer/icons/Swap";
 import { rgba } from "~/renderer/styles/helpers";
 import { hourFormat, useDateFormatted } from "~/renderer/hooks/useDateFormatter";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
 export const getStatusColor = (status: string, theme: DefaultTheme) => {
   if (isSwapOperationPending(status)) {
@@ -105,6 +102,8 @@ const OperationRow = ({
   const dateFormatted = useDateFormatted(operation.date, hourFormat);
   const { t } = useTranslation();
 
+  const unitFrom = useAccountUnit(fromAccount);
+  const unitTo = useAccountUnit(toAccount);
   return (
     <Row
       className={"swap-history-row"}
@@ -157,14 +156,14 @@ const OperationRow = ({
       </Box>
       <Box alignItems={"flex-end"} ml={20}>
         <Text ff={"Inter|SemiBold"} fontSize={4}>
-          <FormattedVal alwaysShowSign val={toAmount} unit={getAccountUnit(toAccount)} showCode />
+          <FormattedVal alwaysShowSign val={toAmount} unit={unitTo} showCode />
         </Text>
         <Text ff={"Inter|SemiBold"} fontSize={3}>
           <FormattedVal
             color="palette.text.shade60"
             alwaysShowSign
             val={fromAmount.times(-1)}
-            unit={getAccountUnit(fromAccount)}
+            unit={unitFrom}
             showCode
           />
         </Text>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/Currencies.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/Currencies.tsx
@@ -30,7 +30,9 @@ export default function Currencies() {
   const currencyId = currency?.id;
   const currencyName = currency?.name;
   const isCurrencyDisabled = useCallback(
-    (currency: Currency) => !currencySettingsDefaults(currency).confirmationsNb,
+    (currency: Currency) =>
+      !currencySettingsDefaults(currency).confirmationsNb &&
+      !currencySettingsDefaults(currency).unit,
     [],
   );
   return (

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/Currencies.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/Currencies.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import {
-  Currency,
-  CryptoCurrency,
-  TokenCurrency,
-  CryptoOrTokenCurrency,
-} from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, TokenCurrency, CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { cryptoCurrenciesSelector } from "~/renderer/reducers/accounts";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import SelectCurrency from "~/renderer/components/SelectCurrency";
@@ -14,7 +9,6 @@ import Box from "~/renderer/components/Box";
 import { SettingsSectionBody as Body, SettingsSectionRow as Row } from "../../SettingsSection";
 import CurrencyRows from "./CurrencyRows";
 import Track from "~/renderer/analytics/Track";
-import { currencySettingsDefaults } from "~/renderer/reducers/settings";
 export default function Currencies() {
   const { t } = useTranslation();
   const currencies = useSelector(cryptoCurrenciesSelector);
@@ -29,12 +23,7 @@ export default function Currencies() {
   );
   const currencyId = currency?.id;
   const currencyName = currency?.name;
-  const isCurrencyDisabled = useCallback(
-    (currency: Currency) =>
-      !currencySettingsDefaults(currency).confirmationsNb &&
-      !currencySettingsDefaults(currency).unit,
-    [],
-  );
+
   return (
     <Box>
       {currencyId && currencyName && (
@@ -58,7 +47,6 @@ export default function Currencies() {
           onChange={handleChangeCurrency}
           currencies={currencies}
           placeholder={t("settings.currencies.selectPlaceholder")}
-          isCurrencyDisabled={isCurrencyDisabled}
         />
       </Row>
       {currency && (

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/CurrencyRows.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/CurrencyRows.tsx
@@ -1,18 +1,19 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { CryptoCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 import Track from "~/renderer/analytics/Track";
 import { setCurrencySettings } from "~/renderer/actions/settings";
 import {
-  currenciesSettingsSelector,
   currencySettingsDefaults,
   CurrencySettings,
+  currencySettingsLocaleSelector,
 } from "~/renderer/reducers/settings";
 import StepperNumber from "~/renderer/components/StepperNumber";
 import { SettingsSectionRow as Row, SettingsSectionRowContainer } from "../../SettingsSection";
 import Box from "~/renderer/components/Box";
 import Select from "~/renderer/components/Select";
+import { State } from "~/renderer/reducers";
 
 type Props = {
   currency: CryptoCurrency;
@@ -23,11 +24,9 @@ type Key = keyof CurrencySettings;
 export default function CurrencyRows({ currency }: Props) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const currenciesSettings = useSelector(currenciesSettingsSelector);
 
-  const currencySettings = useMemo(
-    () => currenciesSettings[currency.ticker],
-    [currenciesSettings, currency.ticker],
+  const currencySettings = useSelector((state: State) =>
+    currencySettingsLocaleSelector(state.settings, currency),
   );
 
   const handleChangeConfirmationsNb = (nb: number) => updateCurrencySettings("confirmationsNb", nb);

--- a/apps/ledger-live-desktop/tests/utils/waitFor.ts
+++ b/apps/ledger-live-desktop/tests/utils/waitFor.ts
@@ -13,13 +13,13 @@ export async function waitFor(
     const interval = setInterval(async () => {
       const condition = await predicate();
       if (condition) {
-        clearInterval(interval as any as number);
+        clearInterval(interval as unknown as number);
         resolve(true);
       }
     }, intervalMs);
 
     setTimeout(() => {
-      clearInterval(interval as any as number);
+      clearInterval(interval as unknown as number);
       reject(new Error("waitFor timeout"));
     }, timeout);
   });

--- a/apps/ledger-live-mobile/e2e/models/market/marketPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/market/marketPage.ts
@@ -4,7 +4,7 @@ export default class MarketPage {
   searchBar = () => getElementById("search-box");
   starButton = () => getElementById("star-asset");
   assetCardBackBtn = () => getElementById("market-back-btn");
-  starMarketListButton = () => getElementById("starred");
+  starMarketListButton = () => getElementById("toggle-starred-currencies");
   buyAssetButton = () => getElementById("market-buy-btn");
 
   searchAsset(asset: string) {

--- a/apps/ledger-live-mobile/e2e/models/market/marketPage.ts
+++ b/apps/ledger-live-mobile/e2e/models/market/marketPage.ts
@@ -4,7 +4,7 @@ export default class MarketPage {
   searchBar = () => getElementById("search-box");
   starButton = () => getElementById("star-asset");
   assetCardBackBtn = () => getElementById("market-back-btn");
-  starMarketListButton = () => getElementById("toggle-starred-currencies");
+  starMarketListButton = () => getElementById("starred");
   buyAssetButton = () => getElementById("market-buy-btn");
 
   searchAsset(asset: string) {


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Remove usage of account.unit or getAccountUnit and replaced it with a more centralised way in Settings for each currency

### 📝 Description

Move "unit" field out of Account and move the related settings from Account settings back to the Currency settings (LLD only currently, LLM will be next)

<img width="336" alt="Screenshot 2024-04-03 at 14 45 04" src="https://github.com/LedgerHQ/ledger-live/assets/112866305/f86de4e8-273a-464d-a588-66a6793dec10">



https://github.com/LedgerHQ/ledger-live/assets/112866305/bd0d409d-4287-4b19-9e8d-66913405f6da



### ❓ Context

- **JIRA or GitHub link**: [LIVE-11770](https://ledgerhq.atlassian.net/browse/LIVE-11770) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11770]: https://ledgerhq.atlassian.net/browse/LIVE-11770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ