### PR TITLE
no strict code ownerships on the end 2 end tests of playwright/detox

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,11 +122,6 @@ apps/ledger-live-mobile/src/components/ServicesWidget/Protect/          @ledgerh
 apps/ledger-live-mobile/src/components/WebRecoverPlayer/                @ledgerhq/recover-software
 apps/ledger-live-mobile/src/screens/Protect/                            @ledgerhq/recover-software
 libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts                 @ledgerhq/recover-software
-
-# UI tests
-apps/ledger-live-desktop/tests/                          @ledgerhq/live-hub @ledgerhq/live-qa
-apps/ledger-live-mobile/e2e/                             @ledgerhq/live-hub @ledgerhq/live-qa
-
 # Cross-team generic files can be opted out (no strict ownership when it concerns everyone)
 apps/ledger-live-desktop/static/i18n/
 apps/ledger-live-mobile/src/locales/
@@ -137,3 +132,6 @@ libs/ledgerjs/packages/errors/src/index.ts
 libs/ledger-live-common/src/config/sharedConfig.ts
 libs/ledger-live-common/package.json
 **/generated/
+# UI tests are concerned by all teams, therefore have no strict ownership, devs generally write tests in context of feature, therefore the PR bringing features will only get ownership through the src/* changes which generally relates to the same tests modified
+apps/ledger-live-desktop/tests/
+apps/ledger-live-mobile/e2e/


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** none

### 📝 Description

We have noticed in recent PRs that a bunch of PR auto assign live-hub team just because they add tests in their own scope in the generic end 2 end tests of LLD and LLM. Similarly to what we did for i18n wordings, errors list, navigations,... there are no strict codeowners of these parts. the End 2 end tests on the end product are actually concerned by all teams (unlike the UI tests on the component system for instance, that indeed belong to live-hub), therefore  we should not have any strict ownership on these paths: actually when devs will write tests in context of adding new feature or modifying some codebase in `src/`, the ownership will be automatically assigned through these src/* changes – and they generally relates to the same tests modified – some tests being "generic" (e.g snapshotting the dashboard/account screen can be impacted by a rework of a coin (recent example of https://github.com/LedgerHQ/ledger-live/pull/6609), but only the blockchain team is actually relevant to determine if the screenshot change is legit in context of that PR change).

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
