### PR TITLE
Feat/live 11901

### DIFF
--- a/.changeset/spotty-tigers-play.md
+++ b/.changeset/spotty-tigers-play.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+remove max toggle button on llm

--- a/apps/ledger-live-mobile/e2e/specs/swap/swap.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/swap/swap.spec.ts
@@ -43,8 +43,12 @@ describe("Swap", () => {
     await swapPage.selectAccount("Ethereum");
   });
 
-  it("should have the send max toggle switch disabled for account coins", async () => {
-    await swapPage.sendMax();
+  it("should not have a max toggle button", async () => {
+    await expect(swapPage.sendMaxToggle()).not.toExist();
+  });
+
+  it("should have the send max toggle switch removed", async () => {
+    await expect(swapPage.sendMaxToggle()).not.toExist();
     await swapPage.openSourceAccountSelector();
     await swapPage.selectAccount("Bitcoin 1 (legacy)");
     await swapPage.enterSourceAmount("0.1");

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/index.tsx
@@ -46,6 +46,8 @@ import { useSelectedSwapRate } from "./useSelectedSwapRate";
 
 type Navigation = StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.Account>;
 
+const IS_MAX_TOGGLE_DISABLED = true;
+
 export function SwapForm({
   route: { params },
 }: MaterialTopTabNavigatorProps<SwapFormNavigatorParamList, ScreenName.SwapForm>) {
@@ -352,7 +354,7 @@ export function SwapForm({
           </Flex>
 
           <Flex paddingY={4}>
-            <Max swapTx={swapTransaction} />
+            {!IS_MAX_TOGGLE_DISABLED && <Max swapTx={swapTransaction} />}
 
             <Button type="main" disabled={!isSwapReady} onPress={onSubmit} testID="exchange-button">
               {t("transfer.swap2.form.cta")}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
