### PR TITLE
[LIVE-12100] Bugfix: Fix `getRedelegations` types & support breaking change of `entries` position in response payload

### DIFF
--- a/.changeset/mighty-years-cough.md
+++ b/.changeset/mighty-years-cough.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Update Cosmos SDK `GetRedelegations` types being incorrect & add support for undocumented breaking changes where `redelegation.entries` can be `null`

--- a/libs/ledger-live-common/src/families/cosmos/api/Cosmos.ts
+++ b/libs/ledger-live-common/src/families/cosmos/api/Cosmos.ts
@@ -280,13 +280,29 @@ export class CosmosAPI {
     });
 
     for (const { entries, redelegation } of redelegationResponses) {
-      for (const { initial_balance: initalBalance, completion_time: completionTime } of entries) {
-        redelegations.push({
-          validatorSrcAddress: redelegation.validator_src_address,
-          validatorDstAddress: redelegation.validator_dst_address,
-          amount: new BigNumber(initalBalance),
-          completionDate: new Date(completionTime),
-        });
+      if (entries) {
+        for (const {
+          redelegation_entry: { initial_balance: initalBalance, completion_time: completionTime },
+        } of entries) {
+          redelegations.push({
+            validatorSrcAddress: redelegation.validator_src_address,
+            validatorDstAddress: redelegation.validator_dst_address,
+            amount: new BigNumber(initalBalance),
+            completionDate: new Date(completionTime),
+          });
+        }
+      } else {
+        for (const {
+          initial_balance: initalBalance,
+          completion_time: completionTime,
+        } of redelegation.entries || []) {
+          redelegations.push({
+            validatorSrcAddress: redelegation.validator_src_address,
+            validatorDstAddress: redelegation.validator_dst_address,
+            amount: new BigNumber(initalBalance),
+            completionDate: new Date(completionTime),
+          });
+        }
       }
     }
 

--- a/libs/ledger-live-common/src/families/cosmos/api/types.ts
+++ b/libs/ledger-live-common/src/families/cosmos/api/types.ts
@@ -264,14 +264,27 @@ export type GetRedelegations = {
       delegator_address: string;
       validator_src_address: string;
       validator_dst_address: string;
+      entries:
+        | {
+            creation_height: string;
+            completion_time: string;
+            initial_balance: string;
+            shares_dst: string;
+            unbonding_id: string;
+            unbonding_on_hold_ref_count: string;
+          }[]
+        | null;
     };
     entries: {
-      creation_height: string;
-      completion_time: string;
-      initial_balance: string;
-      shares_dst: string;
-      unbonding_id: string;
-      unbonding_on_hold_ref_count: string;
+      redelegation_entry: {
+        creation_height: string;
+        completion_time: string;
+        initial_balance: string;
+        shares_dst: string;
+        unbonding_id: string;
+        unbonding_on_hold_ref_count: string;
+      };
+      balance: string;
     }[];
   }[];
   pagination: {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Redelegations shouldn't be breaking with v0.45 nor v0.47 nodes

### 📝 Description

PR fixing the incorrect types on [Cosmos SDK Redelegations](https://docs.cosmos.network/api#tag/Query/operation/Redelegations) and support breaking changes undocumented where `redelegation.entries` can be null

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12100


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
