### PR TITLE
[LIVE-12017][Onboarding][Stax]: Make update from <=1.3.0 unskippable

### DIFF
--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/EarlySecurityCheck.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/EarlySecurityCheck.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { log } from "@ledgerhq/logs";
 import { useGenuineCheck } from "@ledgerhq/live-common/hw/hooks/useGenuineCheck";
 import { useGetLatestAvailableFirmware } from "@ledgerhq/live-common/deviceSDK/hooks/useGetLatestAvailableFirmware";
+import { shouldForceFirmwareUpdate } from "@ledgerhq/live-common/device/use-cases/shouldForceFirmwareUpdate";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import AllowManagerDrawer from "./AllowManagerDrawer";
 import GenuineCheckErrorDrawer from "./GenuineCheckErrorDrawer";
@@ -97,7 +98,8 @@ export const EarlySecurityCheck: React.FC<EarlySecurityCheckProps> = ({
   onCancelOnboarding,
   navigation,
 }) => {
-  const productName = getDeviceModel(device.modelId).productName || device.modelId;
+  const deviceModelId = device.modelId;
+  const productName = getDeviceModel(deviceModelId).productName || deviceModelId;
 
   // If the device is genuine, puts the current step to `genuine-check` and it will automatically go to next step
   // as the `genuineCheckStatus` is also set as `completed`.
@@ -375,6 +377,10 @@ export const EarlySecurityCheck: React.FC<EarlySecurityCheckProps> = ({
   const hasLatestAvailableFirmwareStatus =
     getLatestAvailableFirmwareStatus === "available-firmware" && !!latestAvailableFirmwareVersion;
 
+  const forceFirmwareUpdate =
+    deviceInfo?.version &&
+    shouldForceFirmwareUpdate({ currentVersion: deviceInfo.version, deviceModelId });
+
   return (
     <>
       {firmwareUpdateUiStepStatus === "completed" ? (
@@ -422,6 +428,7 @@ export const EarlySecurityCheck: React.FC<EarlySecurityCheckProps> = ({
         latestAvailableFirmwareVersion={latestAvailableFirmwareVersion}
         notifyOnboardingEarlyCheckEnded={notifyOnboardingEarlyCheckEnded}
         onSkipFirmwareUpdate={onSkipFirmwareUpdate}
+        updateSkippable={!forceFirmwareUpdate}
         onUpdateFirmware={onUpdateFirmware}
       />
       <LanguagePrompt device={device} />

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/EarlySecurityCheckBody.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/EarlySecurityCheckBody.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ScrollView } from "react-native";
-import { Flex, Link, Text } from "@ledgerhq/native-ui";
+import { Flex, InfiniteLoader, Link, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import Button from "~/components/wrappedUi/Button";
 import type { Step, UiCheckStatus } from "./EarlySecurityCheck";
@@ -21,6 +21,7 @@ export type Props = {
   notifyOnboardingEarlyCheckEnded: () => void;
   onSkipFirmwareUpdate: () => void;
   onUpdateFirmware: () => void;
+  updateSkippable: boolean;
 };
 
 /**
@@ -39,6 +40,7 @@ const EarlySecurityCheckBody: React.FC<Props> = ({
   notifyOnboardingEarlyCheckEnded,
   onSkipFirmwareUpdate,
   onUpdateFirmware,
+  updateSkippable,
 }) => {
   const { t } = useTranslation();
 
@@ -152,17 +154,24 @@ const EarlySecurityCheckBody: React.FC<Props> = ({
           { productName },
         );
       }
-
-      secondaryBottomCta = (
-        <OnePressCta
-          PressableComponent={({ pending, ...props }) => (
-            <Link size="large" disabled={pending} {...props} />
-          )}
-          onPress={onSkipFirmwareUpdate}
-        >
-          {t("earlySecurityCheck.firmwareUpdateCheckStep.refused.skipCta")}
-        </OnePressCta>
-      );
+      if (updateSkippable) {
+        secondaryBottomCta = (
+          <OnePressCta
+            PressableComponent={({ pending, ...props }) => (
+              <Link
+                type="shade"
+                size="large"
+                disabled={pending}
+                {...props}
+                Icon={pending ? InfiniteLoader : undefined}
+              />
+            )}
+            onPress={onSkipFirmwareUpdate}
+          >
+            {t("earlySecurityCheck.firmwareUpdateCheckStep.refused.skipCta")}
+          </OnePressCta>
+        );
+      }
 
       break;
     case "inactive":

--- a/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.test.ts
+++ b/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.test.ts
@@ -1,0 +1,74 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { shouldForceFirmwareUpdate } from "./shouldForceFirmwareUpdate";
+
+describe("shouldForceFirmwareUpdate", () => {
+  it("should force firmware update for stax <=1.3.0 and not other versions", () => {
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.2.0", deviceModelId: DeviceModelId.stax }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.2.0-whatever",
+        deviceModelId: DeviceModelId.stax,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.3.0", deviceModelId: DeviceModelId.stax }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.3.0-whatever",
+        deviceModelId: DeviceModelId.stax,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.3.1", deviceModelId: DeviceModelId.stax }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.3.1-whatever",
+        deviceModelId: DeviceModelId.stax,
+      }),
+    ).toBe(false);
+  });
+
+  it("should not force firmware update for other models", () => {
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.2.0", deviceModelId: DeviceModelId.nanoX }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.2.0-whatever",
+        deviceModelId: DeviceModelId.nanoX,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.3.0", deviceModelId: DeviceModelId.nanoX }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.3.0-whatever",
+        deviceModelId: DeviceModelId.nanoX,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.3.1", deviceModelId: DeviceModelId.nanoX }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.3.1-whatever",
+        deviceModelId: DeviceModelId.nanoX,
+      }),
+    ).toBe(false);
+  });
+});

--- a/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.ts
+++ b/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.ts
@@ -1,0 +1,34 @@
+import semver from "semver";
+import { DeviceModelId } from "@ledgerhq/devices";
+
+const noVersionCondition = "<0.0.0"; // this version is never satisfied
+const forceUpdateConditions: Record<DeviceModelId, string> = {
+  nanoX: noVersionCondition,
+  nanoS: noVersionCondition,
+  nanoSP: noVersionCondition,
+  blue: noVersionCondition,
+  europa: noVersionCondition,
+  stax: "<=1.3.0",
+};
+
+/**
+ * Returns whether we should enforce a firmware update if there is one available.
+ *
+ * For example this is used for the Stax device as some of the first devices
+ * shipped have a firmware version that is deprecated (1.3.0).
+ *
+ * @param currentVersion - The current firmware version.
+ * @param deviceModelId - The device model id.
+ */
+export function shouldForceFirmwareUpdate({
+  currentVersion,
+  deviceModelId,
+}: {
+  currentVersion: string;
+  deviceModelId: DeviceModelId;
+}): boolean {
+  return semver.satisfies(
+    semver.coerce(currentVersion) ?? "",
+    forceUpdateConditions[deviceModelId],
+  );
+}

--- a/libs/device-core/src/index.ts
+++ b/libs/device-core/src/index.ts
@@ -31,3 +31,5 @@ export { isSyncOnboardingSupported } from "./capabilities/isSyncOnboardingSuppor
 export { supportedDeviceModelIds } from "./capabilities/isCustomLockScreenSupported";
 // src/customLockScreen/
 export * from "./customLockScreen/screenSpecs";
+// src/firmwareUpdate/
+export { shouldForceFirmwareUpdate } from "./firmwareUpdate/shouldForceFirmwareUpdate";

--- a/libs/ledger-live-common/src/device/use-cases/shouldForceFirmwareUpdate.ts
+++ b/libs/ledger-live-common/src/device/use-cases/shouldForceFirmwareUpdate.ts
@@ -1,0 +1,1 @@
+export { shouldForceFirmwareUpdate } from "@ledgerhq/device-core";

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "doc": "pnpm --filter docs",
     "mobile": "pnpm --filter live-mobile",
     "common": "pnpm --filter live-common",
+    "device-core": "pnpm --filter device-core",
+    "device-react": "pnpm --filter device-react",
     "web-tools": "pnpm --filter web-tools",
     "live-env": "pnpm --filter live-env",
     "portfolio": "pnpm --filter live-portfolio",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM, LLD: Stax onboarding Early Security Checks

### 📝 Description

LLM update skippable (from a version > 1.3.0, here 1.4.0-rc2). Notice that the "Skip" button has been changed to a "shade" style to make it more discrete.
https://github.com/LedgerHQ/ledger-live/assets/91890529/e73de652-9dfb-4c01-84db-56eceae3d890

LLM update unskippable (from a version <= 1.3.0, here 1.2.1-ilX)
https://github.com/LedgerHQ/ledger-live/assets/91890529/b0cdeb17-fc76-46bf-9ccb-d66516e60b5f



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12017] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
