### PR TITLE
fix(llm): fix ui select device screen

### DIFF
--- a/.changeset/hungry-trainers-explain.md
+++ b/.changeset/hungry-trainers-explain.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix ui reg caused by previous PR on selectDevice2 screen. The ui was correct with CC but wrong without

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/index.tsx
@@ -334,90 +334,96 @@ export default function SelectDevice({
               flexDirection: "column",
             }}
           >
-            {isPostOnboardingVisible && (
-              <Box mb={8}>
-                <PostOnboardingEntryPointCard />
-              </Box>
-            )}
-            <Flex
-              flexDirection="row"
-              justifyContent="space-between"
-              alignItems="center"
-              mb={1}
-              px={16}
-            >
-              <Text variant="h5" fontWeight="semiBold">
-                <Trans i18nKey="manager.selectDevice.title" />
-              </Text>
-              {deviceList.length > 0 && (
-                <Touchable
-                  onPress={isChoiceDrawerDisplayedOnAddDevice ? onAddNewPress : openBlePairingFlow}
-                  {...addNewButtonEventProps}
-                >
-                  <Flex flexDirection="row" alignItems="center">
-                    <Text color="primary.c90" mr={3} fontWeight="semiBold">
-                      <Trans
-                        i18nKey={`manager.selectDevice.${
-                          Platform.OS === "android" ? "addWithBluetooth" : "addNewCTA"
-                        }`}
-                      />
-                    </Text>
-                    <IconsLegacy.PlusMedium color="primary.c90" size={15} />
-                  </Flex>
-                </Touchable>
-              )}
-            </Flex>
-
             <Flex>
-              <Flex px={16}>
-                {deviceList.length > 0 ? (
-                  <DeviceList deviceList={deviceList} handleOnSelect={handleOnSelect} />
-                ) : (
-                  <Touchable
-                    touchableTestID="connect-with-bluetooth"
-                    onPress={
-                      isChoiceDrawerDisplayedOnAddDevice ? onAddNewPress : openBlePairingFlow
-                    }
-                    {...addNewButtonEventProps}
-                  >
-                    <Flex
-                      p={5}
-                      mb={4}
-                      borderRadius={5}
-                      flexDirection="row"
-                      alignItems="center"
-                      borderColor="neutral.c40"
-                      borderStyle="dashed"
-                      borderWidth="1px"
-                    >
-                      <IconsLegacy.PlusMedium color="neutral.c90" size={20} />
-                      <Text variant="large" fontWeight="semiBold" ml={5}>
-                        {t(
-                          `manager.selectDevice.${
-                            Platform.OS === "android" ? "addWithBluetooth" : "addALedger"
-                          }`,
-                        )}
-                      </Text>
-                    </Flex>
-                  </Touchable>
+              <Flex>
+                {isPostOnboardingVisible && (
+                  <Box mb={8}>
+                    <PostOnboardingEntryPointCard />
+                  </Box>
                 )}
-                {Platform.OS === "android" &&
-                  USBDevice === undefined &&
-                  ProxyDevice === undefined && (
-                    <Text
-                      color="neutral.c100"
-                      variant="large"
-                      fontWeight="semiBold"
-                      fontSize={4}
-                      lineHeight="21px"
-                      mt={3}
-                      mb={3}
+                <Flex
+                  flexDirection="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  mb={1}
+                  px={16}
+                >
+                  <Text variant="h5" fontWeight="semiBold">
+                    <Trans i18nKey="manager.selectDevice.title" />
+                  </Text>
+                  {deviceList.length > 0 && (
+                    <Touchable
+                      onPress={
+                        isChoiceDrawerDisplayedOnAddDevice ? onAddNewPress : openBlePairingFlow
+                      }
+                      {...addNewButtonEventProps}
                     >
-                      <Trans i18nKey="manager.selectDevice.otgBanner" />
-                    </Text>
+                      <Flex flexDirection="row" alignItems="center">
+                        <Text color="primary.c90" mr={3} fontWeight="semiBold">
+                          <Trans
+                            i18nKey={`manager.selectDevice.${
+                              Platform.OS === "android" ? "addWithBluetooth" : "addNewCTA"
+                            }`}
+                          />
+                        </Text>
+                        <IconsLegacy.PlusMedium color="primary.c90" size={15} />
+                      </Flex>
+                    </Touchable>
                   )}
+                </Flex>
               </Flex>
-              {children}
+
+              <Flex pt={16}>
+                <Flex px={16}>
+                  {deviceList.length > 0 ? (
+                    <DeviceList deviceList={deviceList} handleOnSelect={handleOnSelect} />
+                  ) : (
+                    <Touchable
+                      touchableTestID="connect-with-bluetooth"
+                      onPress={
+                        isChoiceDrawerDisplayedOnAddDevice ? onAddNewPress : openBlePairingFlow
+                      }
+                      {...addNewButtonEventProps}
+                    >
+                      <Flex
+                        p={5}
+                        mb={4}
+                        borderRadius={5}
+                        flexDirection="row"
+                        alignItems="center"
+                        borderColor="neutral.c40"
+                        borderStyle="dashed"
+                        borderWidth="1px"
+                      >
+                        <IconsLegacy.PlusMedium color="neutral.c90" size={20} />
+                        <Text variant="large" fontWeight="semiBold" ml={5}>
+                          {t(
+                            `manager.selectDevice.${
+                              Platform.OS === "android" ? "addWithBluetooth" : "addALedger"
+                            }`,
+                          )}
+                        </Text>
+                      </Flex>
+                    </Touchable>
+                  )}
+                  {Platform.OS === "android" &&
+                    USBDevice === undefined &&
+                    ProxyDevice === undefined && (
+                      <Text
+                        color="neutral.c100"
+                        variant="large"
+                        fontWeight="semiBold"
+                        fontSize={4}
+                        lineHeight="21px"
+                        mt={3}
+                        mb={3}
+                      >
+                        <Trans i18nKey="manager.selectDevice.otgBanner" />
+                      </Text>
+                    )}
+                </Flex>
+                {children}
+              </Flex>
             </Flex>
             <Flex alignItems="center" mt={10} mb={8}>
               <BuyDeviceCTA />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix ui problem caused by a previous PR : [feat/LIVE-11955](https://github.com/LedgerHQ/ledger-live/pull/6593)
When no CC is displayed, the CTA Select device is in the middle of the screen instead of at the top.



| Before        | After         |
| ------------- | ------------- |
|![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/33cbfc14-d37e-4518-b82b-ba047ac22f57)| ![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/be236784-668e-4120-a24b-f62dd8b534f2)|


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
