### PR TITLE
[FIX] :  MarketPerf Widget wasn't updated well when Top 5 crypto is the same for multiples minutes

### DIFF
--- a/.changeset/three-geckos-help.md
+++ b/.changeset/three-geckos-help.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+MarketPerf Widget wasn't updated well when Top 5 crypto is the same for multiples minutes

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/useMarketPerformanceWidget.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/useMarketPerformanceWidget.ts
@@ -3,7 +3,7 @@ import {
   counterValueCurrencySelector,
   selectedTimeRangeSelector,
 } from "~/renderer/reducers/settings";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Order } from "./types";
 
 import { useMarketPerformers } from "@ledgerhq/live-common/market/v2/useMarketPerformers";

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/useMarketPerformanceWidget.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/useMarketPerformanceWidget.ts
@@ -30,10 +30,7 @@ export function useMarketPerformanceWidget() {
     refreshRate,
   });
 
-  const sliced = useMemo(
-    () => getSlicedList(data ?? [], order, timeRange),
-    [data, order, timeRange],
-  );
+  const sliced = getSlicedList(data ?? [], order, timeRange);
 
   return {
     list: sliced,

--- a/libs/ledger-live-common/src/market/v2/useMarketPerformers.ts
+++ b/libs/ledger-live-common/src/market/v2/useMarketPerformers.ts
@@ -18,5 +18,6 @@ export const useMarketPerformers = ({
     queryKey: [QUERY_KEY.MarketPerformers, counterCurrency, range, sort],
     queryFn: () => fetchMarketPerformers({ counterCurrency, range, limit, top, sort, supported }),
     refetchInterval: REFETCH_TIME_ONE_MINUTE * Number(refreshRate),
+    staleTime: REFETCH_TIME_ONE_MINUTE * Number(refreshRate),
     select: data => data.map((currency: MarketItemResponse) => formatPerformer(currency)),
   });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
MarketPerf Widget wasn't updated well when Top 5 crypto is the same for multiples minutes


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
