### PR TITLE
[feat/LIVE-12118]: add buy sell ui flag to enable progressive replacement of multibuy-v2 live app

### DIFF
--- a/.changeset/few-parents-applaud.md
+++ b/.changeset/few-parents-applaud.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Add buy-sell-ui feature flag to enable progressive roll out of new manifest ID.

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
@@ -16,6 +16,7 @@ import Spinner from "../Spinner";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { track } from "~/renderer/analytics/segment";
 import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
+import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
 
 const Container = styled(Box).attrs(() => ({
@@ -104,9 +105,10 @@ export const TopBar = ({ manifest, webviewAPIRef, webviewState }: Props) => {
   const history = useHistory();
   const match = useRouteMatch();
   const { localStorage } = window;
+  const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
   const isInternalApp = useMemo(() => {
-    if (!INTERNAL_APP_IDS.includes(manifest.id)) {
+    if (!internalAppIds.includes(manifest.id)) {
       return false;
     }
 
@@ -118,7 +120,7 @@ export const TopBar = ({ manifest, webviewAPIRef, webviewState }: Props) => {
     const currentHostname = new URL(webviewState.url).hostname;
 
     return manifestHostname === currentHostname;
-  }, [manifest.id, manifest.url, webviewState.url]);
+  }, [manifest.id, manifest.url, webviewState.url, internalAppIds]);
 
   const enablePlatformDevTools = useSelector(enablePlatformDevToolsSelector);
 

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -18,6 +18,7 @@ import {
   INTERNAL_APP_IDS,
   WALLET_API_VERSION,
 } from "@ledgerhq/live-common/wallet-api/constants";
+import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 export type DProps = {
@@ -42,6 +43,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
   const remoteManifest = useRemoteLiveAppManifest(appId);
   const manifest = localManifest || mockManifest || remoteManifest;
   const themeType = useTheme().colors.palette.type;
+  const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
   /**
    * Pass correct account ID
@@ -70,7 +72,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
    * to ensure the context is reset. last-screen is used to give an external app's webview context
    * of the last screen the user was on before navigating to the external app screen.
    */
-  if (manifest?.id && INTERNAL_APP_IDS.includes(manifest.id)) {
+  if (manifest?.id && internalAppIds.includes(manifest.id)) {
     const { localStorage } = window;
     localStorage.removeItem("last-screen");
     localStorage.removeItem("manifest-id");

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -15,7 +15,6 @@ import { LiveAppManifest, Loadable } from "@ledgerhq/live-common/platform/types"
 import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
 import {
   DEFAULT_MULTIBUY_APP_ID,
-  BUY_SELL_UI_APP_ID,
   INTERNAL_APP_IDS,
   WALLET_API_VERSION,
 } from "@ledgerhq/live-common/wallet-api/constants";
@@ -108,7 +107,7 @@ export type ExchangeComponentParams = {
 const Exchange = ({ match }: RouteComponentProps<ExchangeComponentParams>) => {
   const appId = match?.params?.appId;
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.enabled ? BUY_SELL_UI_APP_ID : DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.manifestId || DEFAULT_MULTIBUY_APP_ID;
 
   return <LiveAppExchange appId={appId || defaultPlatform} />;
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -15,9 +15,11 @@ import { LiveAppManifest, Loadable } from "@ledgerhq/live-common/platform/types"
 import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
 import {
   DEFAULT_MULTIBUY_APP_ID,
+  BUY_SELL_UI_APP_ID,
   INTERNAL_APP_IDS,
   WALLET_API_VERSION,
 } from "@ledgerhq/live-common/wallet-api/constants";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 export type DProps = {
   defaultCurrencyId?: string | null;
@@ -105,7 +107,9 @@ export type ExchangeComponentParams = {
 
 const Exchange = ({ match }: RouteComponentProps<ExchangeComponentParams>) => {
   const appId = match?.params?.appId;
+  const buySellUiFlag = useFeature("buySellUi");
+  const defaultPlatform = buySellUiFlag?.enabled ? BUY_SELL_UI_APP_ID : DEFAULT_MULTIBUY_APP_ID;
 
-  return <LiveAppExchange appId={appId || DEFAULT_MULTIBUY_APP_ID} />;
+  return <LiveAppExchange appId={appId || defaultPlatform} />;
 };
 export default Exchange;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -107,7 +107,7 @@ export type ExchangeComponentParams = {
 const Exchange = ({ match }: RouteComponentProps<ExchangeComponentParams>) => {
   const appId = match?.params?.appId;
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.manifestId || DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.params?.manifestId || DEFAULT_MULTIBUY_APP_ID;
 
   return <LiveAppExchange appId={appId || defaultPlatform} />;
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -2,7 +2,11 @@ import React, { useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
-import { DEFAULT_MULTIBUY_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
+import {
+  DEFAULT_MULTIBUY_APP_ID,
+  BUY_SELL_UI_APP_ID,
+} from "@ledgerhq/live-common/wallet-api/constants";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 
@@ -16,6 +20,8 @@ const Stack = createStackNavigator<ExchangeLiveAppNavigatorParamList>();
 const ExchangeBuy = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeBuy>,
 ) => {
+  const buySellUiFlag = useFeature("buySellUi");
+  const defaultPlatform = buySellUiFlag?.enabled ? BUY_SELL_UI_APP_ID : DEFAULT_MULTIBUY_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}
@@ -29,7 +35,7 @@ const ExchangeBuy = (
           goToURL: _props.route.params?.goToURL,
           lastScreen: _props.route.params?.lastScreen,
           mode: "buy",
-          platform: _props.route.params?.platform || DEFAULT_MULTIBUY_APP_ID,
+          platform: _props.route.params?.platform || defaultPlatform,
           referrer: _props.route.params?.referrer,
         },
       }}
@@ -40,6 +46,8 @@ const ExchangeBuy = (
 const ExchangeSell = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeSell>,
 ) => {
+  const buySellUiFlag = useFeature("buySellUi");
+  const defaultPlatform = buySellUiFlag?.enabled ? BUY_SELL_UI_APP_ID : DEFAULT_MULTIBUY_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}
@@ -53,7 +61,7 @@ const ExchangeSell = (
           goToURL: _props.route.params?.goToURL,
           lastScreen: _props.route.params?.lastScreen,
           mode: "sell",
-          platform: _props.route.params?.platform || DEFAULT_MULTIBUY_APP_ID,
+          platform: _props.route.params?.platform || defaultPlatform,
           referrer: _props.route.params?.referrer,
         },
       }}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -2,10 +2,7 @@ import React, { useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
-import {
-  DEFAULT_MULTIBUY_APP_ID,
-  BUY_SELL_UI_APP_ID,
-} from "@ledgerhq/live-common/wallet-api/constants";
+import { DEFAULT_MULTIBUY_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
@@ -21,7 +18,7 @@ const ExchangeBuy = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeBuy>,
 ) => {
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.enabled ? BUY_SELL_UI_APP_ID : DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.manifestId || DEFAULT_MULTIBUY_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}
@@ -47,7 +44,7 @@ const ExchangeSell = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeSell>,
 ) => {
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.enabled ? BUY_SELL_UI_APP_ID : DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.manifestId || DEFAULT_MULTIBUY_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -18,7 +18,7 @@ const ExchangeBuy = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeBuy>,
 ) => {
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.manifestId || DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.params?.manifestId || DEFAULT_MULTIBUY_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}
@@ -44,7 +44,7 @@ const ExchangeSell = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeSell>,
 ) => {
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.manifestId || DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.params?.manifestId || DEFAULT_MULTIBUY_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -50,6 +50,7 @@ import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigato
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebviewState } from "./helpers";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 function renderLoading() {
   return (
@@ -511,8 +512,12 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       tracking.platformLoad(manifest);
     }, [manifest, tracking]);
 
-    const javaScriptCanOpenWindowsAutomatically =
-      manifest.id === DEFAULT_MULTIBUY_APP_ID || manifest.id === BUY_SELL_UI_APP_ID;
+    const buySellUiFlag = useFeature("buySellUi");
+    const buySellAppIds = buySellUiFlag?.manifestId
+      ? [buySellUiFlag.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
+      : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+
+    const javaScriptCanOpenWindowsAutomatically = buySellAppIds.includes(manifest.id);
 
     return (
       <RNWebView

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -35,7 +35,10 @@ import {
 } from "@ledgerhq/live-common/platform/react";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
 import BigNumber from "bignumber.js";
-import { DEFAULT_MULTIBUY_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
+import {
+  DEFAULT_MULTIBUY_APP_ID,
+  BUY_SELL_UI_APP_ID,
+} from "@ledgerhq/live-common/wallet-api/constants";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { NavigatorName, ScreenName } from "~/const";
 import { broadcastSignedTx } from "~/logic/screenTransactionHooks";
@@ -508,7 +511,8 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       tracking.platformLoad(manifest);
     }, [manifest, tracking]);
 
-    const javaScriptCanOpenWindowsAutomatically = manifest.id === DEFAULT_MULTIBUY_APP_ID;
+    const javaScriptCanOpenWindowsAutomatically =
+      manifest.id === DEFAULT_MULTIBUY_APP_ID || manifest.id === BUY_SELL_UI_APP_ID;
 
     return (
       <RNWebView

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -35,10 +35,8 @@ import {
 } from "@ledgerhq/live-common/platform/react";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
 import BigNumber from "bignumber.js";
-import {
-  DEFAULT_MULTIBUY_APP_ID,
-  BUY_SELL_UI_APP_ID,
-} from "@ledgerhq/live-common/wallet-api/constants";
+import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
+import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { NavigatorName, ScreenName } from "~/const";
 import { broadcastSignedTx } from "~/logic/screenTransactionHooks";
@@ -50,7 +48,6 @@ import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigato
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebviewState } from "./helpers";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 function renderLoading() {
   return (
@@ -512,12 +509,9 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       tracking.platformLoad(manifest);
     }, [manifest, tracking]);
 
-    const buySellUiFlag = useFeature("buySellUi");
-    const buySellAppIds = buySellUiFlag?.params?.manifestId
-      ? [buySellUiFlag.params.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
-      : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+    const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
-    const javaScriptCanOpenWindowsAutomatically = buySellAppIds.includes(manifest.id);
+    const javaScriptCanOpenWindowsAutomatically = internalAppIds.includes(manifest.id);
 
     return (
       <RNWebView

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -513,8 +513,8 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     }, [manifest, tracking]);
 
     const buySellUiFlag = useFeature("buySellUi");
-    const buySellAppIds = buySellUiFlag?.manifestId
-      ? [buySellUiFlag.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
+    const buySellAppIds = buySellUiFlag?.params?.manifestId
+      ? [buySellUiFlag.params.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
       : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
 
     const javaScriptCanOpenWindowsAutomatically = buySellAppIds.includes(manifest.id);

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -11,6 +11,7 @@ import {
 } from "@ledgerhq/live-common/wallet-api/constants";
 import { INJECTED_JAVASCRIPT } from "./dappInject";
 import { NoAccountScreen } from "./NoAccountScreen";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   (
@@ -39,8 +40,12 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       webviewRef.current?.reload();
     };
 
-    const javaScriptCanOpenWindowsAutomatically =
-      manifest.id === DEFAULT_MULTIBUY_APP_ID || manifest.id === BUY_SELL_UI_APP_ID;
+    const buySellUiFlag = useFeature("buySellUi");
+    const buySellAppIds = buySellUiFlag?.manifestId
+      ? [buySellUiFlag.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
+      : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+
+    const javaScriptCanOpenWindowsAutomatically = buySellAppIds.includes(manifest.id);
 
     if (!!manifest.dapp && noAccounts) {
       return <NoAccountScreen manifest={manifest} currentAccountHistDb={currentAccountHistDb} />;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -5,13 +5,10 @@ import Config from "react-native-config";
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebView } from "./helpers";
 import { NetworkError } from "./NetworkError";
-import {
-  DEFAULT_MULTIBUY_APP_ID,
-  BUY_SELL_UI_APP_ID,
-} from "@ledgerhq/live-common/wallet-api/constants";
+import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
+import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { INJECTED_JAVASCRIPT } from "./dappInject";
 import { NoAccountScreen } from "./NoAccountScreen";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   (
@@ -40,12 +37,9 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       webviewRef.current?.reload();
     };
 
-    const buySellUiFlag = useFeature("buySellUi");
-    const buySellAppIds = buySellUiFlag?.params?.manifestId
-      ? [buySellUiFlag.params.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
-      : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+    const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
-    const javaScriptCanOpenWindowsAutomatically = buySellAppIds.includes(manifest.id);
+    const javaScriptCanOpenWindowsAutomatically = internalAppIds.includes(manifest.id);
 
     if (!!manifest.dapp && noAccounts) {
       return <NoAccountScreen manifest={manifest} currentAccountHistDb={currentAccountHistDb} />;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -41,8 +41,8 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
     };
 
     const buySellUiFlag = useFeature("buySellUi");
-    const buySellAppIds = buySellUiFlag?.manifestId
-      ? [buySellUiFlag.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
+    const buySellAppIds = buySellUiFlag?.params?.manifestId
+      ? [buySellUiFlag.params.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
       : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
 
     const javaScriptCanOpenWindowsAutomatically = buySellAppIds.includes(manifest.id);

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -5,7 +5,10 @@ import Config from "react-native-config";
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebView } from "./helpers";
 import { NetworkError } from "./NetworkError";
-import { DEFAULT_MULTIBUY_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
+import {
+  DEFAULT_MULTIBUY_APP_ID,
+  BUY_SELL_UI_APP_ID,
+} from "@ledgerhq/live-common/wallet-api/constants";
 import { INJECTED_JAVASCRIPT } from "./dappInject";
 import { NoAccountScreen } from "./NoAccountScreen";
 
@@ -36,7 +39,8 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
       webviewRef.current?.reload();
     };
 
-    const javaScriptCanOpenWindowsAutomatically = manifest.id === DEFAULT_MULTIBUY_APP_ID;
+    const javaScriptCanOpenWindowsAutomatically =
+      manifest.id === DEFAULT_MULTIBUY_APP_ID || manifest.id === BUY_SELL_UI_APP_ID;
 
     if (!!manifest.dapp && noAccounts) {
       return <NoAccountScreen manifest={manifest} currentAccountHistDb={currentAccountHistDb} />;

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -16,6 +16,7 @@ import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import {
   DEFAULT_MULTIBUY_APP_ID,
   INTERNAL_APP_IDS,
+  BUY_SELL_UI_APP_ID,
 } from "@ledgerhq/live-common/wallet-api/constants";
 import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
 
@@ -77,7 +78,11 @@ function BackToInternalDomain({
           referrer: "isExternal",
         },
       });
-    } else if (manifest.id === DEFAULT_MULTIBUY_APP_ID && lastMatchingURL && webviewURL) {
+    } else if (
+      (manifest.id === DEFAULT_MULTIBUY_APP_ID || manifest.id === BUY_SELL_UI_APP_ID) &&
+      lastMatchingURL &&
+      webviewURL
+    ) {
       const currentHostname = new URL(webviewURL).hostname;
       const url = new URL(lastMatchingURL);
       const urlParams = new URLSearchParams(url.searchParams);

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -13,13 +13,9 @@ import { Flex, Icon, Text } from "@ledgerhq/native-ui";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
-import {
-  DEFAULT_MULTIBUY_APP_ID,
-  INTERNAL_APP_IDS,
-  BUY_SELL_UI_APP_ID,
-} from "@ledgerhq/live-common/wallet-api/constants";
+import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
+import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useNavigation } from "@react-navigation/native";
@@ -53,10 +49,7 @@ function BackToInternalDomain({
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
   const [buttonText, setButtonText] = useState("");
 
-  const buySellUiFlag = useFeature("buySellUi");
-  const buySellAppIds = buySellUiFlag?.params?.manifestId
-    ? [buySellUiFlag.params.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
-    : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+  const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
   useEffect(() => {
     (async () => {
@@ -84,7 +77,7 @@ function BackToInternalDomain({
           referrer: "isExternal",
         },
       });
-    } else if (buySellAppIds.includes(manifest.id) && lastMatchingURL && webviewURL) {
+    } else if (internalAppIds.includes(manifest.id) && lastMatchingURL && webviewURL) {
       const currentHostname = new URL(webviewURL).hostname;
       const url = new URL(lastMatchingURL);
       const urlParams = new URLSearchParams(url.searchParams);
@@ -130,9 +123,10 @@ export const WebPTXPlayer = ({ manifest, inputs, disableHeader }: Props) => {
   const lastMatchingURL = useRef<string | null>(null);
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
+  const internalAppIds = useInternalAppIds();
 
   const isInternalApp = useMemo(() => {
-    if (!INTERNAL_APP_IDS.includes(manifest.id)) {
+    if (!internalAppIds.includes(manifest.id)) {
       return false;
     }
 
@@ -144,7 +138,7 @@ export const WebPTXPlayer = ({ manifest, inputs, disableHeader }: Props) => {
     const currentHostname = new URL(webviewState.url).hostname;
 
     return manifestHostname === currentHostname;
-  }, [manifest.id, manifest.url, webviewState.url]);
+  }, [internalAppIds, manifest.id, manifest.url, webviewState.url]);
 
   const navigation =
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -19,6 +19,7 @@ import {
   BUY_SELL_UI_APP_ID,
 } from "@ledgerhq/live-common/wallet-api/constants";
 import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useNavigation } from "@react-navigation/native";
@@ -52,6 +53,11 @@ function BackToInternalDomain({
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
   const [buttonText, setButtonText] = useState("");
 
+  const buySellUiFlag = useFeature("buySellUi");
+  const buySellAppIds = buySellUiFlag?.params?.manifestId
+    ? [buySellUiFlag.params.manifestId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
+    : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+
   useEffect(() => {
     (async () => {
       const lastScreen = (await AsyncStorage.getItem("last-screen")) || "";
@@ -78,11 +84,7 @@ function BackToInternalDomain({
           referrer: "isExternal",
         },
       });
-    } else if (
-      (manifest.id === DEFAULT_MULTIBUY_APP_ID || manifest.id === BUY_SELL_UI_APP_ID) &&
-      lastMatchingURL &&
-      webviewURL
-    ) {
+    } else if (buySellAppIds.includes(manifest.id) && lastMatchingURL && webviewURL) {
       const currentHostname = new URL(webviewURL).hostname;
       const url = new URL(lastMatchingURL);
       const urlParams = new URLSearchParams(url.searchParams);

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/index.tsx
@@ -123,7 +123,7 @@ export const WebPTXPlayer = ({ manifest, inputs, disableHeader }: Props) => {
   const lastMatchingURL = useRef<string | null>(null);
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
-  const internalAppIds = useInternalAppIds();
+  const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
   const isInternalApp = useMemo(() => {
     if (!internalAppIds.includes(manifest.id)) {

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -12,7 +12,10 @@ import {
 import Config from "react-native-config";
 import { useFlipper } from "@react-navigation/devtools";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
-import { DEFAULT_MULTIBUY_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
+import {
+  DEFAULT_MULTIBUY_APP_ID,
+  BUY_SELL_UI_APP_ID,
+} from "@ledgerhq/live-common/wallet-api/constants";
 
 import Braze from "@braze/react-native-sdk";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
@@ -71,7 +74,7 @@ function getProxyURL(url: string) {
   // This is to handle links set in the useFromAmountStatusMessage in LLC.
   // Also handles a difference in paths between LLD on LLD /platform/:app_id
   // but on LLM /discover/:app_id
-  if (hostname === "platform" && [DEFAULT_MULTIBUY_APP_ID].includes(platform)) {
+  if (hostname === "platform" && [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID].includes(platform)) {
     return url.replace("://platform", "://discover");
   }
 

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -12,6 +12,7 @@ import {
 import Config from "react-native-config";
 import { useFlipper } from "@react-navigation/devtools";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import {
   DEFAULT_MULTIBUY_APP_ID,
   BUY_SELL_UI_APP_ID,
@@ -58,7 +59,7 @@ function isStorylyLink(url: string) {
   return url.startsWith("ledgerlive://storyly?");
 }
 
-function getProxyURL(url: string) {
+function getProxyURL(url: string, customBuySellUiAppId?: string) {
   const uri = new URL(url);
   const { hostname, pathname } = uri;
   const platform = pathname.split("/")[1];
@@ -71,10 +72,14 @@ function getProxyURL(url: string) {
     return `ledgerlive://wc?uri=${encodeURIComponent(url)}`;
   }
 
+  const buySellAppIds = customBuySellUiAppId
+    ? [customBuySellUiAppId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
+    : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+
   // This is to handle links set in the useFromAmountStatusMessage in LLC.
   // Also handles a difference in paths between LLD on LLD /platform/:app_id
   // but on LLM /discover/:app_id
-  if (hostname === "platform" && [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID].includes(platform)) {
+  if (hostname === "platform" && buySellAppIds.includes(platform)) {
     return url.replace("://platform", "://discover");
   }
 
@@ -410,6 +415,8 @@ export const DeeplinksProvider = ({
   // Can be either true, false or null, meaning we don't know yet
   const userAcceptedTerms = useGeneralTermsAccepted();
   const storylyContext = useStorylyContext();
+  const buySellUiFlag = useFeature("buySellUi");
+  const buySellUiManifestId = buySellUiFlag?.params?.manifestId;
 
   const linking = useMemo<LinkingOptions<ReactNavigation.RootParamList>>(
     () =>
@@ -438,7 +445,7 @@ export const DeeplinksProvider = ({
               storylyContext.setUrl(url);
             }
 
-            listener(getProxyURL(url));
+            listener(getProxyURL(url, buySellUiManifestId));
           });
           // Clean up the event listeners
           return () => {
@@ -533,6 +540,7 @@ export const DeeplinksProvider = ({
       storylyContext,
       liveAppProviderInitialized,
       manifests,
+      buySellUiManifestId,
     ],
   );
   const [isReady, setIsReady] = React.useState(false);

--- a/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
@@ -19,7 +19,8 @@ import { ExchangeNavigatorParamList } from "~/components/RootNavigator/types/Exc
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
-import { INTERNAL_APP_IDS, WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
+import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
+import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 
 export type Props = StackNavigatorProps<
   ExchangeNavigatorParamList,
@@ -40,6 +41,7 @@ export function BuyAndSellScreen({ route }: Props) {
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const { locale } = useLocale();
   const manifest = localManifest || remoteManifest;
+  const internalAppIds = useInternalAppIds();
 
   /**
    * Pass correct account ID
@@ -71,7 +73,7 @@ export function BuyAndSellScreen({ route }: Props) {
   useEffect(
     () => {
       (async () => {
-        if (manifest?.id && INTERNAL_APP_IDS.includes(manifest.id)) {
+        if (manifest?.id && internalAppIds.includes(manifest.id)) {
           await AsyncStorage.removeItem("last-screen");
           await AsyncStorage.removeItem("manifest-id");
           await AsyncStorage.removeItem("flow-name");

--- a/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
@@ -21,6 +21,7 @@ import { ScreenName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
+import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
 
 export type Props = StackNavigatorProps<
   ExchangeNavigatorParamList,
@@ -41,7 +42,7 @@ export function BuyAndSellScreen({ route }: Props) {
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const { locale } = useLocale();
   const manifest = localManifest || remoteManifest;
-  const internalAppIds = useInternalAppIds();
+  const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
   /**
    * Pass correct account ID

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -156,6 +156,7 @@
     "src/hooks/useSearch.ts",
     "src/hooks/useDebounce.ts",
     "src/hooks/useTimer.ts",
+    "src/hooks/useInternalAppIds.ts",
     "src/hw/actions/app.ts",
     "src/hw/actions/completeExchange.ts",
     "src/hw/actions/initSwap.ts",

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -86,7 +86,6 @@ export const DEFAULT_FEATURES: Features = {
   postOnboardingAssetsTransfer: DEFAULT_FEATURE,
   counterValue: DEFAULT_FEATURE,
   mockFeature: DEFAULT_FEATURE,
-  buySellUi: DEFAULT_FEATURE,
   multibuyNavigation: DEFAULT_FEATURE,
   ptxServiceCtaExchangeDrawer: DEFAULT_FEATURE,
   ptxServiceCtaScreens: DEFAULT_FEATURE,
@@ -375,6 +374,13 @@ export const DEFAULT_FEATURES: Features = {
 
   fetchAdditionalCoins: {
     enabled: false,
+  },
+
+  buySellUi: {
+    enabled: false,
+    params: {
+      manifestId: "multibuy-v2", // Update to "buy-sell-ui" after rollout
+    },
   },
 
   ptxSwapLiveApp: {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -86,6 +86,7 @@ export const DEFAULT_FEATURES: Features = {
   postOnboardingAssetsTransfer: DEFAULT_FEATURE,
   counterValue: DEFAULT_FEATURE,
   mockFeature: DEFAULT_FEATURE,
+  buySellUi: DEFAULT_FEATURE,
   multibuyNavigation: DEFAULT_FEATURE,
   ptxServiceCtaExchangeDrawer: DEFAULT_FEATURE,
   ptxServiceCtaScreens: DEFAULT_FEATURE,

--- a/libs/ledger-live-common/src/hooks/useInternalAppIds.ts
+++ b/libs/ledger-live-common/src/hooks/useInternalAppIds.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { useFeature } from "../featureFlags";
+import { INTERNAL_APP_IDS } from "../wallet-api/constants";
+
+/** Returns array of manifest ids for internal apps that can navigate to and from external urls, e.g. the current version of buy sell live app, which requires javaScriptCanOpenWindowsAutomatically to be enabled. See also WebPTXPlayer. */
+export const useInternalAppIds = () => {
+  const customBuySellAppId = useFeature("buySellUi")?.params?.manifestId;
+
+  const internalAppIds = useMemo(
+    () => (customBuySellAppId ? INTERNAL_APP_IDS.concat([customBuySellAppId]) : INTERNAL_APP_IDS),
+    [customBuySellAppId],
+  );
+
+  return internalAppIds;
+};

--- a/libs/ledger-live-common/src/wallet-api/constants.ts
+++ b/libs/ledger-live-common/src/wallet-api/constants.ts
@@ -33,4 +33,6 @@ export const DISCOVER_INITIAL_CATEGORY = "all";
 
 export const DEFAULT_MULTIBUY_APP_ID = "multibuy-v2";
 
-export const INTERNAL_APP_IDS = [DEFAULT_MULTIBUY_APP_ID];
+export const BUY_SELL_UI_APP_ID = "buy-sell-ui";
+
+export const INTERNAL_APP_IDS = [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -129,7 +129,7 @@ export type Features = CurrencyFeatures & {
   deviceInitialApps: Feature_DeviceInitialApps;
   buyDeviceFromLive: Feature_BuyDeviceFromLive;
   mockFeature: Feature_MockFeature;
-  buySellUi: Feature_BuySellUi;
+  buySellUi: Feature_BuySellUiManifest;
   multibuyNavigation: Feature_MultibuyNavigation;
   referralProgramDesktopSidebar: Feature_ReferralProgramDesktopSidebar;
   referralProgramMobile: Feature_ReferralProgramMobile;
@@ -460,9 +460,12 @@ export type Feature_LldRefreshMarketData = Feature<{
   refreshTime: number;
 }>;
 
+export type Feature_BuySellUiManifest = Feature<{
+  manifestId: string; // id of the app to use for the Buy/Sell UI, e.g. "multibuy-v2"
+}>;
+
 export type Feature_CounterValue = DefaultFeature;
 export type Feature_MockFeature = DefaultFeature;
-export type Feature_BuySellUi = DefaultFeature;
 export type Feature_MultibuyNavigation = DefaultFeature;
 export type Feature_DisableNftSend = DefaultFeature;
 export type Feature_DisableNftLedgerMarket = DefaultFeature;

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -129,6 +129,7 @@ export type Features = CurrencyFeatures & {
   deviceInitialApps: Feature_DeviceInitialApps;
   buyDeviceFromLive: Feature_BuyDeviceFromLive;
   mockFeature: Feature_MockFeature;
+  buySellUi: Feature_BuySellUi;
   multibuyNavigation: Feature_MultibuyNavigation;
   referralProgramDesktopSidebar: Feature_ReferralProgramDesktopSidebar;
   referralProgramMobile: Feature_ReferralProgramMobile;
@@ -461,6 +462,7 @@ export type Feature_LldRefreshMarketData = Feature<{
 
 export type Feature_CounterValue = DefaultFeature;
 export type Feature_MockFeature = DefaultFeature;
+export type Feature_BuySellUi = DefaultFeature;
 export type Feature_MultibuyNavigation = DefaultFeature;
 export type Feature_DisableNftSend = DefaultFeature;
 export type Feature_DisableNftLedgerMarket = DefaultFeature;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:** 
  - Find flag in settings: `buySellUi`
  - It should toggle on/off, but also accept params json:  `{ "params": { "manifestId": "buy-sell-ui" } }`
  - when using manifestId "buy-sell-ui", the URL for buy/sell live app should change to https://buy-sell.ledger.com
  - Other functionality should remain the same.

### 📝 Description

- add buy sell ui flag to enable progressive replacement of multibuy-v2 live app
- when flag is enabled, option to use "buy-sell-ui" manifest id instead of "multibuy-v2" (or to override with a custom staging manifest id)
- allow multibuy logic to apply for either buy-sell manifest

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/9e1e9013-37d1-4fcb-b844-d25331fd6d61)

![image](https://github.com/LedgerHQ/ledger-live/assets/123105524/53123a95-e3a2-4b29-818e-d0d7f9573234)


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12118


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
