### PR TITLE
chore(PROTECT-3040): fix stax recover source & enable

### DIFF
--- a/.changeset/sixty-days-check.md
+++ b/.changeset/sixty-days-check.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix the Recover Restore Onboarding source & enable stax.  

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectUseCase/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/SelectUseCase/index.tsx
@@ -206,8 +206,10 @@ export function SelectUseCase({ setUseCase, setOpenedPedagogyModal }: Props) {
                 onClick={() => {
                   track("Onboarding - Restore With Recover");
 
-                  // An array is used here because we'll have to allow Stax later
-                  if (deviceModelId && [DeviceModelId.nanoX].includes(deviceModelId)) {
+                  if (
+                    deviceModelId &&
+                    [DeviceModelId.nanoX, DeviceModelId.stax].includes(deviceModelId)
+                  ) {
                     setUseCase(UseCase.recover);
                     history.push(`/onboarding/${UseCase.recover}/${ScreenId.pairMyNano}`);
                   } else {

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SyncOnboardingCompanion.tsx
@@ -115,7 +115,7 @@ const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = ({
   const [seedPathStatus, setSeedPathStatus] = useState<SeedPathStatus>("choice_new_or_restore");
 
   const servicesConfig = useFeature("protectServicesDesktop");
-  const recoverRestoreStaxPath = useCustomPath(servicesConfig, "restore", "lld-stax-onboarding");
+  const recoverRestoreStaxPath = useCustomPath(servicesConfig, "restore", "lld-onboarding-24");
 
   const productName = device
     ? getDeviceModel(device.modelId).productName || device.modelId


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

PR to enable stax on onboarding via recover & set the correct deeplink source for lld. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/PROTECT-3040

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
