### PR TITLE
[BUGFIX]: APP crash on receive flow when clicking learn

### DIFF
--- a/.changeset/hot-pumas-obey.md
+++ b/.changeset/hot-pumas-obey.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+App crashes when tapping 'Learn how to withdraw from exchange' in receive flow

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/03-Confirmation.tsx
@@ -39,6 +39,7 @@ import { hasClosedWithdrawBannerSelector } from "~/reducers/settings";
 import { setCloseWithdrawBanner } from "~/actions/settings";
 import * as Animatable from "react-native-animatable";
 import { useCompleteActionCallback } from "~/logic/postOnboarding/useCompleteAction";
+import { urls } from "~/utils/urls";
 
 const AnimatedView = Animatable.View;
 
@@ -121,7 +122,6 @@ function ReceiveConfirmationInner({ navigation, route, account, parentAccount }:
       type: "card",
       page: "Receive Account Qr Code",
     });
-    // @ts-expect-error TYPINGS
     Linking.openURL(urls.withdrawCrypto);
   };
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

App crashes when tapping 'Learn how to withdraw from exchange' in receive flow

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12359] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
