### PR TITLE
bugfix: LIVE-12085 keep swap history when hard sync subAccounts

### DIFF
--- a/.changeset/odd-pumas-grab.md
+++ b/.changeset/odd-pumas-grab.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+bugfix, keep swap history for token when deep cleaning

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/synchronization.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/synchronization.fixtures.ts
@@ -42,16 +42,36 @@ mockGetConfig.mockImplementation((): any => {
   };
 });
 
+export const swapHistory = [
+  {
+    status: "pending",
+    provider: "moonpay",
+    operationId: "js:2:ethereum:0xkvn:+ethereum%2Ferc20%2Fusd__coin-OUT",
+    swapId: "swap1",
+    receiverAccountId: "js:2:ethereum:0xkvn:",
+    fromAmount: new BigNumber("200000"),
+    toAmount: new BigNumber("129430000"),
+  },
+];
+
 export const tokenCurrencies = [
   Object.freeze(getTokenById("ethereum/erc20/usd__coin")),
   Object.freeze(getTokenById("ethereum/erc20/usd_tether__erc20_")),
 ];
 
-export const tokenAccount = makeTokenAccount("0xkvn", tokenCurrencies[0]);
+// export const tokenAccount = makeTokenAccount("0xkvn", tokenCurrencies[0]);
+export const tokenAccount = {
+  ...makeTokenAccount("0xkvn", tokenCurrencies[0]),
+  swapHistory,
+};
 export const account = Object.freeze({
   ...makeAccount("0xkvn", currency, [tokenAccount]),
   syncHash: logic.getSyncHash(currency),
 });
+// export const accountWithTokenSwapHistory = Object.freeze({
+//   ...makeAccount("0xCrema", currency, [tokenAccountWithSwapHistory]),
+//   syncHash: logic.getSyncHash(currency),
+// });
 
 export const coinOperations = [
   makeOperation({

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/synchronization.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/synchronization.fixtures.ts
@@ -59,7 +59,6 @@ export const tokenCurrencies = [
   Object.freeze(getTokenById("ethereum/erc20/usd_tether__erc20_")),
 ];
 
-// export const tokenAccount = makeTokenAccount("0xkvn", tokenCurrencies[0]);
 export const tokenAccount = {
   ...makeTokenAccount("0xkvn", tokenCurrencies[0]),
   swapHistory,
@@ -68,10 +67,6 @@ export const account = Object.freeze({
   ...makeAccount("0xkvn", currency, [tokenAccount]),
   syncHash: logic.getSyncHash(currency),
 });
-// export const accountWithTokenSwapHistory = Object.freeze({
-//   ...makeAccount("0xCrema", currency, [tokenAccountWithSwapHistory]),
-//   syncHash: logic.getSyncHash(currency),
-// });
 
 export const coinOperations = [
   makeOperation({

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/logic.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/logic.unit.test.ts
@@ -481,8 +481,8 @@ describe("EVM Family", () => {
               swapId: "6342cd15-5aa9-4c8c-9fb3-0b67e9b0714a",
               receiverAccountId: "js:2:ethereum:0xkvn:",
               tokenId: "ethereum/erc20/usd__coin",
-              fromAmount: BigNumber("200000"),
-              toAmount: BigNumber("129430000"),
+              fromAmount: new BigNumber("200000"),
+              toAmount: new BigNumber("129430000"),
             },
           ],
         };

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
 import { decodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import { AccountShapeInfo } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
+import { makeTokenAccount } from "../fixtures/common.fixtures";
 import * as etherscanAPI from "../../api/explorer/etherscan";
 import * as synchronization from "../../synchronization";
 import * as nodeApi from "../../api/node/rpc.common";
@@ -25,8 +25,6 @@ import * as logic from "../../logic";
 import { getCoinConfig } from "../../config";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { TokenAccount } from "@ledgerhq/types-live";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 
 jest.mock("../../api/node/rpc.common");
 jest.useFakeTimers().setSystemTime(new Date("2014-04-21"));

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -563,7 +563,7 @@ describe("EVM Family", () => {
           operations: [tokenOperations[0], tokenOperations[1]],
           operationsCount: 2,
           starred: undefined,
-          swapHistory: swapHistory,
+          swapHistory,
         };
         const expectedUsdtAccount = {
           ...makeTokenAccount(account.freshAddress, tokenCurrencies[1]),

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -19,12 +19,14 @@ import {
   tokenCurrencies,
   tokenOperations,
   internalOperations,
+  swapHistory,
 } from "../fixtures/synchronization.fixtures";
 import { UnknownNode } from "../../errors";
 import * as logic from "../../logic";
 import { getCoinConfig } from "../../config";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { TokenAccount } from "@ledgerhq/types-live";
+import { createSwapHistoryMap } from "../../logic";
 
 jest.mock("../../api/node/rpc.common");
 jest.useFakeTimers().setSystemTime(new Date("2014-04-21"));
@@ -542,7 +544,7 @@ describe("EVM Family", () => {
       });
 
       it("should return the right subAccounts", async () => {
-        const swapHistoryMap = new Map<TokenCurrency, TokenAccount["swapHistory"]>();
+        const swapHistoryMap = createSwapHistoryMap(account);
         const tokenAccounts = await synchronization.getSubAccounts(
           {
             ...getAccountShapeParameters,
@@ -561,7 +563,7 @@ describe("EVM Family", () => {
           operations: [tokenOperations[0], tokenOperations[1]],
           operationsCount: 2,
           starred: undefined,
-          swapHistory: [],
+          swapHistory: swapHistory,
         };
         const expectedUsdtAccount = {
           ...makeTokenAccount(account.freshAddress, tokenCurrencies[1]),

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -3,6 +3,8 @@ import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
 import { decodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import { AccountShapeInfo } from "@ledgerhq/coin-framework/bridge/jsHelpers";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { TokenAccount } from "@ledgerhq/types-live";
 import { makeTokenAccount } from "../fixtures/common.fixtures";
 import * as etherscanAPI from "../../api/explorer/etherscan";
 import * as synchronization from "../../synchronization";
@@ -24,8 +26,6 @@ import {
 import { UnknownNode } from "../../errors";
 import * as logic from "../../logic";
 import { getCoinConfig } from "../../config";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { TokenAccount } from "@ledgerhq/types-live";
 import { createSwapHistoryMap } from "../../logic";
 
 jest.mock("../../api/node/rpc.common");

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
 import { decodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import { AccountShapeInfo } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { makeTokenAccount } from "../fixtures/common.fixtures";
+import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
 import * as etherscanAPI from "../../api/explorer/etherscan";
 import * as synchronization from "../../synchronization";
 import * as nodeApi from "../../api/node/rpc.common";
@@ -23,6 +23,10 @@ import {
 import { UnknownNode } from "../../errors";
 import * as logic from "../../logic";
 import { getCoinConfig } from "../../config";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { TokenAccount } from "@ledgerhq/types-live";
+import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 
 jest.mock("../../api/node/rpc.common");
 jest.useFakeTimers().setSystemTime(new Date("2014-04-21"));
@@ -540,6 +544,7 @@ describe("EVM Family", () => {
       });
 
       it("should return the right subAccounts", async () => {
+        const swapHistoryMap = new Map<TokenCurrency, TokenAccount["swapHistory"]>();
         const tokenAccounts = await synchronization.getSubAccounts(
           {
             ...getAccountShapeParameters,
@@ -547,6 +552,8 @@ describe("EVM Family", () => {
           },
           account.id,
           [tokenOperations[0], tokenOperations[1], tokenOperations[3]],
+          undefined,
+          swapHistoryMap,
         );
 
         const expectedUsdcAccount = {
@@ -572,6 +579,7 @@ describe("EVM Family", () => {
       });
 
       it("should return filtered subAccounts from blacklistedTokenIds", async () => {
+        const swapHistoryMap = new Map<TokenCurrency, TokenAccount["swapHistory"]>();
         const tokenAccounts = await synchronization.getSubAccounts(
           {
             ...getAccountShapeParameters,
@@ -580,6 +588,7 @@ describe("EVM Family", () => {
           account.id,
           [tokenOperations[0], tokenOperations[1], tokenOperations[3]],
           [tokenCurrencies[0].id],
+          swapHistoryMap,
         );
 
         const expectedUsdtAccount = {
@@ -619,6 +628,7 @@ describe("EVM Family", () => {
           account.id,
           tokenCurrencies[0],
           [tokenOperations[0], tokenOperations[1], tokenOperations[2]],
+          [],
         );
 
         expect(subAccount).toEqual({

--- a/libs/coin-modules/coin-evm/src/logic.ts
+++ b/libs/coin-modules/coin-evm/src/logic.ts
@@ -407,3 +407,51 @@ export const safeEncodeEIP55 = (addr: string): string => {
     return addr;
   }
 };
+
+/**
+ * Similar to mergeAccount but used to keep previous data we can't fetch on chain
+ */
+export const createAndKeepSwapHistory = (
+  initialAccount: Account | undefined,
+  newSubAccounts: Partial<SubAccount>[],
+): Array<Partial<SubAccount> | SubAccount> => {
+  const oldSubAccounts: Array<Partial<SubAccount> | SubAccount> | undefined =
+    initialAccount?.subAccounts;
+  if (!oldSubAccounts) {
+    return newSubAccounts;
+  }
+
+  // Creating a map of already existing sub accounts by id
+  const oldSubAccountsById: { [key: string]: Partial<SubAccount> } = {};
+  for (const oldSubAccount of oldSubAccounts) {
+    oldSubAccountsById[oldSubAccount.id!] = oldSubAccount;
+  }
+
+  // Looping on new sub accounts to compare them with already existing ones
+  // Already existing will be updated if necessary (see `updatableSubAccountProperties`)
+  // Fresh new sub accounts will be added/pushed after already existing
+  const newSubAccountsToAdd: Partial<SubAccount>[] = [];
+  for (const newSubAccount of newSubAccounts) {
+    const duplicatedAccount: Partial<SubAccount> | undefined =
+      oldSubAccountsById[newSubAccount.id!];
+
+    // If this sub account was not already in the initialAccount
+    if (!duplicatedAccount) {
+      // We'll add it later
+      newSubAccountsToAdd.push(newSubAccount);
+      continue;
+    }
+
+    const updates: Partial<SubAccount> = {};
+
+    updates.swapHistory = duplicatedAccount.swapHistory || [];
+
+    // Modifying the Map with the updated sub account with a new ref
+    oldSubAccountsById[newSubAccount.id!] = {
+      ...newSubAccount,
+      ...updates,
+    };
+  }
+  const updatedSubAccounts = Object.values(oldSubAccountsById);
+  return [...updatedSubAccounts, ...newSubAccountsToAdd];
+};

--- a/libs/coin-modules/coin-evm/src/logic.ts
+++ b/libs/coin-modules/coin-evm/src/logic.ts
@@ -420,10 +420,7 @@ export const createSwapHistoryMap = (
 
   const swapHistoryMap = new Map<TokenCurrency, TokenAccount["swapHistory"]>();
   for (const subAccount of initialAccount.subAccounts) {
-    if (subAccount.type === "TokenAccount") {
-      // <-- not even necessary anymore since we removed the `SubAccount` type now
-      swapHistoryMap.set(subAccount.token, subAccount.swapHistory);
-    }
+    swapHistoryMap.set(subAccount.token, subAccount.swapHistory);
   }
 
   return swapHistoryMap;

--- a/libs/coin-modules/coin-evm/src/logic.ts
+++ b/libs/coin-modules/coin-evm/src/logic.ts
@@ -427,6 +427,9 @@ export const createAndKeepSwapHistory = (
     oldSubAccountsById[oldSubAccount.id!] = oldSubAccount;
   }
 
+  // Creating a new map to not returned deleted accounts
+  const returnAccount: { [key: string]: Partial<SubAccount> } = {};
+
   // Looping on new sub accounts to compare them with already existing ones
   // Already existing will be updated if necessary (see `updatableSubAccountProperties`)
   // Fresh new sub accounts will be added/pushed after already existing
@@ -447,11 +450,11 @@ export const createAndKeepSwapHistory = (
     updates.swapHistory = duplicatedAccount.swapHistory || [];
 
     // Modifying the Map with the updated sub account with a new ref
-    oldSubAccountsById[newSubAccount.id!] = {
+    returnAccount[newSubAccount.id!] = {
       ...newSubAccount,
       ...updates,
     };
   }
-  const updatedSubAccounts = Object.values(oldSubAccountsById);
+  const updatedSubAccounts = Object.values(returnAccount);
   return [...updatedSubAccounts, ...newSubAccountsToAdd];
 };

--- a/libs/coin-modules/coin-evm/src/synchronization.ts
+++ b/libs/coin-modules/coin-evm/src/synchronization.ts
@@ -17,7 +17,7 @@ import { Account, Operation, SubAccount } from "@ledgerhq/types-live";
 import { decodeOperationId } from "@ledgerhq/coin-framework/operation";
 import { nftsFromOperations } from "@ledgerhq/coin-framework/nft/helpers";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { attachOperations, getSyncHash, mergeSubAccounts } from "./logic";
+import { attachOperations, getSyncHash, createAndKeepSwapHistory, mergeSubAccounts } from "./logic";
 import { ExplorerApi } from "./api/explorer/types";
 import { getExplorerApi } from "./api/explorer";
 import { getNodeApi } from "./api/node/index";
@@ -83,9 +83,8 @@ export const getAccountShape: GetAccountShape = async (infos, { blacklistedToken
     blacklistedTokenIds,
   );
   const subAccounts = shouldSyncFromScratch
-    ? newSubAccounts
+    ? createAndKeepSwapHistory(initialAccount, newSubAccounts) // Keep swap history from all account but still create a new subAccount
     : mergeSubAccounts(initialAccount, newSubAccounts); // Merging potential new subAccouns while preserving the references
-
   // Trying to confirm pending operations that we are sure of
   // because they were made in the live
   // Useful for integrations without explorers


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - swapHistory maintained between full syncs

### 📝 Description

`swapHistory` of `TokenAccounts` used to be erased between sync from scratch due to this data not being retrievable on-chain. This PR optimistically maintains those operations and their ref even after a sync from block 0.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
