### PR TITLE
LIVE-12087 - Fix llm prepare sign tx

### DIFF
--- a/.changeset/old-teachers-march.md
+++ b/.changeset/old-teachers-march.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+---
+
+Standardize PrepareSignTx behavior\
+

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.test.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.test.ts
@@ -21,23 +21,15 @@ describe("prepareSignTransaction", () => {
     // Given
     const parentAccount = createAccount("12");
     const childAccount = createTokenAccount("22", "js:2:ethereum:0x012:");
-    const expectedResult: EvmTransaction = {
+    const expectedResult: Partial<EvmTransaction> = {
       amount: new BigNumber("1000"),
       data: Buffer.from([]),
       family: "evm",
-      feesStrategy: "medium",
-      gasPrice: new BigNumber("700000"),
       gasLimit: new BigNumber("1200000"),
-      customGasLimit: new BigNumber("1200000"),
-      mode: "send",
+      gasPrice: new BigNumber("700000"),
       nonce: 8,
       recipient: "0x0123456",
       subAccountId: "js:2:ethereum:0x022:",
-      useAllAmount: false,
-      maxFeePerGas: undefined,
-      maxPriorityFeePerGas: undefined,
-      type: 1,
-      chainId: 0,
     };
 
     // When
@@ -49,7 +41,11 @@ describe("prepareSignTransaction", () => {
 });
 
 // *** UTIL FUNCTIONS ***
-function createEtherumTransaction(): Partial<Transaction & { gasLimit: BigNumber }> {
+function createEtherumTransaction(): Partial<
+  Transaction & {
+    gasLimit: BigNumber;
+  }
+> {
   return {
     family: "evm",
     amount: new BigNumber("1000"),
@@ -149,9 +145,18 @@ function createTokenAccount(id = "32", parentId = "whatever"): TokenAccount {
     pendingOperations: [],
     starred: false,
     balanceHistoryCache: {
-      WEEK: { latestDate: null, balances: [] },
-      HOUR: { latestDate: null, balances: [] },
-      DAY: { latestDate: null, balances: [] },
+      WEEK: {
+        latestDate: null,
+        balances: [],
+      },
+      HOUR: {
+        latestDate: null,
+        balances: [],
+      },
+      DAY: {
+        latestDate: null,
+        balances: [],
+      },
     },
     swapHistory: [],
   };

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
@@ -6,22 +6,15 @@ import BigNumber from "bignumber.js";
 
 export default function prepareSignTransaction(
   account: AccountLike,
-  parentAccount: Account | undefined,
-  liveTx: Partial<Transaction & { gasLimit: BigNumber }>,
+  parentAccount: Account | null | undefined,
+  liveTx: Partial<
+    Transaction & {
+      gasLimit: BigNumber;
+    }
+  >,
 ): TransactionCommon {
   const bridge = getAccountBridge(account, parentAccount);
-  const t = bridge.createTransaction(account);
-  const { recipient, ...txData } = liveTx;
-  const t2 = bridge.updateTransaction(t, {
-    recipient,
+  return bridge.updateTransaction(liveTx, {
     subAccountId: isTokenAccount(account) ? account.id : undefined,
-  });
-
-  return bridge.updateTransaction(t2, {
-    customGasLimit: txData.gasLimit,
-    type: 1,
-    maxFeePerGas: undefined,
-    maxPriorityFeePerGas: undefined,
-    ...txData,
   });
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:**
Transactions creation with Wallet API on LLM


### 📝 Description & ❓ Context

Figment is having issues with `eth_sendTransaction` on LLM (full details on the issue [in this thread](https://ledger-slack-connect.slack.com/archives/CPCS8RW69/p1712107259596239?thread_ts=1709557181.253029&cid=CPCS8RW69)) and while investigating we figured the issue was coming from the way we are setting the customGasLimit here.

The problem doesn't appear on LLD, and as you can see, the custom prepareSignTransaction function we were doing in LLM doesn't exist on LLD.

The change introduced by this PR sets the behavior of LLM on par with LLD in regard to tx preparation in Wallet API.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
