### PR TITLE
feat(PROTECT-3040): capture device model id in recover

### DIFF
--- a/.changeset/wet-wombats-whisper.md
+++ b/.changeset/wet-wombats-whisper.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"ledger-live-mobile": patch
+---
+
+Ensure we send the device model id to recover webview

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/BackupStep.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/BackupStep.tsx
@@ -74,8 +74,7 @@ const BackupBody: React.FC<ChoiceBodyProps> = ({ isOpened }) => {
 
   const servicesConfig = useFeature("protectServicesDesktop");
 
-  const recoverActivatePath =
-    useCustomPath(servicesConfig, "activate", "lld-stax-onboarding") || "";
+  const recoverActivatePath = useCustomPath(servicesConfig, "activate", "lld-onboarding-24") || "";
 
   const navigateToRecover = useCallback(() => {
     console.log("recoverActivatePath", recoverActivatePath);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useRecoverRestoreOnboarding.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useRecoverRestoreOnboarding.ts
@@ -6,7 +6,6 @@ import { saveSettings } from "~/renderer/actions/settings";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
-import { useCustomPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 
 const ONBOARDED_VIA_RECOVER_RESTORE_USER_PREFIX = "ONBOARDED_VIA_RECOVER_RESTORE_USER_";
 
@@ -16,8 +15,6 @@ export const useRecoverRestoreOnboarding = (seedPathStatus?: string) => {
   const recoverServices = useFeature("protectServicesDesktop");
   const recoverStoreId = recoverServices?.params?.protectId ?? "";
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
-  const recoverRestoreStaxPath = useCustomPath(recoverServices, "restore", "lld-onboarding-24");
-
   const [onboardedViaRecoverRestore, setOnboardedViaRecoverRestore] = useState<boolean>();
 
   const confirmRecoverOnboardingStatus = useCallback(async () => {
@@ -41,8 +38,7 @@ export const useRecoverRestoreOnboarding = (seedPathStatus?: string) => {
     const userIsOnboardingOrSettingUp =
       pathname.includes("onboarding") || pathname.includes("settings");
 
-    const syncOnboardingFromRestoreStax =
-      seedPathStatus === "recover_seed" && recoverRestoreStaxPath;
+    const syncOnboardingFromRestoreStax = seedPathStatus === "recover_seed";
 
     if (
       (!userIsOnboardingOrSettingUp || syncOnboardingFromRestoreStax) &&

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -80,11 +80,21 @@ export default function RecoverPlayer({
       lang: locale,
       availableOnDesktop,
       deviceId: state?.deviceId,
+      deviceModelId: device?.modelId,
       currency,
       ...params,
       ...queryParams,
     }),
-    [availableOnDesktop, locale, params, queryParams, state?.deviceId, currency, theme],
+    [
+      theme,
+      locale,
+      availableOnDesktop,
+      device?.modelId,
+      state?.deviceId,
+      currency,
+      params,
+      queryParams,
+    ],
   );
 
   return manifest ? (

--- a/apps/ledger-live-mobile/src/screens/Protect/Player.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/Player.tsx
@@ -86,6 +86,7 @@ export function RecoverPlayer({ navigation, route }: Props) {
           lang: locale,
           currency,
           deviceId: device?.deviceId,
+          deviceModelId: device?.modelId,
           ...params,
         }}
       />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR is to ensure we capture the device & model id and send this to the Recover webview, so that Recover can send the correct device analytics to segment, and ultimately mixpanel.

We mustn't mix up deviceId and deviceModelId, as they both have different internal meanings/references.

In LLD, when the device is connected via a cable then deviceId is empty & deviceModelId is required, but in LLM no cable is required and deviceId is used.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: Relates to https://ledgerhq.atlassian.net/browse/PROTECT-3040 
Related PR in Recover: https://github.com/LedgerHQ/protect-frontend/pull/1027


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
