### PR TITLE
bugfix: close whatever drawer is opened before opening an error drawer

### DIFF
--- a/.changeset/green-turkeys-add.md
+++ b/.changeset/green-turkeys-add.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+close drawer before opening an error drawer for swap live apps LIVE-12405

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -10,7 +10,7 @@ import { Operation } from "@ledgerhq/types-live";
 import { track } from "~/renderer/analytics/segment";
 import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
-import { openExchangeDrawer } from "~/renderer/actions/UI";
+import { closePlatformAppDrawer, openExchangeDrawer } from "~/renderer/actions/UI";
 import { WebviewProps } from "../Web3AppWebview/types";
 import { context } from "~/renderer/drawers/Provider";
 import WebviewErrorDrawer from "~/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer";
@@ -81,6 +81,7 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"]) {
             );
           },
           "custom.exchange.error": ({ error }) => {
+            dispatch(closePlatformAppDrawer());
             setDrawer(WebviewErrorDrawer, error);
             return Promise.resolve();
           },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

close drawer before opening error drawing, prevent double drawer issue

### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-12405)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
