### PR TITLE
bugfix(PROTECT-3040): try for free to redirect to upsell

### DIFF
--- a/.changeset/little-wasps-sing.md
+++ b/.changeset/little-wasps-sing.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Recover Try for free deeplink to navigate user to upsell

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/companionSteps/BackupStep.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/companionSteps/BackupStep.tsx
@@ -102,7 +102,7 @@ const BackupBody: React.FC<ChoiceBodyProps> = ({ isOpened, device }) => {
       screen: ScreenName.Recover,
       params: {
         device,
-        redirectTo: "activate",
+        redirectTo: "upsell",
         // platform: "protect-staging", // TODO: remove this, only for testing in debug
         platform: servicesConfig?.params?.protectId, // TODO: reenable this
         date: new Date().toISOString(), // adding a date to reload the page in case of same device restored again


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR is to fix regression from [this PR](https://github.com/LedgerHQ/ledger-live/commit/93112f027d40ba5c4251a38db2a2d6866ef0fc82#diff-bfa13a0e7eb62d5a30a3fada4d8ba019b752bd315b1fa7243ca4ee9f55a48275R75) merged a week ago. 

Ensuring a user who clicks the `Try for Free` button will be redirected to upsell and no login page associated with activate. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/PROTECT-3040

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
