### PR TITLE
bugfix(PROTECT-3040): recover webview does not reload on device disconnect

### DIFF
--- a/.changeset/angry-garlics-try.md
+++ b/.changeset/angry-garlics-try.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Ensure user remains on Recover without reload given device is disconnected

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -85,16 +85,13 @@ export default function RecoverPlayer({
       ...params,
       ...queryParams,
     }),
-    [
-      theme,
-      locale,
-      availableOnDesktop,
-      device?.modelId,
-      state?.deviceId,
-      currency,
-      params,
-      queryParams,
-    ],
+    /**
+     * deviceModelId is purposely ignored from dependencies.
+     *
+     * This is to ensure the WebRecoverPlayer is not reloaded given the user disconnects their cable.
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [theme, locale, availableOnDesktop, state?.deviceId, currency, params, queryParams],
   );
 
   return manifest ? (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Given a user is on the Recover Live App and disconnects or reconnects their device via a cable, the Recover Web Player will reload due to the useMemo dependencies. This PR is to remove `deviceModelId` from the dependency list to ensure no reload on reconnecting via cable.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/PROTECT-3040


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
