### PR TITLE
fix(wallet-api): align LLM prepareSignTransaction with LLD implementation [LIVE-12087]

### DIFF
--- a/.changeset/hip-seals-design.md
+++ b/.changeset/hip-seals-design.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat: export platform enum for use in LLM test

--- a/.changeset/proud-moles-reply.md
+++ b/.changeset/proud-moles-reply.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix(wallet-api): align LLM prepareSignTransaction with LLD implementation

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -34,7 +34,6 @@ import {
   useListPlatformCurrencies,
 } from "@ledgerhq/live-common/platform/react";
 import trackingWrapper from "@ledgerhq/live-common/platform/tracking";
-import BigNumber from "bignumber.js";
 import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
@@ -240,11 +239,7 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
           accountId,
           transaction,
           (account, parentAccount, { liveTx }) => {
-            const tx = prepareSignTransaction(
-              account,
-              parentAccount,
-              liveTx as Partial<Transaction & { gasLimit: BigNumber }>,
-            );
+            const tx = prepareSignTransaction(account, parentAccount, liveTx);
 
             return new Promise((resolve, reject) => {
               navigation.navigate(NavigatorName.SignTransaction, {

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -14,7 +14,6 @@ import { Operation, SignedOperation } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import trackingWrapper from "@ledgerhq/live-common/wallet-api/tracking";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import BigNumber from "bignumber.js";
 import { useSelector } from "react-redux";
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { WebViewProps, WebView, WebViewMessageEvent } from "react-native-webview";
@@ -374,11 +373,7 @@ function useUiHook(): UiHook {
         onSuccess,
         onError,
       }) => {
-        const tx = prepareSignTransaction(
-          account,
-          parentAccount,
-          liveTx as Partial<Transaction & { gasLimit: BigNumber }>,
-        );
+        const tx = prepareSignTransaction(account, parentAccount, liveTx);
 
         navigation.navigate(NavigatorName.SignTransaction, {
           screen: ScreenName.SignTransactionSummary,

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.test.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.test.ts
@@ -6,8 +6,11 @@ import {
   TokenCurrency,
 } from "@ledgerhq/types-cryptoassets";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
-import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
+import { getWalletAPITransactionSignFlowInfos } from "@ledgerhq/live-common/wallet-api/converters";
+import { WalletAPITransaction } from "@ledgerhq/live-common/wallet-api/types";
+import { getPlatformTransactionSignFlowInfos } from "@ledgerhq/live-common/platform/converters";
+import { PLATFORM_FAMILIES_ENUM, PlatformTransaction } from "@ledgerhq/live-common/platform/types";
 
 import prepareSignTransaction from "./liveSDKLogic";
 
@@ -17,7 +20,7 @@ jest.mock("@ledgerhq/coin-framework/currencies/support", () => ({
 }));
 
 describe("prepareSignTransaction", () => {
-  it("returns a Transaction", () => {
+  it("returns a Transaction for platform", () => {
     // Given
     const parentAccount = createAccount("12");
     const childAccount = createTokenAccount("22", "js:2:ethereum:0x012:");
@@ -25,7 +28,7 @@ describe("prepareSignTransaction", () => {
       amount: new BigNumber("1000"),
       data: Buffer.from([]),
       family: "evm",
-      feesStrategy: "medium",
+      feesStrategy: "custom",
       gasPrice: new BigNumber("700000"),
       gasLimit: new BigNumber("1200000"),
       customGasLimit: new BigNumber("1200000"),
@@ -36,12 +39,53 @@ describe("prepareSignTransaction", () => {
       useAllAmount: false,
       maxFeePerGas: undefined,
       maxPriorityFeePerGas: undefined,
-      type: 1,
+      type: 0,
       chainId: 0,
     };
 
     // When
-    const result = prepareSignTransaction(childAccount, parentAccount, createEtherumTransaction());
+    const tx = createPlatformTransaction();
+
+    const { liveTx } = getPlatformTransactionSignFlowInfos(tx);
+
+    const result = prepareSignTransaction(childAccount, parentAccount, liveTx);
+
+    // Then
+    expect(result).toEqual(expectedResult);
+  });
+
+  it("returns a Transaction for wallet-api", () => {
+    // Given
+    const parentAccount = createAccount("12");
+    const childAccount = createTokenAccount("22", "js:2:ethereum:0x012:");
+    const expectedResult: EvmTransaction = {
+      amount: new BigNumber("1000"),
+      data: Buffer.from([]),
+      family: "evm",
+      feesStrategy: "custom",
+      gasPrice: new BigNumber("700000"),
+      gasLimit: new BigNumber("1200000"),
+      customGasLimit: new BigNumber("1200000"),
+      mode: "send",
+      nonce: 8,
+      recipient: "0x0123456",
+      subAccountId: "js:2:ethereum:0x022:",
+      useAllAmount: false,
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: undefined,
+      type: 0,
+      chainId: 0,
+    };
+
+    // When
+    const tx = createWalletAPITransaction();
+
+    const { liveTx } = getWalletAPITransactionSignFlowInfos({
+      walletApiTransaction: tx,
+      account: childAccount,
+    });
+
+    const result = prepareSignTransaction(childAccount, parentAccount, liveTx);
 
     // Then
     expect(result).toEqual(expectedResult);
@@ -49,9 +93,21 @@ describe("prepareSignTransaction", () => {
 });
 
 // *** UTIL FUNCTIONS ***
-function createEtherumTransaction(): Partial<Transaction & { gasLimit: BigNumber }> {
+function createWalletAPITransaction(): WalletAPITransaction {
   return {
-    family: "evm",
+    family: "ethereum",
+    amount: new BigNumber("1000"),
+    recipient: "0x0123456",
+    nonce: 8,
+    data: Buffer.from("Some data...", "hex"),
+    gasPrice: new BigNumber("700000"),
+    gasLimit: new BigNumber("1200000"),
+  };
+}
+
+function createPlatformTransaction(): PlatformTransaction {
+  return {
+    family: PLATFORM_FAMILIES_ENUM.ETHEREUM,
     amount: new BigNumber("1000"),
     recipient: "0x0123456",
     nonce: 8,

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
@@ -2,12 +2,11 @@ import { isTokenAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { Account, AccountLike, TransactionCommon } from "@ledgerhq/types-live";
-import BigNumber from "bignumber.js";
 
 export default function prepareSignTransaction(
   account: AccountLike,
   parentAccount: Account | undefined,
-  liveTx: Partial<Transaction & { gasLimit: BigNumber }>,
+  liveTx: Partial<Transaction>,
 ): TransactionCommon {
   const bridge = getAccountBridge(account, parentAccount);
   const t = bridge.createTransaction(account);

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/liveSDKLogic.ts
@@ -17,11 +17,5 @@ export default function prepareSignTransaction(
     subAccountId: isTokenAccount(account) ? account.id : undefined,
   });
 
-  return bridge.updateTransaction(t2, {
-    customGasLimit: txData.gasLimit,
-    type: 1,
-    maxFeePerGas: undefined,
-    maxPriorityFeePerGas: undefined,
-    ...txData,
-  });
+  return bridge.updateTransaction(t2, txData);
 }

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -17,6 +17,8 @@ import { z } from "zod";
  */
 export const PLATFORM_FAMILIES = [...Object.values(FAMILIES), "evm"];
 
+export { FAMILIES as PLATFORM_FAMILIES_ENUM };
+
 export type {
   Account as PlatformAccount,
   Currency as PlatformCurrency,


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM wallet-api and platform-sdk `sign.transaction` calls

### 📝 Description

Align LLM prepareSignTransaction with LLD implementation, the original PR is: https://github.com/LedgerHQ/ledger-live/pull/6759
We mainly remove the `customGasLimit` and `type: 1` that doesn't seem to be used and instead rely on the `convertToLiveTransaction` to init everything as done in LLD

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12087]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12087]: https://ledgerhq.atlassian.net/browse/LIVE-12087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ