### PR TITLE
[Bugfix]: Solana delegations minor UI issues

### DIFF
--- a/.changeset/slimy-parents-glow.md
+++ b/.changeset/slimy-parents-glow.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Solana minor delegations ui issues

--- a/apps/ledger-live-desktop/src/renderer/families/solana/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/Delegation/Row.tsx
@@ -145,7 +145,9 @@ export function Row({ account, stakeWithMeta, onManageAction, onExternalLink }: 
             </ToolTip>
           </Box>
         )}
-        <Box ml={1}>{stake.activation.state}</Box>
+        <Box ml={1}>
+          <Trans i18nKey={`solana.delegation.states.${stake.activation.state}`} />
+        </Box>
       </Column>
       <Column>
         <Discreet>{formatAmount(stake.delegation?.stake ?? 0)}</Discreet>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3606,6 +3606,12 @@
         },
         "warning": "Choose your validator wisely: Part of your delegated assets may be irrevocably lost if the validator does not behave appropriately."
       },
+      "states": {
+        "active": "Active",
+        "inactive": "Inactive",
+        "activating": "Activating",
+        "deactivating": "Deactivating"
+      },
       "flow": {
         "title": "Delegate",
         "steps": {

--- a/apps/ledger-live-mobile/src/families/solana/Delegations/Row.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/Delegations/Row.tsx
@@ -134,5 +134,6 @@ const styles = StyleSheet.create({
   },
   rightWrapper: {
     alignItems: "flex-end",
+    marginLeft: 12,
   },
 });


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Check delegations table on LLD and LLM

#### 📝 Description
Minor ui issues in Solana delegations table

1) LLD: Missing translation of delegation status
2) LLM: validator name and status icon gets overlapsed with delegation amount

#### Screenshots with issues
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/5ae0740f-c068-47ba-b7a9-708920125f47" width="800"/>
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/f79914b7-b1ea-4755-bea2-db661cccebe6" height="700"/>

#### Screenshots with fix
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/53553d91-a030-433c-a701-2f720d4e1d30" width="800"/>
<img src="https://github.com/LedgerHQ/ledger-live/assets/3897859/594faf65-9216-43c0-96af-059eafa3871c" height="500"/>


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
[https://ledgerhq.atlassian.net/browse/LIVE-10370](https://ledgerhq.atlassian.net/browse/LIVE-10370)
[https://ledgerhq.atlassian.net/browse/LIVE-10726](https://ledgerhq.atlassian.net/browse/LIVE-10726)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
