### PR TITLE
chore: prevent live-countervalues to fetch invalid date range

### DIFF
--- a/.changeset/cold-bugs-breathe.md
+++ b/.changeset/cold-bugs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": patch
+---
+
+Fixes countervalues library to work even when computer date is oudated

--- a/libs/live-countervalues/src/api/api.ts
+++ b/libs/live-countervalues/src/api/api.ts
@@ -13,13 +13,25 @@ const LATEST_CHUNK = 50;
 const api: CounterValuesAPI = {
   fetchHistorical: async (granularity, { from, to, startDate }) => {
     const format = formatPerGranularity[granularity];
+    const now = new Date();
+    if (now < startDate) {
+      // we can't fetch the future
+      return Promise.resolve({});
+    }
+    const start = format(startDate);
+    const end = format(now);
+    if (start === end) {
+      // if start and end are the same, it's also pointless to fetch
+      return Promise.resolve({});
+    }
+
     const url = URL.format({
       pathname: `${baseURL()}/v3/historical/${granularity}/simple`,
       query: {
         from: inferCurrencyAPIID(from),
         to: inferCurrencyAPIID(to),
-        start: format(startDate),
-        end: format(new Date()),
+        start,
+        end,
       },
     });
     const { data } = await network({ method: "GET", url });


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - countervalues if your computer date is outdated

### 📝 Description

There were an edge cae where, putting your computer system with manual date overrides would create invalid HTTP queries to countervalues API.
We prevent queries to be sent in that case.

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-12217


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
