### PR TITLE
fix manifest loading breaking if no cache

### DIFF
--- a/.changeset/eight-cameras-tease.md
+++ b/.changeset/eight-cameras-tease.md
@@ -1,4 +1,6 @@
 ---
+"ledger-live-desktop": patch
+"live-mobile": patch
 "@ledgerhq/live-common": patch
 ---
 

--- a/.changeset/friendly-cars-ring.md
+++ b/.changeset/friendly-cars-ring.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix manifest loading breaking if no cache

--- a/apps/ledger-live-desktop/src/renderer/components/PlatformAppProviderWrapper.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PlatformAppProviderWrapper.tsx
@@ -49,10 +49,5 @@ export function PlatformAppProviderWrapper({ children }: PlatformAppProviderWrap
 }
 
 function useLocalLiveAppDB() {
-  return useDB(
-    "app",
-    DISCOVER_STORE_KEY,
-    INITIAL_PLATFORM_STATE,
-    state => state.localLiveApp || INITIAL_PLATFORM_STATE.localLiveApp,
-  );
+  return useDB("app", DISCOVER_STORE_KEY, INITIAL_PLATFORM_STATE, state => state.localLiveApp);
 }

--- a/apps/ledger-live-mobile/src/PlatformAppProviderWrapper.tsx
+++ b/apps/ledger-live-mobile/src/PlatformAppProviderWrapper.tsx
@@ -52,6 +52,6 @@ function useLocalLiveAppDB() {
   return useDB<DiscoverDB, DiscoverDB["localLiveApp"]>(
     DISCOVER_STORE_KEY,
     INITIAL_PLATFORM_STATE,
-    state => state.localLiveApp || INITIAL_PLATFORM_STATE.localLiveApp,
+    state => state.localLiveApp,
   );
 }

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -858,7 +858,15 @@ export interface LocalLiveApp {
 }
 
 export function useLocalLiveApp([LocalLiveAppDb, setState]: LocalLiveAppDB): LocalLiveApp {
-  const addLocalManifest = useCallback(
+  useEffect(() => {
+    if (LocalLiveAppDb === undefined) {
+      setState(discoverDB => {
+        return { ...discoverDB, localLiveApp: INITIAL_PLATFORM_STATE.localLiveApp };
+      });
+    }
+  }, [LocalLiveAppDb, setState]);
+  
+    const addLocalManifest = useCallback(
     (newLocalManifest: LiveAppManifest) => {
       setState(discoverDB => {
         const newLocalLiveAppList = discoverDB.localLiveApp?.filter(

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -42,7 +42,11 @@ import openTransportAsSubject, { BidirectionalEvent } from "../hw/openTransportA
 import { AppResult } from "../hw/actions/app";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Transaction } from "../generated/types";
-import { DISCOVER_INITIAL_CATEGORY, MAX_RECENTLY_USED_LENGTH } from "./constants";
+import {
+  DISCOVER_INITIAL_CATEGORY,
+  INITIAL_PLATFORM_STATE,
+  MAX_RECENTLY_USED_LENGTH,
+} from "./constants";
 import { DiscoverDB } from "./types";
 import { LiveAppManifest } from "../platform/types";
 import { WalletState } from "@ledgerhq/live-wallet/store";
@@ -865,8 +869,8 @@ export function useLocalLiveApp([LocalLiveAppDb, setState]: LocalLiveAppDB): Loc
       });
     }
   }, [LocalLiveAppDb, setState]);
-  
-    const addLocalManifest = useCallback(
+
+  const addLocalManifest = useCallback(
     (newLocalManifest: LiveAppManifest) => {
       setState(discoverDB => {
         const newLocalLiveAppList = discoverDB.localLiveApp?.filter(

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -861,7 +861,7 @@ export function useLocalLiveApp([LocalLiveAppDb, setState]: LocalLiveAppDB): Loc
   const addLocalManifest = useCallback(
     (newLocalManifest: LiveAppManifest) => {
       setState(discoverDB => {
-        const newLocalLiveAppList = discoverDB.localLiveApp.filter(
+        const newLocalLiveAppList = discoverDB.localLiveApp?.filter(
           manifest => manifest.id !== newLocalManifest.id,
         );
 


### PR DESCRIPTION
- to replicate the error you'd need to empty out your cache on LLD before replicating the bug 


<img width="1003" alt="SCR-20240513-mirw" src="https://github.com/LedgerHQ/ledger-live/assets/5050709/72a814c9-6444-4fc0-9ca7-9dc8ed39bcc1">


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
