### PR TITLE
fix: prevent app to crash during the unlock phase

### DIFF
--- a/.changeset/thin-seals-tie.md
+++ b/.changeset/thin-seals-tie.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+prevent app to crash during the unlock phase

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -2,6 +2,7 @@ import { Dispatch } from "redux";
 import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { AccountComparator } from "@ledgerhq/live-wallet/ordering";
 import { getKey } from "~/renderer/storage";
+import { PasswordIncorrectError } from "@ledgerhq/errors";
 
 export const removeAccount = (payload: Account) => ({
   type: "DB:REMOVE_ACCOUNT",
@@ -27,7 +28,8 @@ export const reorderAccounts = (comparator: AccountComparator) => (dispatch: Dis
   });
 
 export const fetchAccounts = () => async (dispatch: Dispatch) => {
-  const data: [Account, AccountUserData][] = await getKey("app", "accounts", []);
+  const data = await getKey("app", "accounts", []);
+  if (!data) throw new PasswordIncorrectError("app accounts seems to still be encrypted");
   return dispatch(initAccounts(data));
 };
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD lock screen, unlock with ability to restore accounts
  - the unlock screen will correctly be protected from race condition: once you submit the password, the input password is disabled and the form can't be sent again.

### 📝 Description

Some users seems to experience an issue with accounts being null, this can be caused when the accounts are encrypted and something fail to decrypt it in time, 
this may indicate race condition around https://github.com/LedgerHQ/ledger-live/blob/develop/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx#L44-L55 but at least we contain the error into the management of this code scope instead of a fatal crash that occurs in prod today.

this may reveal another race condition that this PR however don't fix but will help locate it.

<img width="744" alt="Capture d’écran 2024-05-14 à 10 46 48" src="https://github.com/LedgerHQ/ledger-live/assets/211411/782caa5f-21a2-4086-86f6-e99e336e0a31">


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12569


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
