### PR TITLE
[B2CQA][Detox] Reduce NTFGallery et WebView testing flakiness

### DIFF
--- a/apps/ledger-live-mobile/e2e/models/discover/getDevicePage.ts
+++ b/apps/ledger-live-mobile/e2e/models/discover/getDevicePage.ts
@@ -1,5 +1,5 @@
 import { web, by } from "detox";
-import { getElementById, tapByElement } from "../../helpers";
+import { getElementById, isAndroid, tapByElement } from "../../helpers";
 
 export default class GetDevicePage {
   buyNanoButton = () => getElementById("getDevice-buy-button");
@@ -9,8 +9,13 @@ export default class GetDevicePage {
   }
 
   async expectBuyNanoWebPage() {
-    const url = await web.element(by.web.id("__next")).getCurrentUrl();
-    const expectedUrl = "https://shop.ledger.com/";
-    expect(url).toContain(expectedUrl);
+    // Webview testing is flaky on Android
+    if (!isAndroid()) {
+      const url = await web.element(by.web.id("__next")).getCurrentUrl();
+      const expectedUrl = "https://shop.ledger.com/";
+      expect(url).toContain(expectedUrl);
+    } else {
+      console.warn("Skipping webview check on Android");
+    }
   }
 }

--- a/apps/ledger-live-mobile/src/components/Nft/NftGallery/NftList.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftGallery/NftList.tsx
@@ -21,6 +21,7 @@ import FiltersIcon from "~/icons/Filters";
 import { ScreenName } from "~/const";
 import WalletTabSafeAreaView from "../../WalletTab/WalletTabSafeAreaView";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
+import Config from "react-native-config";
 
 const RefreshableCollapsibleHeaderFlatList = globalSyncRefreshControl<FlatListProps<ProtoNFT>>(
   CollapsibleHeaderFlatList,
@@ -81,6 +82,9 @@ const NftList = ({ data, hasNextPage, fetchNextPage, isLoading }: Props) => {
     ],
   };
 
+  const Fade_In_Down = Config.MOCK ? undefined : FadeInDown;
+  const Fade_Out_Down = Config.MOCK ? undefined : FadeOutDown;
+
   const renderItem = useCallback(
     ({ item, index }: { item: ProtoNFT; index: number; count?: number }) => (
       <Flex
@@ -127,7 +131,7 @@ const NftList = ({ data, hasNextPage, fetchNextPage, isLoading }: Props) => {
           <WalletTabSafeAreaView edges={["left", "right"]}>
             <Animated.View>
               {!multiSelectModeEnabled && (
-                <Animated.View entering={FadeInDown}>
+                <Animated.View entering={Fade_In_Down}>
                   <StyledFilterBar
                     width="100%"
                     flexDirection="row"
@@ -205,7 +209,7 @@ const NftList = ({ data, hasNextPage, fetchNextPage, isLoading }: Props) => {
       {data.length > 12 ? <ScrollToTopButton /> : null}
       <Animated.View>
         {multiSelectModeEnabled && (
-          <Animated.View entering={FadeInDown} exiting={FadeOutDown}>
+          <Animated.View entering={Fade_In_Down} exiting={Fade_Out_Down}>
             <BackgroundGradient {...gradient} />
 
             <ButtonsContainer width="100%" justifyContent={"space-between"}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - NFT filter animation

### 📝 Description

Trying to mitigate some flakiness on Detox tests : 
- nftGallery : disabling NFT gallery filter animation when testing which prevented filter to appear
- onboardingReadOnly and market : disabling WebView check on Android (not reliable)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-61](https://ledgerhq.atlassian.net/browse/QAA-61)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-61]: https://ledgerhq.atlassian.net/browse/QAA-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ