### PR TITLE
chore: remove SubAccount type usage

### DIFF
--- a/libs/coin-framework/src/account/balanceHistoryCache.ts
+++ b/libs/coin-framework/src/account/balanceHistoryCache.ts
@@ -4,7 +4,7 @@ import type {
   BalanceHistoryDataCache,
   AccountLike,
   Account,
-  SubAccount,
+  TokenAccount,
 } from "@ledgerhq/types-live";
 import { getOperationAmountNumberWithInternals } from "../operation";
 
@@ -141,7 +141,7 @@ export function recalculateAccountBalanceHistories(res: Account, prev: Account):
 
   if (nextSubAccounts && prevSubAccounts && prevSubAccounts !== nextSubAccounts) {
     // when sub accounts changes, we need to recalculate
-    res.subAccounts = nextSubAccounts.map((subAccount: SubAccount): SubAccount => {
+    res.subAccounts = nextSubAccounts.map((subAccount: TokenAccount): TokenAccount => {
       const old = prevSubAccounts.find(a => a.id === subAccount.id);
 
       if (!old || old.balanceHistoryCache === subAccount.balanceHistoryCache) {

--- a/libs/coin-framework/src/account/helpers.test.ts
+++ b/libs/coin-framework/src/account/helpers.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { Account, SubAccount, TokenAccount } from "@ledgerhq/types-live";
+import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
 import {
   emptyHistoryCache,
@@ -152,7 +152,7 @@ describe(isAccountEmpty.name, () => {
     });
     describe("when account has subaccounts", () => {
       beforeEach(() => {
-        mockAccount.subAccounts = [{} as SubAccount];
+        mockAccount.subAccounts = [{} as TokenAccount];
       });
 
       it("should return false", () => {
@@ -192,7 +192,7 @@ describe(clearAccount.name, () => {
       subAccounts: [
         {
           token: getTokenById("ethereum/erc20/dao_maker"),
-        } as SubAccount,
+        } as TokenAccount,
       ],
       currency: ethereumCurrency,
     };

--- a/libs/coin-framework/src/account/helpers.ts
+++ b/libs/coin-framework/src/account/helpers.ts
@@ -3,20 +3,14 @@ import invariant from "invariant";
 import { getEnv } from "@ledgerhq/live-env";
 import { encodeTokenAccountId } from "./accountId";
 import { emptyHistoryCache } from "./balanceHistoryCache";
-import type {
-  Account,
-  AccountLike,
-  AccountLikeArray,
-  SubAccount,
-  TokenAccount,
-} from "@ledgerhq/types-live";
+import type { Account, AccountLike, AccountLikeArray, TokenAccount } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency, Unit } from "@ledgerhq/types-cryptoassets";
 
 // By convention, a main account is the top level account
 // - in case of an Account is the account itself
-// - in case of a SubAccount it's the parentAccount
+// - in case of a TokenAccount it's the parentAccount
 export const getMainAccount = <A extends Account>(
-  account: A | SubAccount,
+  account: A | TokenAccount,
   parentAccount?: A | null | undefined,
 ): A => {
   const mainAccount = account.type === "Account" ? account : parentAccount;
@@ -113,12 +107,12 @@ export function clearAccount<T extends AccountLike>(
   return copy as T;
 }
 
-export function findSubAccountById(account: Account, id: string): SubAccount | null | undefined {
+export function findSubAccountById(account: Account, id: string): TokenAccount | null | undefined {
   return (account.subAccounts || []).find(a => a.id === id);
 }
 
 // get the token accounts of an account, ignoring those that are zero IF user don't want them
-export function listSubAccounts(account: Account): SubAccount[] {
+export function listSubAccounts(account: Account): TokenAccount[] {
   const accounts = account.subAccounts || [];
 
   if (getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS")) {
@@ -236,7 +230,7 @@ export const findTokenAccountByCurrency = (
   accounts: Account[],
 ):
   | {
-      account?: SubAccount;
+      account?: TokenAccount;
       parentAccount: Account;
     }
   | null

--- a/libs/coin-framework/src/account/pending.ts
+++ b/libs/coin-framework/src/account/pending.ts
@@ -1,4 +1,4 @@
-import type { Account, Operation, SubAccount } from "@ledgerhq/types-live";
+import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { getEnv } from "@ledgerhq/live-env";
 
 export function shouldRetainPendingOperation(account: Account, op: Operation): boolean {
@@ -26,11 +26,11 @@ const appendPendingOp = (ops: Operation[], op: Operation) => {
   return filtered;
 };
 
-function addInSubAccount(subaccounts: SubAccount[], op: Operation) {
+function addInSubAccount(subaccounts: TokenAccount[], op: Operation) {
   const acc = subaccounts.find(sub => sub.id === op.accountId);
 
   if (acc) {
-    const copy: SubAccount = { ...acc };
+    const copy: TokenAccount = { ...acc };
     copy.pendingOperations = appendPendingOp(acc.pendingOperations, op);
     subaccounts[subaccounts.indexOf(acc)] = copy;
   }
@@ -42,7 +42,7 @@ export const addPendingOperation = (account: Account, operation: Operation): Acc
   const { subAccounts } = account;
 
   if (subOperations && subAccounts) {
-    const taCopy: SubAccount[] = subAccounts.slice(0);
+    const taCopy: TokenAccount[] = subAccounts.slice(0);
     subOperations.forEach(op => {
       addInSubAccount(taCopy, op);
     });
@@ -52,7 +52,7 @@ export const addPendingOperation = (account: Account, operation: Operation): Acc
   if (accountCopy.id === operation.accountId) {
     accountCopy.pendingOperations = appendPendingOp(accountCopy.pendingOperations, operation);
   } else if (subAccounts) {
-    const taCopy: SubAccount[] = subAccounts.slice(0);
+    const taCopy: TokenAccount[] = subAccounts.slice(0);
     addInSubAccount(taCopy, operation);
     accountCopy.subAccounts = taCopy;
   }

--- a/libs/coin-framework/src/serialization/account.ts
+++ b/libs/coin-framework/src/serialization/account.ts
@@ -5,7 +5,6 @@ import type {
   AccountRaw,
   Operation,
   OperationRaw,
-  SubAccount,
   TokenAccount,
   TokenAccountRaw,
   TransactionCommon,
@@ -59,7 +58,7 @@ export function fromAccountRaw(rawAccount: AccountRaw, fromRaw?: FromFamiliyRaw)
   } = rawAccount;
 
   const convertOperation = (op: OperationRaw) =>
-    fromOperationRaw(op, id, subAccounts as SubAccount[], fromRaw?.fromOperationExtraRaw);
+    fromOperationRaw(op, id, subAccounts as TokenAccount[], fromRaw?.fromOperationExtraRaw);
 
   const subAccounts =
     subAccountsRaw &&
@@ -116,7 +115,7 @@ export function fromAccountRaw(rawAccount: AccountRaw, fromRaw?: FromFamiliyRaw)
   }
 
   if (subAccounts) {
-    res.subAccounts = subAccounts as SubAccount[];
+    res.subAccounts = subAccounts as TokenAccount[];
   }
 
   if (fromRaw?.assignFromAccountRaw) {

--- a/libs/coin-framework/src/serialization/operation.ts
+++ b/libs/coin-framework/src/serialization/operation.ts
@@ -3,9 +3,9 @@ import {
   AccountBridge,
   Operation,
   OperationRaw,
-  SubAccount,
   SwapOperation,
   SwapOperationRaw,
+  TokenAccount,
   TransactionCommon,
 } from "@ledgerhq/types-live";
 
@@ -86,7 +86,7 @@ export const toOperationRaw = (
 
   return copy;
 };
-export const inferSubOperations = (txHash: string, subAccounts: SubAccount[]): Operation[] => {
+export const inferSubOperations = (txHash: string, subAccounts: TokenAccount[]): Operation[] => {
   const all: Operation[] = [];
 
   for (let i = 0; i < subAccounts.length; i++) {
@@ -137,7 +137,7 @@ export const fromOperationRaw = (
     transactionRaw,
   }: OperationRaw,
   accountId: string,
-  subAccounts?: SubAccount[] | null | undefined,
+  subAccounts?: TokenAccount[] | null | undefined,
   fromOperationExtraRaw?: AccountBridge<TransactionCommon>["fromOperationExtraRaw"],
 ): Operation => {
   const res: Operation = {

--- a/libs/coin-framework/src/test-helpers/bridge-integration-suite.ts
+++ b/libs/coin-framework/src/test-helpers/bridge-integration-suite.ts
@@ -10,12 +10,12 @@ import type {
   AccountBridge,
   AccountLike,
   AccountRawLike,
-  SubAccount,
   SyncConfig,
   CurrenciesData,
   TransactionCommon,
   TransactionStatusCommon,
   CurrencyBridge,
+  TokenAccount,
   TransactionCommonRaw,
   TransactionStatusCommonRaw,
   CryptoCurrencyIds,
@@ -696,7 +696,7 @@ export function testBridge<T extends TransactionCommon, U extends TransactionCom
 
                   const inferSubAccount = () => {
                     invariant(subAccounts, "sub accounts available");
-                    const a = (subAccounts as SubAccount[]).find(a => a.id === subAccountId);
+                    const a = (subAccounts as TokenAccount[]).find(a => a.id === subAccountId);
                     invariant(a, "sub account not found");
                     return a;
                   };

--- a/libs/coin-modules/coin-algorand/src/specs.ts
+++ b/libs/coin-modules/coin-algorand/src/specs.ts
@@ -4,7 +4,7 @@ import type { AppSpec } from "@ledgerhq/coin-framework/bot/types";
 import { getCryptoCurrencyById, listTokensForCryptoCurrency } from "@ledgerhq/cryptoassets/index";
 import { parseCurrencyUnit } from "@ledgerhq/coin-framework/currencies";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { Account, AccountLike, SubAccount } from "@ledgerhq/types-live";
+import { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import expect from "expect";
 import invariant from "invariant";
@@ -27,7 +27,7 @@ const checkSendableToEmptyAccount = (amount: BigNumber, recipient: AccountLike) 
 };
 
 // Get list of ASAs associated with the account
-const getAssetsWithBalance = (account: Account): SubAccount[] => {
+const getAssetsWithBalance = (account: Account): TokenAccount[] => {
   return account.subAccounts
     ? account.subAccounts.filter(a => a.type === "TokenAccount" && a.balance.gt(0))
     : [];
@@ -46,7 +46,7 @@ const pickSiblingsOptedIn = (siblings: Account[], assetId: string): Account | un
 // being opted-in by an account
 
 const getRandomAssetId = (account: Account): string | undefined => {
-  const optedInASA = account.subAccounts?.reduce((old: string[], current: SubAccount) => {
+  const optedInASA = account.subAccounts?.reduce((old: string[], current: TokenAccount) => {
     if (current.type === "TokenAccount") {
       return [...old, current.token.id];
     }

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/common.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/common.fixtures.ts
@@ -14,19 +14,12 @@ import {
 import { encodeNftId } from "@ledgerhq/coin-framework/nft/nftId";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import {
-  Account,
-  DerivationMode,
-  Operation,
-  ProtoNFT,
-  SubAccount,
-  TokenAccount,
-} from "@ledgerhq/types-live";
+import { Account, DerivationMode, Operation, ProtoNFT, TokenAccount } from "@ledgerhq/types-live";
 
 export const makeAccount = (
   address: string,
   currency: CryptoCurrency,
-  subAccounts: SubAccount[] = [],
+  subAccounts: TokenAccount[] = [],
 ): Account => {
   const id = `js:2:${currency.id}:${address}:`;
   const { derivationMode, xpubOrAddress } = decodeAccountId(id);

--- a/libs/coin-modules/coin-evm/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-evm/src/getTransactionStatus.ts
@@ -19,7 +19,12 @@ import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/index";
 import { findSubAccountById, getFeesUnit } from "@ledgerhq/coin-framework/account/index";
-import { Account, AccountBridge, SubAccount, TransactionStatusCommon } from "@ledgerhq/types-live";
+import {
+  Account,
+  AccountBridge,
+  TokenAccount,
+  TransactionStatusCommon,
+} from "@ledgerhq/types-live";
 import { getMinEip1559Fees, getMinLegacyFees } from "./editTransaction/getMinEditTransactionFees";
 import { eip1559TransactionHasFees, getEstimatedFees, legacyTransactionHasFees } from "./logic";
 import { NotEnoughNftOwned, NotOwnedNft, QuantityNeedsToBePositive } from "./errors";
@@ -87,7 +92,7 @@ export const validateRecipient = (
  * Validate the amount of a transaction for an account
  */
 const validateAmount = (
-  account: Account | SubAccount,
+  account: Account | TokenAccount,
   transaction: EvmTransaction,
   totalSpent: BigNumber,
 ): Array<ValidationIssues> => {
@@ -227,7 +232,7 @@ const validateNft = (account: Account, tx: EvmTransaction): Array<ValidationIssu
  * - if sending ETH, warn if fees are more than 10% of the amount
  */
 const validateFeeRatio = (
-  account: Account | SubAccount,
+  account: Account | TokenAccount,
   tx: EvmTransaction,
   estimatedFees: BigNumber,
 ): Array<ValidationIssues> => {

--- a/libs/coin-modules/coin-evm/src/logic.ts
+++ b/libs/coin-modules/coin-evm/src/logic.ts
@@ -5,7 +5,6 @@ import {
   AnyMessage,
   MessageProperties,
   Operation,
-  SubAccount,
   TokenAccount,
 } from "@ledgerhq/types-live";
 import murmurhash from "imurmurhash";
@@ -100,16 +99,16 @@ const updatableSubAccountProperties: { name: string; isOps: boolean }[] = [
  */
 export const mergeSubAccounts = (
   initialAccount: Account | undefined,
-  newSubAccounts: Partial<SubAccount>[],
-): Array<Partial<SubAccount> | SubAccount> => {
-  const oldSubAccounts: Array<Partial<SubAccount> | SubAccount> | undefined =
+  newSubAccounts: Partial<TokenAccount>[],
+): Array<Partial<TokenAccount> | TokenAccount> => {
+  const oldSubAccounts: Array<Partial<TokenAccount> | TokenAccount> | undefined =
     initialAccount?.subAccounts;
   if (!oldSubAccounts) {
     return newSubAccounts;
   }
 
   // Creating a map of already existing sub accounts by id
-  const oldSubAccountsById: { [key: string]: Partial<SubAccount> } = {};
+  const oldSubAccountsById: { [key: string]: Partial<TokenAccount> } = {};
   for (const oldSubAccount of oldSubAccounts) {
     oldSubAccountsById[oldSubAccount.id!] = oldSubAccount;
   }
@@ -117,9 +116,9 @@ export const mergeSubAccounts = (
   // Looping on new sub accounts to compare them with already existing ones
   // Already existing will be updated if necessary (see `updatableSubAccountProperties`)
   // Fresh new sub accounts will be added/pushed after already existing
-  const newSubAccountsToAdd: Partial<SubAccount>[] = [];
+  const newSubAccountsToAdd: Partial<TokenAccount>[] = [];
   for (const newSubAccount of newSubAccounts) {
-    const duplicatedAccount: Partial<SubAccount> | undefined =
+    const duplicatedAccount: Partial<TokenAccount> | undefined =
       oldSubAccountsById[newSubAccount.id!];
 
     // If this sub account was not already in the initialAccount
@@ -129,7 +128,7 @@ export const mergeSubAccounts = (
       continue;
     }
 
-    const updates: Partial<SubAccount> = {};
+    const updates: Partial<TokenAccount> = {};
     for (const { name, isOps } of updatableSubAccountProperties) {
       if (!isOps) {
         // @ts-expect-error FIXME: fix typings

--- a/libs/coin-modules/coin-evm/src/synchronization.ts
+++ b/libs/coin-modules/coin-evm/src/synchronization.ts
@@ -14,7 +14,7 @@ import {
   mergeOps,
   mergeNfts,
 } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { Account, Operation, SubAccount, TokenAccount } from "@ledgerhq/types-live";
+import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { decodeOperationId } from "@ledgerhq/coin-framework/operation";
 import { nftsFromOperations } from "@ledgerhq/coin-framework/nft/helpers";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
@@ -146,7 +146,7 @@ export const getSubAccounts = async (
   lastTokenOperations: Operation[],
   blacklistedTokenIds: string[] = [],
   swapHistoryMap: Map<TokenCurrency, TokenAccount["swapHistory"]>,
-): Promise<Partial<SubAccount>[]> => {
+): Promise<Partial<TokenAccount>[]> => {
   const { currency } = infos;
 
   // Creating a Map of Operations by TokenCurrencies in order to know which TokenAccounts should be synced as well
@@ -167,7 +167,7 @@ export const getSubAccounts = async (
   );
 
   // Fetching all TokenAccounts possible and providing already filtered operations
-  const subAccountsPromises: Promise<Partial<SubAccount>>[] = [];
+  const subAccountsPromises: Promise<Partial<TokenAccount>>[] = [];
   for (const [token, ops] of erc20OperationsByToken.entries()) {
     const swapHistory = swapHistoryMap.get(token) || [];
     subAccountsPromises.push(getSubAccountShape(currency, accountId, token, ops, swapHistory));
@@ -185,7 +185,7 @@ export const getSubAccountShape = async (
   token: TokenCurrency,
   operations: Operation[],
   swapHistory: TokenAccount["swapHistory"],
-): Promise<Partial<SubAccount>> => {
+): Promise<Partial<TokenAccount>> => {
   const nodeApi = getNodeApi(currency);
   const { xpubOrAddress: address } = decodeAccountId(parentId);
   const tokenAccountId = encodeTokenAccountId(parentId, token);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Related to the sunset of [ChildAccount](https://github.com/LedgerHQ/ledger-live/pull/6524), remove the use of `SubAccount` for direct use of `TokenAccount`. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
