### PR TITLE
fix(llm): improve layout on Designed for Stax NFT drawer

### DIFF
--- a/.changeset/loud-jokes-rest.md
+++ b/.changeset/loud-jokes-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add unicode so E Ink Screen will remain on the same line

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6310,7 +6310,7 @@
     "designedForStax": {
       "title": "<0>Designed for</0><1>Ledger</1><2>Stax</2>",
       "drawer": {
-        "description": "This NFT contains an additional picture of the NFT, specifically designed for Ledger Stax's E Ink Screen.\n\nThis picture will be used when you set this NFT as your lock screen.",
+        "description": "This NFT contains an additional picture of the NFT, specifically designed for Ledger Stax's E\u00a0Ink\u00a0Screen.\n\nThis picture will be used when you set this NFT as your lock screen.",
         "cta": "Got it"
       }
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Designed for Stax NFTs drawer

### 📝 Description

There was a linebreak between “E” and “Ink” in the text displayed for “Designed for Stax” NFTs
Add unicode in translation files so "E Ink Screen" will always remain in the same line. This handles even changes directly done in phone settings on font size. 

| Before        | After         |
| ------------- | ------------- |
|![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/736b4929-ca0f-4988-87a4-fd710bcf6188)|![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/bfa6c6a9-a185-41c2-822c-334e41c24aa1)|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12422](https://ledgerhq.atlassian.net/browse/LIVE-12422)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12422]: https://ledgerhq.atlassian.net/browse/LIVE-12422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ