### PR TITLE
fix(common/listApps): custom lock screen size for all compatible models

### DIFF
--- a/.changeset/eleven-houses-hunt.md
+++ b/.changeset/eleven-houses-hunt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix device available storage computation for all devices supporting custom lock screens.

--- a/libs/ledger-live-common/src/apps/listApps/v1.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v1.ts
@@ -19,6 +19,7 @@ import { calculateDependencies, polyfillApp, polyfillApplication } from "../poly
 import { getDeviceName } from "../../device/use-cases/getDeviceNameUseCase";
 import { getLatestFirmwareForDeviceUseCase } from "../../device/use-cases/getLatestFirmwareForDeviceUseCase";
 import { ManagerApiRepository } from "../../device/factories/HttpManagerApiRepositoryFactory";
+import { isCustomLockScreenSupported } from "../../device/use-cases/isCustomLockScreenSupported";
 
 const appsThatKeepChangingHashes = ["Fido U2F", "Security Key"];
 
@@ -258,7 +259,7 @@ export const listApps = (
         .filter(Boolean);
 
       let customImageBlocks = 0;
-      if (deviceModelId === DeviceModelId.stax && !deviceInfo.isRecoveryMode) {
+      if (isCustomLockScreenSupported(deviceModelId) && !deviceInfo.isRecoveryMode) {
         const customImageSize = await customLockScreenFetchSize(transport);
         if (customImageSize) {
           customImageBlocks = Math.ceil(customImageSize / bytesPerBlock);

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -19,6 +19,7 @@ import { getLatestFirmwareForDeviceUseCase } from "../../device/use-cases/getLat
 import { getProviderIdUseCase } from "../../device/use-cases/getProviderIdUseCase";
 import { mapApplicationV2ToApp } from "../polyfill";
 import { ManagerApiRepository } from "../../device/factories/HttpManagerApiRepositoryFactory";
+import { isCustomLockScreenSupported } from "../../device/use-cases/isCustomLockScreenSupported";
 
 // Hash discrepancies for these apps do NOT indicate a potential update,
 // these apps have a mechanism that makes their hash change every time.
@@ -271,14 +272,14 @@ export const listApps = ({
 
       /**
        * Obtain remaining metadata:
-       * - Ledger Stax custom picture: number of blocks taken in storage
+       * - Ledger Stax/Europa custom picture: number of blocks taken in storage
        * - Installed language pack
        * - Device name
        * */
 
-      // Stax specific, account for the size of the CLS for the storage bar.
+      // Stax/Europa specific, account for the size of the CLS for the storage bar.
       let customImageBlocks = 0;
-      if (deviceModelId === DeviceModelId.stax && !deviceInfo.isRecoveryMode) {
+      if (isCustomLockScreenSupported(deviceModelId) && !deviceInfo.isRecoveryMode) {
         const customImageSize = await customLockScreenFetchSize(transport);
         if (customImageSize) {
           customImageBlocks = Math.ceil(customImageSize / bytesPerBlock);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:**
  - Storage computation on Europa devices.

### 📝 Description

On Europa, the custom lock screen size in storage wasn't taken into account in the computation, therefore giving wrong informations about available storage space, and for instance letting the user try to install an app while there is actually so space available for this app.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12411] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12411]: https://ledgerhq.atlassian.net/browse/LIVE-12411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ