### PR TITLE
fix(lld): remove unnecessary information when the balance has not cha…

### DIFF
--- a/.changeset/late-vans-lick.md
+++ b/.changeset/late-vans-lick.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove 0 (currency) when balance hasn't change in the selected time range

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -55,17 +55,21 @@ export function BalanceDiff({ valueChange, unit, isAvailable, ...boxProps }: Pro
             withIcon
           />
         )}
-        <FormattedVal
-          unit={unit}
-          val={valueChange.value}
-          prefix={valueChange.percentage ? " (" : undefined}
-          suffix={valueChange.percentage ? ")" : undefined}
-          withIcon={!valueChange.percentage}
-          alwaysShowSign={!!valueChange.percentage}
-          showCode
-          animateTicker
-          inline
-        />
+        {valueChange.value === 0 ? (
+          <Text color={"palette.text.shade100"}>{"-"}</Text>
+        ) : (
+          <FormattedVal
+            unit={unit}
+            val={valueChange.value}
+            prefix={valueChange.percentage ? " (" : undefined}
+            suffix={valueChange.percentage ? ")" : undefined}
+            withIcon={!valueChange.percentage}
+            alwaysShowSign={!!valueChange.percentage}
+            showCode
+            animateTicker
+            inline
+          />
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
…nged on account page

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Balance Infos in Account

### 📝 Description

Replace 0 (Currency) by `-` in Balance Infos. It was a bit confusing to display 0 Bitcoin when the number of BTC hasn't changed on selected time range. 


| Before        | After         |
| ------------- | ------------- |
|![Screenshot 2024-05-14 at 16 04 52](https://github.com/LedgerHQ/ledger-live/assets/73439207/e67c9bfc-12d7-4a56-b9e9-e9570d3bba12)| ![image](https://github.com/LedgerHQ/ledger-live/assets/73439207/e8e880c4-3b01-4c27-bd75-180409aa718c)|


### ❓ Context

- **JIRA or GitHub link**:[LIVE-8996](https://ledgerhq.atlassian.net/browse/LIVE-8996) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-8996]: https://ledgerhq.atlassian.net/browse/LIVE-8996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ