### PR TITLE
chore: prevent middlewares/db to be active during locked phase

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -8,6 +8,7 @@ import { settingsExportSelector, areSettingsLoaded } from "./../reducers/setting
 import { State } from "../reducers";
 import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { accountUserDataExportSelector } from "@ledgerhq/live-wallet/store";
+import { isLocked } from "../reducers/application";
 let DB_MIDDLEWARE_ENABLED = true;
 
 // ability to temporary disable the db middleware from outside
@@ -28,13 +29,13 @@ function accountsExportSelector(state: State) {
 }
 
 const DBMiddleware: Middleware<{}, State> = store => next => action => {
-  if (DB_MIDDLEWARE_ENABLED && action.type.startsWith("DB:")) {
+  const state = store.getState();
+  if (DB_MIDDLEWARE_ENABLED && action.type.startsWith("DB:") && !isLocked(state)) {
     const [, type] = action.type.split(":");
     store.dispatch({
       type,
       payload: action.payload,
     });
-    const state = store.getState();
     setKey("app", "accounts", accountsExportSelector(state));
     // ^ TODO ultimately we'll do same for accounts to drop DB: pattern
   } else if (DB_MIDDLEWARE_ENABLED && action.type.startsWith(postOnboardingActionTypePrefix)) {


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

to generalize the issue that was fixed in #6863, we can prevent db to attempt to save app.json during the locked state

(this PR is living proposal, just created in order to discuss this)

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
