### PR TITLE
fix(lld): fix analytics useEffect in default

### DIFF
--- a/.changeset/mighty-teachers-brake.md
+++ b/.changeset/mighty-teachers-brake.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix analytics that were overriding app.json

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -53,6 +53,7 @@ import {
   hasSeenAnalyticsOptInPromptSelector,
 } from "~/renderer/reducers/settings";
 import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/postOnboarding/hooks/index";
+import { isLocked as isLockedSelector } from "~/renderer/reducers/application";
 import { setShareAnalytics, setSharePersonalizedRecommendations } from "./actions/settings";
 
 const PlatformCatalog = lazy(() => import("~/renderer/screens/platform"));
@@ -200,13 +201,16 @@ export default function Default() {
   const listAppsV2 = useFeature("listAppsV2minor1");
   const analyticsFF = useFeature("lldAnalyticsOptInPrompt");
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
+  const isLocked = useSelector(isLockedSelector);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!analyticsFF?.enabled || hasSeenAnalyticsOptInPrompt) return;
-    dispatch(setShareAnalytics(false));
-    dispatch(setSharePersonalizedRecommendations(false));
-  });
+    if (!isLocked && analyticsFF?.enabled && !hasSeenAnalyticsOptInPrompt) {
+      dispatch(setShareAnalytics(false));
+      dispatch(setSharePersonalizedRecommendations(false));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLocked]);
 
   useEffect(() => {
     if (!listAppsV2) return;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix analytics useEffect previously introduced that was overriding app.json 
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/pull/6857/commits/9ce66ffc48695fd0add96d48091a7d533b2ff091 & [LIVE-12571](https://ledgerhq.atlassian.net/browse/LIVE-12571)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-12571]: https://ledgerhq.atlassian.net/browse/LIVE-12571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ