### PR TITLE
chore(ethereum-provider): remove import assert from rollup config

### DIFF
--- a/libs/ethereum-provider/rollup.config.mjs
+++ b/libs/ethereum-provider/rollup.config.mjs
@@ -1,8 +1,11 @@
+import { createRequire } from "node:module";
 import dts from "rollup-plugin-dts";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import esbuild from "rollup-plugin-esbuild";
-import pkg from "./package.json";
+
+const require = createRequire(import.meta.url);
+const pkg = require("./package.json");
 
 /**
  * @param {import('rollup').RollupOptions} config

--- a/libs/ethereum-provider/rollup.config.mjs
+++ b/libs/ethereum-provider/rollup.config.mjs
@@ -2,7 +2,7 @@ import dts from "rollup-plugin-dts";
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import esbuild from "rollup-plugin-esbuild";
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json";
 
 /**
  * @param {import('rollup').RollupOptions} config


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove potentially buggy import assert syntax from the ethereum-provider's rollup config

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
