### PR TITLE
chore(ci) [LIVE-12438]: Remove recover input

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -9,11 +9,6 @@ on:
       ref:
         description: the branch to prerelease from
         required: true
-      recover:
-        description: Recover Beta release track
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   prerelease:
@@ -137,7 +132,7 @@ jobs:
               owner: "ledgerhq",
               repo: "ledger-live-build",
               ref: "main",
-              workflow_id: "${{ inputs.recover && 'pre-mobile-recover.yml' || 'pre-mobile.yml' }}",
+              workflow_id: "pre-mobile.yml",
               inputs: {
                 ref: "${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}",
               }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** - CI workflows are not covered by automated tests
- [ ] **Impact of the changes:** 
  - Release Prelease workflow doesn't show the Recover input anymore

### 📝 Description

Remove the workflow recover parameter that was used to build Recover Beta. It is obsolete now.
The pre-mobile-recover.yml has already been removed from ledger-live-build repo


### ❓ Context

- **JIRA or GitHub link**: LIVE-12438

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
