### PR TITLE
fix: no longer uses cache key

### DIFF
--- a/.changeset/unlucky-suits-whisper.md
+++ b/.changeset/unlucky-suits-whisper.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Don't use cachekey to determine when swapStateGet data is updated

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -180,7 +180,7 @@ const SwapWebView = ({ manifest, swapState, liveAppUnavailable }: SwapWebProps) 
       },
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [swapState?.cacheKey]);
+  }, [JSON.stringify(swapState)]);
 
   useEffect(() => {
     if (webviewState.url.includes("/unknown-error")) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- swap live app and custom.swapStateGet no longer uses cachekey to determine when the swap data is updated.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
