### PR TITLE
Fix/live 12705/show swap btn

### DIFF
--- a/.changeset/nine-jeans-tickle.md
+++ b/.changeset/nine-jeans-tickle.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+disaply the disabled swap button when the swap form is not valid

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -26,6 +26,8 @@ import { useRedirectToSwapHistory } from "../utils/index";
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { Box, Button } from "@ledgerhq/react-ui";
+import { t } from "i18next";
 import { usePTXCustomHandlers } from "~/renderer/components/WebPTXPlayer/CustomHandlers";
 import { captureException } from "~/sentry/internal";
 
@@ -255,12 +257,21 @@ const SwapWebView = ({
     }
   };
 
+  // Keep the previous UI
+  // Display only the disabled swap button
   if (
     swapState.error ||
     swapState.fromAmount === "0" ||
     !(fromCurrency && addressFrom && toCurrency && addressTo)
-  )
-    return null;
+  ) {
+    return (
+      <Box width="100%">
+        <Button width="100%" disabled>
+          {t("sidebar.swap")}
+        </Button>
+      </Box>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

- roll back the Swap button when the swap form is pending


https://github.com/LedgerHQ/ledger-live/assets/11476482/67a826ee-4b54-470b-bad1-52e2b312e586


### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-12705

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
