### PR TITLE
fix: hides title for Buy screen

### DIFF
--- a/.changeset/blue-donkeys-yawn.md
+++ b/.changeset/blue-donkeys-yawn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Hides title

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -77,6 +77,7 @@ export default function ExchangeLiveAppNavigator(_props?: Record<string, unknown
         name={ScreenName.ExchangeBuy}
         options={{
           headerStyle: styles.headerNoShadow,
+          title: "",
         }}
       >
         {props => <ExchangeBuy {...props} />}


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:**
  - Buy screen title should not be shown anymore

### 📝 Description

Does not show the default title that comes with React Navigation when navigating to the Buy screen.

### ❓ Context

- [Ticket](https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/873?assignee=712020%3Aa7bf41de-b9e1-4abb-a605-df11ab5c4df6&selectedIssue=LIVE-12357)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
