### PR TITLE
🐛 : [BUGFIX] Layout issue with new Gainers/Losers trend widget if LLD is in French or German

### DIFF
--- a/.changeset/empty-elephants-end.md
+++ b/.changeset/empty-elephants-end.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+There was a Layout issue with new Gainers/Losers trend widget if LLD is in French or German

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AccountLike, ValueChange } from "@ledgerhq/types-live";
 import { Unit } from "@ledgerhq/types-cryptoassets";
@@ -13,6 +13,8 @@ import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { useHistory } from "react-router-dom";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Text } from "@ledgerhq/react-ui";
+import PilldDaysSelect from "../PillsDaysSelect";
+import { useResize } from "~/renderer/hooks/useResize";
 
 type BalanceSinceProps = {
   valueChange: ValueChange;
@@ -135,13 +137,18 @@ export default function BalanceInfos({ totalBalance, valueChange, isAvailable, u
       pathname: "/swap",
     });
   }, [history]);
+
+  const ref = useRef<HTMLDivElement>(null);
+  const { width } = useResize(ref);
+
   return (
-    <Box flow={5}>
+    <Box flow={4} ref={ref}>
       <Box horizontal alignItems="center" justifyContent="space-between">
         <Text variant="h3Inter" fontWeight="semiBold">
           {t("dashboard.header")}
         </Text>
-        <PillsDaysCount />
+
+        {width <= 500 ? <PilldDaysSelect /> : <PillsDaysCount />}
       </Box>
       <Box horizontal>
         <BalanceTotal

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -142,7 +142,7 @@ export default function BalanceInfos({ totalBalance, valueChange, isAvailable, u
   const { width } = useResize(ref);
 
   return (
-    <Box flow={4} ref={ref}>
+    <Box flow={5} ref={ref}>
       <Box horizontal alignItems="center" justifyContent="space-between">
         <Text variant="h3Inter" fontWeight="semiBold">
           {t("dashboard.header")}

--- a/apps/ledger-live-desktop/src/renderer/components/PillsDaysSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PillsDaysSelect.tsx
@@ -1,0 +1,42 @@
+import React, { useMemo } from "react";
+import { PortfolioRangeOption, useTimeRange } from "~/renderer/actions/settings";
+import Select from "~/renderer/components/Select";
+
+type ChangeArgs = { value: PortfolioRangeOption; label: string };
+
+const PilldDaysSelect: React.FC = () => {
+  const [selected, onChange, options] = useTimeRange();
+
+  const mappedOptions = useMemo(
+    () =>
+      options.map(option => ({
+        label: option.label,
+        value: option,
+      })),
+    [options],
+  );
+
+  const mappedSelected = useMemo(() => {
+    const current = options.find(o => o.key === selected) ?? options[0];
+    return {
+      label: current.label,
+      value: current,
+    };
+  }, [options, selected]);
+
+  const avoidEmptyValue = (option?: ChangeArgs | null) => option && onChange(option.value);
+
+  return (
+    <Select
+      isSearchable={false}
+      small
+      minWidth={90}
+      onChange={avoidEmptyValue}
+      renderSelected={(item: { label: unknown }) => item && item.label}
+      value={mappedSelected}
+      options={mappedOptions}
+    />
+  );
+};
+
+export default PilldDaysSelect;

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/components/Header.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/components/Header.tsx
@@ -11,7 +11,7 @@ import { selectedTimeRangeSelector } from "~/renderer/reducers/settings";
 const primary = "primary.c80";
 const neutral = "neutral.c70";
 
-const RESPONSIVE_WIDTH = 275;
+const RESPONSIVE_WIDTH = 330;
 
 export function MarketPerformanceWidgetHeader({ onChangeOrder, order }: HeaderProps) {
   const { t } = useTranslation();


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
There was a Layout issue with new Gainers/Losers trend widget if LLD is in French or German
- on Pills on Dashboard
- on Widget on Selectors (Up/down)

https://github.com/LedgerHQ/ledger-live/assets/112866305/b79628ac-c090-48ab-bde6-077a5239cae8


### ❓ Context

- **JIRA or GitHub link**: [LIVE-12735] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12735]: https://ledgerhq.atlassian.net/browse/LIVE-12735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ