### PR TITLE
ci: Updating nightly for e2e test (speculos)

### DIFF
--- a/.changeset/strange-monkeys-return.md
+++ b/.changeset/strange-monkeys-return.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+updating workflow: adding default value to variables

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -102,12 +102,13 @@ jobs:
         id: tests
         run: |
           export COINAPPS=$PWD/coin-apps
-          if [ "${{ inputs.enable_broadcast }}" = true ]; then export ENABLE_TRANSACTION_BROADCAST=1; fi
-          if [ "${{ inputs.speculos_tests }}" = true ]; then export MOCK=0 && speculos_tests=":speculos"; fi
-          if [ "${{ inputs.invert_filter }}" = true ]; then invert_filter="-invert"; fi
-          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm desktop test:playwright$speculos_tests ${INPUTS_TEST_FILTER:+--grep$invert_filter} "${{ inputs.test_filter }}"
+          export ENABLE_TRANSACTION_BROADCAST=${{ inputs.enable_broadcast || false }}
+          export MOCK=${{ inputs.speculos_tests == 'true' ? 0 : 1 || 0 }}
+          speculos_tests=${{ inputs.speculos_tests == 'true' ? ":speculos" : "" || ":speculos" }}
+          invert_filter=${{ inputs.invert_filter == 'true' ? "-invert" : "" || "" }}
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- pnpm desktop test:playwright$speculos_tests ${inputs.test_filter && "--grep$invert_filter"} "${{ inputs.test_filter || '' }}"
         env:
-          INPUTS_TEST_FILTER: ${{ inputs.test_filter }}
+          INPUTS_TEST_FILTER: ${{ inputs.test_filter || '' }}
           SEED: ${{ secrets.SEED_QAA_B2C }}
       - name: upload diffs to s3
         if: ${{ !cancelled() }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -102,7 +102,7 @@ jobs:
         id: tests
         run: |
           export COINAPPS=$PWD/coin-apps
-          export ENABLE_TRANSACTION_BROADCAST=${{ inputs.enable_broadcast || false }}
+          export ENABLE_TRANSACTION_BROADCAST=${{ inputs.enable_broadcast == 'true' ? true : false || false }}
           export MOCK=${{ inputs.speculos_tests == 'true' ? 0 : 1 || 0 }}
           speculos_tests=${{ inputs.speculos_tests == 'true' ? ":speculos" : "" || ":speculos" }}
           invert_filter=${{ inputs.invert_filter == 'true' ? "-invert" : "" || "" }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- This PR addresses the issue where variables were set to `null` during scheduled workflows, causing the nightly runs to execute mocked tests instead of speculos tests.
- Activation of the Receive test.

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
