### PR TITLE
Feature/dsdk 277 keyring eth implementation

### DIFF
--- a/.changeset/moody-geckos-glow.md
+++ b/.changeset/moody-geckos-glow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/context-module": patch
+---
+
+export ContextModule and ContextResponse model

--- a/.changeset/thick-pans-punch.md
+++ b/.changeset/thick-pans-punch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/keyring-eth": minor
+---
+
+Add keyring-eth implementation

--- a/libs/ledgerjs/packages/context-module/src/index.ts
+++ b/libs/ledgerjs/packages/context-module/src/index.ts
@@ -1,1 +1,3 @@
+export * from "./ContextModule";
 export * from "./DefaultContextModule";
+export * from "./shared/model/ContextResponse";

--- a/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.test.ts
+++ b/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.test.ts
@@ -1,18 +1,159 @@
-import Transport from "@ledgerhq/hw-transport";
+import AppBinding from "@ledgerhq/hw-app-eth";
 import { DefaultKeyringEth } from "./DefaultKeyringEth";
 import { Transaction } from "ethers";
+import { KeyringEth } from "./KeyringEth";
+import { ContextModule } from "@ledgerhq/context-module/lib/ContextModule";
+import { ContextResponse } from "@ledgerhq/context-module";
 
-describe("DefaultEthKeyring", () => {
-  describe("signTransaction function", () => {
-    it("Test1", async () => {
-      const keyring = new DefaultKeyringEth({
-        send: jest.fn(),
-        decorateAppAPIMethods: jest.fn(),
-      } as unknown as Transport);
+describe("DefaultKeyringEth", () => {
+  let keyring: KeyringEth;
 
-      const result = await keyring.signTransaction("", {} as Transaction, {});
+  const mockAppBinding = {
+    provideDomainName: jest.fn(),
+    provideERC20TokenInformation: jest.fn(),
+    provideNFTInformation: jest.fn(),
+    setExternalPlugin: jest.fn(),
+    setPlugin: jest.fn(),
+    getChallenge: jest.fn(),
+    signTransaction: jest.fn(),
+  } as unknown as AppBinding;
+  const mockContextModule = {
+    getContexts: jest.fn(),
+  } as ContextModule;
 
-      expect(result).toEqual({});
+  beforeEach(() => {
+    jest.clearAllMocks();
+    keyring = new DefaultKeyringEth(mockAppBinding, mockContextModule);
+    jest.spyOn(mockAppBinding, "signTransaction").mockResolvedValue({ r: "", s: "", v: "42" });
+  });
+
+  describe("signTransaction calls", () => {
+    it("should call app binding provide with one context provided", async () => {
+      // GIVEN
+      const payload = "payload";
+      const contexts: ContextResponse[] = [{ type: "provideDomainName", payload }];
+      jest.spyOn(mockContextModule, "getContexts").mockResolvedValue(contexts);
+
+      // WHEN
+      await keyring.signTransaction("", {} as Transaction, {});
+
+      // THEN
+      expect(mockAppBinding.provideDomainName).toHaveBeenCalledWith(payload);
+      expect(mockAppBinding.provideERC20TokenInformation).not.toHaveBeenCalled();
+      expect(mockAppBinding.provideNFTInformation).not.toHaveBeenCalled();
+      expect(mockAppBinding.setExternalPlugin).not.toHaveBeenCalled();
+      expect(mockAppBinding.setPlugin).not.toHaveBeenCalled();
+    });
+
+    it("should call multiple app binding provide", async () => {
+      // GIVEN
+      const payloads = ["payload1", "payload2"];
+      const contexts: ContextResponse[] = [
+        { type: "provideERC20TokenInformation", payload: payloads[0] },
+        { type: "provideNFTInformation", payload: payloads[1] },
+      ];
+      jest.spyOn(mockContextModule, "getContexts").mockResolvedValue(contexts);
+
+      // WHEN
+      await keyring.signTransaction("", {} as Transaction, {});
+
+      // THEN
+      expect(mockAppBinding.provideDomainName).not.toHaveBeenCalled();
+      expect(mockAppBinding.provideERC20TokenInformation).toHaveBeenCalledWith(payloads[0]);
+      expect(mockAppBinding.provideNFTInformation).toHaveBeenCalledWith(payloads[1]);
+      expect(mockAppBinding.setExternalPlugin).not.toHaveBeenCalled();
+      expect(mockAppBinding.setPlugin).not.toHaveBeenCalled();
+    });
+
+    it("should call the same multiple app binding provide multiple times", async () => {
+      // GIVEN
+      const payloads = ["payload1", "payload2", "payload3"];
+      const contexts: ContextResponse[] = [
+        { type: "provideERC20TokenInformation", payload: payloads[0] },
+        { type: "provideERC20TokenInformation", payload: payloads[1] },
+        { type: "provideERC20TokenInformation", payload: payloads[2] },
+      ];
+      jest.spyOn(mockContextModule, "getContexts").mockResolvedValue(contexts);
+
+      // WHEN
+      await keyring.signTransaction("", {} as Transaction, {});
+
+      // THEN
+      expect(mockAppBinding.provideDomainName).not.toHaveBeenCalled();
+      expect(mockAppBinding.provideERC20TokenInformation).toHaveBeenCalledWith(payloads[0]);
+      expect(mockAppBinding.provideERC20TokenInformation).toHaveBeenCalledWith(payloads[1]);
+      expect(mockAppBinding.provideERC20TokenInformation).toHaveBeenCalledWith(payloads[2]);
+      expect(mockAppBinding.provideNFTInformation).not.toHaveBeenCalled();
+      expect(mockAppBinding.setExternalPlugin).not.toHaveBeenCalled();
+      expect(mockAppBinding.setPlugin).not.toHaveBeenCalled();
+    });
+
+    it("should call all app binding provide", async () => {
+      // GIVEN
+      const payloads = ["payload1", "payload2", "payload3", "payload4", "payload5"];
+      const contexts: ContextResponse[] = [
+        { type: "provideDomainName", payload: payloads[0] },
+        { type: "provideERC20TokenInformation", payload: payloads[1] },
+        { type: "provideNFTInformation", payload: payloads[2] },
+        { type: "setExternalPlugin", payload: payloads[3] },
+        { type: "setPlugin", payload: payloads[4] },
+      ];
+      jest.spyOn(mockContextModule, "getContexts").mockResolvedValue(contexts);
+
+      // WHEN
+      await keyring.signTransaction("", {} as Transaction, {});
+
+      // THEN
+      expect(mockAppBinding.provideDomainName).toHaveBeenCalledWith(payloads[0]);
+      expect(mockAppBinding.provideERC20TokenInformation).toHaveBeenCalledWith(payloads[1]);
+      expect(mockAppBinding.provideNFTInformation).toHaveBeenCalledWith(payloads[2]);
+      expect(mockAppBinding.setExternalPlugin).toHaveBeenCalledWith(payloads[3]);
+      expect(mockAppBinding.setPlugin).toHaveBeenCalledWith(payloads[4]);
+    });
+
+    it("should handle error context", async () => {
+      // GIVEN
+      const contexts: ContextResponse[] = [{ type: "error", error: new Error() }];
+      jest.spyOn(mockContextModule, "getContexts").mockResolvedValue(contexts);
+
+      // WHEN
+      const response = await keyring.signTransaction("", {} as Transaction, {});
+
+      // THEN
+      expect(response).toEqual({ r: "0x", s: "0x", v: 66 });
+    });
+
+    it("should provide a challenge to the context module", async () => {
+      // GIVEN
+      const challenge = "challenge";
+      const contexts: ContextResponse[] = [{ type: "provideDomainName", payload: "payload" }];
+      jest.spyOn(mockContextModule, "getContexts").mockResolvedValue(contexts);
+      jest.spyOn(mockAppBinding, "getChallenge").mockResolvedValue(challenge);
+
+      // WHEN
+      await keyring.signTransaction("", {} as Transaction, {});
+
+      // THEN
+      expect(mockContextModule.getContexts).toHaveBeenCalledWith(expect.any(Object), {
+        challenge,
+        options: {},
+      });
+    });
+
+    it("should call app binding signTransaction", async () => {
+      // GIVEN
+      const transaction = {} as Transaction;
+      const derivationPath = "derivationPath";
+
+      // WHEN
+      await keyring.signTransaction(derivationPath, transaction, {});
+
+      // THEN
+      expect(mockAppBinding.signTransaction).toHaveBeenCalledWith(
+        derivationPath,
+        "c6808080808080",
+        null,
+      );
     });
   });
 });

--- a/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.test.ts
+++ b/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.test.ts
@@ -189,24 +189,6 @@ describe("DefaultKeyringEth", () => {
         );
         expect(result).toEqual({ r: "", s: "", v: 42 });
       });
-
-      it("should throw an error if the message is not a string", async () => {
-        // GIVEN
-        const message = {
-          message: { message: "message" },
-        } as unknown as EIP712Message;
-        const derivationPath = "derivationPath";
-
-        // WHEN
-        const promise = keyring.signMessage(derivationPath, message, {
-          method: "personalSign",
-        });
-
-        // THEN
-        await expect(promise).rejects.toThrow(
-          "[DefaultKeyringEth] signMessage: personalSign requires a string type for the message parameter",
-        );
-      });
     });
 
     describe("eip712", () => {
@@ -361,22 +343,6 @@ describe("DefaultKeyringEth", () => {
           "90418913cbd47e54cfb74964f7c7905cc502076a3d59974cfc2d79a16261df09",
         );
         expect(result).toEqual({ r: "", s: "", v: 42 });
-      });
-
-      it("should throw an error if the message is not an EIP712Params", async () => {
-        // GIVEN
-        const message = "message";
-        const derivationPath = "derivationPath";
-
-        // WHEN
-        const promise = keyring.signMessage(derivationPath, message, {
-          method: "eip712Hashed",
-        });
-
-        // THEN
-        await expect(promise).rejects.toThrow(
-          "[DefaultKeyringEth] signMessage: eip712Hashed requires an EIP712Params type for the message parameter",
-        );
       });
     });
   });

--- a/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.ts
+++ b/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.ts
@@ -1,5 +1,4 @@
 import { Transaction } from "ethers";
-import Transport from "@ledgerhq/hw-transport";
 import AppBinding from "@ledgerhq/hw-app-eth";
 import {
   EcdsaSignature,
@@ -10,12 +9,15 @@ import {
   SignTransactionOptions,
   GetAddressResult,
 } from "./KeyringEth";
+import { ContextModule } from "@ledgerhq/context-module/lib/ContextModule";
 
 export class DefaultKeyringEth implements KeyringEth {
   private _appBinding: AppBinding;
+  private _contextModule: ContextModule;
 
-  constructor(transport: Transport) {
-    this._appBinding = new AppBinding(transport);
+  constructor(appBinding: AppBinding, contextModule: ContextModule) {
+    this._appBinding = appBinding;
+    this._contextModule = contextModule;
   }
 
   public async signTransaction(

--- a/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.ts
+++ b/libs/ledgerjs/packages/keyring-eth/src/DefaultKeyringEth.ts
@@ -133,11 +133,26 @@ export class DefaultKeyringEth implements KeyringEth {
   }
 
   public async getAddress(
-    _derivationPath: string,
-    _options?: GetAddressOptions,
+    derivationPath: string,
+    options?: GetAddressOptions,
   ): Promise<GetAddressResult> {
-    // TODO: implement
-    return Promise.resolve({} as GetAddressResult);
+    const { address, publicKey } = await this._appBinding.getAddress(
+      derivationPath,
+      options?.displayOnDevice,
+      undefined,
+      options?.chainId,
+    );
+
+    if (!address.startsWith("0x") || !publicKey.startsWith("0x")) {
+      throw new Error("[DefaultKeyringEth] getAddress: Invalid address or public key");
+    }
+
+    const result: GetAddressResult = {
+      address: address as `0x${string}`,
+      publicKey: publicKey as `0x${string}`,
+    };
+
+    return result;
   }
 
   private isEIP712Params(message: unknown): message is EIP712Params {

--- a/libs/ledgerjs/packages/keyring-eth/src/KeyringEth.ts
+++ b/libs/ledgerjs/packages/keyring-eth/src/KeyringEth.ts
@@ -9,10 +9,13 @@ export type EIP712Params = { domainSeparator: `0x${string}`; hashStruct: `0x${st
 
 export type SignTransactionOptions = LoaderOptions["options"];
 
-export type SignMessagePayload = string | EIP712Message | EIP712Params;
-
-// TODO: reinforce the type of the options
-export type SignMessageOptions = { method: "personalSign" | "eip712" | "eip712Hashed" };
+export type SignMessageMethod = "personalSign" | "eip712" | "eip712Hashed";
+export type SignMessageOptions<Method extends SignMessageMethod> = { method: Method };
+export type SignMessageType<Method extends SignMessageMethod> = Method extends "personalSign"
+  ? string
+  : Method extends "eip712"
+    ? EIP712Message
+    : EIP712Params;
 
 export type GetAddressResult = {
   publicKey: string;
@@ -33,9 +36,9 @@ export interface KeyringEth extends Keyring {
     options: SignTransactionOptions,
   ): Promise<EcdsaSignature>;
 
-  signMessage(
+  signMessage<Method extends SignMessageMethod>(
     derivationPath: string,
-    message: SignMessagePayload,
-    options: SignMessageOptions,
+    message: SignMessageType<Method>,
+    options: SignMessageOptions<Method>,
   ): Promise<EcdsaSignature>;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Implement `signTransaction`, `signMessage` and `getAddress` for the new `keyring-eth` module.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [DSDK-277], [DSDK-279]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[DSDK-277]: https://ledgerhq.atlassian.net/browse/DSDK-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-279]: https://ledgerhq.atlassian.net/browse/DSDK-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ