### PR TITLE
chore(trustchain): library sdk development

### DIFF
--- a/apps/web-tools/trustchain/components/Actionable.tsx
+++ b/apps/web-tools/trustchain/components/Actionable.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState } from "react";
-import styled from "styled-components";
+import React, { useCallback, useEffect, useState } from "react";
+import styled, { keyframes } from "styled-components";
 
 const Label = styled.div`
   display: flex;
@@ -33,6 +33,23 @@ const Button = styled.button`
   padding: 10px;
 `;
 
+const rotate = keyframes`
+  from {transform: translate(-50%, -50%) rotate(0deg);}
+  to {transform: translate(-50%, -50%) rotate(360deg);}
+`;
+
+const Spinner = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 24px;
+  height: 24px;
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAAyVBMVEUAAAC9vsDCw8W9v8G9vsD29/fr7O29vsDm5+jx8fK/wML29vf///+9vsHR0tPm5+jt7u7w8PHr7Ozc3d7n6OnExcfGx8nJyszMzM7V1tjZ2tvf4OG9vsDHyMrp6uvIycu9v8HAwcTPz9HCw8W9vsC9vsDBwsTj5OXj5OXW19i9vsDm5+jw8PHy8vL09fW9vsDFxsjJyszAwsS9vsDU1dbLzM7Y2drb3N3c3d7e3+DHyMrBwsTh4uPR0tPDxcfa293R0tTV1ti9vsAll6RJAAAAQnRSTlMA7+t/MAZHQDYjHxABv6xSQjEgFgzi2M7Emop0cGVLD/ryt7Cfj3dmYWBgWjgsGd/Cv7SvopSSg4B6eHZrQjkyKx1dd0xhAAAA9klEQVR4AYWPeXOCMBBHFxIgCQKC3KCo1Wprtfd98/0/VBPb6TC0Wd+/783+ZqELrQkRoIMujFbiaLTwpESC029reB7919d7u6SgYaE8aUCivW84oEUY0lPQc408pxBqHxCIHGiw4Lxtl5h35ALFglouAAaZTj00OJ7NrvDANI/Q4PlQMDbNFA3ekiQRaHGRpmM0eMqyyxgLRlme4ydu8/n8Az3h+37xiRWv/k1RRlhxUtyVD8yCXwaDflHeP1Zr5sIey3WtfvFeVS+rTWAzFobhNhrFf4omWK03wcS2h8OzLd/1TyhiNvkJQu5amocjznm0i6HDF1RMG1aMA/PYAAAAAElFTkSuQmCC");
+  background-size: cover;
+  z-index: 1;
+  animation: ${rotate} 1s linear infinite;
+`;
+
 export function Actionable<I extends Array<unknown>, A>({
   inputs,
   action,
@@ -40,6 +57,7 @@ export function Actionable<I extends Array<unknown>, A>({
   buttonTitle,
   setValue,
   value,
+  children,
 }: {
   buttonTitle: string;
   // inputs or null if not enabled
@@ -51,10 +69,19 @@ export function Actionable<I extends Array<unknown>, A>({
   // in control style, we can provide a value and a setter
   value?: A | null;
   setValue?: (value: A | null) => void;
+  children?: React.ReactNode;
 }) {
   const enabled = !!inputs;
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // if value is set, error should disappear
+  useEffect(() => {
+    if (value !== null && value !== undefined) {
+      setError(null);
+    }
+  }, [value]);
+
   const onClick = useCallback(() => {
     if (!inputs) return;
     setLoading(true);
@@ -85,7 +112,9 @@ export function Actionable<I extends Array<unknown>, A>({
       onClick={onClick}
       display={display}
       buttonTitle={buttonTitle}
-    />
+    >
+      {children}
+    </RenderActionable>
   );
 }
 
@@ -96,6 +125,7 @@ export function RenderActionable({
   onClick,
   display,
   buttonTitle,
+  children,
 }: {
   enabled: boolean;
   error: Error | null;
@@ -103,14 +133,19 @@ export function RenderActionable({
   onClick: () => void;
   display: React.ReactNode | null;
   buttonTitle: string;
+  children?: React.ReactNode;
 }) {
   return (
     <Label>
-      <Button disabled={!enabled || loading} onClick={onClick}>
-        {buttonTitle}
-      </Button>
+      <span style={{ position: "relative" }}>
+        <Button disabled={!enabled || loading} onClick={onClick}>
+          {buttonTitle}
+        </Button>
+        {loading ? <Spinner /> : null}
+      </span>
       {display ? <ValueDisplay>{display}</ValueDisplay> : null}
       {error ? <ErrorDisplay>{error.message}</ErrorDisplay> : null}
+      {children}
     </Label>
   );
 }

--- a/apps/web-tools/trustchain/components/Expand.tsx
+++ b/apps/web-tools/trustchain/components/Expand.tsx
@@ -9,9 +9,17 @@ const Summary = styled.summary`
   cursor: pointer;
   font-weight: bold;
 `;
-export default function Expand({ title, children }: { title: string; children: React.ReactNode }) {
+export default function Expand({
+  title,
+  children,
+  expanded,
+}: {
+  title: string;
+  children: React.ReactNode;
+  expanded?: boolean;
+}) {
   return (
-    <Details>
+    <Details open={expanded}>
       <Summary>{title}</Summary>
       {children}
     </Details>

--- a/apps/web-tools/trustchain/components/IdentityManager.tsx
+++ b/apps/web-tools/trustchain/components/IdentityManager.tsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import { TrustchainSDKContext } from "@ledgerhq/trustchain/types";
+import { TrustchainStore, getInitialStore } from "@ledgerhq/trustchain/store";
+
+const IdentityDoc = styled.div`
+  margin: 10px;
+  color: #666;
+  font-style: italic;
+`;
+
+const IdentityLabel = styled.label`
+  display: block;
+  margin: 5px;
+`;
+
+export function memberNameForPubKey(pubkey: string): string {
+  return "debug-" + pubkey.slice(0, 6);
+}
+
+type Identities = { [_: string]: TrustchainStore };
+
+const initialObject: Identities = {};
+
+export function IdentityManager({
+  state,
+  setState,
+  defaultContext,
+  setContext,
+}: {
+  state: TrustchainStore;
+  setState: (s: TrustchainStore) => void;
+  defaultContext: TrustchainSDKContext;
+  setContext: (context: TrustchainSDKContext) => void;
+}) {
+  // any new state.liveCredentials?.pubkey will be considered a new identity to save
+  // this is the way we identify what is the current member in this list
+  // we save/update it by this key on the localStorage
+  const [identities, setIdentities] = useState(initialObject);
+  useEffect(() => {
+    if (typeof localStorage === "undefined") return;
+    const jsonIdentities = localStorage.getItem("identities");
+    const identities = jsonIdentities ? JSON.parse(jsonIdentities) : {};
+    setIdentities(identities);
+    // check from the url if we find an id
+    const url = new URL(window.location.href);
+    const id = url.searchParams.get("id");
+    if (id && identities[id]) {
+      setState(identities[id]);
+    }
+  }, [setState]);
+
+  // listen to "storage" event that could notify us another tab has changed the localStorage, merge the identities together
+  useEffect(() => {
+    const listener = (e: StorageEvent) => {
+      if (e.key === "identities" && e.storageArea === localStorage) {
+        setIdentities(JSON.parse(e.newValue || "{}"));
+      }
+    };
+    window.addEventListener("storage", listener);
+    return () => {
+      window.removeEventListener("storage", listener);
+    };
+  }, []);
+
+  const currentIdentityKey = state.liveCredentials?.pubkey;
+
+  // sync the current key to the uri query param with id=
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (currentIdentityKey) {
+      url.searchParams.set("id", currentIdentityKey);
+    } else {
+      url.searchParams.delete("id");
+    }
+    window.history.replaceState(null, "", url.toString());
+  }, [currentIdentityKey]);
+
+  // save state to localStorage when it changes, except on initial load
+  useEffect(() => {
+    if (identities !== initialObject) {
+      localStorage.setItem("identities", JSON.stringify(identities));
+    }
+  }, [identities]);
+
+  // update identifies when the state change
+  useEffect(() => {
+    if (currentIdentityKey) {
+      setIdentities(ids => ({ ...ids, [currentIdentityKey]: state }));
+    }
+  }, [currentIdentityKey, state]);
+
+  // always make the context reflects the selected identity
+  useEffect(() => {
+    if (currentIdentityKey) {
+      setContext({
+        applicationId: defaultContext.applicationId,
+        name: memberNameForPubKey(currentIdentityKey),
+      });
+    } else {
+      setContext(defaultContext);
+    }
+  }, [currentIdentityKey, setContext, defaultContext]);
+
+  const onSelectIdentity = useCallback(
+    (pubkey?: string) => {
+      setState((pubkey && identities[pubkey]) || getInitialStore());
+    },
+    [identities, setState],
+  );
+
+  const onRemoveIdentity = useCallback(
+    (pubkey: string) => {
+      setIdentities(ids => {
+        const newIds = { ...ids };
+        delete newIds[pubkey];
+        if (pubkey === currentIdentityKey) {
+          onSelectIdentity();
+        }
+        return newIds;
+      });
+    },
+    [setIdentities, onSelectIdentity, currentIdentityKey],
+  );
+
+  return (
+    <div>
+      <IdentityDoc>
+        This simulates different Live instance. localStorage is used to save to state on your
+        browser to be able to easily restore and switch member identities.
+      </IdentityDoc>
+
+      <div>
+        {Object.entries(identities).map(([pubkey, state]) => (
+          <IdentityLabel key={pubkey}>
+            <input
+              type="radio"
+              name="identity"
+              checked={pubkey === currentIdentityKey}
+              onChange={() => onSelectIdentity(pubkey)}
+            />{" "}
+            <strong>{memberNameForPubKey(pubkey)}</strong>{" "}
+            <button onClick={() => onRemoveIdentity(pubkey)}>Remove</button>
+          </IdentityLabel>
+        ))}
+        <IdentityLabel>
+          <input
+            type="radio"
+            name="identity"
+            checked={!currentIdentityKey}
+            onChange={() => onSelectIdentity()}
+          />{" "}
+          New Identity
+        </IdentityLabel>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-tools/trustchain/useSDK.ts
+++ b/apps/web-tools/trustchain/useSDK.ts
@@ -1,7 +1,0 @@
-import { getSdk } from "@ledgerhq/trustchain";
-import useEnv from "./useEnv";
-
-export default function useSDK() {
-  const mock = useEnv("MOCK");
-  return getSdk(!!mock);
-}

--- a/libs/hw-trustchain/README.md
+++ b/libs/hw-trustchain/README.md
@@ -27,46 +27,39 @@ Ledger Live trustchain hardware layer.
 *   [EditMember](#editmember)
     *   [Parameters](#parameters-6)
 *   [CloseStream](#closestream)
-*   [CommandBlock](#commandblock)
 *   [createCommandBlock](#createcommandblock)
     *   [Parameters](#parameters-7)
-*   [createCommandBlock](#createcommandblock-1)
-    *   [Parameters](#parameters-8)
-*   [signCommandBlock](#signcommandblock)
-    *   [Parameters](#parameters-9)
-*   [hashCommandBlock](#hashcommandblock)
-    *   [Parameters](#parameters-10)
-*   [verifyCommandBlock](#verifycommandblock)
-    *   [Parameters](#parameters-11)
 *   [CommandIssuer](#commandissuer)
 *   [CommandStreamIssuer](#commandstreamissuer)
-    *   [Parameters](#parameters-12)
+    *   [Parameters](#parameters-8)
 *   [CommandStream](#commandstream)
-    *   [Parameters](#parameters-13)
+    *   [Parameters](#parameters-9)
 *   [CommandStream](#commandstream-1)
 *   [Crypto](#crypto)
 *   [crypto](#crypto-1)
 *   [Device](#device)
     *   [isPublicKeyAvailable](#ispublickeyavailable)
     *   [readKey](#readkey)
-        *   [Parameters](#parameters-14)
+        *   [Parameters](#parameters-10)
 *   [createDevice](#createdevice)
 *   [CommandStreamJsonifier](#commandstreamjsonifier)
 *   [device](#device-1)
+*   [encryptUserData](#encryptuserdata)
+    *   [Parameters](#parameters-11)
 *   [ApplicationStreams](#applicationstreams)
 *   [StreamTreeCreateOpts](#streamtreecreateopts)
 *   [PublishKeyEvent](#publishkeyevent)
 *   [StreamTree](#streamtree)
-    *   [Parameters](#parameters-15)
+    *   [Parameters](#parameters-12)
     *   [share](#share)
-        *   [Parameters](#parameters-16)
+        *   [Parameters](#parameters-13)
 *   [StreamTreeCipherMode](#streamtreeciphermode)
 *   [StreamTreeCipher](#streamtreecipher)
-    *   [Parameters](#parameters-17)
+    *   [Parameters](#parameters-14)
     *   [encrypt](#encrypt)
-        *   [Parameters](#parameters-18)
+        *   [Parameters](#parameters-15)
     *   [decrypt](#decrypt)
-        *   [Parameters](#parameters-19)
+        *   [Parameters](#parameters-16)
 
 ### APDU
 
@@ -143,8 +136,6 @@ Returns **ApduDevice**&#x20;
 
 ### CloseStream
 
-### CommandBlock
-
 ### createCommandBlock
 
 Create a new command block.
@@ -156,44 +147,7 @@ Create a new command block.
 *   `signature` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)** The signature of the command block (by default the block is not signed) (optional, default `new Uint8Array()`)
 *   `parent` **([Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) | null)** The parent command block hash (if null, the block is the first block and a parent will be generated) (optional, default `null`)
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[CommandBlock](#commandblock)>**&#x20;
-
-### createCommandBlock
-
-#### Parameters
-
-*   `issuer` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
-*   `commands` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[Command](#command)>**&#x20;
-*   `signature` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**  (optional, default `new Uint8Array()`)
-*   `parent` **([Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) | null)**  (optional, default `null`)
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[CommandBlock](#commandblock)>**&#x20;
-
-### signCommandBlock
-
-#### Parameters
-
-*   `block` **[CommandBlock](#commandblock)**&#x20;
-*   `issuer` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
-*   `secretKey` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[CommandBlock](#commandblock)>**&#x20;
-
-### hashCommandBlock
-
-#### Parameters
-
-*   `block` **[CommandBlock](#commandblock)**&#x20;
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)>**&#x20;
-
-### verifyCommandBlock
-
-#### Parameters
-
-*   `block` **[CommandBlock](#commandblock)**&#x20;
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)>**&#x20;
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<CommandBlock>**&#x20;
 
 ### CommandIssuer
 
@@ -209,7 +163,7 @@ Type: function (device: [Device](#device), tempStream: [CommandStream](#commands
 
 #### Parameters
 
-*   `blocks` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[CommandBlock](#commandblock)>**  (optional, default `[]`)
+*   `blocks` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)\<CommandBlock>**  (optional, default `[]`)
 
 ### CommandStream
 
@@ -248,6 +202,26 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 **Extends Jsonifier**
 
 ### device
+
+### encryptUserData
+
+Ledger Live data are encrypted following pattern based on ECIES.
+For each encryption the Ledger Live instance generates a random keypair over secp256k1 (ephemeral public key)
+and a 16 bytes IV. Ledger Live then perform an ECDH between the command stream public key and
+the ephemeral private key to get the encryption key.
+The data is then encrypted using AES-256-GCM and serialized using the following format:
+1 byte : Version of the format (0x00)
+33 bytes : Compressed ephemeral public key
+16 bytes : Nonce/IV
+16 bytes : Tag/MAC (from AES-256-GCM)
+variable : Encrypted data
+
+#### Parameters
+
+*   `commandStreamPrivateKey` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
+*   `data` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)>**&#x20;
 
 ### ApplicationStreams
 

--- a/libs/hw-trustchain/src/CommandBlock.ts
+++ b/libs/hw-trustchain/src/CommandBlock.ts
@@ -181,9 +181,6 @@ export class CloseStream implements Command {
     ....
     Signature | SIG     | var   # Signature of the command block
 */
-/**
- *
- */
 export interface CommandBlock {
   // The version of the command block format
   version: number;
@@ -205,9 +202,6 @@ export interface CommandBlock {
  * @param parent The parent command block hash (if null, the block is the first block and a parent will be generated)
  * @returns
  */
-/**
- *
- */
 export async function createCommandBlock(
   issuer: Uint8Array,
   commands: Command[],
@@ -226,9 +220,6 @@ export async function createCommandBlock(
   };
 }
 
-/**
- *
- */
 export async function signCommandBlock(
   block: CommandBlock,
   issuer: Uint8Array,
@@ -244,16 +235,10 @@ export async function signCommandBlock(
   };
 }
 
-/**
- *
- */
 export async function hashCommandBlock(block: CommandBlock): Promise<Uint8Array> {
   return await crypto.hash(CommandStreamEncoder.encode([block]));
 }
 
-/**
- *
- */
 export async function verifyCommandBlock(block: CommandBlock): Promise<boolean> {
   const unsignedBlock = { ...block };
   unsignedBlock.signature = new Uint8Array();

--- a/libs/hw-trustchain/src/CommandStreamDecoder.ts
+++ b/libs/hw-trustchain/src/CommandStreamDecoder.ts
@@ -57,7 +57,9 @@ export const TLVCommandStreamDecoder = {
     const readGroupKey = TLV.readPublicKey(TLV.readTLV(buffer, readPath.offset));
     const readIV = TLV.readBytes(TLV.readTLV(buffer, readGroupKey.offset));
     const readEncryptedXpriv = TLV.readBytes(TLV.readTLV(buffer, readIV.offset));
-    const readEphemeralPublicKey = TLV.readBytes(TLV.readTLV(buffer, readEncryptedXpriv.offset));
+    const readEphemeralPublicKey = TLV.readPublicKey(
+      TLV.readTLV(buffer, readEncryptedXpriv.offset),
+    );
     return new Derive(
       readPath.value,
       readGroupKey.value,

--- a/libs/hw-trustchain/src/CommandStreamEncoder.ts
+++ b/libs/hw-trustchain/src/CommandStreamEncoder.ts
@@ -17,7 +17,7 @@ export const TLVCommandStreamEncoder = {
     if (b.topic) {
       object = TLV.pushBytes(object, b.topic);
     } else {
-      object = TLV.pushNull(object);
+      object = TLV.pushBytes(object, new Uint8Array(0));
     }
     object = TLV.pushInt16(object, b.protocolVersion);
     object = TLV.pushPublicKey(object, b.groupKey);

--- a/libs/hw-trustchain/src/Crypto.ts
+++ b/libs/hw-trustchain/src/Crypto.ts
@@ -31,6 +31,14 @@ export interface Crypto {
 export class DerivationPath {
   private constructor() {}
 
+  static hardenedIndex(index: number): number {
+    return index + 0x80000000;
+  }
+
+  static reverseHardenedIndex(index: number): number {
+    return index - 0x80000000;
+  }
+
   static toIndexArray(path: string | number[]): number[] {
     if (Array.isArray(path)) {
       return path;

--- a/libs/hw-trustchain/src/Device.ts
+++ b/libs/hw-trustchain/src/Device.ts
@@ -50,7 +50,7 @@ interface EncryptedSharedKey {
   initializationVector: Uint8Array;
 }
 
-export class SodiumDevice implements Device {
+export class SoftwareDevice implements Device {
   private keyPair: KeyPair;
 
   constructor(kp: KeyPair) {
@@ -234,7 +234,6 @@ export class SodiumDevice implements Device {
     }
 
     return sharedKey.xpriv;
-    //return crypto.computeSymmetricKey(sharedKey.xpriv.slice(0, 32), await tree.getRoot().getStreamPublicKey());
   }
 
   isPublicKeyAvailable(): boolean {
@@ -247,7 +246,7 @@ export class SodiumDevice implements Device {
  */
 export async function createDevice(): Promise<Device> {
   const kp = await crypto.randomKeypair();
-  return new SodiumDevice(kp);
+  return new SoftwareDevice(kp);
 }
 
 export const ISSUER_PLACEHOLDER = new Uint8Array([

--- a/libs/hw-trustchain/src/IndexedTree.ts
+++ b/libs/hw-trustchain/src/IndexedTree.ts
@@ -7,6 +7,10 @@ export class IndexedTree<T> {
     this.children = children;
   }
 
+  public getHighestIndex(): number {
+    return [...this.children.keys()].reduce((a, b) => Math.max(a, b), 0);
+  }
+
   public getChildren(): Map<number, IndexedTree<T>> {
     return this.children;
   }

--- a/libs/hw-trustchain/src/StreamTree.ts
+++ b/libs/hw-trustchain/src/StreamTree.ts
@@ -41,11 +41,17 @@ export class StreamTree {
     this.tree = tree;
   }
 
-  public getApplicationRootPath(applicationId: number): string {
-    // TODO implement with key rotation (currently always returns on roots 0h)
-    const treeRoot = "0h"; // TODO change this
-    const applicationRoot = "0h"; // TODO change this
-    return `${treeRoot}/${applicationId}h/${applicationRoot}`;
+  public getApplicationRootPath(applicationId: number, increment: number = 0): string {
+    // tree index is always 0 in the current implementation
+    const treeIndex = 0;
+    // for application index, we have key rotation that is possible so we need to find the last index
+    const child = this.tree
+      .getChild(DerivationPath.hardenedIndex(treeIndex))
+      ?.getChild(DerivationPath.hardenedIndex(applicationId));
+    const applicationIndex = child
+      ? DerivationPath.reverseHardenedIndex(child.getHighestIndex())
+      : 0;
+    return `${treeIndex}h/${applicationId}h/${applicationIndex + increment}h`;
   }
 
   public async getPublishKeyEvent(
@@ -89,15 +95,6 @@ export class StreamTree {
 
   public getRoot(): CommandStream {
     return this.tree.getValue()!;
-  }
-
-  public createApplicationStreams(
-    owner: Device,
-    applicationId: number,
-  ): Promise<ApplicationStreams> {
-    owner as Device;
-    applicationId as number;
-    throw new Error("Not implemented");
   }
 
   /**

--- a/libs/hw-trustchain/src/__tests__/codec.ts
+++ b/libs/hw-trustchain/src/__tests__/codec.ts
@@ -10,6 +10,7 @@ import { TLV } from "../tlv";
 import { CommandStreamDecoder } from "../CommandStreamDecoder";
 import { CommandStreamEncoder } from "../CommandStreamEncoder";
 import { crypto } from "../Crypto";
+import { CommandStream } from "..";
 
 describe("Encode/Decode command stream tester", () => {
   it("should encode and decode a byte", async () => {
@@ -126,5 +127,20 @@ describe("Encode/Decode command stream tester", () => {
     const reencoded = CommandStreamEncoder.encode(decoded);
     const digestReencoded = await crypto.hash(reencoded);
     expect(digestEncoded).toEqual(digestReencoded);
+  });
+
+  it("decodes a specific command stream", async () => {
+    const tlv =
+      "0101010220824b3168c79e8b61b599751c107117b5c9b647f2b6859de8a245952559707692062102a13e82cd0d2f77d1ab1434d8bd799571e54cd32e1121c5cf82217f8b0b713b6b01010315a8050c800000008000001080000000062103ccf74aa7775b3d39d6cbb0236acee7a7f980b9f6a556a4d814d44b0bd56cb77b05108c51eda6be26623ca919ed17333afcdb054019c0b60ede1692479cc04ce69eae6a0bd51941bab6f044f3dec10c11cf11e6253504d1df6b0aab7dc1996e4eaa7c6f92c29153c59534578901cd7ff4efcea1ae06210268abdb3d49ba4a274ce8660cde0d1eeaf1fea00e281218be775f6b3aefc39756113a040f7765622d746f6f6c732d6563626638062103a270456b0f95714cc61a6473e6b6d8db354a3c377281096bdd2439a5475ecbf80104ffffffff129a05100e5205b4a616b2a4d79b07b4a4932f560540669e741f38fee07956fb0dc0ea9978d55bd5d8424b0d0f66a2c5a45788f92d0ddc283138c7ba62c521de1d604ee7f847c5aed40a11536bbe742af0be8cfd4132062103a270456b0f95714cc61a6473e6b6d8db354a3c377281096bdd2439a5475ecbf80621027003755248202ea8a67d1fcdcd82d7f7022248f3af892fa5307d3ea250dc81050346304402204422a779fd08723d8cba19c0cc11ef7a24f6f1f459cb01598ff1a26f27ea8976022053a554d4f509223f2d08faa5de796fed13a9762f35da08e94884edd1f7c0d015";
+    const decoded = CommandStreamDecoder.decode(crypto.from_hex(tlv));
+    const stream = new CommandStream(decoded);
+    const resolved = await stream.resolve();
+    expect(resolved.getMembersData()).toEqual([
+      {
+        id: "03a270456b0f95714cc61a6473e6b6d8db354a3c377281096bdd2439a5475ecbf8",
+        name: "web-tools-ecbf8",
+        permissions: 4294967295,
+      },
+    ]);
   });
 });

--- a/libs/hw-trustchain/src/__tests__/key_exchange.ts
+++ b/libs/hw-trustchain/src/__tests__/key_exchange.ts
@@ -17,12 +17,7 @@ describe("Symmetric key exchange scenarii", () => {
     const resolved = await stream.resolve();
     expect(resolved.isCreated()).toBe(true);
     expect(resolved.getMembers().length).toBe(1);
-    expect(resolved.getMembersData().length).toBe(1);
-    expect(Object.keys(resolved.getMembersData()[0]).sort()).toEqual([
-      "name",
-      "permission",
-      "publicKey",
-    ]);
+    expect(resolved.getMembersData().length).toBe(0);
     expect(crypto.to_hex(resolved.getTopic()!)).toBe(crypto.to_hex(topic));
     //const parsed = CommandStreamDecoder.decode(CommandStreamEncoder.encode(stream.blocks));
     //console.log(JSON.stringify(CommandStreamJsonifier.jsonify(parsed), null, 2));

--- a/libs/hw-trustchain/src/index.ts
+++ b/libs/hw-trustchain/src/index.ts
@@ -1,4 +1,4 @@
-import { createDevice } from "./Device";
+import { createDevice, SoftwareDevice } from "./Device";
 import * as CS from "./CommandStream";
 import { createApduDevice } from "./ApduDevice";
 import Jsonifier from "./CommandStreamJsonifier";
@@ -6,14 +6,24 @@ import Jsonifier from "./CommandStreamJsonifier";
 export type { Device } from "./Device";
 export type { StreamTreeCipherMode } from "./StreamTreeCipher";
 export { StreamTreeCipher } from "./StreamTreeCipher";
-export { crypto } from "./Crypto";
+export { crypto, DerivationPath } from "./Crypto";
 export { PublicKey } from "./PublicKey";
 export type { CommandType, Command, CommandBlock } from "./CommandBlock";
-export { AddMember, CloseStream, Derive, EditMember, PublishKey, Seed } from "./CommandBlock";
+export {
+  AddMember,
+  CloseStream,
+  Derive,
+  EditMember,
+  PublishKey,
+  Seed,
+  Permissions,
+} from "./CommandBlock";
 export { APDU } from "./ApduDevice";
 export { CommandStreamEncoder } from "./CommandStreamEncoder";
 export { CommandStreamDecoder } from "./CommandStreamDecoder";
 export { Challenge, PubKeyCredential } from "./SeedId";
+export { StreamTree } from "./StreamTree";
+export { SoftwareDevice };
 
 /**
  *

--- a/libs/trustchain/README.md
+++ b/libs/trustchain/README.md
@@ -8,37 +8,54 @@ Ledger Live trustchain layer.
 
 #### Table of Contents
 
-*   [createQRCodeHostInstance](#createqrcodehostinstance)
+*   [getSdk](#getsdk)
     *   [Parameters](#parameters)
+*   [createQRCodeHostInstance](#createqrcodehostinstance)
+    *   [Parameters](#parameters-1)
 *   [onDisplayQRCode](#ondisplayqrcode)
 *   [onDisplayDigits](#ondisplaydigits)
 *   [addMember](#addmember)
 *   [createQRCodeCandidateInstance](#createqrcodecandidateinstance)
-    *   [Parameters](#parameters-1)
+    *   [Parameters](#parameters-2)
 *   [liveCredentials](#livecredentials)
+*   [memberName](#membername)
 *   [scannedUrl](#scannedurl)
 *   [onRequestQRCodeInput](#onrequestqrcodeinput)
 *   [LiveCredentials](#livecredentials-1)
-*   [](#)
 *   [TrustchainSDK](#trustchainsdk)
     *   [Examples](#examples)
     *   [initLiveCredentials](#initlivecredentials)
     *   [seedIdAuthenticate](#seedidauthenticate)
-        *   [Parameters](#parameters-2)
-    *   [liveAuthenticate](#liveauthenticate)
         *   [Parameters](#parameters-3)
-    *   [getOrCreateTrustchain](#getorcreatetrustchain)
+    *   [liveAuthenticate](#liveauthenticate)
         *   [Parameters](#parameters-4)
-    *   [restoreTrustchain](#restoretrustchain)
+    *   [getOrCreateTrustchain](#getorcreatetrustchain)
         *   [Parameters](#parameters-5)
-    *   [getMembers](#getmembers)
+    *   [restoreTrustchain](#restoretrustchain)
         *   [Parameters](#parameters-6)
-    *   [removeMember](#removemember)
+    *   [getMembers](#getmembers)
         *   [Parameters](#parameters-7)
-    *   [addMember](#addmember-1)
+    *   [removeMember](#removemember)
         *   [Parameters](#parameters-8)
-    *   [destroyTrustchain](#destroytrustchain)
+    *   [addMember](#addmember-1)
         *   [Parameters](#parameters-9)
+    *   [destroyTrustchain](#destroytrustchain)
+        *   [Parameters](#parameters-10)
+    *   [encryptUserData](#encryptuserdata)
+        *   [Parameters](#parameters-11)
+    *   [decryptUserData](#decryptuserdata)
+        *   [Parameters](#parameters-12)
+
+### getSdk
+
+Get an implementation of a TrustchainSDK
+
+#### Parameters
+
+*   `isMockEnv` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**&#x20;
+*   `context` **TrustchainSDKContext**&#x20;
+
+Returns **[TrustchainSDK](#trustchainsdk)**&#x20;
 
 ### createQRCodeHostInstance
 
@@ -46,7 +63,7 @@ establish a channel to be able to add a member to the trustchain after displayin
 
 #### Parameters
 
-*   `$0` **{onDisplayQRCode: function (url: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): void, onDisplayDigits: function (digits: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): void, addMember: function (publicKey: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>}**&#x20;
+*   `$0` **{onDisplayQRCode: function (url: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): void, onDisplayDigits: function (digits: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): void, addMember: function (member: TrustchainMember): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<Trustchain>}**&#x20;
 
     *   `$0.onDisplayQRCode` &#x20;
     *   `$0.onDisplayDigits` &#x20;
@@ -70,7 +87,7 @@ Type: function (digits: [string](https://developer.mozilla.org/docs/Web/JavaScri
 
 this function will need to using the TrustchainSDK (and use sdk.addMember)
 
-Type: function (publicKey: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>
+Type: function (member: TrustchainMember): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<Trustchain>
 
 ### createQRCodeCandidateInstance
 
@@ -78,19 +95,26 @@ establish a channel to be able to add myself to the trustchain after scanning th
 
 #### Parameters
 
-*   `$0` **{liveCredentials: [LiveCredentials](#livecredentials), scannedUrl: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), onRequestQRCodeInput: function (config: {digits: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), connected: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)}, callback: function (digits: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): void): void}**&#x20;
+*   `$0` **{liveCredentials: [LiveCredentials](#livecredentials), memberName: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), scannedUrl: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), onRequestQRCodeInput: function (config: {digits: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), connected: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)}, callback: function (digits: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)): void): void}**&#x20;
 
     *   `$0.liveCredentials` &#x20;
+    *   `$0.memberName` &#x20;
     *   `$0.scannedUrl` &#x20;
     *   `$0.onRequestQRCodeInput` &#x20;
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>** a promise that resolves when this is done
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<Trustchain>** a promise that resolves a Trustchain when this is done
 
 ### liveCredentials
 
 the live credentials of the live instance (given by TrustchainSDK)
 
 Type: [LiveCredentials](#livecredentials)
+
+### memberName
+
+the name of the member
+
+Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 ### scannedUrl
 
@@ -107,14 +131,10 @@ Type: function (config: {digits: [number](https://developer.mozilla.org/docs/Web
 
 ### LiveCredentials
 
-helpers to init and handle the trustchain store (what data are stored on instances)
-
-###
-
-TODO reducers with:
-clean action (disable this instance locally)
-init live credentials action
-lenses to get the live credentials and trustchain
+This exports all the logic related to the Trustchain store.
+The Trustchain store is a store that contains the data related to trustchain.
+It essentially is the ledger live's credentials that are only stored on the
+client side and the trustchain returned by the backend.
 
 ### TrustchainSDK
 
@@ -137,7 +157,8 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### seedIdAuthenticate
 
-Provide a token used to create/manage the trustchain at the root level, authenticated with the hardware wallet.
+Auth with a hardware wallet at the trustchain root level.
+The returned token will typically be used to create/manage the trustchain.
 
 ##### Parameters
 
@@ -147,7 +168,9 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### liveAuthenticate
 
-get a token that we can then use for Live credentials. (used for wallet sync)
+Auth with Live credentials.
+A trustchain must have been created and the Live instance must have been added as a member.
+The returned token will typically be used for regular operations like wallet sync.
 
 ##### Parameters
 
@@ -158,47 +181,46 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### getOrCreateTrustchain
 
-used by the trustchain setup flow
-
-*   create trustchain if not exists
-*   add yourself as member
-*   yield the trustchain
+This method will either create the required trustchains (root and application) or restore them.
+The returned trustchain will be initialized on the root level and also will have the branch derivation corresponding to the contextual applicationId.
+It will also have the wallet sync encryption key initialized.
+The latest jwt is also returned because it was potentially updated during the process.
 
 ##### Parameters
 
 *   `transport` **Transport**&#x20;
 *   `seedIdToken` **JWT**&#x20;
 *   `liveInstanceCredentials` **[LiveCredentials](#livecredentials)**&#x20;
+*   `topic` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)?**&#x20;
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<Trustchain>**&#x20;
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<{trustchain: Trustchain, jwt: JWT}>**&#x20;
 
 #### restoreTrustchain
 
-when the trustchain is not valid anymore, we will need to restore it (encryption key is no longer passing, typically during the live authenticate / wallet sync phases)
+Restore the current trustchain encryption key, typically due to a key rotation.
 
 ##### Parameters
 
 *   `liveJWT` **JWT**&#x20;
-*   `trustchain` **Trustchain**&#x20;
+*   `trustchainId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**&#x20;
 *   `liveInstanceCredentials` **[LiveCredentials](#livecredentials)**&#x20;
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<Trustchain>**&#x20;
 
 #### getMembers
 
-list the current members for a given trustchain.
+list the current members of the application trustchain
 
 ##### Parameters
 
 *   `liveJWT` **JWT**&#x20;
 *   `trustchain` **Trustchain**&#x20;
-*   `liveInstanceCredentials` **[LiveCredentials](#livecredentials)**&#x20;
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)\<TrustchainMember>>**&#x20;
 
 #### removeMember
 
-used by the managing synchronized instances flow
+remove a member from the application trustchain
 
 ##### Parameters
 
@@ -212,21 +234,20 @@ Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/
 
 #### addMember
 
-add a member to the trustchain
+add a member to the application trustchain
 
 ##### Parameters
 
-*   `transport` **Transport**&#x20;
-*   `seedIdToken` **JWT**&#x20;
+*   `liveJWT` **JWT**&#x20;
 *   `trustchain` **Trustchain**&#x20;
 *   `liveInstanceCredentials` **[LiveCredentials](#livecredentials)**&#x20;
 *   `member` **TrustchainMember**&#x20;
 
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<Trustchain>**&#x20;
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>**&#x20;
 
 #### destroyTrustchain
 
-completely remove a trustchain
+TBD
 
 ##### Parameters
 
@@ -234,3 +255,25 @@ completely remove a trustchain
 *   `liveJWT` **JWT**&#x20;
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<void>**&#x20;
+
+#### encryptUserData
+
+encrypt data with the trustchain encryption key
+
+##### Parameters
+
+*   `trustchain` **Trustchain**&#x20;
+*   `obj` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)**&#x20;
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)>**&#x20;
+
+#### decryptUserData
+
+decrypt data with the trustchain encryption key
+
+##### Parameters
+
+*   `trustchain` **Trustchain**&#x20;
+*   `data` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>**&#x20;

--- a/libs/trustchain/package.json
+++ b/libs/trustchain/package.json
@@ -59,6 +59,7 @@
     "@ledgerhq/live-network": "workspace:*",
     "@ledgerhq/live-env": "workspace:*",
     "@ledgerhq/errors": "workspace:*",
+    "@ledgerhq/logs": "workspace:*",
     "isomorphic-ws": "5",
     "ws": "8",
     "base64-js": "1"

--- a/libs/trustchain/src/api.ts
+++ b/libs/trustchain/src/api.ts
@@ -57,25 +57,28 @@ async function postChallengeResponse(request: {
     method: "POST",
     data: request,
   });
-  const jwt = {
+  return {
     accessToken: data.access_token,
   };
-  return jwt;
 }
 
 async function refreshAuth(jwt: JWT): Promise<JWT> {
-  const { data } = await network<JWT>({
+  const { data } = await network<APIJWT>({
     url: `${getEnv("TRUSTCHAIN_API")}/v1/refresh`,
     method: "GET",
     headers: {
       Authorization: `Bearer ${jwt.accessToken}`,
     },
   });
-  return data;
+  return {
+    accessToken: data.access_token,
+  };
 }
 
 export type TrustchainsResponse = {
-  [key: string]: unknown;
+  [trustchainId: string]: {
+    [path: string]: string[]; // list of permissions
+  };
 };
 
 async function getTrustchains(jwt: JWT): Promise<TrustchainsResponse> {
@@ -95,7 +98,7 @@ export type TrustchainResponse = {
 
 async function getTrustchain(jwt: JWT, trustchain_id: string): Promise<TrustchainResponse> {
   const { data } = await network<TrustchainResponse>({
-    url: `${getEnv("TRUSTCHAIN_API")}/v1/trustchain/${trustchain_id}`,
+    url: `${getEnv("TRUSTCHAIN_API")}/v1/trustchain/${encodeURIComponent(trustchain_id)}`,
     method: "GET",
     headers: {
       Authorization: `Bearer ${jwt.accessToken}`,
@@ -110,7 +113,7 @@ async function postDerivation(
   commandStream: string,
 ): Promise<void> {
   await network<void>({
-    url: `${getEnv("TRUSTCHAIN_API")}/v1/trustchain/${trustchain_id}/derivation`,
+    url: `${getEnv("TRUSTCHAIN_API")}/v1/trustchain/${encodeURIComponent(trustchain_id)}/derivation`,
     method: "POST",
     headers: {
       Authorization: `Bearer ${jwt.accessToken}`,
@@ -143,7 +146,7 @@ async function putCommands(
   request: PutCommandsRequest,
 ): Promise<void> {
   await network<void>({
-    url: `${getEnv("TRUSTCHAIN_API")}/v1/trustchain/${trustchain_id}/commands`,
+    url: `${getEnv("TRUSTCHAIN_API")}/v1/trustchain/${encodeURIComponent(trustchain_id)}/commands`,
     method: "PUT",
     headers: {
       Authorization: `Bearer ${jwt.accessToken}`,

--- a/libs/trustchain/src/index.ts
+++ b/libs/trustchain/src/index.ts
@@ -1,5 +1,9 @@
-import { sdk as normalSdk } from "./sdk";
+import { SDK } from "./sdk";
 import { mockSdk } from "./mockSdk";
-import { TrustchainSDK } from "./types";
+import { TrustchainSDKContext, TrustchainSDK } from "./types";
 
-export const getSdk = (isMockEnv: boolean): TrustchainSDK => (isMockEnv ? mockSdk : normalSdk);
+/**
+ * Get an implementation of a TrustchainSDK
+ */
+export const getSdk = (isMockEnv: boolean, context: TrustchainSDKContext): TrustchainSDK =>
+  isMockEnv ? mockSdk : new SDK(context);

--- a/libs/trustchain/src/qrcode/cipher.ts
+++ b/libs/trustchain/src/qrcode/cipher.ts
@@ -36,7 +36,6 @@ export function makeCipher(sessionEncryptionKey: Uint8Array): Cipher {
       const text = new TextDecoder().decode(plaintext);
       return JSON.parse(text);
     } catch (e) {
-      console.error(e);
       throw new InvalidEncryptionKeyError("data can't be decrypted");
     }
   }

--- a/libs/trustchain/src/qrcode/index.test.ts
+++ b/libs/trustchain/src/qrcode/index.test.ts
@@ -35,7 +35,11 @@ describe("Trustchain QR Code", () => {
 
   test("digits matching scenario", async () => {
     const onDisplayDigits = jest.fn();
-    const addMember = jest.fn(() => Promise.resolve());
+    const trustchain = {
+      rootId: "test-root-id",
+      walletSyncEncryptionKey: "test-wallet-sync-encryption-key",
+    };
+    const addMember = jest.fn(() => Promise.resolve(trustchain));
     const liveCredentials = convertKeyPairToLiveCredentials(await crypto.randomKeypair());
 
     let scannedUrlResolve: (url: string) => void;
@@ -65,7 +69,7 @@ describe("Trustchain QR Code", () => {
       onRequestQRCodeInput,
     });
 
-    await Promise.all([hostP, candidateP]);
+    const [_, res] = await Promise.all([hostP, candidateP]);
 
     expect(onDisplayDigits).toHaveBeenCalledWith(expect.any(String));
     expect(addMember).toHaveBeenCalled();
@@ -73,5 +77,6 @@ describe("Trustchain QR Code", () => {
       { digits: 3, connected: false },
       expect.any(Function),
     );
+    expect(res).toEqual(trustchain);
   });
 });

--- a/libs/trustchain/src/qrcode/types.ts
+++ b/libs/trustchain/src/qrcode/types.ts
@@ -1,3 +1,5 @@
+import { Trustchain } from "../types";
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type Encrypted<T> = {
   encrypted: string;
@@ -48,7 +50,9 @@ export type Message =
       version: number;
       publisher: string;
       message: "TrustchainAddedMember";
-      payload: Encrypted<Record<string, never>>;
+      payload: Encrypted<{
+        trustchain: Trustchain;
+      }>;
     };
 
 export type DecryptedPayload<M> = M extends { payload: Encrypted<infer T> }

--- a/libs/trustchain/src/sdk.test.ts
+++ b/libs/trustchain/src/sdk.test.ts
@@ -1,7 +1,8 @@
 import { crypto } from "@ledgerhq/hw-trustchain";
-import { sdk } from "./sdk";
+import { getSdk } from ".";
 
 test("encryptUserData + decryptUserData", async () => {
+  const sdk = getSdk(false, { applicationId: 16, name: "test" });
   const obj = {
     foobar: 42,
     toto: "tata",

--- a/libs/trustchain/src/sdk.ts
+++ b/libs/trustchain/src/sdk.ts
@@ -1,37 +1,42 @@
-import { JWT, LiveCredentials, Trustchain, TrustchainMember, TrustchainSDK } from "./types";
-import { crypto, device, Challenge } from "@ledgerhq/hw-trustchain";
+import {
+  JWT,
+  LiveCredentials,
+  TrustchainSDKContext,
+  Trustchain,
+  TrustchainMember,
+  TrustchainSDK,
+} from "./types";
+import {
+  crypto,
+  device,
+  Challenge,
+  CommandStream,
+  CommandStreamEncoder,
+  CommandStreamDecoder,
+  StreamTree,
+  Permissions,
+  DerivationPath,
+  SoftwareDevice,
+  Device,
+} from "@ledgerhq/hw-trustchain";
 import Transport from "@ledgerhq/hw-transport";
 import api from "./api";
 import { KeyPair as CryptoKeyPair } from "@ledgerhq/hw-trustchain/Crypto";
 import { makeCipher } from "./wallet-sync-cipher";
+import { log } from "@ledgerhq/logs";
 
-export function convertKeyPairToLiveCredentials(keyPair: CryptoKeyPair): LiveCredentials {
-  return {
-    pubkey: crypto.to_hex(keyPair.publicKey),
-    privatekey: crypto.to_hex(keyPair.privateKey),
-  };
-}
+export class SDK implements TrustchainSDK {
+  context: TrustchainSDKContext;
 
-export function convertLiveCredentialsToKeyPair(
-  liveInstanceCredentials: LiveCredentials,
-): CryptoKeyPair {
-  return {
-    publicKey: crypto.from_hex(liveInstanceCredentials.pubkey),
-    privateKey: crypto.from_hex(liveInstanceCredentials.privatekey),
-  };
-}
+  constructor(context: TrustchainSDKContext) {
+    this.context = context;
+  }
 
-class SDK implements TrustchainSDK {
   async initLiveCredentials(): Promise<LiveCredentials> {
     const kp = await crypto.randomKeypair();
     return convertKeyPairToLiveCredentials(kp);
   }
 
-  /*
-   * - get challenge
-   * - send to the device to sign it
-   * - post challenge, and get an JWT
-   */
   async seedIdAuthenticate(transport: Transport): Promise<JWT> {
     const hw = device.apdu(transport);
     const challenge = await api.getAuthenticationChallenge();
@@ -66,12 +71,12 @@ class SDK implements TrustchainSDK {
       signAlgorithm: 1,
       publicKey: liveInstanceCredentials.pubkey,
     };
-    const trustchainId = crypto.from_hex(trustchain.rootId);
+    const trustchainId = new TextEncoder().encode(trustchain.rootId);
     const att = new Uint8Array(2 + trustchainId.length);
-    att[0] = 0x01;
+    att[0] = 0x02;
     att[1] = trustchainId.length;
     att.set(trustchainId, 2);
-    const attestation = crypto.to_hex(data);
+    const attestation = crypto.to_hex(att);
     const response = await api.postChallengeResponse({
       challenge: challenge.json,
       signature: {
@@ -87,33 +92,100 @@ class SDK implements TrustchainSDK {
     transport: Transport,
     seedIdToken: JWT,
     liveInstanceCredentials: LiveCredentials,
-  ): Promise<Trustchain> {
-    void transport;
-    void seedIdToken;
-    void liveInstanceCredentials;
-    throw new Error("getOrCreateTrustchain not implemented.");
+    topic?: Uint8Array,
+  ): Promise<{
+    jwt: JWT;
+    trustchain: Trustchain;
+  }> {
+    const hw = device.apdu(transport);
+    let jwt = seedIdToken;
+    let trustchains = await api.getTrustchains(jwt);
+
+    if (Object.keys(trustchains).length === 0) {
+      log("trustchain", "getOrCreateTrustchain: no trustchain yet, let's create one");
+      const streamTree = await StreamTree.createNewTree(hw, { topic });
+      await streamTree.getRoot().resolve(); // double checks the signatures are correct before sending to the backend
+      const commandStream = CommandStreamEncoder.encode(streamTree.getRoot().blocks);
+      await api.postSeed(jwt, crypto.to_hex(commandStream));
+      jwt = await api.refreshAuth(jwt);
+      trustchains = await api.getTrustchains(jwt);
+    }
+
+    // we find our trustchain root id
+    let trustchainRootId: string | undefined;
+    const trustchainRootPath = "m/";
+    for (const [trustchainId, info] of Object.entries(trustchains)) {
+      for (const path in info) {
+        if (path === trustchainRootPath) {
+          trustchainRootId = trustchainId;
+        }
+      }
+    }
+    if (!trustchainRootId) {
+      throw new Error("can't find the trustchain root id");
+    }
+
+    // make a stream tree from all the trustchains associated to this root id
+    let { streamTree } = await fetchTrustchain(jwt, trustchainRootId);
+
+    const path = streamTree.getApplicationRootPath(this.context.applicationId);
+    const child = streamTree.getChild(path);
+    let shouldShare = true;
+    if (child) {
+      const resolved = await child.resolve();
+      const members = resolved.getMembers();
+      shouldShare = !members.some(m => crypto.to_hex(m) === liveInstanceCredentials.pubkey); // not already a member
+    }
+    if (shouldShare) {
+      streamTree = await pushMember(streamTree, path, trustchainRootId, jwt, hw, {
+        id: liveInstanceCredentials.pubkey,
+        name: this.context.name,
+        permissions: Permissions.OWNER,
+      });
+    }
+
+    const walletSyncEncryptionKey = await extractEncryptionKey(
+      streamTree,
+      path,
+      liveInstanceCredentials,
+    );
+
+    const trustchain = {
+      rootId: trustchainRootId,
+      walletSyncEncryptionKey,
+    };
+
+    return { jwt, trustchain };
   }
 
   async restoreTrustchain(
     liveJWT: JWT,
-    trustchain: Trustchain,
+    trustchainId: string,
     liveInstanceCredentials: LiveCredentials,
   ): Promise<Trustchain> {
-    void liveJWT;
-    void trustchain;
-    void liveInstanceCredentials;
-    throw new Error("restoreTrustchain not implemented.");
+    const { streamTree, applicationRootPath } = await fetchTrustchainAndResolve(
+      liveJWT,
+      trustchainId,
+      this.context.applicationId,
+    );
+    const walletSyncEncryptionKey = await extractEncryptionKey(
+      streamTree,
+      applicationRootPath,
+      liveInstanceCredentials,
+    );
+    return {
+      rootId: trustchainId,
+      walletSyncEncryptionKey,
+    };
   }
 
-  async getMembers(
-    liveJWT: JWT,
-    trustchain: Trustchain,
-    liveInstanceCredentials: LiveCredentials,
-  ): Promise<TrustchainMember[]> {
-    void liveJWT;
-    void trustchain;
-    void liveInstanceCredentials;
-    throw new Error("getMembers not implemented.");
+  async getMembers(liveJWT: JWT, trustchain: Trustchain): Promise<TrustchainMember[]> {
+    const { resolved } = await fetchTrustchainAndResolve(
+      liveJWT,
+      trustchain.rootId,
+      this.context.applicationId,
+    );
+    return resolved.getMembersData();
   }
 
   async removeMember(
@@ -122,26 +194,82 @@ class SDK implements TrustchainSDK {
     trustchain: Trustchain,
     liveInstanceCredentials: LiveCredentials,
     member: TrustchainMember,
-  ): Promise<Trustchain> {
-    void transport;
-    void seedIdToken;
-    void trustchain;
-    void liveInstanceCredentials;
-    void member;
-    throw new Error("removeMember not implemented.");
+  ): Promise<{
+    jwt: JWT;
+    trustchain: Trustchain;
+  }> {
+    const hw = device.apdu(transport);
+    const applicationId = this.context.applicationId;
+    const trustchainId = trustchain.rootId;
+    const m = await fetchTrustchainAndResolve(seedIdToken, trustchainId, applicationId);
+    const members = m.resolved.getMembersData();
+    const withoutMember = members.filter(m => m.id !== member.id);
+    if (members.length === withoutMember.length) {
+      throw new Error("member not found");
+    }
+    const withoutMemberOrMe = withoutMember.filter(m => m.id !== liveInstanceCredentials.pubkey);
+    const softwareDevice = getSoftwareDevice(liveInstanceCredentials);
+
+    let { streamTree } = m;
+    const newPath = streamTree.getApplicationRootPath(applicationId, 1);
+
+    // derive a new branch of the tree on the new path
+    streamTree = await pushMember(streamTree, newPath, trustchainId, seedIdToken, hw, {
+      id: liveInstanceCredentials.pubkey,
+      name: this.context.name,
+      permissions: Permissions.OWNER,
+    });
+
+    // add the remaining members
+    for (const m of withoutMemberOrMe) {
+      streamTree = await pushMember(
+        streamTree,
+        newPath,
+        trustchainId,
+        seedIdToken,
+        softwareDevice,
+        m,
+      );
+    }
+    const walletSyncEncryptionKey = await extractEncryptionKey(
+      streamTree,
+      newPath,
+      liveInstanceCredentials,
+    );
+
+    // TODO close previous node
+
+    const jwt = await api.refreshAuth(seedIdToken);
+
+    return {
+      jwt,
+      trustchain: {
+        rootId: trustchainId,
+        walletSyncEncryptionKey,
+      },
+    };
   }
 
   async addMember(
     liveJWT: JWT,
     trustchain: Trustchain,
     liveInstanceCredentials: LiveCredentials,
-    memberPublicKey: TrustchainMember,
-  ): Promise<Trustchain> {
-    void liveJWT;
-    void trustchain;
-    void liveInstanceCredentials;
-    void memberPublicKey;
-    throw new Error("addMember not implemented.");
+    member: TrustchainMember,
+  ): Promise<void> {
+    const { streamTree, applicationRootPath } = await fetchTrustchainAndResolve(
+      liveJWT,
+      trustchain.rootId,
+      this.context.applicationId,
+    );
+    const softwareDevice = getSoftwareDevice(liveInstanceCredentials);
+    await pushMember(
+      streamTree,
+      applicationRootPath,
+      trustchain.rootId,
+      liveJWT,
+      softwareDevice,
+      member,
+    );
   }
 
   async destroyTrustchain(trustchain: Trustchain, liveJWT: JWT): Promise<void> {
@@ -163,4 +291,102 @@ class SDK implements TrustchainSDK {
   }
 }
 
-export const sdk = new SDK();
+export function convertKeyPairToLiveCredentials(keyPair: CryptoKeyPair): LiveCredentials {
+  return {
+    pubkey: crypto.to_hex(keyPair.publicKey),
+    privatekey: crypto.to_hex(keyPair.privateKey),
+  };
+}
+
+export function convertLiveCredentialsToKeyPair(
+  liveInstanceCredentials: LiveCredentials,
+): CryptoKeyPair {
+  return {
+    publicKey: crypto.from_hex(liveInstanceCredentials.pubkey),
+    privateKey: crypto.from_hex(liveInstanceCredentials.privatekey),
+  };
+}
+
+function getSoftwareDevice(liveInstanceCredentials: LiveCredentials): SoftwareDevice {
+  const kp = convertLiveCredentialsToKeyPair(liveInstanceCredentials);
+  return new SoftwareDevice(kp);
+}
+
+async function fetchTrustchain(liveJWT: JWT, trustchainId: string) {
+  const trustchainData = await api.getTrustchain(liveJWT, trustchainId);
+  const streams = Object.values(trustchainData).map(
+    data => new CommandStream(CommandStreamDecoder.decode(crypto.from_hex(data))),
+  );
+  const streamTree = StreamTree.from(...streams);
+  return { streamTree };
+}
+
+async function fetchTrustchainAndResolve(
+  liveJWT: JWT,
+  trustchainId: string,
+  applicationId: number,
+) {
+  const { streamTree } = await fetchTrustchain(liveJWT, trustchainId);
+  const applicationRootPath = streamTree.getApplicationRootPath(applicationId);
+  const applicationNode = streamTree.getChild(applicationRootPath);
+  if (!applicationNode) {
+    throw new Error("could not find the application stream.");
+  }
+  const resolved = await applicationNode.resolve();
+  return { resolved, streamTree, applicationRootPath, applicationNode };
+}
+
+async function extractEncryptionKey(
+  streamTree: StreamTree,
+  path: string,
+  liveInstanceCredentials: LiveCredentials,
+): Promise<string> {
+  const softwareDevice = getSoftwareDevice(liveInstanceCredentials);
+  const pathNumbers = DerivationPath.toIndexArray(path);
+  const key = await softwareDevice.readKey(streamTree, pathNumbers);
+  // private key is in the first 32 bytes
+  return crypto.to_hex(key.slice(0, 32));
+}
+
+async function pushMember(
+  streamTree: StreamTree,
+  path: string,
+  trustchainId: string,
+  jwt: JWT,
+  hw: Device,
+  member: TrustchainMember,
+) {
+  const isNewDerivation = !streamTree.getChild(path);
+  streamTree = await streamTree.share(
+    path,
+    hw,
+    crypto.from_hex(member.id),
+    member.name,
+    member.permissions,
+  );
+  const child = streamTree.getChild(path);
+  if (!child) {
+    throw new Error("StreamTree.share failed to create the child stream.");
+  }
+  await child.resolve(); // double checks the signatures are correct before sending to the backend
+  if (isNewDerivation) {
+    const commandStream = CommandStreamEncoder.encode(child.blocks);
+    await api.postDerivation(jwt, trustchainId, crypto.to_hex(commandStream));
+  } else {
+    const commandStream = CommandStreamEncoder.encode([child.blocks[child.blocks.length - 1]]);
+    await api.putCommands(jwt, trustchainId, {
+      path: shortenPath(path), // FIXME temporary until backend make it explicit?
+      blocks: [crypto.to_hex(commandStream)],
+    });
+  }
+  return streamTree;
+}
+
+function shortenPath(path: string): string {
+  // 0'/16'/1' -> 16'
+  const parts = path.split("/");
+  return parts
+    .map((v, i) => (i % 2 === 1 ? v : ""))
+    .filter(Boolean)
+    .join("/");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5422,6 +5422,9 @@ importers:
       '@ledgerhq/live-network':
         specifier: workspace:*
         version: link:../live-network
+      '@ledgerhq/logs':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/logs
       base64-js:
         specifier: '1'
         version: 1.5.1
@@ -51103,7 +51106,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0
+      jest: 29.7.0(ts-node@10.9.2)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached : no need, lib dev in progress
- [x] **Covered by automatic tests.**  unit tested. for the end 2 end flow, we have the web tools to test tho. <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact for end user at the moment (library development)

### 📝 Description

**improvements in hw-trustchain library**

- fixes `CommandStreamDecoder` on the `readDeriveCommand`
- fixes `CommandStreamEncoder` on the `topic` field (null -> empty bytes)
- refine `CommandStreamResolver#getMembersData()` method. The `MemberData` is now an `{id, name, permissions}` object.
- rename `SodiumDevice` to `SoftwareDevice`
- `IndexedTree#getHighestIndex` added
- improve `StreamTree#getApplicationRootPath` to support key rotation and also offer a way to ask for an increment (to perform a rotation)
- added more tests.
- exported more objects on the main index.ts.

**improvements in trustchain library (sdk)**

- Introduce `TrustchainSDKContext` in order to contain all contextual information the SDK needs. it must be passed to `getSdk(isMocked, context)`.

```typescript
type TrustchainSDKContext = {
  applicationId: number;
  name: string;
};
```

- implements `getOrCreateTrustchain` and `getMembers` (LIVE-12627)
  - method signature change: getMembers no longer need to take live credentials
  - method signature change: `getOrCreateTrustchain` now also returns the jwt because it may have been refreshed.
- implements `restoreTrustchain`.
  - method signature change: it takes a trustchainId instead of a trustchain for a more canonical api. (the concept is that you need to restore the encryption key so we only need the trustchain id here)
- implements `liveAuthenticate` (LIVE-12769)
- implements `removeMember` (LIVE-12628)
- implements `addMember` (LIVE-12864)
- fixes api.ts
  - uri encode the trustchain id
  - refreshAuth fix

**QR Code Sync protocol changes**

- improve the protocol: the host needs to tell the candidate what the Trustchain is, so it will send an encrypted `{trustchain}` object on the last message. that way, the candidate is fully ready for the next steps.

**web tools development improvements**

- add identity management, so you can easily switch between identities. (cross tab support and bookmarkable urls)
- improve UX (buttons show a spinner on activation, refine the expanded)
- Add a way to test `restoreTrustchain`

**others**

- JS Doc improvement

<img width="937" alt="Capture d’écran 2024-06-11 à 12 15 28" src="https://github.com/LedgerHQ/ledger-live/assets/211411/26556c65-829e-4875-beab-d59216cb33a6">


### ❓ Context

- **JIRA or GitHub link**: [live-12612](https://ledgerhq.atlassian.net/browse/LIVE-12612)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
