### PR TITLE
fix(live-common/exchange): fix CAL service integration

### DIFF
--- a/.changeset/stale-comics-own.md
+++ b/.changeset/stale-comics-own.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix crypto-assets-service integration using wrong URL

--- a/libs/ledger-live-common/src/exchange/providers/swap.ts
+++ b/libs/ledger-live-common/src/exchange/providers/swap.ts
@@ -1,6 +1,6 @@
 import { ExchangeProviderNameAndSignature } from ".";
 import { isIntegrationTestEnv } from "../swap/utils/isIntegrationTestEnv";
-import PACKAGE from "../../../package.json";
+import network from "@ledgerhq/live-network";
 
 export type SwapProviderConfig = {
   needsKYC: boolean;
@@ -140,17 +140,13 @@ function transformData(providersData) {
 
 export const getProvidersData = async () => {
   try {
-    const providersData = await (
-      await fetch(
-        "https://crypto-assets-service.api.ledger.com/v1/partners?output=name,signature,public_key,public_key_curve&service_name=swap",
-        {
-          headers: {
-            "X-Ledger-Client-Version": `live-exchange/${PACKAGE.version}`,
-          },
-        },
-      )
-    ).json();
-    return providersData;
+    const providersData = await network({
+      url:
+        "https://crypto-assets-service.api.ledger.com/v1/partners" +
+        "?output=name,signature,public_key,public_key_curve" +
+        "&service_name=swap",
+    });
+    return providersData.data;
   } catch {
     return swapProviders;
   }
@@ -158,10 +154,10 @@ export const getProvidersData = async () => {
 
 export const getProvidersCDNData = async () => {
   try {
-    const providersData = await (
-      await fetch("https://cdn.live.ledger.com/swap-providers/data.json")
-    ).json();
-    return providersData;
+    const providersData = await network({
+      url: "https://cdn.live.ledger.com/swap-providers/data.json",
+    });
+    return providersData.data;
   } catch {
     return swapAdditionData;
   }

--- a/libs/ledger-live-common/src/exchange/providers/swap.ts
+++ b/libs/ledger-live-common/src/exchange/providers/swap.ts
@@ -1,5 +1,6 @@
 import { ExchangeProviderNameAndSignature } from ".";
 import { isIntegrationTestEnv } from "../swap/utils/isIntegrationTestEnv";
+import PACKAGE from "../../../package.json";
 
 export type SwapProviderConfig = {
   needsKYC: boolean;
@@ -141,7 +142,12 @@ export const getProvidersData = async () => {
   try {
     const providersData = await (
       await fetch(
-        "https://crypto-assets-service.api.aws.prd.ldg-tech.com/v1/partners?output=name,payload_signature_computed_format,signature,public_key,public_key_curve",
+        "https://crypto-assets-service.api.ledger.com/v1/partners?output=name,signature,public_key,public_key_curve&service_name=swap",
+        {
+          headers: {
+            "X-Ledger-Client-Version": `live-exchange/${PACKAGE.version}`,
+          },
+        },
       )
     ).json();
     return providersData;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] not covered by automatic tests =>  isofonctional change
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - swap pane

### 📝 Description

Followup of #6853:
- fix internal URL used, bypassing Cloudflare cache
- fix unused field requested
- limit request to swap partners
- add `X-Ledger-Client-Version` header for monitoring

![image](https://github.com/LedgerHQ/ledger-live/assets/102984500/4363ae94-a21a-4c87-b424-5304bd797986)

I did not fix in this PR:
- partners data is requested again at every refresh. It is loaded from disk cache but still seems unnecessary and will cause extra backend load if cache does not work
- I am not sure if using `fetch()` is the preferred way in Ledger Live. Other parts of Ledger Live use `network` shared lib that sets the `X-Ledger-Client-Version` header we need for monitoring: https://github.com/LedgerHQ/ledger-live/blob/develop/libs/live-network/src/network.ts#L251

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
