### PR TITLE
feat(hw-trustchain): add getMembersData

### DIFF
--- a/libs/hw-trustchain/src/__tests__/key_exchange.ts
+++ b/libs/hw-trustchain/src/__tests__/key_exchange.ts
@@ -17,6 +17,12 @@ describe("Symmetric key exchange scenarii", () => {
     const resolved = await stream.resolve();
     expect(resolved.isCreated()).toBe(true);
     expect(resolved.getMembers().length).toBe(1);
+    expect(resolved.getMembersData().length).toBe(1);
+    expect(Object.keys(resolved.getMembersData()[0]).sort()).toEqual([
+      "name",
+      "permission",
+      "publicKey",
+    ]);
     expect(crypto.to_hex(resolved.getTopic()!)).toBe(crypto.to_hex(topic));
     //const parsed = CommandStreamDecoder.decode(CommandStreamEncoder.encode(stream.blocks));
     //console.log(JSON.stringify(CommandStreamJsonifier.jsonify(parsed), null, 2));


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - hw-trustchain lib only

### 📝 Description

have a way to access the members name and permission information

it will be needed for https://ledgerhq.atlassian.net/browse/LIVE-12628

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12842


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
