### PR TITLE
refactor(lld): tableLayout logic move inside newArch

### DIFF
--- a/.changeset/nine-mayflies-jog.md
+++ b/.changeset/nine-mayflies-jog.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Move tableLayout logic inside newArch for collectibles

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutContainer.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutContainer.tsx
@@ -2,10 +2,11 @@ import React, { memo, ReactNode } from "react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import useLayout from "LLD/Collectibles/hooks/useLayout";
+import { Layout, LayoutKey } from "LLD/Collectibles/types/Layouts";
 
 const Container = styled(Box).attrs<{
-  mode?: "grid" | "list";
-}>({})<{ mode: "grid" | "list" }>`
+  mode?: Layout;
+}>({})<{ mode: LayoutKey }>`
   display: ${p => (p.mode === "list" ? "flex" : "grid")};
   grid-gap: ${p => (p.mode === "list" ? 10 : 18)}px;
   grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutContainer.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutContainer.tsx
@@ -1,0 +1,26 @@
+import React, { memo, ReactNode } from "react";
+import styled from "styled-components";
+import Box from "~/renderer/components/Box";
+import useLayout from "LLD/Collectibles/hooks/useLayout";
+
+const Container = styled(Box).attrs<{
+  mode?: "grid" | "list";
+}>({})<{ mode: "grid" | "list" }>`
+  display: ${p => (p.mode === "list" ? "flex" : "grid")};
+  grid-gap: ${p => (p.mode === "list" ? 10 : 18)}px;
+  grid-template-columns: repeat(auto-fill, minmax(235px, 1fr));
+  margin-bottom: 20px;
+`;
+
+type LayoutContainerProps = {
+  children: ReactNode;
+};
+
+const LayoutContainerComponent: React.FC<LayoutContainerProps> = ({
+  children,
+}: LayoutContainerProps) => {
+  const { collectiblesViewMode } = useLayout();
+  return <Container mode={collectiblesViewMode}>{children}</Container>;
+};
+
+export const LayoutContainer = memo(LayoutContainerComponent);

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutToggle.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutToggle.tsx
@@ -5,7 +5,7 @@ import Button from "~/renderer/components/Button";
 import GridIcon from "~/renderer/icons/Grid";
 import ListIcon from "~/renderer/icons/List";
 import useLayout from "LLD/Collectibles/hooks/useLayout";
-import { LayoutsEnum, LayoutKey } from "LLD/Collectibles/types/Layouts";
+import { Layout, LayoutKey } from "LLD/Collectibles/types/Layouts";
 
 const ToggleButton = styled(Button).attrs<{
   active?: boolean;
@@ -25,17 +25,10 @@ const TableLayoutToggleComponent: React.FC = () => {
 
   return (
     <Card horizontal justifyContent="flex-end" p={3} mb={3}>
-      <ToggleButton
-        mr={1}
-        active={isActive(LayoutsEnum.LIST)}
-        onClick={() => setViewMode(LayoutsEnum.LIST)}
-      >
+      <ToggleButton mr={1} active={isActive(Layout.LIST)} onClick={() => setViewMode(Layout.LIST)}>
         <ListIcon />
       </ToggleButton>
-      <ToggleButton
-        active={isActive(LayoutsEnum.GRID)}
-        onClick={() => setViewMode(LayoutsEnum.GRID)}
-      >
+      <ToggleButton active={isActive(Layout.GRID)} onClick={() => setViewMode(Layout.GRID)}>
         <GridIcon />
       </ToggleButton>
     </Card>

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutToggle.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/components/TableLayout/LayoutToggle.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import styled from "styled-components";
+import { Card } from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import GridIcon from "~/renderer/icons/Grid";
+import ListIcon from "~/renderer/icons/List";
+import useLayout from "LLD/Collectibles/hooks/useLayout";
+import { LayoutsEnum, LayoutKey } from "LLD/Collectibles/types/Layouts";
+
+const ToggleButton = styled(Button).attrs<{
+  active?: boolean;
+}>({})<{ active?: boolean }>`
+  height: 30px;
+  width: 30px;
+  padding: 7px;
+  background: ${p =>
+    p.active ? p.theme.colors.pillActiveBackground : p.theme.colors.palette.background.paper};
+  color: ${p => (p.active ? p.theme.colors.wallet : p.theme.colors.palette.divider)};
+`;
+
+const TableLayoutToggleComponent: React.FC = () => {
+  const { collectiblesViewMode, setViewMode } = useLayout();
+
+  const isActive = (mode: LayoutKey) => collectiblesViewMode === mode;
+
+  return (
+    <Card horizontal justifyContent="flex-end" p={3} mb={3}>
+      <ToggleButton
+        mr={1}
+        active={isActive(LayoutsEnum.LIST)}
+        onClick={() => setViewMode(LayoutsEnum.LIST)}
+      >
+        <ListIcon />
+      </ToggleButton>
+      <ToggleButton
+        active={isActive(LayoutsEnum.GRID)}
+        onClick={() => setViewMode(LayoutsEnum.GRID)}
+      >
+        <GridIcon />
+      </ToggleButton>
+    </Card>
+  );
+};
+
+export const TableLayoutToggle = TableLayoutToggleComponent;

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/components/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/components/index.tsx
@@ -4,3 +4,5 @@ export { Media } from "./Media";
 export { Video } from "./Media/Video";
 export { Image } from "./Media/Image";
 export { Placeholder } from "./Media/Placeholder";
+export { TableLayoutToggle } from "./TableLayout/LayoutToggle";
+export { LayoutContainer } from "./TableLayout/LayoutContainer";

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/hooks/useLayout.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/hooks/useLayout.tsx
@@ -2,13 +2,13 @@ import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { collectiblesViewModeSelector } from "~/renderer/reducers/settings";
 import { setCollectiblesViewMode } from "~/renderer/actions/settings";
-import type { LayoutKey } from "LLD/Collectibles/types/Layouts";
+import type { Layout } from "LLD/Collectibles/types/Layouts";
 
 const useLayout = () => {
   const dispatch = useDispatch();
   const collectiblesViewMode = useSelector(collectiblesViewModeSelector);
   const setViewMode = useCallback(
-    (mode: LayoutKey) => dispatch(setCollectiblesViewMode(mode)),
+    (mode: Layout) => dispatch(setCollectiblesViewMode(mode)),
     [dispatch],
   );
 

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/hooks/useLayout.tsx
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/hooks/useLayout.tsx
@@ -1,0 +1,18 @@
+import { useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { collectiblesViewModeSelector } from "~/renderer/reducers/settings";
+import { setCollectiblesViewMode } from "~/renderer/actions/settings";
+import type { LayoutKey } from "LLD/Collectibles/types/Layouts";
+
+const useLayout = () => {
+  const dispatch = useDispatch();
+  const collectiblesViewMode = useSelector(collectiblesViewModeSelector);
+  const setViewMode = useCallback(
+    (mode: LayoutKey) => dispatch(setCollectiblesViewMode(mode)),
+    [dispatch],
+  );
+
+  return { collectiblesViewMode, setViewMode };
+};
+
+export default useLayout;

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/types/Layouts.ts
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/types/Layouts.ts
@@ -1,0 +1,6 @@
+export type LayoutKey = "grid" | "list";
+
+export enum LayoutsEnum {
+  GRID = "grid",
+  LIST = "list",
+}

--- a/apps/ledger-live-desktop/src/newArch/Collectibles/types/Layouts.ts
+++ b/apps/ledger-live-desktop/src/newArch/Collectibles/types/Layouts.ts
@@ -1,6 +1,6 @@
 export type LayoutKey = "grid" | "list";
 
-export enum LayoutsEnum {
+export enum Layout {
   GRID = "grid",
   LIST = "list",
 }

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -24,6 +24,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 import { Language, Locale } from "~/config/languages";
+import { Layout } from "LLD/Collectibles/types/Layouts";
 export type SaveSettings = (a: Partial<Settings>) => {
   type: string;
   payload: Partial<Settings>;
@@ -44,7 +45,7 @@ export const setNftsViewMode = (nftsViewMode: "list" | "grid" | undefined) =>
   saveSettings({
     nftsViewMode,
   });
-export const setCollectiblesViewMode = (collectiblesViewMode: "list" | "grid") =>
+export const setCollectiblesViewMode = (collectiblesViewMode: Layout) =>
   saveSettings({
     collectiblesViewMode,
   });

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -44,6 +44,10 @@ export const setNftsViewMode = (nftsViewMode: "list" | "grid" | undefined) =>
   saveSettings({
     nftsViewMode,
   });
+export const setCollectiblesViewMode = (collectiblesViewMode: "list" | "grid") =>
+  saveSettings({
+    collectiblesViewMode,
+  });
 export const setSelectedTimeRange = (selectedTimeRange: PortfolioRange) =>
   saveSettings({
     selectedTimeRange,

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -29,6 +29,7 @@ import { State } from ".";
 import regionsByKey from "~/renderer/screens/settings/sections/General/regions.json";
 import { getSystemLocale } from "~/helpers/systemLocale";
 import { Handlers } from "./types";
+import { Layout, LayoutKey } from "LLD/Collectibles/types/Layouts";
 
 /* Initial state */
 
@@ -72,7 +73,7 @@ export type SettingsState = {
   dismissedBanners: string[];
   accountsViewMode: "card" | "list";
   nftsViewMode: "grid" | "list";
-  collectiblesViewMode: "grid" | "list";
+  collectiblesViewMode: LayoutKey;
   showAccountsHelperBanner: boolean;
   hideEmptyTokenAccounts: boolean;
   filterTokenOperationsZeroAmount: boolean;
@@ -159,7 +160,7 @@ export const INITIAL_STATE: SettingsState = {
   dismissedBanners: [],
   accountsViewMode: "list",
   nftsViewMode: "list",
-  collectiblesViewMode: "list",
+  collectiblesViewMode: Layout.LIST,
   showAccountsHelperBanner: true,
   hideEmptyTokenAccounts: getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
   filterTokenOperationsZeroAmount: getEnv("FILTER_ZERO_AMOUNT_ERC20_EVENTS"),

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -72,6 +72,7 @@ export type SettingsState = {
   dismissedBanners: string[];
   accountsViewMode: "card" | "list";
   nftsViewMode: "grid" | "list";
+  collectiblesViewMode: "grid" | "list";
   showAccountsHelperBanner: boolean;
   hideEmptyTokenAccounts: boolean;
   filterTokenOperationsZeroAmount: boolean;
@@ -158,6 +159,7 @@ export const INITIAL_STATE: SettingsState = {
   dismissedBanners: [],
   accountsViewMode: "list",
   nftsViewMode: "list",
+  collectiblesViewMode: "list",
   showAccountsHelperBanner: true,
   hideEmptyTokenAccounts: getEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
   filterTokenOperationsZeroAmount: getEnv("FILTER_ZERO_AMOUNT_ERC20_EVENTS"),
@@ -700,6 +702,7 @@ export const preferredDeviceModelSelector = (state: State) => state.settings.pre
 export const sidebarCollapsedSelector = (state: State) => state.settings.sidebarCollapsed;
 export const accountsViewModeSelector = (state: State) => state.settings.accountsViewMode;
 export const nftsViewModeSelector = (state: State) => state.settings.nftsViewMode;
+export const collectiblesViewModeSelector = (state: State) => state.settings.collectiblesViewMode;
 export const sentryLogsSelector = (state: State) => state.settings.sentryLogs;
 export const autoLockTimeoutSelector = (state: State) => state.settings.autoLockTimeout;
 export const shareAnalyticsSelector = (state: State) => state.settings.shareAnalytics;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Move the logic that decides if want to render the collection as a List or as a Grid. Rename all variables containing "NFTs" with "Collectibles"

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-12459](https://ledgerhq.atlassian.net/browse/LIVE-12459)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12459]: https://ledgerhq.atlassian.net/browse/LIVE-12459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ