### PR TITLE
fix: enforce only one version of styled components on dev mode

### DIFF
--- a/.changeset/thin-dolls-give.md
+++ b/.changeset/thin-dolls-give.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Enforce only one version of styled-components on dev mode

--- a/apps/ledger-live-desktop/tools/utils/index.js
+++ b/apps/ledger-live-desktop/tools/utils/index.js
@@ -89,6 +89,7 @@ const buildViteConfig = argv =>
           path.dirname(require.resolve("@ledgerhq/react-ui/package.json")),
           "lib",
         ),
+        "styled-components": [require.resolve("styled-components/dist/styled-components")],
         electron: path.join(__dirname, "electronRendererStubs.js"),
       },
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We need to enforce only one version of styled components on dev mode for LLD.
Otherwise we cannot resolve the theme correctly depending on where we are on our stack (LLD/react-ui/icons)
Without it we do have issue with our theme

![image](https://github.com/LedgerHQ/ledger-live/assets/31533861/37149ddf-8ba2-4a5a-919b-fd94269fad79)
![image](https://github.com/LedgerHQ/ledger-live/assets/31533861/bb2352eb-a0a3-4eff-88fc-f632a81407f8)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
