### PR TITLE
Patch hashgraph-sdk with new metro resolver to use NativeClient

### DIFF
--- a/.changeset/ten-spoons-itch.md
+++ b/.changeset/ten-spoons-itch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Patch hashgraph-sdk to support Metro resolver exports

--- a/apps/ledger-live-mobile/jest.config.js
+++ b/apps/ledger-live-mobile/jest.config.js
@@ -11,6 +11,7 @@ const transformIncludePatterns = [
   "react-native-modal",
   "react-native-animatable",
   "@sentry/react-native",
+  "@hashgraph/sdk",
   "react-native-startup-time",
   "@segment/analytics-react-native",
   "uuid",

--- a/package.json
+++ b/package.json
@@ -165,8 +165,8 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "prettier": "^3.0.3",
     "nyc": "^15.1.0",
+    "prettier": "^3.0.3",
     "rimraf": "^4.4.1",
     "turbo": "1.10.1",
     "typescript": "^5.4.3",
@@ -192,7 +192,8 @@
       "asyncstorage-down@4.2.0": "patches/asyncstorage-down@4.2.0.patch",
       "detox@20.20.2": "patches/detox@20.20.2.patch",
       "usb@2.9.0": "patches/usb@2.9.0.patch",
-      "react-native-video@5.2.1": "patches/react-native-video@5.2.1.patch"
+      "react-native-video@5.2.1": "patches/react-native-video@5.2.1.patch",
+      "@hashgraph/sdk@2.14.2": "patches/@hashgraph__sdk@2.14.2.patch"
     },
     "packageExtensions": {
       "eslint-config-next@*": {

--- a/patches/@hashgraph__sdk@2.14.2.patch
+++ b/patches/@hashgraph__sdk@2.14.2.patch
@@ -1,0 +1,12 @@
+diff --git a/package.json b/package.json
+index af44c5f5b98e37b06817c31523b6d0c080a8bf89..9f565924451a0502cec7979424aa631f7838f74d 100644
+--- a/package.json
++++ b/package.json
+@@ -22,6 +22,7 @@
+     "./package.json": "./package.json",
+     ".": {
+       "import": "./src/index.js",
++      "react-native": "./src/native.js",
+       "require": "./lib/index.cjs"
+     }
+   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ overrides:
 packageExtensionsChecksum: 8b44dc959ddf462fc160cbda4fe2b3bd
 
 patchedDependencies:
+  '@hashgraph/sdk@2.14.2':
+    hash: ftpe7kgiykw2quxzn7vgiqumd4
+    path: patches/@hashgraph__sdk@2.14.2.patch
   asyncstorage-down@4.2.0:
     hash: 2npkndps6fxdasqj3xzcrnnfbe
     path: patches/asyncstorage-down@4.2.0.patch
@@ -2832,7 +2835,7 @@ importers:
         version: 1.2.0
       '@hashgraph/sdk':
         specifier: 2.14.2
-        version: 2.14.2(react-native@0.73.6)(react@18.2.0)
+        version: 2.14.2(patch_hash=ftpe7kgiykw2quxzn7vgiqumd4)(react-native@0.73.6)(react@18.2.0)
       '@keplr-wallet/cosmos':
         specifier: ^0.9.16
         version: 0.9.16
@@ -13698,7 +13701,7 @@ packages:
       protobufjs: 6.11.4
     dev: false
 
-  /@hashgraph/sdk@2.14.2(react-native@0.73.6)(react@18.2.0):
+  /@hashgraph/sdk@2.14.2(patch_hash=ftpe7kgiykw2quxzn7vgiqumd4)(react-native@0.73.6)(react@18.2.0):
     resolution: {integrity: sha512-58CGz+NZvuI7VxpmvFXo7IJc60kWRGIdQeYy1b5Y2j3aO5nwElX8IJGpscB+ZiFepwkHC6gvW3dX9tRV2lWGaQ==}
     engines: {node: '>=10.17.0'}
     peerDependencies:
@@ -13720,6 +13723,7 @@ packages:
       - react
       - react-native
     dev: false
+    patched: true
 
   /@headlessui/react@1.7.18(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Following the upgrade of React Native, we removed our custom resolver to rely on Metro as it supports symlinks now. hashgraph-sdk does not declare react-native files in exports so it uses default one, and we finally use the NodeClient but we can't on react-native as node stdlibs are not available.

By patching hashgraph-sdk we limit the impact of the change. In the future, we should consider other options to support Hedera.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
