### PR TITLE
fix(live-12813): remove the swap webview conditional for demo0

### DIFF
--- a/.changeset/brown-houses-beg.md
+++ b/.changeset/brown-houses-beg.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+remove the swap webview conditional for demo0

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -112,7 +112,7 @@ const SwapWebView = ({
   const locale = useSelector(languageSelector);
   const redirectToHistory = useRedirectToSwapHistory();
   const enablePlatformDevTools = useSelector(enablePlatformDevToolsSelector);
-
+  const demo1 = useFeature("ptxSwapLiveAppDemoOne");
   const hasSwapState = !!swapState;
   const customPTXHandlers = usePTXCustomHandlers(manifest);
 
@@ -262,9 +262,10 @@ const SwapWebView = ({
   // Keep the previous UI
   // Display only the disabled swap button
   if (
-    swapState.error ||
-    swapState.fromAmount === "0" ||
-    !(fromCurrency && addressFrom && toCurrency && addressTo)
+    demo1?.enabled &&
+    (swapState.error ||
+      swapState.fromAmount === "0" ||
+      !(fromCurrency && addressFrom && toCurrency && addressTo))
   ) {
     return (
       <Box width="100%">

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -112,7 +112,8 @@ const SwapWebView = ({
   const locale = useSelector(languageSelector);
   const redirectToHistory = useRedirectToSwapHistory();
   const enablePlatformDevTools = useSelector(enablePlatformDevToolsSelector);
-  const demo1 = useFeature("ptxSwapLiveAppDemoOne");
+  const manifestID = useSwapLiveAppManifestID();
+  const isDemo1Enabled = manifestID?.startsWith(SwapWebManifestIDs.Demo1);
   const hasSwapState = !!swapState;
   const customPTXHandlers = usePTXCustomHandlers(manifest);
 
@@ -261,8 +262,9 @@ const SwapWebView = ({
 
   // Keep the previous UI
   // Display only the disabled swap button
+
   if (
-    demo1?.enabled &&
+    isDemo1Enabled &&
     (swapState.error ||
       swapState.fromAmount === "0" ||
       !(fromCurrency && addressFrom && toCurrency && addressTo))


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

remove the swap webview conditional for demo0

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

 https://ledgerhq.atlassian.net/browse/LIVE-12813
---

### 🧐 Checklist for the PR Reviewers

 
<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
