### PR TITLE
fix(llm): add tracking on pull to refresh

### DIFF
--- a/.changeset/polite-fireants-pay.md
+++ b/.changeset/polite-fireants-pay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+add track on pull to refresh where a sync is triggered or not so we can quantify the amount of Sync requested to the backend

--- a/apps/ledger-live-mobile/src/components/accountSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/accountSyncRefreshControl.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "@react-navigation/native";
 import { useBridgeSync, useAccountSyncState } from "@ledgerhq/live-common/bridge/react/index";
 import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { SYNC_DELAY } from "~/utils/constants";
+import { track } from "~/analytics";
 
 export interface Props {
   accountId?: string;
@@ -24,6 +25,7 @@ export default <P,>(ScrollListLike: React.ComponentType<P>) => {
     const [refreshing, setRefreshing] = useState(false);
 
     function onPress() {
+      track("buttonClicked", { button: "pull to refresh" });
       if (!accountId) return;
       poll();
       setSyncBehavior({

--- a/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
@@ -4,6 +4,7 @@ import { useBridgeSync } from "@ledgerhq/live-common/bridge/react/index";
 import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { SYNC_DELAY } from "~/utils/constants";
+import { track } from "~/analytics";
 
 type Props = {
   error?: Error;
@@ -28,6 +29,7 @@ export default <P,>(
         reason: "user-pull-to-refresh",
       });
       setRefreshing(true);
+      track("buttonClicked", { button: "pull to refresh" });
     }
 
     useEffect(() => {

--- a/apps/ledger-live-mobile/src/newArch/features/Market/hooks/usePullToRefresh.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/hooks/usePullToRefresh.ts
@@ -1,15 +1,24 @@
 import { useState, useCallback, useEffect } from "react";
+import { track } from "~/analytics";
 
 interface UsePullToRefreshProps {
   loading: boolean;
   refresh: () => void;
 }
+
 function usePullToRefresh({ loading, refresh }: UsePullToRefreshProps) {
+  const trackPullToRefresh = useCallback(() => {
+    track("button_clicked", {
+      button: "pull to refresh",
+    });
+  }, []);
+
   const [refreshControlVisible, setRefreshControlVisible] = useState(false);
   const handlePullToRefresh = useCallback(() => {
     refresh();
     setRefreshControlVisible(true);
-  }, [refresh]);
+    trackPullToRefresh();
+  }, [refresh, trackPullToRefresh]);
 
   useEffect(() => {
     if (refreshControlVisible && !loading) setRefreshControlVisible(false);

--- a/apps/ledger-live-mobile/src/screens/Swap/History/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/History/index.tsx
@@ -18,7 +18,7 @@ import Share from "react-native-share";
 import { useDispatch, useSelector } from "react-redux";
 import type { Account } from "@ledgerhq/types-live";
 import { updateAccountWithUpdater } from "~/actions/accounts";
-import { TrackScreen } from "~/analytics";
+import { track, TrackScreen } from "~/analytics";
 import Alert from "~/components/Alert";
 import Button from "~/components/Button";
 import LText from "~/components/LText";
@@ -46,6 +46,11 @@ const History = () => {
   useEffect(() => {
     setSections(getCompleteSwapHistory(accounts));
   }, [accounts, setSections]);
+
+  const refreshSwapHistory = useCallback(() => {
+    setIsRefreshing(true);
+    track("buttonClicked", { button: "pull to refresh" });
+  }, [setIsRefreshing]);
 
   const updateSwapStatus = useCallback(() => {
     let cancelled = false;
@@ -139,9 +144,7 @@ const History = () => {
         style={styles.sectionList}
         contentContainerStyle={styles.contentContainer}
         ListEmptyComponent={_ => <EmptyState />}
-        refreshControl={
-          <RefreshControl refreshing={isRefreshing} onRefresh={() => setIsRefreshing(true)} />
-        }
+        refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={refreshSwapHistory} />}
         ListHeaderComponent={
           sections.length ? (
             <Button


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

add track on pull to refresh where a sync is triggered or not so we can quantify the amount of Sync requested to the backend

https://github.com/LedgerHQ/ledger-live/assets/73439207/83494b86-f77e-4aed-8096-2ee99a7afa70

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:[LIVE-12572](https://ledgerhq.atlassian.net/browse/LIVE-12572) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12572]: https://ledgerhq.atlassian.net/browse/LIVE-12572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ