### PR TITLE
🐛 Fix overriding the analytics opt in when the analyticsOptInPrompt is only enabled for the Onboarding

### DIFF
--- a/.changeset/honest-balloons-walk.md
+++ b/.changeset/honest-balloons-walk.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+LLM / LLD - Fix overriding the analytics opt in when the analyticsOptInPrompt is only enabled for the Onboarding

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -205,7 +205,12 @@ export default function Default() {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!isLocked && analyticsFF?.enabled && !hasSeenAnalyticsOptInPrompt) {
+    if (
+      !isLocked &&
+      analyticsFF?.enabled &&
+      (!hasCompletedOnboarding || analyticsFF?.params?.entryPoints.includes("Portfolio")) &&
+      !hasSeenAnalyticsOptInPrompt
+    ) {
       dispatch(setShareAnalytics(false));
       dispatch(setSharePersonalizedRecommendations(false));
     }

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -32,6 +32,7 @@ import {
   exportSelector as settingsExportSelector,
   osThemeSelector,
   hasSeenAnalyticsOptInPromptSelector,
+  hasCompletedOnboardingSelector,
 } from "~/reducers/settings";
 import { accountsSelector, exportSelector as accountsExportSelector } from "~/reducers/accounts";
 import { exportSelector as bleSelector } from "~/reducers/ble";
@@ -105,13 +106,25 @@ function App() {
   const accounts = useSelector(accountsSelector);
   const analyticsFF = useFeature("llmAnalyticsOptInPrompt");
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!analyticsFF?.enabled || hasSeenAnalyticsOptInPrompt) return;
+    if (
+      !analyticsFF?.enabled ||
+      (hasCompletedOnboarding && !analyticsFF?.params?.entryPoints.includes("Portfolio")) ||
+      hasSeenAnalyticsOptInPrompt
+    )
+      return;
     dispatch(setAnalytics(false));
     dispatch(setPersonalizedRecommendations(false));
-  }, [analyticsFF?.enabled, dispatch, hasSeenAnalyticsOptInPrompt]);
+  }, [
+    analyticsFF?.enabled,
+    analyticsFF?.params?.entryPoints,
+    dispatch,
+    hasSeenAnalyticsOptInPrompt,
+    hasCompletedOnboarding,
+  ]);
 
   useAccountsWithFundsListener(accounts, updateIdentify);
   useAppStateListener();


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix overriding the analytics opt in when the analyticsOptInPrompt is only enabled for the Onboarding
Automated tests covering this are coming in another PR very soon
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12646]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12646]: https://ledgerhq.atlassian.net/browse/LIVE-12646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ