### PR TITLE
fix: clear cache for a countervalues pair that suddenly is no longer supported

### DIFF
--- a/.changeset/mean-baboons-camp.md
+++ b/.changeset/mean-baboons-camp.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": patch
+---
+
+Handle HTTP 422 as a cache clear trigger for the countervalues pair that would suddenly start to be unsupported.

--- a/libs/live-countervalues/src/api/api.ts
+++ b/libs/live-countervalues/src/api/api.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import URL from "url";
 import { getEnv } from "@ledgerhq/live-env";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
@@ -34,7 +34,7 @@ const api: CounterValuesAPI = {
         end,
       },
     });
-    const { data } = await network({ method: "GET", url });
+    const { data } = await network<Record<string, number>>({ method: "GET", url });
     return data;
   },
 
@@ -84,7 +84,7 @@ const api: CounterValuesAPI = {
         },
       });
 
-      const { data } = await network({ method: "GET", url });
+      const { data } = await network<Record<string, number>>({ method: "GET", url });
 
       // store all countervalues in a global map
       for (let i = 0; i < fromIds.length; i++) {
@@ -101,7 +101,7 @@ const api: CounterValuesAPI = {
   },
 
   fetchIdsSortedByMarketcap: async () => {
-    const { data } = await network({
+    const { data } = await network<string[]>({
       method: "GET",
       url: `${baseURL()}/v3/supported/crypto`,
     });

--- a/libs/live-countervalues/src/logic.integration.test.ts
+++ b/libs/live-countervalues/src/logic.integration.test.ts
@@ -16,6 +16,7 @@ import { Currency } from "@ledgerhq/types-cryptoassets";
 import Prando from "prando";
 import api from "./api";
 import { setEnv } from "@ledgerhq/live-env";
+import { pairId } from "./helpers";
 
 const value = "ll-ci/0.0.0";
 setEnv("LEDGER_CLIENT_VERSION", value);
@@ -180,6 +181,80 @@ describe("WETH rules", () => {
       value: 1000000,
     });
     expect(value).toBeGreaterThan(0);
+  });
+});
+
+describe("HTTP 422 management of unsupported rates", () => {
+  // context of this test: https://ledgerhq.atlassian.net/browse/LIVE-11339
+  test("a cache that was accumulated needs to be cleared when a coin becomes disabled", async () => {
+    // for this test, we start with weth
+    const weth = getTokenById("ethereum/erc20/weth");
+    let state = await loadCountervalues(initialState, {
+      trackingPairs: [
+        {
+          from: weth,
+          to: usd,
+          startDate: new Date(now - 10 * DAY),
+        },
+      ],
+      autofillGaps: true,
+      refreshRate: 60000,
+      marketCapBatchingAfterRank: 20,
+    });
+    let value = calculate(state, {
+      disableRounding: true,
+      from: weth,
+      to: usd,
+      value: 1000000,
+    });
+    expect(value).toBeGreaterThan(0);
+    // we will now alter the state to replace the weth token to sether that we know has been disabled by the api
+    const sether = getTokenById("ethereum/erc20/sether");
+    const prevKey = pairId({ from: weth, to: usd });
+    const nextKey = pairId({ from: sether, to: usd });
+    function mutateVisit(o: any) {
+      // we traverse all Object and replace keys
+      if (typeof o === "object" && o !== null) {
+        for (const k in o) {
+          if (k === prevKey) {
+            const v = o[prevKey];
+            delete o[prevKey];
+            o[nextKey] = v;
+          } else {
+            mutateVisit(o[k]);
+          }
+        }
+      }
+    }
+    mutateVisit(state);
+    // at the moment, we still can calculate the value because we didn't refreshed yet
+    value = calculate(state, {
+      disableRounding: true,
+      from: sether,
+      to: usd,
+      value: 1000000,
+    });
+    expect(value).toBeGreaterThan(0);
+
+    state = await loadCountervalues(state, {
+      trackingPairs: [
+        {
+          from: sether,
+          to: usd,
+          startDate: new Date(now - 100 * DAY),
+        },
+      ],
+      autofillGaps: true,
+      refreshRate: 60000,
+      marketCapBatchingAfterRank: 20,
+    });
+    value = calculate(state, {
+      disableRounding: true,
+      from: sether,
+      to: usd,
+      value: 1000000,
+    });
+    expect(value).toBe(undefined);
   });
 });
 

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -274,6 +274,11 @@ export async function loadCountervalues(
               failures: (s?.failures || 0) + 1,
               oldestDateRequested: s?.oldestDateRequested,
             };
+            if (e.status === 422) {
+              // unsupported currency, we force a clear cache in this case
+              delete data[key];
+              delete cache[key];
+            }
           }
 
           log(
@@ -334,8 +339,9 @@ export async function loadCountervalues(
         data[key] = new Map();
       }
 
+      const map = data[key];
       Object.entries(patch[key]).forEach(([k, v]) => {
-        if (typeof v === "number") data[key].set(k, v);
+        if (typeof v === "number") map.set(k, v);
       });
     });
   });


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - countervalues

### 📝 Description

when a token is removed (e.g. on backend), the API returns HTTP 522 and we must treat it as a full refresh (clearing the cache). A typically usecase is cleaning up a spam coin that was accidentally in our countervalues api (e.g. stether that virtually costed millions)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11339](https://ledgerhq.atlassian.net/browse/LIVE-11339)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11339]: https://ledgerhq.atlassian.net/browse/LIVE-11339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ