### PR TITLE
[LIVE-12913] Bugfix - Dirty fix Tron synchronization not always having `tronResources`

### DIFF
--- a/.changeset/friendly-frogs-live.md
+++ b/.changeset/friendly-frogs-live.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add optional chaining to `tronResources.cacheTransactionInfoById` since resources are still unstable which prevents account migration

--- a/libs/ledger-live-common/src/families/tron/synchronization.ts
+++ b/libs/ledger-live-common/src/families/tron/synchronization.ts
@@ -53,7 +53,7 @@ export const getAccountShape: GetAccountShape<TronAccount> = async (
   const spendableBalance = acc.balance ? new BigNumber(acc.balance) : new BigNumber(0);
   const cacheTransactionInfoById = initialAccount
     ? {
-        ...(initialAccount.tronResources.cacheTransactionInfoById || {}),
+        ...(initialAccount?.tronResources?.cacheTransactionInfoById || {}),
       }
     : {};
   const operationsPageSize = Math.min(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x]  **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact

### 📝 Description

`initialAccount` has no `tronResources` in the context of account migration leading to losing your accounts at the QR code scanning level
This dirty fix should buy us more time to investigate why those resources are not always there.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12913


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
