### PR TITLE
bugfix: LIVE-11803 - rename device broken if an app is open

### DIFF
--- a/.changeset/sharp-rabbits-accept.md
+++ b/.changeset/sharp-rabbits-accept.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add a quitApp before launching the renameDevice device flow

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -61,6 +61,12 @@ const reducer = (state: RenameDeviceState, e: Event): RenameDeviceState => {
     case "deviceChange":
       return getInitialState(e.device);
 
+    case "disconnected":
+      return {
+        ...getInitialState(state.device),
+        isLoading: !!e.expected,
+      };
+
     case "error":
       return {
         ...getInitialState(state.device),

--- a/libs/ledger-live-common/src/hw/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/renameDevice.ts
@@ -1,9 +1,15 @@
-import { Observable, concat, from, of } from "rxjs";
-import { map, catchError } from "rxjs/operators";
+import { concat, defer, from, Observable, of, throwError } from "rxjs";
+import { catchError, concatMap } from "rxjs/operators";
+import { DisconnectedDevice } from "@ledgerhq/errors";
 import { withDevice } from "./deviceAccess";
 import editDeviceName from "./editDeviceName";
+import getAppAndVersion from "./getAppAndVersion";
+import { isDashboardName } from "./isDashboardName";
+import quitApp from "./quitApp";
 
 export type RenameDeviceEvent =
+  | { type: "quit-app" }
+  | { type: "on-dashboard" }
   | {
       type: "unresponsiveDevice";
     }
@@ -13,6 +19,17 @@ export type RenameDeviceEvent =
   | {
       type: "device-renamed";
       name: string;
+    }
+  | {
+      type: "waiting-device";
+    }
+  | {
+      type: "disconnected";
+      expected?: boolean;
+    }
+  | {
+      type: "error";
+      error: Error;
     };
 
 export type RenameDeviceRequest = { name: string };
@@ -24,31 +41,90 @@ export type Input = {
 export default function renameDevice({ deviceId, request }: Input): Observable<RenameDeviceEvent> {
   const { name } = request;
 
-  const sub = withDevice(deviceId)(
-    transport =>
-      new Observable(o => {
-        const sub = concat(
-          of(<RenameDeviceEvent>{
-            type: "permission-requested",
+  return withDevice(deviceId)(transport => {
+    /**
+     * We create a new observable that will be returned to the caller
+     * that will be used to subscribe to the RenameDeviceEvent events
+     */
+    return new Observable<RenameDeviceEvent>(o => {
+      /**
+       * Inner function that will be called recursively until the device is on the dashboard
+       * and we can send the renameDevice command to the device
+       */
+      const innerSub: Observable<RenameDeviceEvent> =
+        /**
+         * defer takes a factory function that returns an observable, thus
+         * calling the function again will not use the same output as the previous call
+         */
+        defer(() => from(getAppAndVersion(transport))).pipe(
+          /**
+           * we get the appAndVersion
+           */
+          concatMap(appAndVersion => {
+            if (isDashboardName(appAndVersion.name)) {
+              /**
+               * If we are on the dashboard, we can rename the device
+               */
+              return concat(
+                of<RenameDeviceEvent>({ type: "permission-requested" }),
+                from(editDeviceName(transport, name)).pipe(
+                  concatMap(() => of<RenameDeviceEvent>({ type: "device-renamed", name })),
+                ),
+              );
+            }
+
+            /**
+             * If we are not on dashboard, we quit the app
+             * and send an exepected disconnected event while withDevice will retry to run the innerSub
+             */
+            return concat(
+              of<RenameDeviceEvent>({ type: "quit-app" }),
+              from(quitApp(transport)).pipe(
+                concatMap(() => of<RenameDeviceEvent>({ type: "disconnected", expected: true })),
+              ),
+            );
           }),
-          from(editDeviceName(transport, name)),
+        );
+
+      const sub = innerSub
+        .pipe(
+          catchError((error: Error) => {
+            /**
+             * If the error is that the device is not on the dashboard, we retry the innerSub
+             */
+            if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+              return innerSub;
+            }
+
+            return throwError(() => error);
+          }),
         )
-          .pipe(
-            map(e => e || { type: "device-renamed", name }),
-            catchError((error: Error) =>
-              of({
-                type: "error",
-                error,
-              }),
-            ),
-          )
-          .subscribe(e => o.next(e));
+        .subscribe(o);
 
-        return () => {
-          sub.unsubscribe();
-        };
-      }),
+      return () => {
+        /**
+         * When the observable is unsubscribed, we unsubscribe the innerSub
+         */
+        sub.unsubscribe();
+      };
+    });
+  }).pipe(
+    catchError((error: Error) => {
+      /**
+       *
+       * If the error is that the device is not on the dashboard or Disconnected, we return a waiting-device event
+       * which is not used in the renameDevice reducer, just to trick the UI not to flicker.
+       * We do have a global timeout so that we are not in a infinite loop
+       *
+       */
+      if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+        return of<RenameDeviceEvent>({
+          type: "disconnected",
+          expected: true,
+        });
+      }
+
+      return throwError(() => error);
+    }),
   );
-
-  return sub as Observable<RenameDeviceEvent>;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - renameDevice in live-common to start with a quitApp

### 📝 Description

This bugfix adds the quitApp action before launching the renameDevice flow, thus removing the broken behavior is the user opened an app while the rename device modal is open.

I went with proposal 1 in the ticket, we could have also decided to make the error a bit more explicit but I believe this is a better UX

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11803] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11803]: https://ledgerhq.atlassian.net/browse/LIVE-11803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ