### PR TITLE
fix(lld): camera does not shut off when not scanning qr code

### DIFF
--- a/.changeset/beige-years-pump.md
+++ b/.changeset/beige-years-pump.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix Send: Camera does not shut off when not scanning QR code

--- a/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
@@ -138,7 +138,10 @@ export default class QRCodeCameraPickerCanvas extends PureComponent<
         }),
       ])
         .then(stream => {
-          if (this.unmounted) return;
+          if (this.unmounted) {
+            stream.getTracks().forEach(track => track.stop());
+            return;
+          }
           this.setState({
             error: null,
           });
@@ -153,6 +156,7 @@ export default class QRCodeCameraPickerCanvas extends PureComponent<
               video.srcObject = null;
               video = null;
             }
+            stream.getTracks().forEach(track => track.stop());
           });
           video.onloadedmetadata = () => {
             if (this.unmounted || !video) return;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - QR code scan

### 📝 Description

When "scan qr code" pop up on send flow is opened then closed the video stream isn't stopped. 
To avoid this we cut off the stream once the pop up gets unmounted or if a qr code has been well scanned. 


| Before        | After         |
| ------------- | ------------- |
|https://github.com/LedgerHQ/ledger-live/assets/73439207/486a7eb3-8a7a-4c85-a762-5457f14113b4|https://github.com/LedgerHQ/ledger-live/assets/73439207/f9033832-70d8-4cc8-b8e8-2455472e66ae|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-12938](https://ledgerhq.atlassian.net/browse/LIVE-12938)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12938]: https://ledgerhq.atlassian.net/browse/LIVE-12938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ