### PR TITLE
🐛 [BUGFIX] : Add Fallback for Market Widget Crypto icons

### DIFF
--- a/.changeset/cold-paws-shave.md
+++ b/.changeset/cold-paws-shave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+FIx fallback when no image on MArketWidget

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/components/WidgetList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/MarketPerformanceWidget/components/WidgetList.tsx
@@ -37,8 +37,14 @@ function WidgetRow({ data, index, isFirst, range }: PropsBodyElem) {
           {index}
         </Text>
 
-        <CryptoCurrencyIconWrapper>
-          <img width="32px" height="32px" src={data.image} alt={"currency logo"} />
+        <CryptoCurrencyIconWrapper hasImage={!!data.image}>
+          {data.image ? (
+            <img width="32px" height="32px" src={data.image} alt={"currency logo"} />
+          ) : (
+            <Text color="neutral.c100" variant="h5Inter" fontSize={12}>
+              {data.name.charAt(0).toUpperCase()}
+            </Text>
+          )}
         </CryptoCurrencyIconWrapper>
 
         <Flex ml={2} overflow="hidden" flexDirection="column" alignItems="left">
@@ -96,15 +102,20 @@ function WidgetRow({ data, index, isFirst, range }: PropsBodyElem) {
   );
 }
 
-const CryptoCurrencyIconWrapper = styled.div`
+const CryptoCurrencyIconWrapper = styled(Flex)<{
+  hasImage?: boolean;
+}>`
   height: 32px;
   width: 32px;
   position: relative;
   border-radius: 32px;
   overflow: hidden;
+  background-color: ${p => (p.hasImage ? "transparent" : p.theme.colors.opacityDefault.c05)};
   img {
     object-fit: cover;
   }
+  align-items: center;
+  justify-content: center;
 `;
 
 const EllipsisText = styled(Text)`


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Backend could encounter issues and images would not load. 

A fallback is to be created where we put the letter of the crypto in the image location 
<img width="408" alt="Screenshot 2024-06-10 at 12 01 34" src="https://github.com/LedgerHQ/ledger-live/assets/112866305/f3b5f9f1-ad3a-421d-ad8f-2247f1045927">

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12955] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12955]: https://ledgerhq.atlassian.net/browse/LIVE-12955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ