### PR TITLE
[QAA-106][Detox]Disable flaky webview checks

### DIFF
--- a/apps/ledger-live-mobile/e2e/specs/market.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/market.spec.ts
@@ -39,6 +39,7 @@ describe("Market page for user with no device", () => {
     await marketPage.openAssetPage("Bitcoin (BTC)");
     await marketPage.buyAsset();
     await getDevicePage.buyNano();
-    await getDevicePage.expectBuyNanoWebPage();
+    // Todo: Fix webview check tests
+    // await getDevicePage.expectBuyNanoWebPage();
   });
 });

--- a/apps/ledger-live-mobile/e2e/specs/onboardingReadOnly.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/onboardingReadOnly.spec.ts
@@ -23,7 +23,8 @@ describe("Onboarding - Read Only", () => {
     await onboardingSteps.chooseNoLedgerYet();
     await onboardingSteps.chooseToBuyLedger();
     await getDevicePage.buyNano();
-    await getDevicePage.expectBuyNanoWebPage();
+    // Todo: Fix webview check tests
+    // await getDevicePage.expectBuyNanoWebPage();
   });
 
   $TmsLink("B2CQA-370");
@@ -48,6 +49,7 @@ describe("Onboarding - Read Only", () => {
     await marketPage.openAssetPage("Bitcoin (BTC)");
     await marketPage.buyAsset();
     await getDevicePage.buyNano();
-    await getDevicePage.expectBuyNanoWebPage();
+    // Todo: Fix webview check tests
+    // await getDevicePage.expectBuyNanoWebPage();
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Market and onboarding readonly tests

### 📝 Description

_Buy Nano webview checks are flaky. We disable them until we fix it in [QAA-107](https://ledgerhq.atlassian.net/browse/QAA-107)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-107]: https://ledgerhq.atlassian.net/browse/QAA-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ