### PR TITLE
fix: render swap live app after loading finish

### DIFF
--- a/.changeset/nice-drinks-kiss.md
+++ b/.changeset/nice-drinks-kiss.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: render swap live app after LLD quotes loading finish

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -279,8 +279,6 @@ const SwapWebView = ({
     );
   }
 
-  console.log("SLA hashString", hashString);
-
   return (
     <>
       {enablePlatformDevTools && (

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -212,6 +212,7 @@ const SwapWebView = ({
       from: sourceCurrencyId,
       to: targetCurrencyId,
       amountFrom: swapState?.fromAmount,
+      loading: swapState?.loading,
       addressFrom: addressFrom,
       addressTo: addressTo,
       networkFees: swapState?.estimatedFees,
@@ -232,6 +233,7 @@ const SwapWebView = ({
     fromCurrency,
     swapState?.estimatedFees,
     swapState?.fromAmount,
+    swapState?.loading,
     swapState?.provider,
     targetCurrencyId,
     sourceCurrencyId,
@@ -262,7 +264,6 @@ const SwapWebView = ({
 
   // Keep the previous UI
   // Display only the disabled swap button
-
   if (
     isDemo1Enabled &&
     (swapState.error ||
@@ -277,6 +278,8 @@ const SwapWebView = ({
       </Box>
     );
   }
+
+  console.log("SLA hashString", hashString);
 
   return (
     <>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
 render swap live app after LLD quotes loading finish


https://github.com/LedgerHQ/ledger-live/assets/11476482/2a54fdc3-8c15-42f8-b4dd-f652f556ea6e



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-12813 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
