### PR TITLE
 fix(wallet-api): ripple wrong family name [LIVE-12929]

### DIFF
--- a/.changeset/brave-scissors-brush.md
+++ b/.changeset/brave-scissors-brush.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(wallet-api): ripple wrong family name

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -89,8 +89,10 @@ libs/ledger-live-common/src/wallet-api/                  @ledgerhq/wallet-api
 **/platformAdapter.ts                                    @ledgerhq/wallet-api
 **/walletApiAdapter.ts                                   @ledgerhq/wallet-api
 **/liveapp-sdk.spec.ts                                   @ledgerhq/wallet-api
-**/confirmTransaction.spec.ts                            @ledgerhq/wallet-api
+**/confirmTransaction.spec.ts                             @ledgerhq/wallet-api
 **/wallet-api.spec.ts                                    @ledgerhq/wallet-api
+**/wallet-api.spec.ts-snapshots/                         @ledgerhq/wallet-api
+**/dapp.spec.ts                                          @ledgerhq/wallet-api
 libs/test-utils/                                         @ledgerhq/wallet-api
 
 # Devices team

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-darwin.json
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-darwin.json
@@ -148,7 +148,7 @@
     "id": "ripple",
     "ticker": "XRP",
     "name": "XRP",
-    "family": "xrp",
+    "family": "ripple",
     "color": "#27a2db",
     "decimals": 6
   },

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-linux.json
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-linux.json
@@ -148,7 +148,7 @@
     "id": "ripple",
     "ticker": "XRP",
     "name": "XRP",
-    "family": "xrp",
+    "family": "ripple",
     "color": "#27a2db",
     "decimals": 6
   },

--- a/libs/ledger-live-common/src/helpers.ts
+++ b/libs/ledger-live-common/src/helpers.ts
@@ -9,3 +9,9 @@ export function includes<T extends U, U>(array: ReadonlyArray<T>, element: U): e
 export function objectKeysType<Type extends object>(value: Type): Array<keyof Type> {
   return Object.keys(value) as Array<keyof Type>;
 }
+
+export function reverseRecord<T extends PropertyKey, U extends PropertyKey>(
+  input: Record<T, U>,
+): Record<U, T> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [value, key]));
+}

--- a/libs/ledger-live-common/src/platform/converters.ts
+++ b/libs/ledger-live-common/src/platform/converters.ts
@@ -1,9 +1,10 @@
-import { FAMILIES } from "@ledgerhq/live-app-sdk";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { isTokenAccount } from "../account";
 import byFamily from "../generated/platformAdapter";
 import type { Transaction } from "../generated/types";
 import {
+  FAMILIES_MAPPING_LL_TO_WAPI,
+  FAMILIES_MAPPING_WAPI_TO_LL,
   PlatformAccount,
   PlatformCurrency,
   PlatformCurrencyType,
@@ -75,7 +76,7 @@ export function currencyToPlatformCurrency(currency: PlatformSupportedCurrency):
     id: currency.id,
     ticker: currency.ticker,
     name: currency.name,
-    family: currency.family,
+    family: FAMILIES_MAPPING_LL_TO_WAPI[currency.family] ?? currency.family,
     color: currency.color,
     units: currency.units.map(unit => ({
       name: unit.name,
@@ -92,9 +93,7 @@ export const getPlatformTransactionSignFlowInfos = (
   hasFeesProvided: boolean;
   liveTx: Partial<Transaction>;
 } => {
-  // This is a hack to link WalletAPI "ethereum" family to new "evm" family
-  const isEthereumFamily = platformTx.family === FAMILIES.ETHEREUM;
-  const liveFamily = isEthereumFamily ? "evm" : platformTx.family;
+  const liveFamily = FAMILIES_MAPPING_WAPI_TO_LL[platformTx.family] ?? platformTx.family;
 
   const familyModule = byFamily[liveFamily];
 

--- a/libs/ledger-live-common/src/platform/converters.ts
+++ b/libs/ledger-live-common/src/platform/converters.ts
@@ -3,8 +3,8 @@ import { isTokenAccount } from "../account";
 import byFamily from "../generated/platformAdapter";
 import type { Transaction } from "../generated/types";
 import {
-  FAMILIES_MAPPING_LL_TO_WAPI,
-  FAMILIES_MAPPING_WAPI_TO_LL,
+  FAMILIES_MAPPING_LL_TO_PLATFORM,
+  FAMILIES_MAPPING_PLATFORM_TO_LL,
   PlatformAccount,
   PlatformCurrency,
   PlatformCurrencyType,
@@ -76,7 +76,7 @@ export function currencyToPlatformCurrency(currency: PlatformSupportedCurrency):
     id: currency.id,
     ticker: currency.ticker,
     name: currency.name,
-    family: FAMILIES_MAPPING_LL_TO_WAPI[currency.family] ?? currency.family,
+    family: FAMILIES_MAPPING_LL_TO_PLATFORM[currency.family] ?? currency.family,
     color: currency.color,
     units: currency.units.map(unit => ({
       name: unit.name,
@@ -93,7 +93,7 @@ export const getPlatformTransactionSignFlowInfos = (
   hasFeesProvided: boolean;
   liveTx: Partial<Transaction>;
 } => {
-  const liveFamily = FAMILIES_MAPPING_WAPI_TO_LL[platformTx.family] ?? platformTx.family;
+  const liveFamily = FAMILIES_MAPPING_PLATFORM_TO_LL[platformTx.family] ?? platformTx.family;
 
   const familyModule = byFamily[liveFamily];
 

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -7,14 +7,14 @@ import {
   FAMILIES,
 } from "@ledgerhq/live-app-sdk";
 import { z } from "zod";
-import { reverseRecord } from "../wallet-api/helpers";
+import { reverseRecord } from "../helpers";
 
-export const FAMILIES_MAPPING_WAPI_TO_LL = {
+export const FAMILIES_MAPPING_PLATFORM_TO_LL = {
   ethereum: "evm",
   ripple: "xrp",
 } as const;
 
-export const FAMILIES_MAPPING_LL_TO_WAPI = reverseRecord(FAMILIES_MAPPING_WAPI_TO_LL);
+export const FAMILIES_MAPPING_LL_TO_PLATFORM = reverseRecord(FAMILIES_MAPPING_PLATFORM_TO_LL);
 
 /**
  * this is a hack to add the "evm" family to the list of supported families of
@@ -25,7 +25,7 @@ export const FAMILIES_MAPPING_LL_TO_WAPI = reverseRecord(FAMILIES_MAPPING_WAPI_T
  */
 export const PLATFORM_FAMILIES = [
   ...Object.values(FAMILIES),
-  ...Object.values(FAMILIES_MAPPING_WAPI_TO_LL),
+  ...Object.values(FAMILIES_MAPPING_PLATFORM_TO_LL),
 ];
 
 export { FAMILIES as PLATFORM_FAMILIES_ENUM };

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -7,6 +7,14 @@ import {
   FAMILIES,
 } from "@ledgerhq/live-app-sdk";
 import { z } from "zod";
+import { reverseRecord } from "../wallet-api/helpers";
+
+export const FAMILIES_MAPPING_WAPI_TO_LL = {
+  ethereum: "evm",
+  ripple: "xrp",
+} as const;
+
+export const FAMILIES_MAPPING_LL_TO_WAPI = reverseRecord(FAMILIES_MAPPING_WAPI_TO_LL);
 
 /**
  * this is a hack to add the "evm" family to the list of supported families of
@@ -15,7 +23,10 @@ import { z } from "zod";
  * "ethereum" family, following the "ethereum" / "evm" families merge
  * (and removal of the "ethereum" family)
  */
-export const PLATFORM_FAMILIES = [...Object.values(FAMILIES), "evm", "xrp"];
+export const PLATFORM_FAMILIES = [
+  ...Object.values(FAMILIES),
+  ...Object.values(FAMILIES_MAPPING_WAPI_TO_LL),
+];
 
 export { FAMILIES as PLATFORM_FAMILIES_ENUM };
 

--- a/libs/ledger-live-common/src/wallet-api/constants.ts
+++ b/libs/ledger-live-common/src/wallet-api/constants.ts
@@ -2,7 +2,7 @@ import Fuse from "fuse.js";
 import { AppManifest } from "../wallet-api/types";
 
 import { FAMILIES } from "@ledgerhq/wallet-api-core";
-import { reverseRecord } from "./helpers";
+import { reverseRecord } from "../helpers";
 
 export const FAMILIES_MAPPING_WAPI_TO_LL = {
   ethereum: "evm",

--- a/libs/ledger-live-common/src/wallet-api/constants.ts
+++ b/libs/ledger-live-common/src/wallet-api/constants.ts
@@ -2,13 +2,21 @@ import Fuse from "fuse.js";
 import { AppManifest } from "../wallet-api/types";
 
 import { FAMILIES } from "@ledgerhq/wallet-api-core";
+import { reverseRecord } from "./helpers";
+
+export const FAMILIES_MAPPING_WAPI_TO_LL = {
+  ethereum: "evm",
+  ripple: "xrp",
+} as const;
+
+export const FAMILIES_MAPPING_LL_TO_WAPI = reverseRecord(FAMILIES_MAPPING_WAPI_TO_LL);
 
 /**
  * FIXME
  * This is not robust, we should have an explicit adapter between the wallet API currencies (families) and live currencies (families)
  * For example here, the `ethereum` family on `wallet-api` should be mapped to the `evm` family on LL
  */
-export const WALLET_API_FAMILIES = [...FAMILIES, "evm", "xrp"];
+export const WALLET_API_FAMILIES = [...FAMILIES, ...Object.values(FAMILIES_MAPPING_WAPI_TO_LL)];
 
 export const WALLET_API_VERSION = "2.0.0";
 

--- a/libs/ledger-live-common/src/wallet-api/converters.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.ts
@@ -1,5 +1,6 @@
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { v5 as uuidv5 } from "uuid";
+import { WalletState, accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 import byFamily from "../generated/walletApiAdapter";
 import type { Transaction } from "../generated/types";
 import { isTokenAccount } from "../account";
@@ -10,8 +11,7 @@ import {
   WalletAPISupportedCurrency,
   GetWalletAPITransactionSignFlowInfos,
 } from "./types";
-import { Families } from "@ledgerhq/wallet-api-core";
-import { WalletState, accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
+import { FAMILIES_MAPPING_LL_TO_WAPI, FAMILIES_MAPPING_WAPI_TO_LL } from "./constants";
 
 // The namespace is a randomly generated uuid v4 from https://www.uuidgenerator.net/
 const NAMESPACE = "c3c78073-6844-409e-9e75-171ab4c7f9a2";
@@ -86,7 +86,7 @@ export function currencyToWalletAPICurrency(
     id: currency.id,
     ticker: currency.ticker,
     name: currency.name,
-    family: currency.family === "evm" ? "ethereum" : (currency.family as Families),
+    family: FAMILIES_MAPPING_LL_TO_WAPI[currency.family] ?? currency.family,
     color: currency.color,
     decimals: currency.units[0].magnitude,
   };
@@ -96,9 +96,8 @@ export const getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFl
   WalletAPITransaction,
   Transaction
 > = ({ walletApiTransaction, account }) => {
-  // This is a hack to link WalletAPI "ethereum" family to new "evm" family
-  const isEthereumFamily = walletApiTransaction.family === "ethereum";
-  const liveFamily = isEthereumFamily ? "evm" : walletApiTransaction.family;
+  const liveFamily =
+    FAMILIES_MAPPING_WAPI_TO_LL[walletApiTransaction.family] ?? walletApiTransaction.family;
 
   const familyModule = byFamily[liveFamily];
 

--- a/libs/ledger-live-common/src/wallet-api/helpers.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.ts
@@ -158,9 +158,3 @@ export const stripHexPrefix = (str: string): string => {
 
   return isHexPrefixed(str) ? str.slice(2) : str;
 };
-
-export function reverseRecord<T extends PropertyKey, U extends PropertyKey>(
-  input: Record<T, U>,
-): Record<U, T> {
-  return Object.fromEntries(Object.entries(input).map(([key, value]) => [value, key]));
-}

--- a/libs/ledger-live-common/src/wallet-api/helpers.ts
+++ b/libs/ledger-live-common/src/wallet-api/helpers.ts
@@ -158,3 +158,9 @@ export const stripHexPrefix = (str: string): string => {
 
   return isHexPrefixed(str) ? str.slice(2) : str;
 };
+
+export function reverseRecord<T extends PropertyKey, U extends PropertyKey>(
+  input: Record<T, U>,
+): Record<U, T> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [value, key]));
+}


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - discover live-apps, only changes the ripple family name

### 📝 Description

https://github.com/LedgerHQ/ledger-live/pull/6936 only partially fixed the issue, as the ripple family name would be `xrp` instead of `ripple`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12929] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12929]: https://ledgerhq.atlassian.net/browse/LIVE-12929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ