### PR TITLE
[LIVE-12800] LLD - Storyly cta behavior with deeplinks on LLD

### DIFF
--- a/.changeset/soft-hairs-try.md
+++ b/.changeset/soft-hairs-try.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Storyly cta behavior with deeplinks

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/InformationDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/InformationDrawer.tsx
@@ -77,7 +77,12 @@ export const InformationDrawer = ({
   const tabIndex = useMemo(() => tabs.findIndex(tab => tab.id === tabId), [tabId, tabs]);
   const CurrentPanel = tabs[tabIndex].Component;
   return (
-    <SideDrawer isOpen={isOpen} onRequestClose={onRequestClose} direction="left">
+    <SideDrawer
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      direction="left"
+      forceDisableFocusTrap
+    >
       <Box height="100%" px="40px">
         <TabBar
           fullWidth

--- a/apps/ledger-live-desktop/src/storyly/useStoryly.tsx
+++ b/apps/ledger-live-desktop/src/storyly/useStoryly.tsx
@@ -1,9 +1,13 @@
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { StorylyInstanceID } from "@ledgerhq/types-live";
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useContext } from "react";
 import { useSelector } from "react-redux";
+import { closeAllModal } from "~/renderer/actions/modals";
+import { context } from "~/renderer/drawers/Provider";
+import { useDispatch } from "react-redux";
 import { languageSelector } from "~/renderer/reducers/settings";
 import { StorylyStyleProps, useStorylyDefaultStyleProps } from "./style";
+import { openURL } from "~/renderer/linking";
 import { StorylyRef, StorylyData } from "storyly-web";
 
 /**
@@ -19,6 +23,8 @@ export const useStoryly = (
   instanceId: StorylyInstanceID,
   options?: { styleProps: StorylyStyleProps },
 ) => {
+  const dispatch = useDispatch();
+  const { setDrawer } = useContext(context);
   const ref = useRef<StorylyRef>();
   const dataRef = useRef<StorylyData>();
   const props = useStorylyDefaultStyleProps();
@@ -37,6 +43,14 @@ export const useStoryly = (
         isReady: data => {
           dataRef.current = data;
           // Triggered when story is ready.
+        },
+        actionClicked: story => {
+          if (story?.media?.actionUrl) {
+            openURL(story.media.actionUrl);
+            ref.current?.close?.();
+            dispatch(closeAllModal());
+            setDrawer();
+          }
         },
       },
       props: { ...props, ...options?.styleProps },

--- a/apps/ledger-live-desktop/src/types/storyly-web.d.ts
+++ b/apps/ledger-live-desktop/src/types/storyly-web.d.ts
@@ -6,6 +6,17 @@ declare module "storyly-web" {
     id: number;
   }>;
 
+  type Story = {
+    group_id: number;
+    id: number;
+    index: number;
+    media: {
+      actionUrl?: string;
+    };
+    seen: boolean;
+    title: string;
+  };
+
   /**
    * Storyly Options
    */
@@ -15,6 +26,7 @@ declare module "storyly-web" {
     events?: {
       closeStoryGroup?(): void;
       isReady?(data: StorylyData): void;
+      actionClicked?(story: Story): void;
     };
     lang?: Language;
     segments?: string[];
@@ -29,6 +41,7 @@ declare module "storyly-web" {
     setSegments: (options: StorylyOptions["segments"]) => void;
     setLang: (options: { language: StorylyOptions["lang"] }) => void;
     openStory: (props: openStoryParams) => void;
+    close: () => void;
   }
 
   interface openStoryParams {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix behavior when you click on a CTA in a Story that opens a deeplink.
Multiple tradeoffs:
- We need to force close Modals and Drawers;
- I had to disable the focus trap on the Announcement Drawer otherwise you can't interact with storyly.

To test I added this link at multiple places:
`<a href="ledgerlive://storyly?g=142749&instance=17650">Click me</a>`

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

https://github.com/LedgerHQ/ledger-live/assets/31533861/b7fae94c-caf4-48aa-b4ca-261cde2223c5



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12800

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
