### PR TITLE
[LIVE-12968][LLM] QueuedDrawer: if onClose changes, drawer shouldn't auto close

### DIFF
--- a/.changeset/shy-pots-brush.md
+++ b/.changeset/shy-pots-brush.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix QueuedDrawer component so that onClose prop value can change without triggering an auto close of the drawer.

--- a/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/TestScreens.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/TestScreens.tsx
@@ -181,7 +181,7 @@ export const MainTestScreen = () => {
   const [drawer3RequestingToBeOpened, setDrawer3RequestingToBeOpened] = useState(false);
   const [drawer4ForcingToBeOpened, setDrawer4ForcingToBeOpened] = useState(false);
 
-  const handleDrawer1Close = useCallback(() => setDrawer1RequestingToBeOpened(false), []);
+  const handleDrawer1Close = () => setDrawer1RequestingToBeOpened(false); // purposely not using useCallback to check if drawer behaves well when onClose prop changes
   const handleDrawer2Close = useCallback(() => setDrawer2RequestingToBeOpened(false), []);
   const handleDrawer3Close = useCallback(() => setDrawer3RequestingToBeOpened(false), []);
   const handleDrawer4Close = useCallback(() => setDrawer4ForcingToBeOpened(false), []);

--- a/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/index.tsx
@@ -81,14 +81,17 @@ const QueuedDrawer = ({
     setIsDisplayed(true);
   }, []);
 
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   const triggerClose = useCallback(() => {
     setIsDisplayed(false);
     if (drawerInQueueRef.current?.getPositionInQueue() !== 0) {
       drawerInQueueRef.current?.removeDrawerFromQueue();
       drawerInQueueRef.current = undefined;
     }
-    onClose && onClose();
-  }, [onClose]);
+    onCloseRef.current && onCloseRef.current(); // hack to avoid triggering the useEffect below if the parent changes the onClose prop
+  }, []);
 
   useEffect(() => {
     if (!isFocused && (isRequestingToBeOpened || isForcingToBeOpened)) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Fully covered by automatic tests, I adapted the existing tests so that they would break without this fix in the same kind of situation as the one detected, and they pass.
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - all drawers in LLM

### 📝 Description

The property `onClose` was indirectly a dependency of the `useEffect` that triggers auto closing in some cleanup logic of the `QueuedDrawer` component.
The solution is to keep `onClose` in a ref in the component so that it can still be used in that `useEffect` without triggering the useEffect when its value changes.


https://github.com/LedgerHQ/ledger-live/assets/91890529/952ab900-1ba4-4d0e-909a-a416a4e5c0af


https://github.com/LedgerHQ/ledger-live/assets/91890529/54ae643a-d1fe-4448-a19b-fedbf3ed1600



### ❓ Context

- **JIRA or GitHub link**: [LIVE-12968] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12968]: https://ledgerhq.atlassian.net/browse/LIVE-12968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ