### PR TITLE
fix(llm/QueuedDrawer): QueuedDrawer shouldn't auto close (cherrypick of #7068 for develop)

### DIFF
--- a/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/TestScreens.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/TestScreens.tsx
@@ -181,7 +181,7 @@ export const MainTestScreen = () => {
   const [drawer3RequestingToBeOpened, setDrawer3RequestingToBeOpened] = useState(false);
   const [drawer4ForcingToBeOpened, setDrawer4ForcingToBeOpened] = useState(false);
 
-  const handleDrawer1Close = useCallback(() => setDrawer1RequestingToBeOpened(false), []);
+  const handleDrawer1Close = () => setDrawer1RequestingToBeOpened(false); // purposely not using useCallback to check if drawer behaves well when onClose prop changes
   const handleDrawer2Close = useCallback(() => setDrawer2RequestingToBeOpened(false), []);
   const handleDrawer3Close = useCallback(() => setDrawer3RequestingToBeOpened(false), []);
   const handleDrawer4Close = useCallback(() => setDrawer4ForcingToBeOpened(false), []);

--- a/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/QueuedDrawer/index.tsx
@@ -81,14 +81,17 @@ const QueuedDrawer = ({
     setIsDisplayed(true);
   }, []);
 
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   const triggerClose = useCallback(() => {
     setIsDisplayed(false);
     if (drawerInQueueRef.current?.getPositionInQueue() !== 0) {
       drawerInQueueRef.current?.removeDrawerFromQueue();
       drawerInQueueRef.current = undefined;
     }
-    onClose && onClose();
-  }, [onClose]);
+    onCloseRef.current && onCloseRef.current(); // hack to avoid triggering the useEffect below if the parent changes the onClose prop
+  }, []);
 
   useEffect(() => {
     if (!isFocused && (isRequestingToBeOpened || isForcingToBeOpened)) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. -> No need because the fix is already included in the upcoming LLM release.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - all drawers in LLM

### 📝 Description

Cherrypick of #7068 for the `develop` branch.
Already approved by QA & dev reviewed.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12968] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12968]: https://ledgerhq.atlassian.net/browse/LIVE-12968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ