### PR TITLE
chore(PROTECT-3160): add dev mode to analytics

### DIFF
--- a/.changeset/friendly-clouds-pretend.md
+++ b/.changeset/friendly-clouds-pretend.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add Dev Mode as a property to all events & send to Recover Live App

--- a/.changeset/twelve-berries-try.md
+++ b/.changeset/twelve-berries-try.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add Dev Mode as a property to all events & send to Recover Live App

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -16,6 +16,7 @@ import {
   sharePersonalizedRecommendationsSelector,
   hasSeenAnalyticsOptInPromptSelector,
   trackingEnabledSelector,
+  developerModeSelector,
 } from "~/renderer/reducers/settings";
 import { State } from "~/renderer/reducers";
 import { AccountLike, Feature, FeatureId, Features, idsToLanguage } from "@ledgerhq/types-live";
@@ -98,8 +99,10 @@ const getMandatoryProperties = (store: ReduxStore) => {
   const analyticsEnabled = shareAnalyticsSelector(state);
   const personalizedRecommendationsEnabled = sharePersonalizedRecommendationsSelector(state);
   const hasSeenAnalyticsOptInPrompt = hasSeenAnalyticsOptInPromptSelector(state);
+  const devModeEnabled = developerModeSelector(state);
 
   return {
+    devModeEnabled,
     optInAnalytics: analyticsEnabled,
     optInPersonalRecommendations: personalizedRecommendationsEnabled,
     hasSeenAnalyticsOptInPrompt,
@@ -115,6 +118,7 @@ const extraProperties = (store: ReduxStore) => {
   const device = lastSeenDeviceSelector(state);
   const devices = devicesModelListSelector(state);
   const accounts = accountsSelector(state);
+
   const {
     isBatch1Enabled,
     isBatch2Enabled,

--- a/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/recover/Player.tsx
@@ -4,7 +4,11 @@ import { RouteComponentProps, useHistory } from "react-router-dom";
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useOnboardingStatePolling } from "@ledgerhq/live-common/onboarding/hooks/useOnboardingStatePolling";
 import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState";
-import { counterValueCurrencySelector, languageSelector } from "~/renderer/reducers/settings";
+import {
+  counterValueCurrencySelector,
+  developerModeSelector,
+  languageSelector,
+} from "~/renderer/reducers/settings";
 import WebRecoverPlayer from "~/renderer/components/WebRecoverPlayer";
 import useTheme from "~/renderer/hooks/useTheme";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
@@ -57,6 +61,7 @@ export default function RecoverPlayer({
   const currency = currencySettings.ticker;
 
   const device = useSelector(getCurrentDevice);
+  const devModeEnabled = useSelector(developerModeSelector);
 
   const { onboardingState } = useOnboardingStatePolling({
     device: device || null,
@@ -81,6 +86,7 @@ export default function RecoverPlayer({
       availableOnDesktop,
       deviceId: state?.deviceId,
       deviceModelId: device?.modelId,
+      devModeEnabled,
       currency,
       ...params,
       ...queryParams,

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -53,6 +53,7 @@ import { BrazePlugin } from "./BrazePlugin";
 import { Maybe } from "../types/helpers";
 import { appStartupTime } from "../StartupTimeMarker";
 import { aggregateData, getUniqueModelIdList } from "../logic/modelIdList";
+import { getEnv } from "@ledgerhq/live-env";
 
 let sessionId = uuid();
 const appVersion = `${VersionNumber.appVersion || ""} (${VersionNumber.buildVersion || ""})`;
@@ -102,10 +103,12 @@ const getMandatoryProperties = async (store: AppStore) => {
   const analyticsEnabled = analyticsEnabledSelector(state);
   const personalizedRecommendationsEnabled = personalizedRecommendationsEnabledSelector(state);
   const hasSeenAnalyticsOptInPrompt = hasSeenAnalyticsOptInPromptSelector(state);
+  const devModeEnabled = getEnv("MANAGER_DEV_MODE");
 
   return {
     userId: user?.id,
     braze_external_id: user?.id, // Needed for braze with this exact name
+    devModeEnabled,
     optInAnalytics: analyticsEnabled,
     optInPersonalRecommendations: personalizedRecommendationsEnabled,
     hasSeenAnalyticsOptInPrompt,

--- a/apps/ledger-live-mobile/src/screens/Protect/Player.tsx
+++ b/apps/ledger-live-mobile/src/screens/Protect/Player.tsx
@@ -18,6 +18,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { counterValueCurrencySelector } from "~/reducers/settings";
 import { useSelector } from "react-redux";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 
 export type Props = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.Recover>
@@ -34,6 +35,8 @@ export function RecoverPlayer({ navigation, route }: Props) {
   const remoteManifest = useRemoteLiveAppManifest(appId);
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const { locale } = useLocale();
+  const devModeEnabled = useEnv("MANAGER_DEV_MODE").toString();
+
   const currencySettings = useSelector(counterValueCurrencySelector);
   const currency = currencySettings.ticker;
   const manifest = localManifest || remoteManifest;
@@ -82,6 +85,7 @@ export function RecoverPlayer({ navigation, route }: Props) {
       <WebRecoverPlayer
         manifest={manifest}
         inputs={{
+          devModeEnabled,
           theme,
           lang: locale,
           currency,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** 
  - All analytics events will now receive the `devModeEnabled` value as a property, this property will be sent to the Recover Live App

### 📝 Description

It is valuable to be able to exclude all users/events in Dev Mode in our insights/funnels etc. and ultimately ensure we only track real users.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/PROTECT-3160
- Relates to: https://github.com/LedgerHQ/protect-frontend/pull/1061
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
