### PR TITLE
fix(trustchain): make sure the qrcode logic uses a ws(s):// url

### DIFF
--- a/libs/trustchain/src/qrcode/index.ts
+++ b/libs/trustchain/src/qrcode/index.ts
@@ -34,7 +34,7 @@ export async function createQRCodeHostInstance({
 }): Promise<void> {
   const ephemeralKey = await crypto.randomKeypair();
   const publisher = crypto.to_hex(ephemeralKey.publicKey);
-  const url = `${getEnv("TRUSTCHAIN_API")}/v1/qr?host=${publisher}`;
+  const url = `${getEnv("TRUSTCHAIN_API").replace("http", "ws")}/v1/qr?host=${publisher}`;
   const ws = new WebSocket(url);
   function send(message: Message) {
     ws.send(JSON.stringify(message));


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - trustchain library

### 📝 Description

it seems that some recent implementations ("ws" and Chrome) is permissive to allow a https:// on a WebSocket instanciation, but it is not the case of Electron so we can explicitly replace `ws*` by `http*` (which effectively will replace https by wss too)

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
