### PR TITLE
chore(trustchain): implement CLOSE on removeMember

### DIFF
--- a/libs/hw-trustchain/README.md
+++ b/libs/hw-trustchain/README.md
@@ -53,13 +53,15 @@ Ledger Live trustchain hardware layer.
     *   [Parameters](#parameters-12)
     *   [share](#share)
         *   [Parameters](#parameters-13)
+    *   [close](#close)
+        *   [Parameters](#parameters-14)
 *   [StreamTreeCipherMode](#streamtreeciphermode)
 *   [StreamTreeCipher](#streamtreecipher)
-    *   [Parameters](#parameters-14)
+    *   [Parameters](#parameters-15)
     *   [encrypt](#encrypt)
-        *   [Parameters](#parameters-15)
-    *   [decrypt](#decrypt)
         *   [Parameters](#parameters-16)
+    *   [decrypt](#decrypt)
+        *   [Parameters](#parameters-17)
 
 ### APDU
 
@@ -246,6 +248,17 @@ Share a private key with a member
 *   `member` **[Uint8Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)**&#x20;
 *   `name` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)**&#x20;
 *   `permission` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)**&#x20;
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[StreamTree](#streamtree)>**&#x20;
+
+#### close
+
+Close a stream
+
+##### Parameters
+
+*   `path` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>)**&#x20;
+*   `owner` **[Device](#device)**&#x20;
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[StreamTree](#streamtree)>**&#x20;
 

--- a/libs/hw-trustchain/src/StreamTree.ts
+++ b/libs/hw-trustchain/src/StreamTree.ts
@@ -128,6 +128,17 @@ export class StreamTree {
     }
   }
 
+  /**
+   * Close a stream
+   */
+  public async close(path: string | number[], owner: Device): Promise<StreamTree> {
+    const indexes =
+      typeof path === "string" ? DerivationPath.toIndexArray(path) : (path as number[]);
+    let stream = this.getChild(indexes) || new CommandStream();
+    stream = await stream.edit().close().issue(owner, this);
+    return this.update(stream);
+  }
+
   public update(stream: CommandStream): StreamTree {
     const path = stream.getStreamPath();
     if (path === null) throw new Error("Stream path cannot be null");


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** I was able to manually test the feature. <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - trustchain library

### 📝 Description

To fully complete the implementation of sdk.removeMember a nice to have was to "lock" the previous derivation after a rotation occurred to essentially close the previous branch of the trustchain.

### ❓ Context

- **JIRA or GitHub link**:  LIVE-12987

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
