### PR TITLE
[LIVE-12976] LLM - Fix Storyly close action

### DIFF
--- a/.changeset/eight-pans-promise.md
+++ b/.changeset/eight-pans-promise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix Storyly when it's closed with a previous action

--- a/apps/ledger-live-mobile/src/components/StorylyStories/StorylyProvider.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/StorylyProvider.tsx
@@ -61,10 +61,12 @@ const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
   };
 
   const handleEvent = (e: Storyly.StoryEvent) => {
-    if (e.event === "StoryGroupClosed" || e.event === "StoryGroupCompleted") clear();
+    if (["StoryGroupClosed", "StoryGroupCompleted", "StoryPaused"].includes(e.event)) {
+      clear();
+    }
     if (e.event === "StoryCTAClicked" && e?.story?.media?.actionUrl) {
       Linking.openURL(e.story.media.actionUrl);
-      storylyRef.current?.close?.();
+      clear();
     }
   };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fix two issues:
- When you navigate by clicking into a cta in a Story, the Story is still considered as opened , so when you come back and try to open it again, nothing happens
- When you open a story and touch on the left on the screen, the story is closed as there are no previous story, then the story is not considered as closed and we fall into the same issue as the first one.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12976


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
