### PR TITLE
[Release][LIVE-13049] Bugfix - Ethereum Classic using its own nano app

### DIFF
--- a/.changeset/metal-oranges-heal.md
+++ b/.changeset/metal-oranges-heal.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+Rollback nano app used for Ethereum Classic from Ethereum to Ethereum Classic, due to Classic using a 61 coin type for its derivation, incompatible with the Ethereum app

--- a/libs/ledger-live-common/src/apps/react.test.ts
+++ b/libs/ledger-live-common/src/apps/react.test.ts
@@ -52,6 +52,7 @@ test("Apps hooks - useAppUninstallNeedsDeps - Expect dep apps", () => {
     useAppUninstallNeedsDeps(mockedState, mockedState.appByName["Ethereum"]),
   );
   expect(result.current.dependents.map(({ name }) => name)).toEqual([
+    "Ethereum Classic",
     "Aave",
     "Polygon",
     "Binance Smart Chain",

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -1109,7 +1109,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     id: "ethereum_classic",
     coinType: CoinType.ETH_CLASSIC,
     name: "Ethereum Classic",
-    managerAppName: "Ethereum",
+    managerAppName: "Ethereum Classic",
     ticker: "ETC",
     scheme: "ethereumclassic",
     color: "#3ca569",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Ethereum Classic should require its own app now instead of the generic Ethereum App

### 📝 Description

Due to Ethereum Classic using `coinType` 61 instead of 60 in the context of Ledger Live, it's incompatible with the Ethereum nano app. 
Rolling it back to using its own dedicated manager app.



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-13049


https://github.com/LedgerHQ/ledger-live/assets/44363395/cbb23f59-b442-4a4d-97be-3796cb65bfba


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
