### PR TITLE
fix(llm/lld): change analytics opt-in translations

### DIFF
--- a/.changeset/silly-frogs-swim.md
+++ b/.changeset/silly-frogs-swim.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Update analytics opt-in descriptions

--- a/apps/ledger-live-desktop/src/newArch/AnalyticsOptInPrompt/screens/VariantA/Main/components/MainBody/components/TrackingInfoList/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/AnalyticsOptInPrompt/screens/VariantA/Main/components/MainBody/components/TrackingInfoList/index.tsx
@@ -25,7 +25,7 @@ const TrackingInfoList = ({ title, items, variant }: TrackingInfoListProps) => {
         {title}
       </Text>
       {items.map((text, index) => (
-        <Flex key={index} columnGap={"8px"} alignItems={"center"}>
+        <Flex key={index} columnGap={"8px"}>
           <Icon size={"S"} color={color} />
           <Field variant="paragraph" fontWeight="medium" fontSize={13} color={textColor}>
             {text}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6241,11 +6241,11 @@
   },
   "analyticsOptInPrompt": {
     "variantA": {
-      "description": "Sharing your Ledger Live data helps us understand your preferences, show content that’s relevant to you, and fix technical issues.",
-      "whatWeTrack": "With your consent, Ledger will be able to track:",
+      "description": "Sharing your Ledger Live data helps us understand your preferences and show content that's relevant to you.",
+      "whatWeTrack": "With your consent, Ledger will be able to track data about how you use Ledger Live (including page visits and clicks):",
       "whatWeTrackList": {
-        "1": "Analytics data, including page visits, clicks.",
-        "2": "Personalization data including clicks, page visits, conversion data."
+        "1": "To measure the performance of Ledger Live and enhance both the app and your experience (Analytics).",
+        "2": "To provide you with personalized recommendations and content tailored to your preferences, as well as to help us measure the effectiveness of our marketing campaigns (Personalization)."
       },
       "whatWeDoNotTrack": "Ledger will never track information regarding:",
       "whatWeDoNotTrackList": {
@@ -6257,12 +6257,12 @@
       "refuse": "Refuse all",
       "accept": "Accept all",
       "analyticsData": {
-        "title": "Analytics data",
-        "description": "To help improve Ledger Live, share app’s analytics data, including page visits, clicks."
+        "title": "Analytics",
+        "description": "To measure Ledger Live’s performance and improve both the app and your experience, we share usage data, including page visits and clicks."
       },
       "personalizationData": {
-        "title": "Personalization data",
-        "description": "To get personalized recommendations, share app’s personalization data including, conversion data, clicks, page visits."
+        "title": "Personalization",
+        "description": "To receive personalized recommendations and content that match your preferences and to help us measure the performance of our marketing campaigns, we share app usage data, including clicks, page visits, and conversion data."
       },
       "share": "Share"
     },
@@ -6294,8 +6294,8 @@
     "profileSettings": {
       "personalizedExp": "Personalized experience",
       "analytics": "Analytics",
-      "personalizedExpDesc": "Receive personalised recommendations that match your preferences.",
-      "analyticsDesc": "Enable analytics to help Ledger improve the user experience."
+      "personalizedExpDesc": "Enable Ledger to track app usage data to provide personalized recommendations and content that match your preferences and to help measure the performance of our marketing campaigns.",
+      "analyticsDesc": "Enable Ledger to track app usage data to help measure Ledger Live’s performance and enhance both the app and your experience."
     }
   },
   "walletSync": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2750,9 +2750,9 @@
       "developerMode": "Developer mode",
       "developerModeDesc": "Show developer apps in My Ledger and enable Testnet apps.",
       "analytics": "Analytics",
-      "analyticsDesc": "Enable analytics to help Ledger improve user experience.",
+      "analyticsDesc": "Enable Ledger to track app usage data to help measure Ledger Live’s performance and enhance both the app and your experience.",
       "personalizedRecommendations": "Personalized experience",
-      "personalizedRecommendationsDesc": "Receive personalised recommendations that match your preferences.",
+      "personalizedRecommendationsDesc": "Enable Ledger to track app usage data to provide personalized recommendations and content that match your preferences and to help measure the performance of our marketing campaigns.",
       "analyticsModal": {
         "title": "Share analytics",
         "desc": "Enable analytics to help Ledger improve user experience",
@@ -6580,18 +6580,18 @@
     "variantA": {
       "main": {
         "title": "Help us improve and personalize your experience",
-        "subtitle": "Sharing your Ledger Live data helps us understand your preferences, show content that’s relevant to you, and fix technical issues.",
+        "subtitle": "Sharing your Ledger Live data helps us understand your preferences and show content that's relevant to you.",
         "content": {
           "able": {
-            "title": "With your consent, Ledger will be able to track:",
-            "diagAndUsage": "Analytics data, including page visits, clicks.",
-            "personnalizationData": "Personalization data including clicks, page visits, conversion data."
+            "title": "With your consent, Ledger will be able to track data about how you use Ledger Live (including page visits and clicks):",
+            "diagAndUsage": "To measure the performance of Ledger Live and enhance both the app and your experience (Analytics).",
+            "personnalizationData": "To provide you with personalized recommendations and content tailored to your preferences, as well as to help us measure the effectiveness of our marketing campaigns (Personalization)."
           },
           "unable": {
-            "title": "Ledger will never track information regarding:",
+            "title": "Ledger Live will never track information regarding:",
             "adresses": "Your assets.",
             "balance": "Your portfolio.",
-            "personnalInfos": "Your personal identifying Information."
+            "personnalInfos": "Your personal identifying information (such as your name or your email address)."
           },
           "moreOptions": "Manage your preferences",
           "ctas": {
@@ -6607,12 +6607,12 @@
       "details": {
         "title": "Manage your preferences",
         "analytics": {
-          "title": "Analytics data",
-          "description": "To help improve Ledger Live, share app’s analytics data, including page visits, clicks."
+          "title": "Analytics",
+          "description": "To measure Ledger Live’s performance and improve both the app and your experience, we share usage data, including page visits and clicks."
         },
         "personalizedExp": {
-          "title": "Personalization data",
-          "description": "To get personalized recommendations, share app’s personalization data including, conversion data, clicks, page visits."
+          "title": "Personalization",
+          "description": "To receive personalized recommendations and content that match your preferences and to help us measure the performance of our marketing campaigns, we share app usage data, including clicks, page visits, and conversion data."
         },
         "ctas": {
           "notNow": "Not now",

--- a/apps/ledger-live-mobile/src/screens/AnalyticsOptInPrompt/variantA/Main.tsx
+++ b/apps/ledger-live-mobile/src/screens/AnalyticsOptInPrompt/variantA/Main.tsx
@@ -25,7 +25,7 @@ function renderItems({
     <Flex>
       {items.map((item, index) => {
         return (
-          <Flex pt="6" key={index} flexDirection={"row"} alignItems="flex-start">
+          <Flex pt="6" key={index} flexDirection={"row"} alignItems="flex-start" mr={8}>
             <Flex mr={3}>{IconComponent}</Flex>
             <Text pt={2} color={itemsColor}>
               {item}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Analytics translations
  - opt-in prompt

### 📝 Description

Change the descriptions for Variant A of analytics opt-in prompt
This needed some little UI adjustments so text in LLM fits inside the screen.


```
New translations : 

LLD & LLM Variant A ONLY: 

First opt-in prompt screen : 

Analytics : “To measure the performance of Ledger Live and enhance both the app and your experience (Analytics).”

Personalization : “To provide you with personalized recommendations and content tailored to your preferences, as well as to help us measure the effectiveness of our marketing campaigns (Personalization).”

Second opt-in prompt screen : 

Analytics: “To measure Ledger Live’s performance and improve both the app and your experience, we share usage data, including page visits and clicks.”

Personalization: “To receive personalized recommendations and content that match your preferences and to help us measure the performance of our marketing campaigns, we share app usage data, including clicks, page visits, and conversion data.”

Settings screen :

Analytics : “Enable Ledger to track app usage data to help measure Ledger Live’s performance and enhance both the app and your experience.”

Personalization : “Enable Ledger to track app usage data to provide personalized recommendations and content that match your preferences and to help measure the performance of our marketing campaigns.”

```

| LLM        | LLD         |
| ------------- | ------------- |
|![Screenshot 2024-06-17 at 12 17 18](https://github.com/LedgerHQ/ledger-live/assets/73439207/c09d314b-0093-4897-bd74-289f779abaa3)|<img width="432" alt="Screenshot 2024-06-17 at 12 24 38" src="https://github.com/LedgerHQ/ledger-live/assets/73439207/d82e94c3-dae2-4cf7-8aa8-2d2bb7ef386a">|
| ![Screenshot 2024-06-17 at 12 17 21](https://github.com/LedgerHQ/ledger-live/assets/73439207/4c731da8-0f7f-40cf-bc86-ca9336128eb6)|<img width="432" alt="Screenshot 2024-06-17 at 12 24 40" src="https://github.com/LedgerHQ/ledger-live/assets/73439207/521eb399-fafb-43e7-9f5f-f4c97e4ddc02">|
|![Screenshot 2024-06-17 at 12 17 33](https://github.com/LedgerHQ/ledger-live/assets/73439207/69323009-5c50-49a3-8a8b-3f53490d7d5a) |<img width="1370" alt="Screenshot 2024-06-17 at 12 19 44" src="https://github.com/LedgerHQ/ledger-live/assets/73439207/5d333b8e-6a10-4334-bbf8-f931865033b4">|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-13030](https://ledgerhq.atlassian.net/browse/LIVE-13030)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13030]: https://ledgerhq.atlassian.net/browse/LIVE-13030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ