### PR TITLE
[LIVE-12928][Common] List apps v2 doesn't show apps with isDevTools when Manager in dev mode

### DIFF
--- a/.changeset/quiet-llamas-rush.md
+++ b/.changeset/quiet-llamas-rush.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+List apps v2: fix filtering of apps with isDevMode

--- a/libs/ledger-live-common/src/apps/listApps/v2.test.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.test.ts
@@ -58,6 +58,7 @@ describe("listApps v2", () => {
     const deviceInfo = aDeviceInfoBuilder({ isOSU: true, isBootloader: false });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -80,6 +81,7 @@ describe("listApps v2", () => {
     const deviceInfo = aDeviceInfoBuilder({ isOSU: false, isBootloader: true });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -102,6 +104,7 @@ describe("listApps v2", () => {
     const deviceInfo = aDeviceInfoBuilder({ isOSU: false, isBootloader: false, targetId: 0 });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -129,6 +132,7 @@ describe("listApps v2", () => {
     });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -158,6 +162,7 @@ describe("listApps v2", () => {
     });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -183,6 +188,7 @@ describe("listApps v2", () => {
     });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -214,6 +220,7 @@ describe("listApps v2", () => {
     });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -247,6 +254,7 @@ describe("listApps v2", () => {
     });
 
     listApps({
+      managerDevModeEnabled: false,
       transport,
       deviceInfo,
       managerApiRepository: mockedManagerApiRepository,
@@ -279,6 +287,7 @@ describe("listApps v2", () => {
       let gotResult = false;
 
       listApps({
+        managerDevModeEnabled: false,
         transport,
         deviceInfo,
         managerApiRepository: mockedManagerApiRepository,

--- a/libs/ledger-live-common/src/apps/listApps/v2.ts
+++ b/libs/ledger-live-common/src/apps/listApps/v2.ts
@@ -31,10 +31,10 @@ const emptyHashData = "0".repeat(64);
 type ListAppsParams = {
   transport: Transport;
   deviceInfo: DeviceInfo;
-  deviceProxyModel?: DeviceModelId;
-  managerDevModeEnabled?: boolean;
+  managerDevModeEnabled: boolean;
   forceProvider: number;
   managerApiRepository: ManagerApiRepository;
+  deviceProxyModel?: DeviceModelId;
 };
 
 export const listApps = ({

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -5,7 +5,7 @@ import { findCryptoCurrency } from "../currencies";
 import type { ListAppsResult, AppOp, Exec, InstalledItem } from "./types";
 import { getBTCValues } from "@ledgerhq/live-countervalues/mock";
 import { DeviceModelId, identifyTargetId } from "@ledgerhq/devices";
-import { App, DeviceInfo, FinalFirmware } from "@ledgerhq/types-live";
+import { App, AppType, ApplicationV2, DeviceInfo, FinalFirmware } from "@ledgerhq/types-live";
 
 export const deviceInfo155 = {
   version: "1.5.5",
@@ -245,3 +245,32 @@ export const mockExecWithInstalledContext = (installedInitial: InstalledItem[]):
     );
   };
 };
+
+export function makeAppV2Mock(props: Partial<ApplicationV2>): ApplicationV2 {
+  return {
+    versionId: 1,
+    versionName: "Bitcoin",
+    versionDisplayName: "Bitcoin",
+    version: "1.0.0",
+    currencyId: "bitcoin",
+    description: "Bitcoin app",
+    applicationType: AppType.currency,
+    dateModified: "2021-01-01",
+    icon: "icon",
+    authorName: "Ledger",
+    supportURL: "https://support.ledger.com",
+    contactURL: "https://contact.ledger.com",
+    sourceURL: "https://source.ledger.com",
+    hash: "hash",
+    perso: "perso",
+    parentName: null,
+    firmware: "firmware",
+    firmwareKey: "firmwareKey",
+    delete: "delete",
+    deleteKey: "deleteKey",
+    bytes: 100,
+    warning: null,
+    isDevTools: false,
+    ...props,
+  };
+}

--- a/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.ts
+++ b/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.ts
@@ -44,6 +44,7 @@ export function listAppsUseCase(
         deviceProxyModel: getEnv("DEVICE_PROXY_MODEL") as DeviceModelId,
         managerApiRepository,
         forceProvider: getEnv("FORCE_PROVIDER"),
+        managerDevModeEnabled: getEnv("MANAGER_DEV_MODE"),
       })
     : listAppsV1(transport, deviceInfo, managerApiRepository);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Apps catalog in My Ledger.

### 📝 Description

The environment variable controlling "manager is in dev mode" was not getting passed.
I made this parameter non optional to avoid further similar regressions.

Not strictly related to the fix, but I added some tests to check that the filtering of apps with `isDevTools: true` behaves as expected.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12928] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12928]: https://ledgerhq.atlassian.net/browse/LIVE-12928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ