### PR TITLE
:bug: [LIVE-13054] typing grouped features stax

### DIFF
--- a/.changeset/orange-jokes-dream.md
+++ b/.changeset/orange-jokes-dream.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": major
+"live-mobile": major
+"@ledgerhq/live-common": major
+---
+
+Hotfix typing groupedFeatures

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/GroupedFeatures.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/GroupedFeatures.tsx
@@ -1,4 +1,7 @@
-import { groupedFeatures } from "@ledgerhq/live-common/featureFlags/groupedFeatures";
+import {
+  groupedFeatures,
+  GroupedFeature,
+} from "@ledgerhq/live-common/featureFlags/groupedFeatures";
 import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/FeatureFlagsContext";
 import { Flex, Link, Tag, Box, Switch, Text } from "@ledgerhq/react-ui";
 import { FeatureId } from "@ledgerhq/types-live";
@@ -7,9 +10,9 @@ import { useTranslation } from "react-i18next";
 import FeatureFlagDetails, { Row } from "./FeatureFlagDetails";
 
 type Props = {
-  groupName: string;
+  groupName: GroupedFeature;
   focused: boolean;
-  setFocusedGroupName: (name: string | undefined) => void;
+  setFocusedGroupName: (name: GroupedFeature | undefined) => void;
 };
 
 const GroupedFeatures = ({ groupName, focused, setFocusedGroupName }: Props) => {

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/GroupedFeatures.tsx
@@ -1,4 +1,7 @@
-import { groupedFeatures } from "@ledgerhq/live-common/featureFlags/groupedFeatures";
+import {
+  groupedFeatures,
+  GroupedFeature,
+} from "@ledgerhq/live-common/featureFlags/groupedFeatures";
 import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/FeatureFlagsContext";
 import { Divider, Flex, Link, Switch, Tag } from "@ledgerhq/native-ui";
 import { FeatureId } from "@ledgerhq/types-live";
@@ -8,9 +11,9 @@ import { Pressable } from "react-native";
 import FeatureFlagDetails, { TagEnabled } from "./FeatureFlagDetails";
 
 type Props = {
-  groupName: string;
+  groupName: GroupedFeature;
   focused: boolean;
-  setFocusedGroupName: (name: string | undefined) => void;
+  setFocusedGroupName: (name: GroupedFeature | undefined) => void;
   isLast: boolean;
 };
 

--- a/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FeatureFlagsSettings/index.tsx
@@ -31,6 +31,7 @@ import Alert from "~/components/Alert";
 import GroupedFeatures from "./GroupedFeatures";
 import { featureFlagsBannerVisibleSelector } from "~/reducers/settings";
 import { setFeatureFlagsBannerVisible } from "~/actions/settings";
+import { objectKeysType } from "@ledgerhq/live-common/helpers";
 
 const addFlagHint = `\
 If a feature flag is defined in the Firebase project \
@@ -72,7 +73,7 @@ export default function DebugFeatureFlags() {
   }, [featureFlags, searchInput]);
 
   const filteredGroups = useMemo(() => {
-    return Object.keys(groupedFeatures)
+    return objectKeysType(groupedFeatures)
       .sort()
       .filter(
         groupName =>

--- a/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/groupedFeatures.ts
@@ -1,6 +1,6 @@
 import { FeatureId } from "@ledgerhq/types-live";
 
-type GroupedFeature = "europa" | "disableNft";
+export type GroupedFeature = "europa" | "disableNft";
 
 /** Helper to group several feature flag ids under a common feature flag */
 export const groupedFeatures: Record<


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
