### PR TITLE
⛓️feat(llm): add WS activation drawer from onboarding

### DIFF
--- a/.changeset/tame-rings-hide.md
+++ b/.changeset/tame-rings-hide.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add activation drawer from onboarding entry point

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/index.tsx
@@ -7,7 +7,11 @@ import { useTheme } from "styled-components/native";
 import { TrackScreen } from "~/analytics";
 import Drawer from "LLM/components/Dummy/Drawer";
 
-const Activation = () => {
+type Props<T extends boolean> = T extends true
+  ? { isInsideDrawer: T; openSyncMethodDrawer: () => void }
+  : { isInsideDrawer?: T; openSyncMethodDrawer?: undefined };
+
+const Activation: React.FC<Props<boolean>> = ({ isInsideDrawer, openSyncMethodDrawer }) => {
   const { colors } = useTheme();
   const { t } = useTranslation();
 
@@ -18,7 +22,7 @@ const Activation = () => {
   };
 
   const onPressHasAlreadyCreatedAKey = () => {
-    setIsDrawerOpen(true);
+    isInsideDrawer ? openSyncMethodDrawer() : setIsDrawerOpen(true);
   };
 
   const onPressCloseDrawer = () => {
@@ -48,7 +52,7 @@ const Activation = () => {
         onPressHasAlreadyCreatedAKey={onPressHasAlreadyCreatedAKey}
         onPressSyncAccounts={onPressSyncAccounts}
       />
-      <Drawer isOpen={isDrawerOpen} handleClose={onPressCloseDrawer} />
+      {!isInsideDrawer && <Drawer isOpen={isDrawerOpen} handleClose={onPressCloseDrawer} />}
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationDrawer.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import QueuedDrawer from "LLM/components/QueuedDrawer";
+import Activation from "../../components/Activation";
+import Drawer from "LLM/components/Dummy/Drawer";
+import { TrackScreen } from "~/analytics";
+
+type Props = {
+  isOpen: boolean;
+  reopenDrawer: () => void;
+  handleClose: () => void;
+};
+
+const ActivationDrawer = ({ isOpen, handleClose, reopenDrawer }: Props) => {
+  const [isSyncMethodDrawerOpen, setIsSyncMethodDrawerOpen] = React.useState(false);
+
+  const onPressCloseDrawer = () => {
+    setIsSyncMethodDrawerOpen(false);
+    reopenDrawer();
+  };
+
+  const openSyncMethodDrawer = () => {
+    setIsSyncMethodDrawerOpen(true);
+    handleClose();
+  };
+
+  return (
+    <>
+      <TrackScreen />
+      <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={handleClose}>
+        <Activation isInsideDrawer openSyncMethodDrawer={openSyncMethodDrawer} />
+      </QueuedDrawer>
+
+      <Drawer isOpen={isSyncMethodDrawerOpen} handleClose={onPressCloseDrawer} />
+    </>
+  );
+};
+
+export default ActivationDrawer;

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/accessExistingWallet.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/accessExistingWallet.tsx
@@ -13,8 +13,8 @@ import { OnboardingType } from "~/reducers/types";
 import { SelectionCards } from "./Cards/SelectionCard";
 import OnboardingView from "./OnboardingView";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import Drawer from "LLM/components/Dummy/Drawer";
 import { logDrawer } from "LLM/components/QueuedDrawer/utils/logDrawer";
+import ActivationDrawer from "LLM/features/WalletSync/screens/Activation/ActivationDrawer";
 
 type NavigationProps = StackNavigatorProps<
   OnboardingNavigatorParamList & BaseNavigatorStackParamList,
@@ -52,6 +52,11 @@ function AccessExistingWallet() {
   const closeDrawer = useCallback(() => {
     setIsDrawerVisible(false);
     logDrawer("Wallet Sync Welcome back", "close");
+  }, []);
+
+  const reopenDrawer = useCallback(() => {
+    setIsDrawerVisible(true);
+    logDrawer("Wallet Sync Welcome back", "reopen");
   }, []);
 
   return (
@@ -104,7 +109,11 @@ function AccessExistingWallet() {
               ]),
         ]}
       />
-      <Drawer isOpen={isDrawerVisible} handleClose={closeDrawer} />
+      <ActivationDrawer
+        isOpen={isDrawerVisible}
+        handleClose={closeDrawer}
+        reopenDrawer={reopenDrawer}
+      />
     </OnboardingView>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Onboarding (welcome back)

### 📝 Description

Add activation drawer in onboarding entry point. 
This drawer calls the same component that we call inside a screen for the settings entry point [#7086](https://github.com/LedgerHQ/ledger-live/pull/7086)

https://github.com/LedgerHQ/ledger-live/assets/73439207/961fa2b9-dbe3-4d0c-8824-8f6131d70dde


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12149](https://ledgerhq.atlassian.net/browse/LIVE-12149)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12149]: https://ledgerhq.atlassian.net/browse/LIVE-12149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ