### PR TITLE
:bug: [LIVE-13021] [LLD][Ubuntu] Device not recognised on LLD for Ubuntu

### DIFF
--- a/.changeset/sweet-papayas-complain.md
+++ b/.changeset/sweet-papayas-complain.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/hw-transport-node-hid-singleton": patch
+"@ledgerhq/hw-transport-node-hid-noevents": patch
+"@ledgerhq/hw-transport-node-hid": patch
+---
+
+Force node-hid version to 2.1.2, fix glibc < 2.33 error

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/package.json
@@ -31,7 +31,7 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
-    "node-hid": "^2.1.2"
+    "node-hid": "2.1.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.10",

--- a/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-singleton/package.json
@@ -32,7 +32,7 @@
     "@ledgerhq/hw-transport": "workspace:^",
     "@ledgerhq/hw-transport-node-hid-noevents": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
-    "node-hid": "^2.1.2",
+    "node-hid": "2.1.2",
     "usb": "2.9.0"
   },
   "scripts": {

--- a/libs/ledgerjs/packages/hw-transport-node-hid/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-hid/package.json
@@ -33,7 +33,7 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "lodash": "^4.17.21",
-    "node-hid": "^2.1.2",
+    "node-hid": "2.1.2",
     "usb": "2.9.0"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4341,8 +4341,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       node-hid:
-        specifier: ^2.1.2
-        version: 2.2.0
+        specifier: 2.1.2
+        version: 2.1.2
       usb:
         specifier: 2.9.0
         version: 2.9.0(patch_hash=d5pno5rjlboai2klvccu6wv334)
@@ -4387,8 +4387,8 @@ importers:
         specifier: workspace:^
         version: link:../logs
       node-hid:
-        specifier: ^2.1.2
-        version: 2.2.0
+        specifier: 2.1.2
+        version: 2.1.2
     devDependencies:
       '@types/jest':
         specifier: ^29.5.10
@@ -4436,8 +4436,8 @@ importers:
         specifier: workspace:^
         version: link:../logs
       node-hid:
-        specifier: ^2.1.2
-        version: 2.2.0
+        specifier: 2.1.2
+        version: 2.1.2
       usb:
         specifier: 2.9.0
         version: 2.9.0(patch_hash=d5pno5rjlboai2klvccu6wv334)
@@ -43192,8 +43192,8 @@ packages:
     resolution: {integrity: sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==}
     hasBin: true
 
-  /node-hid@2.2.0:
-    resolution: {integrity: sha512-vj48zh9j555DZzUhMc8tk/qw6xPFrDyPBH1ST1Z/hWaA/juBJw7IuSxPeOgpzNFNU36mGYj+THioRMt1xOdm/g==}
+  /node-hid@2.1.2:
+    resolution: {integrity: sha512-qhCyQqrPpP93F/6Wc/xUR7L8mAJW0Z6R7HMQV8jCHHksAxNDe/4z4Un/H9CpLOT+5K39OPyt9tIQlavxWES3lg==}
     engines: {node: '>=10'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - fix node-hid version to `2.1.2`

### 📝 Description

On ubuntu LTS 20.04 with glibc < 2.33, `node-hid 2.2.0` is looking for a missing version of glibc on runtime during device connexion. 
Force node-hid version to `2.1.2` fix it.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13021] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13021]: https://ledgerhq.atlassian.net/browse/LIVE-13021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ