### PR TITLE
LLM - fix crash on experimental settings screen

### DIFF
--- a/.changeset/real-planets-grab.md
+++ b/.changeset/real-planets-grab.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Fix crash on experimental settings screen

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/index.tsx
@@ -5,7 +5,6 @@ import { isEnvDefault } from "@ledgerhq/live-env";
 import { Alert } from "@ledgerhq/native-ui";
 import { TrackScreen } from "~/analytics";
 import { experimentalFeatures } from "../../../experimental";
-import KeyboardView from "~/components/KeyboardView";
 import FeatureRow from "./FeatureRow";
 import SettingsNavigationScrollView from "../SettingsNavigationScrollView";
 
@@ -13,16 +12,14 @@ export default function ExperimentalSettings() {
   const { t } = useTranslation();
 
   return (
-    <KeyboardView>
-      <SettingsNavigationScrollView>
-        <TrackScreen category="Settings" name="Experimental" />
-        <Alert title={t("settings.experimental.disclaimer")} showIcon={false} />
-        {experimentalFeatures.map(feat =>
-          !feat.shadow || (feat.shadow && !isEnvDefault(feat.name)) ? (
-            <FeatureRow key={feat.name} feature={feat} />
-          ) : null,
-        )}
-      </SettingsNavigationScrollView>
-    </KeyboardView>
+    <SettingsNavigationScrollView>
+      <TrackScreen category="Settings" name="Experimental" />
+      <Alert title={t("settings.experimental.disclaimer")} showIcon={false} />
+      {experimentalFeatures.map(feat =>
+        !feat.shadow || (feat.shadow && !isEnvDefault(feat.name)) ? (
+          <FeatureRow key={feat.name} feature={feat} />
+        ) : null,
+      )}
+    </SettingsNavigationScrollView>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Removing the KeyboardView from the Experimental settings screen to fix a crash happening since the upgrade to React Native 0.73

Here is a github issue of this exact bug : https://github.com/facebook/react-native/issues/42939

This isn't ideal as the keyboard will now go over the fields in the bottom of the screen but it fixes the crash while we implement a better solution
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12996]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12996]: https://ledgerhq.atlassian.net/browse/LIVE-12996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ