### PR TITLE
fix: avoid throwing in getDeviceTransactionConfig [LIVE-12394]

### DIFF
--- a/.changeset/shy-seahorses-divide.md
+++ b/.changeset/shy-seahorses-divide.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+fix: avoid throwing in getDeviceTransactionConfig

--- a/libs/coin-modules/coin-solana/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-solana/src/deviceTransactionConfig.ts
@@ -14,7 +14,6 @@ import type {
   Transaction,
   TransferCommand,
 } from "./types";
-import { assertUnreachable } from "./utils";
 
 // do not show fields like 'To', 'Recipient', etc., as per Ledger policy
 
@@ -27,14 +26,8 @@ function getDeviceTransactionConfig({
   transaction: Transaction;
 }): Array<DeviceTransactionField> {
   const { commandDescriptor } = transaction.model;
-  if (commandDescriptor === undefined) {
-    throw new Error("missing command descriptor");
-  }
-  if (Object.keys(commandDescriptor.errors).length > 0) {
-    throw new Error("unexpected invalid command");
-  }
 
-  return fieldsForCommand(commandDescriptor, account);
+  return commandDescriptor ? fieldsForCommand(commandDescriptor, account) : [];
 }
 
 export default getDeviceTransactionConfig;
@@ -62,7 +55,7 @@ function fieldsForCommand(
     case "stake.split":
       return fieldsForStakeSplit(command);
     default:
-      return assertUnreachable(command);
+      return [];
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

I couldn't reproduce the issue anymore that was present last week with the thrown error but to be sure I propose this change to avoid any error thrown in a render cycle

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12394] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12394]: https://ledgerhq.atlassian.net/browse/LIVE-12394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ