### PR TITLE
feat(LIVE-13069): swap llm currencies from currencies all seem to be cached forever

### DIFF
--- a/.changeset/lemon-pumpkins-speak.md
+++ b/.changeset/lemon-pumpkins-speak.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(LIVE-13069): swap currencies api cache

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
@@ -10,6 +10,7 @@ import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
 import { getEnv } from "@ledgerhq/live-env";
 
 type Props = {
+  baseUrl?: string;
   additionalCoinsFlag?: boolean;
   providers: string[];
 };
@@ -19,11 +20,15 @@ export type ResponseDataAll = {
   to: ResponseDataTo["currencyGroups"];
 };
 
-export async function fetchCurrencyAll({ providers, additionalCoinsFlag = false }: Props) {
+export async function fetchCurrencyAll({
+  baseUrl = getSwapAPIBaseURL(),
+  providers,
+  additionalCoinsFlag = false,
+}: Props) {
   if (getEnv("MOCK") || getEnv("PLAYWRIGHT_RUN"))
     return Promise.resolve(flattenV5CurrenciesAll(fetchCurrencyAllMock));
 
-  const url = new URL(`${getSwapAPIBaseURL()}/currencies/all`);
+  const url = new URL(`${baseUrl}/currencies/all`);
   url.searchParams.append("providers-whitelist", providers.join(","));
   url.searchParams.append("additional-coins-flag", additionalCoinsFlag.toString());
   const headers = getSwapUserIP();

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyFrom.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyFrom.ts
@@ -6,6 +6,7 @@ import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
 import { getEnv } from "@ledgerhq/live-env";
 
 type Props = {
+  baseUrl?: string;
   currencyTo?: string;
   providers: string[];
   additionalCoinsFlag?: boolean;
@@ -19,6 +20,7 @@ export type ResponseData = {
 };
 
 export async function fetchCurrencyFrom({
+  baseUrl = getSwapAPIBaseURL(),
   currencyTo,
   providers,
   additionalCoinsFlag = false,
@@ -27,7 +29,7 @@ export async function fetchCurrencyFrom({
     return flattenV5CurrenciesToAndFrom(fetchCurrencyFromMock);
 
   const headers = getSwapUserIP();
-  const url = new URL(`${getSwapAPIBaseURL()}/currencies/from`);
+  const url = new URL(`${baseUrl}/currencies/from`);
   url.searchParams.append("providers-whitelist", providers.join(","));
   url.searchParams.append("additional-coins-flag", additionalCoinsFlag.toString());
 

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
@@ -8,6 +8,7 @@ import { flattenV5CurrenciesToAndFrom } from "../../utils/flattenV5CurrenciesToA
 import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
 
 type Props = {
+  baseUrl?: string;
   currencyFromId?: string;
   providers: string[];
   additionalCoinsFlag?: boolean;
@@ -22,6 +23,7 @@ type CurrencyGroup = {
 };
 
 export async function fetchCurrencyTo({
+  baseUrl = getSwapAPIBaseURL(),
   currencyFromId,
   providers,
   additionalCoinsFlag = false,
@@ -29,7 +31,7 @@ export async function fetchCurrencyTo({
   if (isIntegrationTestEnv())
     return Promise.resolve(flattenV5CurrenciesToAndFrom(fetchCurrencyToMock));
 
-  const url = new URL(`${getSwapAPIBaseURL()}/currencies/to`);
+  const url = new URL(`${baseUrl}/currencies/to`);
 
   url.searchParams.append("providers-whitelist", providers.join(","));
   url.searchParams.append("additional-coins-flag", additionalCoinsFlag.toString());

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/constants.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/constants.ts
@@ -1,0 +1,1 @@
+export const FETCH_CURRENCIES_TIMEOUT_MS = 1000 * 5 * 60; // 5 mins

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyAll.ts
@@ -1,6 +1,7 @@
 import { useFeature } from "../../../../featureFlags";
 import { useAPI } from "../../../../hooks/useAPI";
 import { fetchCurrencyAll } from "../../api/v5";
+import { FETCH_CURRENCIES_TIMEOUT_MS } from "./constants";
 import { useFilteredProviders } from "./useFilteredProviders";
 
 export function useFetchCurrencyAll() {
@@ -14,7 +15,7 @@ export function useFetchCurrencyAll() {
       providers,
     },
     // assume the all currency list for the given props won't change during a users session.
-    staleTimeout: Infinity,
+    staleTimeout: FETCH_CURRENCIES_TIMEOUT_MS,
     enabled: !loading && !error,
   });
   return {

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyFrom.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyFrom.ts
@@ -1,6 +1,8 @@
+import { getSwapAPIBaseURL } from "../../index";
 import { useFeature } from "../../../../featureFlags";
 import { useAPI } from "../../../../hooks/useAPI";
 import { fetchCurrencyFrom } from "../../api/v5/fetchCurrencyFrom";
+import { FETCH_CURRENCIES_TIMEOUT_MS } from "./constants";
 import { useFilteredProviders } from "./useFilteredProviders";
 
 type Props = {
@@ -16,12 +18,13 @@ export function useFetchCurrencyFrom({ currencyTo, enabled }: Props = {}) {
   return useAPI({
     queryFn: fetchCurrencyFrom,
     queryProps: {
+      baseUrl: getSwapAPIBaseURL(),
       currencyTo,
       additionalCoinsFlag: fetchAdditionalCoins?.enabled,
       providers,
     },
-    // assume a currency list for the given props won't change during a users session.
-    staleTimeout: Infinity,
+    // BE caches this so less of a problem when FE fetches frequently
+    staleTimeout: FETCH_CURRENCIES_TIMEOUT_MS,
     enabled: enabled && !loading && !error,
   });
 }

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyTo.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFetchCurrencyTo.ts
@@ -1,10 +1,12 @@
 import { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/coin-framework/account/helpers";
 
+import { getSwapAPIBaseURL } from "../../index";
 import { fetchCurrencyTo } from "../../api/v5";
 import { useAPI } from "../../../../hooks/useAPI";
 import { useFeature } from "../../../../featureFlags";
 import { useFilteredProviders } from "./useFilteredProviders";
+import { FETCH_CURRENCIES_TIMEOUT_MS } from "./constants";
 
 type Props = {
   fromCurrencyAccount: AccountLike | undefined;
@@ -22,11 +24,13 @@ export function useFetchCurrencyTo({ fromCurrencyAccount }: Props) {
   return useAPI({
     queryFn: fetchCurrencyTo,
     queryProps: {
+      baseUrl: getSwapAPIBaseURL(),
       currencyFromId,
       providers,
       additionalCoinsFlag: fetchAdditionalCoins?.enabled,
     },
-    staleTimeout: Infinity,
+    // BE caches this so less of a problem when FE fetches frequently
+    staleTimeout: FETCH_CURRENCIES_TIMEOUT_MS,
     enabled: !!currencyFromId && !loading && !error,
   });
 }


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Cache fetch currencies from / to for 5mins and url dependent

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13069](https://ledgerhq.atlassian.net/browse/LIVE-13069)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13069]: https://ledgerhq.atlassian.net/browse/LIVE-13069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ