### PR TITLE
:bug: [LIVE-12734] [LLD] Device disconnect during restore apps on LNX causing the app restore to fail

### DIFF
--- a/.changeset/orange-icons-rescue.md
+++ b/.changeset/orange-icons-rescue.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/device-core": patch
+---
+
+Reload app restauration if device disconnected after firmware update with language pack

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/Dashboard.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/Dashboard.tsx
@@ -67,9 +67,9 @@ const Dashboard = ({
     // - If a disconnection happens during a reset prevention period
     //   and the drawer is currently closed
     if (!currentDevice || deviceChangedWhenResetPrevented.current) {
-      onReset([]);
+      onReset(appsToRestore);
     }
-  }, [onReset, preventResetOnDeviceChange, currentDevice, drawerState.open]);
+  }, [appsToRestore, onReset, preventResetOnDeviceChange, currentDevice, drawerState.open]);
   const exec = useMemo(
     () =>
       getEnv("MOCK")

--- a/libs/device-core/src/commands/use-cases/getDeviceName.ts
+++ b/libs/device-core/src/commands/use-cases/getDeviceName.ts
@@ -3,14 +3,6 @@ import { LocalTracer } from "@ledgerhq/logs";
 import { APDU } from "../entities/APDU";
 import { parseGetDeviceNameResponse } from "./parseGetDeviceNameResponse";
 
-/**
- * A first APDU that we send because getDeviceName sometimes misbehaves on LNX
- * if it's not sent.
- * cf. https://github.com/LedgerHQ/ledger-live/pull/2250 where it was removed
- * cf. https://github.com/LedgerHQ/ledger-live/pull/2401 where it was added back
- */
-const CLEANING_APDU: APDU = [0xe0, 0x50, 0x00, 0x00, undefined];
-
 const GET_DEVICE_NAME_APDU: APDU = [0xe0, 0xd2, 0x00, 0x00, Buffer.from([])];
 
 export async function getDeviceName(transport: Transport): Promise<string> {
@@ -19,14 +11,6 @@ export async function getDeviceName(transport: Transport): Promise<string> {
     function: "getDeviceName",
   });
   tracer.trace("Start");
-
-  try {
-    // Legacy: prevents bad apdu response for LNX
-    await transport.send(...CLEANING_APDU);
-  } catch (error) {
-    tracer.trace(`Error on 0xe0500000: ${error}`, { error });
-  }
-  tracer.trace("Sent cleaning 0xe0500000");
 
   const res = await transport.send(...GET_DEVICE_NAME_APDU, [
     StatusCodes.OK,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Investigations for this bug: 
- An old apdu `e0500000`, which is bad formatted, was sent to the device (https://ledgerhq.atlassian.net/browse/LIVE-5273), we chose to delete it as it has no impact to get device/set device on LLM or LLD
- the firmware update bring a device disconnection on next allow manager, but only with a language pack install. Caused by `e053000000` APDU

After several tests that leaded to random behaviors, a trivial solution was to reset the dashboard with the app restauration list after disconnection. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: []LIVE-12734] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

https://github.com/LedgerHQ/ledger-live/assets/145363160/0c995d41-afa1-4bdd-a79b-b3fe7df014a1


<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
