### PR TITLE
fix(lld): Ignore silent JS error on will-frame-navigate second event

### DIFF
--- a/apps/ledger-live-desktop/src/sentry/install.ts
+++ b/apps/ledger-live-desktop/src/sentry/install.ts
@@ -108,6 +108,7 @@ const ignoreErrors = [
   "524 undefined",
   "Missing or invalid topic field", // wallet connect issue
   "Bad status on response: 503", // cryptoorg node
+  "Render frame was disposed before WebFrameMain could be accessed", // LIVE-12926
 ];
 
 export function init(Sentry: typeof SentryMainModule, opts?: Partial<ElectronMainOptions>) {


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD sentry reporting filtering

### 📝 Description

actively ignore `Render frame was disposed before WebFrameMain could be accessed` in the list of Sentry ignored errors to not spam our Sentry with silent reports.

This error is triggered when a second click to a URI link it clicked from inside a live app, e.g. the Stake action in Earn live app.

The error is currently not problematic but just an annoyance in dev mode

<img width="889" alt="bf6f36df-98c5-4e2b-a6ed-fd5435eeac54" src="https://github.com/LedgerHQ/ledger-live/assets/211411/7b898b8d-fc4a-4248-bcda-2bca97d66c1b">

pending a proper report to Electron team, we still need to actively ignore the error to be sent to Sentry and this is what this PR is doing.

### ❓ Context

- **JIRA or GitHub link**: LIVE-12926


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
