### PR TITLE
fix(llm): webview autoplay video on ios

### DIFF
--- a/.changeset/famous-gifts-cough.md
+++ b/.changeset/famous-gifts-cough.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+[iOS] Ledger recover video opens when user clicks on Buy now CTA

--- a/apps/ledger-live-mobile/src/components/WebViewScreen/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebViewScreen/index.tsx
@@ -98,6 +98,7 @@ const WebViewScreen = ({
               startInLoadingState
               javaScriptCanOpenWindowsAutomatically
               allowsBackForwardNavigationGestures
+              mediaPlaybackRequiresUserAction
               onNavigationStateChange={(navState: { canGoBack: boolean }) => {
                 setCanGoBack(!navState.canGoBack);
               }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - All WebViews

### 📝 Description

On ios when user press buy a ledger now it opens a webview and auto play a video. It seems like _mediaPlaybackRequiresUserAction_ property for webview is wrongly documented and is set to _true_ by default only for android. 
See => (https://github.com/react-native-webview/react-native-webview/issues/2369)


| Before        | After         |
| ------------- | ------------- |
|https://github.com/LedgerHQ/ledger-live/assets/73439207/605ab607-e6a6-4d8f-b308-a82b05af73e6|https://github.com/LedgerHQ/ledger-live/assets/73439207/552c424c-51ae-46a2-a287-269f33e92371
|https://github.com/LedgerHQ/ledger-live/assets/73439207/e76f8887-90c4-4efd-be79-50fcada5ac09|https://github.com/LedgerHQ/ledger-live/assets/73439207/d897109f-d295-48eb-8bde-153c63ba139e|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-13024](https://ledgerhq.atlassian.net/browse/LIVE-13024)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13024]: https://ledgerhq.atlassian.net/browse/LIVE-13024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ