### PR TITLE
:bug:fix(llm): typo when 1 account found after scan

### DIFF
--- a/.changeset/rude-flowers-breathe.md
+++ b/.changeset/rude-flowers-breathe.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix typo when scanning for existing account: "1 accounts found" on receive crypto flow

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3078,7 +3078,8 @@
       "addAccount": {
         "title": "Checking for an account...",
         "subtitle": "Checking if you already have an account for {{currencyName}} on the blockchain.",
-        "foundAccounts": "{{count}} accounts found",
+        "foundAccount": "{{count}} account found",
+        "foundAccount_plural": "{{count}} accounts found",
         "stopSynchronization": "Stop synchronization",
         "addingAccount": "No accounts found. Creating a new account for {{currencyName}}..."
       },

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-AddAccount.tsx
@@ -280,6 +280,7 @@ function ScanLoading({
   stopSubscription: () => void;
 }) {
   const { t } = useTranslation();
+  const numberOfAccountsFound = scannedAccounts?.length;
 
   return (
     <Loading
@@ -305,11 +306,11 @@ function ScanLoading({
           m={6}
           justifyContent="flex-end"
         >
-          {scannedAccounts?.length > 0 ? (
+          {numberOfAccountsFound > 0 ? (
             <>
               <LText textAlign="center" mb={6} variant="body" color="neutral.c80">
-                {t("transfer.receive.addAccount.foundAccounts", {
-                  count: scannedAccounts?.length,
+                {t("transfer.receive.addAccount.foundAccount", {
+                  count: numberOfAccountsFound,
                 })}
               </LText>
               <Button type="secondary" onPress={stopSubscription}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Receive funds flow -> sync accounts with Ledger Device -> Scan OnChain Accounts

### 📝 Description

Fix typo if there is only 1 account during sync
Instead of "1 __accounts__  found" we will have "1 __account__ found" without the **s**


| Before        | After         |
| ------------- | ------------- |
|https://github.com/LedgerHQ/ledger-live/assets/73439207/e6da81eb-448c-403f-bc04-c99ab2cbc0ec|https://github.com/LedgerHQ/ledger-live/assets/73439207/b63d1432-d633-4751-9cac-fb5dbd7e65eb|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-12978](https://ledgerhq.atlassian.net/browse/LIVE-12978)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12978]: https://ledgerhq.atlassian.net/browse/LIVE-12978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ