### PR TITLE
[QAA-121][Playwright] Disable time mocking for speculos tests

### DIFF
--- a/apps/ledger-live-desktop/src/index.ts
+++ b/apps/ledger-live-desktop/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import { getEnv } from "@ledgerhq/live-env";
 
-if (getEnv("PLAYWRIGHT_RUN")) {
+if (getEnv("PLAYWRIGHT_RUN") && getEnv("MOCK")) {
   const timemachine = require("timemachine");
   timemachine.config({
     dateString: require("../tests/time").default,

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -93,12 +93,14 @@ async function init() {
     });
     const envs = getLocalStorageEnvs();
     for (const k in envs) setEnvOnAllThreads(k, envs[k]);
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const timemachine = require("timemachine");
-    timemachine.config({
+    if (getEnv("MOCK")) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      dateString: require("../../tests/time").default,
-    });
+      const timemachine = require("timemachine");
+      timemachine.config({
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        dateString: require("../../tests/time").default,
+      });
+    }
   }
   if (window.localStorage.getItem("hard-reset")) {
     await hardReset();

--- a/apps/ledger-live-desktop/tests/specs/speculos/add.account.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/add.account.spec.ts
@@ -11,7 +11,7 @@ const currencies: Currency[] = [
   Currency.DOT,
   Currency.TRX,
   Currency.ADA,
-  //Currency.XLM, //TODO: Reactivate when Date.Parse issue is fixed - desactivate time machine for Speculos tests
+  Currency.XLM,
   Currency.BCH,
   Currency.ALGO,
   Currency.ATOM,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Speculos tests
  - Mocked tests

### 📝 Description

Currently date and time is mocked for all Playwright tests. We choose to disable mocked time for Speculos tests (MOCK false) to prevent some issue in tests (Date.parse is invalid function issue)
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [Speculos test run](https://github.com/LedgerHQ/ledger-live/actions/runs/9641394366)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
