### PR TITLE
fix(LIVE-13072): use NotEnoughGas to suggest buying more currency

### DIFF
--- a/.changeset/tall-moons-flow.md
+++ b/.changeset/tall-moons-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": patch
+---
+
+fix(LIVE-13071): use not enough gas error for Tron

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -255,7 +255,7 @@ const getTransactionStatus = async (
   // Not enough gas check
   // PTX swap uses this to support deeplink to buy additional currency
   //
-  if (estimatedFees.gt(balance) || balance.isZero()) {
+  if (balance.lt(estimatedFees) || balance.isZero()) {
     const query = new URLSearchParams({
       ...(account?.id ? { account: account.id } : {}),
     });

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -1,9 +1,10 @@
-import { getAccountCurrency } from "@ledgerhq/coin-framework/account";
+import { getAccountCurrency, getFeesUnit } from "@ledgerhq/coin-framework/account";
 import {
   AmountRequired,
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
+  NotEnoughGas,
   RecipientRequired,
 } from "@ledgerhq/errors";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies";
@@ -247,6 +248,22 @@ const getTransactionStatus = async (
     });
     warnings.fee = new TronUnexpectedFees("Estimated fees", {
       fees,
+    });
+  }
+
+  //
+  // Not enough gas check
+  // PTX swap uses this to support deeplink to buy additional currency
+  //
+  if (estimatedFees.gt(balance) || balance.isZero()) {
+    const query = new URLSearchParams({
+      ...(account?.id ? { account: account.id } : {}),
+    });
+    errors.gasPrice = new NotEnoughGas(undefined, {
+      fees: formatCurrencyUnit(getFeesUnit(acc.currency), estimatedFees),
+      ticker: acc.currency.ticker,
+      cryptoName: acc.currency.name,
+      links: [`ledgerlive://buy?${query.toString()}`],
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Use `NotEnoughGas` error in `getTransactionStatus` of Tron bridge, this will allow us to prompt user to buy more currencies if needed. 

Use error if the account balance is `0` or below required estimated gas value

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13101](https://ledgerhq.atlassian.net/browse/LIVE-13101)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13101]: https://ledgerhq.atlassian.net/browse/LIVE-13101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ