### PR TITLE
trustchain sdk: some error management and sdk.refreshAuth added

### DIFF
--- a/libs/trustchain/src/errors.ts
+++ b/libs/trustchain/src/errors.ts
@@ -2,3 +2,4 @@ import { createCustomErrorClass } from "@ledgerhq/errors";
 
 export const InvalidDigitsError = createCustomErrorClass("InvalidDigitsError");
 export const InvalidEncryptionKeyError = createCustomErrorClass("InvalidEncryptionKeyError");
+export const TrustchainEjected = createCustomErrorClass("TrustchainEjected");

--- a/libs/trustchain/src/mockSdk.ts
+++ b/libs/trustchain/src/mockSdk.ts
@@ -77,6 +77,10 @@ class MockSDK implements TrustchainSDK {
     });
   }
 
+  async refreshAuth(jwt: JWT): Promise<JWT> {
+    return jwt;
+  }
+
   async restoreTrustchain(
     jwt: JWT,
     trustchainId: string,

--- a/libs/trustchain/src/sdk.ts
+++ b/libs/trustchain/src/sdk.ts
@@ -158,6 +158,10 @@ export class SDK implements TrustchainSDK {
     return { jwt, trustchain };
   }
 
+  async refreshAuth(jwt: JWT): Promise<JWT> {
+    return api.refreshAuth(jwt);
+  }
+
   async restoreTrustchain(
     jwt: JWT,
     trustchainId: string,

--- a/libs/trustchain/src/types.ts
+++ b/libs/trustchain/src/types.ts
@@ -112,6 +112,11 @@ export interface TrustchainSDK {
   }>;
 
   /**
+   * Refresh the current JWT.
+   */
+  refreshAuth(jwt: JWT): Promise<JWT>;
+
+  /**
    * Restore the current trustchain encryption key, typically due to a key rotation.
    */
   restoreTrustchain(


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** coming soon in a general pr <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - trustchain lib

### 📝 Description

- remap device error `UserRefusedOnDevice`. that should make LLD/LLM use the proper wording for the case you refuse on device.
- introduce `TrustchainEjected` error: when you try to do a restoreTrustchain and you are no longer a member (can't read the member key in the trustchain) this error is thrown and the UI will have to reset (eject) the user from the trustchain.
- introduce `sdk.refreshAuth` which can be used to actively refresh a JWT token.
- throw an error when you try to remove yourself because the sdk don't implement this well. pending product to tell us if we still want it supported.

### ❓ Context

- **JIRA or GitHub link**: part of LIVE-13112


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
