### PR TITLE
:bug:fix(RN-UI): animated input didn't watch if there was a value entered

### DIFF
--- a/.changeset/spicy-waves-wave.md
+++ b/.changeset/spicy-waves-wave.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+input animation triggers if there is any value entered

--- a/libs/ui/packages/native/src/components/Form/Input/AnimatedInput/AnimatedNotchedLabel.tsx
+++ b/libs/ui/packages/native/src/components/Form/Input/AnimatedInput/AnimatedNotchedLabel.tsx
@@ -64,11 +64,16 @@ const LineCutout = styled(Flex)<LineCutoutProps>`
 type AnimatedNotchedLabelProps = {
   placeholder: string;
   inputStatus: InputStatus;
+  value: string;
 };
 
-export const AnimatedNotchedLabel = ({ placeholder, inputStatus }: AnimatedNotchedLabelProps) => {
+export const AnimatedNotchedLabel = ({
+  placeholder,
+  inputStatus,
+  value,
+}: AnimatedNotchedLabelProps) => {
   const [labelWidth, setLabelWidth] = useState(0);
-  const notched = inputStatus !== "default";
+  const notched = inputStatus !== "default" || value.length > 0;
 
   const labelTop = useSharedValue(notched ? labelFinalPositions.top : labelInitialPositions.top);
   const labelLeft = useSharedValue(notched ? labelFinalPositions.left : labelInitialPositions.left);

--- a/libs/ui/packages/native/src/components/Form/Input/AnimatedInput/index.tsx
+++ b/libs/ui/packages/native/src/components/Form/Input/AnimatedInput/index.tsx
@@ -46,13 +46,15 @@ const AnimatedInput = (
 
   return (
     <InputContainer status={inputStatus} style={style}>
-      {placeholder && <AnimatedNotchedLabel placeholder={placeholder} inputStatus={inputStatus} />}
+      {placeholder && (
+        <AnimatedNotchedLabel placeholder={placeholder} inputStatus={inputStatus} value={value} />
+      )}
       <BaseInput
         ref={ref}
         onFocus={onFocus}
         onBlur={onBlur}
         error={error}
-        value={value as string}
+        value={value}
         color={theme ? inputTextColor[inputStatus]({ theme }) : "neutral.c100"}
         inputContainerStyle={{
           backgroundColor: "none",


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Animated Input 

### 📝 Description

Animation didn't get triggered on LLM on animated input for ENS. We don't know if this was due to a slow app, an error or smth else. 
To test it we can use react extensions on browser and update manually the value inside the input.
Since we can't reproduce the bug on any env this fix may resolve it. 


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12654](https://ledgerhq.atlassian.net/browse/LIVE-12654) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12654]: https://ledgerhq.atlassian.net/browse/LIVE-12654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ