### PR TITLE
[LIVE-13096][LIVE-13098][LLM][Flex] Wrong redirection and text overlaps during Send

### DIFF
--- a/.changeset/plenty-weeks-double.md
+++ b/.changeset/plenty-weeks-double.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix image overlaps bug during Send on Flex.

--- a/.changeset/weak-kings-flow.md
+++ b/.changeset/weak-kings-flow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix redirecting to wrong workflow bug.

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -35,7 +35,7 @@ import {
   getFeesUnit,
 } from "@ledgerhq/live-common/account/index";
 import { TFunction } from "react-i18next";
-import { DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceModelId, QRCodeDevices } from "@ledgerhq/types-devices";
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { ParamListBase } from "@react-navigation/native";
@@ -773,7 +773,7 @@ export function renderDeviceNotOnboarded({
   navigation: StackNavigationProp<ParamListBase>;
 }) {
   const navigateToOnboarding = () => {
-    if (device.modelId === DeviceModelId.stax) {
+    if (QRCodeDevices.includes(device.modelId)) {
       // On pairing success, navigate to the Sync Onboarding Companion
       navigation.navigate(NavigatorName.BaseOnboarding, {
         screen: NavigatorName.SyncOnboarding,

--- a/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateOnDevice.tsx
@@ -16,7 +16,7 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import { useTheme } from "@react-navigation/native";
 import styled from "styled-components/native";
 import { Flex } from "@ledgerhq/native-ui";
-import { DeviceModelId } from "@ledgerhq/types-devices";
+import { QRCodeDevices } from "@ledgerhq/types-devices";
 import Alert from "./Alert";
 import perFamilyTransactionConfirmFields from "../generated/TransactionConfirmFields";
 import { DataRowUnitValue, TextValueField } from "./ValidateOnDeviceDataRow";
@@ -170,7 +170,7 @@ export default function ValidateOnDevice({
           <AnimationContainer>
             <Animation
               source={getDeviceAnimation({ device, key: "sign", theme })}
-              style={device.modelId === DeviceModelId.stax ? { height: 210 } : {}}
+              style={QRCodeDevices.includes(device.modelId) ? { height: 210 } : {}}
             />
           </AnimationContainer>
           {Title ? (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** 
  - Fix Flex wrong onboarding workflow bug;
  - Fix title overlaps during Send on Flex.

### 📝 Description
  - Fix Flex wrong onboarding workflow bug;
  - Fix title overlaps during Send on Flex.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13096](https://ledgerhq.atlassian.net/browse/LIVE-13096) [LIVE-13098](https://ledgerhq.atlassian.net/browse/LIVE-13098)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13096]: https://ledgerhq.atlassian.net/browse/LIVE-13096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-13098]: https://ledgerhq.atlassian.net/browse/LIVE-13098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ