### PR TITLE
Fix: LIVE-13226 polkadot send for runtime upgrade

### DIFF
--- a/.changeset/lucky-lobsters-rescue.md
+++ b/.changeset/lucky-lobsters-rescue.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/hw-app-polkadot": patch
+"@ledgerhq/live-common": patch
+---
+
+fix: polkadot send tx in LLM

--- a/libs/ledger-live-common/src/families/polkadot/config.ts
+++ b/libs/ledger-live-common/src/families/polkadot/config.ts
@@ -19,12 +19,12 @@ export const polkadotConfig: Record<string, ConfigInfo> = {
         electionStatusThreshold: getEnv("POLKADOT_ELECTION_STATUS_THRESHOLD"),
       },
       metadataShortener: {
-        url: "https://api.zondax.ch/polkadot/transaction/metadata",
+        url: "https://polkadot-metadata-shortener.api.live.ledger.com/transaction/metadata",
       },
       metadataHash: {
-        url: "https://api.zondax.ch/polkadot/node/metadata/hash",
+        url: "https://polkadot-metadata-shortener.api.live.ledger.com/node/metadata/hash",
       },
-      runtimeUpgraded: false,
+      runtimeUpgraded: true,
     },
   },
 };

--- a/libs/ledgerjs/packages/hw-app-polkadot/src/Polkadot.ts
+++ b/libs/ledgerjs/packages/hw-app-polkadot/src/Polkadot.ts
@@ -136,6 +136,8 @@ export default class Polkadot {
         Buffer.from(message),
         Buffer.from(metadata.slice(2), "hex"),
       );
+      // we need to cast the signature to Buffer explicitly. In react native, the signature from signWithMetadata is not necessarily a Buffer
+      signatureRequest.signature = Buffer.from(signatureRequest.signature);
       return {
         signature: signatureRequest.signature.toString("hex"),
         return_code: SW_OK,


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [X] **Impact of the changes: No impact.
  - ...

### 📝 Description

In react-native, the "app.signWithMetadata" method returns a polkadot signature. It is not a Buffer type variable, we need to cast it to Buffer explicitly. It is only related to Ledger Live mobile app.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-13226


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
