### PR TITLE
fix(LIVE-13280): remove the setState in useEffect

### DIFF
--- a/.changeset/thin-pugs-fly.md
+++ b/.changeset/thin-pugs-fly.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+remove unsued useEffect for demo1

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/index.tsx
@@ -462,21 +462,6 @@ const SwapForm = () => {
     swapError,
   });
 
-  useEffect(() => {
-    if (isDemo1Enabled) {
-      setQuoteState({
-        amountTo: undefined,
-        swapError: undefined,
-      });
-    }
-  }, [
-    setQuoteState,
-    sourceAccount,
-    swapWebProps?.toAccountId,
-    swapWebProps?.fromAmount,
-    isDemo1Enabled,
-  ]);
-
   return (
     <Wrapper>
       <TrackPage category="Swap" name="Form" provider={provider} {...swapDefaultTrack} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

- remove unused useEffect for demo1
 
- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-12781
https://ledgerhq.atlassian.net/browse/LIVE-13280
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
