### PR TITLE
[LIVE-13288] Bugfix - Replace TronGrid URI in pagination links

### DIFF
--- a/.changeset/honest-years-remain.md
+++ b/.changeset/honest-years-remain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": patch
+---
+
+Fix Tron API request providing link for next pages with trongrid's URI instead of continuing on the reverse proxy

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -332,7 +332,10 @@ const getTransactions =
         TransactionResponseTronAPI<TransactionTronAPI | MalformedTransactionTronAPI>
       >(url);
 
-    const nextUrl = transactions.meta.links?.next;
+    const nextUrl = transactions.meta.links?.next?.replace(
+      /https:\/\/api(\.[a-z]*)?.trongrid.io/,
+      getBaseApiUrl(),
+    );
     const results = await promiseAllBatched(3, transactions.data || [], async tx => {
       if (isMalformedTransactionTronAPI(tx)) {
         return tx;
@@ -360,7 +363,10 @@ const getTrc20 = async (
 
   return {
     results: transactions.data,
-    nextUrl: transactions.meta.links?.next,
+    nextUrl: transactions.meta.links?.next?.replace(
+      /https:\/\/api(\.[a-z]*)?.trongrid.io/,
+      getBaseApiUrl(),
+    ),
   };
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact, just no more 403 :p 

### 📝 Description

While doing requests to TronGrid, the API might provide some links to follow in order to get either the next paginated response. Those links are directly calling TronGrid, which might rate limit people doing too many requests.
This PR replace the TronGrid's URI with the RP's URI for those links.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-13288


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
