### PR TITLE
chore(trustchain): getOrCreateTrustchain returns a type to explain the effect

### DIFF
--- a/apps/web-tools/trustchain/components/AppGetOrCreateTrustchain.tsx
+++ b/apps/web-tools/trustchain/components/AppGetOrCreateTrustchain.tsx
@@ -27,7 +27,9 @@ export function AppGetOrCreateTrustchain({
   const action = useCallback(
     (memberCredentials: MemberCredentials) =>
       runWithDevice(deviceId, transport =>
-        sdk.getOrCreateTrustchain(transport, memberCredentials, callbacks),
+        sdk
+          .getOrCreateTrustchain(transport, memberCredentials, callbacks)
+          .then(result => result.trustchain),
       ),
     [deviceId, sdk, callbacks],
   );

--- a/libs/trustchain/src/test-scenarios/_template.ts
+++ b/libs/trustchain/src/test-scenarios/_template.ts
@@ -11,7 +11,7 @@ export async function scenario(transport: Transport) {
   const name1 = "cli-member1";
   const sdk1 = getSdk(false, { applicationId, name: name1 });
   const memberCredentials = await sdk1.initMemberCredentials();
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, memberCredentials);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, memberCredentials);
 
   await sdk1.destroyTrustchain(trustchain, memberCredentials);
 }

--- a/libs/trustchain/src/test-scenarios/create2trustchainInARow.ts
+++ b/libs/trustchain/src/test-scenarios/create2trustchainInARow.ts
@@ -8,8 +8,10 @@ export async function scenario(transport: Transport) {
   const creds = await sdk.initMemberCredentials();
 
   const t1 = await sdk.getOrCreateTrustchain(transport, creds);
-  await sdk.destroyTrustchain(t1, creds);
+  await sdk.destroyTrustchain(t1.trustchain, creds);
+  expect(t1.type).toBe("created");
 
   const t2 = await sdk.getOrCreateTrustchain(transport, creds);
-  await sdk.destroyTrustchain(t2, creds);
+  await sdk.destroyTrustchain(t2.trustchain, creds);
+  expect(t2.type).toBe("created");
 }

--- a/libs/trustchain/src/test-scenarios/getOrCreateTransactionCases.ts
+++ b/libs/trustchain/src/test-scenarios/getOrCreateTransactionCases.ts
@@ -21,9 +21,19 @@ export async function scenario(transport: Transport) {
   };
 
   // verify that getOrCreateTrustchain is idempotent
-  const t1 = await sdk1.getOrCreateTrustchain(transport, member1creds, callbacks);
+  const { trustchain: t1, type: type1 } = await sdk1.getOrCreateTrustchain(
+    transport,
+    member1creds,
+    callbacks,
+  );
+  expect(type1).toBe("created");
   expect(totalInteractionCounter).toBe(2); // there are two interaction: one for device auth, one for trustchain addition
-  const t2 = await sdk1.getOrCreateTrustchain(transport, member1creds, callbacks);
+  const { trustchain: t2, type: type2 } = await sdk1.getOrCreateTrustchain(
+    transport,
+    member1creds,
+    callbacks,
+  );
+  expect(type2).toBe("restored");
   expect(totalInteractionCounter).toBe(2); // no more interaction happened
   expect(t1).toEqual(t2);
 
@@ -31,7 +41,12 @@ export async function scenario(transport: Transport) {
   const name2 = "Member 2";
   const sdk2 = getSdk(!!getEnv("MOCK"), { applicationId, name: name2 });
   const member2creds = await sdk2.initMemberCredentials();
-  const t3 = await sdk2.getOrCreateTrustchain(transport, member2creds, callbacks);
+  const { trustchain: t3, type: type3 } = await sdk2.getOrCreateTrustchain(
+    transport,
+    member2creds,
+    callbacks,
+  );
+  expect(type3).toBe("updated");
   expect(t1).toEqual(t3);
 
   // check there are indeed our two members in the trustchain

--- a/libs/trustchain/src/test-scenarios/member3implicitlyAdded.ts
+++ b/libs/trustchain/src/test-scenarios/member3implicitlyAdded.ts
@@ -22,14 +22,14 @@ export async function scenario(transport: Transport) {
   const member3creds = await sdk3.initMemberCredentials();
 
   // auth with the device and init the first trustchain
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds);
 
   // member 1 adds member 2
   const member2 = { name: name2, id: member2creds.pubkey, permissions: 0xffffffff };
   await sdk1.addMember(trustchain, member1creds, member2);
 
   // member 3 do a getOrCreateTrustchain that should add itself implicitly
-  const trustchain3 = await sdk3.getOrCreateTrustchain(transport, member3creds);
+  const { trustchain: trustchain3 } = await sdk3.getOrCreateTrustchain(transport, member3creds);
 
   // list members
   const members = await sdk3.getMembers(trustchain3, member3creds);

--- a/libs/trustchain/src/test-scenarios/randomMemberTryToDestroy.ts
+++ b/libs/trustchain/src/test-scenarios/randomMemberTryToDestroy.ts
@@ -17,7 +17,7 @@ export async function scenario(transport: Transport) {
   const member2creds = await sdk2.initMemberCredentials();
 
   // auth with the device and init the first trustchain
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds);
 
   // now member2 will get an ejected error when trying to destroy the trustchain
   await expect(sdk2.destroyTrustchain(trustchain, member2creds)).rejects.toThrow(TrustchainEjected);

--- a/libs/trustchain/src/test-scenarios/removeMemberWithTheWrongSeed.ts
+++ b/libs/trustchain/src/test-scenarios/removeMemberWithTheWrongSeed.ts
@@ -15,7 +15,7 @@ export async function scenario(transport: Transport, { switchDeviceSeed }: Scena
   const member2creds = await sdk2.initMemberCredentials();
   const member2 = { name: name2, id: member2creds.pubkey, permissions: 0xffffffff };
 
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds);
   await sdk1.addMember(trustchain, member1creds, member2);
   transport = await switchDeviceSeed();
 

--- a/libs/trustchain/src/test-scenarios/removedMemberEjected.ts
+++ b/libs/trustchain/src/test-scenarios/removedMemberEjected.ts
@@ -12,7 +12,7 @@ export async function scenario(transport: Transport) {
   const member1creds = await sdk1.initMemberCredentials();
 
   // auth with the device and init the first trustchain
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds);
 
   // second member initializes itself
   const name2 = "Member 2";

--- a/libs/trustchain/src/test-scenarios/removingAMemberCreatesAnInteraction.ts
+++ b/libs/trustchain/src/test-scenarios/removingAMemberCreatesAnInteraction.ts
@@ -26,7 +26,7 @@ export async function scenario(transport: Transport) {
     },
   };
 
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds, callbacks);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds, callbacks);
   expect(totalInteractionCounter).toBe(2); // there are two interaction: one for device auth, one for trustchain addition
 
   await sdk1.addMember(trustchain, member1creds, member2);

--- a/libs/trustchain/src/test-scenarios/removingYourselfIsForbidden.ts
+++ b/libs/trustchain/src/test-scenarios/removingYourselfIsForbidden.ts
@@ -7,7 +7,7 @@ export async function scenario(transport: Transport) {
   const name1 = "Member 1";
   const sdk1 = getSdk(!!getEnv("MOCK"), { applicationId, name: name1 });
   const member1creds = await sdk1.initMemberCredentials();
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds);
   const members = await sdk1.getMembers(trustchain, member1creds);
   await expect(
     sdk1.removeMember(transport, trustchain, member1creds, members[0]),

--- a/libs/trustchain/src/test-scenarios/success.ts
+++ b/libs/trustchain/src/test-scenarios/success.ts
@@ -14,7 +14,7 @@ export async function scenario(transport: Transport) {
   const member1creds = await sdk1.initMemberCredentials();
 
   // auth with the device and init the first trustchain
-  const trustchain = await sdk1.getOrCreateTrustchain(transport, member1creds);
+  const { trustchain } = await sdk1.getOrCreateTrustchain(transport, member1creds);
 
   // verify we have member 1 in the trustchain
   const members = await sdk1.getMembers(trustchain, member1creds);

--- a/libs/trustchain/src/test-scenarios/tokenExpires.ts
+++ b/libs/trustchain/src/test-scenarios/tokenExpires.ts
@@ -9,7 +9,7 @@ export async function scenario(transport: Transport, { pauseRecorder }: Scenario
 
   const jwt1 = await sdk.withDeviceAuth(transport, jwt => Promise.resolve(jwt));
   await pauseRecorder(6 * 60 * 1000);
-  const trustchain = await sdk.getOrCreateTrustchain(transport, creds);
+  const { trustchain } = await sdk.getOrCreateTrustchain(transport, creds);
   const jwt2 = await sdk.withDeviceAuth(transport, jwt2 => Promise.resolve(jwt2));
   // assert that jwt was refreshed (due to the expiration)
   expect(jwt1).not.toEqual(jwt2);

--- a/libs/trustchain/src/types.ts
+++ b/libs/trustchain/src/types.ts
@@ -65,6 +65,32 @@ export type TrustchainSDKContext = {
   name: string;
 };
 
+export enum TrustchainResultType {
+  created = "created",
+  updated = "updated",
+  restored = "restored",
+}
+
+/**
+ * the trustchain with a result type indicating what happened during getOrCreateTrustchain
+ */
+export type TrustchainResult =
+  | {
+      // the trustchain didn't exist and was created
+      type: TrustchainResultType.created;
+      trustchain: Trustchain;
+    }
+  | {
+      // the trustchain already existed and was updated (typically the current member was added)
+      type: TrustchainResultType.updated;
+      trustchain: Trustchain;
+    }
+  | {
+      // the trustchain existed and was just retrieved (no need to update it)
+      type: TrustchainResultType.restored;
+      trustchain: Trustchain;
+    };
+
 /**
  * cache (default): the SDK will use the cached JWT if it's still valid, otherwise it will refresh it.
  * refresh: the SDK will always refresh the JWT if possible.
@@ -117,7 +143,7 @@ export interface TrustchainSDK {
     memberCredentials: MemberCredentials,
     callbacks?: TrustchainDeviceCallbacks,
     topic?: Uint8Array,
-  ): Promise<Trustchain>;
+  ): Promise<TrustchainResult>;
 
   /**
    * Restore the current trustchain encryption key, typically due to a key rotation.


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - trustchain library, getOrCreateTrustchain

### 📝 Description

The UI needs an evolution to be able to tell what exactly happened on `getOrCreateTrustchain` and branch different wording based on it.

There are 3 cases:

```ts
| {
    // the trustchain didn't exist and was created
    type: "created";
    trustchain: Trustchain;
  }
| {
    // the trustchain already existed and was updated (typically the current member was added)
    type: "updated";
    trustchain: Trustchain;
  }
| {
    // the trustchain existed and was just retrieved (no need to update it)
    type: "restored";
    trustchain: Trustchain;
  }
```

they are covered by our existing integration tests without having to update snapshots.

### ❓ Context

- **JIRA or GitHub link**: n/a (slack request)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
