### PR TITLE
[FEAT]  : Analytics WalletSync

### DIFF
--- a/.changeset/tiny-drinks-smell.md
+++ b/.changeset/tiny-drinks-smell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add analytics for WalletSync

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Activation/01-CreateOrSynchronizeStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Activation/01-CreateOrSynchronizeStep.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components";
 import ButtonV3 from "~/renderer/components/ButtonV3";
 import { LogoWrapper } from "LLD/WalletSync/components/LogoWrapper";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
 
 type Props = {
   goToCreateBackup: () => void;
@@ -16,6 +18,7 @@ export default function CreateOrSynchronizeStep({ goToCreateBackup, goToSync }: 
 
   return (
     <Flex flexDirection="column" alignSelf="center" justifyContent="center" rowGap="24px">
+      <TrackPage category={AnalyticsPage.Activation} />
       <Flex justifyContent="center" alignItems="center">
         <LogoWrapper>
           <Icons.Mobile color={colors.constant.purple} />

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Activation/04-ActivationFinalStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Activation/04-ActivationFinalStep.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-//import { Error } from "../../components/Error";
 import { Success } from "../../components/Success";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { setFlow } from "~/renderer/actions/walletSync";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
+import { AnalyticsPage, useWalletSyncAnalytics } from "../../hooks/useWalletSyncAnalytics";
 
 type Props = {
   isNewBackup: boolean;
@@ -15,8 +15,24 @@ export default function ActivationFinalStep({ isNewBackup }: Props) {
   const dispatch = useDispatch();
   const title = isNewBackup ? "walletSync.success.backup.title" : "walletSync.success.synch.title";
   const desc = isNewBackup ? "walletSync.success.backup.desc" : "walletSync.success.synch.desc";
+
+  const { onClickTrack } = useWalletSyncAnalytics();
+
   const goToSync = () => {
     dispatch(setFlow({ flow: Flow.Synchronize, step: Step.SynchronizeMode }));
+    onClickTrack({
+      button: "Sync with another Ledger Live",
+      page: isNewBackup ? AnalyticsPage.KeyCreated : AnalyticsPage.KeyUpdated,
+      flow: "Wallet Sync",
+    });
   };
-  return <Success title={t(title)} description={t(desc)} withCta onClick={goToSync} />;
+  return (
+    <Success
+      title={t(title)}
+      description={t(desc)}
+      withCta
+      onClick={goToSync}
+      analyticsPage={isNewBackup ? AnalyticsPage.KeyCreated : AnalyticsPage.KeyUpdated}
+    />
+  );
 }

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Activation/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Activation/index.tsx
@@ -11,6 +11,7 @@ import ActivationOrSynchroWithTrustchain from "./03-ActivationOrSynchroWithTrust
 import ActivationFinalStep from "./04-ActivationFinalStep";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import ErrorStep from "./05-ActivationOrSyncError";
+import { AnalyticsPage, useWalletSyncAnalytics } from "../../hooks/useWalletSyncAnalytics";
 
 const WalletSyncActivation = () => {
   const dispatch = useDispatch();
@@ -18,8 +19,24 @@ const WalletSyncActivation = () => {
 
   const { currentStep, goToNextScene } = useFlows();
 
+  const { onClickTrack } = useWalletSyncAnalytics();
+
   const goToSync = () => {
     dispatch(setFlow({ flow: Flow.Synchronize, step: Step.SynchronizeMode }));
+    onClickTrack({
+      button: "Already created a key?",
+      page: AnalyticsPage.Activation,
+      flow: "Wallet Sync",
+    });
+  };
+
+  const goToCreateBackup = () => {
+    goToNextScene();
+    onClickTrack({
+      button: "create your backup",
+      page: AnalyticsPage.Activation,
+      flow: "Wallet Sync",
+    });
   };
 
   const goToActivationOrSynchroWithTrustchain = (device: Device) => {
@@ -31,7 +48,7 @@ const WalletSyncActivation = () => {
     switch (currentStep) {
       default:
       case Step.CreateOrSynchronize:
-        return <CreateOrSynchronizeStep goToCreateBackup={goToNextScene} goToSync={goToSync} />;
+        return <CreateOrSynchronizeStep goToCreateBackup={goToCreateBackup} goToSync={goToSync} />;
       case Step.DeviceAction:
         return <DeviceActionStep goNext={goToActivationOrSynchroWithTrustchain} />;
       case Step.CreateOrSynchronizeTrustChain:

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Manage/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Manage/index.tsx
@@ -9,6 +9,8 @@ import { Option, OptionProps } from "./Option";
 import styled from "styled-components";
 import { useInstances } from "../ManageInstances/useInstances";
 import { useLifeCycle } from "../../hooks/walletSync.hooks";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { AnalyticsPage, useWalletSyncAnalytics } from "../../hooks/useWalletSyncAnalytics";
 
 const Separator = () => {
   const { colors } = useTheme();
@@ -22,16 +24,22 @@ const WalletSyncManage = () => {
 
   const dispatch = useDispatch();
 
+  const { onClickTrack } = useWalletSyncAnalytics();
+
   const goToSync = () => {
     dispatch(setFlow({ flow: Flow.Synchronize, step: Step.SynchronizeMode }));
+
+    onClickTrack({ button: "Synchronize", page: AnalyticsPage.WalletSyncSettings });
   };
 
   const goToManageBackup = () => {
     dispatch(setFlow({ flow: Flow.ManageBackup, step: Step.ManageBackup }));
+    onClickTrack({ button: "Manage Backup", page: AnalyticsPage.WalletSyncSettings });
   };
 
   const goToManageInstances = () => {
     dispatch(setFlow({ flow: Flow.ManageInstances, step: Step.SynchronizedInstances }));
+    onClickTrack({ button: "Manage Instances", page: AnalyticsPage.WalletSyncSettings });
   };
 
   const Options: OptionProps[] = [
@@ -51,6 +59,7 @@ const WalletSyncManage = () => {
 
   return (
     <Box height="100%" paddingX="40px">
+      <TrackPage category={AnalyticsPage.WalletSyncSettings} />
       <Box marginBottom={"24px"}>
         <Text fontSize={23} variant="large">
           {t("walletSync.title")}

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/ManageInstances/04-DeletionError.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/ManageInstances/04-DeletionError.tsx
@@ -6,6 +6,8 @@ import styled, { useTheme } from "styled-components";
 import { setFlow } from "~/renderer/actions/walletSync";
 import ButtonV3 from "~/renderer/components/ButtonV3";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
+import { AnalyticsPage, useWalletSyncAnalytics } from "../../hooks/useWalletSyncAnalytics";
+import TrackPage from "~/renderer/analytics/TrackPage";
 
 const Container = styled(Box)`
   background-color: ${p => p.theme.colors.opacityDefault.c05};
@@ -28,15 +30,21 @@ type Props = {
 
 export const DeletionError = ({ error }: Props) => {
   const dispatch = useDispatch();
+
+  const { onClickTrack } = useWalletSyncAnalytics();
+
   const tryAgain = () => {
     dispatch(setFlow({ flow: Flow.ManageInstances, step: Step.DeviceActionInstance }));
+    onClickTrack({ button: "connect new ledger", page: errorConfig[error].analyticsPage });
   };
   const goToDelete = () => {
     dispatch(setFlow({ flow: Flow.ManageBackup, step: Step.ManageBackup }));
+    onClickTrack({ button: "delete backup", page: errorConfig[error].analyticsPage });
   };
 
   const understood = () => {
     dispatch(setFlow({ flow: Flow.ManageInstances, step: Step.SynchronizedInstances }));
+    onClickTrack({ button: "I understand", page: errorConfig[error].analyticsPage });
   };
   const { t } = useTranslation();
   const { colors } = useTheme();
@@ -51,6 +59,7 @@ export const DeletionError = ({ error }: Props) => {
       ctaSecondary: t("walletSync.unsecuredError.ctaDelete"),
       primaryAction: tryAgain,
       secondaryAction: goToDelete,
+      analyticsPage: AnalyticsPage.Unsecured,
     },
     [ErrorReason.AUTO_REMOVE]: {
       icon: <Icons.InformationFill size={"L"} color={colors.primary.c80} />,
@@ -61,13 +70,23 @@ export const DeletionError = ({ error }: Props) => {
       ctaSecondary: t("walletSync.autoRemoveError.ctaDelete"),
       primaryAction: understood,
       secondaryAction: goToDelete,
+      analyticsPage: AnalyticsPage.AutoRemove,
     },
   };
 
   const getErrorConfig = (error: ErrorReason) => errorConfig[error];
 
-  const { icon, title, description, info, cta, ctaSecondary, primaryAction, secondaryAction } =
-    getErrorConfig(error);
+  const {
+    icon,
+    title,
+    description,
+    info,
+    cta,
+    ctaSecondary,
+    primaryAction,
+    secondaryAction,
+    analyticsPage,
+  } = getErrorConfig(error);
 
   return (
     <Flex
@@ -78,6 +97,7 @@ export const DeletionError = ({ error }: Props) => {
       rowGap="24px"
       paddingX={50}
     >
+      <TrackPage category={analyticsPage} />
       <Container>{icon}</Container>
       <Text fontSize={24} variant="h4Inter" color="neutral.c100" textAlign="center">
         {title}

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/ManageInstances/04-DeletionFinalStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/ManageInstances/04-DeletionFinalStep.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Success } from "../../components/Success";
 import { useTranslation } from "react-i18next";
 import { FinalStepProps } from "./04-DeletionFinalErrorStep";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
 
 export default function DeletionFinalStep({ instance }: FinalStepProps) {
   const { t } = useTranslation();
@@ -11,6 +12,7 @@ export default function DeletionFinalStep({ instance }: FinalStepProps) {
       title={t(title, {
         instanceName: instance?.name,
       })}
+      analyticsPage={AnalyticsPage.InstanceRemovalSuccess}
     />
   );
 }

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/01-SyncModeStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/01-SyncModeStep.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Card } from "../../components/Card";
 import styled, { useTheme } from "styled-components";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
 
 type Props = {
   goToQRCode: () => void;
@@ -14,6 +16,7 @@ export default function SynchronizeModeStep({ goToQRCode, goToSyncWithDevice }: 
   const { colors } = useTheme();
   return (
     <Flex flexDirection="column" rowGap="16px">
+      <TrackPage category={AnalyticsPage.SyncMethod} />
       <Text fontSize={23} variant="large" color="neutral.c100">
         {t("walletSync.synchronize.chooseMethod.title")}
       </Text>

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/02-QRCodeStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/02-QRCodeStep.tsx
@@ -6,6 +6,8 @@ import { rgba } from "~/renderer/styles/helpers";
 import QRCode from "~/renderer/components/QRCode";
 import { useQRCode } from "../../hooks/useQRCode";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
 
 export default function SynchWithQRCodeStep() {
   const { t } = useTranslation();
@@ -53,6 +55,7 @@ export default function SynchWithQRCodeStep() {
 
   return (
     <Flex flexDirection="column" rowGap="24px" alignItems="center" flex={1}>
+      <TrackPage category={AnalyticsPage.SyncWithQR} />
       <Text
         fontSize={23}
         variant="large"

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/03-PinCodeStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/03-PinCodeStep.tsx
@@ -4,6 +4,8 @@ import { Flex, Text } from "@ledgerhq/react-ui";
 import styled, { useTheme } from "styled-components";
 import { useSelector } from "react-redux";
 import { walletSyncQrCodePinCodeSelector } from "~/renderer/reducers/walletSync";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
 
 export default function PinCodeStep() {
   const { t } = useTranslation();
@@ -12,6 +14,7 @@ export default function PinCodeStep() {
 
   return (
     <Flex flexDirection="column" rowGap="16px" justifyContent="center" flex={1}>
+      <TrackPage category={AnalyticsPage.PinCode} />
       <Text
         fontSize={24}
         variant="large"

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/04-SyncFinalStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/04-SyncFinalStep.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { Success } from "../../components/Success";
 import { useTranslation } from "react-i18next";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
 
 export default function SyncFinalStep() {
   const { t } = useTranslation();
   const title = "walletSync.success.synch.title";
   const desc = "walletSync.success.synch.desc";
-  return <Success title={t(title)} description={t(desc)} />;
+  return (
+    <Success title={t(title)} description={t(desc)} analyticsPage={AnalyticsPage.KeyUpdated} />
+  );
 }

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/Flows/Synchronize/index.tsx
@@ -8,14 +8,30 @@ import SynchronizeModeStep from "./01-SyncModeStep";
 import SynchWithQRCodeStep from "./02-QRCodeStep";
 import PinCodeStep from "./03-PinCodeStep";
 import SyncFinalStep from "./04-SyncFinalStep";
+import { AnalyticsPage, useWalletSyncAnalytics } from "../../hooks/useWalletSyncAnalytics";
 
 const SynchronizeWallet = () => {
   const dispatch = useDispatch();
 
   const { currentStep, goToNextScene } = useFlows();
+  const { onClickTrack } = useWalletSyncAnalytics();
 
   const startSyncWithDevice = () => {
     dispatch(setFlow({ flow: Flow.Activation, step: Step.DeviceAction }));
+    onClickTrack({
+      button: "With your Ledger",
+      page: AnalyticsPage.SyncMethod,
+      flow: "Wallet Sync",
+    });
+  };
+
+  const startSyncWithQRcode = () => {
+    goToNextScene();
+    onClickTrack({
+      button: "Scan a QR code",
+      page: AnalyticsPage.SyncMethod,
+      flow: "Wallet Sync",
+    });
   };
 
   const getStep = () => {
@@ -24,7 +40,7 @@ const SynchronizeWallet = () => {
       case Step.SynchronizeMode:
         return (
           <SynchronizeModeStep
-            goToQRCode={goToNextScene}
+            goToQRCode={startSyncWithQRcode}
             goToSyncWithDevice={startSyncWithDevice}
           />
         );

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/components/Success.tsx
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/components/Success.tsx
@@ -2,13 +2,16 @@ import { Box, Flex, Icons, Text } from "@ledgerhq/react-ui";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import styled, { useTheme } from "styled-components";
+import TrackPage from "~/renderer/analytics/TrackPage";
 import ButtonV3 from "~/renderer/components/ButtonV3";
+import { AnalyticsPage } from "../hooks/useWalletSyncAnalytics";
 
 type Props = {
   title?: string;
   description?: string;
   withCta?: boolean;
   onClick?: () => void;
+  analyticsPage?: AnalyticsPage;
 };
 
 const Container = styled(Box)`
@@ -21,11 +24,12 @@ const Container = styled(Box)`
   justify-content: center;
 `;
 
-export const Success = ({ title, description, withCta = false, onClick }: Props) => {
+export const Success = ({ title, description, withCta = false, onClick, analyticsPage }: Props) => {
   const { t } = useTranslation();
   const { colors } = useTheme();
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="center" rowGap="24px">
+      <TrackPage category={String(analyticsPage)} />
       <Container>
         <Icons.CheckmarkCircleFill size={"L"} color={colors.success.c60} />
       </Container>

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/hooks/useWalletSyncAnalytics.ts
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/hooks/useWalletSyncAnalytics.ts
@@ -4,12 +4,25 @@ export enum AnalyticsPage {
   ManageBackup = "Manage Backup",
   ConfirmDeleteBackup = "Confirm Delete Backup",
   ManageInstances = "Manage synchronized instances",
+  Activation = "Activate Wallet Sync",
+  SyncMethod = "Choose sync method",
+  KeyCreated = "Backup creation success",
+  KeyUpdated = "Backup update success",
+  SyncWithQR = "Sync with QR code",
+  PinCode = "Pin code",
+  SettingsGeneral = "Settings General",
+  WalletSyncSettings = "Wallet Sync Settings",
+  InstanceRemovalSuccess = "Instance removal success",
+  Unsecured = "Remove instance wrong device connected",
+  AutoRemove = "Remove current instance",
 }
+
+type Flow = "Wallet Sync";
 
 type OnClickTrack = {
   button: string;
   page: string;
-  flow?: string;
+  flow?: Flow;
 };
 
 export function useWalletSyncAnalytics() {

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/hooks/useWalletSyncAnalytics.ts
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/hooks/useWalletSyncAnalytics.ts
@@ -1,20 +1,32 @@
 import { track } from "~/renderer/analytics/segment";
+import { Step } from "~/renderer/reducers/walletSync";
 
 export enum AnalyticsPage {
   ManageBackup = "Manage Backup",
   ConfirmDeleteBackup = "Confirm Delete Backup",
+  BackupDeleted = "Backup Deleted",
+  BackupDeletionError = "Backup Deletion Error",
+
   ManageInstances = "Manage synchronized instances",
-  Activation = "Activate Wallet Sync",
-  SyncMethod = "Choose sync method",
-  KeyCreated = "Backup creation success",
-  KeyUpdated = "Backup update success",
-  SyncWithQR = "Sync with QR code",
-  PinCode = "Pin code",
-  SettingsGeneral = "Settings General",
-  WalletSyncSettings = "Wallet Sync Settings",
+  DeviceActionInstance = "Device Action Manage Instance",
+  DeleteInstanceWithTrustChain = "Delete instance with trustchain",
   InstanceRemovalSuccess = "Instance removal success",
   Unsecured = "Remove instance wrong device connected",
   AutoRemove = "Remove current instance",
+
+  Activation = "Activate Wallet Sync",
+  DeviceActionActivation = "Device Action Activate Wallet Sync",
+  CreateOrSynchronizeTrustChain = "Create or synchronize with trustchain",
+  SynchronizationError = "Synchronization error",
+  SyncMethod = "Choose sync method",
+  KeyCreated = "Backup creation success",
+  KeyUpdated = "Backup update success",
+
+  SyncWithQR = "Sync with QR code",
+  PinCode = "Pin code",
+
+  SettingsGeneral = "Settings General",
+  WalletSyncSettings = "Wallet Sync Settings",
 }
 
 type Flow = "Wallet Sync";
@@ -25,10 +37,53 @@ type OnClickTrack = {
   flow?: Flow;
 };
 
+type onCloseTrack = {
+  button: string;
+  step: Step;
+  flow: Flow;
+};
+
+export const StepMappedToAnalytics: Record<Step, string> = {
+  [Step.ManageBackup]: AnalyticsPage.ManageBackup,
+  [Step.DeleteBackup]: AnalyticsPage.ConfirmDeleteBackup,
+  [Step.BackupDeleted]: AnalyticsPage.BackupDeleted,
+  [Step.BackupDeletionError]: AnalyticsPage.BackupDeletionError,
+
+  //Activation
+  [Step.CreateOrSynchronize]: AnalyticsPage.Activation,
+  [Step.DeviceAction]: AnalyticsPage.DeviceActionActivation,
+  [Step.CreateOrSynchronizeTrustChain]: AnalyticsPage.CreateOrSynchronizeTrustChain,
+  [Step.ActivationFinal]: AnalyticsPage.KeyCreated,
+  [Step.SynchronizationFinal]: AnalyticsPage.KeyUpdated,
+  [Step.SynchronizationError]: AnalyticsPage.SynchronizationError,
+
+  //Synchronize
+  [Step.SynchronizeMode]: AnalyticsPage.SyncMethod,
+  [Step.SynchronizeWithQRCode]: AnalyticsPage.SyncWithQR,
+  [Step.PinCode]: AnalyticsPage.PinCode,
+  [Step.Synchronized]: AnalyticsPage.KeyUpdated,
+
+  //ManageInstances
+  [Step.SynchronizedInstances]: AnalyticsPage.ManageInstances,
+  [Step.UnsecuredLedger]: AnalyticsPage.Unsecured,
+  [Step.AutoRemoveInstance]: AnalyticsPage.AutoRemove,
+  [Step.DeviceActionInstance]: AnalyticsPage.DeviceActionInstance,
+  [Step.DeleteInstanceWithTrustChain]: AnalyticsPage.DeleteInstanceWithTrustChain,
+  [Step.InstanceSuccesfullyDeleted]: AnalyticsPage.InstanceRemovalSuccess,
+  [Step.InstanceErrorDeletion]: AnalyticsPage.ManageInstances,
+
+  //walletSyncActivated
+  [Step.WalletSyncActivated]: AnalyticsPage.WalletSyncSettings,
+};
+
 export function useWalletSyncAnalytics() {
   const onClickTrack = ({ button, page, flow }: OnClickTrack) => {
     track("button_clicked2", { button, page, flow });
   };
 
-  return { onClickTrack };
+  const onCloseTrack = ({ button, step, flow }: onCloseTrack) => {
+    track("button_clicked2", { button, page: StepMappedToAnalytics[step], flow });
+  };
+
+  return { onClickTrack, onCloseTrack };
 }

--- a/apps/ledger-live-desktop/src/newArch/WalletSync/hooks/useWalletSyncAnalytics.ts
+++ b/apps/ledger-live-desktop/src/newArch/WalletSync/hooks/useWalletSyncAnalytics.ts
@@ -37,7 +37,7 @@ type OnClickTrack = {
   flow?: Flow;
 };
 
-type onCloseTrack = {
+type onActionTrack = {
   button: string;
   step: Step;
   flow: Flow;
@@ -81,9 +81,9 @@ export function useWalletSyncAnalytics() {
     track("button_clicked2", { button, page, flow });
   };
 
-  const onCloseTrack = ({ button, step, flow }: onCloseTrack) => {
+  const onActionTrack = ({ button, step, flow }: onActionTrack) => {
     track("button_clicked2", { button, page: StepMappedToAnalytics[step], flow });
   };
 
-  return { onClickTrack, onCloseTrack };
+  return { onClickTrack, onActionTrack };
 }

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -31,6 +31,7 @@ import { currentRouteNameRef, previousRouteNameRef } from "./screenRefs";
 import { useCallback, useContext } from "react";
 import { analyticsDrawerContext } from "../drawers/Provider";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+
 invariant(typeof window !== "undefined", "analytics/segment must be called on renderer thread");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const os = require("os");
@@ -64,6 +65,16 @@ const getMarketWidgetAnalytics = () => {
   const marketWidget = analyticsFeatureFlagMethod("marketperformanceWidgetDesktop");
 
   return !!marketWidget?.enabled;
+};
+
+const getWalletSyncAttributes = (state: State) => {
+  if (!analyticsFeatureFlagMethod) return false;
+  const walletSync = analyticsFeatureFlagMethod("lldWalletSync");
+
+  return {
+    hasWalletSync: !!walletSync?.enabled,
+    walletSyncActivated: !!state.trustchainStore.trustchain,
+  };
 };
 
 const getPtxAttributes = () => {
@@ -129,6 +140,8 @@ const extraProperties = (store: ReduxStore) => {
   const accounts = accountsSelector(state);
   const ptxAttributes = getPtxAttributes();
 
+  const walletSyncAtributes = getWalletSyncAttributes(state);
+
   const deviceInfo = device
     ? {
         modelId: device.modelId,
@@ -182,6 +195,7 @@ const extraProperties = (store: ReduxStore) => {
     modelIdList: devices,
     ...ptxAttributes,
     ...deviceInfo,
+    ...walletSyncAtributes,
   };
 };
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
@@ -34,7 +34,7 @@ const WalletSyncRow = () => {
   const hasBack = useMemo(() => STEPS_WITH_BACK.includes(currentStep), [currentStep]);
   const trustchain = useSelector(trustchainSelector);
 
-  const { onClickTrack } = useWalletSyncAnalytics();
+  const { onClickTrack, onCloseTrack } = useWalletSyncAnalytics();
 
   const handleBack = () => {
     if (childRef.current) {
@@ -45,6 +45,8 @@ const WalletSyncRow = () => {
   const closeDrawer = () => {
     if (hasBeenFaked) {
       dispatch(resetWalletSync());
+    } else {
+      onCloseTrack({ button: "Close", step: currentStep, flow: "Wallet Sync" });
     }
     setOpen(false);
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
@@ -8,6 +8,10 @@ import { resetWalletSync } from "~/renderer/actions/walletSync";
 import { BackRef, WalletSyncRouter } from "LLD/WalletSync/Flows/router";
 import { STEPS_WITH_BACK, useFlows } from "LLD/WalletSync/Flows/useFlows";
 import { trustchainSelector } from "@ledgerhq/trustchain/store";
+import {
+  AnalyticsPage,
+  useWalletSyncAnalytics,
+} from "~/newArch/WalletSync/hooks/useWalletSyncAnalytics";
 
 /**
  *
@@ -30,6 +34,8 @@ const WalletSyncRow = () => {
   const hasBack = useMemo(() => STEPS_WITH_BACK.includes(currentStep), [currentStep]);
   const trustchain = useSelector(trustchainSelector);
 
+  const { onClickTrack } = useWalletSyncAnalytics();
+
   const handleBack = () => {
     if (childRef.current) {
       childRef.current.goBack();
@@ -46,6 +52,7 @@ const WalletSyncRow = () => {
   const openDrawer = () => {
     if (!hasBeenFaked) {
       goToWelcomeScreenWalletSync(!!trustchain?.rootId);
+      onClickTrack({ button: "Wallet Sync", page: AnalyticsPage.SettingsGeneral });
     }
     setOpen(true);
   };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
@@ -34,11 +34,12 @@ const WalletSyncRow = () => {
   const hasBack = useMemo(() => STEPS_WITH_BACK.includes(currentStep), [currentStep]);
   const trustchain = useSelector(trustchainSelector);
 
-  const { onClickTrack, onCloseTrack } = useWalletSyncAnalytics();
+  const { onClickTrack, onActionTrack } = useWalletSyncAnalytics();
 
   const handleBack = () => {
-    if (childRef.current) {
+    if (childRef.current && hasBack) {
       childRef.current.goBack();
+      onActionTrack({ button: "Back", step: currentStep, flow: "Wallet Sync" });
     }
   };
 
@@ -46,7 +47,7 @@ const WalletSyncRow = () => {
     if (hasBeenFaked) {
       dispatch(resetWalletSync());
     } else {
-      onCloseTrack({ button: "Close", step: currentStep, flow: "Wallet Sync" });
+      onActionTrack({ button: "Close", step: currentStep, flow: "Wallet Sync" });
     }
     setOpen(false);
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add analytics for WalletSync in LLD  related to https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4653973505/Wallet+Sync+-+LLD+Data+Tracking+Plan
- Page
- Button clicked
- Back button
- Close button

Close Event : 


https://github.com/LedgerHQ/ledger-live/assets/112866305/e4ab150d-11c6-4018-ab2d-87470c9c8ae9

Back Event : 


https://github.com/LedgerHQ/ledger-live/assets/112866305/c9060e69-da6d-4d35-9fe0-6c440e362d11




### ❓ Context

- **JIRA or GitHub link**:  [LIVE-12205]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12205]: https://ledgerhq.atlassian.net/browse/LIVE-12205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ