### PR TITLE
feat(web3hub): main and search screen first iteration [LIVE-13176]

### DIFF
--- a/.changeset/cyan-panthers-drop.md
+++ b/.changeset/cyan-panthers-drop.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+fix: use auto instead of fit-content that does not exist on RN

--- a/.changeset/sweet-wolves-push.md
+++ b/.changeset/sweet-wolves-push.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(web3hub): main and search screen first iteration

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -94,6 +94,7 @@ libs/ledger-live-common/src/wallet-api/                  @ledgerhq/wallet-api
 **/wallet-api.spec.ts-snapshots/                         @ledgerhq/wallet-api
 **/dapp.spec.ts                                          @ledgerhq/wallet-api
 libs/test-utils/                                         @ledgerhq/wallet-api
+apps/ledger-live-mobile/src/newArch/features/web3hub/    @ledgerhq/wallet-api
 
 # Devices team
 apps/cli/src/commands/devices                                      @ledgerhq/live-devices

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6699,5 +6699,17 @@
         "secondCta": "Already created a key?"
       }
     }
+  },
+  "web3hub": {
+    "manifestsList": {
+      "title": "Explore",
+      "description": "Discover the best of web3 curated by Ledger"
+    },
+    "main": {
+      "header": {
+        "title": "Explore web3",
+        "placeholder": "Search or type a URL"
+      }
+    }
   }
 }

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/HeaderContext.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/HeaderContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import { SharedValue } from "react-native-reanimated";
+
+export type HeaderContextType = {
+  layoutY?: SharedValue<number>;
+};
+
+export const HeaderContext = createContext<HeaderContextType>({});

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/Navigator.tsx
@@ -1,11 +1,17 @@
 import React from "react";
-import { ScreenName } from "~/const";
+import { useTranslation } from "react-i18next";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useSharedValue } from "react-native-reanimated";
+import { ScreenName } from "~/const";
+import { HeaderContext } from "./HeaderContext";
 import Web3HubMain from "./screens/Web3HubMain";
+import Web3HubMainHeader from "./screens/Web3HubMain/components/Header";
 import Web3HubSearch from "./screens/Web3HubSearch";
+import Web3HubSearchHeader from "./screens/Web3HubSearch/components/Header";
 import Web3HubTabs from "./screens/Web3HubTabs";
+import Web3HubTabsHeader from "./screens/Web3HubTabs/components/Header";
 import Web3HubApp from "./screens/Web3HubApp";
-// import TextInput from "~/components/TextInput";
+import Web3HubAppHeader from "./screens/Web3HubApp/components/Header";
 
 export type Web3HubStackParamList = {
   [ScreenName.Web3HubMain]: undefined;
@@ -19,48 +25,52 @@ export type Web3HubStackParamList = {
 const Stack = createNativeStackNavigator<Web3HubStackParamList>();
 
 export default function Web3HubNavigator() {
+  const { t } = useTranslation();
+  const layoutY = useSharedValue(0);
+
   return (
-    <Stack.Navigator initialRouteName={ScreenName.Web3HubMain}>
-      <Stack.Screen
-        name={ScreenName.Web3HubMain}
-        component={Web3HubMain}
-        options={{
-          title: "Explore web3",
-          // headerLeft: () => {
-          //   return (
-          //     <TextInput
-          //       defaultValue="Search"
-          //       keyboardType="default"
-          //       returnKeyType="done"
-          //       value={search}
-          //       onChangeText={setSearch}
-          //       onSubmitEditing={text => console.log("onSubmitEditing: ", text)}
-          //     />
-          //   );
-          // },
-        }}
-      />
-      <Stack.Screen
-        name={ScreenName.Web3HubSearch}
-        component={Web3HubSearch}
-        options={{
-          title: "Search web3",
-        }}
-      />
-      <Stack.Screen
-        name={ScreenName.Web3HubTabs}
-        component={Web3HubTabs}
-        options={{
-          title: "N Tabs",
-        }}
-      />
-      <Stack.Screen
-        name={ScreenName.Web3HubApp}
-        component={Web3HubApp}
-        options={{
-          title: "Web3 app",
-        }}
-      />
-    </Stack.Navigator>
+    <HeaderContext.Provider
+      value={{
+        layoutY,
+      }}
+    >
+      <Stack.Navigator initialRouteName={ScreenName.Web3HubMain}>
+        <Stack.Screen
+          name={ScreenName.Web3HubMain}
+          component={Web3HubMain}
+          options={{
+            title: t("web3hub.main.header.title"),
+            header: props => (
+              <Web3HubMainHeader title={props.options.title} navigation={props.navigation} />
+            ),
+            animation: "none",
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.Web3HubSearch}
+          component={Web3HubSearch}
+          options={{
+            header: props => <Web3HubSearchHeader navigation={props.navigation} />,
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.Web3HubTabs}
+          component={Web3HubTabs}
+          options={{
+            title: "N Tabs", // Temporary, will probably be changed
+            header: props => (
+              <Web3HubTabsHeader title={props.options.title} navigation={props.navigation} />
+            ),
+          }}
+        />
+        <Stack.Screen
+          name={ScreenName.Web3HubApp}
+          component={Web3HubApp}
+          options={{
+            header: props => <Web3HubAppHeader navigation={props.navigation} />,
+          }}
+        />
+      </Stack.Navigator>
+    </HeaderContext.Provider>
   );
 }

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/__integrations__/mocks/manifests.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/__integrations__/mocks/manifests.ts
@@ -10,7 +10,7 @@ export const data: AppManifest[] = [
     apiVersion: "^2.0.0",
     manifestVersion: "2",
     branch: "stable",
-    categories: [],
+    categories: ["games"],
     currencies: ["**"],
     content: {
       shortDescription: {
@@ -50,7 +50,7 @@ export const data: AppManifest[] = [
     apiVersion: "^2.0.0 || ^1.0.0",
     manifestVersion: "2",
     branch: "debug",
-    categories: ["others"],
+    categories: ["other"],
     currencies: ["**"],
     content: {
       shortDescription: {
@@ -102,12 +102,12 @@ export const data: AppManifest[] = [
       ],
     },
     homepageUrl: "https://www.staderlabs.com/eth/",
-    icon: "https://www.staderlabs.com/assets/images/stader-icon.svg",
+    icon: "https://cdn.live.ledger.com/icons/platform/stader-bnb.png",
     platforms: ["android", "ios", "desktop"],
     apiVersion: "^2.0.0 || ^1.0.0",
     manifestVersion: "2",
     branch: "stable",
-    categories: ["stake/earn/manage"],
+    categories: ["defi"],
     currencies: ["ethereum", "ethereum/erc20/bnb", "bsc"],
     content: {
       shortDescription: {

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/__integrations__/web3hub.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/__integrations__/web3hub.integration.test.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable i18next/no-literal-string */
 import * as React from "react";
-import { screen } from "@testing-library/react-native";
+import { screen, waitForElementToBeRemoved } from "@testing-library/react-native";
 import { render } from "@tests/test-renderer";
 import { Web3HubTest } from "./shared";
 
@@ -8,27 +7,110 @@ describe("Web3Hub integration test", () => {
   it("Should list manifests and navigate to app page", async () => {
     const { user } = render(<Web3HubTest />);
 
-    // Header stuff cannot be tested with the native-stack for now
-    // but we can mock and use the js stack instead if needed
-    // expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
-    expect(await screen.findByText("Dummy Wallet App")).toBeOnTheScreen();
-    await user.press(screen.getByText("Dummy Wallet App"));
+    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
+    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
+      timeout: 1500, // timeout because we mock the return and fake 1s delay
+    });
+
+    expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Dummy Wallet App")[0]);
     expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
     expect(await screen.findByText("dummy")).toBeOnTheScreen();
 
-    // Header stuff cannot be tested with the native-stack
-    // await user.press(screen.getByText("Explore web3"));
-    // expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
-    // The second user press is not working too
-    // expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
-    // await user.press(screen.getByText("Wallet API Tools"));
-    // expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
-    // expect(await screen.findByText("wallet-api-tools")).toBeOnTheScreen();
+    expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Wallet API Tools")[0]);
+    expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
+    expect(await screen.findByText("wallet-api-tools")).toBeOnTheScreen();
 
-    // Header stuff cannot be tested with the native-stack
-    // await user.press(screen.getByText("Explore web3"));
-    // expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+  });
+
+  it("Should list manifests, go to search and navigate to app page", async () => {
+    const { user } = render(<Web3HubTest />);
+
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+
+    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
+    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
+      timeout: 1500, // timeout because we mock the request and fake 1s delay
+    });
+
+    expect(await screen.findByTestId("web3hub-main-header-search")).toBeOnTheScreen();
+    await user.press(screen.getByTestId("web3hub-main-header-search"));
+    expect(await screen.findByTestId("web3hub-search-header-search")).toBeOnTheScreen();
+
+    expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Dummy Wallet App")[0]);
+    expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
+    expect(await screen.findByText("dummy")).toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByTestId("web3hub-search-header-search")).toBeOnTheScreen();
+
+    expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Wallet API Tools")[0]);
+    expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
+    expect(await screen.findByText("wallet-api-tools")).toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByTestId("web3hub-search-header-search")).toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+  });
+
+  it("Should list manifests, select a category and navigate to app page", async () => {
+    const { user } = render(<Web3HubTest />);
+
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+
+    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
+    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
+      timeout: 1500, // timeout because we mock the request and fake 1s delay
+    });
+
+    expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
+
+    expect(await screen.findByText("games")).toBeOnTheScreen();
+    await user.press(screen.getByText("games"));
+
+    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
+    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
+      timeout: 1500, // timeout because we mock the request and fake 1s delay
+    });
+
+    expect(screen.queryByText("Wallet API Tools")).not.toBeOnTheScreen();
+    expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Dummy Wallet App")[0]);
+    expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
+    expect(await screen.findByText("dummy")).toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+
+    // scroll to reveal the end of the list
+    await user.scrollTo(screen.getByTestId("web3hub-categories-scroll"), { x: 500 });
+    expect(await screen.findByText("other")).toBeOnTheScreen();
+    await user.press(screen.getByText("other"));
+
+    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
+    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
+      timeout: 1500, // timeout because we mock the request and fake 1s delay
+    });
+
+    expect(screen.queryByText("Dummy Wallet App")).not.toBeOnTheScreen();
+    expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Wallet API Tools")[0]);
+    expect(await screen.findByText("Web3HubApp")).toBeOnTheScreen();
+    expect(await screen.findByText("wallet-api-tools")).toBeOnTheScreen();
+
+    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/CategoriesList/Badge/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/CategoriesList/Badge/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { Flex, Text } from "@ledgerhq/native-ui";
+
+export default function Badge({
+  label,
+  selected,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <Flex
+        bg={selected ? "primary.c80" : "neutral.c30"}
+        flexDirection={"row"}
+        mx={"6px"}
+        px={4}
+        py={1}
+        justifyContent={"center"}
+        alignItems={"center"}
+        height={32}
+        borderRadius={32}
+      >
+        <Text
+          textTransform="capitalize"
+          fontWeight="semiBold"
+          variant="body"
+          color={selected ? "neutral.c30" : "primary.c80"}
+        >
+          {label}
+        </Text>
+      </Flex>
+    </TouchableOpacity>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/CategoriesList/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/CategoriesList/index.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from "react";
+import { FlashList } from "@shopify/flash-list";
+import { useQuery } from "@tanstack/react-query";
+import { Box } from "@ledgerhq/native-ui";
+import Badge from "./Badge";
+
+const categories = [
+  "games",
+  "defi",
+  "collectibles",
+  "marketplaces",
+  "high-risk",
+  "gambling",
+  "exchanges",
+  "social",
+  "other",
+];
+
+// TODO move this to an api folder or utils for hooks
+const fetchCategoriesMock = async () => {
+  await new Promise(resolve => setTimeout(resolve, 500));
+  return categories;
+};
+
+const selectCategories = (data: string[]) => {
+  return ["all", ...data];
+};
+
+const identityFn = (item: string) => item;
+
+type Props = {
+  selectedCategory: string;
+  selectCategory: (category: string) => void;
+};
+
+export default function CategoriesList({ selectedCategory, selectCategory }: Props) {
+  const categoriesQuery = useQuery({
+    queryKey: ["web3hub/categories"],
+    queryFn: fetchCategoriesMock,
+    select: selectCategories,
+  });
+
+  const categoriesExtraData = useMemo(() => {
+    return {
+      selectedCategory,
+      selectCategory,
+    };
+  }, [selectCategory, selectedCategory]);
+
+  return (
+    <FlashList
+      testID="web3hub-categories-scroll"
+      horizontal
+      contentContainerStyle={{
+        paddingHorizontal: 5,
+      }}
+      keyExtractor={identityFn}
+      renderItem={({ item, extraData }) => {
+        return (
+          <Badge
+            onPress={() => extraData.selectCategory(item)}
+            label={item}
+            selected={extraData.selectedCategory === item}
+          />
+        );
+      }}
+      ListEmptyComponent={<Box height={32} />} // Empty box for first height calculation, could be improved
+      estimatedItemSize={50}
+      data={categoriesQuery.data}
+      showsHorizontalScrollIndicator={false}
+      extraData={categoriesExtraData}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/LoadingIndicator/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/LoadingIndicator/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Box, InfiniteLoader } from "@ledgerhq/native-ui";
+
+export default function LoadingIndicator() {
+  return (
+    <Box height={40} testID="web3hub-loading-indicator">
+      <InfiniteLoader size={30} />
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/ManifestItem/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/ManifestItem/index.tsx
@@ -1,0 +1,135 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import React, { useCallback, useMemo } from "react";
+import { TouchableOpacity } from "react-native";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "@react-navigation/native";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import { AppBranch, AppManifest } from "@ledgerhq/live-common/wallet-api/types";
+import { BaseComposite } from "~/components/RootNavigator/types/helpers";
+import { AppIcon } from "~/screens/Platform/v2/AppIcon";
+import { ScreenName } from "~/const";
+import { Theme } from "~/colors";
+import type { Web3HubStackParamList } from "LLM/features/Web3Hub/Navigator";
+
+type MainProps = BaseComposite<
+  NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubMain>
+>;
+type SearchProps = BaseComposite<
+  NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubSearch>
+>;
+export type NavigationProp = MainProps["navigation"] | SearchProps["navigation"];
+
+function getBranchStyle(branch: AppBranch, colors: Theme["colors"]) {
+  switch (branch) {
+    case "soon":
+      return {
+        color: colors.grey,
+        badgeColor: colors.grey,
+        borderColor: colors.lightFog,
+        backgroundColor: colors.lightFog,
+      };
+
+    case "experimental":
+      return {
+        color: colors.darkBlue,
+        badgeColor: colors.orange,
+        borderColor: colors.orange,
+        backgroundColor: "transparent",
+      };
+
+    case "debug":
+      return {
+        color: colors.darkBlue,
+        badgeColor: colors.grey,
+        borderColor: colors.grey,
+        backgroundColor: "transparent",
+      };
+
+    default:
+      return {
+        color: colors.darkBlue,
+        badgeColor: colors.live,
+        borderColor: colors.live,
+        backgroundColor: "transparent",
+      };
+  }
+}
+
+export default function ManifestItem({
+  manifest,
+  navigation,
+}: {
+  manifest: AppManifest;
+  navigation: NavigationProp;
+}) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const isDisabled = manifest.branch === "soon";
+
+  const handlePress = useCallback(() => {
+    if (isDisabled) {
+      return;
+    }
+    navigation.push(ScreenName.Web3HubApp, {
+      manifestId: manifest.id,
+    });
+  }, [isDisabled, navigation, manifest.id]);
+
+  const { color, badgeColor, borderColor, backgroundColor } = useMemo(
+    () => getBranchStyle(manifest.branch, colors),
+    [colors, manifest.branch],
+  );
+
+  const url = useMemo(() => {
+    return new URL(manifest.url).origin;
+  }, [manifest.url]);
+
+  return (
+    <TouchableOpacity disabled={isDisabled} onPress={handlePress}>
+      <Flex
+        flexDirection="row"
+        alignItems="center"
+        height={72}
+        backgroundColor={colors.card}
+        paddingX={4}
+        paddingY={2}
+      >
+        <AppIcon isDisabled={isDisabled} size={48} name={manifest.name} icon={manifest.icon} />
+        <Flex marginX={16} height="100%" flexGrow={1} flexShrink={1} justifyContent={"center"}>
+          <Flex flexDirection="row" alignItems={"center"} mb={2}>
+            <Text variant="large" color={color} numberOfLines={1} fontWeight="semiBold">
+              {manifest.name}
+            </Text>
+            {manifest.branch !== "stable" && (
+              <Text
+                fontSize="9px"
+                width="auto"
+                paddingX={2}
+                paddingY={1}
+                borderWidth={1}
+                borderRadius={3}
+                borderStyle={"solid"}
+                flexGrow={0}
+                flexShrink={0}
+                marginLeft={3}
+                overflow={"hidden"}
+                textTransform="uppercase"
+                color={badgeColor}
+                borderColor={borderColor}
+                backgroundColor={backgroundColor}
+                fontWeight="semiBold"
+              >
+                {t(`platform.catalog.branch.${manifest.branch}`, {
+                  defaultValue: manifest.branch,
+                })}
+              </Text>
+            )}
+          </Flex>
+          <Text fontSize={13} color={colors.smoke} numberOfLines={1}>
+            {url}
+          </Text>
+        </Flex>
+      </Flex>
+    </TouchableOpacity>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/index.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from "react";
+import { View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { FlashList } from "@shopify/flash-list";
+import {
+  GetNextPageParamFunction,
+  InfiniteData,
+  QueryFunction,
+  useInfiniteQuery,
+} from "@tanstack/react-query";
+import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Box, Text } from "@ledgerhq/native-ui";
+import { MAIN_BUTTON_BOTTOM, MAIN_BUTTON_SIZE } from "~/components/TabBar/shared";
+import ManifestItem, { type NavigationProp } from "./ManifestItem";
+import CategoriesList from "./CategoriesList";
+import LoadingIndicator from "./LoadingIndicator";
+// Temporary and will be replaced with proper mocks in hooks using tanstack query
+import { data } from "../../__integrations__/mocks/manifests";
+
+const manifests = [
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+  ...data,
+];
+
+const PAGE_SIZE = 10;
+
+const fetchManifestsMock: (
+  category: string,
+) => QueryFunction<LiveAppManifest[], string[], number> =
+  category =>
+  async ({ pageParam }) => {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    let list = manifests;
+
+    if (category !== "all") {
+      list = list.filter(manifest => {
+        return manifest.categories.includes(category);
+      });
+    }
+
+    return list.slice((pageParam - 1) * PAGE_SIZE, pageParam * PAGE_SIZE);
+  };
+
+const selectManifests = (data: InfiniteData<LiveAppManifest[], number>) => {
+  return data.pages.flat(1);
+};
+
+const getNextPageParam: GetNextPageParamFunction<number, LiveAppManifest[]> = (
+  lastPage,
+  allPages,
+  lastPageParam,
+) => {
+  if (allPages.length === 0) {
+    return undefined;
+  }
+  if (lastPage.length < PAGE_SIZE) {
+    return undefined;
+  }
+  return lastPageParam + 1;
+};
+
+export default function ManifestList({ navigation }: { navigation: NavigationProp }) {
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  const [selectedCategory, selectCategory] = useState("all");
+
+  const manifestsQuery = useInfiniteQuery({
+    queryKey: ["web3hub/manifests", selectedCategory],
+    queryFn: fetchManifestsMock(selectedCategory),
+    initialPageParam: 1,
+    getNextPageParam,
+    select: selectManifests,
+  });
+
+  const isLoading = manifestsQuery.isLoading || manifestsQuery.isFetching;
+
+  return (
+    <>
+      <Text mt={5} numberOfLines={1} variant="h5" mx={5} accessibilityRole="header">
+        {t("web3hub.manifestsList.title")}
+      </Text>
+      <Text mt={2} mb={5} numberOfLines={1} variant="body" mx={5} accessibilityRole="header">
+        {t("web3hub.manifestsList.description")}
+      </Text>
+
+      <View style={{ height: 32, marginBottom: 2 }}>
+        <CategoriesList selectedCategory={selectedCategory} selectCategory={selectCategory} />
+      </View>
+
+      <FlashList
+        testID="web3hub-manifests-scroll"
+        nestedScrollEnabled
+        contentContainerStyle={{
+          // Using this padding to keep the view visible under the button
+          paddingBottom: MAIN_BUTTON_SIZE + MAIN_BUTTON_BOTTOM + insets.bottom,
+        }}
+        // keyExtractor={item => item.id}
+        renderItem={({ item }) => {
+          return <ManifestItem manifest={item} navigation={navigation} />;
+        }}
+        ListFooterComponent={isLoading ? <LoadingIndicator /> : null}
+        ListEmptyComponent={
+          isLoading ? null : ( // TODO handle empty case
+            <Box height={40}>
+              <Text>{t("common.retry")}</Text>
+            </Box>
+          )
+        }
+        estimatedItemSize={128}
+        data={manifestsQuery.data}
+        onEndReached={manifestsQuery.hasNextPage ? manifestsQuery.fetchNextPage : undefined}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Header/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@react-navigation/native";
+import { NativeStackHeaderProps } from "@react-navigation/native-stack";
+import { Box, Flex, Icons } from "@ledgerhq/native-ui";
+import TextInput from "~/components/TextInput";
+import Touchable from "~/components/Touchable";
+
+const SEARCH_HEIGHT = 60;
+
+type Props = {
+  navigation: NativeStackHeaderProps["navigation"];
+};
+
+export default function Web3HubMainHeader({ navigation }: Props) {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  return (
+    <Box
+      backgroundColor={colors.background}
+      paddingTop={insets.top}
+      height={SEARCH_HEIGHT + insets.top}
+    >
+      <Flex height={SEARCH_HEIGHT} flexDirection="row" alignItems="center">
+        <Touchable testID="navigation-header-back-button" onPress={navigation.goBack}>
+          <Box p={5}>
+            <Icons.ArrowLeft />
+          </Box>
+        </Touchable>
+        <Box width={"80%"}>
+          <TextInput
+            placeholder="Current URL"
+            keyboardType="default"
+            returnKeyType="done"
+            value=""
+            disabled
+          />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/index.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@ledgerhq/native-ui";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React from "react";
+import { View } from "react-native";
 import { BaseComposite } from "~/components/RootNavigator/types/helpers";
-import SafeAreaView from "~/components/SafeAreaView";
 import { ScreenName } from "~/const";
 import { Web3HubStackParamList } from "../../Navigator";
 
@@ -11,18 +11,13 @@ type Props = BaseComposite<NativeStackScreenProps<Web3HubStackParamList, ScreenN
 export default function Web3HubApp({ route }: Props) {
   const { manifestId } = route.params;
   return (
-    <SafeAreaView
-      edges={["top", "left", "right"]}
-      isFlex
+    <View
       style={{
-        flexDirection: "column",
-        gap: 26,
-        marginHorizontal: 24,
-        marginTop: 114,
+        flex: 1,
       }}
     >
       <Text>{ScreenName.Web3HubApp}</Text>
       <Text>{manifestId}</Text>
-    </SafeAreaView>
+    </View>
   );
 }

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/components/Header/index.tsx
@@ -1,0 +1,101 @@
+import { useTranslation } from "react-i18next";
+import React, { useCallback, useContext } from "react";
+import { TouchableOpacity, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@react-navigation/native";
+import { NativeStackHeaderProps } from "@react-navigation/native-stack";
+import Animated, { useAnimatedStyle, interpolate, Extrapolation } from "react-native-reanimated";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import TextInput from "~/components/TextInput";
+import { HeaderContext } from "LLM/features/Web3Hub/HeaderContext";
+import { ScreenName } from "~/const";
+
+const TITLE_HEIGHT = 50;
+const SEARCH_HEIGHT = 60;
+const TOTAL_HEADER_HEIGHT = TITLE_HEIGHT + SEARCH_HEIGHT;
+
+const ANIMATION_HEIGHT = TITLE_HEIGHT - 5;
+const LAYOUT_RANGE = [0, 35];
+
+type Props = {
+  title?: string;
+  navigation: NativeStackHeaderProps["navigation"];
+};
+
+export default function Web3HubMainHeader({ title, navigation }: Props) {
+  const { t } = useTranslation();
+  const { layoutY } = useContext(HeaderContext);
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  const heightStyle = useAnimatedStyle(() => {
+    if (!layoutY) return {};
+
+    return {
+      backgroundColor: colors.background,
+      paddingTop: insets.top,
+      height:
+        interpolate(
+          layoutY.value,
+          LAYOUT_RANGE,
+          [TOTAL_HEADER_HEIGHT, TOTAL_HEADER_HEIGHT - ANIMATION_HEIGHT],
+          Extrapolation.CLAMP,
+        ) + insets.top,
+    };
+  });
+
+  const transformStyle = useAnimatedStyle(() => {
+    if (!layoutY) return {};
+
+    return {
+      transform: [
+        {
+          translateY: interpolate(
+            layoutY.value,
+            LAYOUT_RANGE,
+            [0, -ANIMATION_HEIGHT],
+            Extrapolation.CLAMP,
+          ),
+        },
+      ],
+    };
+  });
+
+  const opacityStyle = useAnimatedStyle(() => {
+    if (!layoutY) return {};
+
+    return {
+      opacity: interpolate(layoutY.value, [0, 35], [1, 0], Extrapolation.CLAMP),
+    };
+  });
+
+  const goToSearch = useCallback(() => {
+    navigation.push(ScreenName.Web3HubSearch, {});
+  }, [navigation]);
+
+  return (
+    <Animated.View style={heightStyle}>
+      <Animated.View style={transformStyle}>
+        <Animated.View style={opacityStyle}>
+          <Text mt={5} mb={2} numberOfLines={1} variant="h4" mx={5} accessibilityRole="header">
+            {title}
+          </Text>
+        </Animated.View>
+        <Flex height={SEARCH_HEIGHT} mx={5} justifyContent="center">
+          <TouchableOpacity onPress={goToSearch}>
+            <View pointerEvents="none">
+              <TextInput
+                testID="web3hub-main-header-search"
+                placeholder={t("web3hub.main.header.placeholder")}
+                keyboardType="default"
+                returnKeyType="done"
+                value=""
+                disabled
+              />
+            </View>
+          </TouchableOpacity>
+        </Flex>
+      </Animated.View>
+    </Animated.View>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/index.tsx
@@ -1,55 +1,31 @@
+import React, { useContext } from "react";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import React from "react";
-import { FlashList } from "@shopify/flash-list";
-import SafeAreaView from "~/components/SafeAreaView";
-import { ScreenName } from "~/const";
+import Animated, { useAnimatedScrollHandler } from "react-native-reanimated";
 import { BaseComposite } from "~/components/RootNavigator/types/helpers";
-import type { Web3HubStackParamList } from "../../Navigator";
-import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
-import AppCard from "~/screens/Platform/Catalog/AppCard";
-// Temporary and will be replaced with proper mocks in hooks using tanstack query
-import { data } from "../../__integrations__/mocks/manifests";
+import { ScreenName } from "~/const";
+import type { Web3HubStackParamList } from "LLM/features/Web3Hub/Navigator";
+import { HeaderContext } from "LLM/features/Web3Hub/HeaderContext";
+import ManifestList from "LLM/features/Web3Hub/components/ManifestsList";
 
 type Props = BaseComposite<NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubMain>>;
 
-function ManifestItem({
-  manifest,
-  navigation,
-}: {
-  manifest: AppManifest;
-  navigation: Props["navigation"];
-}) {
-  return (
-    <AppCard
-      manifest={manifest}
-      onPress={() => {
-        navigation.push(ScreenName.Web3HubApp, {
-          manifestId: manifest.id,
-        });
-      }}
-    />
-  );
-}
-
 export default function Web3HubMain({ navigation }: Props) {
+  const { layoutY } = useContext(HeaderContext);
+
+  const scrollHandler = useAnimatedScrollHandler(event => {
+    if (!layoutY) return;
+    layoutY.value = event.contentOffset.y;
+  });
+
   return (
-    <SafeAreaView
-      edges={["top", "left", "right"]}
-      isFlex
+    <Animated.ScrollView
       style={{
-        flexDirection: "column",
-        gap: 26,
-        marginHorizontal: 24,
-        marginTop: 114,
+        flex: 1,
       }}
+      onScroll={scrollHandler}
+      scrollEventThrottle={16}
     >
-      <FlashList
-        renderItem={({ item }) => {
-          return <ManifestItem manifest={item} navigation={navigation} />;
-        }}
-        estimatedItemSize={50}
-        data={data}
-      />
-    </SafeAreaView>
+      <ManifestList navigation={navigation} />
+    </Animated.ScrollView>
   );
 }

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/components/Header/index.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@react-navigation/native";
+import { NativeStackHeaderProps } from "@react-navigation/native-stack";
+import { Box, Flex, Icons } from "@ledgerhq/native-ui";
+import TextInput from "~/components/TextInput";
+import Touchable from "~/components/Touchable";
+
+const SEARCH_HEIGHT = 60;
+
+type Props = {
+  navigation: NativeStackHeaderProps["navigation"];
+};
+
+export default function Web3HubMainHeader({ navigation }: Props) {
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  const [search, setSearch] = useState("");
+  const { colors } = useTheme();
+
+  return (
+    <Box
+      backgroundColor={colors.background}
+      paddingTop={insets.top}
+      height={SEARCH_HEIGHT + insets.top}
+    >
+      <Flex height={SEARCH_HEIGHT} flexDirection="row" alignItems="center">
+        <Touchable testID="navigation-header-back-button" onPress={navigation.goBack}>
+          <Box p={5}>
+            <Icons.ArrowLeft />
+          </Box>
+        </Touchable>
+        <Box width={"80%"}>
+          <TextInput
+            autoFocus
+            testID="web3hub-search-header-search"
+            placeholder={t("web3hub.main.header.placeholder")}
+            keyboardType="default"
+            returnKeyType="done"
+            value={search}
+            onChangeText={setSearch}
+            // onSubmitEditing={text => console.log("onSubmitEditing: ", text)}
+          />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/index.tsx
@@ -1,26 +1,21 @@
-import { Text } from "@ledgerhq/native-ui";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React from "react";
+import { ScrollView } from "react-native";
 import { BaseComposite } from "~/components/RootNavigator/types/helpers";
-import SafeAreaView from "~/components/SafeAreaView";
 import { ScreenName } from "~/const";
 import { Web3HubStackParamList } from "../../Navigator";
+import ManifestList from "LLM/features/Web3Hub/components/ManifestsList";
 
 type Props = BaseComposite<NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubSearch>>;
 
-export default function Web3HubSearch(_: Props) {
+export default function Web3HubSearch({ navigation }: Props) {
   return (
-    <SafeAreaView
-      edges={["top", "left", "right"]}
-      isFlex
+    <ScrollView
       style={{
-        flexDirection: "column",
-        gap: 26,
-        marginHorizontal: 24,
-        marginTop: 114,
+        flex: 1,
       }}
     >
-      <Text>{ScreenName.Web3HubSearch}</Text>
-    </SafeAreaView>
+      <ManifestList navigation={navigation} />
+    </ScrollView>
   );
 }

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubTabs/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubTabs/components/Header/index.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme } from "@react-navigation/native";
+import { NativeStackHeaderProps } from "@react-navigation/native-stack";
+import { Box, Icons, Text } from "@ledgerhq/native-ui";
+import Touchable from "~/components/Touchable";
+
+const TITLE_HEIGHT = 50;
+
+type Props = {
+  title?: string;
+  navigation: NativeStackHeaderProps["navigation"];
+};
+
+export default function Web3HubMainHeader({ title, navigation }: Props) {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  return (
+    <Box
+      backgroundColor={colors.background}
+      paddingTop={insets.top}
+      height={TITLE_HEIGHT + insets.top}
+    >
+      <Touchable testID="navigation-header-back-button" onPress={navigation.goBack}>
+        <Box p={5}>
+          <Icons.ArrowLeft />
+        </Box>
+      </Touchable>
+      <Text mt={5} mb={2} numberOfLines={1} variant="h4" mx={5} accessibilityRole="header">
+        {title}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubTabs/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubTabs/index.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@ledgerhq/native-ui";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React from "react";
+import { View } from "react-native";
 import { BaseComposite } from "~/components/RootNavigator/types/helpers";
-import SafeAreaView from "~/components/SafeAreaView";
 import { Web3HubStackParamList } from "../../Navigator";
 import { ScreenName } from "~/const";
 
@@ -10,17 +10,12 @@ type Props = BaseComposite<NativeStackScreenProps<Web3HubStackParamList, ScreenN
 
 export default function Web3HubTabs(_: Props) {
   return (
-    <SafeAreaView
-      edges={["top", "left", "right"]}
-      isFlex
+    <View
       style={{
-        flexDirection: "column",
-        gap: 26,
-        marginHorizontal: 24,
-        marginTop: 114,
+        flex: 1,
       }}
     >
       <Text>{ScreenName.Web3HubTabs}</Text>
-    </SafeAreaView>
+    </View>
   );
 }

--- a/libs/ui/packages/native/src/components/Form/Input/BaseInput/index.tsx
+++ b/libs/ui/packages/native/src/components/Form/Input/BaseInput/index.tsx
@@ -143,7 +143,7 @@ const BaseInput = styled.TextInput.attrs((p) => ({
   border: 0;
   flex-shrink: 1;
   display: flex;
-  min-height: fit-content;
+  min-height: auto;
   color: ${(p) => p.theme.colors.neutral.c100};
 `;
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - none feature behind FF

### 📝 Description

Prepared a good template for the other screens
Fixed a lot of small details with the headers and lists while working on it
Implemented some integration tests for the current screens and logic
Only mocks to fetch for now
Started i18n

Also for the changes on the native-ui lib you can see the warning that was printed in the screenshot below, I'm not sure if there is an impact to my change and I suppose that I could also just remove the line

<img width="877" alt="Screenshot 2024-07-10 at 16 08 42" src="https://github.com/LedgerHQ/ledger-live/assets/3009753/6ad06e64-7e1a-4ca8-8ae5-66c0df34dd49">

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13176] [LIVE-13182] [LIVE-13183] [LIVE-13186]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13176]: https://ledgerhq.atlassian.net/browse/LIVE-13176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ