### PR TITLE
fix: imageProcessor webview should have a source [LIVE-13334]

### DIFF
--- a/.changeset/moody-moose-glow.md
+++ b/.changeset/moody-moose-glow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: imageProcessor webview should have a source

--- a/apps/ledger-live-mobile/src/components/CustomImage/ImageHexProcessor.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/ImageHexProcessor.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { WebView, type WebViewMessageEvent } from "react-native-webview";
 import { ImageProcessingError } from "@ledgerhq/live-common/customImage/errors";
 import { ProcessorPreviewResult, ProcessorRawResult } from "./ImageProcessor";
-import { injectedCode } from "./injectedCode/imageHexToBase64Processing";
+import { injectedCode, htmlPage } from "./injectedCode/imageHexToBase64Processing";
 import { InjectedCodeDebugger } from "./InjectedCodeDebugger";
 
 export type Props = ProcessorRawResult & {
@@ -100,12 +100,13 @@ export default class ImageHexProcessor extends React.Component<Props> {
         <Flex flex={0}>
           <WebView
             ref={c => (this.webViewRef = c)}
-            injectedJavaScript={injectedCode}
             androidLayerType="software"
-            androidHardwareAccelerationDisabled
             onError={this.handleWebViewError}
             onLoadEnd={this.handleWebViewLoaded}
             onMessage={this.handleWebViewMessage}
+            originWhitelist={["*"]}
+            source={{ html: htmlPage }}
+            webviewDebuggingEnabled={__DEV__}
           />
         </Flex>
       </>

--- a/apps/ledger-live-mobile/src/components/CustomImage/ImageProcessor.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/ImageProcessor.tsx
@@ -2,7 +2,7 @@ import { Flex } from "@ledgerhq/native-ui";
 import React from "react";
 import { WebView, type WebViewMessageEvent } from "react-native-webview";
 import { ImageProcessingError } from "@ledgerhq/live-common/customImage/errors";
-import { injectedCode } from "./injectedCode/imageBase64ToHexProcessing";
+import { injectedCode, htmlPage } from "./injectedCode/imageBase64ToHexProcessing";
 import { InjectedCodeDebugger } from "./InjectedCodeDebugger";
 import { ImageBase64Data, ImageDimensions } from "./types";
 
@@ -151,12 +151,13 @@ export default class ImageProcessor extends React.Component<Props> {
         <Flex flex={0}>
           <WebView
             ref={c => (this.webViewRef = c)}
-            injectedJavaScript={injectedCode}
             androidLayerType="software"
-            androidHardwareAccelerationDisabled
             onError={this.handleWebViewError}
             onLoadEnd={this.handleWebViewLoaded}
             onMessage={this.handleWebViewMessage}
+            originWhitelist={["*"]}
+            source={{ html: htmlPage }}
+            webviewDebuggingEnabled={__DEV__}
           />
         </Flex>
       </>

--- a/apps/ledger-live-mobile/src/components/CustomImage/injectedCode/imageBase64ToHexProcessing.ts
+++ b/apps/ledger-live-mobile/src/components/CustomImage/injectedCode/imageBase64ToHexProcessing.ts
@@ -268,3 +268,18 @@ function getFunctionBody(str: string) {
 }
 
 export const injectedCode = getFunctionBody(codeToInject.toString());
+
+export const htmlPage = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+      ${injectedCode}
+    </script>
+  </head>
+  <body>
+  </body>
+</html>
+`;

--- a/apps/ledger-live-mobile/src/components/CustomImage/injectedCode/imageHexToBase64Processing.ts
+++ b/apps/ledger-live-mobile/src/components/CustomImage/injectedCode/imageHexToBase64Processing.ts
@@ -100,3 +100,18 @@ function getFunctionBody(str: string) {
 }
 
 export const injectedCode = getFunctionBody(codeToInject.toString());
+
+export const htmlPage = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+      ${injectedCode}
+    </script>
+  </head>
+  <body>
+  </body>
+</html>
+`;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually on simulator
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Set image for stax

### 📝 Description

The `webview` used for the `imageProcessor` was not using a `source` prop, leading to a bad state in the webview not even able to render the error
Also directly injecting the javascript in the html page loaded by the webview instead of using the `injectJavascript` prop

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13334]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13334]: https://ledgerhq.atlassian.net/browse/LIVE-13334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ