### PR TITLE
[LIVE-13346][LLM][BLE] Device search in BLE during onboarding doesn't filter on the selected device

### DIFF
--- a/.changeset/heavy-humans-hide.md
+++ b/.changeset/heavy-humans-hide.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix filter not work bug when clicking device.

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicesScanning.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicesScanning.tsx
@@ -6,7 +6,7 @@ import { HwTransportErrorType } from "@ledgerhq/errors";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { Device, DeviceModelId, QRCodeDevices } from "@ledgerhq/types-devices";
+import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import TransportBLE from "../../react-native-hw-transport-ble";
 import { knownDevicesSelector } from "~/reducers/ble";
@@ -25,7 +25,7 @@ const CANT_SEE_DEVICE_TIMEOUT = 5000;
 
 export type BleDevicesScanningProps = {
   onDeviceSelect: (item: Device) => void;
-  filterByDeviceModelId?: FilterByDeviceModelId;
+  filterByDeviceModelId?: FilterByDeviceModelId | FilterByDeviceModelId[];
   areKnownDevicesDisplayed?: boolean;
   areKnownDevicesPairable?: boolean;
 };
@@ -50,11 +50,8 @@ export default function BleDevicesScanning({
 }: BleDevicesScanningProps) {
   const { t } = useTranslation();
 
-  const isQRCodeDevice =
-    filterByDeviceModelId !== null && QRCodeDevices.includes(filterByDeviceModelId);
-
   const productName =
-    filterByDeviceModelId && !isQRCodeDevice
+    filterByDeviceModelId && !Array.isArray(filterByDeviceModelId)
       ? getDeviceModel(filterByDeviceModelId).productName || filterByDeviceModelId
       : null;
 
@@ -103,11 +100,14 @@ export default function BleDevicesScanning({
   );
 
   const filterByDeviceModelIds = useMemo(() => {
-    if (isQRCodeDevice) {
-      return QRCodeDevices;
+    if (Array.isArray(filterByDeviceModelId)) {
+      return filterByDeviceModelId.filter(
+        // This array should not contain `null` value, this is to make the type check pass
+        (v: FilterByDeviceModelId): v is DeviceModelId => v !== null,
+      );
     }
     return filterByDeviceModelId ? [filterByDeviceModelId] : undefined;
-  }, [filterByDeviceModelId, isQRCodeDevice]);
+  }, [filterByDeviceModelId]);
 
   const { scannedDevices, scanningBleError } = useBleDevicesScanning({
     bleTransportListen: TransportBLE.listen,

--- a/apps/ledger-live-mobile/src/screens/BleDevicePairingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/BleDevicePairingFlow/index.tsx
@@ -1,4 +1,4 @@
-import { Device, DeviceModelId } from "@ledgerhq/types-devices";
+import { Device, QRCodeDevices } from "@ledgerhq/types-devices";
 import React, { useCallback } from "react";
 import { Flex } from "@ledgerhq/native-ui";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -70,7 +70,7 @@ export const BleDevicePairingFlow: React.FC<Props> = ({ navigation }) => {
       <Flex px={6} flex={1}>
         <BleDevicePairingFlowComponent
           key={keyToReset}
-          filterByDeviceModelId={DeviceModelId.stax}
+          filterByDeviceModelId={QRCodeDevices}
           onPairingSuccess={onPairingSuccess}
           requestToSetHeaderOptions={requestToSetHeaderOptions}
         />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM onboarding flow has been updated;
  - Now the property `filterByDeviceModelId` of component `BleDevicePairingFlow` can be passed an array of `DeviceModelId` which will be transferred directly to filter (already supported). This can allow us show all devices with screen after scanning a QR code (no device info included for now).

### 📝 Description

- Fix filter not work bug when clicking device.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13346]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13346]: https://ledgerhq.atlassian.net/browse/LIVE-13346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ