### PR TITLE
chore(trustchain): detect more cases of trustchain refresh needs

### DIFF
--- a/apps/web-tools/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/trustchain/components/AppAccountsSync.tsx
@@ -182,9 +182,8 @@ export default function AppAccountsSync({
         trustchainSdk,
         getCurrentVersion,
         saveNewUpdate,
-        onTrustchainRefreshNeeded,
       }),
-    [trustchainSdk, getCurrentVersion, saveNewUpdate, onTrustchainRefreshNeeded],
+    [trustchainSdk, getCurrentVersion, saveNewUpdate],
   );
 
   const [visualPending, setVisualPending] = useState(true);
@@ -199,10 +198,11 @@ export default function AppAccountsSync({
       getState: () => stateRef.current,
       localStateSelector,
       latestDistantStateSelector,
+      onTrustchainRefreshNeeded,
     });
 
     return unsubscribe;
-  }, [trustchainSdk, walletSyncSdk, trustchain, memberCredentials]);
+  }, [trustchainSdk, walletSyncSdk, trustchain, memberCredentials, onTrustchainRefreshNeeded]);
 
   const setAccounts = useCallback(
     (fn: (_: Account[]) => Account[]) => {

--- a/apps/web-tools/trustchain/components/AppCloudSync.tsx
+++ b/apps/web-tools/trustchain/components/AppCloudSync.tsx
@@ -16,7 +16,6 @@ const liveSchema = walletsync.schema;
 
 export function AppWalletSync({
   trustchain,
-  setTrustchain,
   memberCredentials,
   version,
   setVersion,
@@ -97,20 +96,6 @@ export function AppWalletSync({
     [setVersion, setData, setJson],
   );
 
-  const onTrustchainRefreshNeeded = useCallback(
-    async (trustchain: Trustchain) => {
-      try {
-        const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
-        setTrustchain(newTrustchain);
-      } catch (e) {
-        if (e instanceof TrustchainEjected) {
-          setTrustchain(null);
-        }
-      }
-    },
-    [trustchainSdk, setTrustchain, memberCredentials],
-  );
-
   const walletSyncSdk = useMemo(() => {
     return new CloudSyncSDK({
       slug: liveSlug,
@@ -118,9 +103,8 @@ export function AppWalletSync({
       trustchainSdk,
       getCurrentVersion,
       saveNewUpdate,
-      onTrustchainRefreshNeeded,
     });
-  }, [trustchainSdk, getCurrentVersion, saveNewUpdate, onTrustchainRefreshNeeded]);
+  }, [trustchainSdk, getCurrentVersion, saveNewUpdate]);
 
   const onPull = useCallback(async () => {
     await walletSyncSdk.pull(trustchain, memberCredentials);

--- a/libs/live-wallet/src/walletsync/index.ts
+++ b/libs/live-wallet/src/walletsync/index.ts
@@ -54,6 +54,7 @@ export function walletSyncWatchLoop<UserState>({
   getState,
   localStateSelector,
   latestDistantStateSelector,
+  onTrustchainRefreshNeeded,
 }: {
   watchConfig?: WatchConfig;
   visualConfig?: VisualConfig;
@@ -61,6 +62,7 @@ export function walletSyncWatchLoop<UserState>({
   trustchain: Trustchain;
   memberCredentials: MemberCredentials;
   setVisualPending: (b: boolean) => void;
+  onTrustchainRefreshNeeded: (trustchain: Trustchain) => Promise<void>;
   onError?: (e: unknown) => void;
   getState: () => UserState;
   localStateSelector: (state: UserState) => LocalState;
@@ -79,5 +81,6 @@ export function walletSyncWatchLoop<UserState>({
     getState,
     localStateSelector,
     latestDistantStateSelector,
+    onTrustchainRefreshNeeded,
   });
 }

--- a/libs/trustchain/src/errors.ts
+++ b/libs/trustchain/src/errors.ts
@@ -4,3 +4,4 @@ export const InvalidDigitsError = createCustomErrorClass("InvalidDigitsError");
 export const InvalidEncryptionKeyError = createCustomErrorClass("InvalidEncryptionKeyError");
 export const TrustchainEjected = createCustomErrorClass("TrustchainEjected");
 export const TrustchainNotAllowed = createCustomErrorClass("TrustchainNotAllowed");
+export const TrustchainOutdated = createCustomErrorClass("TrustchainOutdated");

--- a/libs/trustchain/src/sdk.ts
+++ b/libs/trustchain/src/sdk.ts
@@ -419,7 +419,11 @@ async function auth(trustchain: Trustchain, memberCredentials: MemberCredentials
       },
     })
     .catch(e => {
-      if (e instanceof LedgerAPI4xx && e.message.includes("Not a member of trustchain")) {
+      if (
+        e instanceof LedgerAPI4xx &&
+        (e.message.includes("Not a member of trustchain") ||
+          e.message.includes("You are not member"))
+      ) {
         throw new TrustchainEjected(e.message);
       }
       throw e;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - trustchain, live-wallet libs

### 📝 Description

move the handling of `onTrustchainRefreshNeeded` to the **watch loop** to have less to handle in CloudSync sdk.

on the other hand, cloud sync will throw a new error `TrustchainOutdated` when it detects some unusually data delete case, which is what may happens during the rotation and when the user is "active" (poll() with a previously used jwt). A test still covers this part.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-13357 <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
