### PR TITLE
fix(LLD): AccountList not showing the correct name and balance for tokens [CN-142]

### DIFF
--- a/.changeset/healthy-days-pay.md
+++ b/.changeset/healthy-days-pay.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix(LLD): AccountList not showing the correct name and balance for tokens

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
@@ -106,8 +106,8 @@ function Row({
   onAccountSelect: (account: AccountLike, parentAccount?: Account) => void;
 }) {
   const accountCurrency = getAccountCurrency(subAccount || account);
-  const accountName = useAccountName(account);
-  const unit = useAccountUnit(account);
+  const accountName = useAccountName(subAccount || account);
+  const unit = useAccountUnit(subAccount || account);
 
   return (
     <RowContainer

--- a/apps/ledger-live-desktop/tests/page/drawer/drawer.ts
+++ b/apps/ledger-live-desktop/tests/page/drawer/drawer.ts
@@ -6,15 +6,14 @@ export class Drawer extends Component {
   private continueButton = this.page.getByTestId("drawer-continue-button");
   private closeButton = this.page.getByTestId("drawer-close-button");
   private currencyButton = (currency: string) =>
-    this.page.getByTestId(`currency-row-${currency.toLowerCase()}`);
-  private accountButton = (accountName: string, index: number) =>
-    this.page.getByTestId(`account-row-${accountName.toLowerCase()}-${index}`).first();
+    this.page.getByTestId(`currency-row-${currency.toLowerCase()}`).first();
   readonly selectAssetTitle = this.page.getByTestId("select-asset-drawer-title").first();
   readonly selectAccountTitle = this.page.getByTestId("select-account-drawer-title").first();
   readonly swapAmountFrom = this.page.getByTestId("swap-amount-from").first();
   readonly swapAmountTo = this.page.getByTestId("swap-amount-to").first();
   readonly swapAccountFrom = this.page.getByTestId("swap-account-from").first();
   readonly swapAccountTo = this.page.getByTestId("swap-account-to").first();
+  readonly backButton = this.page.getByRole("button", { name: "Back" });
 
   async continue() {
     await this.continueButton.click();
@@ -41,7 +40,14 @@ export class Drawer extends Component {
     await this.currencyButton(currency).click();
   }
 
+  getAccountButton = (accountName: string, index: number) =>
+    this.page.getByTestId(`account-row-${accountName.toLowerCase()}-${index}`).first();
+
   async selectAccount(accountName: string, index = 0) {
-    await this.accountButton(accountName, index).click();
+    await this.getAccountButton(accountName, index).click();
+  }
+
+  back() {
+    return this.backButton.click();
   }
 }

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -229,12 +229,23 @@ test("Wallet API methods @smoke", async ({ page }) => {
       id,
       method: "account.request",
       params: {
-        currencyIds: ["ethereum", "bitcoin"],
+        currencyIds: ["ethereum", "bitcoin", "ethereum/erc20/usd_tether__erc20_"],
       },
     });
 
+    await drawer.waitForDrawerToBeVisible();
+
+    await drawer.selectCurrency("tether usd");
+    // Test name and balance for tokens
+    await expect(drawer.getAccountButton("tether usd", 2)).toContainText(
+      "Tether USD (USDT)71.8174 USDT", // Special space present in the actual rendered element apparently
+    );
+    await drawer.back();
+
     await drawer.selectCurrency("bitcoin");
     await drawer.selectAccount("bitcoin");
+
+    await drawer.waitForDrawerToDisappear();
 
     await expect(response).resolves.toMatchObject({
       id,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - All live-apps that use the account selection with tokens
  - buy/sell
  - earn

### 📝 Description

AccountList not showing the correct name and balance for tokens
Introduced in this big PR: https://github.com/LedgerHQ/ledger-live/pull/6796
It's hard to catch this kind of bug, so it should be covered now with the test

### ❓ Context

- **JIRA or GitHub link**: [CN-142]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-142]: https://ledgerhq.atlassian.net/browse/CN-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ