### PR TITLE
chore(wallet): move to pako compression lib

### DIFF
--- a/libs/live-wallet/package.json
+++ b/libs/live-wallet/package.json
@@ -34,9 +34,9 @@
     "@ledgerhq/types-live": "workspace:*",
     "base64-js": "1",
     "bignumber.js": "9",
-    "fflate": "^0.8.2",
     "isomorphic-ws": "^5.0.0",
     "lodash": "4",
+    "pako": "^2.0.4",
     "rxjs": "7",
     "zod": "^3.22.4"
   },
@@ -44,6 +44,7 @@
     "@ledgerhq/hw-transport-mocker": "workspace:^",
     "@types/jest": "^29.5.10",
     "@types/lodash": "4",
+    "@types/pako": "^2.0.0",
     "@types/ws": "^8.5.3",
     "jest": "^29.7.0",
     "msw": "^2.3.1",

--- a/libs/live-wallet/src/cloudsync/__tests__/cipher.test.ts
+++ b/libs/live-wallet/src/cloudsync/__tests__/cipher.test.ts
@@ -1,0 +1,33 @@
+import { makeCipher } from "../cipher";
+import { MockSDK } from "@ledgerhq/trustchain/mockSdk";
+
+describe("makeCipher on static data set", () => {
+  const trustchainSdk = new MockSDK({
+    applicationId: 16,
+    name: "test",
+  });
+  const cipher = makeCipher(trustchainSdk);
+  const trustchain = {
+    rootId: "mock-root-id",
+    walletSyncEncryptionKey: "test-encryption-key",
+    applicationPath: "0'/16'/0'",
+  };
+  const data = new Uint8Array([1, 2, 3, 4, 5]);
+
+  it("encrypt/decrypt works together", async () => {
+    const encrypted = await cipher.encrypt(trustchain, data);
+    const decrypted = await cipher.decrypt(trustchain, encrypted);
+    expect(decrypted).toMatchObject(data);
+  });
+
+  it("encrypt is stable (non regression on encrypted data)", async () => {
+    const encrypted = await cipher.encrypt(trustchain, data);
+    expect(encrypted).toBe("h2NUqc2vTc0rrs2rTc0trs2tTc0prs2pTc0urs2uTc1S+v+f2Pnn");
+  });
+
+  it("decrypt is stable (non regression on decrypted data)", async () => {
+    const encrypted = "h2NUqc2vTc0rrs2rTc0trs2tTc0prs2pTc0urs2uTc1S+v+f2Pnn";
+    const decrypted = await cipher.decrypt(trustchain, encrypted);
+    expect(decrypted).toMatchObject(data);
+  });
+});

--- a/libs/trustchain/src/mockSdk.ts
+++ b/libs/trustchain/src/mockSdk.ts
@@ -43,6 +43,17 @@ const mockedDeviceJWT = { accessToken: "mock-device-jwt" };
 const trustchains = new Map<string, Trustchain>();
 const trustchainMembers = new Map<string, TrustchainMember[]>();
 
+/**
+ * to mock the encryption/decryption, we just xor the data with 0xff
+ */
+const applyXor = (a: Uint8Array) => {
+  const b = new Uint8Array(a.length);
+  for (let i = 0; i < a.length; i++) {
+    b[i] = a[i] ^ 0xff;
+  }
+  return b;
+};
+
 export class MockSDK implements TrustchainSDK {
   private context: TrustchainSDKContext;
   private lifecyle?: TrustchainLifecycle;
@@ -221,11 +232,11 @@ export class MockSDK implements TrustchainSDK {
 
   encryptUserData(trustchain: Trustchain, input: Uint8Array): Promise<Uint8Array> {
     assertTrustchain(trustchain);
-    return Promise.resolve(input);
+    return Promise.resolve(applyXor(input));
   }
 
   decryptUserData(trustchain: Trustchain, data: Uint8Array): Promise<Uint8Array> {
     assertTrustchain(trustchain);
-    return Promise.resolve(data);
+    return Promise.resolve(applyXor(data));
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5535,15 +5535,15 @@ importers:
       bignumber.js:
         specifier: '9'
         version: 9.1.2
-      fflate:
-        specifier: ^0.8.2
-        version: 0.8.2
       isomorphic-ws:
         specifier: ^5.0.0
         version: 5.0.0(ws@8.16.0)
       lodash:
         specifier: '4'
         version: 4.17.21
+      pako:
+        specifier: ^2.0.4
+        version: 2.1.0
       rxjs:
         specifier: '7'
         version: 7.8.1
@@ -5560,6 +5560,9 @@ importers:
       '@types/lodash':
         specifier: '4'
         version: 4.17.0
+      '@types/pako':
+        specifier: ^2.0.0
+        version: 2.0.3
       '@types/ws':
         specifier: ^8.5.3
         version: 8.5.10
@@ -19141,9 +19144,6 @@ packages:
 
   fetch-retry@5.0.6:
     resolution: {integrity: sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==}
-
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   figures@1.7.0:
     resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
@@ -48961,8 +48961,6 @@ snapshots:
   fetch-retry@4.1.1: {}
 
   fetch-retry@5.0.6: {}
-
-  fflate@0.8.2: {}
 
   figures@1.7.0:
     dependencies:


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-wallet lib

### 📝 Description

Switch `fflate` to `pako` library in `@ledgerhq/live-wallet` because fflate don't support Electron properly. (it features detect renderer as node supported but it's partially supported: ` The V8 platform used by this instance of Node does not support creating Workers`)

NB: `pako` is already used in other part of our monorepo, so it also makes sense to reduce deps

### ❓ Context

- **JIRA or GitHub link**: n/a


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
