### PR TITLE
chore(live-network): only retry network for status code that makes sense

### DIFF
--- a/.changeset/nasty-windows-suffer.md
+++ b/.changeset/nasty-windows-suffer.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-network": minor
+---
+
+live-network no longer retry network calls on HTTP status code that shouldn't be retried like 401 & some others.

--- a/libs/live-network/src/network.ts
+++ b/libs/live-network/src/network.ts
@@ -175,6 +175,10 @@ export type LiveNetworkResponse<T> = {
   data: T;
   status: number;
 };
+
+// inspired by https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md#retry
+const retryableHttpStatusCodes = [408, 413, 429, 500, 502, 503, 504, 521, 522, 524];
+
 /**
  * Network call
  * @param request
@@ -198,9 +202,8 @@ export const newImplementation = async <T = unknown, U = unknown>(
       maxRetry: getEnv("GET_CALLS_RETRY"),
       retryCondition: error => {
         if (error && error.status) {
-          // A 422 shouldn't be retried without change as explained in this documentation
-          // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
-          return error.status !== 422;
+          // not all status codes are retryable
+          return retryableHttpStatusCodes.includes(error.status);
         }
         return true;
       },


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-network

### 📝 Description

This is a generalisation of existing code to explicit the list of statusCodes that are allowed to be retried.

this avoid our stack to do 3 failing http code in a row for http code that will always fails anyway, for instance a Unauthorized case (where you fail authentication). 
**in live-hub context, this is a problem for Wallet Sync feature:**
![Capture d’écran 2024-07-15 à 14 50 22](https://github.com/user-attachments/assets/f31914b7-0ff8-4001-ad04-7afd0cba16c2)

the committed statusCodes list is taken from https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md#retry


### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
