### PR TITLE
chore(wallet): fixes cloudsync api parser on out-of-sync info nullable

### DIFF
--- a/libs/live-wallet/src/cloudsync/api.ts
+++ b/libs/live-wallet/src/cloudsync/api.ts
@@ -20,7 +20,7 @@ const schemaAtomicGetOutOfSync = z.object({
   version: z.number(),
   payload: z.string(),
   date: z.string(),
-  info: z.string().optional(),
+  info: z.string().nullable().optional(),
 });
 const schemaAtomicGetResponse = z.discriminatedUnion("status", [
   schemaAtomicGetNoData,


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-wallet cloudsync

### 📝 Description

extracted from https://github.com/LedgerHQ/ledger-live/pull/7300
this fixes a possible case where the backend sometimes return `info: null` in payload of out-of-sync status of cloudsync

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
