### PR TITLE
chore(walletsync): improve walletsync lib

### DIFF
--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -13,7 +13,9 @@ import {
   setAccountName,
   setAccountNames,
   setAccountStarred,
+  walletStateExportShouldDiffer,
   walletSyncUpdate,
+  wsStateSelector,
 } from "./store";
 import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
@@ -185,7 +187,7 @@ describe("Wallet store", () => {
       wsState: { data: {}, version: 42 },
     };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
-    expect(result.wsState).toEqual({ data: {}, version: 42 });
+    expect(wsStateSelector(result)).toEqual({ data: {}, version: 42 });
   });
 
   it("can export the wallet state", () => {
@@ -196,5 +198,18 @@ describe("Wallet store", () => {
     expect(exportWalletState(result)).toEqual({
       wsState: { data: {}, version: 42 },
     });
+  });
+
+  it("walletStateExportShouldDiffer", () => {
+    const exportedState = {
+      wsState: { data: {}, version: 42 },
+    };
+    const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
+    expect(exportWalletState(result)).toEqual({
+      wsState: { data: {}, version: 42 },
+    });
+    expect(walletStateExportShouldDiffer(initialState, result)).toBe(true);
+    expect(walletStateExportShouldDiffer(initialState, initialState)).toBe(false);
+    expect(walletStateExportShouldDiffer(result, result)).toBe(false);
   });
 });

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -227,3 +227,9 @@ export const accountRawToAccountUserData = (raw: AccountRaw): AccountUserData =>
 export const exportWalletState = (state: WalletState): ExportedWalletState => ({
   wsState: state.wsState,
 });
+
+export const walletStateExportShouldDiffer = (a: WalletState, b: WalletState): boolean => {
+  return a.wsState !== b.wsState;
+};
+
+export const wsStateSelector = (state: WalletState): WSState => state.wsState;

--- a/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
+++ b/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
@@ -8,7 +8,9 @@ import { TrustchainEjected, TrustchainOutdated } from "@ledgerhq/trustchain/erro
 export type WatchConfig =
   | {
       type: "polling";
-      pollingInterval: number;
+      pollingInterval?: number;
+      initialTimeout?: number;
+      userIntentDebounce?: number;
     }
   | {
       type: "notifications";
@@ -36,6 +38,7 @@ export function createWalletSyncWatchLoop<
   trustchain,
   memberCredentials,
   setVisualPending,
+  onStartPolling,
   onTrustchainRefreshNeeded,
   onError,
   getState,
@@ -71,6 +74,10 @@ export function createWalletSyncWatchLoop<
    */
   setVisualPending?: (b: boolean) => void;
   /**
+   * call at beginning of each polling loop
+   */
+  onStartPolling?: () => void;
+  /*
    * called with the trustchain is possibly outdated.
    * a typical implementation is to call trustchainSdk.restoreTrustchain and update trustchain object.
    */
@@ -102,6 +109,7 @@ export function createWalletSyncWatchLoop<
    */
   latestDistantStateSelector: (state: UserState) => DistantState | null;
 }): {
+  onUserRefreshIntent: () => void;
   unsubscribe: () => void;
 } {
   const visualPendingTimeout = visualConfig?.visualPendingTimeout || 1000;
@@ -111,12 +119,15 @@ export function createWalletSyncWatchLoop<
 
   async function loop() {
     // skip if there is something already pending
-    if (pending) return;
+    if (pending || unsubscribed) return;
     pending = true;
     // when it's taking longer than expected, we will visualize the loading
     const visualTimeout =
       setVisualPending && setTimeout(() => setVisualPending(true), visualPendingTimeout);
     try {
+      log("walletsync", "loop");
+      if (onStartPolling) onStartPolling();
+
       // check if there is a pull to do
       await walletSyncSdk.pull(trustchain, memberCredentials);
       if (unsubscribed) return;
@@ -155,11 +166,26 @@ export function createWalletSyncWatchLoop<
     throw new Error("notifications not implemented yet");
   } else {
     const pollingInterval = watchConfig?.pollingInterval || 30000;
-    const interval = setInterval(loop, pollingInterval);
+    const initialTimeout = watchConfig?.initialTimeout || 5000;
+    const userIntentDebounce = watchConfig?.userIntentDebounce || 1000;
+
+    // main loop
+    const callback = () => {
+      timeout = setTimeout(callback, pollingInterval);
+      loop();
+    };
+    let timeout = setTimeout(callback, initialTimeout);
+
     return {
+      onUserRefreshIntent: () => {
+        if (unsubscribed) return;
+        // user intent will cancel the next loop call and reschedule one in a short time
+        clearTimeout(timeout);
+        timeout = setTimeout(callback, userIntentDebounce);
+      },
       unsubscribe: () => {
         unsubscribed = true;
-        clearInterval(interval);
+        clearInterval(timeout);
       },
     };
   }

--- a/libs/live-wallet/src/walletsync/index.ts
+++ b/libs/live-wallet/src/walletsync/index.ts
@@ -51,6 +51,7 @@ export function walletSyncWatchLoop<UserState>({
   memberCredentials,
   setVisualPending,
   onError,
+  onStartPolling,
   getState,
   localStateSelector,
   latestDistantStateSelector,
@@ -64,6 +65,7 @@ export function walletSyncWatchLoop<UserState>({
   setVisualPending: (b: boolean) => void;
   onTrustchainRefreshNeeded: (trustchain: Trustchain) => Promise<void>;
   onError?: (e: unknown) => void;
+  onStartPolling?: () => void;
   getState: () => UserState;
   localStateSelector: (state: UserState) => LocalState;
   latestDistantStateSelector: (state: UserState) => DistantState | null;
@@ -78,6 +80,7 @@ export function walletSyncWatchLoop<UserState>({
     memberCredentials,
     setVisualPending,
     onError,
+    onStartPolling,
     getState,
     localStateSelector,
     latestDistantStateSelector,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-wallet

### 📝 Description

this improve live-wallet/walletsync stack to allows a smooth integration in LLD. ( this code changes is extracted from https://github.com/LedgerHQ/ledger-live/pull/7300 )

- `createWalletSyncWatchLoop`
  - differentiate the polling interval from the initial timeout. ultimately moving to just using `setTimeout` for both.
  - introduces `onStartPolling` which allows us to know when to set the last error (given by `onError`) back to null
  - introduces `onUserRefreshIntent` which is returned by the watch loop and allows the user to force a refresh. we debounce it with a setTimeout.
- introduce `walletStateExportShouldDiffer` predicate to know if live-wallet store's export have changes
- introduce `wsStateSelector` to access the WSState

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
