### PR TITLE
fix(cloudsync): to apply deleted-data on outdated case

### DIFF
--- a/libs/live-wallet/src/cloudsync/__tests__/sdk.test.ts
+++ b/libs/live-wallet/src/cloudsync/__tests__/sdk.test.ts
@@ -176,6 +176,8 @@ describe("CloudSyncSDK basics", () => {
       data = { value: "old" };
       version = 1;
       await expect(sdk.pull(trustchain, creds)).rejects.toThrow(TrustchainOutdated);
+      expect(data).toEqual(null);
+      expect(version).toBe(0);
     } finally {
       data = null;
       version = 0;

--- a/libs/live-wallet/src/cloudsync/sdk.ts
+++ b/libs/live-wallet/src/cloudsync/sdk.ts
@@ -106,9 +106,10 @@ export class CloudSyncSDK<Schema extends ZodType, Data = z.infer<Schema>> {
     );
     switch (response.status) {
       case "no-data": {
-        // no data, nothing to do
         const version = this.getCurrentVersion();
         if (version) {
+          // server have no data anymore, we need to delete our local data and inform upstream that the trustchain may be outdated.
+          await this.saveNewUpdate({ type: "deleted-data" });
           throw new TrustchainOutdated();
         }
         break;


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - live-wallet cloudsync

### 📝 Description

there were a case where you could be stuck forever in a `TrustchainOutdated` case in the watch loop: when CloudSyncSDK see a deleted data from the backend, it needs to dispatch `deleted-data` in order for the user land to effectively save the deletion of the data and the new version to be back to zero. it will still throw TrustchainOutdated as opportunity for user land to also refresh the trustchain (sdk.restoreTrustchain called through the `onTrustchainRefreshNeeded` callback)

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
