### PR TITLE
Activate disabled tests in speculos folder

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/speculos/receive.address.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/receive.address.spec.ts
@@ -18,7 +18,7 @@ const accounts: Account[] = [
 
 //Reactivate test after fixing the GetAppAndVersion issue - Jira: LIVE-12581
 for (const [i, account] of accounts.entries()) {
-  test.describe.skip("Receive", () => {
+  test.describe("Receive", () => {
     test.use({
       userdata: "speculos-tests-app",
       testName: `receiveSpeculos_${account.currency.uiName}`,

--- a/apps/ledger-live-desktop/tests/specs/speculos/subAccount.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/subAccount.spec.ts
@@ -5,7 +5,7 @@ import { addTmsLink } from "tests/utils/allureUtils";
 
 const tokens: Token[] = [
   Token.ETH_USDT,
-  //Token.XLM_USCD, //TODO: Reactivate when Date.Parse issue is fixed - desactivate time machine for Speculos tests
+  Token.XLM_USCD,
   Token.ALGO_USDT,
   Token.TRON_USDT,
   Token.BSC_BUSD,
@@ -55,7 +55,7 @@ for (const [i, token] of tokens.entries()) {
 
 //Reactivate test after fixing the GetAppAndVersion issue - Jira: LIVE-12581
 for (const [i, token] of tokensReceive.entries()) {
-  test.describe.skip("Add subAccount when parent exists", () => {
+  test.describe("Add subAccount when parent exists", () => {
     test.use({
       userdata: "speculos-subAccount",
       testName: `Add subAccount when parent exists (${token.tokenName})`,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
