### PR TITLE
[FEAT] : Improve Market for Backend

### DIFF
--- a/.changeset/cyan-melons-fetch.md
+++ b/.changeset/cyan-melons-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Improve Search for Market when >=2 chars

--- a/.changeset/polite-bananas-relax.md
+++ b/.changeset/polite-bananas-relax.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Lowercase search on market

--- a/.changeset/rare-windows-rhyme.md
+++ b/.changeset/rare-windows-rhyme.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Lower case search + add debounce on Market Search

--- a/apps/ledger-live-desktop/src/renderer/reducers/market.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/market.ts
@@ -16,7 +16,7 @@ const initialState: MarketState = {
     search: "",
     liveCompatible: false,
     page: 1,
-    counterCurrency: "usd",
+    counterCurrency: "USD",
   },
   currentPage: 1,
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/market/components/SearchInputComponent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/components/SearchInputComponent.tsx
@@ -1,8 +1,10 @@
+import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { Flex, SearchInput } from "@ledgerhq/react-ui";
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
+import { track } from "~/renderer/analytics/segment";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 
 const SearchContainer = styled(Flex).attrs({ flexShrink: "1" })`
@@ -18,12 +20,27 @@ type Props = {
 
 function SearchInputComponent({ search, updateSearch }: Props) {
   const { t } = useTranslation();
+
+  const [inputSearch, setInputSearch] = useState(search);
+  const debouncedSearch = useDebounce(inputSearch, 300);
+
+  useEffect(() => {
+    track("Page Market Query", {
+      currencyName: debouncedSearch,
+    });
+    updateSearch(debouncedSearch ? debouncedSearch.trim() : "");
+  }, [debouncedSearch, updateSearch]);
+
+  useEffect(() => {
+    setInputSearch(search.toLowerCase());
+  }, [search]);
+
   return (
     <SearchContainer>
       <SearchInput
         data-test-id="market-search-input"
-        value={search}
-        onChange={updateSearch}
+        value={inputSearch}
+        onChange={setInputSearch}
         placeholder={t("common.search")}
         clearable
       />

--- a/apps/ledger-live-desktop/src/renderer/screens/market/components/SearchInputComponent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/components/SearchInputComponent.tsx
@@ -32,7 +32,7 @@ function SearchInputComponent({ search, updateSearch }: Props) {
   }, [debouncedSearch, updateSearch]);
 
   useEffect(() => {
-    setInputSearch(search.toLowerCase());
+    setInputSearch(search);
   }, [search]);
 
   return (

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/SearchHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/SearchHeader/index.tsx
@@ -29,7 +29,7 @@ function SearchHeader({ search, refresh }: Props) {
   }, [debouncedSearch, refresh]);
 
   useEffect(() => {
-    setInputSearch(search);
+    setInputSearch(search?.toLowerCase());
   }, [search]);
 
   return (

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/SearchHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/SearchHeader/index.tsx
@@ -29,7 +29,7 @@ function SearchHeader({ search, refresh }: Props) {
   }, [debouncedSearch, refresh]);
 
   useEffect(() => {
-    setInputSearch(search?.toLowerCase());
+    setInputSearch(search);
   }, [search]);
 
   return (

--- a/apps/ledger-live-mobile/src/reducers/market.ts
+++ b/apps/ledger-live-mobile/src/reducers/market.ts
@@ -21,7 +21,7 @@ export const INITIAL_STATE: MarketState = {
     search: "",
     liveCompatible: false,
     page: 1,
-    counterCurrency: "usd",
+    counterCurrency: "USD",
   },
   marketFilterByStarredCurrencies: false,
   marketCurrentPage: 1,

--- a/libs/ledger-live-common/src/market/api/index.ts
+++ b/libs/ledger-live-common/src/market/api/index.ts
@@ -42,8 +42,8 @@ export async function fetchList({
       to: counterCurrency,
       sort: getSortParam(order, range),
       ...(search.length >= 2 && { filter: search }),
-      ...(starred.length > 0 && { ids: starred.join(",") }),
-      ...(liveCoinsList.length > 1 && { ids: liveCoinsList.join(",") }),
+      ...(starred.length > 0 && { ids: starred.sort().join(",") }),
+      ...(liveCoinsList.length > 1 && { ids: liveCoinsList.sort().join(",") }),
       ...([Order.topLosers, Order.topGainers].includes(order) && { top: 100 }),
     },
   });

--- a/libs/ledger-live-common/src/market/api/index.ts
+++ b/libs/ledger-live-common/src/market/api/index.ts
@@ -41,7 +41,7 @@ export async function fetchList({
       pageSize: limit,
       to: counterCurrency,
       sort: getSortParam(order, range),
-      ...(search.length >= 1 && { filter: search }),
+      ...(search.length >= 2 && { filter: search }),
       ...(starred.length > 0 && { ids: starred.join(",") }),
       ...(liveCoinsList.length > 1 && { ids: liveCoinsList.join(",") }),
       ...([Order.topLosers, Order.topGainers].includes(order) && { top: 100 }),

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -93,7 +93,7 @@ export function useMarketData(props: MarketListRequestParams): MarketListRequest
         props.order,
         {
           counterCurrency: props.counterCurrency,
-          ...(props.search && props.search?.length >= 1 && { search: props.search }),
+          ...(props.search && props.search?.length >= 2 && { search: props.search }),
           ...(props.starred && props.starred?.length >= 1 && { starred: props.starred }),
           ...(props.liveCoinsList &&
             props.liveCoinsList?.length >= 1 && { liveCoinsList: props.liveCoinsList }),

--- a/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
+++ b/libs/ledger-live-common/src/market/hooks/useMarketDataProvider.ts
@@ -85,6 +85,7 @@ export const useSupportedCurrencies = () =>
   });
 
 export function useMarketData(props: MarketListRequestParams): MarketListRequestResult {
+  const search = props.search?.toLowerCase() ?? "";
   return useQueries({
     queries: Array.from({ length: props.page ?? 1 }, (_, i) => i).map(page => ({
       queryKey: [
@@ -93,7 +94,7 @@ export function useMarketData(props: MarketListRequestParams): MarketListRequest
         props.order,
         {
           counterCurrency: props.counterCurrency,
-          ...(props.search && props.search?.length >= 2 && { search: props.search }),
+          ...(props.search && props.search?.length >= 2 && { search: search }),
           ...(props.starred && props.starred?.length >= 1 && { starred: props.starred }),
           ...(props.liveCoinsList &&
             props.liveCoinsList?.length >= 1 && { liveCoinsList: props.liveCoinsList }),
@@ -101,7 +102,7 @@ export function useMarketData(props: MarketListRequestParams): MarketListRequest
             [Order.topLosers, Order.topGainers].includes(props.order) && { range: props.range }),
         },
       ],
-      queryFn: () => fetchList({ ...props, page }),
+      queryFn: () => fetchList({ ...props, page, search }),
       select: (data: MarketItemResponse[]) => ({
         formattedData: currencyFormatter(data, cryptoCurrenciesList),
         page,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Discussed in 
https://ledgerhq.atlassian.net/wiki/spaces/BE/pages/4867096580/2024-07-18+CVS+freshness+markets+traffic+analysis

Improvements in this PR : 
- Debounced search in LLD
- Uppercase counterCurrency in LLM/LLD
- lowercase search in LLM/LLD
- 2 characters are needed now to trigger search
- sort ids when favorite filter in On

What's next ? 
- LLM pagination fix
- Discrepancy between listing page and coin page

DEMO 

https://github.com/user-attachments/assets/0438f0a8-7cb9-493f-ba12-a047ec2f8fb8

https://github.com/user-attachments/assets/bbb020bc-034b-4ea5-8513-cf0c54142ca5



### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
