### PR TITLE
feat(web3hub): add tabs button to main, search and app screens [LIVE-13181]

### DIFF
--- a/.changeset/tough-bulldogs-ring.md
+++ b/.changeset/tough-bulldogs-ring.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(web3hub): add tabs button to main, search and app screens

--- a/apps/ledger-live-mobile/__tests__/jest-setup.js
+++ b/apps/ledger-live-mobile/__tests__/jest-setup.js
@@ -27,6 +27,20 @@ NativeModules.RNAnalytics = {};
 
 const mockAnalytics = jest.genMockFromModule("@segment/analytics-react-native");
 
+// Overriding the default RNGH mocks
+// to replace TouchableNativeFeedback with TouchableOpacity
+// as the former breaks tests trying to press buttons
+jest.mock("react-native-gesture-handler", () => {
+  const TouchableOpacity = require("react-native").TouchableOpacity;
+  return {
+    ...require("react-native-gesture-handler/lib/commonjs/mocks").default,
+    RawButton: TouchableOpacity,
+    BaseButton: TouchableOpacity,
+    RectButton: TouchableOpacity,
+    BorderlessButton: TouchableOpacity,
+  };
+});
+
 jest.mock("@segment/analytics-react-native", () => mockAnalytics);
 
 jest.mock("react-native-launch-arguments", () => ({}));

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types.ts
@@ -1,9 +1,0 @@
-import { BaseNavigatorStackParamList } from "./types/BaseNavigator";
-
-/* eslint-disable @typescript-eslint/no-namespace */
-declare global {
-  namespace ReactNavigation {
-    // eslint-disable-next-line @typescript-eslint/no-empty-interface
-    interface RootParamList extends BaseNavigatorStackParamList {}
-  }
-}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -14,7 +14,7 @@ import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { MappedSwapOperation } from "@ledgerhq/live-common/exchange/swap/types";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
-import { Web3HubStackParamList } from "LLM/features/Web3Hub/Navigator";
+import type { Web3HubStackParamList } from "LLM/features/Web3Hub/types";
 import { NavigatorName, ScreenName } from "~/const";
 import type { FirmwareUpdateProps } from "~/screens/FirmwareUpdate";
 import type { AccountSettingsNavigatorParamList } from "./AccountSettingsNavigator";
@@ -109,7 +109,7 @@ export type BaseNavigatorStackParamList = {
     customDappURL?: string;
     uri?: string;
   };
-  [NavigatorName.Web3Hub]: NavigatorScreenParams<Web3HubStackParamList> | undefined;
+  [NavigatorName.Web3Hub]: NavigatorScreenParams<Web3HubStackParamList>;
   [ScreenName.Recover]: {
     platform?: string;
     device?: Device;
@@ -316,3 +316,10 @@ export type BaseNavigatorStackParamList = {
   };
   [NavigatorName.LandingPages]: NavigatorScreenParams<LandingPagesNavigatorParamList>;
 };
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace ReactNavigation {
+    interface RootParamList extends BaseNavigatorStackParamList {}
+  }
+}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/MainNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/MainNavigator.ts
@@ -1,6 +1,6 @@
 import { NavigatorScreenParams } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
-import { Web3HubTabStackParamList } from "LLM/features/Web3Hub/TabNavigator";
+import { Web3HubTabStackParamList } from "LLM/features/Web3Hub/types";
 import { DiscoverNavigatorStackParamList } from "./DiscoverNavigator";
 import { MyLedgerNavigatorStackParamList } from "./MyLedgerNavigator";
 import { PortfolioNavigatorStackParamList } from "./PortfolioNavigator";

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/helpers.ts
@@ -12,6 +12,7 @@ import {
 import { StackNavigationProp, StackScreenProps } from "@react-navigation/stack";
 import { BaseNavigatorStackParamList } from "./BaseNavigator";
 import { RootStackParamList } from "./RootNavigator";
+import { MainNavigatorParamList } from "./MainNavigator";
 
 export type RootNavigation = StackNavigationProp<RootStackParamList>;
 export type BaseNavigation = CompositeNavigationProp<
@@ -58,6 +59,32 @@ export type MaterialTopTabNavigatorRoute<
   ParamList extends ParamListBase,
   RouteName = never,
 > = MaterialTopTabNavigatorProps<ParamList, RouteName>["route"];
+
+export type MainComposite<
+  A extends {
+    navigation: NavigationProp<
+      ParamListBase,
+      string,
+      string | undefined,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any
+    >;
+    route: RouteProp<ParamListBase>;
+  },
+> = CompositeScreenProps<
+  A,
+  CompositeScreenProps<
+    StackScreenProps<MainNavigatorParamList>,
+    CompositeScreenProps<
+      StackScreenProps<BaseNavigatorStackParamList>,
+      StackScreenProps<RootStackParamList>
+    >
+  >
+>;
 
 export type BaseComposite<
   A extends {

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/Navigator.tsx
@@ -9,18 +9,10 @@ import Web3HubTabs from "./screens/Web3HubTabs";
 import Web3HubTabsHeader from "./screens/Web3HubTabs/components/Header";
 import Web3HubApp from "./screens/Web3HubApp";
 import Web3HubAppHeader from "./screens/Web3HubApp/components/Header";
+import type { AppProps, SearchProps, TabsProps, Web3HubStackParamList } from "./types";
 
-// Uncomment to use mocks
+// Uncomment to use mocks (you need to reload the app)
 // process.env.MOCK_WEB3HUB = "1";
-
-export type Web3HubStackParamList = {
-  [ScreenName.Web3HubSearch]: undefined;
-  [ScreenName.Web3HubTabs]: undefined;
-  [ScreenName.Web3HubApp]: {
-    manifestId: string;
-    queryParams?: Record<string, string | undefined>;
-  };
-};
 
 const Stack = createNativeStackNavigator<Web3HubStackParamList>();
 
@@ -41,7 +33,11 @@ export default function Navigator() {
           component={Web3HubSearch}
           options={{
             header: props => (
-              <Web3HubSearchHeader navigation={props.navigation} onSearch={setSearch} />
+              <Web3HubSearchHeader
+                // Using as here because we cannot use generics on the header props
+                navigation={props.navigation as SearchProps["navigation"]}
+                onSearch={setSearch}
+              />
             ),
           }}
         />
@@ -51,7 +47,11 @@ export default function Navigator() {
           options={{
             title: "N Tabs", // Temporary, will probably be changed
             header: props => (
-              <Web3HubTabsHeader title={props.options.title} navigation={props.navigation} />
+              <Web3HubTabsHeader
+                title={props.options.title}
+                // Using as here because we cannot use generics on the header props
+                navigation={props.navigation as TabsProps["navigation"]}
+              />
             ),
           }}
         />
@@ -59,7 +59,12 @@ export default function Navigator() {
           name={ScreenName.Web3HubApp}
           component={Web3HubApp}
           options={{
-            header: props => <Web3HubAppHeader navigation={props.navigation} />,
+            header: props => (
+              <Web3HubAppHeader
+                // Using as here because we cannot use generics on the header props
+                navigation={props.navigation as AppProps["navigation"]}
+              />
+            ),
           }}
         />
       </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/TabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/TabNavigator.tsx
@@ -6,11 +6,7 @@ import { ScreenName } from "~/const";
 import { HeaderContext } from "./HeaderContext";
 import Web3HubMain from "./screens/Web3HubMain";
 import Web3HubMainHeader from "./screens/Web3HubMain/components/Header";
-import { SearchProps } from "./types";
-
-export type Web3HubTabStackParamList = {
-  [ScreenName.Web3HubMain]: undefined;
-};
+import { MainProps, Web3HubTabStackParamList } from "./types";
 
 const Stack = createNativeStackNavigator<Web3HubTabStackParamList>();
 
@@ -36,7 +32,7 @@ export default function TabNavigator() {
               <Web3HubMainHeader
                 title={props.options.title}
                 // Using as here because we cannot use generics on the header props
-                navigation={props.navigation as SearchProps["navigation"]}
+                navigation={props.navigation as MainProps["navigation"]}
               />
             ),
             animation: "none",

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/__integrations__/web3hub.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/__integrations__/web3hub.integration.test.tsx
@@ -17,23 +17,28 @@ jest.mock(
     ),
 );
 
+async function waitForLoader() {
+  expect(await screen.findByRole("progressbar")).toBeOnTheScreen();
+  await waitForElementToBeRemoved(() => screen.getByRole("progressbar"), {
+    timeout: 1500, // timeout because we mock the return and fake 1s delay
+  });
+}
+
 describe("Web3Hub integration test", () => {
   it("Should list manifests and navigate to app page", async () => {
     const { user } = render(<Web3HubTest />);
 
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the return and fake 1s delay
-    });
+    await waitForLoader();
 
     expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
     await user.press(screen.getAllByText("Dummy Wallet App")[0]);
     expect(await screen.findByText("dummy-0")).toBeOnTheScreen();
     expect(await screen.findByText("Dummy Wallet App")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    expect(await screen.findByRole("button", { name: /back/i })).toBeOnTheScreen();
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
     expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
@@ -41,7 +46,7 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("wallet-api-tools-0")).toBeOnTheScreen();
     expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
   });
 
@@ -50,10 +55,7 @@ describe("Web3Hub integration test", () => {
 
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeDisabled();
@@ -66,7 +68,7 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("dummy-0")).toBeOnTheScreen();
     expect(await screen.findByText("Dummy Wallet App")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeEnabled();
 
@@ -75,11 +77,11 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("wallet-api-tools-0")).toBeOnTheScreen();
     expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeEnabled();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeDisabled();
@@ -90,20 +92,14 @@ describe("Web3Hub integration test", () => {
 
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
 
     expect(await screen.findByText("games")).toBeOnTheScreen();
     await user.press(screen.getByText("games"));
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect(screen.queryByText("Wallet API Tools")).not.toBeOnTheScreen();
     expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
@@ -111,7 +107,7 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("dummy-0")).toBeOnTheScreen();
     expect(await screen.findByText("Dummy Wallet App")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
     // scroll to reveal the end of the list
@@ -119,10 +115,7 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("other")).toBeOnTheScreen();
     await user.press(screen.getByText("other"));
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect(screen.queryByText("Dummy Wallet App")).not.toBeOnTheScreen();
     expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
@@ -130,7 +123,7 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("wallet-api-tools-0")).toBeOnTheScreen();
     expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
   });
 
@@ -139,10 +132,7 @@ describe("Web3Hub integration test", () => {
 
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeDisabled();
@@ -154,10 +144,7 @@ describe("Web3Hub integration test", () => {
 
     await user.type(screen.getByRole("searchbox"), "Tool");
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect(screen.queryByText("Dummy Wallet App")).not.toBeOnTheScreen();
     expect((await screen.findAllByText("Wallet API Tools"))[0]).toBeOnTheScreen();
@@ -165,7 +152,7 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("wallet-api-tools-0")).toBeOnTheScreen();
     expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeEnabled();
 
@@ -175,10 +162,7 @@ describe("Web3Hub integration test", () => {
     expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
     await user.type(screen.getByRole("searchbox"), "Dummy");
 
-    expect(await screen.findByTestId("web3hub-loading-indicator")).toBeOnTheScreen();
-    await waitForElementToBeRemoved(() => screen.getByTestId("web3hub-loading-indicator"), {
-      timeout: 1500, // timeout because we mock the request and fake 1s delay
-    });
+    await waitForLoader();
 
     expect(screen.queryByText("Wallet API Tools")).not.toBeOnTheScreen();
     expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
@@ -186,11 +170,64 @@ describe("Web3Hub integration test", () => {
     expect(await screen.findByText("dummy-0")).toBeOnTheScreen();
     expect(await screen.findByText("Dummy Wallet App")).toBeOnTheScreen();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeEnabled();
 
-    await user.press(screen.getByTestId("navigation-header-back-button"));
+    await user.press(screen.getByRole("button", { name: /back/i }));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+    expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
+    expect(screen.getByRole("searchbox")).toBeDisabled();
+  });
+
+  it("Should go to tabs from main, search and app pages", async () => {
+    const { user } = render(<Web3HubTest />);
+
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+
+    expect(await screen.findByRole("button", { name: /2/i })).toBeOnTheScreen();
+    await user.press(screen.getByRole("button", { name: /2/i }));
+
+    expect(await screen.findByText("Web3HubTabs")).toBeOnTheScreen();
+    expect(await screen.findByText("N Tabs")).toBeOnTheScreen();
+
+    await user.press(screen.getByRole("button", { name: /back/i }));
+    expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
+
+    expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
+    expect(screen.getByRole("searchbox")).toBeDisabled();
+    await user.press(screen.getByRole("searchbox"));
+    expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
+    expect(screen.getByRole("searchbox")).toBeEnabled();
+
+    expect(await screen.findByRole("button", { name: /2/i })).toBeOnTheScreen();
+    await user.press(screen.getByRole("button", { name: /2/i }));
+
+    expect(await screen.findByText("Web3HubTabs")).toBeOnTheScreen();
+    expect(await screen.findByText("N Tabs")).toBeOnTheScreen();
+
+    await user.press(screen.getByRole("button", { name: /back/i }));
+
+    expect((await screen.findAllByText("Dummy Wallet App"))[0]).toBeOnTheScreen();
+    await user.press(screen.getAllByText("Wallet API Tools")[0]);
+    expect(await screen.findByText("wallet-api-tools-0")).toBeOnTheScreen();
+    expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
+
+    expect(await screen.findByRole("button", { name: /2/i })).toBeOnTheScreen();
+    await user.press(screen.getByRole("button", { name: /2/i }));
+
+    expect(await screen.findByText("Web3HubTabs")).toBeOnTheScreen();
+    expect(await screen.findByText("N Tabs")).toBeOnTheScreen();
+
+    await user.press(screen.getByRole("button", { name: /back/i }));
+    expect(await screen.findByText("wallet-api-tools-0")).toBeOnTheScreen();
+    expect(await screen.findByText("Wallet API Tools")).toBeOnTheScreen();
+
+    await user.press(screen.getByRole("button", { name: /back/i }));
+    expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
+    expect(screen.getByRole("searchbox")).toBeEnabled();
+
+    await user.press(screen.getByRole("button", { name: /back/i }));
     expect(await screen.findByText("Explore web3")).toBeOnTheScreen();
     expect(await screen.findByRole("searchbox")).toBeOnTheScreen();
     expect(screen.getByRole("searchbox")).toBeDisabled();

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/BackButton/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/BackButton/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Box, Icons } from "@ledgerhq/native-ui";
+import { BorderlessButton } from "react-native-gesture-handler";
+
+type Props = {
+  onPress: () => void;
+};
+
+export default function BackButton({ onPress }: Props) {
+  return (
+    <BorderlessButton onPress={onPress} activeOpacity={0.5} borderless={false}>
+      <Box p={4} accessible accessibilityRole="button" aria-label="back">
+        <Icons.ArrowLeft />
+      </Box>
+    </BorderlessButton>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/LoadingIndicator/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/LoadingIndicator/index.tsx
@@ -3,7 +3,7 @@ import { Box, InfiniteLoader } from "@ledgerhq/native-ui";
 
 export default function LoadingIndicator() {
   return (
-    <Box height={40} testID="web3hub-loading-indicator">
+    <Box height={40} accessible accessibilityRole="progressbar">
       <InfiniteLoader size={30} />
     </Box>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/TabButton/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/TabButton/index.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback } from "react";
+import { useTheme } from "@react-navigation/native";
+import { View, StyleSheet } from "react-native";
+import { Text } from "@ledgerhq/native-ui";
+import { BorderlessButton } from "react-native-gesture-handler";
+import type { AppProps, MainProps, SearchProps } from "LLM/features/Web3Hub/types";
+import { NavigatorName, ScreenName } from "~/const";
+
+type Props = {
+  count: number;
+  navigation: MainProps["navigation"] | SearchProps["navigation"] | AppProps["navigation"];
+};
+
+export default function TabButton({ count, navigation }: Props) {
+  const { colors } = useTheme();
+
+  const goToTabs = useCallback(() => {
+    navigation.push(NavigatorName.Web3Hub, {
+      screen: ScreenName.Web3HubTabs,
+    });
+  }, [navigation]);
+
+  return (
+    <BorderlessButton onPress={goToTabs} activeOpacity={0.5} borderless={false}>
+      <View
+        accessible
+        accessibilityRole="button"
+        style={[
+          styles.container,
+          {
+            borderColor: colors.black,
+          },
+        ]}
+      >
+        <Text fontWeight="semiBold" variant="large" style={styles.count}>
+          {count}
+        </Text>
+      </View>
+    </BorderlessButton>
+  );
+}
+
+const TOTAL_SIZE = 48;
+const BORDER_WIDTH = 2;
+const MARGIN = 12;
+const SIZE = TOTAL_SIZE - MARGIN * 2;
+const LINE_HEIGHT = SIZE - BORDER_WIDTH * 2;
+
+const styles = StyleSheet.create({
+  container: {
+    position: "relative",
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: 8,
+    borderWidth: BORDER_WIDTH,
+    margin: MARGIN,
+    width: SIZE,
+    height: SIZE,
+    backgroundColor: "transparent",
+  },
+  count: {
+    lineHeight: LINE_HEIGHT,
+  },
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Header/index.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
-import { NativeStackHeaderProps } from "@react-navigation/native-stack";
-import { Box, Flex, Icons } from "@ledgerhq/native-ui";
+import { Box, Flex } from "@ledgerhq/native-ui";
+import BackButton from "LLM/features/Web3Hub/components/BackButton";
+import TabButton from "LLM/features/Web3Hub/components/TabButton";
+import { AppProps } from "LLM/features/Web3Hub/types";
 import TextInput from "~/components/TextInput";
-import Touchable from "~/components/Touchable";
 
 const SEARCH_HEIGHT = 60;
 
 type Props = {
-  navigation: NativeStackHeaderProps["navigation"];
+  navigation: AppProps["navigation"];
 };
 
-export default function Web3HubMainHeader({ navigation }: Props) {
+export default function Web3HubAppHeader({ navigation }: Props) {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
@@ -22,13 +23,9 @@ export default function Web3HubMainHeader({ navigation }: Props) {
       paddingTop={insets.top}
       height={SEARCH_HEIGHT + insets.top}
     >
-      <Flex height={SEARCH_HEIGHT} flexDirection="row" alignItems="center">
-        <Touchable testID="navigation-header-back-button" onPress={navigation.goBack}>
-          <Box p={5}>
-            <Icons.ArrowLeft />
-          </Box>
-        </Touchable>
-        <Box width={"80%"}>
+      <Flex flex={1} height={SEARCH_HEIGHT} flexDirection="row" alignItems="center">
+        <BackButton onPress={navigation.goBack} />
+        <Flex flex={1}>
           <TextInput
             placeholder="Current URL"
             keyboardType="default"
@@ -36,7 +33,8 @@ export default function Web3HubMainHeader({ navigation }: Props) {
             value=""
             disabled
           />
-        </Box>
+        </Flex>
+        <TabButton count={2} navigation={navigation} />
       </Flex>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/components/Header/index.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from "react-i18next";
 import React, { useCallback, useContext } from "react";
-import { TouchableOpacity, View } from "react-native";
+import { TouchableOpacity, View, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import Animated, { useAnimatedStyle, interpolate, Extrapolation } from "react-native-reanimated";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { useQueryClient } from "@tanstack/react-query";
-import type { SearchProps } from "LLM/features/Web3Hub/types";
+import type { MainProps } from "LLM/features/Web3Hub/types";
 import TextInput from "~/components/TextInput";
 import { HeaderContext } from "LLM/features/Web3Hub/HeaderContext";
 import { queryKey } from "LLM/features/Web3Hub/components/ManifestsList/useManifestsListViewModel";
+import TabButton from "LLM/features/Web3Hub/components/TabButton";
 import { NavigatorName, ScreenName } from "~/const";
 
 const TITLE_HEIGHT = 50;
@@ -21,7 +22,7 @@ const LAYOUT_RANGE = [0, 35];
 
 type Props = {
   title?: string;
-  navigation: SearchProps["navigation"];
+  navigation: MainProps["navigation"];
 };
 
 export default function Web3HubMainHeader({ title, navigation }: Props) {
@@ -50,6 +51,8 @@ export default function Web3HubMainHeader({ title, navigation }: Props) {
     if (!layoutY) return {};
 
     return {
+      // Height necessary for proper transform
+      height: TOTAL_HEADER_HEIGHT,
       transform: [
         {
           translateY: interpolate(
@@ -67,6 +70,7 @@ export default function Web3HubMainHeader({ title, navigation }: Props) {
     if (!layoutY) return {};
 
     return {
+      height: TITLE_HEIGHT,
       opacity: interpolate(layoutY.value, [0, 35], [1, 0], Extrapolation.CLAMP),
     };
   });
@@ -94,8 +98,8 @@ export default function Web3HubMainHeader({ title, navigation }: Props) {
             </Text>
           </TouchableOpacity>
         </Animated.View>
-        <Flex height={SEARCH_HEIGHT} mx={5} justifyContent="center">
-          <TouchableOpacity onPress={goToSearch}>
+        <Flex flex={1} height={SEARCH_HEIGHT} ml={5} flexDirection="row" alignItems="center">
+          <TouchableOpacity style={styles.inputContainer} onPress={goToSearch}>
             <View pointerEvents="none">
               <TextInput
                 role="searchbox"
@@ -107,8 +111,17 @@ export default function Web3HubMainHeader({ title, navigation }: Props) {
               />
             </View>
           </TouchableOpacity>
+          <TabButton count={2} navigation={navigation} />
         </Flex>
       </Animated.View>
     </Animated.View>
   );
 }
+
+const styles = StyleSheet.create({
+  inputContainer: {
+    display: "flex",
+    flex: 1,
+    justifyContent: "center",
+  },
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/components/Header/index.tsx
@@ -2,20 +2,21 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
-import { NativeStackHeaderProps } from "@react-navigation/native-stack";
-import { Box, Flex, Icons } from "@ledgerhq/native-ui";
+import { Box, Flex } from "@ledgerhq/native-ui";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
+import BackButton from "LLM/features/Web3Hub/components/BackButton";
+import TabButton from "LLM/features/Web3Hub/components/TabButton";
+import { SearchProps } from "LLM/features/Web3Hub/types";
 import TextInput from "~/components/TextInput";
-import Touchable from "~/components/Touchable";
 
 const SEARCH_HEIGHT = 60;
 
 type Props = {
-  navigation: NativeStackHeaderProps["navigation"];
+  navigation: SearchProps["navigation"];
   onSearch: (search: string) => void;
 };
 
-export default function Web3HubMainHeader({ navigation, onSearch }: Props) {
+export default function Web3HubSearchHeader({ navigation, onSearch }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -32,13 +33,9 @@ export default function Web3HubMainHeader({ navigation, onSearch }: Props) {
       paddingTop={insets.top}
       height={SEARCH_HEIGHT + insets.top}
     >
-      <Flex height={SEARCH_HEIGHT} flexDirection="row" alignItems="center">
-        <Touchable testID="navigation-header-back-button" onPress={navigation.goBack}>
-          <Box p={5}>
-            <Icons.ArrowLeft />
-          </Box>
-        </Touchable>
-        <Box width={"80%"}>
+      <Flex flex={1} height={SEARCH_HEIGHT} flexDirection="row" alignItems="center">
+        <BackButton onPress={navigation.goBack} />
+        <Flex flex={1}>
           <TextInput
             autoFocus
             role="searchbox"
@@ -49,7 +46,8 @@ export default function Web3HubMainHeader({ navigation, onSearch }: Props) {
             onChangeText={setSearch}
             // onSubmitEditing={text => console.log("onSubmitEditing: ", text)}
           />
-        </Box>
+        </Flex>
+        <TabButton count={2} navigation={navigation} />
       </Flex>
     </Box>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubTabs/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubTabs/components/Header/index.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
-import { NativeStackHeaderProps } from "@react-navigation/native-stack";
-import { Box, Icons, Text } from "@ledgerhq/native-ui";
-import Touchable from "~/components/Touchable";
+import { Box, Text } from "@ledgerhq/native-ui";
+import type { TabsProps } from "LLM/features/Web3Hub/types";
+import BackButton from "LLM/features/Web3Hub/components/BackButton";
 
 const TITLE_HEIGHT = 50;
 
 type Props = {
   title?: string;
-  navigation: NativeStackHeaderProps["navigation"];
+  navigation: TabsProps["navigation"];
 };
 
-export default function Web3HubMainHeader({ title, navigation }: Props) {
+export default function Web3HubTabsHeader({ title, navigation }: Props) {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
@@ -22,11 +22,7 @@ export default function Web3HubMainHeader({ title, navigation }: Props) {
       paddingTop={insets.top}
       height={TITLE_HEIGHT + insets.top}
     >
-      <Touchable testID="navigation-header-back-button" onPress={navigation.goBack}>
-        <Box p={5}>
-          <Icons.ArrowLeft />
-        </Box>
-      </Touchable>
+      <BackButton onPress={navigation.goBack} />
       <Text mt={5} mb={2} numberOfLines={1} variant="h4" mx={5} accessibilityRole="header">
         {title}
       </Text>

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/types.ts
@@ -1,21 +1,32 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
-import type { Web3HubTabStackParamList } from "LLM/features/Web3Hub/TabNavigator";
-import type { Web3HubStackParamList } from "LLM/features/Web3Hub/Navigator";
-import { BaseComposite } from "~/components/RootNavigator/types/helpers";
+import { BaseComposite, MainComposite } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
 
-export type MainProps = BaseComposite<
-  NativeStackScreenProps<Web3HubTabStackParamList, ScreenName.Web3HubMain>
+export type Web3HubTabStackParamList = {
+  [ScreenName.Web3HubMain]: undefined;
+};
+
+export type Web3HubTabScreenProps<T extends keyof Web3HubTabStackParamList> = MainComposite<
+  NativeStackScreenProps<Web3HubTabStackParamList, T>
 >;
 
-export type SearchProps = BaseComposite<
-  NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubSearch>
+export type Web3HubStackParamList = {
+  [ScreenName.Web3HubSearch]: undefined;
+  [ScreenName.Web3HubTabs]: undefined;
+  [ScreenName.Web3HubApp]: {
+    manifestId: string;
+    queryParams?: Record<string, string | undefined>;
+  };
+};
+
+export type Web3HubScreenProps<T extends keyof Web3HubStackParamList> = BaseComposite<
+  NativeStackScreenProps<Web3HubStackParamList, T>
 >;
 
-export type AppProps = BaseComposite<
-  NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubApp>
->;
+export type MainProps = Web3HubTabScreenProps<ScreenName.Web3HubMain>;
 
-export type TabsProps = BaseComposite<
-  NativeStackScreenProps<Web3HubStackParamList, ScreenName.Web3HubTabs>
->;
+export type SearchProps = Web3HubScreenProps<ScreenName.Web3HubSearch>;
+
+export type AppProps = Web3HubScreenProps<ScreenName.Web3HubApp>;
+
+export type TabsProps = Web3HubScreenProps<ScreenName.Web3HubTabs>;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - none behind a disabled FF

### 📝 Description

Add tabs button to main, search and app screens
Added a test for tabs button navigation
Remove some testIDs from the tests and use roles (can be a bit slower but also more correct for accessibility)
Mock buttons from RNGH as it was not working in jest tests
Moved the ReactNavigation declaration merging to ~RootNavigator~BaseNavigator next to the declaration of the ~root~ type (I'll probably do the change to RootNavigator in another PR)
Added MainComposite for tab sub screens used in web3hub tab navigator
Colocate all navigator types
Refactor BackButton
Fixed header styles and animatedStyles for proper placement and sizing

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13181] [LIVE-13184]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13181]: https://ledgerhq.atlassian.net/browse/LIVE-13181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ