### PR TITLE
feat(shouldForceFirmwareUpdate): add <1.1.1 condition for europa

### DIFF
--- a/.changeset/strange-oranges-bake.md
+++ b/.changeset/strange-oranges-bake.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-core": patch
+---
+
+shouldForceFirmwareUpdate: add <1.1.1 condition for europa

--- a/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.test.ts
+++ b/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.test.ts
@@ -37,6 +37,52 @@ describe("shouldForceFirmwareUpdate", () => {
     ).toBe(false);
   });
 
+  it("should force firmware update for europa <1.1.1 and not other versions", () => {
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.0.0", deviceModelId: DeviceModelId.europa }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.0.0-whatever",
+        deviceModelId: DeviceModelId.europa,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.1.0", deviceModelId: DeviceModelId.europa }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.1.0-whatever",
+        deviceModelId: DeviceModelId.europa,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.1.1", deviceModelId: DeviceModelId.europa }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.1.1-whatever",
+        deviceModelId: DeviceModelId.europa,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({ currentVersion: "1.2.0", deviceModelId: DeviceModelId.europa }),
+    ).toBe(false);
+
+    expect(
+      shouldForceFirmwareUpdate({
+        currentVersion: "1.2.0-whatever",
+        deviceModelId: DeviceModelId.europa,
+      }),
+    ).toBe(false);
+  });
+
   it("should not force firmware update for other models", () => {
     expect(
       shouldForceFirmwareUpdate({ currentVersion: "1.2.0", deviceModelId: DeviceModelId.nanoX }),

--- a/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.ts
+++ b/libs/device-core/src/firmwareUpdate/shouldForceFirmwareUpdate.ts
@@ -7,7 +7,7 @@ const forceUpdateConditions: Record<DeviceModelId, string> = {
   nanoS: noVersionCondition,
   nanoSP: noVersionCondition,
   blue: noVersionCondition,
-  europa: noVersionCondition,
+  europa: "<1.1.1",
   stax: "<=1.3.0",
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
