### PR TITLE
chore(walletsync): introduce nonImportedAccountInfos management

### DIFF
--- a/apps/web-tools/trustchain/components/App.tsx
+++ b/apps/web-tools/trustchain/components/App.tsx
@@ -26,11 +26,10 @@ import { AppRestoreTrustchain } from "./AppRestoreTrustchain";
 import { AppWalletSync } from "./AppCloudSync";
 import { AppSetCloudSyncAPIEnv } from "./AppSetCloudSyncAPIEnv";
 import { DeviceInteractionLayer } from "./DeviceInteractionLayer";
-import { Account } from "@ledgerhq/types-live";
-import { WalletState, initialState as walletInitialState } from "@ledgerhq/live-wallet/store";
+import { initialState as walletInitialState } from "@ledgerhq/live-wallet/store";
 import { DistantState, trustchainLifecycle } from "@ledgerhq/live-wallet/walletsync/index";
 import { Loading } from "./Loading";
-import { NonImportedAccountInfo } from "@ledgerhq/live-wallet/lib-es/walletsync/modules/accounts";
+import { State } from "./types";
 
 const Container = styled.div`
   padding: 0 10px 50px 0;
@@ -314,12 +313,6 @@ const App = () => {
       </Container>
     </TrustchainSDKContext.Provider>
   );
-};
-
-type State = {
-  accounts: Account[];
-  walletState: WalletState;
-  nonImportedAccounts: NonImportedAccountInfo[];
 };
 
 const AppAccountsSync = dynamic<{

--- a/apps/web-tools/trustchain/components/App.tsx
+++ b/apps/web-tools/trustchain/components/App.tsx
@@ -30,6 +30,7 @@ import { Account } from "@ledgerhq/types-live";
 import { WalletState, initialState as walletInitialState } from "@ledgerhq/live-wallet/store";
 import { DistantState, trustchainLifecycle } from "@ledgerhq/live-wallet/walletsync/index";
 import { Loading } from "./Loading";
+import { NonImportedAccountInfo } from "@ledgerhq/live-wallet/lib-es/walletsync/modules/accounts";
 
 const Container = styled.div`
   padding: 0 10px 50px 0;
@@ -39,8 +40,9 @@ const Container = styled.div`
   flex-direction: column;
 `;
 
-const initialState = {
+const initialState: State = {
   accounts: [],
+  nonImportedAccounts: [],
   walletState: walletInitialState,
 };
 
@@ -72,12 +74,14 @@ const App = () => {
     setAccountsSync(false);
   }, [setAccountsSync]);
 
+  /*
   // turning accounts sync off will cascade to state reset
   useEffect(() => {
     if (!accountsSync) {
       setState(initialState);
     }
   }, [accountsSync]);
+  */
 
   const [wssdkHandledVersion, setWssdkHandledVersion] = useState(0);
   const [wssdkHandledData, setWssdkHandledData] = useState<DistantState | null>(null);
@@ -315,6 +319,7 @@ const App = () => {
 type State = {
   accounts: Account[];
   walletState: WalletState;
+  nonImportedAccounts: NonImportedAccountInfo[];
 };
 
 const AppAccountsSync = dynamic<{

--- a/apps/web-tools/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/trustchain/components/AppAccountsSync.tsx
@@ -2,7 +2,7 @@ import React, { FormEvent, useCallback, useEffect, useMemo, useRef, useState } f
 import { Observable, concat, find, from, ignoreElements, mergeMap, tap } from "rxjs";
 import { JWT, MemberCredentials, Trustchain } from "@ledgerhq/trustchain/types";
 import { useTrustchainSDK } from "../context";
-import { CloudSyncSDK, UpdateEvent } from "@ledgerhq/live-wallet/cloudsync/index";
+import { CloudSyncSDK } from "@ledgerhq/live-wallet/cloudsync/index";
 import {
   WalletState,
   handlers as walletH,
@@ -11,11 +11,15 @@ import {
   WSState,
   setAccountNames,
   walletSyncUpdate,
+  walletSyncStateSelector,
 } from "@ledgerhq/live-wallet/store";
 import walletsync, {
   liveSlug,
   DistantState,
   walletSyncWatchLoop,
+  makeSaveNewUpdate,
+  LocalState,
+  makeLocalIncrementalUpdate,
 } from "@ledgerhq/live-wallet/walletsync/index";
 import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { Account, BridgeCacheSystem } from "@ledgerhq/types-live";
@@ -28,6 +32,8 @@ import { listSupportedCurrencies } from "@ledgerhq/coin-framework/lib-es/currenc
 import { getCurrencyColor } from "@ledgerhq/live-common/currencies/color";
 import { Loading } from "./Loading";
 import { TrustchainEjected } from "@ledgerhq/trustchain/lib-es/errors";
+import { NonImportedAccountInfo } from "@ledgerhq/live-wallet/lib-es/walletsync/modules/accounts";
+import { Tick } from "./Tick";
 
 /*
 import * as icons from "@ledgerhq/crypto-icons-ui/react";
@@ -36,12 +42,16 @@ import { inferCryptoCurrencyIcon } from "@ledgerhq/live-common/currencies/crypto
 
 type State = {
   accounts: Account[];
+  nonImportedAccounts: NonImportedAccountInfo[];
   walletState: WalletState;
 };
+
+const latestWalletStateSelector = (s: State): WSState => walletSyncStateSelector(s.walletState);
 
 const localStateSelector = (state: State) => ({
   accounts: {
     list: state.accounts,
+    nonImportedAccountInfos: state.nonImportedAccounts,
   },
   accountNames: state.walletState.accountNames,
 });
@@ -70,6 +80,7 @@ export default function AppAccountsSync({
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+  const getState = useCallback(() => stateRef.current, []);
 
   const getCurrentVersion = useCallback(
     () => stateRef.current.walletState.walletSyncState.version,
@@ -92,75 +103,49 @@ export default function AppAccountsSync({
   }, []);
 
   // saveNewUpdate implements the state update logic
-  const saveNewUpdate = useCallback(
-    async (event: UpdateEvent<DistantState>) => {
-      switch (event.type) {
-        case "new-data": {
-          const state = stateRef.current;
-          const version = event.version;
-          const data = event.data;
-          const walletSyncState = state.walletState.walletSyncState;
-          const localState = localStateSelector(state);
-          const ctx = { getAccountBridge, bridgeCache, blacklistedTokenIds: [] };
+  const ctx = useMemo(
+    () => ({ getAccountBridge, bridgeCache, blacklistedTokenIds: [] }),
+    [bridgeCache],
+  );
 
-          console.log("<- incoming data to resolve", data);
-          const resolved = await walletsync.resolveIncomingDistantState(
-            ctx,
-            localState,
-            walletSyncState.data,
-            data,
+  const saveUpdate = useCallback(
+    async (data: DistantState | null, version: number, newLocalState: LocalState | null) => {
+      setState(s => {
+        // we now need to "reverse" the localStateSelector back into our own internal state
+        let walletState = s.walletState;
+        if (newLocalState) {
+          walletState = walletH.BULK_SET_ACCOUNT_NAMES(
+            walletState,
+            setAccountNames(newLocalState.accountNames),
           );
-
-          if (resolved.hasChanges) {
-            console.log("resolved as", resolved);
-            // the important part is to keep one atomic update for all the states
-            setState(s => {
-              const localState = localStateSelector(s);
-              const newLocalState = walletsync.applyUpdate(localState, resolved.update);
-              console.log("new update applied as", newLocalState);
-
-              // we now need to "reverse" the localStateSelector back into our own internal state
-              let walletState = s.walletState;
-              walletState = walletH.BULK_SET_ACCOUNT_NAMES(
-                walletState,
-                setAccountNames(newLocalState.accountNames),
-              );
-              walletState = walletH.WALLET_SYNC_UPDATE(
-                walletState,
-                walletSyncUpdate(data, version),
-              );
-              return {
-                accounts: newLocalState.accounts.list, // save new accounts
-                walletState,
-              };
-            });
-          } else {
-            console.log("resolved. no changes to apply.");
-          }
-          break;
         }
-        case "pushed-data": {
-          // when we push the state, we also need to implement the update on the local state
-          setState(s => ({
-            ...s,
-            walletState: walletH.WALLET_SYNC_UPDATE(
-              s.walletState,
-              walletSyncUpdate(event.data, event.version),
-            ),
-          }));
-          break;
+        walletState = walletH.WALLET_SYNC_UPDATE(walletState, walletSyncUpdate(data, version));
+        if (newLocalState) {
+          return {
+            accounts: newLocalState.accounts.list, // save new accounts
+            nonImportedAccounts: newLocalState.accounts.nonImportedAccountInfos,
+            walletState,
+          };
         }
-        case "deleted-data": {
-          console.log("deleted data");
-          setState(s => ({
-            ...s,
-            walletState: walletH.WALLET_SYNC_UPDATE(s.walletState, walletSyncUpdate(null, 0)),
-          }));
-          break;
-        }
-      }
+        return {
+          ...s,
+          walletState,
+        };
+      });
     },
-    [bridgeCache, setState],
+    [setState],
+  );
+
+  const saveNewUpdate = useMemo(
+    () =>
+      makeSaveNewUpdate({
+        ctx,
+        getState,
+        latestDistantStateSelector,
+        localStateSelector,
+        saveUpdate,
+      }),
+    [ctx, getState, saveUpdate],
   );
 
   const onTrustchainRefreshNeeded = useCallback(
@@ -190,22 +175,49 @@ export default function AppAccountsSync({
   );
 
   const [visualPending, setVisualPending] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [timestamp, setTimestamp] = useState(0);
+  const [onUserRefresh, setOnUserRefresh] = useState<() => void>(() => () => {});
 
   // pull and push wallet sync loop
   useEffect(() => {
-    const { unsubscribe } = walletSyncWatchLoop({
+    const localIncrementUpdate = makeLocalIncrementalUpdate({
+      ctx,
+      getState,
+      latestWalletStateSelector,
+      localStateSelector,
+      saveUpdate,
+    });
+
+    const { unsubscribe, onUserRefreshIntent } = walletSyncWatchLoop({
       walletSyncSdk,
+      localIncrementUpdate,
       trustchain,
       memberCredentials,
       setVisualPending,
-      getState: () => stateRef.current,
+      getState,
       localStateSelector,
       latestDistantStateSelector,
       onTrustchainRefreshNeeded,
+      onError: e => setError(e && e instanceof Error ? e : new Error(String(e))),
+      onStartPolling: () => {
+        setError(null);
+        setTimestamp(Date.now());
+      },
     });
+    setOnUserRefresh(() => onUserRefreshIntent);
 
     return unsubscribe;
-  }, [trustchainSdk, walletSyncSdk, trustchain, memberCredentials, onTrustchainRefreshNeeded]);
+  }, [
+    trustchainSdk,
+    walletSyncSdk,
+    trustchain,
+    memberCredentials,
+    onTrustchainRefreshNeeded,
+    getState,
+    saveUpdate,
+    ctx,
+  ]);
 
   const setAccounts = useCallback(
     (fn: (_: Account[]) => Account[]) => {
@@ -226,6 +238,18 @@ export default function AppAccountsSync({
 
   return (
     <div>
+      {error ? (
+        <div style={{ padding: 10, color: "red" }}>{error.message}</div>
+      ) : timestamp ? (
+        <div
+          style={{
+            textAlign: "center",
+          }}
+        >
+          Synced <Tick timestamp={timestamp} />.{" "}
+          <button onClick={() => onUserRefresh()}>Refresh</button>
+        </div>
+      ) : null}
       <HeadlessShowAccounts
         walletState={state.walletState}
         accounts={state.accounts}
@@ -233,6 +257,11 @@ export default function AppAccountsSync({
         setAccountName={setAccountName}
         loading={visualPending}
       />
+      {state.nonImportedAccounts.length > 0 ? (
+        <div style={{ padding: 10, textAlign: "center", color: "#fa0" }}>
+          ⚠️ {state.nonImportedAccounts.length} non-imported accounts
+        </div>
+      ) : null}
       <HeadlessAddAccounts
         deviceId={deviceId}
         bridgeCache={bridgeCache}

--- a/apps/web-tools/trustchain/components/Tick.tsx
+++ b/apps/web-tools/trustchain/components/Tick.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+
+export function Tick({ timestamp }: { timestamp: number }) {
+  const [now, setNow] = useState(new Date());
+  useEffect(() => {
+    const id = setInterval(() => {
+      setNow(new Date());
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+  return relativeTime(now, new Date(timestamp));
+}
+
+function relativeTime(currentDate: Date, targetDate: Date): string {
+  const diffMilliseconds = targetDate.getTime() - currentDate.getTime();
+
+  const seconds = Math.round(diffMilliseconds / 1000);
+  const minutes = Math.round(seconds / 60);
+  const hours = Math.round(minutes / 60);
+  const days = Math.round(hours / 24);
+  const months = Math.round(days / 30);
+  const years = Math.round(months / 12);
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  if (years) {
+    return rtf.format(years, Math.abs(years) > 1 ? "years" : "year");
+  } else if (months) {
+    return rtf.format(months, Math.abs(months) > 1 ? "months" : "month");
+  } else if (days) {
+    return rtf.format(days, Math.abs(days) > 1 ? "days" : "day");
+  } else if (hours) {
+    return rtf.format(hours, Math.abs(hours) > 1 ? "hours" : "hour");
+  } else if (minutes) {
+    return rtf.format(minutes, Math.abs(minutes) > 1 ? "minutes" : "minute");
+  }
+  return rtf.format(seconds, Math.abs(seconds) > 1 ? "seconds" : "second");
+}

--- a/apps/web-tools/trustchain/components/types.ts
+++ b/apps/web-tools/trustchain/components/types.ts
@@ -1,0 +1,9 @@
+import { WalletState } from "@ledgerhq/live-wallet/store";
+import { Account } from "@ledgerhq/types-live";
+import { NonImportedAccountInfo } from "@ledgerhq/live-wallet/walletsync/modules/accounts";
+
+export type State = {
+  accounts: Account[];
+  walletState: WalletState;
+  nonImportedAccounts: NonImportedAccountInfo[];
+};

--- a/libs/live-wallet/src/ordering.test.ts
+++ b/libs/live-wallet/src/ordering.test.ts
@@ -94,6 +94,7 @@ const walletState: WalletState = {
     data: null,
     version: 0,
   },
+  nonImportedAccountInfos: [],
 };
 
 for (const raw of raws) {

--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -185,6 +185,7 @@ describe("Wallet store", () => {
   it("can import the wallet state", () => {
     const exportedState = {
       walletSyncState: { data: {}, version: 42 },
+      nonImportedAccountInfos: [],
     };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(walletSyncStateSelector(result)).toEqual({ data: {}, version: 42 });
@@ -193,20 +194,24 @@ describe("Wallet store", () => {
   it("can export the wallet state", () => {
     const exportedState = {
       walletSyncState: { data: {}, version: 42 },
+      nonImportedAccountInfos: [],
     };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(exportWalletState(result)).toEqual({
       walletSyncState: { data: {}, version: 42 },
+      nonImportedAccountInfos: [],
     });
   });
 
   it("walletStateExportShouldDiffer", () => {
     const exportedState = {
       walletSyncState: { data: {}, version: 42 },
+      nonImportedAccountInfos: [],
     };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(exportWalletState(result)).toEqual({
       walletSyncState: { data: {}, version: 42 },
+      nonImportedAccountInfos: [],
     });
     expect(walletStateExportShouldDiffer(initialState, result)).toBe(true);
     expect(walletStateExportShouldDiffer(initialState, initialState)).toBe(false);

--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -182,37 +182,24 @@ describe("Wallet store", () => {
     });
   });
 
+  const exportedState = {
+    walletSyncState: { data: {}, version: 42 },
+    nonImportedAccountInfos: [],
+  };
+
   it("can import the wallet state", () => {
-    const exportedState = {
-      walletSyncState: { data: {}, version: 42 },
-      nonImportedAccountInfos: [],
-    };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(walletSyncStateSelector(result)).toEqual({ data: {}, version: 42 });
   });
 
   it("can export the wallet state", () => {
-    const exportedState = {
-      walletSyncState: { data: {}, version: 42 },
-      nonImportedAccountInfos: [],
-    };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
-    expect(exportWalletState(result)).toEqual({
-      walletSyncState: { data: {}, version: 42 },
-      nonImportedAccountInfos: [],
-    });
+    expect(exportWalletState(result)).toEqual(exportedState);
   });
 
   it("walletStateExportShouldDiffer", () => {
-    const exportedState = {
-      walletSyncState: { data: {}, version: 42 },
-      nonImportedAccountInfos: [],
-    };
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
-    expect(exportWalletState(result)).toEqual({
-      walletSyncState: { data: {}, version: 42 },
-      nonImportedAccountInfos: [],
-    });
+    expect(exportWalletState(result)).toEqual(exportedState);
     expect(walletStateExportShouldDiffer(initialState, result)).toBe(true);
     expect(walletStateExportShouldDiffer(initialState, initialState)).toBe(false);
     expect(walletStateExportShouldDiffer(result, result)).toBe(false);

--- a/libs/live-wallet/src/walletsync/__mocks__/modules/accounts.ts
+++ b/libs/live-wallet/src/walletsync/__mocks__/modules/accounts.ts
@@ -1,16 +1,19 @@
 import { genAccount } from "@ledgerhq/coin-framework/mocks/account";
 import { Account } from "@ledgerhq/types-live";
 import { accountDataToAccount } from "../../../liveqr/cross";
+import { NonImportedAccountInfo } from "../../modules/accounts";
 
 type LocalState = {
   list: Account[];
+  nonImportedAccountInfos: NonImportedAccountInfo[];
 };
 
 export const emptyState: LocalState = {
   list: [],
+  nonImportedAccountInfos: [],
 };
 
-export const genState = (index: number) => {
+export const genState = (index: number): LocalState => {
   const list = Array(index + 1)
     .fill(null)
     .map((_, i) =>
@@ -21,14 +24,31 @@ export const genState = (index: number) => {
       }),
     );
 
+  const nonImportedAccountInfos = [];
+
   // we remove some of the accounts in order to create intersection of possibilities (to cover removed account cases)
   let skipEach = 2;
   for (let i = skipEach; i < list.length; i += skipEach) {
-    list.splice(i, 1);
+    const [removed] = list.splice(i, 1);
     skipEach++;
+    if (i % 5 === 0) {
+      // sometimes, we move removed item into nonImportedAccountInfos to cover such case
+      const attempts = (i * 79 + index * 397) % 10;
+      // a random value between 0 and 3 hours
+      const attemptsLastTimestamp = (i * 888888901 + index * 8888927) % (3 * 60 * 60 * 1000);
+      nonImportedAccountInfos.push({
+        id: removed.id,
+        attempts,
+        attemptsLastTimestamp,
+        error: {
+          name: "mock",
+          message: "mock",
+        },
+      });
+    }
   }
 
-  return { list };
+  return { list, nonImportedAccountInfos };
 };
 
 export const convertLocalToDistantState = (localState: { list: Account[] }) =>

--- a/libs/live-wallet/src/walletsync/__tests__/compatibility.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/compatibility.test.ts
@@ -54,8 +54,8 @@ describe("the root WalletSyncDataManager can accept data that misses a new field
     });
   });
 
-  test("on resolveIncomingDistantState (accept new accounts)", async () => {
-    const diff = await walletsync.resolveIncomingDistantState(
+  test("on resolveIncrementalUpdate (accept new accounts)", async () => {
+    const diff = await walletsync.resolveIncrementalUpdate(
       dummyContext,
       emptyState,
       null,
@@ -71,6 +71,7 @@ describe("the root WalletSyncDataManager can accept data that misses a new field
         update: {
           added: [firstaccount],
           removed: [],
+          nonImportedAccountInfos: [],
         },
       });
     } else {
@@ -113,12 +114,12 @@ describe("the general module can accept data that are not yet understood and han
     });
   });
 
-  test("on resolveIncomingDistantState with changes", async () => {
+  test("on resolveIncrementalUpdate with changes", async () => {
     const localData = {
       ...emptyState,
       accounts: genModuleState("accounts", 0),
     };
-    const resolved = await walletsync.resolveIncomingDistantState(
+    const resolved = await walletsync.resolveIncrementalUpdate(
       dummyContext,
       localData,
       // basically we verify the extra data are just going to be ignored

--- a/libs/live-wallet/src/walletsync/__tests__/generic.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/generic.test.ts
@@ -16,7 +16,7 @@ describe("canonical cases", () => {
   it("detects no changes on empty incoming", async () => {
     const localState = genState(5);
     const latestState = convertLocalToDistantState(localState);
-    const resolved = await walletsync.resolveIncomingDistantState(
+    const resolved = await walletsync.resolveIncrementalUpdate(
       dummyContext,
       localState,
       latestState,
@@ -25,12 +25,12 @@ describe("canonical cases", () => {
     expect(resolved).toEqual({ hasChanges: false });
   });
 
-  it("detects no changes on same incoming", async () => {
+  it("detects no changes on same incoming from empty local state", async () => {
     const localState = genState(9);
     const latestState = convertLocalToDistantState(localState);
-    const resolved = await walletsync.resolveIncomingDistantState(
+    const resolved = await walletsync.resolveIncrementalUpdate(
       dummyContext,
-      localState,
+      emptyState,
       latestState,
       latestState,
     );
@@ -69,7 +69,7 @@ describe("canonical cases", () => {
       let update: UpdateEvent | null = null;
 
       it("resolves the transition (distI->distJ) from stateI", async () => {
-        const resolved = await walletsync.resolveIncomingDistantState(
+        const resolved = await walletsync.resolveIncrementalUpdate(
           dummyContext,
           stateI,
           distI,

--- a/libs/live-wallet/src/walletsync/__tests__/modules/accountNames.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/modules/accountNames.test.ts
@@ -97,7 +97,7 @@ describe("accountNames' WalletSyncDataManager", () => {
     const incomingState = {
       "1": "a",
     };
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -117,7 +117,7 @@ describe("accountNames' WalletSyncDataManager", () => {
       "1": "a",
       "2": "b",
     };
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -147,7 +147,7 @@ describe("accountNames' WalletSyncDataManager", () => {
       "1": "a",
       "2": "bbbb",
     };
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,

--- a/libs/live-wallet/src/walletsync/__tests__/modules/accounts.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/modules/accounts.test.ts
@@ -87,27 +87,27 @@ describe("accountNames' WalletSyncDataManager", () => {
     expect(() => manager.schema.parse([account1])).toThrow();
   });
   it("should find no diff on non initialized state vs empty accounts", () => {
-    const localData = { list: [] };
+    const localData = { list: [], nonImportedAccountInfos: [] };
     const latestState = null;
     const diff = manager.diffLocalToDistant(localData, latestState);
     expect(diff).toEqual({ hasChanges: false, nextState: [] });
   });
 
   it("should find no diff on empty state change", () => {
-    const localData = { list: [] };
+    const localData = { list: [], nonImportedAccountInfos: [] };
     const diff = manager.diffLocalToDistant(localData, []);
     expect(diff).toEqual({ hasChanges: false, nextState: [] });
   });
 
   it("should find no diff on same accounts", () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const latestState = [account1, account2].map(convertAccountToDescriptor);
     const diff = manager.diffLocalToDistant(localData, latestState);
     expect(diff).toEqual({ hasChanges: false, nextState: latestState });
   });
 
   it("should find diff on added account", () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const latestState = [account1].map(convertAccountToDescriptor);
     const diff = manager.diffLocalToDistant(localData, latestState);
     expect(diff).toEqual({
@@ -117,7 +117,7 @@ describe("accountNames' WalletSyncDataManager", () => {
   });
 
   it("should find diff on removed account", () => {
-    const localData = { list: [account1] };
+    const localData = { list: [account1], nonImportedAccountInfos: [] };
     const latestState = [account1, account2].map(convertAccountToDescriptor);
     const diff = manager.diffLocalToDistant(localData, latestState);
     expect(diff).toEqual({
@@ -127,10 +127,10 @@ describe("accountNames' WalletSyncDataManager", () => {
   });
 
   it("should find no diff on non initialized state vs empty accounts", async () => {
-    const localData = { list: [] };
+    const localData = { list: [], nonImportedAccountInfos: [] };
     const latestState = null;
     const incomingState: AccountDescriptor[] = [];
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -140,22 +140,17 @@ describe("accountNames' WalletSyncDataManager", () => {
   });
 
   it("should find no diff on empty state change", async () => {
-    const localData = { list: [] };
+    const localData = { list: [], nonImportedAccountInfos: [] };
     const incomingState: AccountDescriptor[] = [];
-    const diff = await manager.resolveIncomingDistantState(
-      dummyContext,
-      localData,
-      [],
-      incomingState,
-    );
+    const diff = await manager.resolveIncrementalUpdate(dummyContext, localData, [], incomingState);
     expect(diff).toEqual({ hasChanges: false });
   });
 
   it("should find no diff on same accounts", async () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const latestState = [account1, account2].map(convertAccountToDescriptor);
     const incomingState = [account1, account2].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -165,10 +160,10 @@ describe("accountNames' WalletSyncDataManager", () => {
   });
 
   it("should find no diff on added account but the account already is here", async () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const latestState = [account1].map(convertAccountToDescriptor);
     const incomingState = [account1, account2].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -180,10 +175,10 @@ describe("accountNames' WalletSyncDataManager", () => {
   });
 
   it("should find diff on added account", async () => {
-    const localData = { list: [account1] };
+    const localData = { list: [account1], nonImportedAccountInfos: [] };
     const latestState = [account1].map(convertAccountToDescriptor);
     const incomingState = [account1, account2].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -194,14 +189,15 @@ describe("accountNames' WalletSyncDataManager", () => {
       update: {
         added: [placeholderAccountFromDescriptor(incomingState[1])],
         removed: [],
+        nonImportedAccountInfos: [],
       },
     });
   });
   it("should find diff on added account from no existing state", async () => {
-    const localData = { list: [] };
+    const localData = { list: [], nonImportedAccountInfos: [] };
     const latestState = null;
     const incomingState = [account1, account2].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -215,15 +211,16 @@ describe("accountNames' WalletSyncDataManager", () => {
           placeholderAccountFromDescriptor(incomingState[1]),
         ],
         removed: [],
+        nonImportedAccountInfos: [],
       },
     });
   });
 
   it("should find diff on removed account", async () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const latestState = [account1, account2].map(convertAccountToDescriptor);
     const incomingState = [account1].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -234,15 +231,16 @@ describe("accountNames' WalletSyncDataManager", () => {
       update: {
         added: [],
         removed: [account2.id],
+        nonImportedAccountInfos: [],
       },
     });
   });
 
   it("should find both a added and removed account", async () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const latestState = [account1, account2].map(convertAccountToDescriptor);
     const incomingState = [account2, account3].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
@@ -253,42 +251,59 @@ describe("accountNames' WalletSyncDataManager", () => {
       update: {
         added: [placeholderAccountFromDescriptor(incomingState[1])],
         removed: [account1.id],
+        nonImportedAccountInfos: [],
       },
     });
   });
 
-  it("should resolve nothing if sync fails", async () => {
-    const localData = { list: [account1] };
+  it("should find non imported account ids on fail sync", async () => {
+    const localData = { list: [account1], nonImportedAccountInfos: [] };
     const latestState = [account1].map(convertAccountToDescriptor);
     const incomingState = [account1, account4unsupported].map(convertAccountToDescriptor);
-    const diff = await manager.resolveIncomingDistantState(
+    const diff = await manager.resolveIncrementalUpdate(
       dummyContext,
       localData,
       latestState,
       incomingState,
     );
-    expect(diff).toEqual({
-      hasChanges: false,
+    expect(diff).toMatchObject({
+      hasChanges: true,
+      update: {
+        added: [],
+        removed: [],
+        nonImportedAccountInfos: [
+          {
+            id: account4unsupported.id,
+            attempts: 1,
+            error: {
+              name: "Error",
+              message: "simulate sync failure",
+            },
+          },
+        ],
+      },
     });
   });
 
   it("should apply added account", () => {
-    const localData = { list: [account1] };
+    const localData = { list: [account1], nonImportedAccountInfos: [] };
     const update = {
       added: [account2],
       removed: [],
+      nonImportedAccountInfos: [],
     };
     const result = manager.applyUpdate(localData, update);
-    expect(result).toEqual({ list: [account1, account2] });
+    expect(result).toEqual({ list: [account1, account2], nonImportedAccountInfos: [] });
   });
 
   it("should apply removed account", () => {
-    const localData = { list: [account1, account2] };
+    const localData = { list: [account1, account2], nonImportedAccountInfos: [] };
     const update = {
       added: [],
       removed: [account2.id],
+      nonImportedAccountInfos: [],
     };
     const result = manager.applyUpdate(localData, update);
-    expect(result).toEqual({ list: [account1] });
+    expect(result).toEqual({ list: [account1], nonImportedAccountInfos: [] });
   });
 });

--- a/libs/live-wallet/src/walletsync/__tests__/specific.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/specific.test.ts
@@ -14,6 +14,7 @@ test("applyUpdate works with accounts update", () => {
       update: {
         added: [account1],
         removed: [],
+        nonImportedAccountInfos: [],
       },
     },
     accountNames: {
@@ -24,6 +25,7 @@ test("applyUpdate works with accounts update", () => {
     ...emptyState,
     accounts: {
       list: [account1],
+      nonImportedAccountInfos: [],
     },
   });
 });

--- a/libs/live-wallet/src/walletsync/aggregator.ts
+++ b/libs/live-wallet/src/walletsync/aggregator.ts
@@ -51,15 +51,15 @@ export function createAggregator<Mods extends Record<string, WalletSyncDataManag
       };
     },
 
-    async resolveIncomingDistantState(ctx, localData, latestState, incomingState) {
-      // Aggregate all promises resulting of each module resolveIncomingDistantState
+    async resolveIncrementalUpdate(ctx, localData, latestState, incomingState) {
+      // Aggregate all promises resulting of each module resolveIncrementalUpdate
 
       type Resolved = {
         [K in keyof Mods]: Promise<UpdateDiff<ExtractUpdateEvent<Mods[K]>>>;
       };
 
       const resolved = mapValues<Mods, Resolved>(modules, (m, k) =>
-        m.resolveIncomingDistantState(
+        m.resolveIncrementalUpdate(
           ctx,
           localData[k],
           latestState && latestState[k] ? latestState[k] : null,

--- a/libs/live-wallet/src/walletsync/incrementalUpdates.ts
+++ b/libs/live-wallet/src/walletsync/incrementalUpdates.ts
@@ -1,0 +1,89 @@
+import { log } from "@ledgerhq/logs";
+import walletsync, { DistantState, LocalState } from ".";
+import { UpdateEvent } from "../cloudsync/sdk";
+import { WalletSyncDataManagerResolutionContext } from "./types";
+import { WSState } from "../store";
+
+export function makeSaveNewUpdate<S>({
+  ctx,
+  getState,
+  latestDistantStateSelector,
+  localStateSelector,
+  saveUpdate,
+}: {
+  ctx: WalletSyncDataManagerResolutionContext;
+  getState: () => S;
+  latestDistantStateSelector: (state: S) => DistantState | null;
+  localStateSelector: (state: S) => LocalState;
+  saveUpdate: (
+    data: DistantState | null,
+    version: number,
+    newLocalState: LocalState | null,
+  ) => Promise<void>;
+}): (event: UpdateEvent<DistantState>) => Promise<void> {
+  return async (event: UpdateEvent<DistantState>) => {
+    log("walletsync", "saveNewUpdate", { event });
+    switch (event.type) {
+      case "new-data": {
+        // we resolve incoming distant state changes
+        const state = getState();
+        const latest = latestDistantStateSelector(state);
+        const local = localStateSelector(state);
+        const data = event.data;
+        const resolved = await walletsync.resolveIncrementalUpdate(ctx, local, latest, data);
+
+        if (resolved.hasChanges) {
+          const version = event.version;
+          const localState = localStateSelector(getState()); // fetch again latest state because it might have changed
+          const newLocalState = walletsync.applyUpdate(localState, resolved.update); // we resolve in sync the new local state to save
+          await saveUpdate(data, version, newLocalState);
+          log("walletsync", "resolved. changes applied.");
+        } else {
+          log("walletsync", "resolved. no changes to apply.");
+        }
+        break;
+      }
+      case "pushed-data": {
+        await saveUpdate(event.data, event.version, null);
+        break;
+      }
+      case "deleted-data": {
+        await saveUpdate(null, 0, null);
+        break;
+      }
+    }
+  };
+}
+
+export function makeLocalIncrementalUpdate<S>({
+  ctx,
+  getState,
+  latestWalletStateSelector,
+  localStateSelector,
+  saveUpdate,
+}: {
+  ctx: WalletSyncDataManagerResolutionContext;
+  getState: () => S;
+  latestWalletStateSelector: (state: S) => WSState;
+  localStateSelector: (state: S) => LocalState;
+  saveUpdate: (
+    data: DistantState | null,
+    version: number,
+    newLocalState: LocalState | null,
+  ) => Promise<void>;
+}): () => Promise<void> {
+  return async () => {
+    // we resolve possible local incremental update
+    const state = getState();
+    const { data, version } = latestWalletStateSelector(state);
+    const local = localStateSelector(state);
+    const resolved = await walletsync.resolveIncrementalUpdate(ctx, local, data, data);
+
+    if (resolved.hasChanges) {
+      const localState = localStateSelector(getState()); // fetch again latest state because it might have changed
+      const newLocalState = walletsync.applyUpdate(localState, resolved.update); // we resolve in sync the new local state to save
+      await saveUpdate(data, version, newLocalState);
+      log("walletsync", "localIncrementalUpdate done.");
+    }
+  };
+}

--- a/libs/live-wallet/src/walletsync/index.ts
+++ b/libs/live-wallet/src/walletsync/index.ts
@@ -5,6 +5,7 @@ import { createWalletSyncWatchLoop, VisualConfig, WatchConfig } from "./createWa
 export { createWalletSyncWatchLoop };
 export type { VisualConfig, WatchConfig };
 export { trustchainLifecycle } from "./trustchainLifecyle";
+export * from "./incrementalUpdates";
 
 // Maintain here the list of modules to aggregate for WalletSync data
 // New modules can be added over time, it's also possible to remove modules but don't replace modules because the schema of a field must not change.
@@ -56,6 +57,7 @@ export function walletSyncWatchLoop<UserState>({
   localStateSelector,
   latestDistantStateSelector,
   onTrustchainRefreshNeeded,
+  localIncrementUpdate,
 }: {
   watchConfig?: WatchConfig;
   visualConfig?: VisualConfig;
@@ -69,6 +71,7 @@ export function walletSyncWatchLoop<UserState>({
   getState: () => UserState;
   localStateSelector: (state: UserState) => LocalState;
   latestDistantStateSelector: (state: UserState) => DistantState | null;
+  localIncrementUpdate: () => Promise<void>;
 }) {
   const walletsync = root;
   return createWalletSyncWatchLoop({
@@ -85,5 +88,6 @@ export function walletSyncWatchLoop<UserState>({
     localStateSelector,
     latestDistantStateSelector,
     onTrustchainRefreshNeeded,
+    localIncrementUpdate,
   });
 }

--- a/libs/live-wallet/src/walletsync/modules/accountNames.ts
+++ b/libs/live-wallet/src/walletsync/modules/accountNames.ts
@@ -21,13 +21,15 @@ const manager: WalletSyncDataManager<
     };
   },
 
-  async resolveIncomingDistantState(_ctx, localData, latestState, incomingState) {
+  // NB: current implementation will take any incoming state changes and replace it all. the risk of conflict is limited but possible.
+  async resolveIncrementalUpdate(_ctx, localData, latestState, incomingState) {
     if (!incomingState) {
       return { hasChanges: false }; // nothing to do, the data is no longer available
     }
 
-    // instead of looking at diff between latestState->incomingState, we just directly jump from the localData to incomingState, so we will look if we have actual changes between these two
-    const hasChanges = !sameDistantState(Object.fromEntries(localData.entries()), incomingState);
+    const hasChanges =
+      latestState !== incomingState && // bail out from "local" increment update
+      !sameDistantState(Object.fromEntries(localData.entries()), incomingState);
 
     if (!hasChanges) {
       return { hasChanges: false };

--- a/libs/live-wallet/src/walletsync/modules/accounts.ts
+++ b/libs/live-wallet/src/walletsync/modules/accounts.ts
@@ -18,28 +18,37 @@ type AccountDescriptor = z.infer<typeof accountDescriptorSchema>;
 
 const schema = z.array(accountDescriptorSchema);
 
+export type NonImportedAccountInfo = {
+  id: string;
+  attempts: number;
+  attemptsLastTimestamp: number;
+  error?: {
+    name: string;
+    message: string;
+  };
+};
+
 const manager: WalletSyncDataManager<
   {
     list: Account[];
-    // TODO there remain a case to solve: when an account failed to be resolved in the past, we would need to eventually retry it. we could do this basically by adding in the resolved the failed
-    // wsStateNonImportedAccountIds: string[]; // TODO
+    nonImportedAccountInfos: NonImportedAccountInfo[];
   },
   {
     removed: string[];
     added: Account[];
-    // wsStateNonImportedAccountIds // TODO
+    nonImportedAccountInfos: NonImportedAccountInfo[];
   },
   typeof schema
 > = {
   schema,
 
-  diffLocalToDistant(localAccounts, latestState) {
+  diffLocalToDistant(localData, latestState) {
     let hasChanges = false;
 
     // let's figure out the new local accounts
     const added: AccountDescriptor[] = [];
     const distantServerAccountIds = new Set<string>(latestState?.map(a => a.id) || []);
-    for (const account of localAccounts.list) {
+    for (const account of localData.list) {
       const id = account.id;
       if (!distantServerAccountIds.has(id)) {
         added.push({
@@ -56,9 +65,10 @@ const manager: WalletSyncDataManager<
 
     // let's figure out the locally deleted accounts that we will need to take into account
     const removed = new Set();
-    const localAccountIds = new Set(localAccounts.list.map(a => a.id));
+    const localAccountIds = new Set(localData.list.map(a => a.id));
+    const nonImportedAccountInfos = new Set(localData.nonImportedAccountInfos.map(a => a.id));
     for (const id of distantServerAccountIds) {
-      if (!localAccountIds.has(id)) {
+      if (!localAccountIds.has(id) && !nonImportedAccountInfos.has(id)) {
         removed.add(id);
         hasChanges = true;
       }
@@ -86,32 +96,74 @@ const manager: WalletSyncDataManager<
     };
   },
 
-  async resolveIncomingDistantState(ctx, localData, latestState, incomingState) {
+  async resolveIncrementalUpdate(ctx, localData, latestState, incomingState) {
     if (!incomingState) {
       return { hasChanges: false }; // nothing to do, the data is no longer available
     }
-    // TODO there remain a case to solve: when an account failed to be resolved in the past, we would need to eventually retry it. we could do this basically by adding in the resolved the failed
 
     const diff = diffWalletSyncState(latestState, incomingState);
 
-    // filter out accounts we may already have
     const existingIds = new Set(localData.list.map(a => a.id));
+
+    let hasChanges = false;
+
+    // non imported accounts are considered as "added" so we have opportunity to recheck them
+    const nonImportedById = new Map<string, NonImportedAccountInfo>();
+    const nextNonImportedById = new Map<string, NonImportedAccountInfo>();
+    for (const nonImported of localData.nonImportedAccountInfos) {
+      nonImportedById.set(nonImported.id, nonImported);
+      const { id, attempts, attemptsLastTimestamp } = nonImported;
+      if (existingIds.has(id)) {
+        hasChanges = true; // at least we need to save the deletion
+        continue; // we actually have the account. ignore.
+      }
+      const accountDescriptor = incomingState.find(a => a.id === id);
+      if (!accountDescriptor) {
+        hasChanges = true; // at least we need to save the deletion
+        // we don't have the account anymore in the distant state. ignore.
+        continue;
+      }
+      const now = Date.now();
+      const shouldRetry = shouldRetryImportAccount(now - attemptsLastTimestamp, attempts);
+      if (shouldRetry) {
+        diff.added.push(accountDescriptor);
+      } else {
+        // we don't retry so we preserve the non imported account for the future
+        nextNonImportedById.set(id, nonImported);
+      }
+    }
+
+    // filter out accounts we may already have
     diff.added = diff.added.filter(a => !existingIds.has(a.id));
 
     const resolved = await resolveWalletSyncDiffIntoSyncUpdate(diff, ctx);
 
-    if (
-      resolved.added.length === 0 &&
-      resolved.removed.length === 0
-      // NB at the moment we don't care about failures, when we preserve it, this needs to be a change
-      /*&&
-      Object.keys(resolved.failures).length === 0
-      */
-    ) {
+    for (const failedId in resolved.failures) {
+      const nonImported = nonImportedById.get(failedId);
+      const { error } = resolved.failures[failedId];
+      hasChanges = true;
+      nextNonImportedById.set(failedId, {
+        id: failedId,
+        attempts: (nonImported?.attempts || 0) + 1,
+        attemptsLastTimestamp: Date.now(),
+        error: {
+          name: error.name,
+          message: error.message,
+        },
+      });
+    }
+
+    if (!hasChanges) {
+      if (resolved.added.length > 0) {
+        hasChanges = true;
+      } else if (resolved.removed.length > 0) {
+        hasChanges = true;
+      }
+    }
+
+    if (!hasChanges) {
       // nothing to do
-      return {
-        hasChanges: false,
-      };
+      return { hasChanges };
     }
 
     return {
@@ -119,6 +171,7 @@ const manager: WalletSyncDataManager<
       update: {
         removed: resolved.removed,
         added: resolved.added,
+        nonImportedAccountInfos: Array.from(nextNonImportedById.values()),
       },
     };
   },
@@ -131,8 +184,8 @@ const manager: WalletSyncDataManager<
       // filter out data we already have typically if they were added at same time
       ...update.added.filter(a => !existingIds.has(a.id)),
     ];
-    // const wsStateNonImportedAccountIds = [];
-    return { list }; // , wsStateNonImportedAccountIds };
+    const nonImportedAccountInfos = update.nonImportedAccountInfos;
+    return { list, nonImportedAccountInfos };
   },
 };
 
@@ -249,6 +302,18 @@ export async function resolveWalletSyncDiffIntoSyncUpdate(
     added,
     failures,
   };
+}
+
+const MINUTE = 60 * 1000;
+const backoffFactor = 1.3;
+const baseWaitTime = 0.5 * MINUTE; // Base wait time in milliseconds
+const maxWaitTime = 120 * MINUTE; // Maximum wait time in milliseconds
+export function shouldRetryImportAccount(elapsedMs: number, attempts: number) {
+  // Calculate the wait time using exponential backoff
+  let waitTime = baseWaitTime * Math.pow(backoffFactor, attempts - 1);
+  // Clamp the wait time to the maximum value
+  waitTime = Math.min(waitTime, maxWaitTime);
+  return elapsedMs > waitTime;
 }
 
 export default manager;

--- a/libs/live-wallet/src/walletsync/types.ts
+++ b/libs/live-wallet/src/walletsync/types.ts
@@ -7,10 +7,10 @@ import { ZodType, z } from "zod";
  *
  * (1) we determine if there are changes between local state and latest distant state by `diffLocalToDistant(localState, latestDist)`. This is a synchronous operation.
  *
- * (2) when receiving a new distant state from cloud sync, the module must calculate the update to apply to the local state. resolveIncomingDistantState calculates the update and applyUpdate applies it.
+ * (2) when receiving a new distant state from cloud sync, the module must calculate the update to apply to the local state. resolveIncrementalUpdate calculates the update and applyUpdate applies it.
  *
  * state transition is done incrementally with a diff, moving from A to B is essentially
- * - resolveIncomingDistantState: solving the transition (distA->distB) from stateA (this is asynchronous, for instance we need to fetch data from the blockchain to get a valid Account state)
+ * - resolveIncrementalUpdate: solving the transition (distA->distB) from stateA (this is asynchronous, for instance we need to fetch data from the blockchain to get a valid Account state)
  * - applyUpdate: applying that transition update to get to stateB
  *
  *  so in other words:
@@ -42,8 +42,9 @@ export interface WalletSyncDataManager<
 
   /**
    * Asynchronously accept new DistantState data and determine the potential Update to do on the local state
+   * The function is also called regularly to check there is no pending update to do in the LocalState, in that case latestState===incomingState, some modules could bail out this case by returning {hasChanges:false}
    */
-  resolveIncomingDistantState: (
+  resolveIncrementalUpdate: (
     ctx: WalletSyncDataManagerResolutionContext,
     localData: LocalState,
     latestState: DistantState | null,


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - wallet sync management of account sync failures

### 📝 Description

This improve the Wallet Sync reconciliation in order to **keep a memory of non imported account ids to be able to eventually restore them.**

this can be tested by limiting the number of supported currencies on the web tools: (but you can also import tezos/cosmos which currently also fails on the web)

![Capture d’écran 2024-07-22 à 17 25 05](https://github.com/user-attachments/assets/1a2c897b-8184-4c10-939f-926aa254357e)


**The previous behaviour:**

non imported accounts management must be done on accounts that could possibly fail the synchronisation (during the resolve). At the moment they become completely ignored and will never appear again on other members. (fail sync = the user had network issues / the backend had issues / the Ledger Live instance don't yet support the coin). worse: in current implementation, account disappear when another member don’t handle such account. this is reproductible today on web tools that don’t support Cosmos nor Tezos (due to CORS issues) and you can easily see that LLD’s account disappear after web tools fetch the incoming update and then determines there is a diff to push since the unsupported accounts are not imported. and this could happen in case of tmp backend issue too, so in short: account can randomly disappear.

**The next behaviour:**

Accounts should be preserved on the instances that don’t support them yet and eventually be imported as soon as they do. let’s consider member A that supports everything and member B that don’t support all accounts.

- when member A push its accounts, member B needs to keep a memory of them, possibly ignore them but make sure to push them back as part of the cloud sync data in order for member A do not delete them.
- when member B eventually support accounts, they will appear after a new resolve
- when member A remove accounts, their deletion need to be propagated in the memory that member B, so when member B do a new edition, member A should not see again the account they just removed.

#### Technical notes

- `resolveIncomingDistantState` is renamed to `resolveIncrementalUpdate` because it serves a bigger purpose: it is no longer just about resolving incoming distant state, but we will also have to regularly call `resolveIncrementalUpdate` in order to search for possible updates.
- the retry strategy that was implemented is to slow down the retries over time to not spam the backends if there is a sync issue that will last for long. it will only retry every X minutes. this is configurable.

#### To schedule in future (JIRA)

- consider a different lifecycle on the wallet sync watch loop to separate the different loops (pull VS local resolve VS check for pushable). only the "pull polling" is something that induce costs on backend, the other are local loops that do nothing if no changes.
- add more unit tests that cover the `nonImportedAccountInfos` management

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-13312


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
