### PR TITLE
[LIVE-13127][LLM][Passkey] Create use case for saving app data inside local storage

### DIFF
--- a/.changeset/tidy-lobsters-taste.md
+++ b/.changeset/tidy-lobsters-taste.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add mobile storage provider for app data backup

--- a/apps/ledger-live-mobile/.unimportedrc.json
+++ b/apps/ledger-live-mobile/.unimportedrc.json
@@ -15,7 +15,8 @@
     "src/components/RootNavigator/types.ts",
     "src/logic/keyboardVisible.ts",
     "src/contentCards/cards/vertical/*",
-    "src/**/__integrations__/*.tsx"
+    "src/**/__integrations__/*.tsx",
+    "src/MobileStorageProvider.ts"
   ],
   "ignoreUnused": [
     "@react-native-masked-view/masked-view",

--- a/apps/ledger-live-mobile/src/MobileStorageProvider.ts
+++ b/apps/ledger-live-mobile/src/MobileStorageProvider.ts
@@ -1,0 +1,64 @@
+import {
+  StorageProvider,
+  AppStorageType,
+  AppStorageKey,
+  isAppStorageType,
+  BackupAppDataError,
+} from "@ledgerhq/live-common/device/use-cases/appDataBackup/types";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+/**
+ * The storage provider for LLM that implements the StorageProvider interface.
+ * This a temporary placement, it could be moved to the appropriate location if needed.
+ */
+export class MobileStorageProvider implements StorageProvider<AppStorageType> {
+  /**
+   * Retrieves the value associated with the specified key from storage.
+   *
+   * @param key - The key of the value to retrieve, type of AppStorageKey.
+   * @returns A promise that resolves to the retrieved value, or null if the key does not exist.
+   * @throws {BackupAppDataError} If the data cannot be parsed or has an invalid data type.
+   */
+  async getItem(key: AppStorageKey): Promise<AppStorageType | null> {
+    const data: string | null = await AsyncStorage.getItem(key);
+    if (!data) {
+      return null;
+    }
+    try {
+      const parsedData = JSON.parse(data);
+      if (isAppStorageType(parsedData)) {
+        return parsedData;
+      }
+    } catch (error: unknown) {
+      throw new BackupAppDataError("Cannot parse the data (SyntaxError).");
+    }
+    throw new BackupAppDataError("Invalid data type.");
+  }
+
+  /**
+   * Sets the value associated with the specified key in storage.
+   *
+   * @param key - The key of the value to set, type of AppStorageKey.
+   * @param value - The value to set, type of AppStorageType.
+   * @returns A promise that resolves when the value has been successfully set.
+   * @throws {BackupAppDataError} If the data cannot be stringified.
+   */
+  async setItem(key: AppStorageKey, value: AppStorageType): Promise<void> {
+    try {
+      const data = JSON.stringify(value);
+      await AsyncStorage.setItem(key, data);
+    } catch (error: unknown) {
+      throw new BackupAppDataError("Cannot stringify the data (TypeError).");
+    }
+  }
+
+  /**
+   * Removes the value associated with the specified key from storage.
+   *
+   * @param key - The key of the value to remove, type of AppStorageKey.
+   * @returns A promise that resolves when the value has been successfully removed.
+   */
+  async removeItem(key: AppStorageKey): Promise<void> {
+    await AsyncStorage.removeItem(key);
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add mobile storage provider for app data backup

### 📝 Description

- Add mobile storage provider for app data backup, using `@react-native-async-storage/async-storage`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13127]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13127]: https://ledgerhq.atlassian.net/browse/LIVE-13127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ