### PR TITLE
[LIVE-12092][LLM] Inconsistency in change lock screen wording

### DIFF
--- a/.changeset/tricky-boats-tie.md
+++ b/.changeset/tricky-boats-tie.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Update wording for changing custom lock screen

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6393,7 +6393,7 @@
   },
   "customImage": {
     "title": "Lock screen picture",
-    "replace": "Replace",
+    "change": "Change",
     "drawer": {
       "options": {
         "uploadFromPhone": "Choose from my picture gallery",

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/CustomLockScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Device/CustomLockScreen.tsx
@@ -64,7 +64,7 @@ const CustomLockScreen: React.FC<{
         Icon={Icons.PictureImage}
         label={t("customImage.title")}
         onPress={disabled ? undefined : handleStartCustomImage}
-        linkLabel={t(deviceHasImage ? "customImage.replace" : "common.add")}
+        linkLabel={t(deviceHasImage ? "customImage.change" : "common.add")}
       />
       <CustomImageBottomModal
         device={device}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Update wording for changing custom lock screen

### 📝 Description

- Update wording for changing custom lock screen.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12092]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12092]: https://ledgerhq.atlassian.net/browse/LIVE-12092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ