### PR TITLE
LLM - Update Storyly

### DIFF
--- a/.changeset/flat-bananas-appear.md
+++ b/.changeset/flat-bananas-appear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Fix storyly issue on android that was displaying a blackscreen after switching app

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -1398,10 +1398,10 @@ PODS:
   - SocketRocket (0.6.1)
   - sovran-react-native (0.4.5):
     - React-Core
-  - Storyly (2.0.2)
-  - storyly-react-native (2.0.1):
+  - Storyly (2.18.1)
+  - storyly-react-native (2.18.1):
     - React
-    - Storyly (~> 2.0.0)
+    - Storyly (= 2.18.1)
   - TOCropViewController (2.5.3)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.9)
@@ -1952,8 +1952,8 @@ SPEC CHECKSUMS:
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sovran-react-native: fd3dc8f1a4b14acdc4ad25fc6b4ac4f52a2a2a15
-  Storyly: df48014753dfb30c663242c26478d5a6c58379e3
-  storyly-react-native: 5c67a9cc9bf2a327ce6544a5093c35d8449ef727
+  Storyly: 97332ff6eccc9ce4024207338f88b34177c95503
+  storyly-react-native: a112c85399fefc126d8d6a7d692be1b7a12bfaa7
   TOCropViewController: 20a14b6a7a098308bf369e7c8d700dc983a974e6
   Yoga: 805bf71192903b20fc14babe48080582fee65a80
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -213,7 +213,7 @@
     "rxjs": "^7.8.1",
     "safe-buffer": "^5.2.1",
     "semver": "^7.3.7",
-    "storyly-react-native": "2.0.1",
+    "storyly-react-native": "2.18.1",
     "styled-components": "^5.3.3",
     "styled-system": "^5.1.5",
     "text-encoding-polyfill": "^0.6.7",

--- a/apps/ledger-live-mobile/src/components/StorylyStories/StorylyProvider.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/StorylyProvider.tsx
@@ -55,7 +55,7 @@ const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
   };
 
   const clear = () => {
-    storylyRef?.current?.close();
+    storylyRef?.current?.closeStory();
     setUrl(null);
     setToken(null);
   };

--- a/apps/ledger-live-mobile/src/components/StorylyStories/index.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/index.tsx
@@ -136,7 +136,7 @@ const Stories: React.FC<Props> = props => {
       }
       if (event.event === "StoryCTAClicked" && event?.story?.media?.actionUrl) {
         Linking.openURL(event.story.media.actionUrl);
-        storylyRef.current?.close?.();
+        storylyRef.current?.closeStory?.();
       }
     },
     [storyGroupList],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1199,8 +1199,8 @@ importers:
         specifier: ^7.3.7
         version: 7.5.4
       storyly-react-native:
-        specifier: 2.0.1
-        version: 2.0.1(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0)
+        specifier: 2.18.1
+        version: 2.18.1(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: ^5.3.3
         version: 5.3.11(@babel/core@7.24.3)(react-is@18.2.0)(react@18.2.0)
@@ -26809,8 +26809,8 @@ packages:
     resolution: {integrity: sha512-8+EIo91bwmeFWPg1eysrxXlhIYv3OsXrznTr4+4Eq0NikqAoq6oBhtlN5K2RGS2lBVF537eN+9jTCNbR+WrzDA==}
     hasBin: true
 
-  storyly-react-native@2.0.1:
-    resolution: {integrity: sha512-UFJBNjrpcrOyC2lpDv/+Bz48PjST10AlnlZbqrN7TrPf2bDpKQ3LwWYU3QiGBXa6yoFXMEuR6NSc/vg1rKynRg==}
+  storyly-react-native@2.18.1:
+    resolution: {integrity: sha512-obmcEiqaMk6MRHg8kaN7AV2bKqOAMFEwC3dFmTbEsfPVCt5IEnSjhtzZ9kYkfndjPiEzvq1ySiZ9GUysxL83NQ==}
     peerDependencies:
       prop-types: '*'
       react: ^18.0.0
@@ -60384,7 +60384,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  storyly-react-native@2.0.1(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0):
+  storyly-react-native@2.18.1(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-native: 0.73.6(@babel/core@7.24.3)(react@18.2.0)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Updated Storyly from 2.0.1 to 2.18.1 to fix the black screen issue after seeing a story and putting the app in background on Android

| Before        | After         |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/5a656149-7fac-45ff-913e-eeb8e6b60822 | https://github.com/user-attachments/assets/aa95aa74-bcde-41be-b692-8a89983db18e|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13103] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13103]: https://ledgerhq.atlassian.net/browse/LIVE-13103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ