### PR TITLE
chore(live-wallet): allow store to be partial

### DIFF
--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -187,6 +187,16 @@ describe("Wallet store", () => {
     nonImportedAccountInfos: [],
   };
 
+  it("allows partial wallet state", () => {
+    const result = handlers.IMPORT_WALLET_SYNC(
+      initialState,
+      importWalletState({
+        walletSyncState: { version: 42, data: {} },
+      }),
+    );
+    expect(result.nonImportedAccountInfos).toEqual([]);
+  });
+
   it("can import the wallet state", () => {
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(walletSyncStateSelector(result)).toEqual({ data: {}, version: 42 });

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -61,7 +61,7 @@ export type HandlersPayloads = {
     data: DistantState | null;
     version: number;
   };
-  IMPORT_WALLET_SYNC: ExportedWalletState;
+  IMPORT_WALLET_SYNC: Partial<ExportedWalletState>;
   SET_NON_IMPORTED_ACCOUNTS: NonImportedAccountInfo[];
 };
 
@@ -133,8 +133,7 @@ export const handlers: WalletHandlers = {
   IMPORT_WALLET_SYNC: (state, { payload }) => {
     return {
       ...state,
-      walletSyncState: payload.walletSyncState,
-      nonImportedAccountInfos: payload.nonImportedAccountInfos,
+      ...payload,
     };
   },
   SET_NON_IMPORTED_ACCOUNTS: (state, { payload }) => {
@@ -167,7 +166,7 @@ export const initAccounts = (accounts: Account[], accountsUserData: AccountUserD
 /**
  * action to import back the wallet state. opposite of exportWalletState
  */
-export const importWalletState = (payload: ExportedWalletState) => ({
+export const importWalletState = (payload: Partial<ExportedWalletState>) => ({
   type: "IMPORT_WALLET_SYNC",
   payload,
 });


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD

### 📝 Description

following #7376 PR, there is a small regression on Live instances that had the `wallet` store created, they will miss the field `nonImportedAccountInfos`, so in the importer, we need to be sure to accept partial object and complete with the initial value if the fields are not yet set.

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
