### PR TITLE
chore: Remove noble/secp256k1 and migrate to "secp256k1" library

### DIFF
--- a/libs/hw-trustchain/package.json
+++ b/libs/hw-trustchain/package.json
@@ -22,8 +22,8 @@
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/logs": "workspace:*",
     "@ledgerhq/live-env": "workspace:*",
-    "@noble/secp256k1": "^1.7.1",
     "bip32": "^4.0.0",
+    "secp256k1": "^5.0.0",
     "create-hmac": "^1.1.7",
     "tiny-secp256k1": "1"
   },
@@ -31,6 +31,7 @@
     "@types/lodash": "4",
     "@types/jest": "^29.5.10",
     "jest": "^29.7.0",
+    "@types/secp256k1": "^4.0.6",
     "ts-jest": "^29.1.1"
   },
   "scripts": {

--- a/libs/hw-trustchain/src/NobleCrypto.ts
+++ b/libs/hw-trustchain/src/NobleCrypto.ts
@@ -1,4 +1,4 @@
-import * as secp from "@noble/secp256k1";
+import * as secp256k1 from "secp256k1";
 import * as ecc from "tiny-secp256k1";
 import { BIP32Factory } from "bip32";
 import hmac from "create-hmac";
@@ -8,10 +8,14 @@ import { Crypto, KeyPair, KeyPairWithChainCode } from "./Crypto";
 
 const bip32 = BIP32Factory(ecc);
 const AES_BLOCK_SIZE = 16;
+const PRIVATE_KEY_SIZE = 32;
 
 export class NobleCryptoSecp256k1 implements Crypto {
   async randomKeypair(): Promise<KeyPair> {
-    const pk = secp.utils.randomPrivateKey();
+    let pk: Uint8Array;
+    do {
+      pk = crypto.randomBytes(PRIVATE_KEY_SIZE);
+    } while (!secp256k1.privateKeyVerify(pk));
     return this.keypairFromSecretKey(pk);
   }
 
@@ -31,13 +35,37 @@ export class NobleCryptoSecp256k1 implements Crypto {
 
   async keypairFromSecretKey(secretKey: Uint8Array): Promise<KeyPair> {
     return {
-      publicKey: secp.getPublicKey(secretKey, true),
+      publicKey: secp256k1.publicKeyCreate(secretKey),
       privateKey: secretKey,
     };
   }
 
-  sign(message: Uint8Array, keyPair: KeyPair): Promise<Uint8Array> {
-    return secp.sign(message, keyPair.privateKey);
+  private derEncode(R: Uint8Array, S: Uint8Array): Uint8Array {
+    if (R[0] > 0x7f) {
+      R = this.concat(new Uint8Array([0x00]), R);
+    }
+    if (S[0] > 0x7f) {
+      S = this.concat(new Uint8Array([0x00]), S);
+    }
+    R = this.concat(new Uint8Array([0x02, R.length]), R);
+    S = this.concat(new Uint8Array([0x02, S.length]), S);
+    const prefix = new Uint8Array([0x30, R.length + S.length]);
+    return this.concat(prefix, this.concat(R, S));
+  }
+
+  private derDecode(signature: Uint8Array): { R: Uint8Array; S: Uint8Array } {
+    const R: Uint8Array = signature.slice(4, 4 + signature[3]);
+    const S: Uint8Array = signature.slice(
+      6 + signature[3],
+      6 + signature[3] + signature[5 + signature[3]],
+    );
+    return { R: R.slice(R.length - PRIVATE_KEY_SIZE), S: S.slice(S.length - PRIVATE_KEY_SIZE) };
+  }
+
+  async sign(message: Uint8Array, keyPair: KeyPair): Promise<Uint8Array> {
+    const signature = secp256k1.ecdsaSign(message, keyPair.privateKey).signature;
+    // DER encoding
+    return this.derEncode(signature.slice(0, 32), signature.slice(32, 64));
   }
 
   async verify(
@@ -45,7 +73,9 @@ export class NobleCryptoSecp256k1 implements Crypto {
     signature: Uint8Array,
     publicKey: Uint8Array,
   ): Promise<boolean> {
-    return secp.verify(signature, message, publicKey);
+    // DER decoding
+    const { R, S } = this.derDecode(signature);
+    return secp256k1.ecdsaVerify(this.concat(R, S), message, publicKey);
   }
 
   private to_array(buffer: Buffer): Uint8Array {
@@ -144,16 +174,12 @@ variable : Encrypted data
     data: Uint8Array,
   ): Promise<Uint8Array> {
     // Generate ephemeral key pair
-    const ephemeralPrivateKey = secp.utils.randomPrivateKey();
-    const ephemeralPublicKey = secp.getPublicKey(ephemeralPrivateKey, true);
+    const ephemeralKeypair = await this.randomKeypair();
 
     // Derive the shared secret using ECDH
     const sharedSecret = await this.ecdh(
-      {
-        privateKey: commandStreamPrivateKey,
-        publicKey: secp.getPublicKey(commandStreamPrivateKey, true),
-      },
-      ephemeralPublicKey,
+      await this.keypairFromSecretKey(commandStreamPrivateKey),
+      ephemeralKeypair.publicKey,
     );
 
     // Normalize the shared secret to be used as AES key
@@ -170,10 +196,10 @@ variable : Encrypted data
 
     // Serialize the format
     const result = new Uint8Array(
-      1 + ephemeralPublicKey.length + iv.length + tag.length + encryptedData.length,
+      1 + ephemeralKeypair.publicKey.length + iv.length + tag.length + encryptedData.length,
     );
     result[0] = 0x00; // Version of the format
-    result.set(ephemeralPublicKey, 1);
+    result.set(ephemeralKeypair.publicKey, 1);
     result.set(iv, 34);
     result.set(tag, 50);
     result.set(encryptedData, 66);
@@ -196,10 +222,7 @@ variable : Encrypted data
 
     // Derive the shared secret using ECDH
     const sharedSecret = await this.ecdh(
-      {
-        privateKey: commandStreamPrivateKey,
-        publicKey: secp.getPublicKey(commandStreamPrivateKey, true),
-      },
+      await this.keypairFromSecretKey(commandStreamPrivateKey),
       ephemeralPublicKey,
     );
 
@@ -215,7 +238,7 @@ variable : Encrypted data
   }
 
   async randomBytes(size: number): Promise<Uint8Array> {
-    return secp.utils.randomBytes(size);
+    return crypto.randomBytes(size);
   }
 
   async ecdh(keyPair: KeyPair, publicKey: Uint8Array): Promise<Uint8Array> {
@@ -230,8 +253,8 @@ variable : Encrypted data
     return digest;
   }
 
-  hash(message: Uint8Array): Promise<Uint8Array> {
-    return secp.utils.sha256(message);
+  async hash(message: Uint8Array): Promise<Uint8Array> {
+    return crypto.createHash("sha256").update(Buffer.from(message)).digest();
   }
 
   from_hex(hex: string): Uint8Array {

--- a/libs/hw-trustchain/src/__tests__/codec.ts
+++ b/libs/hw-trustchain/src/__tests__/codec.ts
@@ -42,7 +42,7 @@ describe("Encode/Decode command stream tester", () => {
     let buffer = new Uint8Array();
     buffer = TLV.pushHash(buffer, hash);
     const decoded = TLV.readHash(TLV.readTLV(buffer, 0));
-    expect(decoded.value).toEqual(hash);
+    expect(crypto.to_hex(decoded.value)).toEqual(crypto.to_hex(hash));
   });
 
   it("should encode and decode bytes", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3049,15 +3049,15 @@ importers:
       '@ledgerhq/logs':
         specifier: workspace:*
         version: link:../ledgerjs/packages/logs
-      '@noble/secp256k1':
-        specifier: ^1.7.1
-        version: 1.7.1
       bip32:
         specifier: ^4.0.0
         version: 4.0.0
       create-hmac:
         specifier: ^1.1.7
         version: 1.1.7
+      secp256k1:
+        specifier: ^5.0.0
+        version: 5.0.0
       tiny-secp256k1:
         specifier: '1'
         version: 1.1.6
@@ -3068,6 +3068,9 @@ importers:
       '@types/lodash':
         specifier: '4'
         version: 4.17.0
+      '@types/secp256k1':
+        specifier: ^4.0.6
+        version: 4.0.6
       jest:
         specifier: ^29.7.0
         version: 29.7.0
@@ -41713,7 +41716,7 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/acorn@4.0.6':
     dependencies:
@@ -41816,7 +41819,7 @@ snapshots:
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/connect@3.4.38':
     dependencies:
@@ -41831,7 +41834,7 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 4.17.21
       '@types/keygrip': 1.0.6
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/create-hmac@1.1.3':
     dependencies:
@@ -41946,7 +41949,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/hammerjs@2.0.45': {}
 
@@ -42056,7 +42059,7 @@ snapshots:
       '@types/http-errors': 2.0.4
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.8
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/koa__router@12.0.3':
     dependencies:
@@ -42111,7 +42114,7 @@ snapshots:
 
   '@types/mysql@2.15.22':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/node-fetch@2.6.11':
     dependencies:
@@ -42174,7 +42177,7 @@ snapshots:
 
   '@types/pbkdf2@3.1.2':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/pg-pool@2.0.4':
     dependencies:
@@ -42182,7 +42185,7 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
       pg-protocol: 1.6.1
       pg-types: 2.2.0
 
@@ -42354,7 +42357,7 @@ snapshots:
 
   '@types/secp256k1@4.0.6':
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
 
   '@types/semver@7.5.7': {}
 
@@ -49421,7 +49424,7 @@ snapshots:
       memfs: 3.5.3
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.6.2
+      semver: 7.5.4
       tapable: 1.1.3
       typescript: 5.4.3
       webpack: 5.89.0
@@ -52693,7 +52696,7 @@ snapshots:
 
   jest-serializer@27.5.1:
     dependencies:
-      '@types/node': 20.12.12
+      '@types/node': 20.14.10
       graceful-fs: 4.2.11
 
   jest-snapshot@27.5.1:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove noble/secp256k1 and use secp256k1 library (which is already used by over LL packages).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-13493

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
