### PR TITLE
:bug:fix(lld): account name on receive flow

### DIFF
--- a/.changeset/four-olives-hammer.md
+++ b/.changeset/four-olives-hammer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+On receive flow default account name was displayed instead of the account name selected by the user

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -38,6 +38,7 @@ import { getLLDCoinFamily } from "~/renderer/families";
 import { firstValueFrom } from "rxjs";
 import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 
 const Separator = styled.div`
   border-top: 1px solid #99999933;
@@ -171,7 +172,8 @@ const StepReceiveFunds = (props: StepProps) => {
 
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   invariant(account && mainAccount, "No account given");
-  const name = token ? token.name : getDefaultAccountName(account);
+  const maybeAccountName = useMaybeAccountName(account);
+  const name = token ? token.name : maybeAccountName || getDefaultAccountName(account);
   const initialDevice = useRef(device);
   const address = mainAccount.freshAddress;
   const [modalVisible, setModalVisible] = useState(false);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Receive flow account name

### 📝 Description

Fix an issue that displayed the default account name on receive flow instead of the user one



| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/589905d8-0e70-4bbf-826f-d776f21df8c8|https://github.com/user-attachments/assets/5e27ad75-adeb-48be-8239-5375bd666b44|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-13496](https://ledgerhq.atlassian.net/browse/LIVE-13496)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13496]: https://ledgerhq.atlassian.net/browse/LIVE-13496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ