### PR TITLE
fix(LLM): skip device check in account.receive for wallet-api [LIVE-13538]

### DIFF
--- a/.changeset/hip-shirts-rule.md
+++ b/.changeset/hip-shirts-rule.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix(LLM): bring back bypass in account receive for wallet-api

--- a/apps/ledger-live-mobile/e2e/page/index.ts
+++ b/apps/ledger-live-mobile/e2e/page/index.ts
@@ -7,6 +7,7 @@ import CryptoDrawer from "./liveApps/cryptoDrawer";
 import CustomLockscreenPage from "./stax/customLockscreen.page";
 import DiscoverPage from "./discover/discover.page";
 import DummyWalletApp from "./liveApps/dummyWalletApp.webView";
+import WalletAPIReceivePage from "./liveApps/walletAPIReceive";
 import ManagerPage from "./manager/manager.page";
 import MarketPage from "./market/market.page";
 import NftGalleryPage from "./wallet/nftGallery.page";
@@ -38,6 +39,7 @@ export class Application {
   public customLockscreen = new CustomLockscreenPage();
   public discover = new DiscoverPage();
   public dummyWalletApp = new DummyWalletApp();
+  public walletAPIReceive = new WalletAPIReceivePage();
   public manager = new ManagerPage();
   public market = new MarketPage();
   public nftGallery = new NftGalleryPage();

--- a/apps/ledger-live-mobile/e2e/page/liveApps/dummyWalletApp.webView.ts
+++ b/apps/ledger-live-mobile/e2e/page/liveApps/dummyWalletApp.webView.ts
@@ -34,6 +34,15 @@ export default class DummyWalletApp {
     });
   }
 
+  async sendAccountReceive() {
+    return await send({
+      method: "account.receive",
+      params: {
+        accountId: "2d23ca2a-069e-579f-b13d-05bc706c7583",
+      },
+    });
+  }
+
   async expectResponse(id: string, response: Promise<Record<string, unknown>>) {
     await expect(response).resolves.toMatchObject({
       jsonrpc: "2.0",

--- a/apps/ledger-live-mobile/e2e/page/liveApps/walletAPIReceive.ts
+++ b/apps/ledger-live-mobile/e2e/page/liveApps/walletAPIReceive.ts
@@ -1,0 +1,15 @@
+import { tapByText } from "../../helpers";
+
+export default class WalletAPIReceive {
+  continueWithoutDevice() {
+    return tapByText("Continue without my device");
+  }
+
+  confirmNoDevice() {
+    return tapByText("Confirm");
+  }
+
+  cancelNoDevice() {
+    return tapByText("Cancel");
+  }
+}

--- a/apps/ledger-live-mobile/e2e/specs/wallet-api.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/wallet-api.spec.ts
@@ -19,6 +19,21 @@ describe("Wallet API methods", () => {
     await app.dummyWalletApp.expectResponse(id, response);
   });
 
+  it("account.request", async () => {
+    const { id, response } = await app.dummyWalletApp.sendAccountReceive();
+    await app.walletAPIReceive.continueWithoutDevice();
+    await app.walletAPIReceive.cancelNoDevice();
+    await app.walletAPIReceive.continueWithoutDevice();
+    await app.walletAPIReceive.confirmNoDevice();
+    await expect(response).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        address: "1xeyL26EKAAR3pStd7wEveajk4MQcrYezeJ",
+      },
+    });
+  });
+
   afterAll(async () => {
     await app.dummyWalletApp.stopApp();
   });

--- a/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/VerifyAccount/index.tsx
@@ -2,10 +2,11 @@ import React, { useCallback, useMemo, useState } from "react";
 import { View, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useSelector } from "react-redux";
+import { Trans } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
 import { getMainAccount, getReceiveFlowError } from "@ledgerhq/live-common/account/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { Flex } from "@ledgerhq/native-ui";
+import { Flex, Text } from "@ledgerhq/native-ui";
 import { accountScreenSelector } from "~/reducers/accounts";
 import { TrackScreen } from "~/analytics";
 import SelectDevice2 from "~/components/SelectDevice2";
@@ -18,10 +19,13 @@ import { RootComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { ScreenName } from "~/const";
 import { useAppDeviceAction } from "~/hooks/deviceActions";
+import Button from "~/components/wrappedUi/Button";
 
 type NavigationProps = RootComposite<
   StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.VerifyAccount>
 >;
+
+const edges = ["left", "right"] as const;
 
 export default function VerifyAccount({ navigation, route }: NavigationProps) {
   const action = useAppDeviceAction();
@@ -57,6 +61,10 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
     onDone();
   }, [account, onSuccess, onDone]);
 
+  const onSkipDevice = useCallback(() => {
+    setSkipDevice(true);
+  }, []);
+
   const handleSkipClose = useCallback(() => {
     setSkipDevice(false);
   }, []);
@@ -83,6 +91,7 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
   const tokenCurrency = account && account.type === "TokenAccount" ? account.token : undefined;
   return (
     <SafeAreaView
+      edges={edges}
       style={[
         styles.root,
         {
@@ -97,6 +106,16 @@ export default function VerifyAccount({ navigation, route }: NavigationProps) {
           stopBleScanning={!!device}
           requestToSetHeaderOptions={requestToSetHeaderOptions}
         />
+        <View>
+          <View style={styles.header}>
+            <Text style={styles.headerText} color="grey">
+              <Trans i18nKey="SelectDevice.withoutDeviceHeader" />
+            </Text>
+          </View>
+          <Button onPress={onSkipDevice} event="WithoutDevice" type={"main"} mt={6} mb={6}>
+            <Trans i18nKey="SelectDevice.withoutDevice" />
+          </Button>
+        </View>
       </Flex>
       {device ? (
         <DeviceActionModal
@@ -145,5 +164,12 @@ const styles = StyleSheet.create({
   },
   modalContainer: {
     flexDirection: "row",
+  },
+  header: {
+    alignItems: "center",
+  },
+  headerText: {
+    fontSize: 14,
+    lineHeight: 21,
   },
 });


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Wallet-API: account.receive flow used in buy/sell live apps usually

### 📝 Description

The old device selection UI was removed recently in the PR: https://github.com/LedgerHQ/ledger-live/pull/6383
But we removed the button to skip the device check too
This PR brings back the button under the new device selection UI for the wallet-api account.receive handler

| Before        | After         |
| ------------- | ------------- |
| <img width="436" alt="Screenshot 2024-07-30 at 15 34 35" src="https://github.com/user-attachments/assets/22b2f092-d966-4e0b-8c6a-c23b9dc2a7b7"> | <img width="429" alt="Screenshot 2024-07-30 at 11 59 34" src="https://github.com/user-attachments/assets/6fa3a7f1-93e4-41fc-b48c-361bd29eb12b"> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13538]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13538]: https://ledgerhq.atlassian.net/browse/LIVE-13538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ