### PR TITLE
LLM - Wallet Sync accounts synchronisation added

### DIFF
--- a/.changeset/weak-melons-grow.md
+++ b/.changeset/weak-melons-grow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LLM - Added wallet sync accounts synchronisation

--- a/apps/ledger-live-mobile/src/AppProviders.tsx
+++ b/apps/ledger-live-mobile/src/AppProviders.tsx
@@ -12,6 +12,7 @@ import SnackbarContainer from "~/screens/NotificationCenter/Snackbar/SnackbarCon
 import PostOnboardingProviderWrapped from "~/logic/postOnboarding/PostOnboardingProviderWrapped";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { CountervaluesMarketcap } from "@ledgerhq/live-countervalues-react/index";
+import { WalletSyncProvider } from "LLM/features/WalletSync/components/WalletSyncContext";
 
 type AppProvidersProps = {
   initialCountervalues?: CounterValuesStateRaw;
@@ -24,24 +25,26 @@ function AppProviders({ initialCountervalues, children }: AppProvidersProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <BridgeSyncProvider>
-        <CountervaluesMarketcap>
-          <CounterValuesProvider initialState={initialCountervalues}>
-            <ButtonUseTouchableContext.Provider value={true}>
-              <OnboardingContextProvider>
-                <PostOnboardingProviderWrapped>
-                  <ToastProvider>
-                    <NotificationsProvider>
-                      <SnackbarContainer />
-                      <NftMetadataProvider getCurrencyBridge={getCurrencyBridge}>
-                        {children}
-                      </NftMetadataProvider>
-                    </NotificationsProvider>
-                  </ToastProvider>
-                </PostOnboardingProviderWrapped>
-              </OnboardingContextProvider>
-            </ButtonUseTouchableContext.Provider>
-          </CounterValuesProvider>
-        </CountervaluesMarketcap>
+        <WalletSyncProvider>
+          <CountervaluesMarketcap>
+            <CounterValuesProvider initialState={initialCountervalues}>
+              <ButtonUseTouchableContext.Provider value={true}>
+                <OnboardingContextProvider>
+                  <PostOnboardingProviderWrapped>
+                    <ToastProvider>
+                      <NotificationsProvider>
+                        <SnackbarContainer />
+                        <NftMetadataProvider getCurrencyBridge={getCurrencyBridge}>
+                          {children}
+                        </NftMetadataProvider>
+                      </NotificationsProvider>
+                    </ToastProvider>
+                  </PostOnboardingProviderWrapped>
+                </OnboardingContextProvider>
+              </ButtonUseTouchableContext.Provider>
+            </CounterValuesProvider>
+          </CountervaluesMarketcap>
+        </WalletSyncProvider>
       </BridgeSyncProvider>
     </QueryClientProvider>
   );

--- a/apps/ledger-live-mobile/src/actions/accounts.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.ts
@@ -5,6 +5,7 @@ import type {
   AccountsDeleteAccountPayload,
   AccountsImportAccountsPayload,
   AccountsReorderPayload,
+  AccountsReplacePayload,
   AccountsUpdateAccountWithUpdaterPayload,
 } from "./types";
 import { AccountsActionTypes } from "./types";
@@ -51,4 +52,8 @@ export const updateAccount = (payload: Pick<Account, "id"> & Partial<Account>) =
 export const deleteAccount = createAction<AccountsDeleteAccountPayload>(
   AccountsActionTypes.DELETE_ACCOUNT,
 );
+export const replaceAccounts = createAction<AccountsReplacePayload>(
+  AccountsActionTypes.SET_ACCOUNTS,
+);
+
 export const cleanCache = createAction(AccountsActionTypes.CLEAN_CACHE);

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -58,12 +58,14 @@ export type AccountsUpdateAccountWithUpdaterPayload = {
   updater: (arg0: Account) => Account;
 };
 export type AccountsDeleteAccountPayload = Account;
+export type AccountsReplacePayload = Account[];
 export type AccountsPayload =
   | HandlersPayloads["INIT_ACCOUNTS"]
   | AccountsReorderPayload
   | AccountsImportAccountsPayload
   | AccountsUpdateAccountWithUpdaterPayload
   | AccountsDeleteAccountPayload
+  | AccountsReplacePayload
   | Account;
 
 // === APPSTATE ACTIONS ===

--- a/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
+++ b/apps/ledger-live-mobile/src/components/globalSyncRefreshControl.tsx
@@ -5,6 +5,7 @@ import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { SYNC_DELAY } from "~/utils/constants";
 import { track } from "~/analytics";
+import { useWalletSyncUserState } from "~/newArch/features/WalletSync/components/WalletSyncContext";
 
 type Props = {
   error?: Error;
@@ -19,6 +20,7 @@ export default <P,>(
     const { colors, dark } = useTheme();
     const [refreshing, setRefreshing] = useState(false);
     const setSyncBehavior = useBridgeSync();
+    const { onUserRefresh } = useWalletSyncUserState();
     const { poll } = useCountervaluesPolling();
     const IsFocused = useIsFocused();
     function onRefresh() {
@@ -30,6 +32,7 @@ export default <P,>(
       });
       setRefreshing(true);
       track("buttonClicked", { button: "pull to refresh" });
+      onUserRefresh();
     }
 
     useEffect(() => {

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -13,6 +13,7 @@ import {
   getProtect,
   getMarketState,
   getTrustchainState,
+  getWalletExportState,
 } from "../db";
 import { importSettings, setSupportedCounterValues } from "~/actions/settings";
 import { importStore as importAccountsRaw } from "~/actions/accounts";
@@ -23,6 +24,7 @@ import { listCachedCurrencyIds, hydrateCurrency } from "~/bridge/cache";
 import { getCryptoCurrencyById, listSupportedFiats } from "@ledgerhq/live-common/currencies/index";
 import { importMarket } from "~/actions/market";
 import { importTrustchainStoreState } from "@ledgerhq/trustchain/store";
+import { importWalletState } from "@ledgerhq/live-wallet/store";
 
 export default class LedgerStoreProvider extends Component<
   {
@@ -118,6 +120,11 @@ export default class LedgerStoreProvider extends Component<
     const trustchainStore = await getTrustchainState();
     if (trustchainStore) {
       this.props.store.dispatch(importTrustchainStoreState(trustchainStore));
+    }
+
+    const walletStore = await getWalletExportState();
+    if (walletStore) {
+      this.props.store.dispatch(importWalletState(walletStore));
     }
 
     const protect = await getProtect();

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -13,6 +13,7 @@ import store from "./logic/storeWrapper";
 import type { User } from "./types/store";
 import type { BleState, MarketState, ProtectState, SettingsState } from "./reducers/types";
 import { TrustchainStore } from "@ledgerhq/trustchain/store";
+import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
 
 export type Notifications = {
   announcements: Announcement[];
@@ -281,6 +282,15 @@ export function getTrustchainState(): Promise<TrustchainStore> {
 
 export async function saveTrustchainState(obj: TrustchainStore): Promise<void> {
   await store.save("trustchain", obj);
+}
+
+export async function getWalletExportState(): Promise<ExportedWalletState> {
+  const wallet = (await store.get("wallet")) as ExportedWalletState;
+  return wallet;
+}
+
+export async function saveWalletExportState(obj: ExportedWalletState): Promise<void> {
+  await store.save("wallet", obj);
 }
 
 export async function getProtect(): Promise<ProtectState> {

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -29,6 +29,7 @@ import {
   savePostOnboardingState,
   saveMarketState,
   saveTrustchainState,
+  saveWalletExportState,
 } from "./db";
 import {
   exportSelector as settingsExportSelector,
@@ -88,6 +89,8 @@ import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/po
 import QueuedDrawersContextProvider from "~/newArch/components/QueuedDrawer/QueuedDrawersContextProvider";
 import { exportMarketSelector } from "./reducers/market";
 import { trustchainStoreSelector } from "@ledgerhq/trustchain/store";
+import { walletSelector } from "~/reducers/wallet";
+import { exportWalletState, walletStateExportShouldDiffer } from "@ledgerhq/live-wallet/store";
 
 if (Config.DISABLE_YELLOW_BOX) {
   LogBox.ignoreAllLogs();
@@ -105,6 +108,10 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
+
+function walletExportSelector(state: State) {
+  return exportWalletState(walletSelector(state));
+}
 
 function App() {
   const accounts = useSelector(accountsSelector);
@@ -217,6 +224,13 @@ function App() {
     throttle: 500,
     getChangesStats: (a, b) => a.trustchain !== b.trustchain,
     lense: trustchainStoreSelector,
+  });
+
+  useDBSaveEffect({
+    save: saveWalletExportState,
+    throttle: 500,
+    getChangesStats: (a, b) => walletStateExportShouldDiffer(a.wallet, b.wallet),
+    lense: walletExportSelector,
   });
 
   return (

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/WalletSyncContext/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/WalletSyncContext/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { useWatchWalletSync, WalletSyncUserState } from "../../hooks/useWatchWalletSync";
+
+export const WalletSyncContext = React.createContext<WalletSyncUserState>({
+  visualPending: false,
+  walletSyncError: null,
+  onUserRefresh: () => {},
+});
+
+export const useWalletSyncUserState = () => React.useContext(WalletSyncContext);
+
+export function WalletSyncProvider({ children }: { children: React.ReactNode }) {
+  const walletSyncState = useWatchWalletSync();
+  return (
+    <WalletSyncContext.Provider value={walletSyncState}>{children}</WalletSyncContext.Provider>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useDestroyTrustchain.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useDestroyTrustchain.ts
@@ -7,9 +7,12 @@ import {
 } from "@ledgerhq/trustchain/store";
 import { useMutation } from "@tanstack/react-query";
 import { QueryKey } from "./type.hooks";
+import { useCloudSyncSDK } from "./useWatchWalletSync";
+import { walletSyncUpdate } from "@ledgerhq/live-wallet/store";
 
 export function useDestroyTrustchain() {
   const dispatch = useDispatch();
+  const cloudSyncSDK = useCloudSyncSDK();
   const sdk = useTrustchainSdk();
   const trustchain = useSelector(trustchainSelector);
   const memberCredentials = useSelector(memberCredentialsSelector);
@@ -19,12 +22,13 @@ export function useDestroyTrustchain() {
       if (!trustchain || !memberCredentials) {
         return;
       }
-
+      await cloudSyncSDK.destroy(trustchain, memberCredentials);
       await sdk.destroyTrustchain(trustchain, memberCredentials);
     },
     mutationKey: [QueryKey.destroyTrustchain, trustchain],
     onSuccess: () => {
       dispatch(resetTrustchainStore());
+      dispatch(walletSyncUpdate(null, 0));
     },
   });
 

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { MemberCredentials, Trustchain, TrustchainSDK } from "@ledgerhq/trustchain/types";
+import { setTrustchain, resetTrustchainStore } from "@ledgerhq/trustchain/store";
+import { TrustchainEjected } from "@ledgerhq/trustchain/errors";
+import { log } from "@ledgerhq/logs";
+
+export function useOnTrustchainRefreshNeeded(
+  trustchainSdk: TrustchainSDK,
+  memberCredentials: MemberCredentials | null,
+): (trustchain: Trustchain) => Promise<void> {
+  const dispatch = useDispatch();
+  const onTrustchainRefreshNeeded = useCallback(
+    async (trustchain: Trustchain) => {
+      try {
+        if (!memberCredentials) return;
+        log("walletsync", "onTrustchainRefreshNeeded " + trustchain.rootId);
+        const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
+        dispatch(setTrustchain(newTrustchain));
+      } catch (e) {
+        if (e instanceof TrustchainEjected) {
+          dispatch(resetTrustchainStore());
+        }
+      }
+    },
+    [dispatch, trustchainSdk, memberCredentials],
+  );
+  return onTrustchainRefreshNeeded;
+}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -12,10 +12,7 @@ import walletsync, {
   makeLocalIncrementalUpdate,
 } from "@ledgerhq/live-wallet/walletsync/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
-import { walletSelector } from "~/renderer/reducers/wallet";
 import { memberCredentialsSelector, trustchainSelector } from "@ledgerhq/trustchain/store";
-import { State } from "~/renderer/reducers";
-import { cache as bridgeCache } from "~/renderer/bridge/cache";
 import {
   setAccountNames,
   setNonImportedAccounts,
@@ -23,11 +20,14 @@ import {
   walletSyncUpdate,
   WSState,
 } from "@ledgerhq/live-wallet/store";
-import { replaceAccounts } from "~/renderer/actions/accounts";
-import { latestDistantStateSelector } from "~/renderer/reducers/wallet";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { useOnTrustchainRefreshNeeded } from "./useOnTrustchainRefreshNeeded";
 import { Dispatch } from "redux";
+import { walletSelector } from "~/reducers/wallet";
+import { State } from "~/reducers/types";
+import { bridgeCache } from "~/bridge/cache";
+import { replaceAccounts } from "~/actions/accounts";
+import { latestDistantStateSelector } from "~/reducers/wallet";
 
 const latestWalletStateSelector = (s: State): WSState => walletSyncStateSelector(walletSelector(s));
 
@@ -35,7 +35,7 @@ function localStateSelector(state: State): LocalState {
   // READ. connect the redux state to the walletsync modules
   return {
     accounts: {
-      list: state.accounts,
+      list: state.accounts.active,
       nonImportedAccountInfos: state.wallet.nonImportedAccountInfos,
     },
     accountNames: state.wallet.accountNames,

--- a/apps/ledger-live-mobile/src/reducers/accounts.ts
+++ b/apps/ledger-live-mobile/src/reducers/accounts.ts
@@ -35,6 +35,7 @@ import type {
   AccountsUpdateAccountWithUpdaterPayload,
   SettingsBlacklistTokenPayload,
   DangerouslyOverrideStatePayload,
+  AccountsReplacePayload,
 } from "../actions/types";
 import { AccountsActionTypes } from "../actions/types";
 import accountModel from "../logic/accountModel";
@@ -103,6 +104,10 @@ const handlers: ReducerMap<AccountsState, Payload> = {
     active: state.active.filter(
       acc => acc.id !== (action as Action<AccountsDeleteAccountPayload>).payload.id,
     ),
+  }),
+
+  [AccountsActionTypes.SET_ACCOUNTS]: (state, action) => ({
+    active: (action as Action<AccountsReplacePayload>).payload,
   }),
 
   [AccountsActionTypes.CLEAN_CACHE]: (state: AccountsState) => ({

--- a/apps/ledger-live-mobile/src/reducers/wallet.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.ts
@@ -6,12 +6,14 @@ import {
   handlers,
   isStarredAccountSelector,
   accountNameWithDefaultSelector,
+  walletSyncStateSelector,
 } from "@ledgerhq/live-wallet/store";
 import { handleActions } from "redux-actions";
 import { State } from "./types";
 import { createSelector } from "reselect";
 import { useSelector } from "react-redux";
 import { AccountLike } from "@ledgerhq/types-live";
+import { DistantState } from "@ledgerhq/live-wallet/walletsync/index";
 
 export const walletSelector = (state: State): WalletState => state.wallet;
 
@@ -20,6 +22,10 @@ export const accountStarredSelector = createSelector(
   (_: State, { accountId }: { accountId: string }) => accountId,
   (wallet, accountId) => isStarredAccountSelector(wallet, { accountId }),
 );
+
+export function latestDistantStateSelector(state: State): DistantState | null {
+  return walletSyncStateSelector(walletSelector(state)).data;
+}
 
 export const useMaybeAccountName = (
   account: AccountLike | null | undefined,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Added the watch loop to synchronise LLM accounts using wallet sync
See a demo [here](https://ledger.slack.com/archives/C076F0JQZ5E/p1722355896408899)

Also fixed a bug on desktop by reseting the error and pending state of wallet sync when the trustchain has been deleted
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-12640] [LIVE-13542]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-12640]: https://ledgerhq.atlassian.net/browse/LIVE-12640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ