### PR TITLE
[LIVE-11916][LLM] My Ledger search bar sticky & auto scroll

### DIFF
--- a/.changeset/spicy-pumpkins-lick.md
+++ b/.changeset/spicy-pumpkins-lick.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+My Ledger: make search bar sticky

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsList/Searchbar.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsList/Searchbar.tsx
@@ -7,6 +7,8 @@ import { Flex, IconsLegacy } from "@ledgerhq/native-ui";
 type Props = {
   searchQuery?: string;
   onQueryUpdate: (_: string) => void;
+  onFocus?(): void;
+  onBlur?(): void;
 };
 
 const SearchbarContainer = styled(Flex).attrs({
@@ -25,7 +27,7 @@ const SearchbarTextInput = styled(TextInput).attrs({
   flex: 1,
 })``;
 
-export default ({ searchQuery, onQueryUpdate }: Props) => {
+export default ({ searchQuery, onQueryUpdate, onFocus, onBlur }: Props) => {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const textInput = useRef<TextInput>(null);
@@ -40,6 +42,8 @@ export default ({ searchQuery, onQueryUpdate }: Props) => {
         returnKeyType="search"
         maxLength={50}
         onChangeText={onQueryUpdate}
+        onFocus={onFocus}
+        onBlur={onBlur}
         placeholder={t("manager.appList.searchApps")}
         placeholderTextColor={colors.neutral.c70}
         value={searchQuery}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** nope sorry
- [x] **Impact of the changes:**
  - cf. description

### 📝 Description

The apps search bar in My Ledger is now automatically sticking to the top of the screen.
There is also an auto scroll to that search bar whenever the input field gets focus or when the input changes.

> iOS
> 
> https://github.com/user-attachments/assets/a6b3307c-c4c3-420d-966a-b6ab52738315

> Android
> 
> https://github.com/user-attachments/assets/ed9465e0-60e0-4a4c-b686-51913611388a



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11916]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11916]: https://ledgerhq.atlassian.net/browse/LIVE-11916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ