### PR TITLE
chore(walletsync): enhance the websocket notifications hook for watch loop

### DIFF
--- a/apps/web-tools/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/trustchain/components/AppAccountsSync.tsx
@@ -34,6 +34,7 @@ import { Loading } from "./Loading";
 import { TrustchainEjected } from "@ledgerhq/trustchain/lib-es/errors";
 import { Tick } from "./Tick";
 import { State } from "./types";
+import { Actionable } from "./Actionable";
 
 /*
 import * as icons from "@ledgerhq/crypto-icons-ui/react";
@@ -176,6 +177,8 @@ export default function AppAccountsSync({
   const [timestamp, setTimestamp] = useState(0);
   const [onUserRefresh, setOnUserRefresh] = useState<() => void>(() => () => {});
 
+  const [watchConfig, setWatchConfig] = useState({ notificationsEnabled: false });
+
   // pull and push wallet sync loop
   useEffect(() => {
     const localIncrementUpdate = makeLocalIncrementalUpdate({
@@ -187,6 +190,7 @@ export default function AppAccountsSync({
     });
 
     const { unsubscribe, onUserRefreshIntent } = walletSyncWatchLoop({
+      watchConfig,
       walletSyncSdk,
       localIncrementUpdate,
       trustchain,
@@ -214,6 +218,7 @@ export default function AppAccountsSync({
     getState,
     saveUpdate,
     ctx,
+    watchConfig,
   ]);
 
   const setAccounts = useCallback(
@@ -263,6 +268,17 @@ export default function AppAccountsSync({
         deviceId={deviceId}
         bridgeCache={bridgeCache}
         setAccounts={setAccounts}
+      />
+
+      <Actionable
+        buttonTitle="Toggle WebSocket notifications"
+        inputs={[watchConfig.notificationsEnabled]}
+        action={enabled => !enabled}
+        value={watchConfig.notificationsEnabled}
+        setValue={notificationsEnabled =>
+          typeof notificationsEnabled === "boolean" && setWatchConfig({ notificationsEnabled })
+        }
+        valueDisplay={v => (v ? "Listening" : "Not listening")}
       />
     </div>
   );


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - watch loop

### 📝 Description

- reduce the loop to 10s

- small evolution on the `watchConfig` object,
as documented by https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4902912002/future+improvement+consideration
we simply can consider that websocket notifications is a small enhancement **on top** of the regular polling mecanism.


We can test on the web tools, the websocket mode is disabled by default

![Capture d’écran 2024-08-02 à 11 21 11](https://github.com/user-attachments/assets/b223f9ea-9457-4d6b-86aa-0d2dce937f62)



### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
