### PR TITLE
fix(live-13597): show error when balance minus network fees is a negative value

### DIFF
--- a/.changeset/tidy-berries-perform.md
+++ b/.changeset/tidy-berries-perform.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+show error when balance minus network fees is a negative value

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -3,9 +3,9 @@ import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/index";
 import {
   AmountRequired,
   FeeNotLoaded,
+  NotEnoughBalanceSwap,
   NotEnoughGas,
   NotEnoughGasSwap,
-  NotEnoughBalanceSwap,
 } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import { useMemo } from "react";
@@ -171,6 +171,11 @@ export const useSwapTransaction = ({
     isEnabled,
   });
 
+  // libs/coin-modules/coin-evm/src/prepareTransaction.ts L47
+  // returns 0 if the balance - fees is less than 0
+  const maxAmountLowerThanBallanceError =
+    isMaxEnabled && fromState.amount?.eq(0) ? new NotEnoughBalanceSwap() : undefined;
+
   return {
     ...bridgeTransaction,
     swap: {
@@ -193,7 +198,7 @@ export const useSwapTransaction = ({
     },
     setFromAmount,
     toggleMax,
-    fromAmountError,
+    fromAmountError: maxAmountLowerThanBallanceError || fromAmountError,
     fromAmountWarning,
     setToAccount,
     setToCurrency,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Might be a Legacy error. The function that is preparing the transaction and calculate the possible the max value is returning MAX number between (balance - fees, 0). So the a very low balance - fees is < 0, then 0 is returned. 

I added an error for this case. isMaxEnabled and fromAmount is 0

- show error when balance - network fees < 0

![image](https://github.com/user-attachments/assets/5380aacc-12f3-42e0-8fff-dc4ff0cb469a)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-13597

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
