### PR TITLE
[LIVE-11555][LLD][Firmware update] Update stuck at the end for old firmwares.

### DIFF
--- a/.changeset/red-beans-report.md
+++ b/.changeset/red-beans-report.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix firmware update for old firmware versions

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -103,6 +103,7 @@ apps/cli/src/commands/devices                                      @ledgerhq/liv
 **/components/CustomImage                                          @ledgerhq/live-devices
 **/SyncOnboarding/**                                               @ledgerhq/live-devices
 **/OnboardingAppInstall/**																				 @ledgerhq/live-devices
+**/UpdateFirmwareModal/**																					 @ledgerhq/live-devices
 apps/**/components/DeviceAction/                                   @ledgerhq/live-devices
 apps/ledger-live-mobile/src/screens/MyLedger*/             	       @ledgerhq/live-devices
 apps/ledger-live-mobile/src/newArch/features/FirmwareUpdate/       @ledgerhq/live-devices

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/Disclaimer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/Disclaimer.tsx
@@ -6,7 +6,7 @@ import TrackPage from "~/renderer/analytics/TrackPage";
 import Markdown, { Notes } from "~/renderer/components/Markdown";
 
 type Props = {
-  firmware?: FirmwareUpdateContext;
+  firmware: FirmwareUpdateContext;
   onContinue(): void;
 };
 

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/helpers/createFirmwareUpdateSteps.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/helpers/createFirmwareUpdateSteps.ts
@@ -10,6 +10,16 @@ import { Step, StepId, STEPS } from "../types";
 import { isDeviceLocalizationSupported } from "@ledgerhq/live-common/device/use-cases/isDeviceLocalizationSupported";
 import { isCustomLockScreenSupported } from "@ledgerhq/live-common/device/use-cases/isCustomLockScreenSupported";
 
+export function isRestoreStepEnabled(
+  deviceModelId: DeviceModelId,
+  firmware: FirmwareUpdateContext,
+): boolean {
+  return (
+    isCustomLockScreenSupported(deviceModelId) ||
+    isDeviceLocalizationSupported(firmware.final.name, deviceModelId)
+  );
+}
+
 export const createFirmwareUpdateSteps = ({
   firmware,
   withFinal,
@@ -17,15 +27,13 @@ export const createFirmwareUpdateSteps = ({
   deviceModelId,
   stateStepId,
 }: {
-  firmware?: FirmwareUpdateContext;
+  firmware: FirmwareUpdateContext;
   withFinal: boolean;
   withResetStep: boolean;
   deviceModelId: DeviceModelId;
   stateStepId: StepId;
 }) => {
-  const hasRestoreStep =
-    isCustomLockScreenSupported(deviceModelId) ||
-    (firmware && isDeviceLocalizationSupported(firmware.final.name, deviceModelId));
+  const hasRestoreStep = isRestoreStepEnabled(deviceModelId, firmware);
 
   const restoreStepLabel =
     stateStepId === STEPS.FINISH

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -22,7 +22,7 @@ export type Props = {
   withAppsToReinstall: boolean;
   onDrawerClose: (reinstall?: boolean) => void;
   onRequestClose: () => void;
-  firmware?: FirmwareUpdateContext;
+  firmware: FirmwareUpdateContext;
   stepId: StepId;
   error?: Error | null | undefined;
   deviceModelId: DeviceModelId;
@@ -55,7 +55,7 @@ const UpdateModal = ({
   const [err, setErr] = useState<MaybeError>(error || null);
   const [CLSBackup, setCLSBackup] = useState<string>();
   const [updatedDeviceInfo, setUpdatedDeviceInfo] = useState<DeviceInfo | undefined>(undefined);
-  const withFinal = useMemo(() => hasFinalFirmware(firmware?.final), [firmware]);
+  const withFinal = useMemo(() => hasFinalFirmware(firmware.final), [firmware]);
   const [cancel, setCancel] = useState<boolean>(false);
 
   const isDisconnectedDeviceError = err instanceof DisconnectedDevice;
@@ -120,7 +120,7 @@ const UpdateModal = ({
     setUpdatedDeviceInfo,
 
     appsToBeReinstalled: withAppsToReinstall,
-    transitionTo: setStateStepId,
+    transitionTo: setStateStepId, // FIXME: this is a really bad idea that should be reworked, as the steps are determined dynamically, a child might want to transition to a step that doesn't exist
     CLSBackup,
     deviceModelId,
     error: err,

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/02-step-flash-mcu.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/02-step-flash-mcu.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { hasFinalFirmware } from "@ledgerhq/live-common/hw/hasFinalFirmware";
-import { isDeviceLocalizationSupported } from "@ledgerhq/live-common/device/use-cases/isDeviceLocalizationSupported";
 import firmwareUpdateMain from "@ledgerhq/live-common/hw/firmwareUpdate-main";
 import { withDevicePolling } from "@ledgerhq/live-common/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
@@ -17,6 +16,7 @@ import { mockedEventEmitter } from "~/renderer/components/debug/DebugMock";
 import Installing from "../Installing";
 import { Body as StepUpdatingBody } from "./02-step-updating";
 import { StepProps } from "../types";
+import { isRestoreStepEnabled } from "../helpers/createFirmwareUpdateSteps";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -98,9 +98,8 @@ const StepFlashMcu = ({
         .subscribe({
           next: setUpdatedDeviceInfo,
           complete: () => {
-            const shouldGoToLanguageStep =
-              firmware && isDeviceLocalizationSupported(firmware.final.name, deviceModelId);
-            transitionTo(shouldGoToLanguageStep ? "restore" : "finish");
+            const nextStep = isRestoreStepEnabled(deviceModelId, firmware) ? "restore" : "finish";
+            transitionTo(nextStep);
           },
           error: (error: Error) => {
             setError(error);
@@ -132,8 +131,6 @@ const StepFlashMcu = ({
 
   // Updates the MCU
   useEffect(() => {
-    if (!firmware) return;
-
     setTimeout(() => {
       setInitialDelayPhase(false);
     }, DELAY_PHASE);

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/02-step-updating.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/02-step-updating.tsx
@@ -12,6 +12,7 @@ import { mockedEventEmitter } from "~/renderer/components/debug/DebugMock";
 import { renderFirmwareUpdating } from "~/renderer/components/DeviceAction/rendering";
 import useTheme from "~/renderer/hooks/useTheme";
 import { StepProps } from "../types";
+import { isRestoreStepEnabled } from "../helpers/createFirmwareUpdateSteps";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -56,7 +57,8 @@ const StepUpdating = ({
       .subscribe({
         next: setUpdatedDeviceInfo,
         complete: () => {
-          transitionTo("restore");
+          const nextStep = isRestoreStepEnabled(deviceModelId, firmware) ? "restore" : "finish";
+          transitionTo(nextStep);
         },
         error: (error: Error) => {
           setError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/types.ts
@@ -13,7 +13,7 @@ export const STEPS = {
 export type StepId = (typeof STEPS)[keyof typeof STEPS];
 
 export type StepProps = {
-  firmware?: FirmwareUpdateContext;
+  firmware: FirmwareUpdateContext;
   appsToBeReinstalled: boolean;
   onDrawerClose: (reinstall?: boolean) => void;
   error?: Error | null | undefined;


### PR DESCRIPTION
also fix unnecessary optional type

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Firmware update on LLD

### 📝 Description

For devices / old firmwares not supporting device localisation (language packs), the update process on LLD was breaking as it was trying to go to the restore step which does not exist.

This bug affects Nano S of course but also all Nano X and SP firmwares old enough that they don't have an upgrade path straight to a firmware version supporting the device localisation.

I have patched this issue for the "restore" step but a deeper rework of the firmware update process on LLD would be wise later on as the way of doing things might lead to another similar bug in the future. Right now, due to the current stack and lack of ways for mocking firmware updates, doing a rework of the flow brings too much risk so it's not done in this PR.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-11555] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-11555]: https://ledgerhq.atlassian.net/browse/LIVE-11555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ