### PR TITLE
[LIVE-13596] Bugfix - Remove `NotEnoughBalanceInParentAccount` error from coin-evm

### DIFF
--- a/.changeset/two-rabbits-fail.md
+++ b/.changeset/two-rabbits-fail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Remove `NotEnoughBalanceInParentAccount` error from `validateAmount` check in `getTransactionStatus` as it was redundant with a `validateGas` test

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -8,7 +8,6 @@ import {
   InvalidAddress,
   MaxFeeTooLow,
   NotEnoughBalance,
-  NotEnoughBalanceInParentAccount,
   NotEnoughGas,
   PriorityFeeHigherThanMaxFee,
   PriorityFeeTooHigh,
@@ -242,18 +241,15 @@ describe("EVM Family", () => {
           );
         });
 
-        it("should detected parent account not having enough fund for a token transaction and have an error", async () => {
+        it("should detect token account not having enough balance for a tx and have an error", async () => {
           const res = await getTransactionStatus(
-            {
-              ...account,
-              balance: new BigNumber(0),
-            },
+            { ...account, subAccounts: [{ ...tokenAccount, balance: new BigNumber(0) }] },
             erc20Transaction,
           );
 
           expect(res.errors).toEqual(
             expect.objectContaining({
-              amount: new NotEnoughBalanceInParentAccount(),
+              amount: new NotEnoughBalance(),
             }),
           );
         });

--- a/libs/coin-modules/coin-evm/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-evm/src/getTransactionStatus.ts
@@ -7,7 +7,6 @@ import {
   InvalidAddress,
   MaxFeeTooLow,
   NotEnoughBalance,
-  NotEnoughBalanceInParentAccount,
   NotEnoughGas,
   PriorityFeeHigherThanMaxFee,
   PriorityFeeTooHigh,
@@ -118,9 +117,7 @@ const validateAmount = (
     errors.amount = new AmountRequired(); // "Amount required"
   } else if (totalSpent.isGreaterThan(account.balance)) {
     // if not enough to make the transaction
-    errors.amount = isTokenTransaction
-      ? new NotEnoughBalanceInParentAccount() // Insufficient balance in the parent account
-      : new NotEnoughBalance(); // "Sorry, insufficient funds"
+    errors.amount = new NotEnoughBalance(); // "Sorry, insufficient funds"
   }
   return [errors, warnings];
 };


### PR DESCRIPTION
from amount validation, the test is redundant with `validateGas` tests

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Change of error message

### 📝 Description

Simply removes the redundant test in `getTransactionStatus` returning a `NotEnoughBalanceInParentAccount` error for Token transactions with not enough balance to pay for the fees. This specific test is already done in the `validateGas` function.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
