### PR TITLE
[LIVE-13575][LLD, LLM][MyLedger]: Filtering of apps depending on feature flag

### DIFF
--- a/.changeset/khaki-melons-exist.md
+++ b/.changeset/khaki-melons-exist.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+My Ledger: fix & refactor logic of "is app supported by Ledger Live" depending on feature flags, and associated filters in apps catalog. Now this logic is in one single place and fully unit tested.

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/AppActions.tsx
@@ -61,7 +61,6 @@ type Props = {
   setAppUninstallDep?: (a: { dependents: App[]; app: App }) => void;
   isLiveSupported: boolean;
   addAccount?: () => void;
-  featureFlagActivated: boolean;
 };
 
 // eslint-disable-next-line react/display-name
@@ -80,7 +79,6 @@ const AppActions = React.memo(
     setAppUninstallDep,
     isLiveSupported,
     addAccount,
-    featureFlagActivated,
   }: Props) => {
     const { name, type } = app;
 
@@ -141,7 +139,7 @@ const AppActions = React.memo(
 
     // FIXME: given the heavy use of conditions in the rendering logic below,
     // it would be better to derive this value from the same rendering logic...
-    const hasTwoItems = showLearnMore || (hasSpecificAction && installed && featureFlagActivated);
+    const hasTwoItems = showLearnMore || (hasSpecificAction && installed);
 
     return (
       <AppActionsWrapper right={!hasTwoItems}>
@@ -182,7 +180,7 @@ const AppActions = React.memo(
           />
         ) : showActions ? (
           <>
-            {installed && featureFlagActivated ? (
+            {installed ? (
               isCurrencyApp && isLiveSupported ? (
                 <Tooltip
                   content={

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, memo, useCallback, useEffect, useRef, useMemo } from "react";
+import React, { useState, memo, useCallback, useEffect, useRef } from "react";
 import { useLocation, useHistory } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
@@ -21,12 +21,10 @@ import { openModal } from "~/renderer/actions/modals";
 import debounce from "lodash/debounce";
 import InstallSuccessBanner from "./InstallSuccessBanner";
 import SearchBox from "../../../accounts/AccountList/SearchBox";
-import { App, FeatureId } from "@ledgerhq/types-live";
+import { App } from "@ledgerhq/types-live";
 import { AppType, SortOptions } from "@ledgerhq/live-common/apps/filtering";
 import NoResults from "~/renderer/icons/NoResults";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/index";
-import camelCase from "lodash/camelCase";
 import { getEnv } from "@ledgerhq/live-env";
 
 // sticky top bar with extra width to cover card boxshadow underneath
@@ -128,17 +126,6 @@ const AppsList = ({
 
   const displayedAppList = isDeviceTab ? device : catalog;
 
-  const { getFeature } = useFeatureFlags();
-  const enabledAppList = useMemo(
-    () =>
-      displayedAppList.filter(({ currencyId }: App) => {
-        if (!currencyId) return true;
-        const currencyFeatureKey = camelCase(`currency_${currencyId}`) as FeatureId;
-        return getFeature(currencyFeatureKey)?.enabled ?? true;
-      }),
-    [displayedAppList, getFeature],
-  );
-
   const mapApp = useCallback(
     (app: App, appStoreView: boolean, onlyUpdate?: boolean, showActions?: boolean) => {
       return (
@@ -238,8 +225,8 @@ const AppsList = ({
                 />
               )}
             </FilterHeader>
-            {enabledAppList.length ? (
-              enabledAppList.map((app: App) => mapApp(app, !isDeviceTab))
+            {displayedAppList.length ? (
+              displayedAppList.map((app: App) => mapApp(app, !isDeviceTab))
             ) : (
               <Placeholder
                 query={query}

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/AppsScreen.tsx
@@ -17,7 +17,7 @@ import {
   predictOptimisticState,
   reducer,
 } from "@ledgerhq/live-common/apps/index";
-import { App, DeviceInfo, FeatureId } from "@ledgerhq/types-live";
+import { App, DeviceInfo } from "@ledgerhq/types-live";
 import { useAppsSections } from "@ledgerhq/live-common/apps/react";
 
 import { Text, Flex } from "@ledgerhq/native-ui";
@@ -51,8 +51,6 @@ import { ScreenName } from "~/const";
 import { lastSeenDeviceSelector } from "~/reducers/settings";
 import ProviderWarning from "./ProviderWarning";
 import { UpdateStep } from "../FirmwareUpdate";
-import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/index";
-import camelCase from "lodash/camelCase";
 import { useTheme } from "styled-components/native";
 import KeyboardView from "~/components/KeyboardView";
 import { getEnv } from "@ledgerhq/live-env";
@@ -392,17 +390,6 @@ const AppsScreen = ({
     [listHeader, onScroll, renderFooter, renderRow, renderSearchBar],
   );
 
-  const { getFeature, isFeature } = useFeatureFlags();
-  const enabledApps = useMemo(
-    () =>
-      catalog.filter(({ currencyId }: App) => {
-        if (!currencyId) return true;
-        const currencyFeatureKey = camelCase(`currency_${currencyId}`) as FeatureId;
-        return isFeature(currencyFeatureKey) ? getFeature(currencyFeatureKey)?.enabled : true;
-      }),
-    [catalog, getFeature, isFeature],
-  );
-
   return (
     <Flex flex={1} bg="background.main" px={6}>
       <Search
@@ -412,7 +399,7 @@ const AppsScreen = ({
           shouldSort: false,
         }}
         value={query.trim()}
-        items={enabledApps}
+        items={catalog}
         render={renderList}
         renderEmptySearch={renderList}
       />

--- a/libs/ledger-live-common/src/apps/filtering.ts
+++ b/libs/ledger-live-common/src/apps/filtering.ts
@@ -1,7 +1,8 @@
+import camelCase from "lodash/fp/camelCase";
 import type { InstalledItem } from "./types";
 import { getCryptoCurrencyById, isCurrencySupported } from "../currencies";
 import { useMemo } from "react";
-import type { App } from "@ledgerhq/types-live";
+import type { App, Feature, FeatureId } from "@ledgerhq/types-live";
 
 export type SortOptions = {
   type?: "name" | "marketcap" | "default";
@@ -21,6 +22,8 @@ export type FilterOptions = {
   installQueue?: string[];
   installedApps: InstalledItem[];
   type: AppType[];
+  isFeature: (key: string) => boolean;
+  getFeature: (key: FeatureId) => Feature | null;
 };
 
 type UpdateAwareInstalledApps = Record<string, boolean>;
@@ -39,13 +42,40 @@ const searchFilter =
     return queries.some(query => terms.toLowerCase().includes(query));
   };
 
+/**
+ * Checks if the app's associated currency is supported in Ledger Live.
+ *
+ * It boils down to: if the app has a currencyId, check if the currency is supported.
+ * The currency can be unsupported if there is a feature flag that disables it.
+ */
+export function isAppAssociatedCurrencySupported({
+  app,
+  isFeature,
+  getFeature,
+}: {
+  app: App;
+  isFeature: (key: string) => boolean;
+  getFeature: (key: FeatureId) => Feature | null;
+}): boolean {
+  if (["swap", "plugin"].includes(app.type)) return true;
+  if (!app.currencyId) return false;
+  if (!isCurrencySupported(getCryptoCurrencyById(app.currencyId))) return false;
+
+  const currencyFeatureKey = camelCase(`currency_${app.currencyId}`) as FeatureId;
+  if (!isFeature(currencyFeatureKey)) return true; // no associated feature flag, the currency is supported
+  if (getFeature(currencyFeatureKey)?.enabled === false) return false;
+  return true;
+}
+
 function typeFilter(
   filters: AppType[] = ["all"],
   updateAwareInstalledApps: UpdateAwareInstalledApps,
   installQueue: string[] = [],
+  isFeature: (key: string) => boolean,
+  getFeature: (key: FeatureId) => Feature | null,
 ) {
-  return (app: App): boolean => {
-    return filters.every(filter => {
+  return (app: App): boolean =>
+    filters.every(filter => {
       switch (filter) {
         case "installed":
           return installQueue.includes(app.name) || app.name in updateAwareInstalledApps;
@@ -54,14 +84,13 @@ function typeFilter(
         case "updatable":
           return app.name in updateAwareInstalledApps && !updateAwareInstalledApps[app.name];
         case "supported":
-          return app.currencyId && isCurrencySupported(getCryptoCurrencyById(app.currencyId));
+          return isAppAssociatedCurrencySupported({ app, isFeature, getFeature });
         case "not_supported":
-          return !app.currencyId || !isCurrencySupported(getCryptoCurrencyById(app.currencyId));
+          return !isAppAssociatedCurrencySupported({ app, isFeature, getFeature });
         default:
           return true;
       }
     });
-  };
 }
 
 export const sortApps = (apps: App[], _options: SortOptions): App[] => {
@@ -90,7 +119,15 @@ export const filterApps = (apps: App[], _options: FilterOptions): App[] => {
 
   return apps
     .filter(searchFilter(query))
-    .filter(typeFilter(type, updateAwareInstalledApps, installQueue));
+    .filter(
+      typeFilter(
+        type,
+        updateAwareInstalledApps,
+        installQueue,
+        _options.isFeature,
+        _options.getFeature,
+      ),
+    );
 };
 
 export const sortFilterApps = (
@@ -106,23 +143,8 @@ export const useSortedFilteredApps = (
   _filterOptions: FilterOptions,
   _sortOptions: SortOptions,
 ): App[] => {
-  const { query, installedApps, type: filterType, installQueue } = _filterOptions;
-  const { type: sortType, order } = _sortOptions;
   return useMemo(
-    () =>
-      sortFilterApps(
-        apps,
-        {
-          query,
-          installedApps,
-          type: filterType,
-          installQueue,
-        },
-        {
-          type: sortType,
-          order,
-        },
-      ),
-    [apps, query, installedApps, filterType, installQueue, sortType, order],
+    () => sortFilterApps(apps, _filterOptions, _sortOptions),
+    [apps, _filterOptions, _sortOptions],
   );
 };

--- a/libs/ledger-live-common/src/apps/react.ts
+++ b/libs/ledger-live-common/src/apps/react.ts
@@ -1,6 +1,6 @@
 import { useState, useReducer, useEffect, useMemo } from "react";
 import type { Exec, State, Action, ListAppsResult } from "./types";
-import type { AppType, SortOptions } from "./filtering";
+import type { AppType, FilterOptions, SortOptions } from "./filtering";
 import { useSortedFilteredApps } from "./filtering";
 import {
   reducer,
@@ -11,6 +11,7 @@ import {
 } from "./logic";
 import { runAppOp } from "./runner";
 import { App } from "@ledgerhq/types-live";
+import { useFeatureFlags } from "../featureFlags";
 
 type UseAppsRunnerResult = [State, (arg0: Action) => void];
 // use for React apps. support dynamic change of the state.
@@ -85,17 +86,21 @@ export function useAppsSections(state: State, opts: AppsSectionsOpts): AppsSecti
     () => apps.filter(({ name }) => installed.some(i => i.name === name && !i.updated)),
     [apps, installed],
   );
+  const { getFeature, isFeature } = useFeatureFlags();
   const update = appsUpdating.length > 0 ? appsUpdating : updatableAppList;
-  const filterParam = useMemo(
+  const filterParam: FilterOptions = useMemo(
     () => ({
       query: opts.query,
       installedApps: installed,
       type: [opts.appFilter],
+      getFeature,
+      isFeature,
     }),
-    [installed, opts.appFilter, opts.query],
+    [getFeature, installed, isFeature, opts.appFilter, opts.query],
   );
 
   const catalog = useSortedFilteredApps(apps, filterParam, opts.sort);
+
   const installedAppList = useSortedFilteredApps(
     apps,
     {
@@ -103,6 +108,8 @@ export function useAppsSections(state: State, opts: AppsSectionsOpts): AppsSecti
       installedApps: installed,
       installQueue,
       type: ["installed"],
+      getFeature,
+      isFeature,
     },
     {
       type: "default",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - My Ledger app catalog

### 📝 Description

Fix & refactor the  logic of "is app supported by Ledger Live" depending on feature flags, as well as associated filters in apps catalog.
Now this logic is in one single place and fully unit tested.

The main issue addressed is that for apps that associated to a currency with a feature flag, those apps were totally gone from the catalog if the feature flag was disabled, which shouldn't be the case. The correct behaviour is to filter out those apps only when the filter "Supported in Live" is selected.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13575]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13575]: https://ledgerhq.atlassian.net/browse/LIVE-13575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ