### PR TITLE
chore(lld): handle uncaughtException to console instead of Electron GUI

### DIFF
--- a/apps/ledger-live-desktop/src/main/setup.ts
+++ b/apps/ledger-live-desktop/src/main/setup.ts
@@ -147,6 +147,15 @@ ipcMain.handle("deactivate-keep-screen-awake", (_ev, id?: number) => {
 
 process.setMaxListeners(0);
 
+// In production mode, we do not want Electron's default GUI to show the error. Instead we will output to the console.
+if (!__DEV__) {
+  process.on("uncaughtException", function (error) {
+    const stack = error.stack ? error.stack : `${error.name}: ${error.message}`;
+    const message = "Uncaught Exception:\n" + stack;
+    console.error(message);
+  });
+}
+
 // eslint-disable-next-line no-console
 console.log(`Ledger Live ${__APP_VERSION__}`);
 contextMenu({


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD, click on a URI scheme from inside a iframe.

### 📝 Description

- Some `Render frame was disposed before WebFrameMain could be accessed` error occurs on a second `will-frame-navigate` Event from an iframe done in our Electron app.
- This makes LLD's showing a GUI popup with the error shown to the user which is due to Electron's default implementation of handling `uncaughtException` in here: https://github.com/electron/electron/blob/ba8ad4716b58bb84bca85282f4ccbbd19af828a5/lib/browser/init.ts#L21-L37
- As we don't need this `will-frame-navigate` event at all, we can afford to just ignore the error, and instead of having Electron's default impl, we will provide our own uncaughtException handler **in production mode** to be outputting errors to **console.error** instead of an annoying popup on user's side.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-12926

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
