### PR TITLE
chore(walletsync): clean up TODOs comments

### DIFF
--- a/libs/live-wallet/src/cloudsync/sdk.ts
+++ b/libs/live-wallet/src/cloudsync/sdk.ts
@@ -109,8 +109,7 @@ export class CloudSyncSDK<Schema extends ZodType, Data = z.infer<Schema>>
         break;
       }
       case "out-of-sync": {
-        // WHAT TO DO? maybe we ignore because in this case we just wait for a pull?
-        console.warn("out-of-sync", response);
+        // TODO: LIVE-13634
       }
     }
   }

--- a/libs/live-wallet/src/cloudsync/sdk.ts
+++ b/libs/live-wallet/src/cloudsync/sdk.ts
@@ -109,7 +109,7 @@ export class CloudSyncSDK<Schema extends ZodType, Data = z.infer<Schema>>
         break;
       }
       case "out-of-sync": {
-        // TODO: LIVE-13634
+        // nothing to do. we will just eventually retry in the watch loop.
       }
     }
   }

--- a/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
+++ b/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
@@ -133,7 +133,6 @@ export function createWalletSyncWatchLoop<UserState, LocalState, Update, Schema 
       if (onStartPolling) onStartPolling();
 
       // check if there is a pull to do
-      // TODO this needs to be called separately, probably more often than the rest of this logic.
       await walletSyncSdk.pull(trustchain, memberCredentials);
       if (unsubscribed) return;
 

--- a/libs/live-wallet/src/walletsync/modules/README.md
+++ b/libs/live-wallet/src/walletsync/modules/README.md
@@ -40,7 +40,6 @@ const manager: WalletSyncDataManager<
       return { hasChanges: false };
     }
 
-    // TODO: we should implement a smarter diffing here
     // let hasChanges = false;
     // if (!hasChanges) {
     //   return { hasChanges: false };


### PR DESCRIPTION
<!--

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** no need. <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact

### 📝 Description

replace TODOs by Jira tickets.

- `LIVE 13633`
- `LIVE 13634` + no more console.warn in CloudSyncSDK#push out-of-sync case
- useless todo in the template of walletsync module

### ❓ Context

- **JIRA or GitHub link**: N/A


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
