### PR TITLE
chore(trustchain): remove console.error that are annoying for LLM development

### DIFF
--- a/libs/trustchain/src/qrcode/index.ts
+++ b/libs/trustchain/src/qrcode/index.ts
@@ -4,6 +4,7 @@ import { MemberCredentials, Trustchain, TrustchainMember } from "../types";
 import { makeCipher, makeMessageCipher } from "./cipher";
 import { Message } from "./types";
 import { InvalidDigitsError } from "../errors";
+import { log } from "@ledgerhq/logs";
 
 const version = 1;
 
@@ -109,7 +110,6 @@ export async function createQRCodeHostInstance({
           }
           case "Failure": {
             finished = true;
-            console.error(data);
             const error = fromErrorMessage(data.payload);
             reject(error);
             ws.close();
@@ -120,7 +120,6 @@ export async function createQRCodeHostInstance({
           }
         }
       } catch (e) {
-        console.error(e);
         ws.close();
         reject(e);
       }
@@ -214,7 +213,7 @@ export async function createQRCodeCandidateInstance({
           }
           case "Failure": {
             finished = true;
-            console.error(data);
+            log("trustchain/qrcode", "Failure", { data });
             const error = fromErrorMessage(data.payload);
             reject(error);
             ws.close();
@@ -224,7 +223,6 @@ export async function createQRCodeCandidateInstance({
             throw new Error("unexpected message");
         }
       } catch (e) {
-        console.error(e);
         ws.close();
         reject(e);
       }


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.**  no need <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - logs

### 📝 Description

we don't need to `console.error` when the error is returned in a Promise reject, the other side could possibly log it, but it's also a normal user flow (if you input the wrong digits) so we shouldn't console.error it. especially that on React Native, it would display as an error screen in dev mode.

### ❓ Context

- **JIRA or GitHub link**: na


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
