### PR TITLE
LIVE-13406 display operation denied screen instead of enable blind signing screen

### DIFF
--- a/.changeset/tidy-zoos-remain.md
+++ b/.changeset/tidy-zoos-remain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-eth": patch
+---
+
+remapTransactionRelatedErrors maps 0x6a80 to operation denied error

--- a/libs/ledgerjs/packages/hw-app-eth/src/Eth.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/Eth.ts
@@ -31,7 +31,7 @@ import {
 } from "./utils";
 import { domainResolutionFlow } from "./modules/Domains";
 import ledgerService from "./services/ledger";
-import { EthAppNftNotSupported, EthAppPleaseEnableContractData } from "./errors";
+import { EthAppNftNotSupported, EthAppOperationDenied } from "./errors";
 import { signEIP712HashedMessage, signEIP712Message } from "./modules/EIP712";
 import { EIP712Message } from "@ledgerhq/types-live";
 
@@ -49,9 +49,7 @@ const starkQuantizationTypeMap = {
 
 const remapTransactionRelatedErrors = e => {
   if (e && e.statusCode === 0x6a80) {
-    return new EthAppPleaseEnableContractData(
-      "Please enable Blind signing or Contract data in the Ethereum app Settings",
-    );
+    return new EthAppOperationDenied();
   }
 
   return e;

--- a/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
@@ -4,3 +4,4 @@ export const EthAppPleaseEnableContractData = createCustomErrorClass(
   "EthAppPleaseEnableContractData",
 );
 export const EthAppNftNotSupported = createCustomErrorClass("EthAppNftNotSupported");
+export const EthAppOperationDenied = createCustomErrorClass("TransactionRefusedOnDevice");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:**  When blind signing and rejecting a transaction, display the operation denied screen (you'll find screenshots of the error screens in jira issue)
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: LIVE-13406


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
