### PR TITLE
fix(trustchain): removed member ejected on get members

### DIFF
--- a/.changeset/breezy-cups-flow.md
+++ b/.changeset/breezy-cups-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/trustchain": patch
+---
+
+Trustchain - Removed member ejected on get members

--- a/libs/trustchain/src/sdk.ts
+++ b/libs/trustchain/src/sdk.ts
@@ -197,7 +197,11 @@ export class SDK implements TrustchainSDK {
     const { resolved } = await this.withAuth(trustchain, memberCredentials, jwt =>
       this.fetchTrustchainAndResolve(jwt, trustchain.rootId, this.context.applicationId),
     );
-    return resolved.getMembersData();
+    const members = resolved.getMembersData();
+    if (!members.some(m => m.id === memberCredentials.pubkey)) {
+      throw new TrustchainEjected("Not a member of trustchain");
+    }
+    return members;
   }
 
   async removeMember(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

If current member is not in the result of the get members, we throw a TrustchainEjected error. It is catched by LLM and LLD to redirect the user to the synchronize screen

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13409]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13409]: https://ledgerhq.atlassian.net/browse/LIVE-13409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ