### PR TITLE
:lipstick:feat(llm/ui): tab selector width

### DIFF
--- a/.changeset/early-plums-train.md
+++ b/.changeset/early-plums-train.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/native-ui": patch
+---
+
+Make llm tab selector component size following the size of the biggest label

--- a/libs/ui/packages/native/src/components/Form/TabSelector/index.tsx
+++ b/libs/ui/packages/native/src/components/Form/TabSelector/index.tsx
@@ -5,13 +5,13 @@ import styled, { useTheme } from "styled-components/native";
 import { TouchableOpacity } from "react-native";
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from "react-native-reanimated";
 
-const StyledTouchableOpacity = styled(TouchableOpacity)`
+const StyledTouchableOpacity = styled(TouchableOpacity)<{ width: number }>`
+  width: ${(p) => p.width}px;
   flex: 1;
-  overflow: hidden;
+  height: 100%;
 `;
 
 const StyledFlex = styled(Flex)<{ isSelected: boolean }>`
-  width: 100%;
   height: 100%;
   justify-content: center;
   align-items: center;
@@ -19,6 +19,7 @@ const StyledFlex = styled(Flex)<{ isSelected: boolean }>`
 
 const StyledText = styled(Text)<{ isSelected: boolean }>`
   line-height: 14.52px;
+  overflow: visible;
   text-align: center;
   font-size: 12px;
   color: ${(p) =>
@@ -30,6 +31,7 @@ interface OptionButtonProps<T> {
   selectedOption: T;
   handleSelectOption: (option: T) => void;
   label: string;
+  width: number;
 }
 
 const OptionButton = <T,>({
@@ -37,18 +39,14 @@ const OptionButton = <T,>({
   selectedOption,
   handleSelectOption,
   label,
+  width,
 }: OptionButtonProps<T>) => {
   const isSelected = selectedOption === option;
 
   return (
-    <StyledTouchableOpacity onPress={() => handleSelectOption(option)}>
+    <StyledTouchableOpacity width={width} onPress={() => handleSelectOption(option)}>
       <StyledFlex isSelected={isSelected}>
-        <StyledText
-          fontWeight="semiBold"
-          isSelected={isSelected}
-          ellipsizeMode="tail"
-          numberOfLines={1}
-        >
+        <StyledText fontWeight="semiBold" isSelected={isSelected} numberOfLines={1}>
           {label}
         </StyledText>
       </StyledFlex>
@@ -70,10 +68,18 @@ export default function TabSelector<T extends string | number>({
   labels,
 }: TabSelectorProps<T>): JSX.Element {
   const { colors } = useTheme();
-  const translateX = useSharedValue(-39);
+
+  const longuestLabel =
+    labels[options[0]].length > labels[options[1]].length ? options[0] : options[1];
+
+  const widthFactor = 8;
+  const margin = 20;
+  const width = labels[longuestLabel].length * widthFactor + margin;
+  const semiWidth = width / 2;
+  const translateX = useSharedValue(-semiWidth);
 
   useEffect(() => {
-    translateX.value = withSpring(selectedOption === options[0] ? -40 : 40, {
+    translateX.value = withSpring(selectedOption === options[0] ? -semiWidth : semiWidth, {
       damping: 30,
       stiffness: 80,
     });
@@ -90,18 +96,18 @@ export default function TabSelector<T extends string | number>({
       flexDirection={"row"}
       justifyContent={"center"}
       alignItems={"center"}
-      width={"157px"}
+      width={width * 2 + 4}
       height={"35px"}
       borderRadius={"40px"}
-      padding={"2px"}
       bg={colors.opacityDefault.c05}
+      position={"relative"}
     >
       <Animated.View
         style={[
           {
             position: "absolute",
-            width: "48%",
-            height: "96%",
+            width: width - 2,
+            height: "90%",
             backgroundColor: colors.primary.c80,
             borderRadius: 40,
           },
@@ -110,7 +116,8 @@ export default function TabSelector<T extends string | number>({
       />
       {options.map((option) => (
         <OptionButton
-          key={option as unknown as string}
+          width={width}
+          key={option}
           option={option}
           selectedOption={selectedOption}
           handleSelectOption={handleSelectOption}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - RN UI lib

### 📝 Description

Make the tab selector component more responsive based on the size of the largest option. 

On storybook
https://github.com/user-attachments/assets/8582fd04-1575-4357-be17-3664c6026bc4

On LLM WS Drawer
https://github.com/user-attachments/assets/7bd8808b-68d7-44b2-8cfb-c6793108da2d


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  No Ticket<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
