### PR TITLE
CN-197: add param partnerTestBaseUrl to be passed to buy-sell app

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -98,6 +98,10 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
             ...customUrlParams,
             lang: locale,
             devMode,
+            ...(manifest?.providerTestBaseUrl && {
+              providerTestBaseUrl: manifest?.providerTestBaseUrl,
+            }),
+
             ...Object.fromEntries(searchParams.entries()),
           }}
         />

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -98,8 +98,8 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
             ...customUrlParams,
             lang: locale,
             devMode,
-            ...(manifest?.providerTestBaseUrl && {
-              providerTestBaseUrl: manifest?.providerTestBaseUrl,
+            ...(localManifest?.providerTestBaseUrl && {
+              providerTestBaseUrl: localManifest?.providerTestBaseUrl,
             }),
 
             ...Object.fromEntries(searchParams.entries()),

--- a/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/BuyAndSell/index.tsx
@@ -97,6 +97,9 @@ export function BuyAndSellScreen({ route }: Props) {
           theme,
           lang: locale,
           devMode,
+          ...(localManifest?.providerTestBaseUrl && {
+            providerTestBaseUrl: localManifest?.providerTestBaseUrl,
+          }),
           ...customParams,
           ...Object.fromEntries(searchParams.entries()),
         }}

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -126,6 +126,7 @@ export type LiveAppManifest = {
   currencies: string[] | "*";
   visibility: Visibility;
   highlight?: boolean;
+  providerTestBaseUrl?: string;
   content: {
     cta?: TranslatableString;
     subtitle?: TranslatableString;


### PR DESCRIPTION
### Description

This PR accepts another a new variable only from a local manifest called `providerTestBaseUrl` which would be passed to the `buy-sell-ui` that will use it for changing the widgetUrl for allowing us and partners to test in staging or dev environments. 

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
