### PR TITLE
fix: missing query params for web3hub manifests requests [LIVE-13726]

### DIFF
--- a/.changeset/eighty-candles-boil.md
+++ b/.changeset/eighty-candles-boil.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: missing query params for web3hub manifests requests

--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 36176158
-        versionName "3.40.1"
+        versionName "3.48.0"
         resValue "string", "build_config_package", "com.ledger.live"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
@@ -35,7 +35,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.40.1</string>
+	<string>3.48.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/useManifestsListViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/ManifestsList/useManifestsListViewModel.ts
@@ -1,20 +1,39 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import {
   fetchManifests,
   selectManifests,
   getNextPageParam,
   fetchManifestsMock,
 } from "LLM/features/Web3Hub/utils/api/manifests";
+import { useLocale } from "~/context/Locale";
 
-export const queryKey = (selectedCategory: string) => ["web3hub/manifests", selectedCategory];
+export const queryKey = (
+  selectedCategory: string,
+  isExperimentalAppEnabled: boolean,
+  isDebugAppEnabled: boolean,
+  locale: string,
+) => [
+  "web3hub/manifests",
+  selectedCategory,
+  isExperimentalAppEnabled ? "exp-on" : "exp-off",
+  isDebugAppEnabled ? "debug-on" : "debug-off",
+  locale,
+];
 
 const isInTest = process.env.NODE_ENV === "test" || !!process.env.MOCK_WEB3HUB;
 const queryFn = isInTest ? fetchManifestsMock : fetchManifests;
 
 export default function useManifestListViewModel(selectedCategory: string) {
+  const isExperimentalAppEnabled = useEnv<"PLATFORM_EXPERIMENTAL_APPS">(
+    "PLATFORM_EXPERIMENTAL_APPS",
+  ) as boolean;
+  const isDebugAppEnabled = useEnv<"PLATFORM_DEBUG">("PLATFORM_DEBUG") as boolean;
+  const { locale } = useLocale();
+
   const manifestsQuery = useInfiniteQuery({
-    queryKey: queryKey(selectedCategory),
-    queryFn: queryFn(selectedCategory, ""),
+    queryKey: queryKey(selectedCategory, isExperimentalAppEnabled, isDebugAppEnabled, locale),
+    queryFn: queryFn(selectedCategory, "", isExperimentalAppEnabled, isDebugAppEnabled, locale),
     initialPageParam: 1,
     getNextPageParam,
     select: selectManifests,

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/useWeb3HubAppViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/useWeb3HubAppViewModel.ts
@@ -1,15 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchManifestById, fetchManifestByIdMock } from "LLM/features/Web3Hub/utils/api/manifests";
+import { useLocale } from "~/context/Locale";
 
-export const queryKey = (manifestId: string) => ["web3hub/manifest", manifestId];
+export const queryKey = (manifestId: string, locale: string) => [
+  "web3hub/manifest",
+  manifestId,
+  locale,
+];
 
 const isInTest = process.env.NODE_ENV === "test" || !!process.env.MOCK_WEB3HUB;
 const queryFn = isInTest ? fetchManifestByIdMock : fetchManifestById;
 
 export default function useWeb3HubAppViewModel(manifestId: string) {
+  const { locale } = useLocale();
+
   const manifestQuery = useQuery({
-    queryKey: queryKey(manifestId),
-    queryFn: queryFn(manifestId),
+    queryKey: queryKey(manifestId, locale),
+    queryFn: queryFn(manifestId, locale),
   });
 
   return {

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/components/Header/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubMain/components/Header/index.tsx
@@ -5,9 +5,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@react-navigation/native";
 import { SharedValue } from "react-native-reanimated";
 import { Flex, Text } from "@ledgerhq/native-ui";
-import { useQueryClient } from "@tanstack/react-query";
 import type { MainProps } from "LLM/features/Web3Hub/types";
-import { queryKey } from "LLM/features/Web3Hub/components/ManifestsList/useManifestsListViewModel";
 import AnimatedBar from "LLM/features/Web3Hub/components/AnimatedBar";
 import TabButton from "LLM/features/Web3Hub/components/TabButton";
 import TextInput from "~/components/TextInput";
@@ -35,13 +33,6 @@ export default function Web3HubMainHeader({ title, navigation, layoutY }: Props)
     });
   }, [navigation]);
 
-  // TODO remove later
-  // Useful for testing the infinite loading and onEndReach working correctly
-  const queryClient = useQueryClient();
-  const clearCache = useCallback(() => {
-    queryClient.resetQueries({ queryKey: queryKey("all") });
-  }, [queryClient]);
-
   return (
     <AnimatedBar
       pt={insets.top}
@@ -52,11 +43,9 @@ export default function Web3HubMainHeader({ title, navigation, layoutY }: Props)
       opacityHeight={TITLE_HEIGHT}
       totalHeight={TOTAL_HEADER_HEIGHT}
       opacityChildren={
-        <TouchableOpacity onPress={clearCache}>
-          <Text mt={5} mb={2} numberOfLines={1} variant="h4" mx={5} accessibilityRole="header">
-            {title}
-          </Text>
-        </TouchableOpacity>
+        <Text mt={5} mb={2} numberOfLines={1} variant="h4" mx={5} accessibilityRole="header">
+          {title}
+        </Text>
       }
     >
       <Flex height={SEARCH_HEIGHT} ml={5} flexDirection="row" alignItems="center">

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/components/SearchList/useSearchListViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/components/SearchList/useSearchListViewModel.ts
@@ -1,20 +1,44 @@
+import { useMemo } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import {
   fetchManifests,
   selectManifests,
   getNextPageParam,
   fetchManifestsMock,
 } from "LLM/features/Web3Hub/utils/api/manifests";
+import { useLocale } from "~/context/Locale";
 
-export const queryKey = (search: string) => ["web3hub/manifests/search", search];
+export const queryKey = (
+  search: string,
+  isExperimentalAppEnabled: boolean,
+  isDebugAppEnabled: boolean,
+  locale: string,
+) => [
+  "web3hub/manifests/search",
+  search,
+  isExperimentalAppEnabled ? "exp-on" : "exp-off",
+  isDebugAppEnabled ? "debug-on" : "debug-off",
+  locale,
+];
 
 const isInTest = process.env.NODE_ENV === "test" || !!process.env.MOCK_WEB3HUB;
 const queryFn = isInTest ? fetchManifestsMock : fetchManifests;
 
 export default function useSearchListViewModel(search: string) {
+  const trimmedSearch = useMemo(() => {
+    return search.trim();
+  }, [search]);
+
+  const isExperimentalAppEnabled = useEnv<"PLATFORM_EXPERIMENTAL_APPS">(
+    "PLATFORM_EXPERIMENTAL_APPS",
+  ) as boolean;
+  const isDebugAppEnabled = useEnv<"PLATFORM_DEBUG">("PLATFORM_DEBUG") as boolean;
+  const { locale } = useLocale();
+
   const manifestsQuery = useInfiniteQuery({
-    queryKey: queryKey(search),
-    queryFn: queryFn("", search),
+    queryKey: queryKey(trimmedSearch, isExperimentalAppEnabled, isDebugAppEnabled, locale),
+    queryFn: queryFn("", trimmedSearch, isExperimentalAppEnabled, isDebugAppEnabled, locale),
     initialPageParam: 1,
     getNextPageParam,
     select: selectManifests,


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually as we use mocks on our tests
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Web3hub but still behind a disabled FF

### 📝 Description

Add missing query params for web3hub manifests requests
Also matches the current prod version for Android and iOS build in dev to get the proper manifest back from the API

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13726]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13726]: https://ledgerhq.atlassian.net/browse/LIVE-13726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ