### PR TITLE
fix: freeze when opening a live-app [LIVE-13411]

### DIFF
--- a/.changeset/tricky-forks-fly.md
+++ b/.changeset/tricky-forks-fly.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: freeze when opening a live-app

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/BottomBar.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/BottomBar.tsx
@@ -1,17 +1,12 @@
 import React, { RefObject, useCallback } from "react";
 import { TouchableOpacity } from "react-native";
-import { Flex, Text } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
 import { ArrowLeftMedium, ArrowRightMedium, ReverseMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useTheme } from "styled-components/native";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
-import { useDappCurrentAccount } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { safeGetRefValue, CurrentAccountHistDB } from "@ledgerhq/live-common/wallet-api/react";
 import { WebviewAPI, WebviewState } from "../Web3AppWebview/types";
-import Button from "../Button";
-import { Trans } from "react-i18next";
-import CircleCurrencyIcon from "../CircleCurrencyIcon";
-import { useSelectAccount } from "../Web3AppWebview/helpers";
-import { useMaybeAccountName } from "~/reducers/wallet";
+import SelectAccountButton from "./SelectAccountButton";
 
 type BottomBarProps = {
   manifest: AppManifest;
@@ -48,7 +43,6 @@ export function BottomBar({
   currentAccountHistDb,
 }: BottomBarProps) {
   const { colors } = useTheme();
-  const { currentAccount } = useDappCurrentAccount(currentAccountHistDb);
   const shouldDisplaySelectAccount = !!manifest.dapp;
 
   const handleForward = useCallback(() => {
@@ -69,10 +63,6 @@ export function BottomBar({
     webview.reload();
   }, [webviewAPIRef]);
 
-  const { onSelectAccount } = useSelectAccount({ manifest, currentAccountHistDb });
-
-  const currentAccountName = useMaybeAccountName(currentAccount);
-
   return (
     <Flex flexDirection="row" paddingY={4} paddingX={4} alignItems="center">
       <Flex flexDirection="row" flex={1}>
@@ -92,27 +82,7 @@ export function BottomBar({
       </Flex>
 
       {shouldDisplaySelectAccount ? (
-        <Button type="primary" onPress={onSelectAccount}>
-          {!currentAccount ? (
-            <Text>
-              <Trans i18nKey="common.selectAccount" />
-            </Text>
-          ) : (
-            <Flex flexDirection="row" height={50} alignItems="center" justifyContent="center">
-              <CircleCurrencyIcon
-                size={24}
-                currency={
-                  currentAccount.type === "TokenAccount"
-                    ? currentAccount.token
-                    : currentAccount.currency
-                }
-              />
-              <Text color={"neutral.c20"} ml={4}>
-                {currentAccountName}
-              </Text>
-            </Flex>
-          )}
-        </Button>
+        <SelectAccountButton manifest={manifest} currentAccountHistDb={currentAccountHistDb} />
       ) : null}
 
       <IconButton onPress={handleReload} alignSelf="flex-end">

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/SelectAccountButton.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/SelectAccountButton.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
+import { CurrentAccountHistDB } from "@ledgerhq/live-common/wallet-api/react";
+import { useDappCurrentAccount } from "@ledgerhq/live-common/wallet-api/useDappLogic";
+import Button from "~/components/Button";
+import CircleCurrencyIcon from "~/components/CircleCurrencyIcon";
+import { useSelectAccount } from "~/components/Web3AppWebview/helpers";
+import { useMaybeAccountName } from "~/reducers/wallet";
+
+type SelectAccountButtonProps = {
+  manifest: AppManifest;
+  currentAccountHistDb: CurrentAccountHistDB;
+};
+
+export default function SelectAccountButton({
+  manifest,
+  currentAccountHistDb,
+}: SelectAccountButtonProps) {
+  const { currentAccount } = useDappCurrentAccount(currentAccountHistDb);
+
+  const { onSelectAccount } = useSelectAccount({ manifest, currentAccountHistDb });
+
+  const currentAccountName = useMaybeAccountName(currentAccount);
+
+  return (
+    <Button type="primary" onPress={onSelectAccount}>
+      {!currentAccount ? (
+        <Text>
+          <Trans i18nKey="common.selectAccount" />
+        </Text>
+      ) : (
+        <Flex flexDirection="row" height={50} alignItems="center" justifyContent="center">
+          <CircleCurrencyIcon
+            size={24}
+            currency={
+              currentAccount.type === "TokenAccount"
+                ? currentAccount.token
+                : currentAccount.currency
+            }
+          />
+          <Text color={"neutral.c20"} ml={4}>
+            {currentAccountName}
+          </Text>
+        </Flex>
+      )}
+    </Button>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Web3Player/BottomBar.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Web3Player/BottomBar.tsx
@@ -1,23 +1,18 @@
 import React, { RefObject, useCallback } from "react";
 import { TouchableOpacity } from "react-native";
 import { useTheme } from "@react-navigation/native";
-import { Trans } from "react-i18next";
 import Animated, {
   useAnimatedStyle,
   interpolate,
   Extrapolation,
   SharedValue,
 } from "react-native-reanimated";
-import { Flex, Text } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 import { ArrowLeftMedium, ArrowRightMedium, ReverseMedium } from "@ledgerhq/native-ui/assets/icons";
 import { safeGetRefValue, CurrentAccountHistDB } from "@ledgerhq/live-common/wallet-api/react";
-import { useDappCurrentAccount } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { WebviewAPI, WebviewState } from "~/components/Web3AppWebview/types";
-import Button from "~/components/Button";
-import CircleCurrencyIcon from "~/components/CircleCurrencyIcon";
-import { useSelectAccount } from "~/components/Web3AppWebview/helpers";
-import { useMaybeAccountName } from "~/reducers/wallet";
+import SelectAccountButton from "./SelectAccountButton";
 
 const BAR_HEIGHT = 60;
 export const TOTAL_HEADER_HEIGHT = BAR_HEIGHT;
@@ -61,7 +56,6 @@ export function BottomBar({
   layoutY,
 }: BottomBarProps) {
   const { colors } = useTheme();
-  const { currentAccount } = useDappCurrentAccount(currentAccountHistDb);
   const shouldDisplaySelectAccount = !!manifest.dapp;
 
   const handleForward = useCallback(() => {
@@ -81,10 +75,6 @@ export function BottomBar({
 
     webview.reload();
   }, [webviewAPIRef]);
-
-  const { onSelectAccount } = useSelectAccount({ manifest, currentAccountHistDb });
-
-  const currentAccountName = useMaybeAccountName(currentAccount);
 
   const heightStyle = useAnimatedStyle(() => {
     if (!layoutY) return {};
@@ -132,27 +122,7 @@ export function BottomBar({
           </Flex>
 
           {shouldDisplaySelectAccount ? (
-            <Button type="primary" onPress={onSelectAccount}>
-              {!currentAccount ? (
-                <Text>
-                  <Trans i18nKey="common.selectAccount" />
-                </Text>
-              ) : (
-                <Flex flexDirection="row" height={50} alignItems="center" justifyContent="center">
-                  <CircleCurrencyIcon
-                    size={24}
-                    currency={
-                      currentAccount.type === "TokenAccount"
-                        ? currentAccount.token
-                        : currentAccount.currency
-                    }
-                  />
-                  <Text color={"neutral.c20"} ml={4}>
-                    {currentAccountName}
-                  </Text>
-                </Flex>
-              )}
-            </Button>
+            <SelectAccountButton manifest={manifest} currentAccountHistDb={currentAccountHistDb} />
           ) : null}
 
           <IconButton onPress={handleReload} alignSelf="flex-end">

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Web3Player/SelectAccountButton.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Web3Player/SelectAccountButton.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
+import { CurrentAccountHistDB } from "@ledgerhq/live-common/wallet-api/react";
+import { useDappCurrentAccount } from "@ledgerhq/live-common/wallet-api/useDappLogic";
+import Button from "~/components/Button";
+import CircleCurrencyIcon from "~/components/CircleCurrencyIcon";
+import { useSelectAccount } from "~/components/Web3AppWebview/helpers";
+import { useMaybeAccountName } from "~/reducers/wallet";
+
+type SelectAccountButtonProps = {
+  manifest: AppManifest;
+  currentAccountHistDb: CurrentAccountHistDB;
+};
+
+export default function SelectAccountButton({
+  manifest,
+  currentAccountHistDb,
+}: SelectAccountButtonProps) {
+  const { currentAccount } = useDappCurrentAccount(currentAccountHistDb);
+
+  const { onSelectAccount } = useSelectAccount({ manifest, currentAccountHistDb });
+
+  const currentAccountName = useMaybeAccountName(currentAccount);
+
+  return (
+    <Button type="primary" onPress={onSelectAccount}>
+      {!currentAccount ? (
+        <Text>
+          <Trans i18nKey="common.selectAccount" />
+        </Text>
+      ) : (
+        <Flex flexDirection="row" height={50} alignItems="center" justifyContent="center">
+          <CircleCurrencyIcon
+            size={24}
+            currency={
+              currentAccount.type === "TokenAccount"
+                ? currentAccount.token
+                : currentAccount.currency
+            }
+          />
+          <Text color={"neutral.c20"} ml={4}>
+            {currentAccountName}
+          </Text>
+        </Flex>
+      )}
+    </Button>
+  );
+}


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Not really possible to test a perf regression, I validated the improvement locally
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Web3Hub live-app opening (still behind a disabled FF)
  - Discover and other live-apps (should open faster now)

### 📝 Description

This fix (https://github.com/LedgerHQ/ledger-live/pull/7230) introduced a performance regression in some cases (e.g. when a lot of tokens are defined in the currencies field of the manifest) as we now get the currency list again and again.
This PR only removes the listing of currencies that we were doing on all apps even if it was not using the dapp browser v3, this helps most apps for the moment but we still need to improve the performance of the currency listing.

In a next PR we'll try to remove the spreading done on tokens, only do the minimal work necessary to get the informations and try to improve caching on this by instead listening to changes to only pull currencies when it updates.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13411]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13411]: https://ledgerhq.atlassian.net/browse/LIVE-13411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ