### PR TITLE
fix: hidden header should show again when searching [LIVE-13727]

### DIFF
--- a/.changeset/chilled-bikes-agree.md
+++ b/.changeset/chilled-bikes-agree.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: hidden header should show again when searching

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubSearch/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import type { SearchProps } from "LLM/features/Web3Hub/types";
@@ -12,6 +12,11 @@ const edges = ["top", "bottom", "left", "right"] as const;
 export default function Web3HubSearch({ navigation }: SearchProps) {
   const [search, setSearch] = useState("");
   const { layoutY, scrollHandler } = useScrollHandler(TOTAL_HEADER_HEIGHT);
+
+  // Reset the layoutY value when search changes
+  useEffect(() => {
+    layoutY.value = 0;
+  }, [layoutY, search]);
 
   return (
     <SafeAreaView edges={edges} style={{ flex: 1 }}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Animation are not tested automatically, I tested it manually
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Web3Hub still behind a disabled FF

### 📝 Description

Hidden header should show again when searching
On the search page the header can be hidden while keeping the focus on the search bar, if you add or remove a character while the header is hidden it won’t show again when the list reset to the top

| Before        | After         |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/72fc96ad-f001-4449-ad45-95563dd9360d">  | <video src="https://github.com/user-attachments/assets/9eb693c5-22f5-4c3f-8f93-cb811d0637aa"> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13727]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13727]: https://ledgerhq.atlassian.net/browse/LIVE-13727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ