### PR TITLE
Ledger Sync - Fixed the getOrCreateTrustchain when another instance deleted the trustchain

### DIFF
--- a/.changeset/heavy-eggs-protect.md
+++ b/.changeset/heavy-eggs-protect.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/trustchain": patch
+---
+
+LLM / LLD - Fix the getOrCreateTrustchain that wasn't working when another instance destroyed the trustchain

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/walletSync.hooks.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/walletSync.hooks.ts
@@ -9,15 +9,18 @@ import {
   TrustchainOutdated,
 } from "@ledgerhq/trustchain/errors";
 import { useRestoreTrustchain } from "./useRestoreTrustchain";
+import { useTrustchainSdk } from "./useTrustchainSdk";
 
 export const useLifeCycle = () => {
   const dispatch = useDispatch();
+  const sdk = useTrustchainSdk();
 
   const { refetch: restoreTrustchain } = useRestoreTrustchain();
 
   function reset() {
     dispatch(resetTrustchainStore());
     dispatch(setFlow({ flow: Flow.Activation, step: Step.CreateOrSynchronize }));
+    sdk.invalidateJwt();
   }
 
   const includesErrorActions: { [key: string]: () => void } = {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/walletSync.hooks.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/walletSync.hooks.ts
@@ -6,15 +6,18 @@ import { useNavigation } from "@react-navigation/native";
 import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 import { ScreenName } from "~/const";
+import { useTrustchainSdk } from "./useTrustchainSdk";
 
 export const useLifeCycle = () => {
   const dispatch = useDispatch();
+  const sdk = useTrustchainSdk();
 
   const navigation = useNavigation<StackNavigatorNavigation<WalletSyncNavigatorStackParamList>>();
 
   function reset() {
     dispatch(resetTrustchainStore());
     navigation.navigate(ScreenName.WalletSyncActivationInit);
+    sdk.invalidateJwt();
   }
 
   const includesErrorActions: { [key: string]: () => void } = {

--- a/libs/trustchain/src/mockSdk.ts
+++ b/libs/trustchain/src/mockSdk.ts
@@ -238,4 +238,8 @@ export class MockSDK implements TrustchainSDK {
     assertTrustchain(trustchain);
     return Promise.resolve(applyXor(data));
   }
+
+  invalidateJwt(): void {
+    this.deviceJwtAcquired = false;
+  }
 }

--- a/libs/trustchain/src/sdk.ts
+++ b/libs/trustchain/src/sdk.ts
@@ -314,6 +314,11 @@ export class SDK implements TrustchainSDK {
     );
   }
 
+  invalidateJwt() {
+    this.jwt = undefined;
+    this.hwDeviceProvider.clearJwt();
+  }
+
   async destroyTrustchain(
     trustchain: Trustchain,
     memberCredentials: MemberCredentials,
@@ -321,8 +326,7 @@ export class SDK implements TrustchainSDK {
     await this.withAuth(trustchain, memberCredentials, jwt =>
       this.api.deleteTrustchain(jwt, trustchain.rootId),
     );
-    this.jwt = undefined;
-    this.hwDeviceProvider.clearJwt();
+    this.invalidateJwt();
   }
 
   async encryptUserData(trustchain: Trustchain, input: Uint8Array): Promise<Uint8Array> {

--- a/libs/trustchain/src/types.ts
+++ b/libs/trustchain/src/types.ts
@@ -226,6 +226,8 @@ export interface TrustchainSDK {
    * decrypt data with the trustchain encryption key
    */
   decryptUserData(trustchain: Trustchain, data: Uint8Array): Promise<Uint8Array>;
+
+  invalidateJwt(): void;
 }
 
 export interface TrustchainDeviceCallbacks {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Fixed the getOrCreateTrustchain when another instance deleted the trustchain
It was due to Ledger Live using the previous token to create a new trustchain
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13540]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13540]: https://ledgerhq.atlassian.net/browse/LIVE-13540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ