### PR TITLE
[LIVE-13694][LLD] Fix app install hanging on Windows due to memory overload

### DIFF
--- a/.changeset/early-countries-begin.md
+++ b/.changeset/early-countries-begin.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/logs": minor
+"@ledgerhq/hw-transport-node-hid-noevents": patch
+"@ledgerhq/react-native-hw-transport-ble": patch
+"ledger-live-desktop": patch
+---
+
+Remove withType method on `LocalTracer` because it was being overused, causing memory overloads.

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -108,7 +108,7 @@ export class IPCTransport extends Transport {
     { abortTimeoutMs }: { abortTimeoutMs?: number } = {},
   ): Promise<Buffer> {
     const apduHex = apdu.toString("hex");
-    this.tracer.withType("ipc-apdu").trace(`=> ${apduHex}`);
+    this.tracer.trace(`=> ${apduHex}`, undefined, "ipc-apdu");
 
     const responseHex = await rendererRequest(transportExchangeChannel, {
       descriptor: this.id,
@@ -117,7 +117,7 @@ export class IPCTransport extends Transport {
       context: this.tracer.getContext(),
     });
 
-    this.tracer.withType("ipc-apdu").trace(`<= ${responseHex}`);
+    this.tracer.trace(`<= ${responseHex}`, undefined, "ipc-apdu");
     return Buffer.from(responseHex as string, "hex");
   }
 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -172,7 +172,7 @@ export default class TransportNodeHidNoEvents extends Transport {
 
     const b = await this.exchangeAtomicImpl(async () => {
       const { channel, packetSize } = this;
-      tracer.trace(`=> ${apdu.toString("hex")}`, { channel, packetSize }, "apdu");
+      tracer.trace(`=> ${apdu.toString("hex")}`, { channel, packetSize });
 
       const framingHelper = hidFraming(channel, packetSize);
 
@@ -192,7 +192,7 @@ export default class TransportNodeHidNoEvents extends Transport {
         acc = framingHelper.reduceResponse(acc, buffer);
       }
 
-      tracer.trace(`<= ${result.toString("hex")}`, { channel, packetSize }, "apdu");
+      tracer.trace(`<= ${result.toString("hex")}`, { channel, packetSize });
       return result;
     });
 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -174,7 +174,7 @@ export default class TransportNodeHidNoEvents extends Transport {
 
     const b = await this.exchangeAtomicImpl(async () => {
       const { channel, packetSize } = this;
-      tracer.withType("apdu").trace(`=> ${apdu.toString("hex")}`, { channel, packetSize });
+      tracer.trace(`=> ${apdu.toString("hex")}`, { channel, packetSize }, "apdu");
 
       const framingHelper = hidFraming(channel, packetSize);
 
@@ -194,7 +194,7 @@ export default class TransportNodeHidNoEvents extends Transport {
         acc = framingHelper.reduceResponse(acc, buffer);
       }
 
-      tracer.withType("apdu").trace(`<= ${result.toString("hex")}`, { channel, packetSize });
+      tracer.trace(`<= ${result.toString("hex")}`, { channel, packetSize }, "apdu");
       return result;
     });
 

--- a/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-hid-noevents/src/TransportNodeHid.ts
@@ -167,9 +167,7 @@ export default class TransportNodeHidNoEvents extends Transport {
    * @returns a promise of apdu response
    */
   async exchange(apdu: Buffer): Promise<Buffer> {
-    const tracer = this.tracer.withUpdatedContext({
-      function: "exchange",
-    });
+    const { tracer } = this;
     tracer.trace("Exchanging APDU ...");
 
     const b = await this.exchangeAtomicImpl(async () => {

--- a/libs/ledgerjs/packages/logs/README.md
+++ b/libs/ledgerjs/packages/logs/README.md
@@ -21,14 +21,12 @@ Utility library that is used by all Ledger libraries to dispatch logs so we can 
     *   [Parameters](#parameters-1)
 *   [LocalTracer](#localtracer)
     *   [Parameters](#parameters-2)
-    *   [withType](#withtype)
-        *   [Parameters](#parameters-3)
     *   [withContext](#withcontext)
-        *   [Parameters](#parameters-4)
+        *   [Parameters](#parameters-3)
     *   [withUpdatedContext](#withupdatedcontext)
-        *   [Parameters](#parameters-5)
+        *   [Parameters](#parameters-4)
 *   [listen](#listen)
-    *   [Parameters](#parameters-6)
+    *   [Parameters](#parameters-5)
 
 ### Log
 
@@ -97,19 +95,6 @@ This is simple for now, but can be improved later.
 *   `` &#x20;
 *   `type`  A given type (not level) for the current local tracer ("hw", "withDevice", etc.)
 *   `context`  Anything representing the context where the log occurred
-
-#### withType
-
-Create a new instance of the LocalTracer with an updated `type`
-
-It does not mutate the calling instance, but returns a new LocalTracer,
-following a simple builder pattern.
-
-##### Parameters
-
-*   `type` **LogType**&#x20;
-
-Returns **[LocalTracer](#localtracer)**&#x20;
 
 #### withContext
 

--- a/libs/ledgerjs/packages/logs/src/index.ts
+++ b/libs/ledgerjs/packages/logs/src/index.ts
@@ -99,9 +99,9 @@ export class LocalTracer {
     private context?: TraceContext,
   ) {}
 
-  trace(message: string, data?: TraceContext) {
+  trace(message: string, data?: TraceContext, overrideType?: LogType) {
     trace({
-      type: this.type,
+      type: overrideType ?? this.type,
       message,
       data,
       context: this.context,
@@ -126,16 +126,6 @@ export class LocalTracer {
 
   setType(type: LogType) {
     this.type = type;
-  }
-
-  /**
-   * Create a new instance of the LocalTracer with an updated `type`
-   *
-   * It does not mutate the calling instance, but returns a new LocalTracer,
-   * following a simple builder pattern.
-   */
-  withType(type: LogType): LocalTracer {
-    return new LocalTracer(type, this.context);
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** no automated test can simply cover the bug we had
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - the changes just impact the logging system to make it more light weight in terms of memory impact

### 📝 Description

In `TransportNodeHid`, at every APDU exchange, a new `LocalTracer` was instantiated, just to change the `type` of the log to `"apdu"`.

In the context of an app install or firmware install, the `Transport` receives several 10s or 100s of APDUs at once that it is supposed to sequentially send to the device. For big apps, the install was just hanging.

After investigation, we discovered that the line of code doing `this.tracer.withType("apdu").trace(/*string with the APDU*/)` was causing this issue, while replacing it by `this.tracer.trace(/*string with the APDU*/)` (which does not instanciate a new `LocalTracer`) was fixing the issue.

**This line of code was causing the internal process to hang, _probably_ because of the garbage collector struggling to get more memory to allocate for this new object.**
For obscure reasons that we could not explain, no exception seems to be thrown when the issue happens, and debugging this is very painful as it only happens on _release_ builds on _Windows_...

**Note on the durability of the solution:**
This PR fixes the issue, but nothing prevents a similar issue to happen later in the `InternalProcess` (where the node hid transport lives).
A good solution would just be to do some refactoring and get rid of the internal process completely as it is only used for the transport now (it was doing much more computation heavy stuff in the past I believe), and move the node-hid transport to main... But this is not for now.
I'm saying we should kill this process, because it is very hard to debug, everything relies on IPC with the `main` process, even the logging system, so it can be a big PITA to work with, and it could simplify greatly the implementation of the node-hid transport for Ledger Live Desktop.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13694] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13694]: https://ledgerhq.atlassian.net/browse/LIVE-13694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ