### PR TITLE
feat(CN-220): rough spike demo forwarding modal props to drawer

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/drawers/EVMStakeDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/EVMStakeDrawer/index.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Account } from "@ledgerhq/types-live";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+
+import { Chip, Flex, Text } from "@ledgerhq/react-ui";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { EthStakingModalBody } from "~/renderer/families/evm/StakeFlowModal/EthStakingModalBody";
+import { SideDrawer } from "~/renderer/components/SideDrawer";
+import { setDrawer } from "../Provider";
+
+type Props = {
+  account: Account;
+  singleProviderRedirectMode?: boolean;
+  /** Analytics source */
+  source?: string;
+  hasCheckbox?: boolean;
+};
+
+const EVMStakingDrawer = ({ account, hasCheckbox, singleProviderRedirectMode, source }: Props) => {
+  const ethStakingProviders = useFeature("ethStakingProviders");
+  const providers = ethStakingProviders?.params?.listProvider;
+
+  const providersByCategory: ProvidersByFilter = useMemo(
+    () =>
+      (providers || [])?.reduce(
+        (acc, provider) => {
+          console.log("provider", provider);
+          // Push all into staking category
+          acc["staking"].push(provider);
+
+          if (provider.queryParams?.restake) {
+            // TODO: Add this query param data in Firebase
+            acc["restaking"].push(provider);
+          }
+          return acc as ProvidersByFilter;
+        },
+        { staking: [], restaking: [] } as ProvidersByFilter,
+      ),
+    [providers],
+  );
+
+  const { activeKey, changeTab } = useProvidersFilter(providersByCategory);
+
+  if (!ethStakingProviders?.enabled) {
+    return null;
+  }
+
+  const onClose = () => {
+    console.log("dispatch close drawer");
+    setDrawer();
+  };
+
+  return (
+    <SideDrawer isOpen direction="left" title="Test EVM Side drawer" onRequestClose={onClose}>
+      <Flex flexDirection={"column"}>
+        <TrackPage category="ETH Stake Modal" name="Main Modal" />
+
+        <ProvidersFilterTabs providers={providersByCategory} changeTab={changeTab} />
+        <EthStakingModalBody
+          onClose={onClose}
+          account={account}
+          hasCheckbox={hasCheckbox}
+          singleProviderRedirectMode={singleProviderRedirectMode}
+          source={source}
+          listProviders={providersByCategory[activeKey]}
+        />
+      </Flex>
+    </SideDrawer>
+  );
+};
+
+export default EVMStakingDrawer;
+
+export type ProvidersByFilter = Record<string, Provider[]>;
+
+export type Provider = {
+  id: string;
+  name: string;
+  liveAppId: string;
+  supportLink?: string;
+  icon?: string;
+  queryParams?: Record<string, string>;
+};
+
+export function useProvidersFilter(providersMap: ProvidersByFilter) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const changeTab = useCallback((activeIndex: number) => setActiveIndex(activeIndex), []);
+
+  const categories = Object.keys(providersMap);
+  const activeKey = categories[activeIndex];
+
+  return {
+    activeKey,
+    changeTab,
+  };
+}
+
+type ProvidersFilterProps = {
+  changeTab: (nextIndex: number) => void;
+  providers: ProvidersByFilter;
+};
+
+export function ProvidersFilterTabs({ changeTab, providers }: ProvidersFilterProps) {
+  return (
+    <Chip onTabChange={i => changeTab(i)} initialActiveIndex={0} data-test-id={`date-tabs`}>
+      {Object.keys(providers).map(key => (
+        <Text whiteSpace="nowrap" textTransform="uppercase" key={key}>
+          {key}
+        </Text>
+      ))}
+    </Chip>
+  );
+}

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -1,10 +1,9 @@
-import React from "react";
+import { useEffect } from "react";
 import { Account } from "@ledgerhq/types-live";
-import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import Modal, { ModalBody } from "~/renderer/components/Modal";
-import { Flex } from "@ledgerhq/react-ui";
-import TrackPage from "~/renderer/analytics/TrackPage";
-import { EthStakingModalBody } from "./EthStakingModalBody";
+import { useDispatch } from "react-redux";
+import { closeModal } from "~/renderer/actions/modals";
+import { setDrawer } from "~/renderer/drawers/Provider";
+import EVMStakingDrawer from "~/renderer/drawers/EVMStakeDrawer";
 
 type Props = {
   account: Account;
@@ -14,40 +13,16 @@ type Props = {
   hasCheckbox?: boolean;
 };
 
-const StakingModal = ({ account, hasCheckbox, singleProviderRedirectMode, source }: Props) => {
-  const ethStakingProviders = useFeature("ethStakingProviders");
-  const providers = ethStakingProviders?.params?.listProvider;
+const StakingModal = (props: Props) => {
+  const dispatch = useDispatch();
 
-  if (!ethStakingProviders?.enabled) {
-    return null;
-  }
+  useEffect(() => {
+    // Effectively pretend this is not a modal any more, and just open the side drawer with the same props
+    dispatch(closeModal("MODAL_EVM_STAKE"));
+    setDrawer(EVMStakingDrawer, props);
+  }, [dispatch, props]);
 
-  return (
-    <Modal
-      name="MODAL_EVM_STAKE"
-      centered
-      width={500}
-      render={({ onClose }) => (
-        <ModalBody
-          pt={0}
-          onClose={onClose}
-          render={() => (
-            <Flex justifyContent={"center"}>
-              <TrackPage category="ETH Stake Modal" name="Main Modal" />
-              <EthStakingModalBody
-                onClose={onClose}
-                account={account}
-                hasCheckbox={hasCheckbox}
-                singleProviderRedirectMode={singleProviderRedirectMode}
-                source={source}
-                listProviders={providers}
-              />
-            </Flex>
-          )}
-        />
-      )}
-    />
-  );
+  return null;
 };
 
 export default StakingModal;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
@@ -14,7 +14,7 @@ export type ModalsData = {
 };
 
 const modals: MakeModalsType<ModalsData> = {
-  MODAL_EVM_STAKE,
+  MODAL_EVM_STAKE, // Now opens a side-drawer instead of a modal
   MODAL_EVM_EDIT_TRANSACTION: EditTransactionModal,
 };
 

--- a/apps/ledger-live-desktop/src/renderer/modals/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.ts
@@ -84,6 +84,7 @@ export type Modals = MakeModalsType<ModalData>;
 
 const modals: Modals = {
   ...globalModals,
+  //  What if one is now a side drawer...?
   ...coinModals,
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The entire logic of the staking flows is based around modals. The simplest implementation of a side drawer outside of the webview is to forward the same props and content to a side drawer. 

<img width="1192" alt="image" src="https://github.com/user-attachments/assets/e54f8ec0-5872-4dd6-b96f-6446c93d6b61">

- ideally we would have more control directly from the webview itself (but this would be a non-native web-based solution and may not work with the rest of the electron app)


### ❓ Context

- **JIRA or GitHub link**: [CN-220](https://ledgerhq.atlassian.net/browse/CN-220)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-220]: https://ledgerhq.atlassian.net/browse/CN-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ