### PR TITLE
Feat/wallet sync synchronize via qr code from mobile to desktop

### DIFF
--- a/.changeset/dirty-drinks-roll.md
+++ b/.changeset/dirty-drinks-roll.md
@@ -1,0 +1,8 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/trustchain": minor
+"@ledgerhq/web-tools": minor
+---
+
+Ledger Sync - Added the synchronization of a trustchain from mobile to desktop by scanning the QR code

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/manageSynchronizedInstances.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/manageSynchronizedInstances.test.tsx
@@ -7,6 +7,7 @@ jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
     getMembers: (mockedSdk.getMembers = jest.fn()),
     removeMember: (mockedSdk.removeMember = jest.fn()),
+    initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
   }),
 }));
 

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/manageYourBackup.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/manageYourBackup.test.tsx
@@ -8,6 +8,7 @@ jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
     destroyTrustchain: (mockedSdk.destroyTrustchain = jest.fn()),
     getMembers: (mockedSdk.getMembers = jest.fn()),
+    initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
   }),
 }));
 

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/useWatchWalletSync.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/useWatchWalletSync.test.ts
@@ -31,6 +31,7 @@ jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
     getMembers: (mockedSdk.getMembers = jest.fn()),
     removeMember: (mockedSdk.removeMember = jest.fn()),
+    initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
   }),
 }));
 

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/walletSync.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/walletSync.test.tsx
@@ -4,7 +4,15 @@
 import React from "react";
 import { render, screen, waitFor } from "tests/testUtils";
 import { initialStateWalletSync } from "~/renderer/reducers/walletSync";
-import { WalletSyncTestApp } from "./shared";
+import { WalletSyncTestApp, mockedSdk } from "./shared";
+
+jest.mock("../hooks/useTrustchainSdk", () => ({
+  useTrustchainSdk: () => ({
+    getMembers: (mockedSdk.getMembers = jest.fn()),
+    removeMember: (mockedSdk.removeMember = jest.fn()),
+    initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
+  }),
+}));
 
 describe("Rendering", () => {
   it("should loads and displays WalletSync Row", async () => {

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/Error.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/components/Error.tsx
@@ -11,6 +11,7 @@ type Props = {
   cta?: string;
   onClick?: () => void;
   analyticsPage?: AnalyticsPage;
+  ctaVariant?: "shade" | "main";
 };
 
 const Container = styled(Box)`
@@ -23,7 +24,14 @@ const Container = styled(Box)`
   justify-content: center;
 `;
 
-export const Error = ({ title, description, cta, onClick, analyticsPage }: Props) => {
+export const Error = ({
+  title,
+  description,
+  cta,
+  onClick,
+  analyticsPage,
+  ctaVariant = "shade",
+}: Props) => {
   const { colors } = useTheme();
   return (
     <Flex flexDirection="column" alignItems="center" justifyContent="center" rowGap="24px">
@@ -38,7 +46,7 @@ export const Error = ({ title, description, cta, onClick, analyticsPage }: Props
         {description}
       </Text>
       {cta && onClick && (
-        <ButtonV3 variant="shade" onClick={onClick}>
+        <ButtonV3 variant={ctaVariant} onClick={onClick}>
           {cta}
         </ButtonV3>
       )}

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useInstanceName.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useInstanceName.ts
@@ -1,0 +1,14 @@
+import os from "os";
+
+const platformMap: Record<string, string | undefined> = {
+  darwin: "Mac",
+  win32: "Windows",
+  linux: "Linux",
+};
+
+export function useInstanceName(): string {
+  const platform = os.platform();
+  const hostname = os.hostname();
+  const name = `${platformMap[platform] || platform}${hostname ? " " + hostname : ""}`;
+  return name;
+}

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useQRCode.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useQRCode.ts
@@ -1,15 +1,20 @@
 import { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/trustchain/qrcode/index";
-import { InvalidDigitsError } from "@ledgerhq/trustchain/errors";
+import { InvalidDigitsError, NoTrustchainInitialized } from "@ledgerhq/trustchain/errors";
 import { useDispatch, useSelector } from "react-redux";
 import { setFlow, setQrCodePinCode } from "~/renderer/actions/walletSync";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
-import { trustchainSelector, memberCredentialsSelector } from "@ledgerhq/trustchain/store";
+import {
+  trustchainSelector,
+  memberCredentialsSelector,
+  setTrustchain,
+} from "@ledgerhq/trustchain/store";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
 import { useQueryClient } from "@tanstack/react-query";
 import { QueryKey } from "./type.hooks";
+import { useInstanceName } from "./useInstanceName";
 
 export function useQRCode() {
   const queryClient = useQueryClient();
@@ -24,13 +29,14 @@ export function useQRCode() {
   const [isLoading, setIsLoading] = useState(false);
   const [url, setUrl] = useState<string | null>(null);
   const [error, setError] = useState<Error | null>(null);
+  const memberName = useInstanceName();
 
   const goToActivation = useCallback(() => {
     dispatch(setFlow({ flow: Flow.Activation, step: Step.DeviceAction }));
   }, [dispatch]);
 
   const startQRCodeProcessing = useCallback(() => {
-    if (!trustchain || !memberCredentials) return;
+    if (!memberCredentials) return;
 
     setError(null);
     setIsLoading(true);
@@ -44,18 +50,29 @@ export function useQRCode() {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCode }));
       },
       addMember: async member => {
-        await sdk.addMember(trustchain, memberCredentials, member);
-        return trustchain;
+        if (trustchain) {
+          await sdk.addMember(trustchain, memberCredentials, member);
+          return trustchain;
+        }
+        throw new NoTrustchainInitialized();
       },
+      memberCredentials,
+      memberName,
+      alreadyHasATrustchain: !!trustchain,
     })
       .catch(e => {
         if (e instanceof InvalidDigitsError) {
           dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCodeError }));
+        } else if (e instanceof NoTrustchainInitialized) {
+          dispatch(setFlow({ flow: Flow.Synchronize, step: Step.UnbackedError }));
         }
         setError(e);
         throw e;
       })
-      .then(() => {
+      .then(newTrustchain => {
+        if (newTrustchain) {
+          dispatch(setTrustchain(newTrustchain));
+        }
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.Synchronized }));
         queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
         setUrl(null);
@@ -63,7 +80,7 @@ export function useQRCode() {
         setIsLoading(false);
         setError(null);
       });
-  }, [trustchain, memberCredentials, trustchainApiBaseUrl, dispatch, sdk, queryClient]);
+  }, [memberCredentials, trustchainApiBaseUrl, memberName, dispatch, trustchain, sdk, queryClient]);
 
   return {
     url,

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useTrustchainSdk.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useTrustchainSdk.ts
@@ -1,4 +1,3 @@
-import os from "os";
 import { useMemo } from "react";
 import { getEnv } from "@ledgerhq/live-env";
 import { getSdk } from "@ledgerhq/trustchain/index";
@@ -10,12 +9,7 @@ import { walletSyncStateSelector } from "@ledgerhq/live-wallet/store";
 import { TrustchainSDK } from "@ledgerhq/trustchain/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-
-const platformMap: Record<string, string | undefined> = {
-  darwin: "Mac",
-  win32: "Windows",
-  linux: "Linux",
-};
+import { useInstanceName } from "./useInstanceName";
 
 let sdkInstance: TrustchainSDK | null = null;
 
@@ -24,15 +18,13 @@ export function useTrustchainSdk() {
   const { trustchainApiBaseUrl, cloudSyncApiBaseUrl } = getWalletSyncEnvironmentParams(
     featureWalletSync?.params?.environment,
   );
+  const name = useInstanceName();
   const isMockEnv = !!getEnv("MOCK");
 
   const defaultContext = useMemo(() => {
     const applicationId = 16;
-    const platform = os.platform();
-    const hostname = os.hostname();
-    const name = `${platformMap[platform] || platform}${hostname ? " " + hostname : ""}`;
     return { applicationId, name, apiBaseUrl: trustchainApiBaseUrl };
-  }, [trustchainApiBaseUrl]);
+  }, [trustchainApiBaseUrl, name]);
 
   const store = useStore();
   const lifecycle = useMemo(

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useWalletSyncAnalytics.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useWalletSyncAnalytics.ts
@@ -27,6 +27,7 @@ export enum AnalyticsPage {
   SyncWithQR = "Sync with QR code",
   PinCode = "Pin code",
   PinCodeError = "Pin code error",
+  UnbackedError = "No trustchain initialized error",
 
   SettingsGeneral = "Settings General",
   WalletSyncSettings = "Wallet Sync Settings",
@@ -66,6 +67,7 @@ export const StepMappedToAnalytics: Record<Step, string> = {
   [Step.PinCode]: AnalyticsPage.PinCode,
   [Step.PinCodeError]: AnalyticsPage.PinCodeError,
   [Step.Synchronized]: AnalyticsPage.KeyUpdated,
+  [Step.UnbackedError]: AnalyticsPage.UnbackedError,
 
   //ManageInstances
   [Step.SynchronizedInstances]: AnalyticsPage.ManageInstances,

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Activation/02-DeviceActionStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Activation/02-DeviceActionStep.tsx
@@ -1,14 +1,11 @@
 import React from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import OpenOrInstallTrustChainApp from "../DeviceActions/openOrInstall";
-import { useInitMemberCredentials } from "../../hooks/useInitMemberCredentials";
 
 type Props = {
   goNext: (device: Device) => void;
 };
 
 export default function DeviceActionStep({ goNext }: Props) {
-  useInitMemberCredentials();
-
   return <OpenOrInstallTrustChainApp goNext={goNext} />;
 }

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Synchronize/05-UnbackedError.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Synchronize/05-UnbackedError.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Error } from "../../components/Error";
+import { useTranslation } from "react-i18next";
+import { AnalyticsPage } from "../../hooks/useWalletSyncAnalytics";
+import { useDispatch } from "react-redux";
+import { setFlow } from "~/renderer/actions/walletSync";
+import { Flow, Step } from "~/renderer/reducers/walletSync";
+
+export default function UnbackedError() {
+  const { t } = useTranslation();
+
+  const dispatch = useDispatch();
+
+  return (
+    <Error
+      title={t("walletSync.synchronize.unbackedError.title")}
+      description={t("walletSync.synchronize.unbackedError.description")}
+      analyticsPage={AnalyticsPage.UnbackedError}
+      cta={t("walletSync.synchronize.unbackedError.cta")}
+      onClick={() => dispatch(setFlow({ flow: Flow.Activation, step: Step.DeviceAction }))}
+      ctaVariant="main"
+    />
+  );
+}

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Synchronize/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Synchronize/index.tsx
@@ -10,6 +10,7 @@ import PinCodeStep from "./03-PinCodeStep";
 import SyncFinalStep from "./04-SyncFinalStep";
 import { AnalyticsPage, useWalletSyncAnalytics } from "../../hooks/useWalletSyncAnalytics";
 import PinCodeErrorStep from "./05-PinCodeError";
+import UnbackedErrorStep from "./05-UnbackedError";
 import { BackProps, BackRef } from "../router";
 
 const SynchronizeWallet = forwardRef<BackRef, BackProps>((_props, ref) => {
@@ -66,10 +67,15 @@ const SynchronizeWallet = forwardRef<BackRef, BackProps>((_props, ref) => {
       case Step.PinCodeError:
         return <PinCodeErrorStep />;
 
+      case Step.UnbackedError:
+        return <UnbackedErrorStep />;
+
       case Step.Synchronized:
         return <SyncFinalStep />;
     }
   };
+
+  const centeredItems = [Step.Synchronized, Step.PinCodeError, Step.UnbackedError];
 
   return (
     <Flex
@@ -77,12 +83,8 @@ const SynchronizeWallet = forwardRef<BackRef, BackProps>((_props, ref) => {
       height="100%"
       paddingX="40px"
       rowGap="48px"
-      alignItems={
-        [Step.Synchronized, Step.PinCodeError].includes(currentStep) ? "center" : undefined
-      }
-      justifyContent={
-        [Step.Synchronized, Step.PinCodeError].includes(currentStep) ? "center" : undefined
-      }
+      alignItems={centeredItems.includes(currentStep) ? "center" : undefined}
+      justifyContent={centeredItems.includes(currentStep) ? "center" : undefined}
     >
       {getStep()}
     </Flex>

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/router.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/router.tsx
@@ -6,6 +6,7 @@ import SynchronizeWallet from "./Synchronize";
 import WalletSyncManageInstances from "./ManageInstances";
 import WalletSyncActivation from "./Activation";
 import WalletSyncManage from "./Manage";
+import { useInitMemberCredentials } from "../hooks/useInitMemberCredentials";
 
 export interface BackRef {
   goBack: () => void;
@@ -14,6 +15,7 @@ export interface BackRef {
 export interface BackProps {}
 
 export const WalletSyncRouter = forwardRef<BackRef, BackProps>((_props, ref) => {
+  useInitMemberCredentials();
   const walletSyncFlow = useSelector(walletSyncFlowSelector);
 
   switch (walletSyncFlow) {

--- a/apps/ledger-live-desktop/src/renderer/reducers/walletSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/walletSync.ts
@@ -30,6 +30,7 @@ export enum Step {
   SynchronizeWithQRCode = "SynchronizeWithQRCode",
   PinCode = "PinCode",
   PinCodeError = "PinCodeError",
+  UnbackedError = "UnbackedError",
   Synchronized = "Synchronized",
 
   //ManageInstances

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6508,6 +6508,11 @@
           }
         }
       },
+      "unbackedError": {
+        "title": "You need to create your encryption key first",
+        "description": "Please make sure you’ve created an encryption key on one of your Ledger Live apps before continuing your synchronization.",
+        "cta": "Create your encryption key"
+      },
       "pinCode": {
         "title": "Enter the code",
         "description": "Type the code displayed on the other Ledger Live you want to sync with.",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6843,6 +6843,11 @@
             "desc": "Make sure the code you type is the one displayed on the other Ledger Live instance.",
             "tryAgain": "Try again"
           }
+        },
+        "unbacked": {
+          "title": "You need to create your encryption key first",
+          "desc": "Please make sure you’ve created an encryption key on one of your Ledger Live apps before continuing your synchronization.",
+          "cta": "Create your encryption key"
         }
       }
     }

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/StepFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/StepFlow.tsx
@@ -11,6 +11,7 @@ import PinCodeDisplay from "LLM/features/WalletSync/screens/Synchronize/PinCodeD
 import PinCodeInput from "LLM/features/WalletSync/screens/Synchronize/PinCodeInput";
 import { useInitMemberCredentials } from "LLM/features/WalletSync/hooks/useInitMemberCredentials";
 import { useSyncWithQrCode } from "LLM/features/WalletSync/hooks/useSyncWithQrCode";
+import UnbackedError from "~/newArch/features/WalletSync/screens/Synchronize/UnbackedError";
 
 type Props = {
   currentStep: Steps;
@@ -21,6 +22,7 @@ type Props = {
   currentOption: Options;
   navigateToChooseSyncMethod: () => void;
   navigateToQrCodeMethod: () => void;
+  onCreateKey: () => void;
   onQrCodeScanned: () => void;
   qrProcess: {
     url: string | null;
@@ -41,6 +43,7 @@ const StepFlow = ({
   onQrCodeScanned,
   qrProcess,
   setCurrentStep,
+  onCreateKey,
 }: Props) => {
   const { memberCredentials } = useInitMemberCredentials();
 
@@ -94,6 +97,9 @@ const StepFlow = ({
 
       case Steps.SyncError:
         return <SyncError tryAgain={navigateToQrCodeMethod} />;
+
+      case Steps.UnbackedError:
+        return <UnbackedError create={onCreateKey} />;
 
       default:
         return null;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/index.tsx
@@ -30,6 +30,7 @@ function View({
   navigateToQrCodeMethod,
   qrProcess,
   onQrCodeScanned,
+  onCreateKey,
 }: ViewProps) {
   const CustomDrawerHeader = () => <DrawerHeader onClose={onCloseAddAccountDrawer} />;
 
@@ -53,6 +54,7 @@ function View({
           navigateToQrCodeMethod={navigateToQrCodeMethod}
           qrProcess={qrProcess}
           onQrCodeScanned={onQrCodeScanned}
+          onCreateKey={onCreateKey}
         />
       </Flex>
     </QueuedDrawer>

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/useAddAccountViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/useAddAccountViewModel.ts
@@ -2,21 +2,34 @@ import { useCallback, useState } from "react";
 import { track } from "~/analytics";
 import { useQRCodeHost } from "LLM/features/WalletSync/hooks/useQRCodeHost";
 import { Options, Steps } from "LLM/features/WalletSync/types/Activation";
+import { NavigatorName, ScreenName } from "~/const";
+import {
+  AnalyticsButton,
+  AnalyticsPage,
+  useLedgerSyncAnalytics,
+} from "~/newArch/features/WalletSync/hooks/useLedgerSyncAnalytics";
+import { useNavigation } from "@react-navigation/native";
+import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 
 type AddAccountDrawerProps = {
   isOpened: boolean;
   onClose: () => void;
 };
 
+type NavigationProps = BaseComposite<
+  StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncActivationProcess>
+>;
+
 const startingStep = Steps.AddAccountMethod;
 
 const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) => {
   const [currentStep, setCurrentStep] = useState<Steps>(startingStep);
   const [currentOption, setCurrentOption] = useState<Options>(Options.SCAN);
-
+  const { onClickTrack } = useLedgerSyncAnalytics();
   const navigateToChooseSyncMethod = () => setCurrentStep(Steps.ChooseSyncMethod);
   const navigateToQrCodeMethod = () => setCurrentStep(Steps.QrCodeMethod);
-
+  const navigation = useNavigation<NavigationProps["navigation"]>();
   const onGoBack = () => setCurrentStep(prevStep => getPreviousStep(prevStep));
 
   const reset = () => {
@@ -54,6 +67,13 @@ const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) =>
     currentOption,
   });
 
+  const onCreateKey = () => {
+    onClickTrack({ button: AnalyticsButton.CreateYourKey, page: AnalyticsPage.Unbacked });
+    navigation.navigate(NavigatorName.WalletSync, {
+      screen: ScreenName.WalletSyncActivationProcess,
+    });
+  };
+
   const onQrCodeScanned = () => setCurrentStep(Steps.PinInput);
 
   return {
@@ -73,6 +93,7 @@ const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) =>
       isLoading,
       pinCode,
     },
+    onCreateKey,
   };
 };
 

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/synchronizeWithQrCode.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/synchronizeWithQrCode.integration.test.tsx
@@ -4,13 +4,23 @@ import { render, screen, waitFor } from "@tests/test-renderer";
 import { INITIAL_TEST, WalletSyncSettingsNavigator } from "./shared";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
 
-jest.mock("@ledgerhq/trustchain/qrcode/index", () => ({
-  createQRCodeHostInstance: () => ({
-    trustchainApiBaseUrl: getWalletSyncEnvironmentParams("STAGING").trustchainApiBaseUrl,
-    onDisplayQRCode: jest.fn().mockImplementation(url => url),
-    onDisplayDigits: jest.fn().mockImplementation(digits => digits),
-    addMember: jest.fn(),
+jest.mock("../hooks/useQRCodeHost", () => ({
+  useQRCodeHost: () => ({
+    setCurrentStep: jest.fn(),
+    currentStep: jest.fn(),
+    currentOption: jest.fn(),
+    url: "ledger.com",
   }),
+}));
+
+jest.mock("@ledgerhq/trustchain/qrcode/index", () => ({
+  createQRCodeHostInstance: () =>
+    Promise.resolve({
+      trustchainApiBaseUrl: getWalletSyncEnvironmentParams("STAGING").trustchainApiBaseUrl,
+      onDisplayQRCode: jest.fn().mockImplementation(url => url),
+      onDisplayDigits: jest.fn().mockImplementation(digits => digits),
+      addMember: jest.fn(),
+    }),
 }));
 
 describe("SynchronizeWithQrCode", () => {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/useWatchWalletSync.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/useWatchWalletSync.test.ts
@@ -31,6 +31,7 @@ jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
     getMembers: (mockedSdk.getMembers = jest.fn()),
     removeMember: (mockedSdk.removeMember = jest.fn()),
+    initMemberCredentials: (mockedSdk.initMemberCredentials = jest.fn()),
   }),
 }));
 

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -75,6 +75,7 @@ const ActivationFlow = ({
             onQrCodeScanned={handleQrCodeScanned}
             currentOption={currentOption}
             setSelectedOption={setOption}
+            qrCodeValue={qrProcess.url}
           />
         );
 

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -10,6 +10,7 @@ import PinCodeInput from "../../screens/Synchronize/PinCodeInput";
 import SyncError from "../../screens/Synchronize/SyncError";
 import { useInitMemberCredentials } from "../../hooks/useInitMemberCredentials";
 import { useSyncWithQrCode } from "../../hooks/useSyncWithQrCode";
+import UnbackedError from "../../screens/Synchronize/UnbackedError";
 
 type Props = {
   currentStep: Steps;
@@ -25,6 +26,7 @@ type Props = {
   currentOption: Options;
   setOption: (option: Options) => void;
   setCurrentStep: (step: Steps) => void;
+  onCreateKey: () => void;
 };
 
 const ActivationFlow = ({
@@ -36,6 +38,7 @@ const ActivationFlow = ({
   setOption,
   onQrCodeScanned,
   setCurrentStep,
+  onCreateKey,
 }: Props) => {
   const { memberCredentials } = useInitMemberCredentials();
 
@@ -86,6 +89,8 @@ const ActivationFlow = ({
       case Steps.SyncError:
         return <SyncError tryAgain={navigateToQrCodeMethod} />;
 
+      case Steps.UnbackedError:
+        return <UnbackedError create={onCreateKey} />;
       default:
         return null;
     }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Error/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Error/index.tsx
@@ -7,6 +7,7 @@ type Props = {
   mainButton: {
     label: string;
     onPress: () => void;
+    outline: boolean;
   };
 };
 
@@ -26,7 +27,7 @@ export function ErrorComponent({ title, desc, mainButton }: Props) {
         </Text>
       </Flex>
       <Flex mt={8}>
-        <Button type="main" outline onPress={mainButton.onPress}>
+        <Button type="main" outline={mainButton.outline} onPress={mainButton.onPress}>
           {mainButton.label}
         </Button>
       </Flex>

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Synchronize/QrCode.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Synchronize/QrCode.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, Text } from "@ledgerhq/native-ui";
+import { Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import styled, { useTheme } from "styled-components/native";
 import QRCode from "react-native-qrcode-svg";
 import getWindowDimensions from "~/logic/getWindowDimensions";
@@ -12,7 +12,7 @@ const Italic = styled(Text)`
 // Won't work since we don't have inter italic font
 
 type Props = {
-  qrCodeValue: string;
+  qrCodeValue?: string | null;
 };
 
 const QrCode = ({ qrCodeValue }: Props) => {
@@ -79,12 +79,16 @@ const QrCode = ({ qrCodeValue }: Props) => {
         justifyContent={"center"}
         testID="ws-qr-code-displayed"
       >
-        <QRCode
-          value={qrCodeValue}
-          logo={require("~/images/bigSquareLogo.png")}
-          logoSize={65}
-          size={QRCodeSize}
-        />
+        {qrCodeValue ? (
+          <QRCode
+            value={qrCodeValue}
+            logo={require("~/images/bigSquareLogo.png")}
+            logoSize={65}
+            size={QRCodeSize}
+          />
+        ) : (
+          <InfiniteLoader size={65} />
+        )}
       </Flex>
       <BottomContainer steps={steps} />
     </Flex>

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useLedgerSyncAnalytics.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useLedgerSyncAnalytics.ts
@@ -18,6 +18,7 @@ export enum AnalyticsPage {
   SyncWithNoKey = "Sync with no key",
   LedgerSyncActivated = "Ledger Sync activated",
   AutoRemove = "Remove current instance",
+  Unbacked = "Unbacked",
 }
 
 export enum AnalyticsFlow {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useQRCodeHost.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useQRCodeHost.ts
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/trustchain/qrcode/index";
-import { InvalidDigitsError } from "@ledgerhq/trustchain/errors";
-import { useSelector } from "react-redux";
-import { trustchainSelector, memberCredentialsSelector } from "@ledgerhq/trustchain/store";
+import { InvalidDigitsError, NoTrustchainInitialized } from "@ledgerhq/trustchain/errors";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  trustchainSelector,
+  memberCredentialsSelector,
+  setTrustchain,
+} from "@ledgerhq/trustchain/store";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { Options, Steps } from "../types/Activation";
 import { useNavigation } from "@react-navigation/native";
@@ -11,6 +15,7 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
 import { useQueryClient } from "@tanstack/react-query";
 import { QueryKey } from "./type.hooks";
+import { useInstanceName } from "./useInstanceName";
 
 interface Props {
   setCurrentStep: (step: Steps) => void;
@@ -23,11 +28,13 @@ export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Pr
   const trustchain = useSelector(trustchainSelector);
   const memberCredentials = useSelector(memberCredentialsSelector);
   const sdk = useTrustchainSdk();
+  const dispatch = useDispatch();
 
   const featureWalletSync = useFeature("llmWalletSync");
   const { trustchainApiBaseUrl } = getWalletSyncEnvironmentParams(
     featureWalletSync?.params?.environment,
   );
+  const memberName = useInstanceName();
 
   const [isLoading, setIsLoading] = useState(false);
   const [url, setUrl] = useState<string | null>(null);
@@ -37,7 +44,7 @@ export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Pr
   const navigation = useNavigation();
 
   const startQRCodeProcessing = useCallback(() => {
-    if (!trustchain || !memberCredentials || isLoading) return;
+    if (!memberCredentials || isLoading) return;
 
     setError(null);
     setIsLoading(true);
@@ -45,29 +52,26 @@ export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Pr
       trustchainApiBaseUrl,
       onDisplayQRCode: url => {
         setUrl(url);
-
-        //TODO-remove when clearing code, used to test behavior with webTool
-        // eslint-disable-next-line no-console
-        console.log("onDisplayQRCode", url);
       },
       onDisplayDigits: digits => {
         setPinCode(digits);
         setCurrentStep(Steps.PinDisplay);
       },
       addMember: async member => {
-        await sdk.addMember(trustchain, memberCredentials, member);
-        return trustchain;
-      },
-    })
-      .catch(e => {
-        if (e instanceof InvalidDigitsError) {
-          setCurrentStep(Steps.SyncError);
-          return;
+        if (trustchain) {
+          await sdk.addMember(trustchain, memberCredentials, member);
+          return trustchain;
         }
-        setError(e);
-        throw e;
-      })
-      .then(() => {
+        throw new NoTrustchainInitialized();
+      },
+      memberCredentials,
+      memberName,
+      alreadyHasATrustchain: !!trustchain,
+    })
+      .then(newTrustchain => {
+        if (newTrustchain) {
+          dispatch(setTrustchain(newTrustchain));
+        }
         queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
         navigation.navigate(NavigatorName.WalletSync, {
           screen: ScreenName.WalletSyncSuccess,
@@ -79,16 +83,29 @@ export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Pr
         setUrl(null);
         setPinCode(null);
         setIsLoading(false);
+      })
+      .catch(e => {
+        if (e instanceof InvalidDigitsError) {
+          setCurrentStep(Steps.SyncError);
+          return;
+        } else if (e instanceof NoTrustchainInitialized) {
+          setCurrentStep(Steps.UnbackedError);
+          return;
+        }
+        setError(e);
+        throw e;
       });
   }, [
     trustchain,
     memberCredentials,
     isLoading,
     trustchainApiBaseUrl,
+    memberName,
     setCurrentStep,
     sdk,
     queryClient,
     navigation,
+    dispatch,
   ]);
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useSyncWithQrCode.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useSyncWithQrCode.ts
@@ -59,6 +59,9 @@ export const useSyncWithQrCode = () => {
         if (e instanceof InvalidDigitsError) {
           setCurrentStep(Steps.SyncError);
           return;
+        } else {
+          setCurrentStep(Steps.UnbackedError);
+          return;
         }
         throw e;
       }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationDrawer.tsx
@@ -22,6 +22,7 @@ function View({
   canGoBack,
   navigateToChooseSyncMethod,
   navigateToQrCodeMethod,
+  onCreateKey,
   onQrCodeScanned,
   goBackToPreviousStep,
   handleClose,
@@ -53,6 +54,7 @@ function View({
             setOption={setCurrentOption}
             onQrCodeScanned={onQrCodeScanned}
             setCurrentStep={setCurrentStep}
+            onCreateKey={onCreateKey}
           />
         </Flex>
       </QueuedDrawer>

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
@@ -7,6 +7,10 @@ import {
 } from "../../hooks/useLedgerSyncAnalytics";
 import { useQRCodeHost } from "../../hooks/useQRCodeHost";
 import { Options } from "LLM/features/WalletSync/types/Activation";
+import { NavigatorName, ScreenName } from "~/const";
+import { useNavigation } from "@react-navigation/native";
+import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 
 type Props = {
   isOpen: boolean;
@@ -14,11 +18,15 @@ type Props = {
   handleClose: () => void;
 };
 
+type NavigationProps = BaseComposite<
+  StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncActivationProcess>
+>;
+
 const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) => {
   const { onClickTrack } = useLedgerSyncAnalytics();
   const [currentStep, setCurrentStep] = useState<Steps>(startingStep);
   const [currentOption, setCurrentOption] = useState<Options>(Options.SCAN);
-
+  const navigation = useNavigation<NavigationProps["navigation"]>();
   const hasCustomHeader = useMemo(() => currentStep === Steps.QrCodeMethod, [currentStep]);
   const canGoBack = useMemo(
     () => currentStep === Steps.ChooseSyncMethod && startingStep === Steps.Activation,
@@ -61,6 +69,13 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
     handleClose();
   };
 
+  const onCreateKey = () => {
+    onClickTrack({ button: AnalyticsButton.CreateYourKey, page: AnalyticsPage.Unbacked });
+    navigation.navigate(NavigatorName.WalletSync, {
+      screen: ScreenName.WalletSyncActivationProcess,
+    });
+  };
+
   const { url, error, isLoading, pinCode } = useQRCodeHost({
     setCurrentStep,
     currentStep,
@@ -82,6 +97,7 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
     currentOption,
     setCurrentOption,
     setCurrentStep,
+    onCreateKey,
   };
 };
 

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/QrCodeMethod.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/QrCodeMethod.tsx
@@ -15,9 +15,15 @@ interface Props {
   setSelectedOption: (option: OptionsType) => void;
   onQrCodeScanned: (data: string) => void;
   currentOption: Options;
+  qrCodeValue?: string | null;
 }
 
-const QrCodeMethod = ({ setSelectedOption, onQrCodeScanned, currentOption }: Props) => {
+const QrCodeMethod = ({
+  setSelectedOption,
+  onQrCodeScanned,
+  currentOption,
+  qrCodeValue,
+}: Props) => {
   const { onClickTrack } = useLedgerSyncAnalytics();
   const { t } = useTranslation();
 
@@ -44,7 +50,7 @@ const QrCodeMethod = ({ setSelectedOption, onQrCodeScanned, currentOption }: Pro
         return (
           <>
             <TrackScreen category={AnalyticsPage.ShowQRCode} />
-            <QrCode qrCodeValue="ledger.com" />
+            <QrCode qrCodeValue={qrCodeValue} />
           </>
         );
     }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/SyncError.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/SyncError.tsx
@@ -15,6 +15,7 @@ export default function SyncError({ tryAgain }: Props) {
       mainButton={{
         label: t("walletSync.synchronize.qrCode.pinCode.error.tryAgain"),
         onPress: tryAgain,
+        outline: true,
       }}
     />
   );

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/UnbackedError.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/UnbackedError.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ErrorComponent } from "../../components/Error";
+
+interface Props {
+  create: () => void;
+}
+
+export default function UnbackedError({ create }: Props) {
+  const { t } = useTranslation();
+  return (
+    <ErrorComponent
+      title={t("walletSync.synchronize.qrCode.unbacked.title")}
+      desc={t("walletSync.synchronize.qrCode.unbacked.desc")}
+      mainButton={{
+        label: t("walletSync.synchronize.qrCode.unbacked.cta"),
+        onPress: create,
+        outline: false,
+      }}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/types/Activation.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/types/Activation.ts
@@ -14,4 +14,5 @@ export enum Steps {
   PinDisplay = "PinDisplay",
   PinInput = "PinInput",
   SyncError = "SyncError",
+  UnbackedError = "UnbackedError",
 }

--- a/apps/web-tools/trustchain/components/App.tsx
+++ b/apps/web-tools/trustchain/components/App.tsx
@@ -267,6 +267,7 @@ const App = () => {
             <AppQRCodeCandidate
               memberCredentials={memberCredentials}
               setTrustchain={setTrustchain}
+              trustchain={trustchain}
             />
           </Expand>
         </Expand>

--- a/apps/web-tools/trustchain/components/AppQRCodeCandidate.tsx
+++ b/apps/web-tools/trustchain/components/AppQRCodeCandidate.tsx
@@ -1,18 +1,22 @@
 import React, { useCallback, useState } from "react";
 import { createQRCodeCandidateInstance } from "@ledgerhq/trustchain/qrcode/index";
-import { InvalidDigitsError } from "@ledgerhq/trustchain/errors";
+import { InvalidDigitsError, NoTrustchainInitialized } from "@ledgerhq/trustchain/errors";
 import { MemberCredentials, Trustchain } from "@ledgerhq/trustchain/types";
 import { Actionable } from "./Actionable";
 import { memberNameForPubKey } from "./IdentityManager";
 import { Input } from "./Input";
+import { useTrustchainSDK } from "../context";
 
 export function AppQRCodeCandidate({
   memberCredentials,
   setTrustchain,
+  trustchain,
 }: {
   memberCredentials: MemberCredentials | null;
   setTrustchain: (trustchain: Trustchain | null) => void;
+  trustchain: Trustchain | null;
 }) {
+  const sdk = useTrustchainSDK();
   const [scannedUrl, setScannedUrl] = useState<string | null>(null);
   const [input, setInput] = useState<string | null>(null);
   const [digits, setDigits] = useState<number | null>(null);
@@ -33,9 +37,19 @@ export function AppQRCodeCandidate({
         scannedUrl,
         memberName: memberNameForPubKey(memberCredentials.pubkey),
         onRequestQRCodeInput,
+        addMember: async member => {
+          if (trustchain) {
+            await sdk.addMember(trustchain, memberCredentials, member);
+            return trustchain;
+          }
+          throw new NoTrustchainInitialized();
+        },
+        alreadyHasATrustchain: !!trustchain,
       })
         .then(trustchain => {
-          setTrustchain(trustchain);
+          if (trustchain) {
+            setTrustchain(trustchain);
+          }
           return true;
         })
         .catch(e => {
@@ -54,7 +68,7 @@ export function AppQRCodeCandidate({
           setInputCallback(null);
         });
     },
-    [onRequestQRCodeInput, setTrustchain],
+    [onRequestQRCodeInput, sdk, setTrustchain, trustchain],
   );
 
   const handleSendDigits = useCallback(

--- a/apps/web-tools/trustchain/components/AppQRCodeHost.tsx
+++ b/apps/web-tools/trustchain/components/AppQRCodeHost.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/trustchain/qrcode/index";
-import { InvalidDigitsError } from "@ledgerhq/trustchain/errors";
+import { InvalidDigitsError, NoTrustchainInitialized } from "@ledgerhq/trustchain/errors";
 import { MemberCredentials, Trustchain } from "@ledgerhq/trustchain/types";
 import { RenderActionable } from "./Actionable";
 import QRCode from "./QRCode";
@@ -30,9 +30,15 @@ export function AppQRCodeHost({
         setDigits(digits);
       },
       addMember: async member => {
-        await sdk.addMember(trustchain, memberCredentials, member);
-        return trustchain;
+        if (trustchain) {
+          await sdk.addMember(trustchain, memberCredentials, member);
+          return trustchain;
+        }
+        throw new NoTrustchainInitialized();
       },
+      memberCredentials,
+      memberName: "WebTools",
+      alreadyHasATrustchain: !!trustchain,
     })
       .catch(e => {
         if (e instanceof InvalidDigitsError) {

--- a/libs/trustchain/src/errors.ts
+++ b/libs/trustchain/src/errors.ts
@@ -6,3 +6,7 @@ export const TrustchainEjected = createCustomErrorClass("TrustchainEjected");
 export const TrustchainNotAllowed = createCustomErrorClass("TrustchainNotAllowed");
 export const TrustchainOutdated = createCustomErrorClass("TrustchainOutdated");
 export const TrustchainNotFound = createCustomErrorClass("TrustchainNotFound");
+export const NoTrustchainInitialized = createCustomErrorClass("NoTrustchainInitialized");
+export const TrustchainsAlreadyInitialized = createCustomErrorClass(
+  "TrustchainsAlreadyInitialized",
+);

--- a/libs/trustchain/src/qrcode/index.test.ts
+++ b/libs/trustchain/src/qrcode/index.test.ts
@@ -39,6 +39,7 @@ describe("Trustchain QR Code", () => {
     };
     const addMember = jest.fn(() => Promise.resolve(trustchain));
     const memberCredentials = convertKeyPairToLiveCredentials(await crypto.randomKeypair());
+    const memberName = "foo";
 
     let scannedUrlResolve: (url: string) => void;
     const scannedUrlPromise = new Promise<string>(resolve => {
@@ -56,14 +57,18 @@ describe("Trustchain QR Code", () => {
       onDisplayQRCode,
       onDisplayDigits,
       addMember,
+      memberCredentials,
+      memberName,
+      alreadyHasATrustchain: !!trustchain,
     });
 
     const scannedUrl = await scannedUrlPromise;
-    const memberName = "foo";
 
     const candidateP = createQRCodeCandidateInstance({
       memberCredentials,
       memberName,
+      alreadyHasATrustchain: false,
+      addMember,
       scannedUrl,
       onRequestQRCodeInput,
     });

--- a/libs/trustchain/src/qrcode/types.ts
+++ b/libs/trustchain/src/qrcode/types.ts
@@ -38,6 +38,12 @@ export type Message =
   | {
       version: number;
       publisher: string;
+      message: "TrustchainRequestCredential";
+      payload: Encrypted<Record<string, never>>;
+    }
+  | {
+      version: number;
+      publisher: string;
       message: "TrustchainShareCredential";
       payload: Encrypted<{
         // public key of the member


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Added the synchronization of a trustchain from mobile to desktop by scanning the QR code

This hasn't been tested manually yet
Integration tests to be added once the backend supports those changes
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13743] [LIVE-13756]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13743]: https://ledgerhq.atlassian.net/browse/LIVE-13743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ