### PR TITLE
[FIX]: Fix starting step when WS is activated and you want to sync again

### DIFF
--- a/.changeset/tame-rocks-lay.md
+++ b/.changeset/tame-rocks-lay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix starting step when WS is activated and you want to sync again

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Manage/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Manage/index.tsx
@@ -140,7 +140,7 @@ const WalletSyncManage = () => {
       </InstancesRow>
 
       <ActivationDrawer
-        startingStep={Steps.QrCodeMethod}
+        startingStep={Steps.ChooseSyncMethod}
         isOpen={isSyncDrawerOpen}
         handleClose={closeSyncDrawer}
       />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix starting step when WS is activated and you want to sync again

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13693] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13693]: https://ledgerhq.atlassian.net/browse/LIVE-13693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ