### PR TITLE
fix: return transaction.feesStrategy gasOption instead of the medium value

### DIFF
--- a/.changeset/wicked-eyes-explain.md
+++ b/.changeset/wicked-eyes-explain.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix evm getFeeData to return requested option value

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/api/node/ledger.unit.test.ts
@@ -386,7 +386,7 @@ describe("EVM Family", () => {
         }
       });
 
-      it("should return the medium value of the Ledger explorers gas tracker", async () => {
+      it("should return the fee data based on the transaction's feesStrategy", async () => {
         jest.spyOn(LEDGER_GAS_TRACKER, "getGasOptions").mockImplementation(async () => ({
           slow: {
             maxFeePerGas: new BigNumber(1),
@@ -408,16 +408,64 @@ describe("EVM Family", () => {
           },
         }));
 
-        const legacyFeeData = await LEDGER_API.getFeeData(currency, { type: 0 } as any);
-        const eip1559FeeData = await LEDGER_API.getFeeData(currency, { type: 2 } as any);
+        const slowFeeData = await LEDGER_API.getFeeData(currency, {
+          type: 2,
+          feesStrategy: "slow",
+        } as any);
+        const mediumFeeData = await LEDGER_API.getFeeData(currency, {
+          type: 2,
+          feesStrategy: "medium",
+        } as any);
+        const fastFeeData = await LEDGER_API.getFeeData(currency, {
+          type: 2,
+          feesStrategy: "fast",
+        } as any);
 
-        expect(legacyFeeData).toEqual({
+        expect(slowFeeData).toEqual({
+          maxFeePerGas: new BigNumber(1),
+          maxPriorityFeePerGas: new BigNumber(2),
+          gasPrice: new BigNumber(3),
+          nextBaseFee: new BigNumber(4),
+        });
+        expect(mediumFeeData).toEqual({
           maxFeePerGas: new BigNumber(5),
           maxPriorityFeePerGas: new BigNumber(6),
           gasPrice: new BigNumber(7),
           nextBaseFee: new BigNumber(8),
         });
-        expect(eip1559FeeData).toEqual({
+        expect(fastFeeData).toEqual({
+          maxFeePerGas: new BigNumber(9),
+          maxPriorityFeePerGas: new BigNumber(10),
+          gasPrice: new BigNumber(11),
+          nextBaseFee: new BigNumber(12),
+        });
+      });
+
+      it("should return medium fee data if feesStrategy is not provided", async () => {
+        jest.spyOn(LEDGER_GAS_TRACKER, "getGasOptions").mockImplementation(async () => ({
+          slow: {
+            maxFeePerGas: new BigNumber(1),
+            maxPriorityFeePerGas: new BigNumber(2),
+            gasPrice: new BigNumber(3),
+            nextBaseFee: new BigNumber(4),
+          },
+          medium: {
+            maxFeePerGas: new BigNumber(5),
+            maxPriorityFeePerGas: new BigNumber(6),
+            gasPrice: new BigNumber(7),
+            nextBaseFee: new BigNumber(8),
+          },
+          fast: {
+            maxFeePerGas: new BigNumber(9),
+            maxPriorityFeePerGas: new BigNumber(10),
+            gasPrice: new BigNumber(11),
+            nextBaseFee: new BigNumber(12),
+          },
+        }));
+
+        const feeData = await LEDGER_API.getFeeData(currency, { type: 2 } as any);
+
+        expect(feeData).toEqual({
           maxFeePerGas: new BigNumber(5),
           maxPriorityFeePerGas: new BigNumber(6),
           gasPrice: new BigNumber(7),

--- a/libs/coin-modules/coin-evm/src/api/node/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/api/node/ledger.ts
@@ -229,7 +229,7 @@ export const getFeeData: NodeApi["getFeeData"] = async (currency, transaction) =
     throw new LedgerNodeUsedIncorrectly();
   }
 
-  const { medium } = await getGasOptions({
+  const options = await getGasOptions({
     currency: {
       ...currency,
       ethereumLikeInfo: {
@@ -249,7 +249,7 @@ export const getFeeData: NodeApi["getFeeData"] = async (currency, transaction) =
     },
   });
 
-  return medium;
+  return options?.[transaction.feesStrategy as keyof typeof options] ?? options.medium;
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When not providing gasOption, prepare Transactions makes a node api call to fetch medium fees regardless of what is asked on feeStrategy. This PR aims to fix this by returning the option asked on the transaction before defaulting to medium

### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-13775)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
