### PR TITLE
refactor: remove old manifest id for buy-sell "multibuy-v2"

### DIFF
--- a/.changeset/real-pets-travel.md
+++ b/.changeset/real-pets-travel.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+removes old manifest id for buy-sell app

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -17,7 +17,7 @@ import { getParentAccount, isTokenAccount } from "@ledgerhq/live-common/account/
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
 import {
-  DEFAULT_MULTIBUY_APP_ID,
+  BUY_SELL_UI_APP_ID,
   INTERNAL_APP_IDS,
   WALLET_API_VERSION,
 } from "@ledgerhq/live-common/wallet-api/constants";
@@ -114,7 +114,7 @@ export type ExchangeComponentParams = {
 const Exchange = ({ match }: RouteComponentProps<ExchangeComponentParams>) => {
   const appId = match?.params?.appId;
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.params?.manifestId || DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.params?.manifestId || BUY_SELL_UI_APP_ID;
 
   return <LiveAppExchange appId={appId || defaultPlatform} />;
 };

--- a/apps/ledger-live-desktop/tests/specs/market/market.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/market/market.spec.ts
@@ -5,6 +5,7 @@ import { MarketPage } from "../../page/market.page";
 import { Layout } from "../../component/layout.component";
 import { MarketCoinPage } from "../../page/market.coin.page";
 import { LiveAppWebview } from "../../models/LiveAppWebview";
+import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 
 test.use({ userdata: "skip-onboarding" });
 
@@ -14,7 +15,7 @@ test.beforeAll(async () => {
   // Check that dummy app in tests/dummy-ptx-app has been started successfully
   testServerIsRunning = await LiveAppWebview.startLiveApp("dummy-ptx-app/public", {
     name: "Buy App",
-    id: "multibuy-v2",
+    id: BUY_SELL_UI_APP_ID,
     permissions: ["account.request"],
   });
 

--- a/apps/ledger-live-desktop/tests/specs/services/buy.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/buy.spec.ts
@@ -8,6 +8,7 @@ import { AccountPage } from "../../page/account.page";
 import { SettingsPage } from "../../page/settings.page";
 import { MarketPage } from "../../page/market.page";
 import { LiveAppWebview } from "../../models/LiveAppWebview";
+import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 
 test.use({
   userdata: "1AccountBTC1AccountETH",
@@ -22,7 +23,7 @@ test.beforeAll(async () => {
   // Check that dummy app in tests/dummy-ptx-app has been started successfully
   testServerIsRunning = await LiveAppWebview.startLiveApp("dummy-ptx-app/public", {
     name: "Buy App",
-    id: "multibuy-v2",
+    id: BUY_SELL_UI_APP_ID,
     permissions: ["account.request"],
   });
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/currencies/index";
-import { DEFAULT_MULTIBUY_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
+import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
@@ -18,7 +18,7 @@ const ExchangeBuy = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeBuy>,
 ) => {
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.params?.manifestId || DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.params?.manifestId || BUY_SELL_UI_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}
@@ -44,7 +44,7 @@ const ExchangeSell = (
   _props: StackNavigatorProps<ExchangeLiveAppNavigatorParamList, ScreenName.ExchangeSell>,
 ) => {
   const buySellUiFlag = useFeature("buySellUi");
-  const defaultPlatform = buySellUiFlag?.params?.manifestId || DEFAULT_MULTIBUY_APP_ID;
+  const defaultPlatform = buySellUiFlag?.params?.manifestId || BUY_SELL_UI_APP_ID;
   return (
     <BuyAndSellScreen
       {..._props}

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -13,10 +13,7 @@ import Config from "react-native-config";
 import { useFlipper } from "@react-navigation/devtools";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import {
-  DEFAULT_MULTIBUY_APP_ID,
-  BUY_SELL_UI_APP_ID,
-} from "@ledgerhq/live-common/wallet-api/constants";
+import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
 
 import Braze from "@braze/react-native-sdk";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
@@ -73,8 +70,8 @@ function getProxyURL(url: string, customBuySellUiAppId?: string) {
   }
 
   const buySellAppIds = customBuySellUiAppId
-    ? [customBuySellUiAppId, DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID]
-    : [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID];
+    ? [customBuySellUiAppId, BUY_SELL_UI_APP_ID]
+    : [BUY_SELL_UI_APP_ID];
 
   // This is to handle links set in the useFromAmountStatusMessage in LLC.
   // Also handles a difference in paths between LLD on LLD /platform/:app_id
@@ -375,29 +372,29 @@ const getOnboardingLinkingOptions = (acceptedTermsOfUse: boolean) => ({
     screens: !acceptedTermsOfUse
       ? {}
       : {
-          [NavigatorName.BaseOnboarding]: {
-            screens: {
-              [NavigatorName.Onboarding]: {
-                initialRouteName: ScreenName.OnboardingWelcome,
-                screens: {
-                  [ScreenName.OnboardingBleDevicePairingFlow]: "sync-onboarding",
-                },
+        [NavigatorName.BaseOnboarding]: {
+          screens: {
+            [NavigatorName.Onboarding]: {
+              initialRouteName: ScreenName.OnboardingWelcome,
+              screens: {
+                [ScreenName.OnboardingBleDevicePairingFlow]: "sync-onboarding",
               },
             },
           },
-          [NavigatorName.Base]: {
-            screens: {
-              [ScreenName.PostBuyDeviceScreen]: "hw-purchase-success",
-              /**
-               * @params ?platform: string
-               * ie: "ledgerlive://discover/protect?theme=light" will open the catalog and the protect dapp with a light theme as parameter
-               */
-              [ScreenName.PlatformApp]: "discover/:platform",
-              [ScreenName.Recover]: "recover/:platform",
-              [ScreenName.RedirectToOnboardingRecoverFlow]: "recover-restore-flow",
-            },
+        },
+        [NavigatorName.Base]: {
+          screens: {
+            [ScreenName.PostBuyDeviceScreen]: "hw-purchase-success",
+            /**
+             * @params ?platform: string
+             * ie: "ledgerlive://discover/protect?theme=light" will open the catalog and the protect dapp with a light theme as parameter
+             */
+            [ScreenName.PlatformApp]: "discover/:platform",
+            [ScreenName.Recover]: "recover/:platform",
+            [ScreenName.RedirectToOnboardingRecoverFlow]: "recover-restore-flow",
           },
         },
+      },
   },
 });
 

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -372,29 +372,29 @@ const getOnboardingLinkingOptions = (acceptedTermsOfUse: boolean) => ({
     screens: !acceptedTermsOfUse
       ? {}
       : {
-        [NavigatorName.BaseOnboarding]: {
-          screens: {
-            [NavigatorName.Onboarding]: {
-              initialRouteName: ScreenName.OnboardingWelcome,
-              screens: {
-                [ScreenName.OnboardingBleDevicePairingFlow]: "sync-onboarding",
+          [NavigatorName.BaseOnboarding]: {
+            screens: {
+              [NavigatorName.Onboarding]: {
+                initialRouteName: ScreenName.OnboardingWelcome,
+                screens: {
+                  [ScreenName.OnboardingBleDevicePairingFlow]: "sync-onboarding",
+                },
               },
             },
           },
-        },
-        [NavigatorName.Base]: {
-          screens: {
-            [ScreenName.PostBuyDeviceScreen]: "hw-purchase-success",
-            /**
-             * @params ?platform: string
-             * ie: "ledgerlive://discover/protect?theme=light" will open the catalog and the protect dapp with a light theme as parameter
-             */
-            [ScreenName.PlatformApp]: "discover/:platform",
-            [ScreenName.Recover]: "recover/:platform",
-            [ScreenName.RedirectToOnboardingRecoverFlow]: "recover-restore-flow",
+          [NavigatorName.Base]: {
+            screens: {
+              [ScreenName.PostBuyDeviceScreen]: "hw-purchase-success",
+              /**
+               * @params ?platform: string
+               * ie: "ledgerlive://discover/protect?theme=light" will open the catalog and the protect dapp with a light theme as parameter
+               */
+              [ScreenName.PlatformApp]: "discover/:platform",
+              [ScreenName.Recover]: "recover/:platform",
+              [ScreenName.RedirectToOnboardingRecoverFlow]: "recover-restore-flow",
+            },
           },
         },
-      },
   },
 });
 

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -385,7 +385,7 @@ export const DEFAULT_FEATURES: Features = {
   buySellUi: {
     enabled: false,
     params: {
-      manifestId: BUY_SELL_UI_APP_ID, // Update to "buy-sell-ui" after rollout
+      manifestId: BUY_SELL_UI_APP_ID,
     },
   },
 

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -7,6 +7,7 @@ import {
 } from "@ledgerhq/types-live";
 import reduce from "lodash/reduce";
 import { formatToFirebaseFeatureId } from "./firebaseFeatureFlags";
+import { BUY_SELL_UI_APP_ID } from "../wallet-api/constants";
 
 /**
  * Default disabled feature.
@@ -384,7 +385,7 @@ export const DEFAULT_FEATURES: Features = {
   buySellUi: {
     enabled: false,
     params: {
-      manifestId: "multibuy-v2", // Update to "buy-sell-ui" after rollout
+      manifestId: BUY_SELL_UI_APP_ID, // Update to "buy-sell-ui" after rollout
     },
   },
 

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -475,7 +475,7 @@ export type Feature_LlmRefreshMarketData = Feature<{
 }>;
 
 export type Feature_BuySellUiManifest = Feature<{
-  manifestId: string; // id of the app to use for the Buy/Sell UI, e.g. "multibuy-v2"
+  manifestId: string; // id of the app to use for the Buy/Sell UI, e.g. "buy-sell-ui"
 }>;
 
 export type Feature_LldWalletSync = Feature<{


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist


### 📝 Description
Removes old manifest id for buy sell `multibuy-v2`. The manifest ID we currently use is `buy-sell-ui`

### ❓ Context

- [LIVE-13748](https://ledgerhq.atlassian.net/browse/LIVE-13748)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13748]: https://ledgerhq.atlassian.net/browse/LIVE-13748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ