### PR TITLE
[BUGFIX]: Add fromLedgerSyncOnboarding to trigger right onClose action for Activation

### DIFF
--- a/.changeset/fresh-sloths-boil.md
+++ b/.changeset/fresh-sloths-boil.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add fromLedgerSyncOnboarding to trigger right onClose action for Activation

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -69,6 +69,7 @@ import {
   SettingsClearDismissedContentCardsPayload,
   SettingsAddStarredMarketcoinsPayload,
   SettingsRemoveStarredMarketcoinsPayload,
+  SettingsSetFromLedgerSyncOnboardingPayload,
 } from "./types";
 import { ImageType } from "~/components/CustomImage/types";
 
@@ -279,6 +280,10 @@ export const setHasSeenAnalyticsOptInPrompt = createAction<SettingsSetHasSeenAna
 
 export const setDismissedContentCard = createAction<SettingsSetDismissedContentCardsPayload>(
   SettingsActionTypes.SET_DISMISSED_CONTENT_CARD,
+);
+
+export const setFromLedgerSyncOnboarding = createAction<SettingsSetFromLedgerSyncOnboardingPayload>(
+  SettingsActionTypes.SET_LEDGER_SYNC_ONBOARDING,
 );
 
 export const clearDismissedContentCards = createAction<SettingsClearDismissedContentCardsPayload>(

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -281,6 +281,7 @@ export enum SettingsActionTypes {
   SET_HAS_SEEN_ANALYTICS_OPT_IN_PROMPT = "SET_HAS_SEEN_ANALYTICS_OPT_IN_PROMPT",
   SET_DISMISSED_CONTENT_CARD = "SET_DISMISSED_CONTENT_CARD",
   CLEAR_DISMISSED_CONTENT_CARDS = "CLEAR_DISMISSED_CONTENT_CARDS",
+  SET_LEDGER_SYNC_ONBOARDING = "SET_LEDGER_SYNC_ONBOARDING",
 
   ADD_STARRED_MARKET_COINS = "ADD_STARRED_MARKET_COINS",
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
@@ -385,6 +386,7 @@ export type SettingsSetSupportedCounterValues = SettingsState["supportedCounterV
 export type SettingsSetHasSeenAnalyticsOptInPrompt = SettingsState["hasSeenAnalyticsOptInPrompt"];
 export type SettingsSetDismissedContentCardsPayload = SettingsState["dismissedContentCards"];
 export type SettingsClearDismissedContentCardsPayload = string[];
+export type SettingsSetFromLedgerSyncOnboardingPayload = boolean;
 
 export type SettingsAddStarredMarketcoinsPayload = Unpacked<SettingsState["starredMarketCoins"]>;
 export type SettingsRemoveStarredMarketcoinsPayload = Unpacked<SettingsState["starredMarketCoins"]>;
@@ -444,6 +446,7 @@ export type SettingsPayload =
   | SettingsSetHasSeenAnalyticsOptInPrompt
   | SettingsSetDismissedContentCardsPayload
   | SettingsClearDismissedContentCardsPayload
+  | SettingsSetFromLedgerSyncOnboardingPayload
   | SettingsAddStarredMarketcoinsPayload
   | SettingsRemoveStarredMarketcoinsPayload;
 

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationSuccess.tsx
@@ -1,10 +1,20 @@
 import React from "react";
 import { Success } from "../../components/Success";
 import { useTranslation } from "react-i18next";
-import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import {
+  BaseComposite,
+  RootNavigationComposite,
+  StackNavigatorNavigation,
+  StackNavigatorProps,
+} from "~/components/RootNavigator/types/helpers";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 
 import { NavigatorName, ScreenName } from "~/const";
+import { useDispatch, useSelector } from "react-redux";
+import { isFromLedgerSyncOnboardingSelector } from "~/reducers/settings";
+import { useNavigation } from "@react-navigation/native";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { setFromLedgerSyncOnboarding } from "~/actions/settings";
 
 type Props = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncSuccess>
@@ -12,19 +22,30 @@ type Props = BaseComposite<
 
 export function ActivationSuccess({ navigation, route }: Props) {
   const { t } = useTranslation();
-
+  const isFromLedgerSyncOnboarding = useSelector(isFromLedgerSyncOnboardingSelector);
   const { created } = route.params;
   const title = created ? "walletSync.success.activation" : "walletSync.success.sync";
   const desc = created ? "walletSync.success.activationDesc" : "walletSync.success.syncDesc";
+  const dispatch = useDispatch();
+
+  const navigationOnbarding =
+    useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
 
   function syncAnother(): void {
     navigation.navigate(ScreenName.WalletSyncActivationProcess);
   }
 
   function close(): void {
-    navigation.navigate(NavigatorName.Settings, {
-      screen: ScreenName.GeneralSettings,
-    });
+    if (isFromLedgerSyncOnboarding) {
+      dispatch(setFromLedgerSyncOnboarding(false));
+      navigationOnbarding.navigate(NavigatorName.Base, {
+        screen: NavigatorName.Main,
+      });
+    } else {
+      navigation.navigate(NavigatorName.Settings, {
+        screen: ScreenName.GeneralSettings,
+      });
+    }
   }
 
   return (

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -79,6 +79,7 @@ import type {
   SettingsClearDismissedContentCardsPayload,
   SettingsAddStarredMarketcoinsPayload,
   SettingsRemoveStarredMarketcoinsPayload,
+  SettingsSetFromLedgerSyncOnboardingPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -174,6 +175,7 @@ export const INITIAL_STATE: SettingsState = {
   hasSeenAnalyticsOptInPrompt: false,
   dismissedContentCards: {},
   starredMarketCoins: [],
+  fromLedgerSyncOnboarding: false,
 };
 
 const pairHash = (from: { ticker: string }, to: { ticker: string }) =>
@@ -638,6 +640,12 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     };
   },
 
+  [SettingsActionTypes.SET_LEDGER_SYNC_ONBOARDING]: (state, action) => ({
+    ...state,
+    fromLedgerSyncOnboarding: (action as Action<SettingsSetFromLedgerSyncOnboardingPayload>)
+      .payload,
+  }),
+
   [SettingsActionTypes.ADD_STARRED_MARKET_COINS]: (state, action) => ({
     ...state,
     starredMarketCoins: [
@@ -874,5 +882,7 @@ export const supportedCounterValuesSelector = (state: State) =>
 export const hasSeenAnalyticsOptInPromptSelector = (state: State) =>
   state.settings.hasSeenAnalyticsOptInPrompt;
 export const dismissedContentCardsSelector = (state: State) => state.settings.dismissedContentCards;
+export const isFromLedgerSyncOnboardingSelector = (state: State) =>
+  state.settings.fromLedgerSyncOnboarding;
 
 export const starredMarketCoinsSelector = (state: State) => state.settings.starredMarketCoins;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -263,6 +263,7 @@ export type SettingsState = {
   hasSeenAnalyticsOptInPrompt: boolean;
   dismissedContentCards: { [id: string]: number };
   starredMarketCoins: string[];
+  fromLedgerSyncOnboarding: boolean;
 };
 
 export type NotificationsSettings = {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/accessExistingWallet.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/accessExistingWallet.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { useTheme } from "styled-components/native";
-import { setOnboardingType } from "~/actions/settings";
+import { setFromLedgerSyncOnboarding, setOnboardingType } from "~/actions/settings";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
@@ -47,14 +47,16 @@ function AccessExistingWallet() {
 
   const openDrawer = useCallback(() => {
     dispatch(setOnboardingType(OnboardingType.walletSync));
+    dispatch(setFromLedgerSyncOnboarding(true));
     setIsDrawerVisible(true);
     logDrawer("Wallet Sync Welcome back", "open");
   }, [dispatch]);
 
   const closeDrawer = useCallback(() => {
     setIsDrawerVisible(false);
+    dispatch(setFromLedgerSyncOnboarding(false));
     logDrawer("Wallet Sync Welcome back", "close");
-  }, []);
+  }, [dispatch]);
 
   return (
     <OnboardingView


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

`fromLedgerSyncOnboarding` added in Store to differentiate where we come from to close correctly and redirect to the right screen



https://github.com/user-attachments/assets/1c6cd0fe-5277-4cf5-a3b8-049338baaa86



### ❓ Context

- **JIRA or GitHub link**: 
- [LIVE-13772] 
- [LIVE-13773]
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13772]: https://ledgerhq.atlassian.net/browse/LIVE-13772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-13773]: https://ledgerhq.atlassian.net/browse/LIVE-13773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ