### PR TITLE
🗝️ [FIX]: llm "Delete my encryption key" action on wrong seed errors

### DIFF
--- a/.changeset/selfish-poets-arrive.md
+++ b/.changeset/selfish-poets-arrive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix "Delete my encryption key" action on wrong seed errors

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useFollowInstructionDrawer.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useFollowInstructionDrawer.ts
@@ -1,0 +1,54 @@
+import { useNavigation } from "@react-navigation/native";
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
+import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
+import { ScreenName } from "~/const";
+import { useDestroyTrustchain } from "./useDestroyTrustchain";
+
+export enum SceneKind {
+  DeviceInstructions,
+  Loader,
+  WrongSeedError,
+  KeyError,
+  GenericError,
+}
+type Scene =
+  | { kind: SceneKind.DeviceInstructions; device: Device }
+  | { kind: SceneKind.Loader }
+  | { kind: SceneKind.WrongSeedError }
+  | { kind: SceneKind.KeyError }
+  | { kind: SceneKind.GenericError; error: Error };
+
+export type DrawerProps = {
+  scene: Scene;
+  onRetry: () => void;
+  goToDelete: () => void;
+  backToKeyError: () => void;
+  confirmDeleteKey: () => void;
+};
+
+export function useFollowInstructionDrawer(): [DrawerProps, Dispatch<SetStateAction<Scene>>] {
+  const navigation = useNavigation<StackNavigatorNavigation<WalletSyncNavigatorStackParamList>>();
+  const { deleteMutation } = useDestroyTrustchain();
+
+  const [scene, setScene] = useState<Scene>({ kind: SceneKind.Loader });
+
+  // eslint-disable-next-line no-console
+  const onRetry = useCallback(() => console.log("onRetry"), []);
+
+  const goToDelete = useCallback(() => {
+    setScene({ kind: SceneKind.WrongSeedError });
+  }, []);
+
+  const backToKeyError = useCallback(() => {
+    setScene({ kind: SceneKind.KeyError });
+  }, []);
+
+  const confirmDeleteKey = useCallback(async () => {
+    await deleteMutation.mutateAsync();
+    navigation.navigate(ScreenName.WalletSyncManageKeyDeleteSuccess);
+  }, [deleteMutation, navigation]);
+
+  return [{ scene, onRetry, goToDelete, backToKeyError, confirmDeleteKey }, setScene];
+}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationInstructionDrawer.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationInstructionDrawer.tsx
@@ -11,15 +11,11 @@ type Props = {
 };
 
 const FollowInstructionsDrawer = ({ isOpen, handleClose, device }: Props) => {
-  const { error, userDeviceInteraction } = useAddMember({ device });
-
   return (
     <GenericFollowInstructionsDrawer
+      {...useAddMember({ device })}
       isOpen={isOpen}
       handleClose={handleClose}
-      device={device}
-      userDeviceInteraction={userDeviceInteraction}
-      error={error}
     />
   );
 };

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/FollowInstructions/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/FollowInstructions/index.tsx
@@ -3,50 +3,59 @@ import QueuedDrawer from "LLM/components/QueuedDrawer";
 import { TrackScreen } from "~/analytics";
 import FollowInstructions from "../../components/FollowInstructions";
 
-import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import GenericErrorView from "~/components/GenericErrorView";
 import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
-import { TrustchainNotAllowed } from "@ledgerhq/trustchain/errors";
+import { ConfirmManageKey } from "../../components/ManageKey/Confirm";
 import { DeletionError, ErrorReason } from "../../components/ManageInstances/DeletionError";
+import { DrawerProps, SceneKind } from "../../hooks/useFollowInstructionDrawer";
 
-type Props = {
+type Props = DrawerProps & {
   isOpen: boolean;
   handleClose: () => void;
-  device: Device | null;
-  userDeviceInteraction: boolean;
-  error: Error | null;
-  goToDelete?: () => void;
 };
 
 const GenericFollowInstructionsDrawer = ({
   isOpen,
   handleClose,
-  device,
-  error,
-  userDeviceInteraction,
+  scene,
   goToDelete,
+  backToKeyError,
+  confirmDeleteKey,
 }: Props) => {
+  const getScene = () => {
+    switch (scene.kind) {
+      case SceneKind.DeviceInstructions:
+        return <FollowInstructions device={scene.device} />;
+
+      case SceneKind.Loader:
+        return (
+          <Flex alignItems="center" justifyContent="center" height={150}>
+            <InfiniteLoader size={50} />
+          </Flex>
+        );
+
+      case SceneKind.WrongSeedError:
+        return <ConfirmManageKey onClickConfirm={confirmDeleteKey} onCancel={backToKeyError} />;
+
+      case SceneKind.KeyError:
+        return (
+          <DeletionError
+            error={ErrorReason.UNSECURED}
+            tryAgain={handleClose}
+            goToDelete={goToDelete}
+          />
+        );
+
+      case SceneKind.GenericError:
+        return <GenericErrorView error={scene.error} withDescription withHelp hasExportLogButton />;
+    }
+  };
+
   return (
     <>
       <TrackScreen />
       <QueuedDrawer isRequestingToBeOpened={isOpen} onClose={handleClose}>
-        {error ? (
-          error instanceof TrustchainNotAllowed ? (
-            <DeletionError
-              error={ErrorReason.UNSECURED}
-              tryAgain={handleClose}
-              goToDelete={goToDelete}
-            />
-          ) : (
-            <GenericErrorView error={error} withDescription withHelp hasExportLogButton />
-          )
-        ) : userDeviceInteraction && device ? (
-          <FollowInstructions device={device} />
-        ) : (
-          <Flex alignItems="center" justifyContent="center" height={150}>
-            <InfiniteLoader size={50} />
-          </Flex>
-        )}
+        {getScene()}
       </QueuedDrawer>
     </>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/ManageInstances/DeletionInstructionDrawer.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/ManageInstances/DeletionInstructionDrawer.tsx
@@ -13,16 +13,11 @@ type Props = {
 };
 
 const DeletionFollowInstructionsDrawer = ({ isOpen, handleClose, device, member }: Props) => {
-  const { error, userDeviceInteraction, goToDelete } = useRemoveMember({ device, member });
-
   return (
     <GenericFollowInstructionsDrawer
+      {...useRemoveMember({ device, member })}
       isOpen={isOpen}
       handleClose={handleClose}
-      device={device}
-      userDeviceInteraction={userDeviceInteraction}
-      error={error}
-      goToDelete={goToDelete}
     />
   );
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The "Delete my encryption key" on the wrong seed error was not doing anything on the add member flow and just lead to the main wallet sync page on the remove member flow.

It now shows the delete key confirmation drawer:

https://github.com/user-attachments/assets/f9dad0a7-70f4-48bd-8072-1cd1dc6ba3de


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-13779]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13779]: https://ledgerhq.atlassian.net/browse/LIVE-13779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ