### PR TITLE
[LIVE-10655][LLD] Fix removal of custom lock screen

### DIFF
--- a/.changeset/twenty-bottles-leave.md
+++ b/.changeset/twenty-bottles-leave.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Fix removal of custom lock screen on LLD

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
@@ -19,10 +19,6 @@ import useIsMounted from "@ledgerhq/live-common/hooks/useIsMounted";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { analyticsPageNames, analyticsFlowName } from "./shared";
 import { useTrack } from "~/renderer/analytics/segment";
-import { setDrawer } from "~/renderer/drawers/Provider";
-import RemoveCustomImage from "../manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage";
-import { useSelector } from "react-redux";
-import { lastSeenCustomImageSelector } from "~/renderer/reducers/settings";
 
 type Props = StepProps & {
   onResult: (res: ImageBase64Data) => void;
@@ -31,6 +27,7 @@ type Props = StepProps & {
   setIsShowingNftGallery: (_: boolean) => void;
   loading?: boolean;
   hasCustomLockScreen?: boolean;
+  onClickRemoveCustomImage: () => void;
 };
 
 const defaultMediaTypes = ["original", "big", "preview"];
@@ -56,6 +53,7 @@ const StepChooseImage: React.FC<Props> = props => {
     isShowingNftGallery,
     setIsShowingNftGallery,
     hasCustomLockScreen,
+    onClickRemoveCustomImage,
   } = props;
   const isMounted = useIsMounted();
   const { t } = useTranslation();
@@ -111,12 +109,6 @@ const StepChooseImage: React.FC<Props> = props => {
     [isMounted, onError, selectedNftId],
   );
 
-  const lastSeenCustomImage = useSelector(lastSeenCustomImageSelector);
-
-  const onRemove = useCallback(() => {
-    setDrawer(RemoveCustomImage, {});
-  }, []);
-
   return (
     <StepContainer
       footer={
@@ -166,12 +158,12 @@ const StepChooseImage: React.FC<Props> = props => {
               });
             }}
           />
-          {hasCustomLockScreen || lastSeenCustomImage?.size ? (
+          {hasCustomLockScreen ? (
             <Link
               size="medium"
               color="error.c60"
               mt={10}
-              onClick={onRemove}
+              onClick={onClickRemoveCustomImage}
               Icon={IconsLegacy.TrashMedium}
             >
               {t("removeCurrentPicture.cta")}

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/index.tsx
@@ -36,6 +36,7 @@ import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { useTrack } from "~/renderer/analytics/segment";
 import DeviceModelPicker from "~/renderer/components/CustomImage/DeviceModelPicker";
 import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
+import RemoveCustomImage from "../manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage";
 
 type Props = {
   imageUri?: string;
@@ -44,6 +45,7 @@ type Props = {
   reopenPreviousDrawer?: () => void;
   deviceModelId: DeviceModelId | null;
   hasCustomLockScreen?: boolean;
+  setHasCustomLockScreen?: (value: boolean) => void;
 };
 
 const orderedSteps: Step[] = [
@@ -62,6 +64,7 @@ const CustomImage: React.FC<Props> = props => {
     reopenPreviousDrawer,
     isFromPostOnboardingEntryPoint,
     hasCustomLockScreen,
+    setHasCustomLockScreen,
   } = props;
   const { t } = useTranslation();
   const track = useTrack();
@@ -159,8 +162,9 @@ const CustomImage: React.FC<Props> = props => {
     }, []);
 
   const handleStepTransferResult = useCallback(() => {
+    setHasCustomLockScreen && setHasCustomLockScreen(true);
     setTransferDone(true);
-  }, []);
+  }, [setHasCustomLockScreen]);
 
   const handleError = useCallback(
     (step: Step, error: Error) => {
@@ -236,6 +240,20 @@ const CustomImage: React.FC<Props> = props => {
     <DeviceModelPicker deviceModelId={deviceModelId} onChange={setDeviceModelId} />
   ) : null;
 
+  const [isShowingRemoveCustomImage, setIsShowingRemoveCustomImage] = useState(false);
+  const onClickRemoveCustomImage = useCallback(() => {
+    setIsShowingRemoveCustomImage(true);
+  }, []);
+
+  if (isShowingRemoveCustomImage) {
+    return (
+      <RemoveCustomImage
+        onClose={() => setDrawer()}
+        onRemoved={setHasCustomLockScreen ? () => setHasCustomLockScreen(false) : undefined}
+      />
+    );
+  }
+
   return (
     <Flex
       flexDirection="column"
@@ -271,6 +289,7 @@ const CustomImage: React.FC<Props> = props => {
               isShowingNftGallery={isShowingNftGallery}
               setIsShowingNftGallery={setIsShowingNftGallery}
               hasCustomLockScreen={hasCustomLockScreen}
+              onClickRemoveCustomImage={onClickRemoveCustomImage}
             />
           </FlowStepper.Indexed.Step>
           <FlowStepper.Indexed.Step

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/CustomImageManagerButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/CustomImageManagerButton.tsx
@@ -11,15 +11,20 @@ type Props = {
   disabled?: boolean;
   deviceModelId: CLSSupportedDeviceModelId;
   hasCustomLockScreen: boolean;
+  setHasCustomLockScreen: (value: boolean) => void;
 };
 
 const CustomImageManagerButton = (props: Props) => {
   const { t } = useTranslation();
-  const { disabled, deviceModelId, hasCustomLockScreen } = props;
+  const { disabled, deviceModelId, hasCustomLockScreen, setHasCustomLockScreen } = props;
 
   const onAdd = useCallback(() => {
-    setDrawer(CustomImage, { deviceModelId, hasCustomLockScreen }, { forceDisableFocusTrap: true });
-  }, [deviceModelId, hasCustomLockScreen]);
+    setDrawer(
+      CustomImage,
+      { deviceModelId, hasCustomLockScreen, setHasCustomLockScreen },
+      { forceDisableFocusTrap: true },
+    );
+  }, [deviceModelId, hasCustomLockScreen, setHasCustomLockScreen]);
 
   return (
     <Flex flexDirection="row" columnGap={3} alignItems="center">

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
@@ -18,9 +18,9 @@ const TextEllipsis = styled.div`
   text-overflow: ellipsis;
 `;
 
-type Props = { onClose?: () => void };
+type Props = { onClose: () => void; onRemoved?: () => void };
 
-const RemoveCustomImage: React.FC<Props> = ({ onClose }) => {
+const RemoveCustomImage: React.FC<Props> = ({ onClose, onRemoved }) => {
   const request = useMemo(() => ({}), []);
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -40,7 +40,8 @@ const RemoveCustomImage: React.FC<Props> = ({ onClose }) => {
     setCompleted(true);
     setRunning(false);
     dispatch(clearLastSeenCustomImage());
-  }, [dispatch]);
+    onRemoved && onRemoved();
+  }, [dispatch, onRemoved]);
 
   const onError = useCallback(
     (error: Error) => {

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/index.tsx
@@ -62,6 +62,7 @@ type Props = {
   installQueue: string[];
   uninstallQueue: string[];
   hasCustomLockScreen: boolean;
+  setHasCustomLockScreen: (value: boolean) => void;
 };
 
 /**
@@ -81,6 +82,7 @@ const DeviceInformationSummary = ({
   installQueue,
   uninstallQueue,
   hasCustomLockScreen,
+  setHasCustomLockScreen,
 }: Props) => {
   const navigationLocked = useSelector(isNavigationLocked);
 
@@ -167,6 +169,7 @@ const DeviceInformationSummary = ({
                   disabled={navigationLocked}
                   deviceModelId={deviceModel.id}
                   hasCustomLockScreen={hasCustomLockScreen}
+                  setHasCustomLockScreen={setHasCustomLockScreen}
                 />
               </>
             ) : null}

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/index.tsx
@@ -172,6 +172,9 @@ const DeviceDashboard = ({
   }, [reduxDispatch, result.customImageBlocks]);
 
   const disableFirmwareUpdate = state.installQueue.length > 0 || state.uninstallQueue.length > 0;
+
+  const [hasCustomLockScreen, setHasCustomLockScreen] = useState(result.customImageBlocks !== 0);
+
   return (
     <>
       {renderFirmwareUpdateBanner
@@ -212,7 +215,8 @@ const DeviceDashboard = ({
           device={device}
           deviceName={deviceName}
           isIncomplete={isIncomplete}
-          hasCustomLockScreen={result.customImageBlocks !== 0}
+          hasCustomLockScreen={hasCustomLockScreen}
+          setHasCustomLockScreen={setHasCustomLockScreen}
         />
         <ProviderWarning />
         <AppList

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
@@ -1,47 +1,169 @@
 import { StatusCodes, UnexpectedBootloader, UserRefusedOnDevice } from "@ledgerhq/errors";
-import { command as customLockScreenRemove } from "./customLockScreenRemove";
+import removeImage, { command } from "./customLockScreenRemove";
 import Transport from "@ledgerhq/hw-transport";
 import { ImageDoesNotExistOnDevice } from "../errors";
+import { withDevice } from "./deviceAccess";
+import { from } from "rxjs";
+import getDeviceInfo from "./getDeviceInfo";
+import { DeviceInfo } from "@ledgerhq/types-live";
+
+jest.mock("./deviceAccess");
+const mockedWithDevice = jest.mocked(withDevice);
+function mockWithDevice(transport: Transport) {
+  mockedWithDevice.mockReturnValue(job => from(job(transport)));
+}
+
+jest.mock("./getDeviceInfo");
+const mockedGetDeviceInfo = jest.mocked(getDeviceInfo);
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore next-line
 const mockTransportGenerator = out => ({ send: () => out }) as Transport;
 
 describe("customLockScreenRemove", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test("should succeed if user approves", async () => {
     const mockedTransport: Transport = mockTransportGenerator(
       Buffer.from(StatusCodes.OK.toString(16), "hex"),
     );
-    await expect(customLockScreenRemove(mockedTransport)).resolves.toBeUndefined();
+    await expect(command(mockedTransport)).resolves.toBeUndefined();
   });
 
   test("should fail with correct error if user refuses", async () => {
     const mockedTransport: Transport = mockTransportGenerator(
       Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex"),
     );
-    await expect(customLockScreenRemove(mockedTransport)).rejects.toThrow(UserRefusedOnDevice);
+    await expect(command(mockedTransport)).rejects.toThrow(UserRefusedOnDevice);
   });
 
   test("should throw if user refuses", async () => {
     const mockedTransport: Transport = mockTransportGenerator(
       Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex"),
     );
-    await expect(customLockScreenRemove(mockedTransport)).rejects.toThrow(Error);
+    await expect(command(mockedTransport)).rejects.toThrow(Error);
   });
 
   test("missing image, should throw", async () => {
     const mockedTransport = mockTransportGenerator(
       Buffer.from(StatusCodes.CUSTOM_IMAGE_EMPTY.toString(16), "hex"),
     );
-    await expect(customLockScreenRemove(mockedTransport)).rejects.toThrow(
-      ImageDoesNotExistOnDevice,
-    );
+    await expect(command(mockedTransport)).rejects.toThrow(ImageDoesNotExistOnDevice);
   });
 
   test("unexpected bootloader or any other code, should throw", async () => {
     const mockedTransport = mockTransportGenerator(
       Buffer.from(StatusCodes.DEVICE_IN_RECOVERY_MODE.toString(16), "hex"),
     );
-    await expect(customLockScreenRemove(mockedTransport)).rejects.toThrow(UnexpectedBootloader);
+    await expect(command(mockedTransport)).rejects.toThrow(UnexpectedBootloader);
+  });
+});
+
+describe("removeImage deviceAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWithDevice(new Transport());
+  });
+
+  it('should emit an "unresponsiveDevice" event if getDeviceInfo takes too long', done => {
+    mockedGetDeviceInfo.mockImplementation(() => new Promise(() => {}));
+
+    removeImage({ deviceId: "deviceId", request: {} }).subscribe({
+      next: event => {
+        if (!event) {
+          done(new Error("unexpected undefined event"));
+        }
+        const { type } = event;
+        if (type === "unresponsiveDevice") {
+          done();
+        } else {
+          done(new Error("unexpected event"));
+        }
+      },
+      error: err => {
+        done(err); // it should not error
+      },
+    });
+  });
+
+  it("should error if getDeviceInfo fails", done => {
+    mockedGetDeviceInfo.mockRejectedValue(new Error("failed"));
+
+    removeImage({ deviceId: "deviceId", request: {} }).subscribe({
+      next: () => {
+        done(new Error("unexpected event"));
+      },
+      error: err => {
+        try {
+          expect(err).toMatchObject(new Error("failed"));
+          done();
+        } catch (e) {
+          done(e);
+        }
+      },
+    });
+  });
+
+  it("should complete with the correct events in case of success", done => {
+    mockedGetDeviceInfo.mockResolvedValue({} as DeviceInfo);
+    mockWithDevice(mockTransportGenerator(Buffer.from(StatusCodes.OK.toString(16), "hex")));
+
+    const expectedEventTypes = ["removeImagePermissionRequested", "imageRemoved"];
+    const observedEventTypes: string[] = [];
+
+    removeImage({ deviceId: "deviceId", request: {} }).subscribe({
+      next: event => {
+        if (!event) {
+          done(new Error("unexpected undefined event"));
+        }
+        const { type } = event;
+        observedEventTypes.push(type);
+      },
+      complete: () => {
+        try {
+          expect(observedEventTypes).toEqual(expectedEventTypes);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      },
+      error: err => {
+        done(err); // it should not error
+      },
+    });
+  });
+
+  it("should complete with the correct events in case of failure", done => {
+    mockedGetDeviceInfo.mockResolvedValue({} as DeviceInfo);
+    mockWithDevice(
+      mockTransportGenerator(Buffer.from(StatusCodes.USER_REFUSED_ON_DEVICE.toString(16), "hex")),
+    );
+
+    const expectedEventTypes = ["removeImagePermissionRequested"];
+    const observedEventTypes: string[] = [];
+
+    removeImage({ deviceId: "deviceId", request: {} }).subscribe({
+      next: event => {
+        if (!event) {
+          done(new Error("unexpected undefined event"));
+        }
+        const { type } = event;
+        observedEventTypes.push(type);
+      },
+      complete: () => {
+        done(new Error("unexpected completion"));
+      },
+      error: err => {
+        try {
+          expect(observedEventTypes).toEqual(expectedEventTypes);
+          expect(err).toMatchObject(new UserRefusedOnDevice());
+          done();
+        } catch (e) {
+          done(e); // it should not error
+        }
+      },
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Removal of custom lock screen on LLM & LLD

### 📝 Description

There were 2 issues:

#### 1. Drawer issue, device action being remounted twice:
In LLD, the device action for CLS removal was mounted in a new drawer.
It seems like in LLD when opening a new drawer, the component inside is remounted almost immediately. This might be a deeper issue that I don't want to fix just for this bug.
For a device action that starts immediately on mount, it's bad because it means the command will be sent twice in a row to the device, without waiting for completion.
The fix for that is simply to reuse the drawer that we are already in.

#### 2. Bad usage of observables in the `customLockScreenRemove` device action:
We were doing some weird stuff to ensure that errors were caught (the `.subscribe(subscriber)` part).
TypeScript was detecting that something was wrong, but we were doing a wrong type assertion.
It was causing an issue where the observable would never emit the final event "imageRemoved" on success.
The fix is to implement error handling properly. Full test coverage was added.

#### Before
completely broken

https://github.com/user-attachments/assets/3bc65ddb-1515-429f-8ab8-31f3df769ff8



#### Demo
it's working fine now 🎉 

https://github.com/user-attachments/assets/e18506b4-fcb9-4b4c-b2a5-9cc381639646


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-10655] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-10655]: https://ledgerhq.atlassian.net/browse/LIVE-10655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ