### PR TITLE
🐦‍🔥 [FIX]: Refresh ledger sync QR code on expiration

### DIFF
--- a/.changeset/sweet-spies-sell.md
+++ b/.changeset/sweet-spies-sell.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/errors": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/trustchain": patch
+---
+
+Refresh ledger sync QR code on expiration

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useQRCode.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useQRCode.ts
@@ -1,6 +1,11 @@
 import { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/trustchain/qrcode/index";
-import { InvalidDigitsError, NoTrustchainInitialized } from "@ledgerhq/trustchain/errors";
+import {
+  InvalidDigitsError,
+  NoTrustchainInitialized,
+  QRCodeWSClosed,
+} from "@ledgerhq/trustchain/errors";
+import { MemberCredentials } from "@ledgerhq/trustchain/types";
 import { useDispatch, useSelector } from "react-redux";
 import { setFlow, setQrCodePinCode } from "~/renderer/actions/walletSync";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
@@ -12,9 +17,11 @@ import {
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { QueryKey } from "./type.hooks";
 import { useInstanceName } from "./useInstanceName";
+
+const MIN_TIME_TO_REFRESH = 30_000;
 
 export function useQRCode() {
   const queryClient = useQueryClient();
@@ -26,73 +33,76 @@ export function useQRCode() {
   const { trustchainApiBaseUrl } = getWalletSyncEnvironmentParams(
     featureWalletSync?.params?.environment,
   );
-  const [isLoading, setIsLoading] = useState(false);
   const [url, setUrl] = useState<string | null>(null);
-  const [error, setError] = useState<Error | null>(null);
   const memberName = useInstanceName();
 
   const goToActivation = useCallback(() => {
     dispatch(setFlow({ flow: Flow.Activation, step: Step.DeviceAction }));
   }, [dispatch]);
 
-  const startQRCodeProcessing = useCallback(() => {
-    if (!memberCredentials) return;
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: (memberCredentials: MemberCredentials) =>
+      createQRCodeHostInstance({
+        trustchainApiBaseUrl,
+        onDisplayQRCode: url => {
+          setUrl(url);
+        },
+        onDisplayDigits: digits => {
+          dispatch(setQrCodePinCode(digits));
+          dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCode }));
+        },
+        addMember: async member => {
+          if (trustchain) {
+            await sdk.addMember(trustchain, memberCredentials, member);
+            return trustchain;
+          }
+          throw new NoTrustchainInitialized();
+        },
+        memberCredentials,
+        memberName,
+        alreadyHasATrustchain: !!trustchain,
+      }),
 
-    setError(null);
-    setIsLoading(true);
-    createQRCodeHostInstance({
-      trustchainApiBaseUrl,
-      onDisplayQRCode: url => {
-        setUrl(url);
-      },
-      onDisplayDigits: digits => {
-        dispatch(setQrCodePinCode(digits));
-        dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCode }));
-      },
-      addMember: async member => {
-        if (trustchain) {
-          await sdk.addMember(trustchain, memberCredentials, member);
-          return trustchain;
-        }
-        throw new NoTrustchainInitialized();
-      },
-      memberCredentials,
-      memberName,
-      alreadyHasATrustchain: !!trustchain,
-    })
-      .catch(e => {
-        if (e instanceof InvalidDigitsError) {
-          dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCodeError }));
-        } else if (e instanceof NoTrustchainInitialized) {
-          dispatch(setFlow({ flow: Flow.Synchronize, step: Step.UnbackedError }));
-        }
-        setError(e);
-        throw e;
-      })
-      .then(newTrustchain => {
-        if (newTrustchain) {
-          dispatch(setTrustchain(newTrustchain));
-        }
-        dispatch(
-          setFlow({
-            flow: Flow.Synchronize,
-            step: Step.SynchronizeLoading,
-            nextStep: Step.Synchronized,
-            hasTrustchainBeenCreated: false,
-          }),
-        );
-        queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
-        setUrl(null);
-        dispatch(setQrCodePinCode(null));
-        setIsLoading(false);
-        setError(null);
-      });
-  }, [memberCredentials, trustchainApiBaseUrl, memberName, dispatch, trustchain, sdk, queryClient]);
+    // Don't use retry here because it always uses a delay despite setting it to 0
+    onError(e) {
+      if (e instanceof QRCodeWSClosed) {
+        const { time } = e as unknown as { time: number };
+        if (time >= MIN_TIME_TO_REFRESH) startQRCodeProcessing();
+      }
+      if (e instanceof InvalidDigitsError) {
+        dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCodeError }));
+      }
+      if (e instanceof NoTrustchainInitialized) {
+        dispatch(setFlow({ flow: Flow.Synchronize, step: Step.UnbackedError }));
+      }
+    },
+
+    onSuccess(newTrustchain) {
+      if (newTrustchain) {
+        dispatch(setTrustchain(newTrustchain));
+      }
+      dispatch(
+        setFlow({
+          flow: Flow.Synchronize,
+          step: Step.SynchronizeLoading,
+          nextStep: Step.Synchronized,
+          hasTrustchainBeenCreated: false,
+        }),
+      );
+      queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
+      setUrl(null);
+      dispatch(setQrCodePinCode(null));
+    },
+  });
+
+  const startQRCodeProcessing = useCallback(() => {
+    if (memberCredentials) mutate(memberCredentials);
+  }, [mutate, memberCredentials]);
 
   return {
     url,
     error,
-    isLoading,
+    isLoading: isPending,
     startQRCodeProcessing,
     goToActivation,
   };

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useQRCodeHost.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useQRCodeHost.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/trustchain/qrcode/index";
-import { InvalidDigitsError, NoTrustchainInitialized } from "@ledgerhq/trustchain/errors";
+import {
+  InvalidDigitsError,
+  NoTrustchainInitialized,
+  QRCodeWSClosed,
+} from "@ledgerhq/trustchain/errors";
+import { MemberCredentials } from "@ledgerhq/trustchain/types";
 import { useDispatch, useSelector } from "react-redux";
 import {
   trustchainSelector,
@@ -13,9 +18,11 @@ import { useNavigation } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { QueryKey } from "./type.hooks";
 import { useInstanceName } from "./useInstanceName";
+
+const MIN_TIME_TO_REFRESH = 30_000;
 
 interface Props {
   setCurrentStep: (step: Steps) => void;
@@ -36,77 +43,68 @@ export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Pr
   );
   const memberName = useInstanceName();
 
-  const [isLoading, setIsLoading] = useState(false);
   const [url, setUrl] = useState<string | null>(null);
-  const [error, setError] = useState<Error | null>(null);
   const [pinCode, setPinCode] = useState<string | null>(null);
 
   const navigation = useNavigation();
 
-  const startQRCodeProcessing = useCallback(() => {
-    if (!memberCredentials || isLoading) return;
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: (memberCredentials: MemberCredentials) =>
+      createQRCodeHostInstance({
+        trustchainApiBaseUrl,
+        onDisplayQRCode: url => {
+          setUrl(url);
+        },
+        onDisplayDigits: digits => {
+          setPinCode(digits);
+          setCurrentStep(Steps.PinDisplay);
+        },
+        addMember: async member => {
+          if (trustchain) {
+            await sdk.addMember(trustchain, memberCredentials, member);
+            return trustchain;
+          }
+          throw new NoTrustchainInitialized();
+        },
+        memberCredentials,
+        memberName,
+        alreadyHasATrustchain: !!trustchain,
+      }),
 
-    setError(null);
-    setIsLoading(true);
-    createQRCodeHostInstance({
-      trustchainApiBaseUrl,
-      onDisplayQRCode: url => {
-        setUrl(url);
-      },
-      onDisplayDigits: digits => {
-        setPinCode(digits);
-        setCurrentStep(Steps.PinDisplay);
-      },
-      addMember: async member => {
-        if (trustchain) {
-          await sdk.addMember(trustchain, memberCredentials, member);
-          return trustchain;
-        }
-        throw new NoTrustchainInitialized();
-      },
-      memberCredentials,
-      memberName,
-      alreadyHasATrustchain: !!trustchain,
-    })
-      .then(newTrustchain => {
-        if (newTrustchain) {
-          dispatch(setTrustchain(newTrustchain));
-        }
-        queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
-        navigation.navigate(NavigatorName.WalletSync, {
-          screen: ScreenName.WalletSyncLoading,
-          params: {
-            created: false,
-          },
-        });
-
-        setUrl(null);
-        setPinCode(null);
-        setIsLoading(false);
-      })
-      .catch(e => {
-        if (e instanceof InvalidDigitsError) {
-          setCurrentStep(Steps.SyncError);
-          return;
-        } else if (e instanceof NoTrustchainInitialized) {
-          setCurrentStep(Steps.UnbackedError);
-          return;
-        }
-        setError(e);
-        throw e;
+    onSuccess: newTrustchain => {
+      if (newTrustchain) {
+        dispatch(setTrustchain(newTrustchain));
+      }
+      queryClient.invalidateQueries({ queryKey: [QueryKey.getMembers] });
+      navigation.navigate(NavigatorName.WalletSync, {
+        screen: ScreenName.WalletSyncLoading,
+        params: {
+          created: false,
+        },
       });
-  }, [
-    trustchain,
-    memberCredentials,
-    isLoading,
-    trustchainApiBaseUrl,
-    memberName,
-    setCurrentStep,
-    sdk,
-    queryClient,
-    navigation,
-    dispatch,
-  ]);
+
+      setUrl(null);
+      setPinCode(null);
+    },
+
+    // Don't use retry here because it always uses a delay despite setting it to 0
+    onError: e => {
+      if (e instanceof QRCodeWSClosed) {
+        const { time } = e as unknown as { time: number };
+        if (time >= MIN_TIME_TO_REFRESH) startQRCodeProcessing();
+      }
+      if (e instanceof InvalidDigitsError) {
+        setCurrentStep(Steps.SyncError);
+      }
+      if (e instanceof NoTrustchainInitialized) {
+        setCurrentStep(Steps.UnbackedError);
+      }
+    },
+  });
+
+  const startQRCodeProcessing = useCallback(() => {
+    if (memberCredentials) mutate(memberCredentials);
+  }, [mutate, memberCredentials]);
 
   useEffect(() => {
     if (currentStep === Steps.QrCodeMethod && currentOption === Options.SHOW_QR) {
@@ -117,7 +115,7 @@ export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Pr
   return {
     url,
     error,
-    isLoading,
+    isLoading: isPending,
     startQRCodeProcessing,
     pinCode,
   };

--- a/libs/ledgerjs/packages/errors/src/helpers.ts
+++ b/libs/ledgerjs/packages/errors/src/helpers.ts
@@ -19,7 +19,7 @@ export interface LedgerErrorConstructor<F extends { [key: string]: unknown }>
 
 export const createCustomErrorClass = <
   F extends { [key: string]: unknown },
-  T extends LedgerErrorConstructor<F>,
+  T extends LedgerErrorConstructor<F> = LedgerErrorConstructor<F>,
 >(
   name: string,
 ): T => {

--- a/libs/trustchain/src/errors.ts
+++ b/libs/trustchain/src/errors.ts
@@ -11,3 +11,5 @@ export const TrustchainAlreadyInitialized = createCustomErrorClass("TrustchainAl
 export const TrustchainAlreadyInitializedWithOtherSeed = createCustomErrorClass(
   "TrustchainAlreadyInitializedWithOtherSeed",
 );
+
+export const QRCodeWSClosed = createCustomErrorClass<{ time: number }>("QRCodeWSClosed");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

It retries the QR code processing flow when the WS closes unexpectedly. Since AFAIK there is no way to make sure the WS closed because of the QR code expiration: if the connection closes in less than 30 seconds the flow is not retried and the old error is shown. Here's a demo the behaviour with a min time 3 seconds:

https://github.com/user-attachments/assets/14c923dd-8da3-4e9c-a1f9-e3733958dbbe

I ended up using react query because I was getting some weird behaviour with the old logic. However I didn't manage to use the build in `retry` option because the `delay` option didn't work for me it kept on retrying after +30 seconds instead of immediatley 🤷.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-13766]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13766]: https://ledgerhq.atlassian.net/browse/LIVE-13766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ