### PR TITLE
[LIVE-13826] Fix access to My Ledger when listApps APDU not supported

### DIFF
--- a/.changeset/thick-fans-give.md
+++ b/.changeset/thick-fans-give.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Fix listApps: fallback to HSM script runner if listApps APDU is not available

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -93,9 +93,9 @@ const cmd = ({ deviceId, request }: Input): Observable<ConnectManagerEvent> =>
                   [
                     StatusCodes.CLA_NOT_SUPPORTED,
                     StatusCodes.INS_NOT_SUPPORTED,
+                    StatusCodes.UNKNOWN_APDU,
                     0x6e01, // No StatusCodes definition
                     0x6d01, // No StatusCodes definition
-                    0x6d02, // No StatusCodes definition
                   ].includes(e.statusCode))
               ) {
                 return from(getAppAndVersion(transport)).pipe(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM+LLD: Access to My Ledger

### 📝 Description

On old firmwares, the `listApps` APDU is not supported (for instance on Nano X 1.2.4).
Prior to #7453, we were not using that APDU, but always using the HSM to request the list of apps to the device. Sending the `listApps` APDU directly is an optimisation, as it avoids network calls, and it's doable in case the user has already allowed a secure connection on their device. But it fails for old firmwares.

So the solution chosen here, to not have a logic that depends on versions, is to first try to send the APDU, and if it fails, we proceed with the HSM method.

#### Before:


https://github.com/user-attachments/assets/d4925a32-5acd-4c97-904d-0fba0022ac5f



#### After:


https://github.com/user-attachments/assets/ffaa7afc-72b2-4341-93c7-0cb30b501180



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13826] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13826]: https://ledgerhq.atlassian.net/browse/LIVE-13826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ