### PR TITLE
fix: uses correct status for fee drawers and disable button if any er…

### DIFF
--- a/.changeset/fifty-eels-breathe.md
+++ b/.changeset/fifty-eels-breathe.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: uses correct status for fee drawers and disable button if any error is present

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -102,7 +102,7 @@ export default function FeesDrawerLiveApp({
           <SendAmountFields
             account={parentAccount || (mainAccount as Account)}
             parentAccount={parentAccount}
-            status={status}
+            status={transactionStatus}
             transaction={transaction}
             onChange={handleSetTransaction}
             updateTransaction={handleUpdateTransaction}
@@ -124,7 +124,7 @@ export default function FeesDrawerLiveApp({
 
       <Box mt={3} mx={3} alignSelf="flex-end">
         <Button
-          disabled={!!transactionStatus.errors?.amount}
+          disabled={Object.keys(transactionStatus.errors).length > 0}
           variant={"main"}
           outline
           borderRadius={48}


### PR DESCRIPTION
…ror is present

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

fix: uses correct status for fee drawers and disable button if any error is present

### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-11922)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
