### PR TITLE
:sparkles: (device) [LIVE-13852]: implement delete app data use case

### DIFF
--- a/.changeset/tall-mayflies-study.md
+++ b/.changeset/tall-mayflies-study.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add new use case to delete locally stored app data (llm/lld)

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6222,6 +6222,15 @@
     },
     "TonMinimumRequired": {
       "title": "Insufficient funds. The minimum required balance is 0.02 TON."
+    },
+    "BackupAppDataError": {
+      "title": "Error during app data backup"
+    },
+    "RestoreAppDataError": {
+      "title": "Error restoring app data"
+    },
+    "DeleteAppDataError": {
+      "title": "Error deleting app data"
     }
   },
   "cryptoOrg": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -958,6 +958,15 @@
     },
     "TonMinimumRequired": {
       "title": "Insufficient funds. The minimum required balance is 0.02 TON."
+    },
+    "BackupAppDataError": {
+      "title": "Error during app data backup"
+    },
+    "RestoreAppDataError": {
+      "title": "Error restoring app data"
+    },
+    "DeleteAppDataError": {
+      "title": "Error deleting app data"
     }
   },
   "crash": {

--- a/libs/device-core/src/commands/use-cases/app-backup/restoreAppStorageInit.ts
+++ b/libs/device-core/src/commands/use-cases/app-backup/restoreAppStorageInit.ts
@@ -1,7 +1,13 @@
 import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
 import { LocalTracer } from "@ledgerhq/logs";
 import type { APDU } from "../../entities/APDU";
-import { AppNotFound, InvalidAppNameLength, InvalidBackupLength, PinNotSet } from "../../../errors";
+import {
+  AppNotFound,
+  InvalidAppNameLength,
+  InvalidBackupLength,
+  PinNotSet,
+  UserRefusedOnDevice,
+} from "../../../errors";
 
 /**
  * Name in documentation: INS_APP_STORAGE_RESTORE_INIT
@@ -81,8 +87,9 @@ export function parseResponse(data: Buffer): void {
     case StatusCodes.APP_NOT_FOUND_OR_INVALID_CONTEXT:
       throw new AppNotFound("Application not found.");
     case StatusCodes.DEVICE_IN_RECOVERY_MODE:
-    case StatusCodes.USER_REFUSED_ON_DEVICE:
       break;
+    case StatusCodes.USER_REFUSED_ON_DEVICE:
+      throw new UserRefusedOnDevice("User refused on device.");
     case StatusCodes.PIN_NOT_SET:
       throw new PinNotSet("Invalid consent, PIN is not set.");
     case StatusCodes.INVALID_APP_NAME_LENGTH:

--- a/libs/device-core/src/errors.ts
+++ b/libs/device-core/src/errors.ts
@@ -27,3 +27,5 @@ export const InvalidBackupState = createCustomErrorClass("InvalidBackupState");
 export const InvalidRestoreState = createCustomErrorClass("InvalidRestoreState");
 // 0x6734
 export const InvalidChunkLength = createCustomErrorClass("InvalidChunkLength");
+// 0x5501
+export const UserRefusedOnDevice = createCustomErrorClass("UserRefusedOnDevice");

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -328,7 +328,10 @@
     "src/notifications/AnnouncementProvider/helpers.ts",
     "src/reactNativeSvg.d.ts",
     "src/rxjs/operators/throwIf.ts",
-    "src/walletSync/getEnvironmentParams.ts"
+    "src/walletSync/getEnvironmentParams.ts",
+    "src/device/use-cases/appDataBackup/deleteAppData.ts",
+    "src/device/use-cases/appDataBackup/deleteAppDataUseCase.ts",
+    "src/device/use-cases/appDataBackup/deleteAppDataUseCaseDI.ts"
   ],
   "ignoreUnused": [
     "@ledgerhq/hw-transport-mocker",

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppData.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppData.test.ts
@@ -1,0 +1,177 @@
+import { Observable, firstValueFrom, lastValueFrom } from "rxjs";
+import { deleteAppData } from "./deleteAppData";
+import {
+  AppStorageType,
+  DeleteAppDataError,
+  DeleteAppDataEvent,
+  DeleteAppDataEventType,
+  StorageProvider,
+} from "./types";
+import { DeviceModelId } from "@ledgerhq/devices";
+
+jest.mock("@ledgerhq/hw-transport");
+
+describe("deleteAppData", () => {
+  let appName: string;
+  let deviceModelId: DeviceModelId;
+  let storageProvider: StorageProvider<AppStorageType>;
+
+  const setItem = jest.fn();
+  const getItem = jest.fn();
+  const removeItem = jest.fn();
+
+  beforeEach(() => {
+    appName = "MyApp";
+    deviceModelId = DeviceModelId.stax;
+    storageProvider = {
+      getItem,
+      setItem,
+      removeItem,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("success case", () => {
+    it("should delete the app data by emitting relative events sequentially", async () => {
+      const deleteObservable: Observable<DeleteAppDataEvent> = deleteAppData(
+        appName,
+        deviceModelId,
+        storageProvider,
+      );
+      const events: DeleteAppDataEvent[] = [];
+
+      getItem.mockResolvedValue({
+        appDataInfo: {
+          size: 6,
+          dataVersion: "test",
+          hasSettings: true,
+          hasData: true,
+          hash: "test",
+        },
+        appData: "bGVkZ2Vy", // base64 encoded "ledger"
+      });
+
+      removeItem.mockResolvedValue(undefined);
+
+      // Subscribe to the observable to receive the delete events
+      deleteObservable.subscribe((event: DeleteAppDataEvent) => {
+        events.push(event);
+      });
+
+      const firstValue: DeleteAppDataEvent = await firstValueFrom(deleteObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      const lastValue: DeleteAppDataEvent = await lastValueFrom(deleteObservable);
+      expect(lastValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleted,
+      });
+
+      expect(events).toHaveLength(2);
+    });
+
+    it("should emit specific event when there is no app data to delete", async () => {
+      const deleteObservable: Observable<DeleteAppDataEvent> = deleteAppData(
+        appName,
+        deviceModelId,
+        storageProvider,
+      );
+      const events: DeleteAppDataEvent[] = [];
+
+      getItem.mockResolvedValue(null);
+
+      // Subscribe to the observable to receive the delete events
+      deleteObservable.subscribe((event: DeleteAppDataEvent) => {
+        events.push(event);
+      });
+
+      const firstValue: DeleteAppDataEvent = await firstValueFrom(deleteObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      const lastValue: DeleteAppDataEvent = await lastValueFrom(deleteObservable);
+      expect(lastValue).toEqual({
+        type: DeleteAppDataEventType.NoAppDataToDelete,
+      });
+
+      expect(events).toHaveLength(2);
+    });
+  });
+
+  describe("error case", () => {
+    it("should emit an error event when there is an error during the deletion process", async () => {
+      const deleteObservable: Observable<DeleteAppDataEvent> = deleteAppData(
+        appName,
+        deviceModelId,
+        storageProvider,
+      );
+
+      const events: DeleteAppDataEvent[] = [];
+
+      getItem.mockResolvedValue({
+        appDataInfo: {
+          size: 6,
+          dataVersion: "test",
+          hasSettings: true,
+          hasData: true,
+          hash: "test",
+        },
+        appData: "bGVkZ2Vy", // base64 encoded "ledger"
+      });
+
+      removeItem.mockRejectedValue(new Error("Failed to delete app data"));
+
+      // Subscribe to the observable to receive the delete events
+      deleteObservable.subscribe((event: DeleteAppDataEvent) => {
+        events.push(event);
+      });
+
+      const firstValue: DeleteAppDataEvent = await firstValueFrom(deleteObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      lastValueFrom(deleteObservable).catch(e => {
+        expect(e).toBeInstanceOf(DeleteAppDataError);
+        expect(e.message).toBe("Failed to delete app data");
+      });
+
+      expect(events).toHaveLength(1);
+    });
+
+    it("should emit an error event when there is an error getting the app data from storage", async () => {
+      const deleteObservable: Observable<DeleteAppDataEvent> = deleteAppData(
+        appName,
+        deviceModelId,
+        storageProvider,
+      );
+
+      getItem.mockRejectedValue(new Error("Error fetching app data"));
+
+      lastValueFrom(deleteObservable).catch(e => {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toBe("Error fetching app data");
+      });
+    });
+
+    it("should emit an error event when there is an unkown error getting the app data from storage", async () => {
+      const deleteObservable: Observable<DeleteAppDataEvent> = deleteAppData(
+        appName,
+        deviceModelId,
+        storageProvider,
+      );
+
+      getItem.mockRejectedValue(null);
+
+      lastValueFrom(deleteObservable).catch(e => {
+        expect(e).toBeInstanceOf(Error);
+        expect(e.message).toBe("Unknown error");
+      });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppData.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppData.ts
@@ -1,0 +1,54 @@
+import { catchError, from, Observable, of, switchMap, throwError } from "rxjs";
+import { DeviceModelId } from "@ledgerhq/devices";
+import {
+  AppName,
+  AppStorageType,
+  DeleteAppDataError,
+  DeleteAppDataEvent,
+  DeleteAppDataEventType,
+  StorageProvider,
+} from "./types";
+
+export function deleteAppData(
+  appName: AppName,
+  deviceModelId: DeviceModelId,
+  storageProvider: StorageProvider<AppStorageType>,
+): Observable<DeleteAppDataEvent> {
+  const obs = new Observable<DeleteAppDataEvent>(subscriber => {
+    subscriber.next({ type: DeleteAppDataEventType.AppDataDeleteStarted });
+    const sub = from(storageProvider.getItem(`${deviceModelId}-${appName}`))
+      .pipe(
+        catchError(e => {
+          if (e instanceof Error) {
+            subscriber.error(e);
+          } else {
+            subscriber.error(new Error("Unknown error"));
+          }
+          return of(null);
+        }),
+        switchMap(async item => {
+          if (item) {
+            try {
+              await storageProvider.removeItem(`${deviceModelId}-${appName}`);
+              subscriber.next({ type: DeleteAppDataEventType.AppDataDeleted });
+              subscriber.complete();
+            } catch (e: unknown) {
+              const message = e instanceof Error ? e.message : "Error deleting app data";
+              throwError(() => new DeleteAppDataError(message));
+            }
+          } else {
+            subscriber.next({ type: DeleteAppDataEventType.NoAppDataToDelete });
+            subscriber.complete();
+          }
+        }),
+      )
+      .subscribe();
+
+    return () => {
+      subscriber.complete();
+      sub.unsubscribe();
+    };
+  });
+
+  return obs;
+}

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCase.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCase.test.ts
@@ -1,0 +1,179 @@
+import { concat, firstValueFrom, lastValueFrom, Observable, of, throwError } from "rxjs";
+import { DeviceModelId } from "@ledgerhq/devices";
+import {
+  AppStorageType,
+  DeleteAppDataError,
+  DeleteAppDataEvent,
+  DeleteAppDataEventType,
+  StorageProvider,
+} from "./types";
+import { deleteAppDataUseCase } from "./deleteAppDataUseCase";
+
+describe("deleteAppDataUseCase", () => {
+  let appName: string;
+  let deviceModelId: DeviceModelId;
+  let storageProvider: StorageProvider<AppStorageType>;
+
+  const setItem = jest.fn();
+  const getItem = jest.fn();
+  const removeItem = jest.fn();
+  const deleteAppDataFn = jest.fn();
+
+  beforeEach(() => {
+    appName = "MyApp";
+    deviceModelId = DeviceModelId.stax;
+    storageProvider = {
+      setItem,
+      getItem,
+      removeItem,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("success cases", () => {
+    it("should emit the correct events when the app data is deleted", async () => {
+      deleteAppDataFn.mockReturnValue(
+        concat(
+          of({
+            type: DeleteAppDataEventType.AppDataDeleteStarted,
+          }),
+          of({
+            type: DeleteAppDataEventType.AppDataDeleted,
+          }),
+        ),
+      );
+
+      const deleteAppDataUseCaseObservable: Observable<DeleteAppDataEvent> = deleteAppDataUseCase(
+        appName,
+        deviceModelId,
+        storageProvider,
+        deleteAppDataFn,
+      );
+
+      const firstValue = await firstValueFrom(deleteAppDataUseCaseObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      const secondValue = await lastValueFrom(deleteAppDataUseCaseObservable);
+      expect(secondValue).toEqual({ type: DeleteAppDataEventType.AppDataDeleted });
+    });
+
+    it("should emit the correct events when the app data is not found", async () => {
+      deleteAppDataFn.mockReturnValue(
+        concat(
+          of({
+            type: DeleteAppDataEventType.AppDataDeleteStarted,
+          }),
+          of({
+            type: DeleteAppDataEventType.NoAppDataToDelete,
+          }),
+        ),
+      );
+
+      const deleteAppDataUseCaseObservable: Observable<DeleteAppDataEvent> = deleteAppDataUseCase(
+        appName,
+        deviceModelId,
+        storageProvider,
+        deleteAppDataFn,
+      );
+
+      const firstValue = await firstValueFrom(deleteAppDataUseCaseObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      const secondValue = await lastValueFrom(deleteAppDataUseCaseObservable);
+      expect(secondValue).toEqual({ type: DeleteAppDataEventType.NoAppDataToDelete });
+    });
+  });
+
+  describe("error cases", () => {
+    it("should emit the correct events when there is an error deleting the app data", async () => {
+      deleteAppDataFn.mockReturnValue(
+        concat(
+          of({
+            type: DeleteAppDataEventType.AppDataDeleteStarted,
+          }),
+          throwError(() => new DeleteAppDataError("Error deleting app data")),
+        ),
+      );
+
+      const deleteAppDataUseCaseObservable: Observable<DeleteAppDataEvent> = deleteAppDataUseCase(
+        appName,
+        deviceModelId,
+        storageProvider,
+        deleteAppDataFn,
+      );
+
+      const firstValue = await firstValueFrom(deleteAppDataUseCaseObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      lastValueFrom(deleteAppDataUseCaseObservable).catch(error => {
+        expect(error).toBeInstanceOf(DeleteAppDataError);
+        expect(error.message).toBe("Error deleting app data");
+      });
+    });
+
+    it("should emit the correct events when there is an error getting the app data", async () => {
+      deleteAppDataFn.mockReturnValue(
+        concat(
+          of({
+            type: DeleteAppDataEventType.AppDataDeleteStarted,
+          }),
+          throwError(() => new DeleteAppDataError("Error getting app data")),
+        ),
+      );
+
+      const deleteAppDataUseCaseObservable: Observable<DeleteAppDataEvent> = deleteAppDataUseCase(
+        appName,
+        deviceModelId,
+        storageProvider,
+        deleteAppDataFn,
+      );
+
+      const firstValue = await firstValueFrom(deleteAppDataUseCaseObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      lastValueFrom(deleteAppDataUseCaseObservable).catch(error => {
+        expect(error).toBeInstanceOf(DeleteAppDataError);
+        expect(error.message).toBe("Error getting app data");
+      });
+    });
+
+    it("should emit the correct events when there is an unknown error", async () => {
+      deleteAppDataFn.mockReturnValue(
+        concat(
+          of({
+            type: DeleteAppDataEventType.AppDataDeleteStarted,
+          }),
+          throwError(() => new Error("Unknown error")),
+        ),
+      );
+
+      const deleteAppDataUseCaseObservable: Observable<DeleteAppDataEvent> = deleteAppDataUseCase(
+        appName,
+        deviceModelId,
+        storageProvider,
+        deleteAppDataFn,
+      );
+
+      const firstValue = await firstValueFrom(deleteAppDataUseCaseObservable);
+      expect(firstValue).toEqual({
+        type: DeleteAppDataEventType.AppDataDeleteStarted,
+      });
+
+      lastValueFrom(deleteAppDataUseCaseObservable).catch(error => {
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBe("Unknown error");
+      });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCase.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCase.ts
@@ -1,22 +1,12 @@
-import { from, Observable } from "rxjs";
-import { AppName, AppStorageType, DeleteAppDataEvent, StorageProvider } from "./types";
-import { DeviceModelId } from "@ledgerhq/devices";
+import { Observable } from "rxjs";
+import { DeleteAppDataEvent } from "./types";
 
 /**
  * Delete the local app data for a specific app on a Ledger device.
  *
- * @param appName name of the app to delete data for
- * @param deviceModelId model id of the device
- * @param storageProvider storage provider object used for storing the backup data
  * @param deleteAppDataFn function that returns observable for the delete process
  * @returns Observable<DeleteAppDataEvent>
  */
-export function deleteAppDataUseCase(
-  appName: AppName,
-  deviceModelId: DeviceModelId,
-  storageProvider: StorageProvider<AppStorageType>,
-  deleteAppDataFn: () => Observable<DeleteAppDataEvent>,
-) {
-  const obs: Observable<DeleteAppDataEvent> = from(deleteAppDataFn());
-  return obs;
+export function deleteAppDataUseCase(deleteAppDataFn: () => Observable<DeleteAppDataEvent>) {
+  return deleteAppDataFn();
 }

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCase.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCase.ts
@@ -1,0 +1,22 @@
+import { from, Observable } from "rxjs";
+import { AppName, AppStorageType, DeleteAppDataEvent, StorageProvider } from "./types";
+import { DeviceModelId } from "@ledgerhq/devices";
+
+/**
+ * Delete the local app data for a specific app on a Ledger device.
+ *
+ * @param appName name of the app to delete data for
+ * @param deviceModelId model id of the device
+ * @param storageProvider storage provider object used for storing the backup data
+ * @param deleteAppDataFn function that returns observable for the delete process
+ * @returns Observable<DeleteAppDataEvent>
+ */
+export function deleteAppDataUseCase(
+  appName: AppName,
+  deviceModelId: DeviceModelId,
+  storageProvider: StorageProvider<AppStorageType>,
+  deleteAppDataFn: () => Observable<DeleteAppDataEvent>,
+) {
+  const obs: Observable<DeleteAppDataEvent> = from(deleteAppDataFn());
+  return obs;
+}

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCaseDI.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCaseDI.ts
@@ -1,0 +1,15 @@
+import { Observable } from "rxjs";
+import { AppName, AppStorageType, DeleteAppDataEvent, StorageProvider } from "./types";
+import { DeviceModelId } from "@ledgerhq/devices";
+import { deleteAppData } from "./deleteAppData";
+import { deleteAppDataUseCase } from "./deleteAppDataUseCase";
+
+export function deleteAppDataUseCaseDI(
+  appName: AppName,
+  deviceModelId: DeviceModelId,
+  storageProvider: StorageProvider<AppStorageType>,
+): Observable<DeleteAppDataEvent> {
+  return deleteAppDataUseCase(appName, deviceModelId, storageProvider, () =>
+    deleteAppData(appName, deviceModelId, storageProvider),
+  );
+}

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCaseDI.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/deleteAppDataUseCaseDI.ts
@@ -9,7 +9,5 @@ export function deleteAppDataUseCaseDI(
   deviceModelId: DeviceModelId,
   storageProvider: StorageProvider<AppStorageType>,
 ): Observable<DeleteAppDataEvent> {
-  return deleteAppDataUseCase(appName, deviceModelId, storageProvider, () =>
-    deleteAppData(appName, deviceModelId, storageProvider),
-  );
+  return deleteAppDataUseCase(() => deleteAppData(appName, deviceModelId, storageProvider));
 }

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
@@ -142,3 +142,31 @@ export type RestoreAppDataEvent =
  * An error that occurs during the restore process, the error message should be descriptive when thrown.
  */
 export const RestoreAppDataError = createCustomErrorClass("RestoreAppDataError");
+
+export enum DeleteAppDataEventType {
+  AppDataDeleteStarted = "appDataDeleteStarted",
+  /**
+   * The application data has been deleted.
+   */
+  AppDataDeleted = "appDataDeleted",
+  /**
+   * There is no application data to delete.
+   */
+  NoAppDataToDelete = "noAppDataToDelete",
+}
+
+export type DeleteAppDataEvent =
+  | {
+      type: DeleteAppDataEventType.AppDataDeleteStarted;
+    }
+  | {
+      type: DeleteAppDataEventType.AppDataDeleted;
+    }
+  | {
+      type: DeleteAppDataEventType.NoAppDataToDelete;
+    };
+
+/**
+ * An error that occurs during the delete process (local data), the error message should be descriptive when thrown.
+ */
+export const DeleteAppDataError = createCustomErrorClass("DeleteAppDataError");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - add new delete app data use case in live-common/device

### 📝 Description

Added a new usecase for the deletion of local app data stored on the device storage (llm/lld)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13852] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13852]: https://ledgerhq.atlassian.net/browse/LIVE-13852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ