### PR TITLE
feat: btc and evm fee drawer display amount errors when editing fees

### DIFF
--- a/.changeset/popular-chairs-melt.md
+++ b/.changeset/popular-chairs-melt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+btc and evm fee drawer display amount errors when editing fees too high

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
@@ -68,7 +68,7 @@ const Fields: Props = ({
   }, [account.currency.id, account.id, dispatch, history]);
 
   const { errors } = status;
-  const { gasPrice: messageGas, amount: messageAmount } = errors;
+  const { amount: messageAmount } = errors;
 
   /* TODO: How do we set default RBF to be true ? (@gre)
    * Meanwhile, using this trick (please don't kill me)
@@ -181,14 +181,13 @@ const Fields: Props = ({
             mapStrategies={mapStrategies}
             status={status}
           />
-          {messageGas ||
-            (messageAmount && (
-              <Flex onClick={onBuyClick}>
-                <Alert type="warning">
-                  <TranslatedError error={messageGas || messageAmount} />
-                </Alert>
-              </Flex>
-            ))}
+          {messageAmount && (
+            <Flex onClick={onBuyClick}>
+              <Alert type="warning">
+                <TranslatedError error={messageAmount} />
+              </Alert>
+            </Flex>
+          )}
         </>
       )}
     </>

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
@@ -68,7 +68,8 @@ const Fields: Props = ({
   }, [account.currency.id, account.id, dispatch, history]);
 
   const { errors } = status;
-  const { gasPrice: messageGas } = errors;
+  const { gasPrice: messageGas, amount: messageAmount } = errors;
+
   /* TODO: How do we set default RBF to be true ? (@gre)
    * Meanwhile, using this trick (please don't kill me)
    */
@@ -180,13 +181,14 @@ const Fields: Props = ({
             mapStrategies={mapStrategies}
             status={status}
           />
-          {messageGas && (
-            <Flex onClick={onBuyClick}>
-              <Alert type="warning">
-                <TranslatedError error={messageGas} />
-              </Alert>
-            </Flex>
-          )}
+          {messageGas ||
+            (messageAmount && (
+              <Flex onClick={onBuyClick}>
+                <Alert type="warning">
+                  <TranslatedError error={messageGas || messageAmount} />
+                </Alert>
+              </Flex>
+            ))}
         </>
       )}
     </>

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
@@ -111,14 +111,13 @@ const Root: NonNullable<EvmFamily["sendAmountFields"]>["component"] = props => {
           <SelectFeeStrategy gasOptions={gasOptions} onClick={onFeeStrategyClick} {...props} />
         </>
       )}
-      {messageGas ||
-        (messageAmount && (
-          <Flex onClick={onBuyClick}>
-            <Alert type="warning" data-testid="alert-insufficient-funds-warning">
-              <TranslatedError error={messageGas || messageAmount} />
-            </Alert>
-          </Flex>
-        ))}
+      {(messageGas || messageAmount) && (
+        <Flex onClick={onBuyClick}>
+          <Alert type="warning" data-testid="alert-insufficient-funds-warning">
+            <TranslatedError error={messageGas || messageAmount} />
+          </Alert>
+        </Flex>
+      )}
     </>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
@@ -25,8 +25,7 @@ const Root: NonNullable<EvmFamily["sendAmountFields"]>["component"] = props => {
   const bridge: AccountBridge<EvmTransaction> = getAccountBridge(account);
 
   const { errors } = props.status;
-  const { gasPrice: messageGas } = errors;
-
+  const { gasPrice: messageGas, amount: messageAmount } = errors;
   const dispatch = useDispatch();
   const history = useHistory();
 
@@ -112,13 +111,14 @@ const Root: NonNullable<EvmFamily["sendAmountFields"]>["component"] = props => {
           <SelectFeeStrategy gasOptions={gasOptions} onClick={onFeeStrategyClick} {...props} />
         </>
       )}
-      {messageGas && (
-        <Flex onClick={onBuyClick}>
-          <Alert type="warning" data-testid="alert-insufficient-funds-warning">
-            <TranslatedError error={messageGas} />
-          </Alert>
-        </Flex>
-      )}
+      {messageGas ||
+        (messageAmount && (
+          <Flex onClick={onBuyClick}>
+            <Alert type="warning" data-testid="alert-insufficient-funds-warning">
+              <TranslatedError error={messageGas || messageAmount} />
+            </Alert>
+          </Flex>
+        ))}
     </>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -116,11 +116,6 @@ export default function FeesDrawerLiveApp({
         )}
       </Box>
       <Divider />
-      {transactionStatus.errors?.amount && (
-        <Box>
-          <ErrorBanner error={transactionStatus.errors?.amount} />
-        </Box>
-      )}
 
       <Box mt={3} mx={3} alignSelf="flex-end">
         <Button

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -9,7 +9,6 @@ import { t } from "i18next";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { Button, Divider } from "@ledgerhq/react-ui";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
-import ErrorBanner from "~/renderer/components/ErrorBanner";
 
 type Props = {
   setTransaction: SwapTransactionType["setTransaction"];


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...
  
   Send workflow change 

https://github.com/user-attachments/assets/6092cb77-560a-42e3-a96c-f7ce1b3c1f46



### 📝 Description

For swaps we need to display all errors using the same UI inside the fee drawer. This PR makes it so that amountError are displayed inside the drawer 

https://github.com/user-attachments/assets/929bbdf8-d38a-4fb8-8862-1bd80e31eaf8



### ❓ Context

[**LIVE-13853**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-13853)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
