### PR TITLE
Fix legacy derivation paths missing for EVM based coins

### DIFF
--- a/libs/coin-framework/src/derivation.ts
+++ b/libs/coin-framework/src/derivation.ts
@@ -200,8 +200,7 @@ const legacyDerivations: Partial<Record<CryptoCurrency["id"], DerivationMode[]>>
   vechain: ["vechain"],
   stacks: ["stacks_wallet"],
   ton: ["ton"],
-  ethereum: ["ethM", "ethMM"],
-  ethereum_classic: ["ethM", "ethMM", "etcM"],
+  ethereum_classic: ["etcM"],
   solana: ["solanaMain", "solanaSub"],
   solana_devnet: ["solanaMain", "solanaSub"],
   solana_testnet: ["solanaMain", "solanaSub"],
@@ -374,6 +373,11 @@ export const getDerivationModesForCurrency = (currency: CryptoCurrency): Derivat
   if (currency.id in legacyDerivations) {
     all = all.concat(legacyDerivations[currency.id] || []);
   }
+
+  if (currency.family === "evm") {
+    all = all.concat(["ethM", "ethMM"]);
+  }
+
   if (currency.forkedFrom) {
     all.push("unsplit");
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Add missing legacy derivation path for every EVM based coins. I use the same address since ledger live is a chrome extension, and until now I had to use metamask on m PC to make transactions for every EVM based coin. This prevent me from aggregating my whole portfolio in ledger live and from using my phone to make transactions on Arbitrum for example.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
