### PR TITLE
🔏 [FIX]: Trustchain "Expected signature to be an Uint8Array with length 64" error

### DIFF
--- a/.changeset/shaggy-crabs-approve.md
+++ b/.changeset/shaggy-crabs-approve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-trustchain": patch
+---
+
+Fix the "Expected signature to be an Uint8Array with length 64" error

--- a/libs/hw-trustchain/src/NobleCrypto.ts
+++ b/libs/hw-trustchain/src/NobleCrypto.ts
@@ -53,7 +53,7 @@ export class NobleCryptoSecp256k1 implements Crypto {
     return this.concat(prefix, this.concat(R, S));
   }
 
-  public derDecode(signature: Uint8Array): { R: Uint8Array; S: Uint8Array } {
+  private derDecode(signature: Uint8Array): { R: Uint8Array; S: Uint8Array } {
     const R: Uint8Array = signature.slice(4, 4 + signature[3]);
     const S: Uint8Array = signature.slice(
       6 + signature[3],

--- a/libs/hw-trustchain/src/NobleCrypto.ts
+++ b/libs/hw-trustchain/src/NobleCrypto.ts
@@ -53,13 +53,16 @@ export class NobleCryptoSecp256k1 implements Crypto {
     return this.concat(prefix, this.concat(R, S));
   }
 
-  private derDecode(signature: Uint8Array): { R: Uint8Array; S: Uint8Array } {
+  public derDecode(signature: Uint8Array): { R: Uint8Array; S: Uint8Array } {
     const R: Uint8Array = signature.slice(4, 4 + signature[3]);
     const S: Uint8Array = signature.slice(
       6 + signature[3],
       6 + signature[3] + signature[5 + signature[3]],
     );
-    return { R: R.slice(R.length - PRIVATE_KEY_SIZE), S: S.slice(S.length - PRIVATE_KEY_SIZE) };
+    return {
+      R: this.enforceLength(R, PRIVATE_KEY_SIZE),
+      S: this.enforceLength(S, PRIVATE_KEY_SIZE),
+    };
   }
 
   async sign(message: Uint8Array, keyPair: KeyPair): Promise<Uint8Array> {
@@ -103,6 +106,19 @@ export class NobleCryptoSecp256k1 implements Crypto {
     c.set(a);
     c.set(b, a.length);
     return c;
+  }
+
+  private enforceLength(buffer: Uint8Array, length: number): Uint8Array {
+    if (buffer.length > length) {
+      return buffer.slice(buffer.length - length); // truncate extra bytes from the start
+    } else if (buffer.length < length) {
+      const padded = new Uint8Array(length);
+      const start = length - buffer.length;
+      padded.set(Array(start).fill(0));
+      padded.set(buffer, start);
+      return padded;
+    }
+    return buffer;
   }
 
   private pad(message: Uint8Array): Uint8Array {

--- a/libs/hw-trustchain/src/__tests__/crypto.ts
+++ b/libs/hw-trustchain/src/__tests__/crypto.ts
@@ -27,4 +27,18 @@ describe("Sodium wrapper tester", () => {
     const decrypted = await crypto.decryptUserData(keypair.privateKey, encrypted);
     expect(crypto.to_hex(decrypted)).toBe(crypto.to_hex(data));
   });
+
+  it("should verify truncated signature by padding 0s from the start", async () => {
+    const hash = crypto.from_hex(
+      "19514a2e50bfad4a6de397ebde776191cbb720e8bbfcc3c165385c3664c03341",
+    );
+    const signature = crypto.from_hex(
+      // Here the "S" part of the signature is only 31 bytes long it should be padded with a 0
+      "3043022052a82876fcd4d9d8383ce12a7e4d96bb4c1d9e71e857cd087c092b87cec6baeb021f6b86b9a3bab1e7794ca6ef081c66cb6e6dff06cceddbd23e1f25089e311784",
+    );
+    const issuer = crypto.from_hex(
+      "026e7bf1e015da491674be5796b15d6fabd1f454aad478a6a223934e5a872719e0",
+    );
+    expect(await crypto.verify(hash, signature, issuer)).toBe(true);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix the "Expected signature to be an Uint8Array with length 64" error. It was due to some part of the signature being shorter than the expected 32 + 32 bytes. I think it's because leading zeros are getting truncated in segments of the Apdu devices responses.

### ❓ Context

- [LIVE-13829]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13829]: https://ledgerhq.atlassian.net/browse/LIVE-13829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ