### PR TITLE
Feat/llm ledger sync redirection on sync again

### DIFF
--- a/.changeset/strange-shrimps-clean.md
+++ b/.changeset/strange-shrimps-clean.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LLM - Ledger Sync redirects to Qr code when syncing again after a successful sync

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -36,6 +36,7 @@ import type {
 import type { Unpacked } from "../types/helpers";
 import { HandlersPayloads } from "@ledgerhq/live-wallet/store";
 import { ImportAccountsReduceInput } from "@ledgerhq/live-wallet/liveqr/importAccounts";
+import { Steps } from "LLM/features/WalletSync/types/Activation";
 
 //  === ACCOUNTS ACTIONS ===
 
@@ -530,11 +531,16 @@ export type MarketPayload =
 export enum WalletSyncActionTypes {
   WALLET_SYNC_SET_MANAGE_KEY_DRAWER = "WALLET_SYNC_SET_MANAGE_KEY_DRAWER",
   LEDGER_SYNC_SET_ACTIVATE_DRAWER = "LEDGER_SYNC_SET_ACTIVATE_DRAWER",
+  LEDGER_SYNC_SET_ACTIVATE_STEP = "LEDGER_SYNC_SET_ACTIVATE_STEP",
 }
 
 export type WalletSyncSetManageKeyDrawerPayload = boolean;
 export type WalletSyncSetActivateDrawer = boolean;
-export type WalletSyncPayload = WalletSyncSetManageKeyDrawerPayload | WalletSyncSetActivateDrawer;
+export type WalletSyncSetActivateStep = Steps;
+export type WalletSyncPayload =
+  | WalletSyncSetManageKeyDrawerPayload
+  | WalletSyncSetActivateDrawer
+  | WalletSyncSetActivateStep;
 
 // === PAYLOADS ===
 

--- a/apps/ledger-live-mobile/src/actions/walletSync.ts
+++ b/apps/ledger-live-mobile/src/actions/walletSync.ts
@@ -1,6 +1,10 @@
 import { createAction } from "redux-actions";
 import { WalletSyncActionTypes } from "./types";
-import type { WalletSyncSetActivateDrawer, WalletSyncSetManageKeyDrawerPayload } from "./types";
+import type {
+  WalletSyncSetActivateDrawer,
+  WalletSyncSetActivateStep,
+  WalletSyncSetManageKeyDrawerPayload,
+} from "./types";
 
 export const setWallectSyncManageKeyDrawer = createAction<WalletSyncSetManageKeyDrawerPayload>(
   WalletSyncActionTypes.WALLET_SYNC_SET_MANAGE_KEY_DRAWER,
@@ -8,4 +12,8 @@ export const setWallectSyncManageKeyDrawer = createAction<WalletSyncSetManageKey
 
 export const setLedgerSyncActivateDrawer = createAction<WalletSyncSetActivateDrawer>(
   WalletSyncActionTypes.LEDGER_SYNC_SET_ACTIVATE_DRAWER,
+);
+
+export const setLedgerSyncActivateStep = createAction<WalletSyncSetActivateStep>(
+  WalletSyncActionTypes.LEDGER_SYNC_SET_ACTIVATE_STEP,
 );

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/StepFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/StepFlow.tsx
@@ -11,14 +11,13 @@ import PinCodeDisplay from "LLM/features/WalletSync/screens/Synchronize/PinCodeD
 import PinCodeInput from "LLM/features/WalletSync/screens/Synchronize/PinCodeInput";
 import { useInitMemberCredentials } from "LLM/features/WalletSync/hooks/useInitMemberCredentials";
 import { useSyncWithQrCode } from "LLM/features/WalletSync/hooks/useSyncWithQrCode";
-import { SpecificError } from "~/newArch/features/WalletSync/components/Error/SpecificError";
-import { ErrorReason } from "~/newArch/features/WalletSync/hooks/useSpecificError";
+import { SpecificError } from "LLM/features/WalletSync/components/Error/SpecificError";
+import { ErrorReason } from "LLM/features/WalletSync/hooks/useSpecificError";
+import { useCurrentStep } from "LLM/features/WalletSync/hooks/useCurrentStep";
 
 type Props = {
-  currentStep: Steps;
   currency?: CryptoCurrency | TokenCurrency | null;
   doesNotHaveAccount?: boolean;
-  setCurrentStep: (step: Steps) => void;
   setCurrentOption: (option: Options) => void;
   currentOption: Options;
   navigateToChooseSyncMethod: () => void;
@@ -36,23 +35,22 @@ type Props = {
 const StepFlow = ({
   doesNotHaveAccount,
   currency,
-  currentStep,
   setCurrentOption,
   currentOption,
   navigateToChooseSyncMethod,
   navigateToQrCodeMethod,
   onQrCodeScanned,
   qrProcess,
-  setCurrentStep,
   onCreateKey,
 }: Props) => {
+  const { currentStep, setCurrentStep } = useCurrentStep();
   const { memberCredentials } = useInitMemberCredentials();
 
   const { handleStart, handleSendDigits, inputCallback, nbDigits } = useSyncWithQrCode();
 
   const handleQrCodeScanned = (data: string) => {
     onQrCodeScanned();
-    if (memberCredentials) handleStart(data, memberCredentials, setCurrentStep);
+    if (memberCredentials) handleStart(data, memberCredentials);
   };
 
   const handlePinCodeSubmit = (input: string) => {

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/index.tsx
@@ -6,6 +6,7 @@ import DrawerHeader from "LLM/features/WalletSync/components/Synchronize/DrawerH
 import { Flex } from "@ledgerhq/native-ui";
 import StepFlow from "./components/StepFlow";
 import { Steps } from "LLM/features/WalletSync/types/Activation";
+import { useCurrentStep } from "LLM/features/WalletSync/hooks/useCurrentStep";
 
 type ViewProps = ReturnType<typeof useAddAccountViewModel> & AddAccountProps;
 
@@ -21,10 +22,8 @@ function View({
   doesNotHaveAccount,
   currency,
   onCloseAddAccountDrawer,
-  currentStep,
   onGoBack,
   currentOption,
-  setCurrentStep,
   setCurrentOption,
   navigateToChooseSyncMethod,
   navigateToQrCodeMethod,
@@ -32,6 +31,7 @@ function View({
   onQrCodeScanned,
   onCreateKey,
 }: ViewProps) {
+  const { currentStep } = useCurrentStep();
   const CustomDrawerHeader = () => <DrawerHeader onClose={onCloseAddAccountDrawer} />;
 
   return (
@@ -46,8 +46,6 @@ function View({
         <StepFlow
           doesNotHaveAccount={doesNotHaveAccount}
           currency={currency}
-          currentStep={currentStep}
-          setCurrentStep={setCurrentStep}
           setCurrentOption={setCurrentOption}
           currentOption={currentOption}
           navigateToChooseSyncMethod={navigateToChooseSyncMethod}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/synchronizeWithQrCode.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/synchronizeWithQrCode.integration.test.tsx
@@ -6,8 +6,6 @@ import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/get
 
 jest.mock("../hooks/useQRCodeHost", () => ({
   useQRCodeHost: () => ({
-    setCurrentStep: jest.fn(),
-    currentStep: jest.fn(),
     currentOption: jest.fn(),
     url: "ledger.com",
   }),

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -12,9 +12,9 @@ import { useInitMemberCredentials } from "../../hooks/useInitMemberCredentials";
 import { useSyncWithQrCode } from "../../hooks/useSyncWithQrCode";
 import { SpecificError } from "../Error/SpecificError";
 import { ErrorReason } from "../../hooks/useSpecificError";
+import { useCurrentStep } from "../../hooks/useCurrentStep";
 
 type Props = {
-  currentStep: Steps;
   navigateToChooseSyncMethod: () => void;
   navigateToQrCodeMethod: () => void;
   qrProcess: {
@@ -26,28 +26,26 @@ type Props = {
   onQrCodeScanned: () => void;
   currentOption: Options;
   setOption: (option: Options) => void;
-  setCurrentStep: (step: Steps) => void;
   onCreateKey: () => void;
 };
 
 const ActivationFlow = ({
-  currentStep,
   navigateToChooseSyncMethod,
   navigateToQrCodeMethod,
   qrProcess,
   currentOption,
   setOption,
   onQrCodeScanned,
-  setCurrentStep,
   onCreateKey,
 }: Props) => {
+  const { currentStep, setCurrentStep } = useCurrentStep();
   const { memberCredentials } = useInitMemberCredentials();
 
   const { handleStart, handleSendDigits, inputCallback, nbDigits } = useSyncWithQrCode();
 
   const handleQrCodeScanned = (data: string) => {
     onQrCodeScanned();
-    if (memberCredentials) handleStart(data, memberCredentials, setCurrentStep);
+    if (memberCredentials) handleStart(data, memberCredentials);
   };
 
   const handlePinCodeSubmit = (input: string) => {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useCurrentStep.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useCurrentStep.ts
@@ -1,0 +1,21 @@
+import { useDispatch, useSelector } from "react-redux";
+import { activateDrawerStepSelector } from "~/reducers/walletSync";
+import { Steps } from "../types/Activation";
+import { setLedgerSyncActivateStep } from "~/actions/walletSync";
+import { useCallback } from "react";
+
+export function useCurrentStep() {
+  const dispatch = useDispatch();
+  const currentStep = useSelector(activateDrawerStepSelector);
+  const setCurrentStep = useCallback(
+    (step: Steps) => {
+      dispatch(setLedgerSyncActivateStep(step));
+    },
+    [dispatch],
+  );
+
+  return {
+    currentStep,
+    setCurrentStep,
+  };
+}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useQRCodeHost.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useQRCodeHost.ts
@@ -21,16 +21,16 @@ import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/get
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { QueryKey } from "./type.hooks";
 import { useInstanceName } from "./useInstanceName";
+import { useCurrentStep } from "./useCurrentStep";
 
 const MIN_TIME_TO_REFRESH = 30_000;
 
 interface Props {
-  setCurrentStep: (step: Steps) => void;
-  currentStep: Steps;
   currentOption: Options;
 }
 
-export function useQRCodeHost({ setCurrentStep, currentStep, currentOption }: Props) {
+export function useQRCodeHost({ currentOption }: Props) {
+  const { currentStep, setCurrentStep } = useCurrentStep();
   const queryClient = useQueryClient();
   const trustchain = useSelector(trustchainSelector);
   const memberCredentials = useSelector(memberCredentialsSelector);

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useSyncWithQrCode.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useSyncWithQrCode.ts
@@ -14,8 +14,10 @@ import { Steps } from "../types/Activation";
 import { NavigatorName, ScreenName } from "~/const";
 import { useInstanceName } from "./useInstanceName";
 import { useTrustchainSdk } from "./useTrustchainSdk";
+import { useCurrentStep } from "./useCurrentStep";
 
 export const useSyncWithQrCode = () => {
+  const { setCurrentStep } = useCurrentStep();
   const [nbDigits, setDigits] = useState<number | null>(null);
   const [input, setInput] = useState<string | null>(null);
   const instanceName = useInstanceName();
@@ -48,11 +50,7 @@ export const useSyncWithQrCode = () => {
   }, [navigation]);
 
   const handleStart = useCallback(
-    async (
-      url: string,
-      memberCredentials: MemberCredentials,
-      setCurrentStep: (step: Steps) => void,
-    ) => {
+    async (url: string, memberCredentials: MemberCredentials) => {
       try {
         const newTrustchain = await createQRCodeCandidateInstance({
           memberCredentials,
@@ -94,7 +92,7 @@ export const useSyncWithQrCode = () => {
         throw e;
       }
     },
-    [instanceName, onRequestQRCodeInput, trustchain, dispatch, onSyncFinished, sdk],
+    [instanceName, onRequestQRCodeInput, trustchain, onSyncFinished, sdk, dispatch, setCurrentStep],
   );
 
   const handleSendDigits = useCallback(

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationDrawer.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationDrawer.tsx
@@ -17,7 +17,6 @@ type Props = {
 
 function View({
   isOpen,
-  currentStep,
   hasCustomHeader,
   canGoBack,
   navigateToChooseSyncMethod,
@@ -30,7 +29,6 @@ function View({
   qrProcess,
   currentOption,
   setCurrentOption,
-  setCurrentStep,
 }: ViewProps) {
   const CustomDrawerHeader = () => <DrawerHeader onClose={handleClose} />;
 
@@ -46,14 +44,12 @@ function View({
       >
         <Flex maxHeight={"90%"}>
           <ActivationFlow
-            currentStep={currentStep}
             navigateToChooseSyncMethod={navigateToChooseSyncMethod}
             navigateToQrCodeMethod={navigateToQrCodeMethod}
             qrProcess={qrProcess}
             currentOption={currentOption}
             setOption={setCurrentOption}
             onQrCodeScanned={onQrCodeScanned}
-            setCurrentStep={setCurrentStep}
             onCreateKey={onCreateKey}
           />
         </Flex>

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/ActivationSuccess.tsx
@@ -17,6 +17,9 @@ import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/Ba
 import { setFromLedgerSyncOnboarding } from "~/actions/settings";
 import { AnalyticsButton, AnalyticsFlow, AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
 import { track } from "~/analytics";
+import { setLedgerSyncActivateDrawer } from "~/actions/walletSync";
+import { Steps } from "../../types/Activation";
+import { useCurrentStep } from "../../hooks/useCurrentStep";
 
 type Props = BaseComposite<
   StackNavigatorProps<WalletSyncNavigatorStackParamList, ScreenName.WalletSyncSuccess>
@@ -30,6 +33,7 @@ export function ActivationSuccess({ navigation, route }: Props) {
   const desc = created ? "walletSync.success.activationDesc" : "walletSync.success.syncDesc";
   const page = created ? AnalyticsPage.BackupCreationSuccess : AnalyticsPage.SyncSuccess;
   const dispatch = useDispatch();
+  const { setCurrentStep } = useCurrentStep();
 
   const navigationOnbarding =
     useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
@@ -40,7 +44,14 @@ export function ActivationSuccess({ navigation, route }: Props) {
       page,
       flow: AnalyticsFlow.LedgerSync,
     });
-    navigation.navigate(ScreenName.WalletSyncActivationProcess);
+    if (isFromLedgerSyncOnboarding) {
+      dispatch(setFromLedgerSyncOnboarding(false));
+    }
+    setCurrentStep(Steps.QrCodeMethod);
+    navigation.navigate(NavigatorName.Settings, {
+      screen: ScreenName.GeneralSettings,
+    });
+    dispatch(setLedgerSyncActivateDrawer(true));
   }
 
   function close(): void {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Steps } from "../../types/Activation";
 import {
   AnalyticsButton,
@@ -11,6 +11,7 @@ import { NavigatorName, ScreenName } from "~/const";
 import { useNavigation } from "@react-navigation/native";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
+import { useCurrentStep } from "../../hooks/useCurrentStep";
 
 type Props = {
   isOpen: boolean;
@@ -24,7 +25,11 @@ type NavigationProps = BaseComposite<
 
 const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) => {
   const { onClickTrack } = useLedgerSyncAnalytics();
-  const [currentStep, setCurrentStep] = useState<Steps>(startingStep);
+  const { currentStep, setCurrentStep } = useCurrentStep();
+
+  useEffect(() => {
+    setCurrentStep(startingStep);
+  }, [startingStep, setCurrentStep]);
   const [currentOption, setCurrentOption] = useState<Options>(Options.SCAN);
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const hasCustomHeader = useMemo(() => currentStep === Steps.QrCodeMethod, [currentStep]);
@@ -76,14 +81,11 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
   };
 
   const { url, error, isLoading, pinCode } = useQRCodeHost({
-    setCurrentStep,
-    currentStep,
     currentOption,
   });
 
   return {
     isOpen,
-    currentStep,
     hasCustomHeader,
     canGoBack,
     navigateToChooseSyncMethod,
@@ -95,7 +97,6 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
     qrProcess: { url, error, isLoading, pinCode },
     currentOption,
     setCurrentOption,
-    setCurrentStep,
     onCreateKey,
   };
 };

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -29,6 +29,7 @@ import { ImageType } from "../components/CustomImage/types";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/live-common/device/use-cases/isCustomLockScreenSupported";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { TrustchainStore } from "@ledgerhq/trustchain/store";
+import { Steps } from "LLM/features/WalletSync/types/Activation";
 
 // === ACCOUNT STATE ===
 
@@ -347,6 +348,7 @@ export type MarketState = {
 export type WalletSyncState = {
   isManageKeyDrawerOpen: boolean;
   isActivateDrawerOpen: boolean;
+  activateDrawerStep: Steps;
 };
 
 // === ROOT STATE ===

--- a/apps/ledger-live-mobile/src/reducers/walletSync.ts
+++ b/apps/ledger-live-mobile/src/reducers/walletSync.ts
@@ -5,12 +5,15 @@ import {
   WalletSyncActionTypes,
   WalletSyncPayload,
   WalletSyncSetActivateDrawer,
+  WalletSyncSetActivateStep,
   WalletSyncSetManageKeyDrawerPayload,
 } from "../actions/types";
+import { Steps } from "LLM/features/WalletSync/types/Activation";
 
 export const INITIAL_STATE: WalletSyncState = {
   isManageKeyDrawerOpen: false,
   isActivateDrawerOpen: false,
+  activateDrawerStep: Steps.Activation,
 };
 
 const handlers: ReducerMap<WalletSyncState, WalletSyncPayload> = {
@@ -22,6 +25,10 @@ const handlers: ReducerMap<WalletSyncState, WalletSyncPayload> = {
     ...state,
     isActivateDrawerOpen: (action as Action<WalletSyncSetActivateDrawer>).payload,
   }),
+  [WalletSyncActionTypes.LEDGER_SYNC_SET_ACTIVATE_STEP]: (state, action) => ({
+    ...state,
+    activateDrawerStep: (action as Action<WalletSyncSetActivateStep>).payload,
+  }),
 };
 
 export const storeSelector = (state: State): WalletSyncState => state.walletSync;
@@ -29,5 +36,7 @@ export const manageKeyDrawerSelector = (state: State): boolean =>
   state.walletSync.isManageKeyDrawerOpen;
 export const activateDrawerSelector = (state: State): boolean =>
   state.walletSync.isActivateDrawerOpen;
+export const activateDrawerStepSelector = (state: State): Steps =>
+  state.walletSync.activateDrawerStep;
 
 export default handleActions<WalletSyncState, WalletSyncPayload>(handlers, INITIAL_STATE);

--- a/apps/ledger-live-mobile/src/screens/Settings/General/WalletSyncRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/WalletSyncRow.tsx
@@ -14,6 +14,7 @@ import ActivationDrawer from "LLM/features/WalletSync/screens/Activation/Activat
 import { Steps } from "LLM/features/WalletSync/types/Activation";
 import { activateDrawerSelector } from "~/reducers/walletSync";
 import { setLedgerSyncActivateDrawer } from "~/actions/walletSync";
+import { useCurrentStep } from "LLM/features/WalletSync/hooks/useCurrentStep";
 
 const WalletSyncRow = () => {
   const { t } = useTranslation();
@@ -22,10 +23,12 @@ const WalletSyncRow = () => {
 
   const isDrawerVisible = useSelector(activateDrawerSelector);
   const dispatch = useDispatch();
+  const { setCurrentStep } = useCurrentStep();
 
   const closeDrawer = useCallback(() => {
     dispatch(setLedgerSyncActivateDrawer(false));
-  }, [dispatch]);
+    setCurrentStep(Steps.Activation);
+  }, [dispatch, setCurrentStep]);
   const trustchain = useSelector(trustchainSelector);
 
   const navigateToWalletSyncActivationScreen = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Ledger sync redirects on qr code when trying to sync again after a successful sync
Instead of passing the `currentStep` and the `setCurrentStep` of the activation drawer to every components, we store it with redux and use an action to handle to state of the current step. This gives us more control over it and it allows us to set the step from anywhere
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13849]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13849]: https://ledgerhq.atlassian.net/browse/LIVE-13849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ