### PR TITLE
fix: issue with BTC fee drawer when close/open and using custom

### DIFF
--- a/.changeset/wet-kids-call.md
+++ b/.changeset/wet-kids-call.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-bitcoin": minor
+"ledger-live-desktop": minor
+---
+
+fix: some issue with btc custom fees when reopening drawer

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
@@ -44,7 +44,9 @@ const Fields: Props = ({
   const bridge = getAccountBridge(account);
   const { t } = useTranslation();
   const [coinControlOpened, setCoinControlOpened] = useState(false);
-  const [isAdvanceMode, setAdvanceMode] = useState(!transaction.feesStrategy);
+  const [isAdvanceMode, setAdvanceMode] = useState(
+    !transaction.feesStrategy || transaction.feesStrategy === "custom",
+  );
   const strategies = useFeesStrategy(account, transaction);
   const onCoinControlOpen = useCallback(() => setCoinControlOpened(true), []);
   const onCoinControlClose = useCallback(() => setCoinControlOpened(false), []);

--- a/libs/coin-modules/coin-bitcoin/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-bitcoin/src/prepareTransaction.ts
@@ -18,12 +18,18 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
   const feePerByte = inferFeePerByte(transaction, networkInfo);
 
   if (
-    (transaction.networkInfo === networkInfo &&
-      (feePerByte === transaction.feePerByte || feePerByte.eq(transaction.feePerByte || 0))) ||
-    transaction.feesStrategy === "custom"
+    transaction.networkInfo === networkInfo &&
+    (feePerByte === transaction.feePerByte || feePerByte.eq(transaction.feePerByte || 0))
   ) {
     // nothing changed
     return transaction;
+  }
+  // if fees strategy is custom, we don't want to change the feePerByte but we still want to update the networkInfo
+  if (transaction.feesStrategy === "custom") {
+    return {
+      ...transaction,
+      networkInfo,
+    };
   }
 
   return {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

fix: issue with BTC fee drawer when close/open to keep custom opened. and to keep networkInfo

### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-13910)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
