### PR TITLE
🩹 [FIX]: Extra device action at the end of the remove member flow on LLM

### DIFF
--- a/.changeset/polite-masks-warn.md
+++ b/.changeset/polite-masks-warn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix extra device action at the end of the remove member flow

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useFollowInstructionDrawer.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useFollowInstructionDrawer.ts
@@ -63,7 +63,7 @@ export function useFollowInstructionDrawer(
 
   useEffect(() => {
     run(setScene);
-  }, [...deps]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { scene, retry, goToDelete, backToKeyError, confirmDeleteKey };
 }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useRemoveMember.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useRemoveMember.ts
@@ -67,6 +67,6 @@ export function useRemoveMember({ device, member }: Props): DrawerProps {
         }
       }
     },
-    [member, device, memberCredentials, sdk, transitionToNextScreen, trustchain],
+    [device, member, memberCredentials, sdk, transitionToNextScreen, !trustchain],
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Don't run extra device action at the end of the remove member flow on LLM.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
