### PR TITLE
[FIX]: Fix navigation on Drawer when AlreadySecuredOtherSeed error

### DIFF
--- a/.changeset/gorgeous-ways-exercise.md
+++ b/.changeset/gorgeous-ways-exercise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix navigation on Drawer when AlreadySecuredOtherSeed error

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useFollowInstructionDrawer.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useFollowInstructionDrawer.ts
@@ -9,7 +9,7 @@ import { useDestroyTrustchain } from "./useDestroyTrustchain";
 export enum SceneKind {
   DeviceInstructions,
   Loader,
-  WrongSeedError,
+  ConfirmDeleteWrongSeedError,
   KeyError,
   UnbackedError,
   GenericError,
@@ -19,7 +19,7 @@ export enum SceneKind {
 type Scene =
   | { kind: SceneKind.DeviceInstructions; device: Device }
   | { kind: SceneKind.Loader }
-  | { kind: SceneKind.WrongSeedError }
+  | { kind: SceneKind.ConfirmDeleteWrongSeedError }
   | { kind: SceneKind.KeyError }
   | { kind: SceneKind.AlreadySecuredSameSeed }
   | { kind: SceneKind.AlreadySecuredOtherSeed }
@@ -30,7 +30,7 @@ export type DrawerProps = {
   scene: Scene;
   retry: () => void;
   goToDelete: () => void;
-  backToKeyError: () => void;
+  backToWrongSeedError: () => void;
   confirmDeleteKey: () => void;
 };
 
@@ -49,11 +49,11 @@ export function useFollowInstructionDrawer(
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const goToDelete = useCallback(() => {
-    setScene({ kind: SceneKind.WrongSeedError });
+    setScene({ kind: SceneKind.ConfirmDeleteWrongSeedError });
   }, []);
 
-  const backToKeyError = useCallback(() => {
-    setScene({ kind: SceneKind.KeyError });
+  const backToWrongSeedError = useCallback(() => {
+    setScene({ kind: SceneKind.AlreadySecuredOtherSeed });
   }, []);
 
   const confirmDeleteKey = useCallback(async () => {
@@ -65,5 +65,5 @@ export function useFollowInstructionDrawer(
     run(setScene);
   }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { scene, retry, goToDelete, backToKeyError, confirmDeleteKey };
+  return { scene, retry, goToDelete, backToWrongSeedError, confirmDeleteKey };
 }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/FollowInstructions/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/FollowInstructions/index.tsx
@@ -28,7 +28,7 @@ const GenericFollowInstructionsDrawer = ({
   handleClose,
   scene,
   goToDelete,
-  backToKeyError,
+  backToWrongSeedError,
   confirmDeleteKey,
   retry,
 }: Props) => {
@@ -47,8 +47,10 @@ const GenericFollowInstructionsDrawer = ({
           </Flex>
         );
 
-      case SceneKind.WrongSeedError:
-        return <ConfirmManageKey onClickConfirm={confirmDeleteKey} onCancel={backToKeyError} />;
+      case SceneKind.ConfirmDeleteWrongSeedError:
+        return (
+          <ConfirmManageKey onClickConfirm={confirmDeleteKey} onCancel={backToWrongSeedError} />
+        );
 
       case SceneKind.KeyError:
         return (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix navigation on Drawer when AlreadySecuredOtherSeed error

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13934] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13934]: https://ledgerhq.atlassian.net/browse/LIVE-13934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ