### PR TITLE
fix: evm fee drawer correcly updates tx after changing fee strat (aligned with BTC)

### DIFF
--- a/.changeset/two-seas-remember.md
+++ b/.changeset/two-seas-remember.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix: evm fee drawer correcly updates tx after changing fee strat (aligned with BTC)

--- a/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/SendAmountFields/index.tsx
@@ -62,13 +62,23 @@ const Root: NonNullable<EvmFamily["sendAmountFields"]>["component"] = props => {
 
   const onFeeStrategyClick = useCallback(
     ({ feesStrategy }: { feesStrategy: Strategy }) => {
-      updateTransaction((tx: EvmTransaction) =>
-        bridge.updateTransaction(tx, {
+      updateTransaction((tx: EvmTransaction) => {
+        let gasValues = {};
+
+        // ts tricks to not complain about type0 into type2
+        if (gasOptions && feesStrategy in gasOptions) {
+          gasValues = Object.fromEntries(
+            Object.entries(gasOptions[feesStrategy]).filter(([key]) => key in tx),
+          );
+        }
+
+        return bridge.updateTransaction(tx, {
           feesStrategy,
-        }),
-      );
+          ...gasValues,
+        });
+      });
     },
-    [updateTransaction, bridge],
+    [updateTransaction, bridge, gasOptions],
   );
 
   if (loading) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

BTC does this https://github.com/LedgerHQ/ledger-live/blob/1f7406327583cb61944cab18023e966b5ac467aa/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx#L92-L97 
Imo it is better than prepareTransaction again after and refetch gasValues

### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
](https://ledgerhq.atlassian.net/browse/LIVE-13912)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
