### PR TITLE
feat: use account id instead of currency id

### DIFF
--- a/.changeset/afraid-stingrays-hunt.md
+++ b/.changeset/afraid-stingrays-hunt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+use account id instead of currency id for sla passthrough

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -278,7 +278,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
             }
           : {}),
       }).toString(),
-    [isOffline, state.defaultAccount, state.defaultParentAccount, walletState],
+    [isOffline, state?.defaultAccount, state?.defaultParentAccount, walletState],
   );
 
   const onSwapWebviewError = (error?: SwapLiveError) => {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -266,12 +266,12 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
     () =>
       new URLSearchParams({
         ...(isOffline ? { isOffline: "true" } : {}),
-        ...(state.defaultAccount
+        ...(state?.defaultAccount
           ? {
               fromAccountId: accountToWalletAPIAccount(
                 walletState,
                 state.defaultAccount,
-                state.defaultParentAccount,
+                state?.defaultParentAccount,
               ).id,
             }
           : {}),

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -1,9 +1,9 @@
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
-import { getAccountIdFromWalletAccountId } from "@ledgerhq/live-common/wallet-api/converters";
+
 import { handlers as loggerHandlers } from "@ledgerhq/live-common/wallet-api/CustomLogger/server";
 import { getEnv } from "@ledgerhq/live-env";
-import BigNumber from "bignumber.js";
+
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
@@ -29,8 +29,6 @@ import {
   accountToWalletAPIAccount,
   getAccountIdFromWalletAccountId,
 } from "@ledgerhq/live-common/wallet-api/converters";
-import { track } from "~/renderer/analytics/segment";
-import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 
 import { GasOptions } from "@ledgerhq/coin-evm/lib/types/transaction";
 import { getMainAccount, getParentAccount } from "@ledgerhq/live-common/account/helpers";

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -24,6 +24,13 @@ import {
 } from "~/renderer/reducers/settings";
 import { captureException } from "~/sentry/renderer";
 import WebviewErrorDrawer from "./WebviewErrorDrawer/index";
+import BigNumber from "bignumber.js";
+import {
+  accountToWalletAPIAccount,
+  getAccountIdFromWalletAccountId,
+} from "@ledgerhq/live-common/wallet-api/converters";
+import { track } from "~/renderer/analytics/segment";
+import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 
 import { GasOptions } from "@ledgerhq/coin-evm/lib/types/transaction";
 import { getMainAccount, getParentAccount } from "@ledgerhq/live-common/account/helpers";
@@ -39,6 +46,8 @@ import { useLocation } from "react-router";
 import { NetworkStatus, useNetworkStatus } from "~/renderer/hooks/useNetworkStatus";
 import { transformToBigNumbers, useGetSwapTrackingProperties } from "../utils/index";
 import FeesDrawerLiveApp from "./FeesDrawerLiveApp";
+import { walletSelector } from "~/renderer/reducers/wallet";
+import { Account, AccountLike } from "@ledgerhq/types-live";
 
 export class UnableToLoadSwapLiveError extends Error {
   constructor(message: string) {
@@ -91,7 +100,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
       palette: { type: themeType },
     },
   } = useTheme();
-
+  const walletState = useSelector(walletSelector);
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const { setDrawer } = React.useContext(context);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
@@ -101,7 +110,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
   const accounts = useSelector(flattenAccountsSelector);
   const { t } = useTranslation();
   const swapDefaultTrack = useGetSwapTrackingProperties();
-  const { state } = useLocation<{ defaultCurrency?: { id: string } }>();
+  const { state } = useLocation<{ defaultAccount?: AccountLike; defaultParentAccount?: Account }>();
 
   const { networkStatus } = useNetworkStatus();
   const isOffline = networkStatus === NetworkStatus.OFFLINE;
@@ -258,11 +267,18 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
   const hashString = useMemo(
     () =>
       new URLSearchParams({
-        ...(state?.defaultCurrency?.id ? { from: state?.defaultCurrency?.id } : {}),
         ...(isOffline ? { isOffline: "true" } : {}),
+        ...(state.defaultAccount
+          ? {
+              fromAccountId: accountToWalletAPIAccount(
+                walletState,
+                state.defaultAccount,
+                state.defaultParentAccount,
+              ).id,
+            }
+          : {}),
       }).toString(),
-
-    [isOffline, state?.defaultCurrency?.id],
+    [isOffline, state.defaultAccount, state.defaultParentAccount, walletState],
   );
 
   const onSwapWebviewError = (error?: SwapLiveError) => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
