### PR TITLE
fix: fallback screen settings button icon rendering with the right color

### DIFF
--- a/.changeset/tasty-pandas-behave.md
+++ b/.changeset/tasty-pandas-behave.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Assign the right color to settings icon in Fallback camera permission screen

--- a/apps/ledger-live-mobile/src/components/RequiresCameraPermissions/Fallback.tsx
+++ b/apps/ledger-live-mobile/src/components/RequiresCameraPermissions/Fallback.tsx
@@ -15,8 +15,6 @@ type Props = {
   hasNoBackground?: boolean;
 };
 
-const IconSettings = () => <Icon name="settings" size={16} color="neutral.c100" />;
-
 const FallbackCameraBody: React.FC<Props> = ({
   title,
   description,
@@ -26,6 +24,8 @@ const FallbackCameraBody: React.FC<Props> = ({
   hasNoBackground,
 }: Props) => {
   const { colors } = useTheme();
+
+  const IconSettings = () => <Icon name="settings" size={16} color={colors.neutral.c00} />;
 
   return (
     <Flex flex={1} bg={hasNoBackground ? "transparent" : "background.main"} px={6}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Fix setting icon rendering color 
#### Before ❌
![image](https://github.com/user-attachments/assets/7c392633-4e4c-4210-9a8f-bd55dd8c6c9a)
#### After ✅
![image](https://github.com/user-attachments/assets/6c47d208-171c-49df-a074-b4c5292166e6)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
