### PR TITLE
:sparkles: (device-core): add new reinstallConfiguration consent use case

### DIFF
--- a/.changeset/strong-steaks-rule.md
+++ b/.changeset/strong-steaks-rule.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/errors": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add new PINNotSet error

--- a/.changeset/twelve-owls-accept.md
+++ b/.changeset/twelve-owls-accept.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/device-core": minor
+---
+
+Add new reinstallConfiguration consent use case

--- a/.changeset/wet-clocks-nail.md
+++ b/.changeset/wet-clocks-nail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-cli": minor
+---
+
+Implement reinstallConfiguration command

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,6 +30,8 @@
     "@ledgerhq/coin-bitcoin": "workspace:^",
     "@ledgerhq/coin-framework": "workspace:^",
     "@ledgerhq/cryptoassets": "workspace:^",
+    "@ledgerhq/device-core": "workspace:^",
+    "@ledgerhq/devices": "workspace:^",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-btc": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:^",

--- a/apps/cli/src/commands-index.ts
+++ b/apps/cli/src/commands-index.ts
@@ -47,6 +47,7 @@ import i18n from "./commands/device/i18n";
 import listApps from "./commands/device/listApps";
 import managerListApps from "./commands/device/managerListApps";
 import proxy from "./commands/device/proxy";
+import reinstallConfigurationConsent from "./commands/device/reinstallConfigurationConsent";
 import repl from "./commands/device/repl";
 import speculosList from "./commands/device/speculosList";
 import balanceHistory from "./commands/live/balanceHistory";
@@ -110,6 +111,7 @@ export default {
   listApps,
   managerListApps,
   proxy,
+  reinstallConfigurationConsent,
   repl,
   speculosList,
   balanceHistory,

--- a/apps/cli/src/commands/device/reinstallConfigurationConsent.ts
+++ b/apps/cli/src/commands/device/reinstallConfigurationConsent.ts
@@ -1,0 +1,64 @@
+import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
+import getDeviceInfo from "@ledgerhq/live-common/hw/getDeviceInfo";
+import customLockScreenFetchHash from "@ledgerhq/live-common/hw/customLockScreenFetchHash";
+import listApps from "@ledgerhq/live-common/hw/listApps";
+import {
+  getAppStorageInfo,
+  isCustomLockScreenSupported,
+  reinstallConfigurationConsent,
+  ReinstallConfigArgs,
+} from "@ledgerhq/device-core";
+import { identifyTargetId } from "@ledgerhq/devices";
+import { deviceOpt } from "../../scan";
+import { from, map, switchMap } from "rxjs";
+
+export default {
+  description:
+    "Consent to allow restoring state of device after a firmware update (apps, language pack, custom lock screen and app data)",
+  args: [
+    deviceOpt,
+    {
+      name: "format",
+      alias: "f",
+      type: String,
+      typeDesc: "raw | json | default",
+    },
+  ],
+  job: ({ device }: { device: string }) => {
+    return withDevice(device || "")(t =>
+      from(listApps(t)).pipe(
+        map(apps => apps.filter(app => !!app.name)),
+        switchMap(async apps => {
+          const reinstallAppsLength = apps.length;
+          let storageLength = 0;
+          for (const app of apps) {
+            const appStorageInfo = await getAppStorageInfo(t, app.name);
+            if (appStorageInfo) {
+              storageLength++;
+            }
+          }
+          const deviceInfo = await getDeviceInfo(t);
+          if (!deviceInfo.seTargetId) throw new Error("Cannot get device info");
+          const deviceModel = identifyTargetId(deviceInfo.seTargetId);
+          if (!deviceModel) throw new Error("Cannot get device model");
+
+          const cls = isCustomLockScreenSupported(deviceModel.id)
+            ? await customLockScreenFetchHash(t)
+            : false;
+
+          const langId = deviceInfo?.languageId ?? 0;
+
+          const args: ReinstallConfigArgs = [
+            langId > 0 ? 0x01 : 0x00,
+            cls ? 0x01 : 0x00,
+            reinstallAppsLength,
+            storageLength,
+          ];
+
+          return args;
+        }),
+        switchMap(args => reinstallConfigurationConsent(t, args)),
+      ),
+    );
+  },
+};

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6244,6 +6244,9 @@
     },
     "DeleteAppDataError": {
       "title": "Error deleting app data"
+    },
+    "PinNotSet": {
+      "title": "PIN not set"
     }
   },
   "cryptoOrg": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -893,6 +893,9 @@
     "NearStakingThresholdNotMet": {
       "title": "Amount needs to be at least {{threshold}}"
     },
+    "PinNotSet": {
+      "title": "PIN not set"
+    },
     "PriorityFeeTooLow": {
       "title": "Priority fee is lower than the recommended value"
     },

--- a/libs/device-core/src/commands/entities/ReinstallConfigEntity.ts
+++ b/libs/device-core/src/commands/entities/ReinstallConfigEntity.ts
@@ -1,0 +1,15 @@
+export type ReinstallConfigArgs = [
+  // 0x00 = false, 0x01 = true
+  ReinstallLanguagePack: 0x00 | 0x01, // 1 byte
+  ReinstallCustomLockScreen: 0x00 | 0x01, // 1 byte
+  ReinstallAppsNum: number, // 1 byte UINT8
+  ReinstallAppDataNum: number, // 1 byte UINT8
+];
+
+// TODO: model used when getting the config from the device before a software update
+// export type ReinstallConfig = {
+//   languageId?: LanguageId,
+//   CustomLockScreen?: CustomLockScreen,
+//   reinstallApps: AppName[],
+//   reinstallStorage: AppName[],
+// };

--- a/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.test.ts
+++ b/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.test.ts
@@ -1,0 +1,56 @@
+import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { reinstallConfigurationConsent } from "./reinstallConfigurationConsent";
+import { PinNotSet, UserRefusedOnDevice } from "@ledgerhq/errors";
+
+describe("reinstallConfigurationConsent", () => {
+  let transport: Transport;
+
+  beforeEach(() => {
+    transport = {
+      send: jest.fn().mockResolvedValue(Buffer.from([])),
+      getTraceContext: jest.fn().mockResolvedValue(undefined),
+    } as unknown as Transport;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("success cases", () => {
+    it("should call the send function with correct parameters", async () => {
+      transport.send = jest.fn().mockResolvedValue(Buffer.from([0x90, 0x00]));
+      await reinstallConfigurationConsent(transport, [0x00, 0x00, 0x00, 0x00]);
+      expect(transport.send).toHaveBeenCalledWith(
+        0xe0,
+        0x6f,
+        0x00,
+        0x00,
+        Buffer.from([0x00, 0x00, 0x00, 0x00]),
+        [StatusCodes.OK, StatusCodes.USER_REFUSED_ON_DEVICE, StatusCodes.PIN_NOT_SET],
+      );
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw UserRefusedOnDevice if the user refused on device", async () => {
+      transport.send = jest.fn().mockResolvedValue(Buffer.from([0x55, 0x01]));
+      await expect(
+        reinstallConfigurationConsent(transport, [0x00, 0x00, 0x00, 0x00]),
+      ).rejects.toThrow(new UserRefusedOnDevice("User refused on device"));
+    });
+
+    it("should throw PINNotSet if the PIN is not set", async () => {
+      transport.send = jest.fn().mockResolvedValue(Buffer.from([0x55, 0x02]));
+      await expect(
+        reinstallConfigurationConsent(transport, [0x00, 0x00, 0x00, 0x00]),
+      ).rejects.toThrow(new PinNotSet("PIN not set"));
+    });
+
+    it("should throw TransportStatusError if the response status is invalid", async () => {
+      transport.send = jest.fn().mockResolvedValue(Buffer.from([0x6f, 0x00]));
+      await expect(
+        reinstallConfigurationConsent(transport, [0x00, 0x00, 0x00, 0x00]),
+      ).rejects.toThrow(new TransportStatusError(0x6f00));
+    });
+  });
+});

--- a/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.ts
+++ b/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.ts
@@ -1,0 +1,75 @@
+import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { LocalTracer } from "@ledgerhq/logs";
+import { UserRefusedOnDevice, PinNotSet } from "@ledgerhq/errors";
+import type { APDU } from "../../entities/APDU";
+import type { ReinstallConfigArgs } from "../../entities/ReinstallConfigEntity";
+
+/**
+ * Name in documentation: REINSTALL_CONFIG
+ * cla: 0xe0
+ * ins: 0x6f
+ * p1: 0x00
+ * p2: 0x00
+ * data: CHUNK_LEN + CHUNK to configure at runtime
+ */
+const REINSTALL_CONFIG = [0xe0, 0x6f, 0x00, 0x00] as const;
+
+/**
+ * 0x9000: Success.
+ * 0xYYYY: already in REINSTALL mode
+ * 0xZZZZ: if other error (TBD)
+ */
+const RESPONSE_STATUS_SET: number[] = [
+  StatusCodes.OK,
+  StatusCodes.USER_REFUSED_ON_DEVICE,
+  StatusCodes.PIN_NOT_SET,
+];
+
+/**
+ * Requests consent from the user to allow reinstalling all the previous
+ * settings after an OS update.
+ *
+ * @param transport - The transport object used to communicate with the device.
+ * @returns A promise that resolves when the consent is granted.
+ */
+export async function reinstallConfigurationConsent(
+  transport: Transport,
+  args: ReinstallConfigArgs,
+): Promise<void> {
+  const tracer = new LocalTracer("hw", {
+    transport: transport.getTraceContext(),
+    function: "reinstallConfigurationConsent",
+  });
+  tracer.trace("Start");
+
+  const apdu: Readonly<APDU> = [...REINSTALL_CONFIG, Buffer.from(args)];
+
+  const response = await transport.send(...apdu, RESPONSE_STATUS_SET);
+
+  return parseResponse(response);
+}
+
+/**
+ * Parses the response data buffer, check the status code and return the data.
+ *
+ * @param data - The response data buffer w/ status code.
+ * @returns The response data as a buffer w/o status code.
+ */
+export function parseResponse(data: Buffer): void {
+  const tracer = new LocalTracer("hw", {
+    function: "parseResponse@reinstallConfigurationConsent",
+  });
+  const status = data.readUInt16BE(data.length - 2);
+  tracer.trace("Result status from 0xe06f0000", { status });
+
+  switch (status) {
+    case StatusCodes.OK:
+      return;
+    case StatusCodes.USER_REFUSED_ON_DEVICE:
+      throw new UserRefusedOnDevice("User refused on device");
+    case StatusCodes.PIN_NOT_SET:
+      throw new PinNotSet("PIN not set");
+    default:
+      throw new TransportStatusError(status);
+  }
+}

--- a/libs/device-core/src/index.ts
+++ b/libs/device-core/src/index.ts
@@ -5,6 +5,7 @@ export type {
   OsuFirmware,
   FirmwareUpdateContextEntity,
 } from "./managerApi/entities/FirmwareUpdateContextEntity";
+export type { ReinstallConfigArgs } from "./commands/entities/ReinstallConfigEntity";
 export type { ManagerApiRepository } from "./managerApi/repositories/ManagerApiRepository";
 export { HttpManagerApiRepository } from "./managerApi/repositories/HttpManagerApiRepository";
 export { StubManagerApiRepository } from "./managerApi/repositories/StubManagerApiRepository";
@@ -42,3 +43,5 @@ export * from "./customLockScreen/screenSpecs";
 export { shouldForceFirmwareUpdate } from "./firmwareUpdate/shouldForceFirmwareUpdate";
 // errors
 export * from "./errors";
+// src/commands/consent/
+export { reinstallConfigurationConsent } from "./commands/use-cases/consent/reinstallConfigurationConsent";

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -125,6 +125,7 @@ export const UserRefusedAddress = createCustomErrorClass("UserRefusedAddress");
 export const UserRefusedFirmwareUpdate = createCustomErrorClass("UserRefusedFirmwareUpdate");
 export const UserRefusedAllowManager = createCustomErrorClass("UserRefusedAllowManager");
 export const UserRefusedOnDevice = createCustomErrorClass("UserRefusedOnDevice"); // TODO rename because it's just for transaction refusal
+export const PinNotSet = createCustomErrorClass("PinNotSet");
 export const ExpertModeRequired = createCustomErrorClass("ExpertModeRequired");
 export const TransportOpenUserCancelled = createCustomErrorClass("TransportOpenUserCancelled");
 export const TransportInterfaceNotAvailable = createCustomErrorClass(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,12 @@ importers:
       '@ledgerhq/cryptoassets':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/cryptoassets
+      '@ledgerhq/device-core':
+        specifier: workspace:^
+        version: link:../../libs/device-core
+      '@ledgerhq/devices':
+        specifier: workspace:*
+        version: link:../../libs/ledgerjs/packages/devices
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/errors


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - new PINNotSet in @ledgerhq/errors + error entry in translation file for LLM / LLD
  - new consent usecase reinstallConfiguration in @ledgerhq/device-core
  - implement new usecase in CLI

### 📝 Description

Implement new APDU to give consent after an OS update to reinstall the whole config of the device.
This allows us to skip all the user consent for each step (language pack, custom locksceen, apps, and now apps data) and only require one approval before the whole restore flow.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13028] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13028]: https://ledgerhq.atlassian.net/browse/LIVE-13028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ