### PR TITLE
fix: 🔁 device selection after aborted flow

### DIFF
--- a/.changeset/lemon-starfishes-do.md
+++ b/.changeset/lemon-starfishes-do.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix device selection after LedgerSync aborted flow

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -1,7 +1,7 @@
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { Action, Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Alert, Flex } from "@ledgerhq/native-ui";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components/native";
 import { PartialNullable } from "~/types/helpers";
@@ -23,6 +23,7 @@ type Props<Req, Stt, Res> = {
   renderOnResult?: (_: Res) => JSX.Element | null;
   onSelectDeviceLink?: () => void;
   analyticsPropertyFlow?: string;
+  registerDeviceSelection?: (selectDevice: (device: Device) => void) => void;
 };
 
 export default function DeviceActionModal<Req, Stt, Res>({
@@ -36,6 +37,7 @@ export default function DeviceActionModal<Req, Stt, Res>({
   onModalHide,
   onSelectDeviceLink,
   analyticsPropertyFlow,
+  registerDeviceSelection,
 }: Props<Req, Stt, Res>) {
   const { t } = useTranslation();
   const showAlert = !device?.wired;
@@ -53,6 +55,12 @@ export default function DeviceActionModal<Req, Stt, Res>({
       onClose();
     }
   }, [onClose, result]);
+
+  useEffect(() => {
+    registerDeviceSelection?.(() => {
+      setResult(null);
+    });
+  }, [registerDeviceSelection]);
 
   return (
     <QueuedDrawer

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -23,7 +23,7 @@ type Props<Req, Stt, Res> = {
   renderOnResult?: (_: Res) => JSX.Element | null;
   onSelectDeviceLink?: () => void;
   analyticsPropertyFlow?: string;
-  registerDeviceSelection?: (selectDevice: (device: Device) => void) => void;
+  registerDeviceSelection?: (onDeviceUpdated: () => void) => void;
 };
 
 export default function DeviceActionModal<Req, Stt, Res>({
@@ -57,9 +57,7 @@ export default function DeviceActionModal<Req, Stt, Res>({
   }, [onClose, result]);
 
   useEffect(() => {
-    registerDeviceSelection?.(() => {
-      setResult(null);
-    });
+    registerDeviceSelection?.(() => setResult(null));
   }, [registerDeviceSelection]);
 
   return (

--- a/apps/ledger-live-mobile/src/hooks/deviceActions.ts
+++ b/apps/ledger-live-mobile/src/hooks/deviceActions.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { createAction as appCreateAction } from "@ledgerhq/live-common/hw/actions/app";
 import { createAction as transactionCreateAction } from "@ledgerhq/live-common/hw/actions/transaction";
 import { createAction as startExchangeCreateAction } from "@ledgerhq/live-common/hw/actions/startExchange";
@@ -11,6 +11,7 @@ import { createAction as staxFetchImageCreateAction } from "@ledgerhq/live-commo
 import { createAction as installLanguageCreateAction } from "@ledgerhq/live-common/hw/actions/installLanguage";
 import { createAction as staxRemoveImageCreateAction } from "@ledgerhq/live-common/hw/actions/customLockScreenRemove";
 import { createAction as renameDeviceCreateAction } from "@ledgerhq/live-common/hw/actions/renameDevice";
+import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import renameDevice from "@ledgerhq/live-common/hw/renameDevice";
 import customLockScreenLoad from "@ledgerhq/live-common/hw/customLockScreenLoad";
 import installLanguage from "@ledgerhq/live-common/hw/installLanguage";
@@ -123,4 +124,19 @@ export function useRenameDeviceAction() {
     () => renameDeviceCreateAction(mock ? renameDeviceExecMock : renameDevice),
     [mock],
   );
+}
+
+export function useSelectDevice() {
+  const [device, setDevice] = useState<Device | null | undefined>(null);
+
+  const onDeviceUpdated = useRef<() => void>();
+  const registerDeviceSelection = useCallback((handler: () => void) => {
+    onDeviceUpdated.current = handler;
+  }, []);
+  const selectDevice = useCallback((device: Device | null | undefined) => {
+    setDevice(device);
+    onDeviceUpdated.current?.();
+  }, []);
+
+  return { device, selectDevice, registerDeviceSelection };
 }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -52,6 +52,8 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
 
   const navigation = useNavigation<NavigationProps["navigation"]>();
 
+  const onClose = () => selectDevice(null);
+
   const onResult = useCallback(
     (payload: AppResult) => {
       goToFollowInstructions(payload.device);
@@ -116,7 +118,7 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
         />
       </Flex>
       <DeviceActionModal
-        onClose={() => selectDevice(null)}
+        onClose={onClose}
         device={device}
         onResult={onResult}
         action={action}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, memo } from "react";
+import React, { useCallback, useState, memo, useRef } from "react";
 import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { Trans } from "react-i18next";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -52,8 +52,13 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
 
   const navigation = useNavigation<NavigationProps["navigation"]>();
 
+  const selectDeviceRef = useRef<(device: Device) => void>();
+  const registerDeviceSelection = useCallback((selectDevice: (device: Device) => void) => {
+    selectDeviceRef.current = selectDevice;
+  }, []);
   const onSelectDevice = useCallback((device: Device) => {
     setDevice(device);
+    selectDeviceRef.current?.(device);
   }, []);
 
   const onClose = () => setDevice(null);
@@ -128,6 +133,7 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
         action={action}
         request={request}
         onError={onError}
+        registerDeviceSelection={registerDeviceSelection}
       />
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/02-SelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/02-SelectDevice.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect } from "react";
 import { StyleSheet, SafeAreaView } from "react-native";
-import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useIsFocused, useTheme } from "@react-navigation/native";
 import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
 import { Flex } from "@ledgerhq/native-ui";
@@ -16,7 +15,7 @@ import type { AddAccountsNavigatorParamList } from "~/components/RootNavigator/t
 import SkipSelectDevice from "../SkipSelectDevice";
 import AddAccountsHeaderRightClose from "./AddAccountsHeaderRightClose";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
-import { useAppDeviceAction } from "~/hooks/deviceActions";
+import { useAppDeviceAction, useSelectDevice } from "~/hooks/deviceActions";
 
 type Props = StackNavigatorProps<AddAccountsNavigatorParamList, ScreenName.AddAccountsSelectDevice>;
 
@@ -32,17 +31,17 @@ export default function AddAccountsSelectDevice({ navigation, route }: Props) {
   const action = useAppDeviceAction();
   const { currency, analyticsPropertyFlow } = route.params;
   const { colors } = useTheme();
-  const [device, setDevice] = useState<Device | null | undefined>(null);
+  const { device, selectDevice, registerDeviceSelection } = useSelectDevice();
   const isFocused = useIsFocused();
 
   const onClose = useCallback(() => {
-    setDevice(null);
-  }, []);
+    selectDevice(null);
+  }, [selectDevice]);
 
   const onResult = useCallback(
     // @ts-expect-error should be AppResult but navigation.navigate does not agree
     meta => {
-      setDevice(null);
+      selectDevice(null);
       const { inline } = route.params;
       const arg = { ...route.params, ...meta };
 
@@ -52,7 +51,7 @@ export default function AddAccountsSelectDevice({ navigation, route }: Props) {
         navigation.navigate(ScreenName.AddAccountsAccounts, arg);
       }
     },
-    [navigation, route],
+    [selectDevice, navigation, route],
   );
 
   useEffect(() => {
@@ -89,10 +88,10 @@ export default function AddAccountsSelectDevice({ navigation, route }: Props) {
         },
       ]}
     >
-      <SkipSelectDevice route={route} onResult={setDevice} />
+      <SkipSelectDevice route={route} onResult={selectDevice} />
       <Flex px={16} py={8} flex={1}>
         <SelectDevice2
-          onSelect={setDevice}
+          onSelect={selectDevice}
           stopBleScanning={!!device || !isFocused}
           requestToSetHeaderOptions={requestToSetHeaderOptions}
         />
@@ -105,8 +104,9 @@ export default function AddAccountsSelectDevice({ navigation, route }: Props) {
         request={{
           currency: currency && isTokenCurrency(currency) ? currency.parentCurrency : currency,
         }}
-        onSelectDeviceLink={() => setDevice(null)}
+        onSelectDeviceLink={() => selectDevice(null)}
         analyticsPropertyFlow={analyticsPropertyFlow || "add account"}
+        registerDeviceSelection={registerDeviceSelection}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

**I'm opened to alternative solutions.**

TLDR: I'm not completely satisfied with this solution but I don't see another way which doesn't involve a major refactor.

The issue comes from the current structure of `DeviceActionModal` which relies on the `device` prop and `result` internal state to trigger the drawer. Once `result` is set the drawer is not supposed to re-opened and since `device` is not necessary reset something like this doesn't always work:
```js
useEffect(() => {
  if (!device) return () => setResult(null);
}, [device]);
```
(also it might break some other flow unrelated to ledger sync).

The way I see it selecting a device should imperatively trigger the device interaction. But this component is used this way everywhere else there is a device interaction on LLM.

https://github.com/user-attachments/assets/30f1e63d-fbae-4d7c-899a-d4767ce1c0d9

### ❓ Context

- [LIVE-13937]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13937]: https://ledgerhq.atlassian.net/browse/LIVE-13937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ