### PR TITLE
[LIVE-13976] Bugfix - Allow missing coinRef with EIP-712 filters V2

### DIFF
--- a/.changeset/tricky-pans-obey.md
+++ b/.changeset/tricky-pans-obey.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-eth": patch
+---
+
+Allow token to not be provided to the device (might not be existing in CAL) when providing filters V2 for the EIP-712 messages

--- a/libs/ledgerjs/packages/hw-app-eth/tests/EIP712/utils.unit.test.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/tests/EIP712/utils.unit.test.ts
@@ -622,6 +622,63 @@ describe("EIP712", () => {
           "Array of tokens is not supported with a single coin ref",
         );
       });
+
+      it("should order correctly the map", () => {
+        const filters = {
+          fields: [
+            {
+              coin_ref: 1,
+              format: "token",
+              label: "Amount allowance",
+              path: "details.token2",
+              signature:
+                "304402203b28bb137a21a6f08903489c6b158fd54280367d6bb72f87bf3e2f287a92440f02207ecc609b12b363cd0e8cbef7079776dfb363cef2fc11da39750598ee4cda4877",
+            },
+            {
+              coin_ref: 1,
+              format: "amount",
+              label: "Amount allowance",
+              path: "details.amount2",
+              signature:
+                "30440220574f7322c9cd212d295c15d92a48aeb6b490978cb87d61fe8afb71b97053ceb7022016489970af3ff80903a45a966ea07dd9ca1435f6b6da9124e03f3087485d1c5b",
+            },
+            {
+              coin_ref: 0,
+              format: "token",
+              label: "Amount allowance",
+              path: "details.token",
+              signature:
+                "304402203b28bb137a21a6f08903489c6b158fd54280367d6bb72f87bf3e2f287a92440f02207ecc609b12b363cd0e8cbef7079776dfb363cef2fc11da39750598ee4cda4877",
+            },
+            {
+              coin_ref: 0,
+              format: "amount",
+              label: "Amount allowance",
+              path: "details.amount",
+              signature:
+                "30440220574f7322c9cd212d295c15d92a48aeb6b490978cb87d61fe8afb71b97053ceb7022016489970af3ff80903a45a966ea07dd9ca1435f6b6da9124e03f3087485d1c5b",
+            },
+            {
+              format: "raw",
+              label: "Approve to spender",
+              path: "spender",
+              signature:
+                "30450221008eecd0e1f432daf722fd00c54038a4cd4d96624cc117ddfb12c7ed10a59b260d02203d34c811a5918c2654e301a071b624088aa9a0813f19dbfa1c803f3dcec64557",
+            },
+          ],
+        } as any;
+        const message = {
+          message: {
+            details: { token: "0x01", amount: "0x02", token2: "0x03", amount2: "0x04" },
+            spender: "0x05",
+          },
+        } as any;
+
+        expect(getCoinRefTokensMap(filters, false, message)).toEqual({
+          0: { token: "0x01" },
+          1: { token: "0x03" },
+        });
+      });
     });
 
     describe("getAppAndVersion", () => {
@@ -685,10 +742,10 @@ describe("EIP712", () => {
         ).toEqual(Buffer.concat([Buffer.from("7B", "hex"), sigBuffer]));
       });
 
-      it("should should throw if a token hasn't been registered by the device", () => {
-        expect(() =>
+      it("should return the coinRef if a token hasn't been registered by the device (token not in CAL for example)", () => {
+        expect(
           getPayloadForFilterV2("token", 0, { 0: { token: "0x01" } }, displayNameBuffer, sigBuffer),
-        ).toThrow("Missing coinRef");
+        ).toEqual(Buffer.concat([Buffer.from("00", "hex"), sigBuffer]));
       });
 
       it("should return a payload for an amount filter", () => {
@@ -703,8 +760,8 @@ describe("EIP712", () => {
         ).toEqual(Buffer.concat([displayNameBuffer, Buffer.from("7B", "hex"), sigBuffer]));
       });
 
-      it("should should throw if a token hasn't been registered by the device", () => {
-        expect(() =>
+      it("should return the coinRef if a token hasn't been registered by the device (token not in CAL for example)", () => {
+        expect(
           getPayloadForFilterV2(
             "amount",
             0,
@@ -712,7 +769,7 @@ describe("EIP712", () => {
             displayNameBuffer,
             sigBuffer,
           ),
-        ).toThrow("Missing coinRef");
+        ).toEqual(Buffer.concat([displayNameBuffer, Buffer.from("00", "hex"), sigBuffer]));
       });
 
       it("should should throw for an unknown filter format", () => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no more throws when a token isn't in CAL

### 📝 Description

When a token isn't in CAL, we can't send the correct descriptors to the device (`PROVIDE_ERC20_TOKEN_INFOS`) which is supposed to return the token "index" it has in memory. Due to this not being possible, we were throwing an error `missing coinRef` without ever sending anymore APDUs.
This behavior will be changed in the next ethereum nano app, and the app is now expecting the `coinRef` even if the token descriptor hasn't been provided.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-13976


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
