### PR TITLE
fix: add safety margin to estimated fees for hedera

### DIFF
--- a/.changeset/dry-weeks-bow.md
+++ b/.changeset/dry-weeks-bow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Add safety margin to Hedera fee estimates

--- a/libs/ledger-live-common/src/families/hedera/utils.ts
+++ b/libs/ledger-live-common/src/families/hedera/utils.ts
@@ -20,7 +20,8 @@ export async function getEstimatedFees(account: Account): Promise<BigNumber> {
     if (data[0]) {
       return new BigNumber(10000)
         .dividedBy(new BigNumber(data[0]))
-        .integerValue(BigNumber.ROUND_CEIL);
+        .integerValue(BigNumber.ROUND_CEIL)
+        .multipliedBy(estimatedFeeSafetyRate);
     }
     // eslint-disable-next-line no-empty
   } catch {}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Should allow more flexibility around changing fee estimates for "Send Max"

### 📝 Description

Add safety margin to Hedera fee estimates

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
