### PR TITLE
Fix stability of device selection screenshot

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/onboarding/connect-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/connect-device.spec.ts
@@ -25,8 +25,7 @@ test.describe.parallel("Onboarding", () => {
       await test.step("Get started", async () => {
         await onboardingPage.getStarted();
         await onboardingPage.hoverDevice(Nano.nanoS);
-        await new Promise(r => setTimeout(r, 300)); // wait for the animation to finish
-        await expect(page).toHaveScreenshot("v3-device-selection.png");
+        await expect(page).toHaveScreenshot("v3-device-selection.png", { animations: "disabled" });
       });
 
       await test.step(`[${nano}] Select Device`, async () => {

--- a/apps/ledger-live-desktop/tests/specs/onboarding/restore-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/restore-device.spec.ts
@@ -27,6 +27,7 @@ test.describe.parallel("Onboarding", () => {
         await onboardingPage.hoverDevice(Nano.nanoS);
         await expect(page).toHaveScreenshot("v3-device-selection.png", {
           mask: [page.locator("video")],
+          animations: "disabled",
         });
       });
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bugfixes, you can explain the previous behavior and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
