### PR TITLE
:bug:fix(lld): fix export to csv account name

### DIFF
--- a/.changeset/thick-glasses-swim.md
+++ b/.changeset/thick-glasses-swim.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+fix issue following CVS migration. The export didn't include account name

--- a/apps/ledger-live-desktop/src/renderer/modals/ExportOperations/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExportOperations/index.tsx
@@ -1,7 +1,7 @@
 import { ipcRenderer } from "electron";
 import React, { memo, useState, useCallback } from "react";
 import { Trans } from "react-i18next";
-import { connect } from "react-redux";
+import { connect, useSelector } from "react-redux";
 import styled from "styled-components";
 import { createStructuredSelector } from "reselect";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
@@ -23,6 +23,7 @@ import IconCheckCircle from "~/renderer/icons/CheckCircle";
 import Alert from "~/renderer/components/Alert";
 import { ModalData } from "../types";
 import { useTechnicalDateFn } from "~/renderer/hooks/useDateFormatter";
+import { walletSelector } from "~/renderer/reducers/wallet";
 
 type OwnProps = {};
 type Props = OwnProps & {
@@ -57,6 +58,8 @@ function ExportOperations({ accounts, closeModal, countervalueCurrency }: Props)
   const [success, setSuccess] = useState(false);
   const countervalueState = useCountervaluesState();
   const getDateTxt = useTechnicalDateFn();
+  const walletState = useSelector(walletSelector);
+
   const exportCsv = useCallback(async () => {
     const path = await ipcRenderer.invoke("show-save-dialog", {
       title: "Exported account transactions",
@@ -75,13 +78,14 @@ function ExportOperations({ accounts, closeModal, countervalueCurrency }: Props)
           accounts.filter(account => checkedIds.includes(account.id)),
           countervalueCurrency,
           countervalueState,
+          walletState,
         ),
         () => {
           setSuccess(true);
         },
       );
     }
-  }, [accounts, checkedIds, countervalueCurrency, countervalueState, getDateTxt]);
+  }, [accounts, checkedIds, countervalueCurrency, countervalueState, getDateTxt, walletState]);
   const onClose = useCallback(() => closeModal("MODAL_EXPORT_OPERATIONS"), [closeModal]);
   const handleButtonClick = useCallback(() => {
     let exporting = false;

--- a/libs/ledger-live-common/src/csvExport.ts
+++ b/libs/ledger-live-common/src/csvExport.ts
@@ -7,6 +7,7 @@ import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import type { Currency } from "@ledgerhq/types-cryptoassets";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { WalletState, accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 
 type Field = {
   title: string;
@@ -16,6 +17,7 @@ type Field = {
     arg2: Operation,
     arg3: Currency | null | undefined,
     arg4: CounterValuesState | null | undefined,
+    arg5: WalletState | null | undefined,
   ) => string;
 };
 
@@ -64,8 +66,10 @@ const fields: Field[] = [
   },
   {
     title: "Account Name",
-    // FIXME: we need to inject wallet state if we want the actual user's account name
-    cell: (account, parentAccount) => getDefaultAccountName(getMainAccount(account, parentAccount)),
+    cell: (account, parentAccount, _op, _counterValueCurrency, _countervalueState, walletState) =>
+      walletState
+        ? accountNameWithDefaultSelector(walletState, account)
+        : getDefaultAccountName(getMainAccount(account, parentAccount)),
   },
   {
     title: "Account xpub",
@@ -128,12 +132,20 @@ const accountRows = (
   parentAccount: Account | null | undefined,
   counterValueCurrency?: Currency,
   countervalueState?: CounterValuesState,
+  walletState?: WalletState,
 ): Array<string[]> =>
   account.operations
     .reduce((ops: Operation[], op) => ops.concat(flattenOperationWithInternalsAndNfts(op)), [])
     .map(operation =>
       fields.map(field =>
-        field.cell(account, parentAccount, operation, counterValueCurrency, countervalueState),
+        field.cell(
+          account,
+          parentAccount,
+          operation,
+          counterValueCurrency,
+          countervalueState,
+          walletState,
+        ),
       ),
     );
 
@@ -141,20 +153,25 @@ const accountsRows = (
   accounts: Account[],
   counterValueCurrency?: Currency,
   countervalueState?: CounterValuesState,
-): Array<string[]> =>
-  flattenAccounts(accounts).reduce((all: Array<string[]>, account) => {
+  walletState?: WalletState,
+): Array<string[]> => {
+  return flattenAccounts(accounts).reduce((all: Array<string[]>, account) => {
     const parentAccount =
       account.type !== "Account" ? accounts.find(a => a.id === account.parentId) : null;
-    return all.concat(accountRows(account, parentAccount, counterValueCurrency, countervalueState));
+    return all.concat(
+      accountRows(account, parentAccount, counterValueCurrency, countervalueState, walletState),
+    );
   }, []);
+};
 
 export const accountsOpToCSV = (
   accounts: Account[],
   counterValueCurrency?: Currency,
   countervalueState?: CounterValuesState, // cvs state required for countervalues export
+  walletState?: WalletState, // wallet state required for account name
 ): string =>
   fields.map(field => field.title).join(",") +
   newLine +
-  accountsRows(accounts, counterValueCurrency, countervalueState)
+  accountsRows(accounts, counterValueCurrency, countervalueState, walletState)
     .map(row => row.map(value => value.replace(/[,\n\r]/g, "")).join(","))
     .join(newLine);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - export to csv

### 📝 Description

Accounts names were not exported in the csv it's now fixed. 

<img width="543" alt="image" src="https://github.com/user-attachments/assets/1b39e940-f7ab-47f4-a086-d50965abbb28">



<!--

| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-14076](https://ledgerhq.atlassian.net/browse/LIVE-14076)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14076]: https://ledgerhq.atlassian.net/browse/LIVE-14076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ