### PR TITLE
fix: 🐛 Password lock blocked on QRScan

### DIFF
--- a/.changeset/tiny-gifts-matter.md
+++ b/.changeset/tiny-gifts-matter.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Block password lock when scanning QR

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/useAddAccountViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/useAddAccountViewModel.ts
@@ -7,6 +7,8 @@ import { useNavigation } from "@react-navigation/native";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 import { useCurrentStep } from "LLM/features/WalletSync/hooks/useCurrentStep";
+import { blockPasswordLock } from "~/actions/appstate";
+import { useDispatch } from "react-redux";
 
 type AddAccountDrawerProps = {
   isOpened: boolean;
@@ -20,18 +22,23 @@ type NavigationProps = BaseComposite<
 const startingStep = Steps.AddAccountMethod;
 
 const useAddAccountViewModel = ({ isOpened, onClose }: AddAccountDrawerProps) => {
+  const dispatch = useDispatch();
   const { currentStep, setCurrentStep } = useCurrentStep();
   const [currentOption, setCurrentOption] = useState<Options>(Options.SCAN);
   const navigateToChooseSyncMethod = () => setCurrentStep(Steps.ChooseSyncMethod);
-  const navigateToQrCodeMethod = () => setCurrentStep(Steps.QrCodeMethod);
+  const navigateToQrCodeMethod = () => {
+    dispatch(blockPasswordLock(true)); // Avoid Background on Android
+    setCurrentStep(Steps.QrCodeMethod);
+  };
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const onGoBack = () => setCurrentStep(getPreviousStep(currentStep));
 
   useEffect(() => {
     setCurrentStep(startingStep);
-  }, [setCurrentStep]);
+  }, [isOpened, setCurrentStep]);
 
   const reset = () => {
+    dispatch(blockPasswordLock(false));
     setCurrentStep(startingStep);
     setCurrentOption(Options.SCAN);
   };

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Activation/useActivationDrawerModel.ts
@@ -12,6 +12,8 @@ import { useNavigation } from "@react-navigation/native";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { WalletSyncNavigatorStackParamList } from "~/components/RootNavigator/types/WalletSyncNavigator";
 import { useCurrentStep } from "../../hooks/useCurrentStep";
+import { useDispatch } from "react-redux";
+import { blockPasswordLock } from "~/actions/appstate";
 
 type Props = {
   isOpen: boolean;
@@ -27,9 +29,12 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
   const { onClickTrack } = useLedgerSyncAnalytics();
   const { currentStep, setCurrentStep } = useCurrentStep();
 
+  const dispatch = useDispatch();
+
   useEffect(() => {
     setCurrentStep(startingStep);
-  }, [startingStep, setCurrentStep]);
+  }, [startingStep, isOpen, setCurrentStep]);
+
   const [currentOption, setCurrentOption] = useState<Options>(Options.SCAN);
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const hasCustomHeader = useMemo(() => currentStep === Steps.QrCodeMethod, [currentStep]);
@@ -59,6 +64,8 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
       button: AnalyticsButton.ScanQRCode,
       page: AnalyticsPage.ChooseSyncMethod,
     });
+
+    dispatch(blockPasswordLock(true));
     setCurrentStep(Steps.QrCodeMethod);
   };
 
@@ -69,6 +76,7 @@ const useActivationDrawerModel = ({ isOpen, startingStep, handleClose }: Props) 
   const goBackToPreviousStep = () => setCurrentStep(getPreviousStep(currentStep));
 
   const onCloseDrawer = () => {
+    dispatch(blockPasswordLock(false));
     resetStep();
     resetOption();
     handleClose();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Password lock blocked on QRScan

Fix also Step when coming back to AddAccount if I used LedgerSync from GeneralSettings, Drawer was empty => `isOpen` added in deps


### ❓ Context

- **JIRA or GitHub link**: [LIVE-14101] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14101]: https://ledgerhq.atlassian.net/browse/LIVE-14101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ