### PR TITLE
fix(trustchain): 🚦 allow members to sync immediately after getting removed

### DIFF
--- a/.changeset/forty-panthers-clean.md
+++ b/.changeset/forty-panthers-clean.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/trustchain": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Allow members to sync immediately after getting removed

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useAddMember.ts
@@ -76,7 +76,7 @@ export function useAddMember({ device }: { device: Device | null }) {
             onEndRequestUserInteraction: () => setUserDeviceInteraction(false),
           },
           undefined,
-          trustchainRef?.current?.rootId,
+          trustchainRef?.current ?? undefined,
         );
 
         transitionToNextScreen(trustchainResult);

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useAddMember.ts
@@ -76,7 +76,7 @@ export function useAddMember({ device }: { device: Device | null }) {
             onEndRequestUserInteraction: () => setUserDeviceInteraction(false),
           },
           undefined,
-          trustchainRef?.current ?? undefined,
+          trustchainRef.current ?? undefined,
         );
 
         transitionToNextScreen(trustchainResult);

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useAddMember.ts
@@ -61,7 +61,7 @@ export function useAddMember({ device }: { device: Device | null }): DrawerProps
             onEndRequestUserInteraction: () => setScene({ kind: SceneKind.Loader }),
           },
           undefined,
-          trustchainRef?.current?.rootId,
+          trustchainRef?.current ?? undefined,
         );
         if (trustchainResult) {
           transitionToNextScreen(trustchainResult);

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useAddMember.ts
@@ -61,7 +61,7 @@ export function useAddMember({ device }: { device: Device | null }): DrawerProps
             onEndRequestUserInteraction: () => setScene({ kind: SceneKind.Loader }),
           },
           undefined,
-          trustchainRef?.current ?? undefined,
+          trustchainRef.current ?? undefined,
         );
         if (trustchainResult) {
           transitionToNextScreen(trustchainResult);

--- a/libs/trustchain/src/types.ts
+++ b/libs/trustchain/src/types.ts
@@ -175,7 +175,7 @@ export interface TrustchainSDK {
     memberCredentials: MemberCredentials,
     callbacks?: GetOrCreateTrustchainCallbacks,
     topic?: Uint8Array,
-    currentTrustchainId?: string,
+    currentTrustchain?: Trustchain,
   ): Promise<TrustchainResult>;
 
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The ticket (linked below) suggests to display a different error in this case. However if the user initiates a synchronization with a device after being removed from the trustchain I think the process should go to completion, no matter if the synchronization is done with the same seed or with a different one. This is the solution introduced by this PR. WDYT ?

https://github.com/user-attachments/assets/172308c0-5256-4f7d-8b6e-41ba6ba926a3


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-14088]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14088]: https://ledgerhq.atlassian.net/browse/LIVE-14088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ