### PR TITLE
:sparkles:(llm/lld): add dynamic learn more for LS activation

### DIFF
--- a/.changeset/unlucky-beds-leave.md
+++ b/.changeset/unlucky-beds-leave.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/types-live": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+add a field to ledger sync feature flag so we can use a dynamic learn more link

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/shared.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/shared.tsx
@@ -29,6 +29,7 @@ export const lldWalletSyncFeatureFlag = {
         initialTimeout: 5000,
         userIntentDebounce: 1000,
       },
+      learnMoreLink: "https://www.ledger.com",
     },
   },
 };

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/walletSync.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/__tests__/walletSync.test.tsx
@@ -4,7 +4,8 @@
 import React from "react";
 import { render, screen, waitFor } from "tests/testUtils";
 import { initialStateWalletSync } from "~/renderer/reducers/walletSync";
-import { WalletSyncTestApp, mockedSdk } from "./shared";
+import { WalletSyncTestApp, lldWalletSyncFeatureFlag, mockedSdk } from "./shared";
+import { INITIAL_STATE as INITIAL_STATE_SETTINGS } from "~/renderer/reducers/settings";
 
 jest.mock("../hooks/useTrustchainSdk", () => ({
   useTrustchainSdk: () => ({
@@ -20,8 +21,30 @@ describe("Rendering", () => {
     expect(screen.getByRole("button", { name: "Manage" })).toBeTruthy();
   });
 
-  it("should open drawer and display Wallet Sync Activation flow", async () => {
-    const { user } = render(<WalletSyncTestApp />, {
+  it("should open drawer and display Wallet Sync Activation flow with learnMore link", async () => {
+    const { user, store } = render(<WalletSyncTestApp />, {
+      initialState: {
+        walletSync: initialStateWalletSync,
+        settings: {
+          ...INITIAL_STATE_SETTINGS,
+          overriddenFeatureFlags: lldWalletSyncFeatureFlag,
+        },
+      },
+    });
+    const button = screen.getByRole("button", { name: "Manage" });
+
+    await user.click(button);
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Sync your accounts" })).toBeDefined(),
+    );
+
+    expect(screen.getByText("Already synced a Ledger Live app?")).toBeDefined();
+    expect(store.getState().settings.overriddenFeatureFlags.lldWalletSync.enabled).toBe(true);
+    expect(screen.getByText(/learn more/i)).toBeDefined();
+  });
+
+  it("should open drawer and display Wallet Sync Activation flow without learnMore link", async () => {
+    const { user, store } = render(<WalletSyncTestApp />, {
       initialState: {
         walletSync: initialStateWalletSync,
       },
@@ -34,5 +57,7 @@ describe("Rendering", () => {
     );
 
     expect(screen.getByText("Already synced a Ledger Live app?")).toBeDefined();
+    expect(store.getState().settings.overriddenFeatureFlags.lldWalletSync).toBe(undefined);
+    expect(screen.queryByText(/learn more/i)).toBeNull();
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Activation/01-CreateOrSynchronizeStep.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Activation/01-CreateOrSynchronizeStep.tsx
@@ -6,6 +6,8 @@ import ButtonV3 from "~/renderer/components/ButtonV3";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { AnalyticsPage } from "../../hooks/useLedgerSyncAnalytics";
 import { LogoWrapper } from "../../components/LogoWrapper";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { openURL } from "~/renderer/linking";
 
 type Props = {
   goToCreateBackup: () => void;
@@ -15,6 +17,15 @@ type Props = {
 export default function CreateOrSynchronizeStep({ goToCreateBackup, goToSync }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const ledgerSyncFF = useFeature("lldWalletSync");
+  const learnMoreUrl = ledgerSyncFF?.params?.learnMoreLink;
+  const hasLearnMoreLink = !!learnMoreUrl;
+
+  const onLearnMore = () => {
+    if (learnMoreUrl) {
+      openURL(learnMoreUrl);
+    }
+  };
 
   return (
     <Flex flexDirection="column" alignSelf="center" justifyContent="center" rowGap="24px">
@@ -39,17 +50,28 @@ export default function CreateOrSynchronizeStep({ goToCreateBackup, goToSync }: 
       <Text fontSize={14} variant="body" color="hsla(0, 0%, 58%, 1)" textAlign="center">
         {t("walletSync.activate.description")}
       </Text>
-      <Flex justifyContent="center">
-        <ButtonV3 variant="main" onClick={goToCreateBackup}>
-          {t("walletSync.activate.cta")}
+      <Flex justifyContent="center" width="100%">
+        <ButtonV3 variant="main" width="100%" onClick={goToCreateBackup}>
+          <Text variant="body" color="neutral.c00" fontSize={14} flexShrink={1}>
+            {t("walletSync.activate.cta")}
+          </Text>
         </ButtonV3>
       </Flex>
 
-      <Link onClick={goToSync} alignItems="center" justifyContent="center">
-        <Text variant="body" fontSize={14} flexShrink={1}>
-          {t("walletSync.alreadySync")}
-        </Text>
-      </Link>
+      <Flex justifyContent="center" width="100%">
+        <ButtonV3 variant="shade" width="100%" onClick={goToSync}>
+          <Text variant="body" fontSize={14} flexShrink={1}>
+            {t("walletSync.alreadySync")}
+          </Text>
+        </ButtonV3>
+      </Flex>
+      {hasLearnMoreLink && (
+        <Link onClick={onLearnMore}>
+          <Text variant="body" fontSize={14} flexShrink={1}>
+            {t("walletSync.learnMore")}
+          </Text>
+        </Link>
+      )}
     </Flex>
   );
 }

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Activation/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/Activation/index.tsx
@@ -90,7 +90,6 @@ const WalletSyncActivation = forwardRef<BackRef, BackProps>((_props, ref) => {
       paddingX="64px"
       alignItems="center"
       justifyContent="center"
-      rowGap="48px"
     >
       {getStep()}
     </Flex>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6452,6 +6452,7 @@
       "cta": "Sync your accounts"
     },
     "alreadySync": "Already synced a Ledger Live app?",
+    "learnMore": "Learn more",
     "manage": {
       "cta": "Manage",
       "synchronize": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6761,7 +6761,8 @@
         "title": "Sync your accounts across all platforms",
         "description": "Your Ledger will generate an encryption key, ensuring your data remains private and retrievable only by you.",
         "mainCta": "Sync your accounts",
-        "secondCta": "Already synced a Ledger Live app?"
+        "secondCta": "Already synced a Ledger Live app?",
+        "learnMore": "Learn More"
       }
     },
     "deviceSelection": {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/shared.tsx
@@ -64,6 +64,7 @@ export const INITIAL_TEST = (state: State) => ({
         params: {
           environment: "STAGING",
           watchConfig: {},
+          learnMoreLink: "https://www.ledger.com",
         },
       },
     },

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/walletSyncActivation.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/walletSyncActivation.integration.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { screen } from "@testing-library/react-native";
 import { render, waitFor } from "@tests/test-renderer";
-import { WalletSyncSharedNavigator } from "./shared";
+import { INITIAL_TEST, WalletSyncSharedNavigator } from "./shared";
 import { DeviceLike, State } from "~/reducers/types";
 import { setEnv } from "@ledgerhq/live-env";
 import { DeviceModelId } from "@ledgerhq/types-devices";
@@ -74,5 +74,38 @@ describe("WalletSyncActivation", () => {
     // await waitFor(async () => {
     //   expect(await screen.findByText(`Continue on your Ledger Stax`)).toBeVisible();
     // });
+  });
+
+  it("Should open WalletSyncActivation Flow with learn More link", async () => {
+    render(<WalletSyncSharedNavigator />, {
+      overrideInitialState: INITIAL_TEST,
+    });
+
+    expect(await screen.findByText(/sync your accounts across all platforms/i)).toBeVisible();
+    expect(await screen.findByText(/learn more/i)).toBeVisible();
+  });
+
+  it("Should open WalletSyncActivation Flow without learn More link", async () => {
+    render(<WalletSyncSharedNavigator />, {
+      overrideInitialState: (state: State) => ({
+        ...state,
+        settings: {
+          ...state.settings,
+          readOnlyModeEnabled: false,
+          overriddenFeatureFlags: {
+            llmWalletSync: {
+              enabled: true,
+              params: {
+                environment: "STAGING",
+                watchConfig: {},
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    expect(await screen.findByText(/sync your accounts across all platforms/i)).toBeVisible();
+    expect(screen.queryByText(/learn more/i)).toBeUndefined;
   });
 });

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/Actions.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/Actions.tsx
@@ -10,9 +10,14 @@ import {
 type Props = {
   onPressSyncAccounts: () => void;
   onPressHasAlreadyCreatedAKey: () => void;
+  onPressLearnMore?: () => void;
 };
 
-const Actions = ({ onPressSyncAccounts, onPressHasAlreadyCreatedAKey }: Props) => {
+const Actions = ({
+  onPressSyncAccounts,
+  onPressHasAlreadyCreatedAKey,
+  onPressLearnMore,
+}: Props) => {
   const { t } = useTranslation();
   const { onClickTrack } = useLedgerSyncAnalytics();
 
@@ -36,19 +41,35 @@ const Actions = ({ onPressSyncAccounts, onPressHasAlreadyCreatedAKey }: Props) =
 
   return (
     <Flex flexDirection="column" justifyContent="center" alignItems="center" rowGap={32}>
-      <Button
-        type="main"
-        alignSelf={"stretch"}
-        minWidth={"100%"}
-        size="large"
-        onPress={onPressSync}
-        accessibilityRole="button"
-      >
-        {t("walletSync.activation.screen.mainCta")}
-      </Button>
-      <Link size="large" onPress={onPressHasAlreadyAKey}>
-        {t("walletSync.activation.screen.secondCta")}
-      </Link>
+      <Flex flexDirection="column" justifyContent="center" alignItems="center" rowGap={16}>
+        <Button
+          type="main"
+          alignSelf={"stretch"}
+          minWidth={"100%"}
+          size="large"
+          onPress={onPressSync}
+          accessibilityRole="button"
+        >
+          {t("walletSync.activation.screen.mainCta")}
+        </Button>
+        <Button
+          type={"default"}
+          border={"1px solid"}
+          borderColor={"neutral.c50"}
+          alignSelf={"stretch"}
+          minWidth={"100%"}
+          size="large"
+          onPress={onPressHasAlreadyAKey}
+          accessibilityRole="button"
+        >
+          {t("walletSync.activation.screen.secondCta")}
+        </Button>
+      </Flex>
+      {onPressLearnMore && (
+        <Link size="medium" onPress={onPressLearnMore}>
+          {t("walletSync.activation.screen.learnMore")}
+        </Link>
+      )}
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/index.tsx
@@ -5,18 +5,28 @@ import { Flex, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
 import { useInitMemberCredentials } from "../../hooks/useInitMemberCredentials";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { Linking } from "react-native";
 
 type Props = { onSyncMethodPress: () => void };
 
 const Activation: React.FC<Props> = ({ onSyncMethodPress }) => {
   const { colors } = useTheme();
   const { t } = useTranslation();
+  const walletSyncFF = useFeature("llmWalletSync");
+  const learnMoreLink = walletSyncFF?.params?.learnMoreLink;
 
   useInitMemberCredentials();
 
   const onPressSyncAccounts = () => onSyncMethodPress();
 
   const onPressHasAlreadyCreatedAKey = () => onSyncMethodPress();
+
+  const onPressLearnMore = () => {
+    if (learnMoreLink) {
+      Linking.openURL(learnMoreLink);
+    }
+  };
 
   return (
     <Flex flexDirection="column" justifyContent="center" alignItems="center" rowGap={24}>
@@ -39,6 +49,7 @@ const Activation: React.FC<Props> = ({ onSyncMethodPress }) => {
       <Actions
         onPressHasAlreadyCreatedAKey={onPressHasAlreadyCreatedAKey}
         onPressSyncAccounts={onPressSyncAccounts}
+        onPressLearnMore={onPressLearnMore}
       />
     </Flex>
   );

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -478,6 +478,7 @@ export const DEFAULT_FEATURES: Features = {
     params: {
       environment: "STAGING",
       watchConfig: {},
+      learnMoreLink: "",
     },
   },
   llmWalletSync: {
@@ -485,6 +486,7 @@ export const DEFAULT_FEATURES: Features = {
     params: {
       environment: "STAGING",
       watchConfig: {},
+      learnMoreLink: "",
     },
   },
   lldNftsGalleryNewArch: DEFAULT_FEATURE,

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -480,10 +480,12 @@ export type Feature_BuySellUiManifest = Feature<{
 export type Feature_LldWalletSync = Feature<{
   environment: WalletSyncEnvironment;
   watchConfig: WalletSyncWatchConfig;
+  learnMoreLink: string;
 }>;
 export type Feature_LlmWalletSync = Feature<{
   environment: WalletSyncEnvironment;
   watchConfig: WalletSyncWatchConfig;
+  learnMoreLink: string;
 }>;
 
 export type Feature_CounterValue = DefaultFeature;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LS activation LLD and LLM

### 📝 Description

Add a field to the feature flag so we can dynamically change the learn more url when activate ledger sync.  
The learmore link will appears only if a value is provided
The UI has changed on both LLD and LLM

Good and bad case integration tests added

The new field is `learnMoreLink` 

LLD : 
https://github.com/user-attachments/assets/92fae350-6a76-4b0f-920c-efbfa6aeb3e9


LLM : 
https://github.com/user-attachments/assets/bc0fec2d-8b05-4673-aa08-33feb6ec6eaf

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14081](https://ledgerhq.atlassian.net/browse/LIVE-14081) & [LIVE-14082](https://ledgerhq.atlassian.net/browse/LIVE-14082)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14081]: https://ledgerhq.atlassian.net/browse/LIVE-14081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ