### PR TITLE
fix: only open error drawer if no drawer opened

### DIFF
--- a/.changeset/cuddly-eggs-cross.md
+++ b/.changeset/cuddly-eggs-cross.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: double drawer fixed, only open error drawer if no drawer open

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -93,5 +93,5 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"]) {
         },
       }),
     };
-  }, [accounts, tracking, manifest, dispatch, setDrawer]);
+  }, [accounts, tracking, manifest, dispatch, setDrawer, isDrawerOpen]);
 }

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -14,11 +14,14 @@ import { closePlatformAppDrawer, openExchangeDrawer } from "~/renderer/actions/U
 import { WebviewProps } from "../Web3AppWebview/types";
 import { context } from "~/renderer/drawers/Provider";
 import WebviewErrorDrawer from "~/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer";
+import { platformAppDrawerStateSelector } from "~/renderer/reducers/UI";
 
 export function usePTXCustomHandlers(manifest: WebviewProps["manifest"]) {
   const dispatch = useDispatch();
   const accounts = useSelector(flattenAccountsSelector);
   const { setDrawer } = React.useContext(context);
+
+  const { isOpen: isDrawerOpen } = useSelector(platformAppDrawerStateSelector);
 
   const tracking = useMemo(
     () =>
@@ -81,8 +84,10 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"]) {
             );
           },
           "custom.exchange.error": ({ error }) => {
-            dispatch(closePlatformAppDrawer());
-            setDrawer(WebviewErrorDrawer, error);
+            if (!isDrawerOpen) {
+              dispatch(closePlatformAppDrawer());
+              setDrawer(WebviewErrorDrawer, error);
+            }
             return Promise.resolve();
           },
         },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Instead of trying to guess the state of LL inside exchangeSDK, just check if something is open and do not open a new drawer when receiving an error ... 
Really nice fix thanks @chrisduma-ledger for the idea, somehow we all missed it

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
