### PR TITLE
LLM - Update Storyly and fixes issues

### DIFF
--- a/.changeset/sixty-insects-rescue.md
+++ b/.changeset/sixty-insects-rescue.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Update Storyly and fix some issues

--- a/apps/ledger-live-mobile/ios/Podfile.lock
+++ b/apps/ledger-live-mobile/ios/Podfile.lock
@@ -1398,10 +1398,10 @@ PODS:
   - SocketRocket (0.6.1)
   - sovran-react-native (0.4.5):
     - React-Core
-  - Storyly (2.18.1)
-  - storyly-react-native (2.18.1):
+  - Storyly (3.6.0)
+  - storyly-react-native (3.6.0):
     - React
-    - Storyly (= 2.18.1)
+    - Storyly (= 3.6.0)
   - TOCropViewController (2.5.3)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.9)
@@ -1959,8 +1959,8 @@ SPEC CHECKSUMS:
   SentryPrivate: d651efb234cf385ec9a1cdd3eff94b5e78a0e0fe
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sovran-react-native: fd3dc8f1a4b14acdc4ad25fc6b4ac4f52a2a2a15
-  Storyly: 97332ff6eccc9ce4024207338f88b34177c95503
-  storyly-react-native: a112c85399fefc126d8d6a7d692be1b7a12bfaa7
+  Storyly: 310297bcf4493d3d5b41e71834fba49502c8067a
+  storyly-react-native: f14aab1a353a8c685b1ab3371fb5fd0c028bc311
   TOCropViewController: 20a14b6a7a098308bf369e7c8d700dc983a974e6
   Yoga: 805bf71192903b20fc14babe48080582fee65a80
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -217,7 +217,7 @@
     "rn-fetch-blob": "^0.12.0",
     "rxjs": "^7.8.1",
     "semver": "^7.3.7",
-    "storyly-react-native": "2.18.1",
+    "storyly-react-native": "3.6.0",
     "styled-components": "^5.3.3",
     "styled-system": "^5.1.5",
     "text-encoding-polyfill": "^0.6.7",

--- a/apps/ledger-live-mobile/src/components/StorylyStories/StorylyProvider.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/StorylyProvider.tsx
@@ -4,6 +4,7 @@ import { Linking } from "react-native";
 import { Feature_Storyly, StorylyInstanceType } from "@ledgerhq/types-live";
 import React, { createContext, useState, useContext, ReactNode, useRef, useEffect } from "react";
 import { Storyly } from "storyly-react-native";
+import { useSettings } from "~/hooks";
 
 interface StorylyProviderProps {
   children: ReactNode;
@@ -27,6 +28,7 @@ const getTokenForInstanceId = (stories: StoriesType, targetInstanceId: string): 
 const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
   const [url, setUrl] = useState<string | null>(null);
   const [token, setToken] = useState<string | null>(null);
+  const { language } = useSettings();
 
   const storylyRef = useRef<Storyly>(null);
 
@@ -61,11 +63,14 @@ const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
   };
 
   const handleEvent = (e: Storyly.StoryEvent) => {
-    if (["StoryGroupClosed", "StoryGroupCompleted", "StoryPaused"].includes(e.event)) {
+    if (
+      (e.event === "StoryPreviousClicked" && e.story?.index === 0) ||
+      ["StoryGroupClosed", "StoryGroupCompleted"].includes(e.event)
+    ) {
       clear();
     }
-    if (e.event === "StoryCTAClicked" && e?.story?.media?.actionUrl) {
-      Linking.openURL(e.story.media.actionUrl);
+    if (e.event === "StoryCTAClicked" && e?.story?.actionUrl) {
+      Linking.openURL(e.story.actionUrl);
       clear();
     }
   };
@@ -81,6 +86,7 @@ const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
             style={{ flex: 1 }} // necessary for touches to work
             onLoad={handleLoad}
             onEvent={handleEvent}
+            storylyLocale={language}
           />
         </Flex>
       ) : null}

--- a/apps/ledger-live-mobile/src/components/StorylyStories/StorylyWrapper.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/StorylyWrapper.tsx
@@ -57,6 +57,7 @@ const StorylyLocalizedWrapper = forwardRef((props: Props, ref: ForwardedRef<Stor
       {...props}
       storylyId={storylyInstanceId}
       storylySegments={segments}
+      storylyLocale={language}
       onLoad={handleLoad}
       storylyTestMode={storyConfig.testingEnabled}
       style={{ flex: 1 }} // necessary for touches to work

--- a/apps/ledger-live-mobile/src/components/StorylyStories/index.tsx
+++ b/apps/ledger-live-mobile/src/components/StorylyStories/index.tsx
@@ -134,8 +134,8 @@ const Stories: React.FC<Props> = props => {
         const newStoryGroupList = computeNewStoryGroupList(storyGroupList, event);
         if (!isEqual(storyGroupList, newStoryGroupList)) setStoryGroupList(newStoryGroupList);
       }
-      if (event.event === "StoryCTAClicked" && event?.story?.media?.actionUrl) {
-        Linking.openURL(event.story.media.actionUrl);
+      if (event.event === "StoryCTAClicked" && event?.story?.actionUrl) {
+        Linking.openURL(event.story.actionUrl);
         storylyRef.current?.closeStory?.();
       }
     },

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -516,6 +516,10 @@ export const DeeplinksProvider = ({
           }
           const platform = pathname.split("/")[1];
 
+          if (isStorylyLink(url.toString())) {
+            storylyContext.setUrl(url.toString());
+          }
+
           if (hostname === "earn") {
             if (searchParams.get("action") === "info-modal") {
               const message = searchParams.get("message") ?? "";

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { ListRenderItemInfo, Linking, Platform } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useFocusEffect } from "@react-navigation/native";
-import { Box, Flex } from "@ledgerhq/native-ui";
+import { Box, Button, Flex } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { ReactNavigationPerformanceView } from "@shopify/react-native-performance-navigation";
@@ -54,6 +54,7 @@ import ContentCardsLocation from "~/dynamicContent/ContentCardsLocation";
 import { ContentCardLocation } from "~/dynamicContent/types";
 import usePortfolioAnalyticsOptInPrompt from "~/hooks/analyticsOptInPrompt/usePorfolioAnalyticsOptInPrompt";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
+import { useSettings } from "~/hooks";
 
 export { default as PortfolioTabIcon } from "./TabIcon";
 
@@ -141,6 +142,32 @@ function PortfolioScreen({ navigation }: NavigationProps) {
     hasTokenAccountsWithPositiveBalance || // always show token accounts if they are not empty
     (!hideEmptyTokenAccount && hasTokenAccounts); // conditionally show empty token accounts
 
+  const { language } = useSettings();
+  const mappedLanguage: {
+    [k: string]: string;
+  } = {
+    de: "de-DE",
+    el: "el-GR",
+    en: "en-US",
+    es: "es-ES",
+    fi: "fi-FI",
+    fr: "fr-FR",
+    hu: "hu-HU",
+    it: "it-IT",
+    ja: "ja-JP",
+    ko: "ko-KR",
+    nl: "nl-NL",
+    no: "no-NO",
+    pl: "pl-PL",
+    pt: "pt-BR",
+    ru: "ru-RU",
+    sr: "sr-SR",
+    sv: "sv-SV",
+    tr: "tr-TR",
+    zh: "zh-CN",
+    ar: "ar-EG",
+  };
+  const trueLocale = mappedLanguage[language] || "en-US";
   const data = useMemo(
     () => [
       <WalletTabSafeAreaView key="portfolioHeaderElements" edges={["left", "right"]}>
@@ -156,6 +183,18 @@ function PortfolioScreen({ navigation }: NavigationProps) {
           />
         ) : null}
       </WalletTabSafeAreaView>,
+      <Button
+        key="my-button"
+        type="shade"
+        size="large"
+        outline
+        mt={6}
+        onPress={() => {
+          Linking.openURL("ledgerlive://storyly?g=142749&instance=17650&play=sg");
+        }}
+      >
+        {`Display story with language "${trueLocale}"`}
+      </Button>,
       showAssets ? (
         <Box background={colors.background.main} px={6} mt={6} key="PortfolioAssets">
           <RecoverBanner />
@@ -202,6 +241,7 @@ function PortfolioScreen({ navigation }: NavigationProps) {
     [
       onBackFromUpdate,
       showAssets,
+      trueLocale,
       colors.background.main,
       hideEmptyTokenAccount,
       openAddModal,

--- a/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/index.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { ListRenderItemInfo, Linking, Platform } from "react-native";
 import { useTranslation } from "react-i18next";
 import { useFocusEffect } from "@react-navigation/native";
-import { Box, Button, Flex } from "@ledgerhq/native-ui";
+import { Box, Flex } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { ReactNavigationPerformanceView } from "@shopify/react-native-performance-navigation";
@@ -54,7 +54,6 @@ import ContentCardsLocation from "~/dynamicContent/ContentCardsLocation";
 import { ContentCardLocation } from "~/dynamicContent/types";
 import usePortfolioAnalyticsOptInPrompt from "~/hooks/analyticsOptInPrompt/usePorfolioAnalyticsOptInPrompt";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
-import { useSettings } from "~/hooks";
 
 export { default as PortfolioTabIcon } from "./TabIcon";
 
@@ -142,32 +141,6 @@ function PortfolioScreen({ navigation }: NavigationProps) {
     hasTokenAccountsWithPositiveBalance || // always show token accounts if they are not empty
     (!hideEmptyTokenAccount && hasTokenAccounts); // conditionally show empty token accounts
 
-  const { language } = useSettings();
-  const mappedLanguage: {
-    [k: string]: string;
-  } = {
-    de: "de-DE",
-    el: "el-GR",
-    en: "en-US",
-    es: "es-ES",
-    fi: "fi-FI",
-    fr: "fr-FR",
-    hu: "hu-HU",
-    it: "it-IT",
-    ja: "ja-JP",
-    ko: "ko-KR",
-    nl: "nl-NL",
-    no: "no-NO",
-    pl: "pl-PL",
-    pt: "pt-BR",
-    ru: "ru-RU",
-    sr: "sr-SR",
-    sv: "sv-SV",
-    tr: "tr-TR",
-    zh: "zh-CN",
-    ar: "ar-EG",
-  };
-  const trueLocale = mappedLanguage[language] || "en-US";
   const data = useMemo(
     () => [
       <WalletTabSafeAreaView key="portfolioHeaderElements" edges={["left", "right"]}>
@@ -183,18 +156,6 @@ function PortfolioScreen({ navigation }: NavigationProps) {
           />
         ) : null}
       </WalletTabSafeAreaView>,
-      <Button
-        key="my-button"
-        type="shade"
-        size="large"
-        outline
-        mt={6}
-        onPress={() => {
-          Linking.openURL("ledgerlive://storyly?g=142749&instance=17650&play=sg");
-        }}
-      >
-        {`Display story with language "${trueLocale}"`}
-      </Button>,
       showAssets ? (
         <Box background={colors.background.main} px={6} mt={6} key="PortfolioAssets">
           <RecoverBanner />
@@ -241,7 +202,6 @@ function PortfolioScreen({ navigation }: NavigationProps) {
     [
       onBackFromUpdate,
       showAssets,
-      trueLocale,
       colors.background.main,
       hideEmptyTokenAccount,
       openAddModal,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1235,8 +1235,8 @@ importers:
         specifier: ^7.3.7
         version: 7.5.4
       storyly-react-native:
-        specifier: 2.18.1
-        version: 2.18.1(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0)
+        specifier: 3.6.0
+        version: 3.6.0(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0)
       styled-components:
         specifier: ^5.3.3
         version: 5.3.11(@babel/core@7.24.3)(react-is@18.2.0)(react@18.2.0)
@@ -27547,8 +27547,8 @@ packages:
     resolution: {integrity: sha512-Wt04pPTO71pwmRmsgkyZhNo4Bvdb/1pBAMsIFb9nQLykEdzzpXjvingxFFvdOG4nIowzwgxD+CLlyRqVJqnATw==}
     hasBin: true
 
-  storyly-react-native@2.18.1:
-    resolution: {integrity: sha512-obmcEiqaMk6MRHg8kaN7AV2bKqOAMFEwC3dFmTbEsfPVCt5IEnSjhtzZ9kYkfndjPiEzvq1ySiZ9GUysxL83NQ==}
+  storyly-react-native@3.6.0:
+    resolution: {integrity: sha512-YDHTQe6W91GMZ6jlV+tstJNTvBK2PWWqGLBZUovdbrq3Sh1evzbGC5cG0yicH752FGRDC/U0sjTE8FBuiRwVUg==}
     peerDependencies:
       prop-types: '*'
       react: ^18.0.0
@@ -61856,7 +61856,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  storyly-react-native@2.18.1(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0):
+  storyly-react-native@3.6.0(prop-types@15.8.1)(react-native@0.73.6(@babel/core@7.24.3)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-native: 0.73.6(@babel/core@7.24.3)(react@18.2.0)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Update `storyly-react-native` from 2.18.1 to 3.6.0
Stories are now displayed in the user's app language
Fixes the following issues : 
- Story was closing instead of pausing when user long pressed
- Story was not displayed on cold app start when triggered by a deep link
- No more black screen when putting the app in the background in the middle of a story

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14103] [LIVE-14119] [LIVE-13778] [LIVE-13857]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14103]: https://ledgerhq.atlassian.net/browse/LIVE-14103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ