### PR TITLE
fix(LLD): Retry CLS installation after locking & unlocking device

### DIFF
--- a/.changeset/shaggy-meals-rescue.md
+++ b/.changeset/shaggy-meals-rescue.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+LLD will retry CLS installation on Stax and Flex after locking & unlocking device while CLS image in being uploaded

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomLockScreenDeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomLockScreenDeviceAction/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
-import { setLastSeenCustomImage, clearLastSeenCustomImage } from "~/renderer/actions/settings";
+import { setLastSeenCustomImage } from "~/renderer/actions/settings";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { createAction } from "@ledgerhq/live-common/hw/actions/customLockScreenLoad";
 import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
@@ -54,7 +54,6 @@ const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props =>
     onResult,
     onSkip,
     source,
-    remountMe,
     onTryAnotherImage,
     onError,
     blockNavigation,
@@ -101,12 +100,8 @@ const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props =>
 
   useEffect(() => {
     if (!error) return;
-    // Once transferred the old image is wiped, we need to clear it from the data.
-    if (error instanceof ImageCommitRefusedOnDevice) {
-      dispatch(clearLastSeenCustomImage());
-    }
     onError && onError(error);
-  }, [dispatch, error, onError]);
+  }, [error, onError]);
 
   const shouldNavBeBlocked = !!validDevice && !isError;
   useEffect(() => {
@@ -114,9 +109,9 @@ const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props =>
   }, [shouldNavBeBlocked, blockNavigation]);
 
   const handleRetry = useCallback(() => {
-    if (isRefusedOnStaxError) onTryAnotherImage();
-    else remountMe();
-  }, [isRefusedOnStaxError, onTryAnotherImage, remountMe]);
+    if (onTryAnotherImage) onTryAnotherImage();
+    else if (status.onRetry) status.onRetry();
+  }, [status, onTryAnotherImage]);
 
   return (
     <Flex flexDirection="column" flex={1} justifyContent="center">


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

LLD will retry CLS installation on Stax and Flex after locking & unlocking device while CLS image is being uploaded

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13238](https://ledgerhq.atlassian.net/browse/LIVE-13238)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13238]: https://ledgerhq.atlassian.net/browse/LIVE-13238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ