### PR TITLE
LLD - Braze Content cards clicks tracking

### DIFF
--- a/.changeset/gentle-fireants-nail.md
+++ b/.changeset/gentle-fireants-nail.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+LLD - Fix Content Cards clicks tracking and other issues

--- a/apps/ledger-live-desktop/src/renderer/components/Carousel/helpers.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Carousel/helpers.tsx
@@ -107,8 +107,10 @@ export const useDefaultSlides = (): {
       if (currentCard) {
         // For some reason braze won't log the click event if the card url is empty
         // Setting it as the card id just to have a dummy non empty value
-        isTrackedUser &&
-          braze.logContentCardClick({ ...currentCard, url: currentCard.id } as braze.ClassicCard);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        currentCard.url = currentCard.id;
+        isTrackedUser && braze.logContentCardClick(currentCard as braze.ClassicCard);
       }
     },
     [cachedContentCards, isTrackedUser],

--- a/apps/ledger-live-desktop/src/renderer/components/Carousel/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Carousel/index.tsx
@@ -154,17 +154,23 @@ const Carousel = ({
   const [paused, setPaused] = useState(false);
   const [reverse, setReverse] = useState(false);
   const transitions = useTransition(index, p => p, getTransitions(type, reverse));
+  const [hasLoggedFirstImpression, setHasLoggedFirstImpression] = useState(false);
 
   useEffect(() => {
-    logSlideImpression(0);
-  }, [logSlideImpression]);
+    if (!hasLoggedFirstImpression) {
+      setHasLoggedFirstImpression(true);
+      logSlideImpression(0);
+    }
+  }, [hasLoggedFirstImpression, logSlideImpression]);
 
   const changeVisibleSlide = useCallback(
-    (index: number) => {
-      setIndex(index);
-      logSlideImpression(index);
+    (newIndex: number) => {
+      if (index !== newIndex) {
+        setIndex(newIndex);
+        logSlideImpression(newIndex);
+      }
     },
-    [logSlideImpression],
+    [index, logSlideImpression],
   );
 
   const onChooseSlide = useCallback(

--- a/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useActionCards.tsx
@@ -56,8 +56,10 @@ const useActionCards = () => {
     if (currentCard) {
       // For some reason braze won't log the click event if the card url is empty
       // Setting it as the card id just to have a dummy non empty value
-      isTrackedUser &&
-        braze.logContentCardClick({ ...currentCard, url: currentCard.id } as braze.ClassicCard);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      currentCard.url = currentCard.id;
+      isTrackedUser && braze.logContentCardClick(currentCard as braze.ClassicCard);
       link && openURL(link);
     }
     if (actionCard) {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -117,8 +117,6 @@ export async function useBraze() {
 
     if (user) braze.changeUser(isTrackedUser ? user.id : anonymousBrazeId.current);
 
-    braze.requestPushPermission();
-
     braze.requestContentCardsRefresh();
 
     braze.subscribeToContentCardsUpdates(cards => {
@@ -153,6 +151,7 @@ export async function useBraze() {
   }, [dispatch, devMode, isTrackedUser, contentCardsDissmissed, anonymousBrazeId]);
 
   useEffect(() => {
+    console.log("Init Braze");
     initBraze();
   }, [initBraze]);
 }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -151,7 +151,6 @@ export async function useBraze() {
   }, [dispatch, devMode, isTrackedUser, contentCardsDissmissed, anonymousBrazeId]);
 
   useEffect(() => {
-    console.log("Init Braze");
     initBraze();
   }, [initBraze]);
 }

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
@@ -88,8 +88,10 @@ export function useNotifications() {
       if (currentCard) {
         // For some reason braze won't log the click event if the card url is empty
         // Setting it as the card id just to have a dummy non empty value
-        isTrackedUser &&
-          braze.logContentCardClick({ ...currentCard, url: currentCard.id } as braze.ClassicCard);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        currentCard.url = currentCard.id;
+        isTrackedUser && braze.logContentCardClick(currentCard as braze.ClassicCard);
       }
 
       track("contentcard_clicked", {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Fixed an issue with the tracking of the content cards on desktop because we were doing a copy of the `Braze.ClassicCard` object instead of passing the original one to the `logContentCardClick` method.
Also fixes some issues with the tracking of the carousel that was triggered at every rerender.
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14043]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14043]: https://ledgerhq.atlassian.net/browse/LIVE-14043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ