### PR TITLE
[FIX/LIVE-14165]: use spendable balance and account id for token accounts

### DIFF
--- a/.changeset/thin-readers-attend.md
+++ b/.changeset/thin-readers-attend.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Use spendable balance for account selection drawer and parent account name in token selection

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
@@ -106,7 +106,7 @@ function Row({
   onAccountSelect: (account: AccountLike, parentAccount?: Account) => void;
 }) {
   const accountCurrency = getAccountCurrency(subAccount || account);
-  const accountName = useAccountName(subAccount || account);
+  const accountName = useAccountName(account);
   const unit = useAccountUnit(subAccount || account);
 
   return (
@@ -149,7 +149,7 @@ function Row({
         <Box horizontal alignItems="center" marginLeft="12px">
           <FormattedVal
             color="palette.text.shade50"
-            val={subAccount ? subAccount.balance : account.balance}
+            val={subAccount ? subAccount.spendableBalance : account.spendableBalance}
             unit={unit}
             showCode
           />

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -238,7 +238,7 @@ test("Wallet API methods @smoke", async ({ page }) => {
     await drawer.selectCurrency("tether usd");
     // Test name and balance for tokens
     await expect(drawer.getAccountButton("tether usd", 2)).toContainText(
-      "Tether USD (USDT)71.8174 USDT", // Special space present in the actual rendered element apparently
+      "Ethereum 3 (USDT)71.8174 USDT", // Special space present in the actual rendered element apparently
     );
     await drawer.back();
 


### PR DESCRIPTION

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- use spendable balance instead of balance.
- use parent account name as prefix for token accounts.

![Screenshot 2024-09-20 at 11 38 33](https://github.com/user-attachments/assets/124d97c3-b110-4e11-b8ab-424e138abcb8)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-14165


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
