### PR TITLE
fix(wallet-api): open any deep-link from the webview on LLM

### DIFF
--- a/.changeset/tough-terms-film.md
+++ b/.changeset/tough-terms-film.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+fix(wallet-api): open any deep-link from the webview on LLM
+
+Needed for wallet-connect-live-app deep-link back to mobile dApps

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -507,13 +507,9 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     const onOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
       const { targetUrl } = event.nativeEvent;
-      Linking.canOpenURL(targetUrl).then(supported => {
-        if (supported) {
-          Linking.openURL(targetUrl);
-        } else {
-          console.error(`Don't know how to open URI: ${targetUrl}`);
-        }
-      });
+      // Don't use canOpenURL as we cannot check unknown apps on the phone
+      // Without listing everything in plist and android manifest
+      Linking.openURL(targetUrl);
     }, []);
 
     useEffect(() => {

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -163,13 +163,9 @@ export function useWebView(
 
   const onOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
     const { targetUrl } = event.nativeEvent;
-    Linking.canOpenURL(targetUrl).then(supported => {
-      if (supported) {
-        Linking.openURL(targetUrl);
-      } else {
-        console.error(`Don't know how to open URI: ${targetUrl}`);
-      }
-    });
+    // Don't use canOpenURL as we cannot check unknown apps on the phone
+    // Without listing everything in plist and android manifest
+    Linking.openURL(targetUrl);
   }, []);
 
   return {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** We don't have proper tests for deeplink currently AFAIK, so I tested this manually
- [x] **Impact of the changes:** 
  - Discover and live-apps deeplink usage (impact pretty low as we just try to open the deeplink always instead of sometimes)

### 📝 Description

Open any deep-link from the webview on LLM
Needed for wallet-connect-live-app deep-link back to mobile dApps

`CanOpenUrl` would require us to list every deep-link scheme we want to test and it's not possible in our case: https://stackoverflow.com/a/67111267

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13641]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13641]: https://ledgerhq.atlassian.net/browse/LIVE-13641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ