### PR TITLE
LLD - Fix Braze Modal not responding when a drawer is opened

### DIFF
--- a/.changeset/silent-melons-lie.md
+++ b/.changeset/silent-melons-lie.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+LLD - Fix Braze Modal not responding when the wallet sync drawer or the analytics opt in drawer are opened

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/index.tsx
@@ -37,6 +37,7 @@ const AnalyticsOptInPrompt = memo(
         style={{
           background: colors.background.main,
         }}
+        forceDisableFocusTrap
       >
         <Box height={"100%"}>
           {isVariantB ? (

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/WalletSync.tsx
@@ -83,6 +83,7 @@ const WalletSyncRow = () => {
         onRequestClose={closeDrawer}
         onRequestBack={hasBack ? handleBack : undefined}
         direction="left"
+        forceDisableFocusTrap
       >
         <WalletSyncRouter ref={childRef} />
       </SideDrawer>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Disabling focus trap on analytics and wallet sync drawers to fix the braze modal that wasn't responding when displayed on top of them
Fix tested on a staging build


https://github.com/user-attachments/assets/6116ccb1-6193-4b35-8678-1ac7b6463a91


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13870]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13870]: https://ledgerhq.atlassian.net/browse/LIVE-13870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ