### PR TITLE
chore(lld): 👍 dismiss the analytics prompt in all e2e tests

### DIFF
--- a/.changeset/wicked-cheetahs-tan.md
+++ b/.changeset/wicked-cheetahs-tan.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Dismiss the analytics prompt in all e2e tests

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantA/Main/components/MainFooter/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantA/Main/components/MainFooter/index.tsx
@@ -38,7 +38,13 @@ const MainFooter = ({ setWantToManagePreferences, onShareAnalyticsChange }: Main
           >
             {t("analyticsOptInPrompt.variantA.refuse")}
           </Button>
-          <Button variant={"main"} size={"large"} borderRadius={48} onClick={handleAcceptClick}>
+          <Button
+            variant={"main"}
+            size={"large"}
+            borderRadius={48}
+            onClick={handleAcceptClick}
+            data-testid="accept-analytics-button"
+          >
             {t("analyticsOptInPrompt.variantA.accept")}
           </Button>
         </Flex>

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantB/components/Footer/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantB/components/Footer/index.tsx
@@ -35,6 +35,7 @@ const VariantBFooter = ({ clickOptions }: VariantBFooterProps) => {
           borderRadius={48}
           flex={1}
           onClick={clickOptions.accept}
+          data-testid="accept-analytics-button"
         >
           {t("analyticsOptInPrompt.variantB.accept")}
         </Button>

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -176,7 +176,12 @@ export const test = base.extend<TestFixtures>({
     await page.waitForSelector("#loader-container", { state: "hidden" });
 
     // Click on accept analytics button if it exists
-    page.getByTestId("accept-analytics-button").click();
+    page
+      .getByTestId("accept-analytics-button")
+      .click()
+      .catch(() => {
+        // Do nothing
+      });
 
     // use page in the test
     await use(page);

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -175,6 +175,9 @@ export const test = base.extend<TestFixtures>({
     await page.waitForLoadState("domcontentloaded");
     await page.waitForSelector("#loader-container", { state: "hidden" });
 
+    // Click on accept analytics button if it exists
+    page.getByTestId("accept-analytics-button").click();
+
     // use page in the test
     await use(page);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Run LLDs e2e by just automatically accepting analytics on the app launch. I picked accept over refuse to potentially cover more code with the tests, but I'm not completely sure what makes more sense.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-13650]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13650]: https://ledgerhq.atlassian.net/browse/LIVE-13650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ