### PR TITLE
fix: remove rewards from near staking

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/near/Staking/Header.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/Staking/Header.tsx
@@ -33,9 +33,6 @@ export const Header = () => (
       <Trans i18nKey="near.stake.table.staked" />
     </TableLine>
     <TableLine>
-      <Trans i18nKey="delegation.rewards" />
-    </TableLine>
-    <TableLine>
       <Trans i18nKey="near.stake.table.pending" />
     </TableLine>
     <TableLine>

--- a/apps/ledger-live-desktop/src/renderer/families/near/Staking/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/Staking/Row.tsx
@@ -88,7 +88,6 @@ export function Row({
     validatorId,
     staked,
     formattedAmount,
-    formattedRewards,
     formattedPending,
     formattedAvailable,
     validator,
@@ -149,11 +148,6 @@ export function Row({
       <Column>
         <Ellipsis>
           <Discreet>{formattedAmount}</Discreet>
-        </Ellipsis>
-      </Column>
-      <Column>
-        <Ellipsis>
-          <Discreet>{formattedRewards}</Discreet>
         </Ellipsis>
       </Column>
       <Column>

--- a/apps/ledger-live-mobile/src/families/near/Staking/index.tsx
+++ b/apps/ledger-live-mobile/src/families/near/Staking/index.tsx
@@ -150,14 +150,6 @@ function StakingPositions({ account }: Props) {
             ),
           },
           {
-            label: t("near.staking.drawer.rewards"),
-            Component: (
-              <LText numberOfLines={1} semiBold style={[styles.valueText]}>
-                {stakingPosition.formattedRewards ?? ""}
-              </LText>
-            ),
-          },
-          {
             label: t("near.staking.drawer.pending"),
             Component: (
               <LText numberOfLines={1} semiBold style={[styles.valueText]}>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5916,7 +5916,6 @@
         "status": "Status",
         "active": "Active",
         "inactive": "Inactive",
-        "rewards": "Rewards",
         "pending": "Pending",
         "available": "Withdrawable"
       },

--- a/libs/coin-modules/coin-near/src/account.ts
+++ b/libs/coin-modules/coin-near/src/account.ts
@@ -24,8 +24,8 @@ function formatAccountSpecifics(account: NearAccount): string {
     str += `\n    Staking Positions:\n`;
     str += nearResources.stakingPositions
       .map(
-        ({ validatorId, staked, pending, available, rewards }) =>
-          `        Validator ID: ${validatorId} | Staked: ${staked} | Pending Release: ${pending} | Available: ${available} | Rewards: ${rewards}`,
+        ({ validatorId, staked, pending, available }) =>
+          `        Validator ID: ${validatorId} | Staked: ${staked} | Pending Release: ${pending} | Available: ${available}`,
       )
       .join("\n");
   }

--- a/libs/coin-modules/coin-near/src/api/node.ts
+++ b/libs/coin-modules/coin-near/src/api/node.ts
@@ -248,12 +248,10 @@ export const getStakingPositions = async (
         available = unstaked;
         pending = new BigNumber(0);
       }
-      let rewards = new BigNumber(0);
 
       const staked = new BigNumber(rawStaked);
       available = new BigNumber(available);
       pending = new BigNumber(pending);
-      rewards = new BigNumber(rawTotal || "0").minus(staked);
 
       const stakingThreshold = getYoctoThreshold();
 
@@ -271,7 +269,6 @@ export const getStakingPositions = async (
         staked,
         available,
         pending,
-        rewards: rewards.gt(0) ? rewards : new BigNumber(0),
         validatorId,
       };
     }),

--- a/libs/coin-modules/coin-near/src/api/node.ts
+++ b/libs/coin-modules/coin-near/src/api/node.ts
@@ -217,7 +217,7 @@ export const getStakingPositions = async (
   const activeDelegatedStakeBalance = await account.getActiveDelegatedStakeBalance();
 
   const stakingPositions = await Promise.all(
-    activeDelegatedStakeBalance.stakedValidators.map(async ({ validatorId, amount: rawTotal }) => {
+    activeDelegatedStakeBalance.stakedValidators.map(async ({ validatorId }) => {
       const contract = new nearAPI.Contract(account, validatorId, {
         viewMethods: [
           "get_account_staked_balance",

--- a/libs/coin-modules/coin-near/src/api/sdk.types.ts
+++ b/libs/coin-modules/coin-near/src/api/sdk.types.ts
@@ -69,7 +69,6 @@ export type NearStakingPosition = {
   staked: BigNumber;
   available: BigNumber;
   pending: BigNumber;
-  rewards: BigNumber;
   validatorId: string;
 };
 

--- a/libs/coin-modules/coin-near/src/logic.ts
+++ b/libs/coin-modules/coin-near/src/logic.ts
@@ -119,7 +119,6 @@ export const mapStakingPositions = (
     return {
       ...sp,
       formattedAmount: formatCurrencyUnit(unit, sp.staked, formatConfig),
-      formattedRewards: formatCurrencyUnit(unit, sp.rewards, formatConfig),
       formattedPending: formatCurrencyUnit(unit, sp.pending, formatConfig),
       formattedAvailable: formatCurrencyUnit(unit, sp.available, formatConfig),
       rank,

--- a/libs/coin-modules/coin-near/src/serialization.ts
+++ b/libs/coin-modules/coin-near/src/serialization.ts
@@ -10,14 +10,12 @@ export function toNearResourcesRaw(r: NearResources): NearResourcesRaw {
     pendingBalance: pendingBalance.toString(),
     availableBalance: availableBalance.toString(),
     storageUsageBalance: storageUsageBalance.toString(),
-    stakingPositions: stakingPositions.map(
-      ({ staked, validatorId, available, pending }) => ({
-        staked: staked.toString(),
-        available: available.toString(),
-        pending: pending.toString(),
-        validatorId,
-      }),
-    ),
+    stakingPositions: stakingPositions.map(({ staked, validatorId, available, pending }) => ({
+      staked: staked.toString(),
+      available: available.toString(),
+      pending: pending.toString(),
+      validatorId,
+    })),
   };
 }
 
@@ -34,14 +32,12 @@ export function fromNearResourcesRaw(r: NearResourcesRaw): NearResources {
     pendingBalance: new BigNumber(pendingBalance),
     availableBalance: new BigNumber(availableBalance),
     storageUsageBalance: new BigNumber(storageUsageBalance),
-    stakingPositions: stakingPositions.map(
-      ({ staked, validatorId, available, pending }) => ({
-        staked: new BigNumber(staked),
-        available: new BigNumber(available),
-        pending: new BigNumber(pending),
-        validatorId,
-      }),
-    ),
+    stakingPositions: stakingPositions.map(({ staked, validatorId, available, pending }) => ({
+      staked: new BigNumber(staked),
+      available: new BigNumber(available),
+      pending: new BigNumber(pending),
+      validatorId,
+    })),
   };
 }
 

--- a/libs/coin-modules/coin-near/src/serialization.ts
+++ b/libs/coin-modules/coin-near/src/serialization.ts
@@ -11,11 +11,10 @@ export function toNearResourcesRaw(r: NearResources): NearResourcesRaw {
     availableBalance: availableBalance.toString(),
     storageUsageBalance: storageUsageBalance.toString(),
     stakingPositions: stakingPositions.map(
-      ({ staked, validatorId, available, pending, rewards }) => ({
+      ({ staked, validatorId, available, pending }) => ({
         staked: staked.toString(),
         available: available.toString(),
         pending: pending.toString(),
-        rewards: rewards.toString(),
         validatorId,
       }),
     ),
@@ -36,11 +35,10 @@ export function fromNearResourcesRaw(r: NearResourcesRaw): NearResources {
     availableBalance: new BigNumber(availableBalance),
     storageUsageBalance: new BigNumber(storageUsageBalance),
     stakingPositions: stakingPositions.map(
-      ({ staked, validatorId, available, pending, rewards }) => ({
+      ({ staked, validatorId, available, pending }) => ({
         staked: new BigNumber(staked),
         available: new BigNumber(available),
         pending: new BigNumber(pending),
-        rewards: new BigNumber(rewards),
         validatorId,
       }),
     ),

--- a/libs/coin-modules/coin-near/src/types.ts
+++ b/libs/coin-modules/coin-near/src/types.ts
@@ -54,7 +54,6 @@ export type NearResourcesRaw = {
     staked: string;
     available: string;
     pending: string;
-    rewards: string;
     validatorId: string;
   }[];
 };
@@ -73,7 +72,6 @@ export type NearValidatorItem = {
 
 export type NearMappedStakingPosition = NearStakingPosition & {
   formattedAmount: string;
-  formattedRewards: string;
   formattedPending: string;
   formattedAvailable: string;
   rank: number;

--- a/libs/ledger-live-common/src/families/near/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/near/__snapshots__/bridge.integration.test.ts.snap
@@ -18,7 +18,6 @@ exports[`near currency bridge scanAccounts near seed 1 1`] = `
         {
           "available": "10000000000000000001",
           "pending": "0",
-          "rewards": "10000000000000000001",
           "staked": "0",
           "validatorId": "figment.poolv1.near",
         },

--- a/libs/ledger-live-common/src/families/near/banner.test.ts
+++ b/libs/ledger-live-common/src/families/near/banner.test.ts
@@ -125,7 +125,6 @@ describe("near/banner", () => {
       staked: new BigNumber("1.29802125309300073830514e+23"),
       available: new BigNumber("1"),
       pending: new BigNumber("0"),
-      rewards: new BigNumber("1.462125309300073830515e+21"),
       validatorId: "vcap.poolv1.near",
     };
     jest.spyOn(preloadedData, "getCurrentNearPreloadData").mockReturnValue(validatorsMap);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
- Remove rewards from Near staking position(s)
- Clean the code accordingly
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->
![Screenshot 2024-09-24 at 13 38 45](https://github.com/user-attachments/assets/c2f00595-32f2-4c0a-847a-3d6ac79bced2)

![Screenshot 2024-09-25 at 08 43 27](https://github.com/user-attachments/assets/bc8dc921-9065-4597-9bf4-774afea46bad)

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [Jira-11709](https://ledgerhq.atlassian.net/browse/LIVE-11709)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
