### PR TITLE
chore(llm): 👌 always skip the analytics prompt in e2e tests

### DIFF
--- a/.changeset/strong-goats-rush.md
+++ b/.changeset/strong-goats-rush.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Always skip the analytics prompt in e2e tests

--- a/apps/ledger-live-mobile/.env.mock
+++ b/apps/ledger-live-mobile/.env.mock
@@ -9,7 +9,7 @@ ADJUST_APP_TOKEN=cbxft2ch7wn4
 BRAZE_ANDROID_API_KEY="be5e1bc8-43f1-4864-b097-076a3c693a43"
 BRAZE_IOS_API_KEY="e0a7dfaf-fc30-48f6-b998-01dbebbb73a4"
 BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"
-FEATURE_FLAGS={"ratingsPrompt":{"enabled":false},"brazePushNotifications":{"enabled":false},"llmAnalyticsOptInPrompt":{"enabled":false}}
+FEATURE_FLAGS={"ratingsPrompt":{"enabled":false},"brazePushNotifications":{"enabled":false}}
 # Fix random iOS app crash https://github.com/wix/Detox/pull/3135
 SIMCTL_CHILD_NSZombieEnabled=YES
 MOCK_REMOTE_LIVE_MANIFEST=[{"name":"Dummy Wallet API Live App","homepageUrl":"https://developers.ledger.com/","icon":"","platforms":["ios","android","desktop"],"apiVersion":"2.0.0","manifestVersion":"1","branch":"stable","categories":["tools"],"currencies":"*","content":{"shortDescription":{"en":"App to test the Wallet API"},"description":{"en":"App to test the Wallet API with Playwright"}},"permissions":["account.list","account.receive","account.request","currency.list","device.close","device.exchange","device.transport","message.sign","transaction.sign","transaction.signAndBroadcast","storage.set","storage.get","bitcoin.getXPub","wallet.capabilities","wallet.userId","wallet.info"],"domains":["http://*"],"visibility":"complete","id":"dummy-live-app","url":"http://localhost:52619"}]

--- a/apps/ledger-live-mobile/e2e/bridge/server.ts
+++ b/apps/ledger-live-mobile/e2e/bridge/server.ts
@@ -2,6 +2,7 @@ import { Server, WebSocket } from "ws";
 import path from "path";
 import fs from "fs";
 import net from "net";
+import merge from "lodash/merge";
 import { toAccountRaw } from "@ledgerhq/live-common/account/index";
 import { NavigatorName } from "../../src/const";
 import { Subject } from "rxjs";
@@ -83,7 +84,9 @@ export async function loadConfig(fileName: string, agreed: true = true): Promise
 
   const { data } = JSON.parse(f.toString());
 
-  await postMessage({ type: "importSettings", id: uniqueId(), payload: data.settings });
+  const defaultSettings = { shareAnalytics: true, hasSeenAnalyticsOptInPrompt: true };
+  const settings = merge(defaultSettings, data.settings);
+  await postMessage({ type: "importSettings", id: uniqueId(), payload: settings });
 
   navigate(NavigatorName.Base);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Do not display the analytics prompt modal in LLM e2e tests by providing `shareAnalytics: true, hasSeenAnalyticsOptInPrompt: true` as default settings. Personally I prefer this approach over the one in #7878 because it doesn't an add extra interaction on each test (which AFAIK would have been way more costly on detox than playwright). That said it looks very unconventional with what was done before. So there might be a better solution.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-13649]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13649]: https://ledgerhq.atlassian.net/browse/LIVE-13649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ