### PR TITLE
fix: specify Xcode version in LLM readme

### DIFF
--- a/apps/ledger-live-mobile/README.md
+++ b/apps/ledger-live-mobile/README.md
@@ -25,7 +25,7 @@ We also share core business logic with Ledger Live mobile through [@ledgerhq/liv
 
 ### iOS
 
-- XCode
+- XCode (our CI builds currently run 15.4, so 15.4 is recommended)
 - Ruby 3.3.0 or above. The macOS built-in Ruby [does not work properly for installing dependencies of the iOS app](https://jeffreymorgan.io/articles/ruby-on-macos-with-rvm/), you have to install Ruby with for instance [Homebrew](https://brew.sh/) or [rvm](https://rvm.io/rvm/install) and make sure that `which ruby` points to that newly installed Ruby.
 
 ### Android


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adds a recommended version for Xcode. Currently running builds on v16 breaks due to [this issue](https://github.com/getsentry/sentry-react-native/issues/3883) with our current sentry version, but ultimately the bigger problem is that as a team we run 15.4 everywhere and don't really support 16 yet.

### ❓ Context

No ticket


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
