### PR TITLE
chore: mark start tasks as `persistent` to enable `interactive` mode

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -68,7 +68,8 @@
     },
     "start": {
       "cache": false,
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "persistent": true
     },
     "unimported": {
       "cache": false


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. not needed for this type of changes
- [ ] **Covered by automatic tests.** Tested locally with `pnpm dev:llm` metro bundler allows to reload the app or open the debug menu
- [x] **Impact of the changes:** 
  - Dev env

### 📝 Description

Mark start tasks as `persistent` to enable `interactive` mode
From the doc: Label a task as persistent to prevent other tasks from depending on long-running processes. https://turbo.build/repo/docs/reference/configuration#persistent

Tested locally with `pnpm dev:llm`, metro bundler allows to reload the app or open the debug menu

### ❓ Context

- **JIRA or GitHub link**: none


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
