### PR TITLE
fix(wallet-api): only call success and fail handlers when closing the flow on LLM

### DIFF
--- a/.changeset/clever-rocks-watch.md
+++ b/.changeset/clever-rocks-watch.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": patch
+---
+
+fix(wallet-api): only call success and fail handlers when closing the flow on LLM
+
+Allows to properly retry the sign message without sending an error through the wallet-api
+We also only send the success when we actually close the last success screen

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
@@ -22,14 +22,12 @@ export default function ValidationError({ navigation, route }: Navigation) {
   const { colors } = useTheme();
   const { error, onFailHandler } = route.params;
 
-  useEffect(() => {
+  const onClose = useCallback(() => {
     if (onFailHandler && error) {
       onFailHandler(error);
     }
-  }, [onFailHandler, error]);
-  const onClose = useCallback(() => {
     navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
-  }, [navigation]);
+  }, [error, navigation, onFailHandler]);
   const retry = useCallback(() => {
     navigation.goBack();
   }, [navigation]);

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationSuccess.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback } from "react";
 import { View, StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
@@ -25,14 +25,13 @@ export default function ValidationSuccess({
   const { t } = useTranslation();
   const { signature, onConfirmationHandler } = route.params;
 
-  useEffect(() => {
+  const onClose = useCallback(() => {
     if (onConfirmationHandler && signature) {
       onConfirmationHandler(signature);
     }
-  }, [onConfirmationHandler, signature]);
-  const onClose = useCallback(() => {
     navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
-  }, [navigation]);
+  }, [navigation, onConfirmationHandler, signature]);
+
   return (
     <View
       style={[


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Manually tested as we removed the tests that would actually use the UI (we should probably try to do that again)
- [x] **Impact of the changes:**
  - Wallet API sign message flow on LLM

### 📝 Description

Now only call success and fail handlers when closing the flow on LLM
Allows to properly retry the sign message without sending an error through the wallet-api
We also only send the success when we actually close the last success screen

For success flow we could also auto close if the handler is present to remove an action but I prefer to keep things as close as we currently have it

### ❓ Context

- **JIRA or GitHub link**: none


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
