### PR TITLE
fix(LLM): wallet-connect deep-link from native app for a request would reload the page [LIVE-13641]

### DIFF
--- a/.changeset/sour-poets-play.md
+++ b/.changeset/sour-poets-play.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+---
+
+fix(LLM): wallet-connect deep-link from native app for a request would reload the page
+
+Reloading the page would break the wallet-api flow shown when coming back to the app

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -459,7 +459,7 @@ export const DeeplinksProvider = ({
             ) {
               const uri = isWalletConnectUrl(url) ? url : new URL(url).searchParams.get("uri");
               // Only update for a connection not a request
-              if (uri && !new URL(uri).searchParams.get("requestId")) {
+              if (uri && uri !== "wc:" && !new URL(uri).searchParams.get("requestId")) {
                 // TODO use wallet-api to push event instead of reloading the webview
                 dispatch(setWallectConnectUri(uri));
               }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually. We don't have test for wc deep-links and this one needs to be created from another native app making automated tests harder
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Wallet-connect deeplink on LLM

### 📝 Description

Wallet-connect deep-link from native app for a request would reload the page
Instead of receiving the usual deeplink with a requestId and topic we would receive a `wc:` invalid link that updated the uri used in the webview
Reloading the page would break the wallet-api flow shown when coming back to the app

We will consider cancelling a flow in the wallet-api if the page is reloaded like that with a message and probably logs for us in order to avoid it happening again

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13641]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13641]: https://ledgerhq.atlassian.net/browse/LIVE-13641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ