### PR TITLE
fix(LLM): allow wallet-connect live-app to open a deep-link at any time [LIVE-13641]

### DIFF
--- a/.changeset/slow-dingos-destroy.md
+++ b/.changeset/slow-dingos-destroy.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+fix(LLM): allow wallet-connect live-app to open a deep-link at any time
+
+Refactor by sharing a single constant for wallet-connect live-app manifest id

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking.ts
@@ -19,6 +19,7 @@ import { useStorylyContext } from "~/storyly/StorylyProvider";
 import { useNavigateToPostOnboardingHubCallback } from "~/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback";
 import { usePostOnboardingDeeplinkHandler } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { setDrawerVisibility as setLedgerSyncDrawerVisibility } from "../actions/walletSync";
+import { WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 
 const getAccountsOrSubAccountsByCurrency = (
   currency: CryptoOrTokenCurrency,
@@ -315,8 +316,9 @@ export function useDeepLinkHandler() {
           }
           break;
         case "wc": {
+          const wcPathname = `/platform/${WC_ID}`;
           // Only prevent requests if already on the wallet connect live-app
-          if (location.pathname === "/platform/ledger-wallet-connect") {
+          if (location.pathname === wcPathname) {
             try {
               // Prevent a request from updating the live-app url and reloading it
               if (!query.uri || new URL(query.uri).searchParams.get("requestId")) {
@@ -327,7 +329,7 @@ export function useDeepLinkHandler() {
             }
           }
           setTrackingSource("deeplink");
-          navigate("/platform/ledger-wallet-connect", query);
+          navigate(wcPathname, query);
 
           break;
         }

--- a/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/AccountHeaderActions.tsx
@@ -39,6 +39,7 @@ import { ManageAction } from "~/renderer/families/types";
 import { getAvailableProviders } from "@ledgerhq/live-common/exchange/swap/index";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { isWalletConnectSupported } from "@ledgerhq/live-common/walletConnect/index";
+import { WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 
 type RenderActionParams = {
   label: React.ReactNode;
@@ -137,7 +138,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
       initialAccountId: mainAccount.id,
     };
     history.push({
-      pathname: "/platform/ledger-wallet-connect",
+      pathname: `/platform/${WC_ID}`,
       state: params,
     });
   }, [mainAccount.id, history]);

--- a/apps/ledger-live-mobile/src/components/RootNavigator/WalletConnectLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/WalletConnectLiveAppNavigator.tsx
@@ -10,8 +10,7 @@ import { LiveApp } from "~/screens/Platform";
 import { uriSelector } from "~/reducers/walletconnect";
 import { setWallectConnectUri } from "~/actions/walletconnect";
 import { WalletConnectLiveAppNavigatorParamList } from "./types/WalletConnectLiveAppNavigator";
-
-const PLATFORM = "ledger-wallet-connect";
+import { WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 
 const options = {
   headerBackImage: () => (
@@ -48,7 +47,7 @@ export default function WalletConnectLiveAppNavigator() {
                 key: _props.route.key,
                 name: ScreenName.PlatformApp,
                 params: {
-                  platform: PLATFORM,
+                  platform: WC_ID,
                   uri: uri || _props.route.params?.uri,
                   requestId: _props.route.params?.requestId,
                   sessionTopic: _props.route.params?.sessionTopic,

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -5,7 +5,7 @@ import Config from "react-native-config";
 import { WebviewAPI, WebviewProps } from "./types";
 import { useWebView } from "./helpers";
 import { NetworkError } from "./NetworkError";
-import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
+import { INTERNAL_APP_IDS, WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { INJECTED_JAVASCRIPT } from "./dappInject";
 import { NoAccountScreen } from "./NoAccountScreen";
@@ -41,7 +41,8 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     const internalAppIds = useInternalAppIds() || INTERNAL_APP_IDS;
 
-    const javaScriptCanOpenWindowsAutomatically = internalAppIds.includes(manifest.id);
+    const javaScriptCanOpenWindowsAutomatically =
+      internalAppIds.includes(manifest.id) || manifest.id === WC_ID;
 
     if (!!manifest.dapp && noAccounts) {
       return <NoAccountScreen manifest={manifest} currentAccountHistDb={currentAccountHistDb} />;

--- a/apps/ledger-live-mobile/src/screens/Platform/v2/hooks.ts
+++ b/apps/ledger-live-mobile/src/screens/Platform/v2/hooks.ts
@@ -14,6 +14,7 @@ import {
   DAPP_DISCLAIMER_ID,
   DISCOVER_STORE_KEY,
   BROWSE_SEARCH_OPTIONS,
+  WC_ID,
 } from "@ledgerhq/live-common/wallet-api/constants";
 import { DiscoverDB, AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 import { useNavigation, useRoute } from "@react-navigation/native";
@@ -100,8 +101,6 @@ export type Disclaimer = DisclaimerRaw & {
   openApp: (manifest: AppManifest) => void;
 };
 
-const WALLET_CONNECT_LIVE_APP = "ledger-wallet-connect";
-
 function useDisclaimer(appendRecentlyUsed: (manifest: AppManifest) => void): Disclaimer {
   const isReadOnly = useSelector(readOnlyModeEnabledSelector);
   const [isDismissed, dismiss] = useBanner(DAPP_DISCLAIMER_ID);
@@ -117,7 +116,7 @@ function useDisclaimer(appendRecentlyUsed: (manifest: AppManifest) => void): Dis
     (manifest: AppManifest) => {
       // Navigate to the WalletConnect navigator screen instead of the discover one
       // In order to avoid issue with deeplinks opening wallet-connect multiple times
-      if (manifest.id === WALLET_CONNECT_LIVE_APP) {
+      if (manifest.id === WC_ID) {
         navigation.navigate(NavigatorName.WalletConnect, {
           screen: ScreenName.WalletConnectConnect,
           params: {},

--- a/libs/ledger-live-common/src/wallet-api/constants.ts
+++ b/libs/ledger-live-common/src/wallet-api/constants.ts
@@ -49,4 +49,6 @@ export const BUY_SELL_UI_APP_ID = "buy-sell-ui";
 
 export const CARD_APP_ID = "card-program";
 
+export const WC_ID = "ledger-wallet-connect";
+
 export const INTERNAL_APP_IDS = [DEFAULT_MULTIBUY_APP_ID, BUY_SELL_UI_APP_ID, CARD_APP_ID];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually as it involves testing deep-links from a live-app, and I don't think we can do that we detox currently
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Wallet-connect live-app

### 📝 Description

Allow wallet-connect live-app to open a deep-link at any time on LLM
Refactor by sharing a single constant for wallet-connect live-app manifest id

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-13641]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13641]: https://ledgerhq.atlassian.net/browse/LIVE-13641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ