### PR TITLE
chore(lld): 👌 always skip the analytics prompt in e2e tests

### DIFF
--- a/.changeset/big-snakes-marry.md
+++ b/.changeset/big-snakes-marry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Always skip the analytics prompt in e2e tests

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -61,8 +61,13 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     () =>
       isEntryPointIncludedInFlagParams &&
       lldAnalyticsOptInPromptFlag?.enabled &&
-      !hasSeenAnalyticsOptInPrompt,
-    [lldAnalyticsOptInPromptFlag, hasSeenAnalyticsOptInPrompt, isEntryPointIncludedInFlagParams],
+      (!hasSeenAnalyticsOptInPrompt || entryPoint === EntryPoint.onboarding),
+    [
+      lldAnalyticsOptInPromptFlag,
+      hasSeenAnalyticsOptInPrompt,
+      entryPoint,
+      isEntryPointIncludedInFlagParams,
+    ],
   );
 
   const onSubmit = () => {

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -61,13 +61,8 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     () =>
       isEntryPointIncludedInFlagParams &&
       lldAnalyticsOptInPromptFlag?.enabled &&
-      (!hasSeenAnalyticsOptInPrompt || entryPoint === EntryPoint.onboarding),
-    [
-      lldAnalyticsOptInPromptFlag,
-      hasSeenAnalyticsOptInPrompt,
-      entryPoint,
-      isEntryPointIncludedInFlagParams,
-    ],
+      !hasSeenAnalyticsOptInPrompt,
+    [lldAnalyticsOptInPromptFlag, hasSeenAnalyticsOptInPrompt, isEntryPointIncludedInFlagParams],
   );
 
   const onSubmit = () => {

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantA/Main/components/MainFooter/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantA/Main/components/MainFooter/index.tsx
@@ -38,7 +38,13 @@ const MainFooter = ({ setWantToManagePreferences, onShareAnalyticsChange }: Main
           >
             {t("analyticsOptInPrompt.variantA.refuse")}
           </Button>
-          <Button variant={"main"} size={"large"} borderRadius={48} onClick={handleAcceptClick}>
+          <Button
+            data-testid="accept-analytics-button"
+            variant={"main"}
+            size={"large"}
+            borderRadius={48}
+            onClick={handleAcceptClick}
+          >
             {t("analyticsOptInPrompt.variantA.accept")}
           </Button>
         </Flex>

--- a/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantB/components/Footer/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AnalyticsOptInPrompt/screens/VariantB/components/Footer/index.tsx
@@ -30,6 +30,7 @@ const VariantBFooter = ({ clickOptions }: VariantBFooterProps) => {
           {t("analyticsOptInPrompt.variantB.refuse")}
         </Button>
         <Button
+          data-testid="accept-analytics-button"
           variant={"main"}
           size={"large"}
           borderRadius={48}

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -18,6 +18,7 @@ type TestFixtures = {
   theme: "light" | "dark" | "no-preference" | undefined;
   speculosApp: AppInfos;
   userdata?: string;
+  settings: Record<string, unknown>;
   userdataDestinationPath: string;
   userdataOriginalFile?: string;
   userdataFile: string;
@@ -41,6 +42,7 @@ export const test = base.extend<TestFixtures>({
   lang: "en-US",
   theme: "dark",
   userdata: undefined,
+  settings: { shareAnalytics: true, hasSeenAnalyticsOptInPrompt: true },
   featureFlags: undefined,
   simulateCamera: undefined,
   speculosApp: undefined,
@@ -66,6 +68,7 @@ export const test = base.extend<TestFixtures>({
       theme,
       userdataDestinationPath,
       userdataOriginalFile,
+      settings,
       env,
       featureFlags,
       simulateCamera,
@@ -77,15 +80,10 @@ export const test = base.extend<TestFixtures>({
     // create userdata path
     await fsPromises.mkdir(userdataDestinationPath, { recursive: true });
 
-    const userData = {
-      data: {
-        settings: { shareAnalytics: true, hasSeenAnalyticsOptInPrompt: true },
-      },
-    };
-    const testUserData = userdataOriginalFile
+    const fileUserData = userdataOriginalFile
       ? await fsPromises.readFile(userdataOriginalFile, { encoding: "utf-8" }).then(JSON.parse)
       : {};
-    merge(userData, testUserData);
+    const userData = merge({ data: { settings } }, fileUserData);
     await fsPromises.writeFile(`${userdataDestinationPath}/app.json`, JSON.stringify(userData));
 
     let device: any | undefined;

--- a/apps/ledger-live-desktop/tests/page/onboarding.page.ts
+++ b/apps/ledger-live-desktop/tests/page/onboarding.page.ts
@@ -4,6 +4,7 @@ import { AppPage } from "tests/page/abstractClasses";
 export class OnboardingPage extends AppPage {
   deviceAction = new DeviceAction(this.page);
   private getStartedButton = this.page.locator('button:has-text("Get Started")');
+  private acceptAnalyticsButton = this.page.getByTestId("accept-analytics-button");
   private selectDeviceButton = (deviceId: string) => this.page.getByTestId(`v3-device-${deviceId}`);
   private checkMyNanoButton = this.page.locator('button:has-text("Check my Nano")');
   readonly continueButton = this.page.locator('button:has-text("Continue")');
@@ -36,6 +37,9 @@ export class OnboardingPage extends AppPage {
 
   async getStarted() {
     await this.getStartedButton.click();
+
+    // Click on accept analytics button if it exists
+    await this.acceptAnalyticsButton.click().catch(() => {});
   }
 
   async hoverDevice(device: "nanoS" | "nanoX" | "nanoSP" | "stax") {

--- a/apps/ledger-live-desktop/tests/specs/onboarding/connect-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/connect-device.spec.ts
@@ -2,6 +2,10 @@ import { expect } from "@playwright/test";
 import test from "../../fixtures/common";
 import { OnboardingPage } from "../../page/onboarding.page";
 
+test.use({
+  settings: { hasSeenAnalyticsOptInPrompt: false },
+});
+
 enum Nano {
   nanoX = "nanoX",
   nanoS = "nanoS",

--- a/apps/ledger-live-desktop/tests/specs/onboarding/restore-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/restore-device.spec.ts
@@ -2,6 +2,10 @@ import { expect } from "@playwright/test";
 import test from "../../fixtures/common";
 import { OnboardingPage } from "../../page/onboarding.page";
 
+test.use({
+  settings: { hasSeenAnalyticsOptInPrompt: false },
+});
+
 enum Nano {
   nanoX = "nanoX",
   nanoS = "nanoS",

--- a/apps/ledger-live-desktop/tests/specs/onboarding/setup-device.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/onboarding/setup-device.spec.ts
@@ -2,6 +2,10 @@ import test from "../../fixtures/common";
 import { expect } from "@playwright/test";
 import { OnboardingPage } from "../../page/onboarding.page";
 
+test.use({
+  settings: { hasSeenAnalyticsOptInPrompt: false },
+});
+
 enum Nano {
   nanoX = "nanoX",
   nanoS = "nanoS",

--- a/apps/ledger-live-desktop/tests/specs/syncOnboarding/manual.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/syncOnboarding/manual.spec.ts
@@ -2,8 +2,10 @@ import { expect } from "@playwright/test";
 import test from "../../fixtures/common";
 import { OnboardingPage } from "../../page/onboarding.page";
 import { DeviceModelId } from "@ledgerhq/devices";
+
 test.use({
   env: { MOCK_NO_BYPASS: "1" },
+  settings: { hasSeenAnalyticsOptInPrompt: false },
 });
 
 const modelIds = [

--- a/apps/ledger-live-desktop/tests/userdata/1AccountBTC1AccountETH-encrypted.json
+++ b/apps/ledger-live-desktop/tests/userdata/1AccountBTC1AccountETH-encrypted.json
@@ -18,7 +18,7 @@
       "loaded": true,
       "shareAnalytics": true,
       "sharePersonalizedRecommandations": false,
-      "hasSeenAnalyticsOptInPrompt": false,
+      "hasSeenAnalyticsOptInPrompt": true,
       "sentryLogs": true,
       "lastUsedVersion": "99.99.99",
       "dismissedBanners": [],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Dismiss analytics prompt in LLDs tests by using settings value of `shareAnalytics: true, hasSeenAnalyticsOptInPrompt: true` by default. Use `hasSeenAnalyticsOptInPrompt: true` in onboarding tests to go through the normal user experience.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-13650]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13650]: https://ledgerhq.atlassian.net/browse/LIVE-13650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ