### PR TITLE
chore(llm): 🏚️ run tests at `e2e/specs/*.spec.ts`

### DIFF
--- a/.changeset/six-hairs-raise.md
+++ b/.changeset/six-hairs-raise.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Run tests files at `e2e/specs/*.spec.ts`

--- a/apps/ledger-live-mobile/e2e/jest.config.js
+++ b/apps/ledger-live-mobile/e2e/jest.config.js
@@ -35,7 +35,7 @@ module.exports = async () => ({
   },
   setupFilesAfterEnv: ["<rootDir>/e2e/setup.ts"],
   testTimeout: 150000,
-  testMatch: ["<rootDir>/e2e/specs/!(speculos)/**/*.spec.ts"],
+  testMatch: ["<rootDir>/e2e/specs/{*.spec.ts,!(speculos)/**/*.spec.ts}"],
   reporters: ["detox/runners/jest/reporter", ["jest-allure2-reporter", jestAllure2ReporterOptions]],
   globalSetup: "detox/runners/jest/globalSetup",
   globalTeardown: "<rootDir>/e2e/jest.globalTeardown.ts",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Tests files at `e2e/specs/*.spec.ts` are no longer run. It comes from a change in #7789 which looks accidental to me. Here's the change in the glob pattern (from https://www.digitalocean.com/community/tools/glob)

| Before        | After         |
| ------------- | ------------- |
|  <img width="407" alt="image" src="https://github.com/user-attachments/assets/79515aa6-ddba-4450-a975-6b54834fdcfa">   | <img width="407" alt="image" src="https://github.com/user-attachments/assets/6e9311c6-6cf5-4e04-aaf4-c7ca093b299c"> |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
