### PR TITLE
Ledger Sync - Fix side effect causing the synchronization to stop working

### DIFF
--- a/.changeset/brown-ducks-rule.md
+++ b/.changeset/brown-ducks-rule.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-wallet": patch
+---
+
+Ledger Sync - Fixed side effect that caused the synchronization to stop working

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -24,7 +24,10 @@ import {
   WSState,
 } from "@ledgerhq/live-wallet/store";
 import { replaceAccounts } from "~/renderer/actions/accounts";
-import { latestDistantStateSelector } from "~/renderer/reducers/wallet";
+import {
+  latestDistantStateSelector,
+  latestDistantVersionSelector,
+} from "~/renderer/reducers/wallet";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { useOnTrustchainRefreshNeeded } from "./useOnTrustchainRefreshNeeded";
 import { Dispatch } from "redux";
@@ -80,6 +83,7 @@ export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
         ctx,
         getState,
         latestDistantStateSelector,
+        latestDistantVersionSelector,
         localStateSelector,
         saveUpdate,
       }),

--- a/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
@@ -27,6 +27,10 @@ export function latestDistantStateSelector(state: State): DistantState | null {
   return walletSyncStateSelector(walletSelector(state)).data;
 }
 
+export function latestDistantVersionSelector(state: State): number {
+  return walletSyncStateSelector(walletSelector(state)).version;
+}
+
 export const useMaybeAccountName = (
   account: AccountLike | null | undefined,
 ): string | undefined => {

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -27,7 +27,7 @@ import { walletSelector } from "~/reducers/wallet";
 import { State } from "~/reducers/types";
 import { bridgeCache } from "~/bridge/cache";
 import { replaceAccounts } from "~/actions/accounts";
-import { latestDistantStateSelector } from "~/reducers/wallet";
+import { latestDistantStateSelector, latestDistantVersionSelector } from "~/reducers/wallet";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
 
@@ -80,6 +80,7 @@ export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
         ctx,
         getState,
         latestDistantStateSelector,
+        latestDistantVersionSelector,
         localStateSelector,
         saveUpdate,
       }),

--- a/apps/ledger-live-mobile/src/reducers/wallet.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.ts
@@ -27,6 +27,10 @@ export function latestDistantStateSelector(state: State): DistantState | null {
   return walletSyncStateSelector(walletSelector(state)).data;
 }
 
+export function latestDistantVersionSelector(state: State): number {
+  return walletSyncStateSelector(walletSelector(state)).version;
+}
+
 export const useMaybeAccountName = (
   account: AccountLike | null | undefined,
 ): string | undefined => {

--- a/apps/web-tools/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/trustchain/components/AppAccountsSync.tsx
@@ -53,6 +53,7 @@ const localStateSelector = (state: State) => ({
 });
 
 const latestDistantStateSelector = (state: State) => state.walletState.walletSyncState.data;
+const latestDistantVersionSelector = (state: State) => state.walletState.walletSyncState.version;
 
 export default function AppAccountsSync({
   deviceId,
@@ -141,6 +142,7 @@ export default function AppAccountsSync({
         ctx,
         getState,
         latestDistantStateSelector,
+        latestDistantVersionSelector,
         localStateSelector,
         saveUpdate,
       }),

--- a/libs/live-wallet/src/walletsync/incrementalUpdates.ts
+++ b/libs/live-wallet/src/walletsync/incrementalUpdates.ts
@@ -8,12 +8,14 @@ export function makeSaveNewUpdate<S>({
   ctx,
   getState,
   latestDistantStateSelector,
+  latestDistantVersionSelector,
   localStateSelector,
   saveUpdate,
 }: {
   ctx: WalletSyncDataManagerResolutionContext;
   getState: () => S;
   latestDistantStateSelector: (state: S) => DistantState | null;
+  latestDistantVersionSelector: (state: S) => number;
   localStateSelector: (state: S) => LocalState;
   saveUpdate: (
     data: DistantState | null,
@@ -27,6 +29,7 @@ export function makeSaveNewUpdate<S>({
       case "new-data": {
         // we resolve incoming distant state changes
         const state = getState();
+        const latestVersion = latestDistantVersionSelector(state);
         const latest = latestDistantStateSelector(state);
         const local = localStateSelector(state);
         const data = event.data;
@@ -40,6 +43,9 @@ export function makeSaveNewUpdate<S>({
           log("walletsync", "resolved. changes applied.");
         } else {
           log("walletsync", "resolved. no changes to apply.");
+        }
+        if (event.version !== latestVersion) {
+          await saveUpdate(data, event.version, null);
         }
         break;
       }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

This PR fixes an issue that caused the synchronization to be broken for an instance in the following situation : 
When the local wallet sync state version was different than the one returned by the cloud sync api (when pushing or pulling data) and the `resolveIncrementalUpdate` function didn't detect any changes between the latestState and the distantState, the local version wasn't updated and all subsequent call to the cloud sync api were returning an out of sync state.
This is fixed by updating the local version to the value returned by the cloud sync api even if there were no differences between the latest data and the distant data. That way the following calls made to pull data from the cloud sync api will be successfull and the synchronization will keep working.
 
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14041]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14041]: https://ledgerhq.atlassian.net/browse/LIVE-14041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ