### PR TITLE
chore: 🗺️ fix IDE go to definition feature for some libs

### DIFF
--- a/.changeset/cuddly-zebras-give.md
+++ b/.changeset/cuddly-zebras-give.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/native-ui": patch
+"@ledgerhq/ui-shared": patch
+"@ledgerhq/icons-ui": patch
+"@ledgerhq/react-ui": patch
+---
+
+Fix IDE go to definition feature for some libs

--- a/libs/ui/packages/icons/tsconfig.json
+++ b/libs/ui/packages/icons/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../../tsconfig.base",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "jsx": "react",
     "baseUrl": ".",
     "rootDir": "./src",

--- a/libs/ui/packages/native/tsconfig.json
+++ b/libs/ui/packages/native/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react-native",
     "composite": true,
+    "declarationMap": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "strict": true,

--- a/libs/ui/packages/react/tsconfig.json
+++ b/libs/ui/packages/react/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../../tsconfig.base",
   "compilerOptions": {
     "composite": true,
+    "declarationMap": true,
     "jsx": "react",
     "lib": ["es2019", "dom"],
     "baseUrl": ".",

--- a/libs/ui/packages/shared/tsconfig.json
+++ b/libs/ui/packages/shared/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "declaration": true,
+    "declarationMap": true,
     "outDir": "./lib",
     "forceConsistentCasingInFileNames": true
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add [declaration map](https://www.typescriptlang.org/tsconfig/#declarationMap) on dependencies where they are missing. It allows quickly checking the references definitions on IDEs.
I was exploring the code base a bit for tech day, and realised the declaration maps where missing for some packages (mostly the design system related dependencies. 

Before:

https://github.com/user-attachments/assets/a75f19eb-4dc2-4f45-a562-9aea421d3d06

After:

https://github.com/user-attachments/assets/9a1820b9-6f6d-408c-a2f3-fd402bba4b91

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
