### PR TITLE
fix(coin-solana): transition of outdated Solana GetStakeActivation endpoint

### DIFF
--- a/.changeset/shy-apples-tickle.md
+++ b/.changeset/shy-apples-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Replace outdated solana getStakeActivation endpoint

--- a/libs/coin-modules/coin-solana/src/api/chain/account/index.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/account/index.ts
@@ -1,1 +1,7 @@
-export { tryParseAsTokenAccount, parseTokenAccountInfo, tryParseAsVoteAccount } from "./parser";
+export {
+  tryParseAsTokenAccount,
+  parseTokenAccountInfo,
+  tryParseAsVoteAccount,
+  tryParseAsStakeAccount,
+  parseStakeHistoryEntry,
+} from "./parser";

--- a/libs/coin-modules/coin-solana/src/api/chain/account/parser.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/account/parser.ts
@@ -2,7 +2,7 @@ import { ParsedAccountData } from "@solana/web3.js";
 import { create } from "superstruct";
 import { PARSED_PROGRAMS } from "../program/constants";
 import { ParsedInfo } from "../validators";
-import { StakeAccountInfo } from "./stake";
+import { StakeAccount, StakeAccountInfo, StakeHistoryEntry } from "./stake";
 import { TokenAccount, TokenAccountInfo } from "./token";
 import { VoteAccount, VoteAccountInfo } from "./vote";
 
@@ -52,6 +52,22 @@ export function tryParseAsVoteAccount(
 
 export function parseStakeAccountInfo(info: unknown): StakeAccountInfo {
   return create(info, StakeAccountInfo);
+}
+
+export function tryParseAsStakeAccount(
+  data: ParsedAccountData,
+): StakeAccountInfo | undefined | Error {
+  const routine = () => {
+    const info = create(data.parsed, ParsedInfo);
+    const parsed = create(info, StakeAccount);
+    return parseStakeAccountInfo(parsed.info);
+  };
+
+  return onThrowReturnError(routine);
+}
+
+export function parseStakeHistoryEntry(entry: unknown) {
+  return create(entry, StakeHistoryEntry);
 }
 
 function onThrowReturnError<R>(fn: () => R) {

--- a/libs/coin-modules/coin-solana/src/api/chain/account/stake.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/account/stake.ts
@@ -2,7 +2,7 @@
 
 import { Infer, number, nullable, enums, type } from "superstruct";
 import { PublicKeyFromString } from "../validators/pubkey";
-import { BigNumFromString } from "../validators/bignum";
+import { BigNumFromNumber, BigNumFromString } from "../validators/bignum";
 
 export type StakeAccountType = Infer<typeof StakeAccountType>;
 export const StakeAccountType = enums(["uninitialized", "initialized", "delegated", "rewardsPool"]);
@@ -21,18 +21,29 @@ export const StakeMeta = type({
   }),
 });
 
+export const Delegation = type({
+  voter: PublicKeyFromString,
+  stake: BigNumFromString,
+  activationEpoch: BigNumFromString,
+  deactivationEpoch: BigNumFromString,
+  warmupCooldownRate: number(),
+});
+export type Delegation = Infer<typeof Delegation>;
+
+export const StakeHistoryEntry = type({
+  epoch: BigNumFromNumber,
+  effective: BigNumFromNumber,
+  activating: BigNumFromNumber,
+  deactivating: BigNumFromNumber,
+});
+export type StakeHistoryEntry = Infer<typeof StakeHistoryEntry>;
+
 export type StakeAccountInfo = Infer<typeof StakeAccountInfo>;
 export const StakeAccountInfo = type({
   meta: StakeMeta,
   stake: nullable(
     type({
-      delegation: type({
-        voter: PublicKeyFromString,
-        stake: BigNumFromString,
-        activationEpoch: BigNumFromString,
-        deactivationEpoch: BigNumFromString,
-        warmupCooldownRate: number(),
-      }),
+      delegation: Delegation,
       creditsObserved: number(),
     }),
   ),

--- a/libs/coin-modules/coin-solana/src/api/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/index.ts
@@ -16,6 +16,7 @@ import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
 import { getEnv } from "@ledgerhq/live-env";
 import { NetworkError } from "@ledgerhq/errors";
 import { Awaited } from "../../logic";
+import { getStakeActivation } from "./stake-activation";
 
 export const LATEST_BLOCKHASH_MOCK = "EEbZs6DmDyDjucyYbo3LwVJU7pQYuVopYcYTSEZXskW3";
 
@@ -44,7 +45,7 @@ export type ChainAPI = Readonly<{
     authAddr: string,
   ) => ReturnType<Connection["getParsedProgramAccounts"]>;
 
-  getStakeActivation: (stakeAccAddr: string) => ReturnType<Connection["getStakeActivation"]>;
+  getStakeActivation: (stakeAccAddr: string) => ReturnType<typeof getStakeActivation>;
 
   getInflationReward: (addresses: string[]) => ReturnType<Connection["getInflationReward"]>;
 
@@ -162,7 +163,7 @@ export function getChainAPI(
     ),
 
     getStakeActivation: (stakeAccAddr: string) =>
-      connection().getStakeActivation(new PublicKey(stakeAccAddr)).catch(remapErrors),
+      getStakeActivation(connection(), new PublicKey(stakeAccAddr)).catch(remapErrors),
 
     getInflationReward: (addresses: string[]) =>
       connection()

--- a/libs/coin-modules/coin-solana/src/api/chain/stake-activation/delegation.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/stake-activation/delegation.ts
@@ -1,0 +1,169 @@
+import BigNumber from "bignumber.js";
+import { Delegation, StakeHistoryEntry } from "../account/stake";
+
+export interface StakeActivatingAndDeactivating {
+  effective: BigNumber;
+  activating: BigNumber;
+  deactivating: BigNumber;
+}
+
+interface EffectiveAndActivating {
+  effective: BigNumber;
+  activating: BigNumber;
+}
+
+function getStakeHistoryEntry(
+  epoch: BigNumber,
+  stakeHistory: StakeHistoryEntry[],
+): StakeHistoryEntry | null {
+  for (const entry of stakeHistory) {
+    if (entry.epoch.eq(epoch)) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+const WARMUP_COOLDOWN_RATE = 0.09;
+
+function getStakeAndActivating(
+  delegation: Delegation,
+  targetEpoch: BigNumber,
+  stakeHistory: StakeHistoryEntry[],
+): EffectiveAndActivating {
+  if (delegation.activationEpoch.eq(delegation.deactivationEpoch)) {
+    // activated but instantly deactivated; no stake at all regardless of target_epoch
+    return {
+      effective: BigNumber(0),
+      activating: BigNumber(0),
+    };
+  } else if (targetEpoch.eq(delegation.activationEpoch)) {
+    // all is activating
+    return {
+      effective: BigNumber(0),
+      activating: delegation.stake,
+    };
+  } else if (targetEpoch.lt(delegation.activationEpoch)) {
+    // not yet enabled
+    return {
+      effective: BigNumber(0),
+      activating: BigNumber(0),
+    };
+  }
+
+  let currentEpoch = delegation.activationEpoch;
+  let entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+  if (entry !== null) {
+    // target_epoch > self.activation_epoch
+
+    // loop from my activation epoch until the target epoch summing up my entitlement
+    // current effective stake is updated using its previous epoch's cluster stake
+    let currentEffectiveStake = BigNumber(0);
+    while (entry !== null) {
+      currentEpoch = currentEpoch.plus(1);
+      const remaining = delegation.stake.minus(currentEffectiveStake);
+      const weight = remaining.div(entry.activating);
+      const newlyEffectiveClusterStake = entry.effective.multipliedBy(WARMUP_COOLDOWN_RATE);
+      const newlyEffectiveStake = BigNumber.max(
+        BigNumber(1),
+        weight.multipliedBy(newlyEffectiveClusterStake).integerValue(BigNumber.ROUND_HALF_CEIL),
+      );
+
+      currentEffectiveStake = currentEffectiveStake.plus(newlyEffectiveStake);
+      if (currentEffectiveStake.gte(delegation.stake)) {
+        currentEffectiveStake = delegation.stake;
+        break;
+      }
+
+      if (currentEpoch.gte(targetEpoch) || currentEpoch.gte(delegation.deactivationEpoch)) {
+        break;
+      }
+      entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+    }
+    return {
+      effective: currentEffectiveStake,
+      activating: delegation.stake.minus(currentEffectiveStake),
+    };
+  } else {
+    // no history or I've dropped out of history, so assume fully effective
+    return {
+      effective: delegation.stake,
+      activating: BigNumber(0),
+    };
+  }
+}
+
+export function getStakeActivatingAndDeactivating(
+  delegation: Delegation,
+  targetEpoch: BigNumber,
+  stakeHistory: StakeHistoryEntry[],
+): StakeActivatingAndDeactivating {
+  const { effective, activating } = getStakeAndActivating(delegation, targetEpoch, stakeHistory);
+
+  // then de-activate some portion if necessary
+  if (targetEpoch.lt(delegation.deactivationEpoch)) {
+    return {
+      effective,
+      activating,
+      deactivating: BigNumber(0),
+    };
+  } else if (targetEpoch.eq(delegation.deactivationEpoch)) {
+    // can only deactivate what's activated
+    return {
+      effective,
+      activating: BigNumber(0),
+      deactivating: effective,
+    };
+  }
+  let currentEpoch = delegation.deactivationEpoch;
+  let entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+  if (entry !== null) {
+    // target_epoch > self.activation_epoch
+    // loop from my deactivation epoch until the target epoch
+    // current effective stake is updated using its previous epoch's cluster stake
+    let currentEffectiveStake = effective;
+    while (entry !== null) {
+      currentEpoch = currentEpoch.plus(1);
+      // if there is no deactivating stake at prev epoch, we should have been
+      // fully undelegated at this moment
+      if (entry.deactivating.eq(0)) {
+        break;
+      }
+
+      // I'm trying to get to zero, how much of the deactivation in stake
+      //   this account is entitled to take
+      const weight = currentEffectiveStake.div(entry.deactivating);
+
+      // portion of newly not-effective cluster stake I'm entitled to at current epoch
+      const newlyNotEffectiveClusterStake = entry.effective.multipliedBy(WARMUP_COOLDOWN_RATE);
+      const newlyNotEffectiveStake = BigNumber.max(
+        BigNumber(1),
+        weight.multipliedBy(newlyNotEffectiveClusterStake).integerValue(BigNumber.ROUND_HALF_CEIL),
+      );
+
+      currentEffectiveStake = currentEffectiveStake.minus(newlyNotEffectiveStake);
+      if (currentEffectiveStake.lte(0)) {
+        currentEffectiveStake = BigNumber(0);
+        break;
+      }
+
+      if (currentEpoch.gte(targetEpoch)) {
+        break;
+      }
+      entry = getStakeHistoryEntry(currentEpoch, stakeHistory);
+    }
+
+    // deactivating stake should equal to all of currently remaining effective stake
+    return {
+      effective: currentEffectiveStake,
+      deactivating: currentEffectiveStake,
+      activating: BigNumber(0),
+    };
+  } else {
+    return {
+      effective: BigNumber(0),
+      activating: BigNumber(0),
+      deactivating: BigNumber(0),
+    };
+  }
+}

--- a/libs/coin-modules/coin-solana/src/api/chain/stake-activation/index.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/stake-activation/index.ts
@@ -1,0 +1,1 @@
+export { getStakeActivation } from "./rpc";

--- a/libs/coin-modules/coin-solana/src/api/chain/stake-activation/rpc.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/stake-activation/rpc.ts
@@ -1,0 +1,90 @@
+import { Connection, PublicKey, SYSVAR_STAKE_HISTORY_PUBKEY } from "@solana/web3.js";
+import { BigNumber } from "bignumber.js";
+import { getStakeActivatingAndDeactivating, StakeActivatingAndDeactivating } from "./delegation";
+import { parseStakeHistoryEntry, tryParseAsStakeAccount } from "../account";
+
+function getStakeActivationState({
+  activating,
+  deactivating,
+  effective,
+}: StakeActivatingAndDeactivating) {
+  if (deactivating.gt(0)) {
+    return "deactivating";
+  } else if (activating.gt(0)) {
+    return "activating";
+  } else if (effective.gt(0)) {
+    return "active";
+  } else {
+    return "inactive";
+  }
+}
+
+type StakeActivationState = "active" | "inactive" | "activating" | "deactivating";
+
+export interface StakeActivationData {
+  state: StakeActivationState;
+  active: number;
+  inactive: number;
+}
+
+// Replacement for outdated connection.getStakeActivation rpc endpoint.
+// Based on example from Solana team https://github.com/solana-developers/solana-rpc-get-stake-activation
+// TODO: Install solana-rpc-get-stake-activation via npm package when it's published.
+export async function getStakeActivation(
+  connection: Connection,
+  stakeAddress: PublicKey,
+): Promise<StakeActivationData> {
+  const [epochInfo, { stakeAccountOrErr, stakeAccountLamports }, stakeHistory] = await Promise.all([
+    connection.getEpochInfo(),
+
+    (async () => {
+      const stakeAccount = await connection.getParsedAccountInfo(stakeAddress);
+      if (stakeAccount === null || stakeAccount.value === null) {
+        throw new Error("Account not found");
+      }
+      const stakeAccountOrErr =
+        "parsed" in stakeAccount.value.data
+          ? tryParseAsStakeAccount(stakeAccount.value.data)
+          : undefined;
+
+      return { stakeAccountOrErr, stakeAccountLamports: stakeAccount.value.lamports };
+    })(),
+
+    (async () => {
+      const stakeHistoryAccount = await connection.getParsedAccountInfo(
+        SYSVAR_STAKE_HISTORY_PUBKEY,
+      );
+      if (stakeHistoryAccount.value === null || !("parsed" in stakeHistoryAccount.value.data)) {
+        throw new Error("StakeHistory not found");
+      }
+      return stakeHistoryAccount.value.data.parsed.info.map((entry: any) => {
+        return parseStakeHistoryEntry({ epoch: entry.epoch, ...entry.stakeHistory });
+      });
+    })(),
+  ]);
+
+  if (stakeAccountOrErr instanceof Error) throw stakeAccountOrErr;
+
+  const { effective, activating, deactivating } = stakeAccountOrErr?.stake
+    ? getStakeActivatingAndDeactivating(
+        stakeAccountOrErr.stake.delegation,
+        BigNumber(epochInfo.epoch),
+        stakeHistory,
+      )
+    : {
+        effective: BigNumber(0),
+        activating: BigNumber(0),
+        deactivating: BigNumber(0),
+      };
+
+  const state = getStakeActivationState({ effective, activating, deactivating });
+  const inactive = BigNumber(stakeAccountLamports)
+    .minus(effective)
+    .minus(stakeAccountOrErr?.meta.rentExemptReserve || 0);
+
+  return {
+    state,
+    active: effective.toNumber(),
+    inactive: inactive.toNumber(),
+  };
+}

--- a/libs/coin-modules/coin-solana/src/api/chain/validators/bignum.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/validators/bignum.ts
@@ -1,7 +1,12 @@
-import { coerce, instance, string } from "superstruct";
+import { coerce, instance, number, string } from "superstruct";
 import { BigNumber } from "bignumber.js";
 
 export const BigNumFromString = coerce(instance(BigNumber), string(), value => {
   if (typeof value === "string") return new BigNumber(value, 10);
+  throw new Error("invalid big num");
+});
+
+export const BigNumFromNumber = coerce(instance(BigNumber), number(), value => {
+  if (typeof value === "number") return new BigNumber(value, 10);
   throw new Error("invalid big num");
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:**
  - Delegations table

### 📝 Description
Multiple RPC endpoints scheduled to be removed on Solana due to transition to Agave 2.0 on Mainnet. See [transition guide](https://github.com/anza-xyz/agave/wiki/Agave-v2.0-Transition-Guide#step-2-review-removed-rpc-endpoints-and-sdk-elements). 
This PR replaces outdated `GetStakeActivation` endpoint with a [solution](https://github.com/solana-developers/solana-rpc-get-stake-activation) provided by Solana team.

### Screenshots
![image](https://github.com/user-attachments/assets/627a5f6f-4e02-4c5b-8e3d-7982007c6cc7)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
