### PR TITLE
:sparkles:(lld): add hide inscription feature

### DIFF
--- a/.changeset/sweet-impalas-destroy.md
+++ b/.changeset/sweet-impalas-destroy.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-nft-react": patch
+"@ledgerhq/live-nft": patch
+---
+
+Add the hide inscription feature for ordinals

--- a/apps/ledger-live-desktop/src/newArch/components/ContextMenu/CollectibleContextMenu.tsx
+++ b/apps/ledger-live-desktop/src/newArch/components/ContextMenu/CollectibleContextMenu.tsx
@@ -16,6 +16,8 @@ type Props = {
   leftClick?: boolean;
   goBackToAccount?: boolean;
   typeOfCollectible: CollectibleType;
+  inscriptionId?: string;
+  inscriptionName?: string;
 };
 
 export default function CollectionContextMenu({
@@ -26,6 +28,8 @@ export default function CollectionContextMenu({
   leftClick,
   goBackToAccount = false,
   typeOfCollectible,
+  inscriptionId,
+  inscriptionName,
 }: Props) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -36,6 +40,8 @@ export default function CollectionContextMenu({
     collectionName,
     collectionAddress,
     account,
+    inscriptionId,
+    inscriptionName,
     dispatch,
     setDrawer,
     history,

--- a/apps/ledger-live-desktop/src/newArch/components/ContextMenu/createContextMenuItems.ts
+++ b/apps/ledger-live-desktop/src/newArch/components/ContextMenu/createContextMenuItems.ts
@@ -12,6 +12,8 @@ type Props = {
   collectionAddress: string;
   collectionName?: string | null;
   goBackToAccount?: boolean;
+  inscriptionId?: string;
+  inscriptionName?: string;
   typeOfCollectible: CollectibleType;
   dispatch: Dispatch;
   setDrawer: () => void;
@@ -24,6 +26,8 @@ export function createContextMenuItems({
   collectionName,
   collectionAddress,
   account,
+  inscriptionId,
+  inscriptionName,
   dispatch,
   setDrawer,
   history,
@@ -41,6 +45,28 @@ export function createContextMenuItems({
             openModal("MODAL_HIDE_NFT_COLLECTION", {
               collectionName: collectionName ?? collectionAddress,
               collectionId: `${account.id}|${collectionAddress}`,
+              onClose: () => {
+                if (goBackToAccount) {
+                  setDrawer();
+                  history.replace(`account/${account.id}`);
+                }
+              },
+            }),
+          ),
+      },
+    ];
+  }
+  if (typeOfCollectible === CollectibleTypeEnum.Inscriptions) {
+    return [
+      {
+        key: "hide",
+        label: t("ordinals.inscriptions.hide"),
+        Icon: IconsLegacy.NoneMedium,
+        callback: () =>
+          dispatch(
+            openModal("MODAL_HIDE_INSCRIPTION", {
+              inscriptionName: String(inscriptionName),
+              inscriptionId: String(inscriptionId),
               onClose: () => {
                 if (goBackToAccount) {
                   setDrawer();

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/DetailsDrawer/Actions.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/DetailsDrawer/Actions.tsx
@@ -5,23 +5,33 @@ import { useTranslation } from "react-i18next";
 import { ExternalViewerButton } from "LLD/features/Collectibles/components/DetailDrawer/components";
 import { SimpleHashNft } from "@ledgerhq/live-nft/api/types";
 import { Account } from "@ledgerhq/types-live";
+import { useHideInscriptions } from "LLD/features/Collectibles/hooks/useHideInscriptions";
 
 type ActionsProps = {
   inscription: SimpleHashNft;
   account: Account;
+  onModalClose: () => void;
 };
 
-const Actions: React.FC<ActionsProps> = ({ inscription, account }) => {
+const Actions: React.FC<ActionsProps> = ({ inscription, account, onModalClose }) => {
   const { t } = useTranslation();
+  const { openConfirmHideInscriptionModal } = useHideInscriptions();
+
+  const onClick = () => {
+    openConfirmHideInscriptionModal(
+      inscription.name || inscription.contract.name || "",
+      String(inscription.extra_metadata?.ordinal_details?.inscription_id),
+      onModalClose,
+    );
+  };
+
   return (
     <Flex alignItems="center" columnGap={12}>
       <Button
         outlineGrey
         style={{ flex: 1, justifyContent: "center" }}
         my={4}
-        onClick={() => {
-          /* TODO */
-        }}
+        onClick={onClick}
         center
       >
         <Flex columnGap={1}>

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/DetailsDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/DetailsDrawer/index.tsx
@@ -47,7 +47,7 @@ const View: React.FC<ViewProps> = ({ data, rareSat, account, inscription, onClos
       </DetailDrawer.Subtitle>
     )}
     <DetailDrawer.Actions>
-      <Actions account={account} inscription={inscription} />
+      <Actions account={account} onModalClose={onClose} inscription={inscription} />
     </DetailDrawer.Actions>
   </DetailDrawer>
 );

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/HideModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/HideModal/Body.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Text } from "@ledgerhq/react-ui";
+import Box from "~/renderer/components/Box";
+import { Trans, useTranslation } from "react-i18next";
+import ModalBody from "~/renderer/components/Modal/ModalBody";
+import Button from "~/renderer/components/Button";
+import { useHideInscriptions } from "LLD/features/Collectibles/hooks/useHideInscriptions";
+
+const Body = ({
+  onClose,
+  inscriptionName,
+  inscriptionId,
+}: {
+  onClose: () => void;
+  inscriptionName: string;
+  inscriptionId: string;
+}) => {
+  const { t } = useTranslation();
+  const { hideInscription } = useHideInscriptions();
+
+  const confirmHide = () => {
+    onClose();
+    hideInscription(inscriptionId);
+  };
+
+  return (
+    <ModalBody
+      onClose={onClose}
+      title={t("ordinals.inscriptions.modal.title")}
+      render={() => (
+        <Box>
+          <Box
+            color="palette.text.shade60"
+            mb={2}
+            mt={3}
+            alignItems={"center"}
+            textAlign={"center"}
+          >
+            <Trans
+              i18nKey="ordinals.inscriptions.modal.desc"
+              t={t}
+              values={{ inscriptionName }}
+              components={[<Text key={1} ff="Inter|SemiBold" alignSelf={"center"} />]}
+            />
+          </Box>
+        </Box>
+      )}
+      renderFooter={() => (
+        <Box horizontal alignItems="center" justifyContent="flex-end" flow={2}>
+          <Button onClick={onClose}>{t("common.cancel")}</Button>
+          <Button data-testid="modal-confirm-button" onClick={confirmHide} primary>
+            {t("ordinals.inscriptions.hide")}
+          </Button>
+        </Box>
+      )}
+    />
+  );
+};
+export default Body;

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/HideModal/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/HideModal/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import Modal from "~/renderer/components/Modal";
+import Body from "./Body";
+
+const HideNftCollectionModal = () => (
+  <Modal
+    name="MODAL_HIDE_INSCRIPTION"
+    centered
+    render={({ data, onClose }) => (
+      <Body
+        inscriptionName={data.inscriptionName}
+        inscriptionId={data.inscriptionId}
+        onClose={() => {
+          onClose?.();
+          data?.onClose?.();
+        }}
+      />
+    )}
+  />
+);
+export default HideNftCollectionModal;

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/Item/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/Item/index.tsx
@@ -4,10 +4,14 @@ import TableRow from "LLD/features/Collectibles/components/Collection/TableRow";
 import { GroupedNftOrdinals } from "@ledgerhq/live-nft-react/index";
 import { findCorrespondingSat } from "LLD/features/Collectibles/utils/findCorrespondingSat";
 import { processRareSat } from "../helpers";
+import { CollectibleTypeEnum } from "LLD/features/Collectibles/types/enum/Collectibles";
+import { BitcoinAccount } from "@ledgerhq/coin-bitcoin/lib/types";
+import CollectionContextMenu from "LLD/components/ContextMenu/CollectibleContextMenu";
 
 type ItemProps = {
   isLoading: boolean;
   inscriptionsGroupedWithRareSats: GroupedNftOrdinals[];
+  account: BitcoinAccount;
 } & InscriptionsItemProps;
 
 const Item: React.FC<ItemProps> = ({
@@ -17,6 +21,7 @@ const Item: React.FC<ItemProps> = ({
   media,
   nftId,
   inscriptionsGroupedWithRareSats,
+  account,
   onClick,
 }) => {
   const correspondingRareSat = findCorrespondingSat(inscriptionsGroupedWithRareSats, nftId);
@@ -25,15 +30,23 @@ const Item: React.FC<ItemProps> = ({
   }, [correspondingRareSat]);
 
   return (
-    <TableRow
-      isLoading={isLoading}
-      tokenName={tokenName}
-      collectionName={collectionName}
-      tokenIcons={rareSat?.icons || []}
-      media={media}
-      rareSatName={rareSat?.names || []}
-      onClick={onClick}
-    />
+    <CollectionContextMenu
+      account={account}
+      collectionAddress={nftId}
+      typeOfCollectible={CollectibleTypeEnum.Inscriptions}
+      inscriptionId={nftId}
+      inscriptionName={tokenName}
+    >
+      <TableRow
+        isLoading={isLoading}
+        tokenName={tokenName}
+        collectionName={collectionName}
+        tokenIcons={rareSat?.icons || []}
+        media={media}
+        rareSatName={rareSat?.names || []}
+        onClick={onClick}
+      />
+    </CollectionContextMenu>
   );
 };
 

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/helpers.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/helpers.ts
@@ -7,7 +7,7 @@ export function getInscriptionsData(
 ) {
   return inscriptions.map(item => ({
     tokenName: item.name || item.contract.name || "",
-    nftId: item.nft_id,
+    nftId: String(item.extra_metadata?.ordinal_details?.inscription_id),
     collectionName: item.collection.name,
     media: {
       uri: item.image_url || item.previews?.image_small_url,

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/index.tsx
@@ -14,12 +14,14 @@ import { CollectibleTypeEnum } from "LLD/features/Collectibles/types/enum/Collec
 import Button from "~/renderer/components/Button";
 import { useTranslation } from "react-i18next";
 import { GroupedNftOrdinals } from "@ledgerhq/live-nft-react/index";
+import { BitcoinAccount } from "@ledgerhq/coin-bitcoin/lib/types";
 
 type ViewProps = ReturnType<typeof useInscriptionsModel> & {
   isLoading: boolean;
   isError: boolean;
   error: Error | null;
   inscriptionsGroupedWithRareSats: GroupedNftOrdinals[];
+  account: BitcoinAccount;
   onReceive: () => void;
 };
 
@@ -29,6 +31,7 @@ type Props = {
   isError: boolean;
   error: Error | null;
   inscriptionsGroupedWithRareSats: GroupedNftOrdinals[];
+  account: BitcoinAccount;
   onReceive: () => void;
   onInscriptionClick: (inscription: SimpleHashNft) => void;
 };
@@ -40,6 +43,7 @@ const View: React.FC<ViewProps> = ({
   inscriptions,
   error,
   inscriptionsGroupedWithRareSats,
+  account,
   onShowMore,
   onReceive,
 }) => {
@@ -57,6 +61,7 @@ const View: React.FC<ViewProps> = ({
         {hasInscriptions &&
           inscriptions.map((item, index) => (
             <Item
+              account={account}
               key={index}
               isLoading={isLoading}
               inscriptionsGroupedWithRareSats={inscriptionsGroupedWithRareSats}
@@ -85,6 +90,7 @@ const Inscriptions: React.FC<Props> = ({
   isError,
   error,
   inscriptionsGroupedWithRareSats,
+  account,
   onReceive,
   onInscriptionClick,
 }) => (
@@ -92,6 +98,7 @@ const Inscriptions: React.FC<Props> = ({
     isLoading={isLoading}
     isError={isError}
     error={error}
+    account={account}
     onReceive={onReceive}
     inscriptionsGroupedWithRareSats={inscriptionsGroupedWithRareSats}
     {...useInscriptionsModel({ inscriptions, onInscriptionClick })}

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/useInscriptionsModel.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/components/Inscriptions/useInscriptionsModel.tsx
@@ -22,11 +22,17 @@ export const useInscriptionsModel = ({ inscriptions, onInscriptionClick }: Props
     useState<InscriptionsItemProps[]>(initialDisplayedObjects);
 
   useEffect(() => {
-    if (displayedObjects.length === 0) {
-      if (items.length > 3) setDisplayShowMore(true);
+    const filteredDisplayedObjects = displayedObjects.filter(displayedObject =>
+      items.some(item => item.nftId === displayedObject.nftId),
+    );
+    if (filteredDisplayedObjects.length !== displayedObjects.length) {
+      setDisplayedObjects(items.slice(0, filteredDisplayedObjects.length + 1));
+    } else if (displayedObjects.length === 0 && items.length > 3) {
+      setDisplayShowMore(true);
       setDisplayedObjects(items.slice(0, 3));
     }
-  }, [items, displayedObjects.length]);
+    if (displayedObjects.length === items.length) setDisplayShowMore(false);
+  }, [items, displayedObjects]);
 
   const onShowMore = () => {
     setDisplayedObjects(prevDisplayedObjects => {

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/screens/Account/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/screens/Account/index.tsx
@@ -36,6 +36,7 @@ const View: React.FC<ViewProps> = ({
       onReceive={onReceive}
       onInscriptionClick={onInscriptionClick}
       inscriptionsGroupedWithRareSats={inscriptionsGroupedWithRareSats}
+      account={account}
     />
     <RareSats rareSats={rareSats} onReceive={onReceive} {...rest} />
     <DiscoveryDrawer isOpen={isDrawerOpen} onClose={handleDrawerClose} />

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/screens/Account/useBitcoinAccountModel.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Ordinals/screens/Account/useBitcoinAccountModel.ts
@@ -7,6 +7,7 @@ import { openModal } from "~/renderer/actions/modals";
 import { setHasSeenOrdinalsDiscoveryDrawer } from "~/renderer/actions/settings";
 import { hasSeenOrdinalsDiscoveryDrawerSelector } from "~/renderer/reducers/settings";
 import { findCorrespondingSat } from "LLD/features/Collectibles/utils/findCorrespondingSat";
+import { useHideInscriptions } from "LLD/features/Collectibles/hooks/useHideInscriptions";
 
 interface Props {
   account: BitcoinAccount;
@@ -14,6 +15,7 @@ interface Props {
 
 export const useBitcoinAccountModel = ({ account }: Props) => {
   const dispatch = useDispatch();
+
   const hasSeenDiscoveryDrawer = useSelector(hasSeenOrdinalsDiscoveryDrawerSelector);
   const [selectedInscription, setSelectedInscription] = useState<SimpleHashNft | null>(null);
   const [correspondingRareSat, setCorrespondingRareSat] = useState<
@@ -24,6 +26,8 @@ export const useBitcoinAccountModel = ({ account }: Props) => {
     account,
   });
 
+  const { filterInscriptions } = useHideInscriptions();
+  const filteredInscriptions = filterInscriptions(inscriptions);
   const [isDrawerOpen, setIsDrawerOpen] = useState(!hasSeenDiscoveryDrawer);
 
   useEffect(() => {
@@ -56,7 +60,7 @@ export const useBitcoinAccountModel = ({ account }: Props) => {
 
   return {
     rareSats,
-    inscriptions,
+    inscriptions: filteredInscriptions,
     rest,
     isDrawerOpen,
     selectedInscription,

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/__integration__/bitcoinPage.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/__integration__/bitcoinPage.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, waitFor } from "tests/testUtils";
 import { BitcoinPage } from "./shared";
 import { openURL } from "~/renderer/linking";
 import { DeviceModelId } from "@ledgerhq/devices";
+import { INITIAL_STATE as INITIAL_STATE_SETTINGS } from "~/renderer/reducers/settings";
 
 jest.mock(
   "electron",
@@ -22,20 +23,22 @@ describe("displayBitcoinPage", () => {
     const { user } = render(<BitcoinPage />, {
       initialState: {
         settings: {
+          ...INITIAL_STATE_SETTINGS,
           hasSeenOrdinalsDiscoveryDrawer: true,
           devicesModelList: [DeviceModelId.stax, DeviceModelId.europa],
+          hiddenOrdinalsAsset: [],
         },
       },
     });
 
     await waitFor(() => expect(screen.getByText(/the great war #3695/i)).toBeVisible());
-    await waitFor(() => expect(screen.getByText(/see more inscriptions/i)).toBeVisible());
+    expect(screen.getByText(/see more inscriptions/i)).toBeVisible();
     await user.click(screen.getByText(/see more inscriptions/i));
     await user.click(screen.getByText(/see more inscriptions/i));
-    await waitFor(() => expect(screen.getByText(/bitcoin puppet #71/i)).toBeVisible());
-    await waitFor(() => expect(screen.queryAllByTestId(/raresaticon-pizza-0/i)).toHaveLength(2));
-    await user.hover(screen.queryAllByTestId(/raresaticon-pizza-0/i)[0]);
-    await waitFor(() => expect(screen.getByText(/papa john's pizza/i)).toBeVisible());
+    expect(screen.getByText(/bitcoin puppet #71/i)).toBeVisible();
+    expect(screen.getByTestId(/raresaticon-pizza-0/i)).toBeVisible();
+    await user.hover(screen.getByTestId(/raresaticon-pizza-0/i));
+    expect(screen.getByText(/papa john's pizza/i)).toBeVisible();
   });
 
   it("should open discovery drawer when it is the first time feature is activated", async () => {
@@ -50,16 +53,34 @@ describe("displayBitcoinPage", () => {
     const { user } = render(<BitcoinPage />, {
       initialState: {
         settings: {
+          ...INITIAL_STATE_SETTINGS,
           hasSeenOrdinalsDiscoveryDrawer: true,
           devicesModelList: [DeviceModelId.stax, DeviceModelId.europa],
+          hiddenOrdinalsAsset: [],
         },
       },
     });
 
     await waitFor(() => expect(screen.getByText(/the great war #3695/i)).toBeVisible());
     await user.click(screen.getByText(/the great war #3695/i));
-    await expect(screen.getByText(/hide/i)).toBeVisible();
-    // sat name
-    await expect(screen.getByText(/dlngbapxjdv/i)).toBeVisible();
+    expect(screen.getByText(/hide/i)).toBeVisible();
+    expect(screen.getByText(/dlngbapxjdv/i)).toBeVisible();
+  });
+
+  it("should open context menu", async () => {
+    const { user } = render(<BitcoinPage />, {
+      initialState: {
+        settings: {
+          ...INITIAL_STATE_SETTINGS,
+          hasSeenOrdinalsDiscoveryDrawer: true,
+          devicesModelList: [DeviceModelId.stax, DeviceModelId.europa],
+          hiddenOrdinalsAsset: [],
+        },
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText(/the great war #3695/i)).toBeVisible());
+    await user.pointer({ keys: "[MouseRight>]", target: screen.getByText(/the great war #3695/i) });
+    expect(screen.getByText(/hide inscription/i));
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/hooks/useHideInscriptions.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/hooks/useHideInscriptions.ts
@@ -1,0 +1,48 @@
+import { SimpleHashNft } from "@ledgerhq/live-nft/api/types";
+import { useDispatch, useSelector } from "react-redux";
+import { openModal } from "~/renderer/actions/modals";
+import { hideOrdinalsAsset, unhideOrdinalsAsset } from "~/renderer/actions/settings";
+import { hiddenOrdinalsAssetSelector } from "~/renderer/reducers/settings";
+
+export const useHideInscriptions = () => {
+  const dispatch = useDispatch();
+  const hiddenOrdinalAssets = useSelector(hiddenOrdinalsAssetSelector);
+
+  const filterInscriptions = (inscriptions: SimpleHashNft[]) => {
+    return inscriptions.filter(inscription => {
+      return !hiddenOrdinalAssets.includes(
+        String(inscription.extra_metadata?.ordinal_details?.inscription_id),
+      );
+    });
+  };
+
+  const hideInscription = (inscriptionId: string) => {
+    dispatch(hideOrdinalsAsset(inscriptionId));
+  };
+
+  const unHideInscription = (inscriptionId: string) => {
+    dispatch(unhideOrdinalsAsset(inscriptionId));
+  };
+
+  const openConfirmHideInscriptionModal = (
+    inscriptionName: string,
+    inscriptionId: string,
+    onModalClose: () => void,
+  ) => {
+    dispatch(
+      openModal("MODAL_HIDE_INSCRIPTION", {
+        inscriptionName,
+        inscriptionId,
+        onClose: () => onModalClose(),
+      }),
+    );
+  };
+
+  return {
+    filterInscriptions,
+    hideInscription,
+    unHideInscription,
+    openConfirmHideInscriptionModal,
+    hiddenOrdinalAssets,
+  };
+};

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -218,6 +218,11 @@ export const hideNftCollection = (collectionId: string) => ({
   type: "HIDE_NFT_COLLECTION",
   payload: collectionId,
 });
+export const hideOrdinalsAsset = (inscriptionId: string) => ({
+  type: "HIDE_ORDINALS_ASSET",
+  payload: inscriptionId,
+});
+
 export const setLastSeenCustomImage = (lastSeenCustomImage: {
   imageSize: number;
   imageHash: string;
@@ -246,6 +251,10 @@ export const showToken = (tokenId: string) => ({
 export const unhideNftCollection = (collectionId: string) => ({
   type: "UNHIDE_NFT_COLLECTION",
   payload: collectionId,
+});
+export const unhideOrdinalsAsset = (inscriptionId: string) => ({
+  type: "UNHIDE_ORDINALS_ASSET",
+  payload: inscriptionId,
 });
 type FetchSettings = (a: SettingsState) => (a: Dispatch<Action<"FETCH_SETTINGS">>) => void;
 export const fetchSettings: FetchSettings = (settings: SettingsState) => dispatch => {

--- a/apps/ledger-live-desktop/src/renderer/modals/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/index.ts
@@ -30,6 +30,7 @@ import MODAL_PROTECT_DISCOVER from "./ProtectDiscover";
 import MODAL_CONFIRM from "./ConfirmModal";
 import MODAL_ERROR from "./ErrorModal";
 import MODAL_VAULT_SIGNER from "./VaultSigner";
+import MODAL_HIDE_INSCRIPTION from "LLD/features/Collectibles/Ordinals/components/Inscriptions/HideModal";
 
 import MODAL_WALLET_SYNC_DEBUGGER from "./WalletSyncDebugger";
 import MODAL_SIMPLEHASH_TOOLS from "./SimpleHashTools";
@@ -63,6 +64,7 @@ const globalModals: GlobalModals = {
   MODAL_CREATE_LOCAL_APP,
   MODAL_WALLET_SYNC_DEBUGGER,
   MODAL_SIMPLEHASH_TOOLS,
+  MODAL_HIDE_INSCRIPTION,
 
   // Platform
   MODAL_PLATFORM_EXCHANGE_START,

--- a/apps/ledger-live-desktop/src/renderer/modals/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/types.ts
@@ -88,6 +88,11 @@ export type GlobalModalData = {
   MODAL_CONFIRM: ConfirmProps;
   MODAL_ERROR: ErrorProps;
   MODAL_VAULT_SIGNER: undefined;
+  MODAL_HIDE_INSCRIPTION: {
+    inscriptionName: string;
+    inscriptionId: string;
+    onClose?: () => void;
+  };
 };
 
 /**

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -82,6 +82,7 @@ export type SettingsState = {
   starredAccountIds?: string[];
   blacklistedTokenIds: string[];
   hiddenNftCollections: string[];
+  hiddenOrdinalsAsset: string[];
   deepLinkUrl: string | undefined | null;
   lastSeenCustomImage: {
     size: number;
@@ -181,6 +182,7 @@ export const INITIAL_STATE: SettingsState = {
   latestFirmware: null,
   blacklistedTokenIds: [],
   hiddenNftCollections: [],
+  hiddenOrdinalsAsset: [],
   deepLinkUrl: null,
   firstTimeLend: false,
   showClearCacheBanner: false,
@@ -226,6 +228,8 @@ type HandlersPayloads = {
   BLACKLIST_TOKEN: string;
   UNHIDE_NFT_COLLECTION: string;
   HIDE_NFT_COLLECTION: string;
+  UNHIDE_ORDINALS_ASSET: string;
+  HIDE_ORDINALS_ASSET: string;
   LAST_SEEN_DEVICE_INFO: {
     lastSeenDevice: DeviceModelInfo;
     latestFirmware: FirmwareUpdateContext;
@@ -331,6 +335,20 @@ const handlers: SettingsHandlers = {
     return {
       ...state,
       hiddenNftCollections: [...collections, collectionId],
+    };
+  },
+  UNHIDE_ORDINALS_ASSET: (state, { payload: inscriptionId }) => {
+    const ids = state.hiddenOrdinalsAsset;
+    return {
+      ...state,
+      hiddenOrdinalsAsset: ids.filter(id => id !== inscriptionId),
+    };
+  },
+  HIDE_ORDINALS_ASSET: (state, { payload: inscriptionId }) => {
+    const collections = state.hiddenOrdinalsAsset;
+    return {
+      ...state,
+      hiddenOrdinalsAsset: [...collections, inscriptionId],
     };
   },
   LAST_SEEN_DEVICE_INFO: (state, { payload }) => ({
@@ -743,6 +761,7 @@ export const enableLearnPageStagingUrlSelector = (state: State) =>
   state.settings.enableLearnPageStagingUrl;
 export const blacklistedTokenIdsSelector = (state: State) => state.settings.blacklistedTokenIds;
 export const hiddenNftCollectionsSelector = (state: State) => state.settings.hiddenNftCollections;
+export const hiddenOrdinalsAssetSelector = (state: State) => state.settings.hiddenOrdinalsAsset;
 export const hasCompletedOnboardingSelector = (state: State) =>
   state.settings.hasCompletedOnboarding || getEnv("SKIP_ONBOARDING");
 export const dismissedBannersSelector = (state: State) => state.settings.dismissedBanners || [];

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/components/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/components/Row.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { HiddenNftCollectionRowContainer, IconContainer } from "./styledComponents";
+import { Flex, Icons } from "@ledgerhq/react-ui";
+import { Media } from "LLD/features/Collectibles/components";
+import Skeleton from "~/renderer/components/Nft/Skeleton";
+import Text from "~/renderer/components/Text";
+import { useRowModel } from "./useRowModel";
+
+type Props = {
+  inscriptionId: string;
+  unHideInscription: () => void;
+};
+
+type ViewProps = ReturnType<typeof useRowModel>;
+
+function View({ unHideInscription, isLoading, previewUri, inscriptionName }: ViewProps) {
+  return (
+    <HiddenNftCollectionRowContainer>
+      <Flex flex={1}>
+        <Skeleton show={isLoading} minHeight={32} width={132}>
+          <Flex flex={1} alignItems="center">
+            <Media
+              mediaFormat="preview"
+              isLoading={isLoading}
+              useFallback={true}
+              contentType="image"
+              mediaType="image"
+              uri={previewUri}
+              size={32}
+            />
+            <Text
+              style={{
+                marginLeft: 10,
+                flex: 1,
+              }}
+              ff="Inter|Medium"
+              color="palette.text.shade100"
+              fontSize={3}
+            >
+              {inscriptionName}
+            </Text>
+          </Flex>
+        </Skeleton>
+      </Flex>
+      <IconContainer onClick={unHideInscription}>
+        <Icons.Close size="S" />
+      </IconContainer>
+    </HiddenNftCollectionRowContainer>
+  );
+}
+
+export const Row = ({ inscriptionId, unHideInscription }: Props) => {
+  return <View {...useRowModel({ inscriptionId, unHideInscription })} />;
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/components/styledComponents.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/components/styledComponents.ts
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+import Box from "~/renderer/components/Box";
+
+export const IconContainer = styled.div`
+  color: ${p => p.theme.colors.palette.text.shade60};
+  text-align: center;
+  &:hover {
+    cursor: pointer;
+    color: ${p => p.theme.colors.palette.text.shade40};
+  }
+`;
+export const HiddenNftCollectionRowContainer = styled(Box).attrs({
+  alignItems: "center",
+  horizontal: true,
+  flow: 1,
+  py: 1,
+})`
+  margin: 0px;
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.colors.palette.text.shade10};
+  }
+  padding: 14px 6px;
+`;
+export const Body = styled(Box)`
+  &:not(:empty) {
+    padding: 0 20px;
+  }
+`;
+
+export const Show = styled(Box).attrs<{ visible?: boolean }>({})<{ visible?: boolean }>`
+  transform: rotate(${p => (p.visible ? 0 : 270)}deg);
+`;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/components/useRowModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/components/useRowModel.ts
@@ -1,0 +1,19 @@
+import { useFetchOrdinalByTokenId } from "@ledgerhq/live-nft-react";
+
+type Props = {
+  inscriptionId: string;
+  unHideInscription: () => void;
+};
+export const useRowModel = ({ inscriptionId, unHideInscription }: Props) => {
+  const { data, isLoading } = useFetchOrdinalByTokenId(inscriptionId);
+
+  const inscriptionName = data?.name || data?.contract.name || inscriptionId;
+  const previewUri = data?.previews?.image_large_url || data?.image_url;
+
+  return {
+    inscriptionName,
+    previewUri,
+    isLoading,
+    unHideInscription,
+  };
+};

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/index.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import useHiddenInscriptionsModel from "./useHiddenInscriptionsModel";
+import { useTranslation } from "react-i18next";
+import { SettingsSection as Section, SettingsSectionRow as Row } from "../../../SettingsSection";
+import Box from "~/renderer/components/Box";
+import Track from "~/renderer/analytics/Track";
+import { Show, Body } from "./components/styledComponents";
+import { Row as HiddenInscriptionRow } from "./components/Row";
+import { Icons } from "@ledgerhq/react-ui";
+type ViewProps = ReturnType<typeof useHiddenInscriptionsModel>;
+
+function View({
+  hiddenOrdinalAssets,
+  sectionVisible,
+  unHideInscription,
+  toggleCurrencySection,
+}: ViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Section
+      style={{
+        flowDirection: "column",
+      }}
+    >
+      <Track onUpdate event="HiddenOrdinalsAssets dropdown" opened={sectionVisible} />
+      <Row
+        title={t("settings.accounts.hiddenOrdinalsAsset.title")}
+        desc={t("settings.accounts.hiddenOrdinalsAsset.desc")}
+        onClick={toggleCurrencySection}
+        contentContainerStyle={
+          hiddenOrdinalAssets.length
+            ? {
+                cursor: "pointer",
+              }
+            : undefined
+        }
+      >
+        {hiddenOrdinalAssets.length ? (
+          <Box horizontal alignItems="center">
+            <Box ff="Inter" fontSize={3} mr={2}>
+              {t("settings.accounts.hiddenOrdinalsAsset.count", {
+                count: hiddenOrdinalAssets.length,
+              })}
+            </Box>
+            <Show visible={sectionVisible}>
+              <Icons.ChevronDown size="S" />
+            </Show>
+          </Box>
+        ) : null}
+      </Row>
+
+      {sectionVisible && (
+        <Body>
+          {hiddenOrdinalAssets.map(inscriptionId => {
+            return (
+              <HiddenInscriptionRow
+                key={inscriptionId}
+                unHideInscription={() => unHideInscription(inscriptionId)}
+                inscriptionId={inscriptionId}
+              />
+            );
+          })}
+        </Body>
+      )}
+    </Section>
+  );
+}
+
+const HiddenInscriptions = () => {
+  return <View {...useHiddenInscriptionsModel()} />;
+};
+
+export default HiddenInscriptions;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/useHiddenInscriptionsModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenInscriptions/useHiddenInscriptionsModel.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+import { useHideInscriptions } from "~/newArch/features/Collectibles/hooks/useHideInscriptions";
+
+const useHiddenInscriptionsModel = () => {
+  const { hiddenOrdinalAssets, unHideInscription } = useHideInscriptions();
+  const [sectionVisible, setSectionVisible] = useState(false);
+
+  const toggleCurrencySection = useCallback(() => {
+    setSectionVisible(prevState => !prevState);
+  }, [setSectionVisible]);
+
+  return {
+    hiddenOrdinalAssets,
+    sectionVisible,
+    unHideInscription,
+    toggleCurrencySection,
+  };
+};
+
+export default useHiddenInscriptionsModel;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenNFTCollections.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenNFTCollections.tsx
@@ -6,16 +6,15 @@ import { useNftMetadata, useNftCollectionMetadata } from "@ledgerhq/live-nft-rea
 import { SettingsSection as Section, SettingsSectionRow as Row } from "../../SettingsSection";
 import Text from "~/renderer/components/Text";
 import Box from "~/renderer/components/Box";
-import IconCross from "~/renderer/icons/Cross";
 import Media from "~/renderer/components/Nft/Media";
 import Skeleton from "~/renderer/components/Nft/Skeleton";
 import { unhideNftCollection } from "~/renderer/actions/settings";
 import { hiddenNftCollectionsSelector } from "~/renderer/reducers/settings";
 import { accountSelector } from "~/renderer/reducers/accounts";
 import Track from "~/renderer/analytics/Track";
-import IconAngleDown from "~/renderer/icons/AngleDown";
 import { State } from "~/renderer/reducers";
 import { NFTMetadata } from "@ledgerhq/types-live";
+import { Icons } from "@ledgerhq/react-ui";
 
 const HiddenNftCollectionRow = ({
   contractAddress,
@@ -69,7 +68,7 @@ const HiddenNftCollectionRow = ({
         {collectionMetadata?.tokenName || contractAddress}
       </Text>
       <IconContainer onClick={onUnhide}>
-        <IconCross size={16} />
+        <Icons.Close size="S" />
       </IconContainer>
     </HiddenNftCollectionRowContainer>
   );
@@ -115,7 +114,7 @@ export default function HiddenNftCollections() {
               })}
             </Box>
             <Show visible={sectionVisible}>
-              <IconAngleDown size={24} />
+              <Icons.ChevronDown size="S" />
             </Show>
           </Box>
         ) : null}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/index.tsx
@@ -8,8 +8,12 @@ import SectionExport from "./Export";
 import Currencies from "./Currencies";
 import BlacklistedTokens from "./BlacklistedTokens";
 import HiddenNftCollections from "./HiddenNFTCollections";
+import HiddenInscriptions from "./HiddenInscriptions";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 export default function SectionAccounts() {
   const { t } = useTranslation();
+  const ordinalsFeatureFlag = useFeature("lldnewArchOrdinals");
+  const isOrdinalsEnabled = ordinalsFeatureFlag?.enabled;
 
   return (
     <Body>
@@ -25,6 +29,7 @@ export default function SectionAccounts() {
       <FilterTokenOperationsZeroAmount />
       <BlacklistedTokens />
       <HiddenNftCollections />
+      {isOrdinalsEnabled && <HiddenInscriptions />}
       <Currencies />
     </Body>
   );

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4354,14 +4354,20 @@
       "tokenBlacklist": {
         "title": "Hidden tokens",
         "desc": "You can hide tokens by going to the parent account then right-clicking on the token and selecting 'Hide token'.",
-        "count": "{{count}} token",
-        "count_plural": "{{count}} tokens"
+        "count": "1 token",
+        "count_other": "{{count}} tokens"
       },
       "hiddenNftCollections": {
         "title": "Hidden NFT Collections",
         "desc": "You can hide NFT Collections by right-clicking on the collection name and selecting 'Hide NFT Collection'.",
-        "count": "{{count}} collection",
-        "count_plural": "{{count}} collections"
+        "count": "1 collection",
+        "count_other": "{{count}} collections"
+      },
+      "hiddenOrdinalsAsset": {
+        "title": "Hidden Inscriptions",
+        "desc": "You can hide Inscription by right-clicking on the inscription and selecting 'Hide Inscription'.",
+        "count": "1 inscription",
+        "count_other": "{{count}} inscriptions"
       },
       "fullNode": {
         "title": "Connect Bitcoin full node",
@@ -6608,6 +6614,11 @@
       "seeMore": "See more inscriptions",
       "empty": "To add Inscriptions, simply send them to your Bitcoin address.",
       "receive": "Receive Inscription",
+      "hide": "Hide Inscription",
+      "modal": {
+        "title": "Hide Inscription",
+        "desc": "This action will hide the following inscription <0>{{inscriptionName}}</0> from your account. You can unhide it at any time from the settings."
+      },
       "discoveryDrawer": {
         "title": "Discover Ordinals",
         "description": "Do you know that you may own valuable rare sats and inscriptions?",

--- a/apps/ledger-live-desktop/tests/testUtils.tsx
+++ b/apps/ledger-live-desktop/tests/testUtils.tsx
@@ -16,6 +16,7 @@ import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import DrawerProvider from "~/renderer/drawers/Provider";
 import { FirebaseFeatureFlagsProvider } from "~/renderer/components/FirebaseFeatureFlags";
 import { getFeature } from "./featureFlags";
+import ContextMenuWrapper from "~/renderer/components/ContextMenu/ContextMenuWrapper";
 
 config.disabled = true;
 
@@ -58,7 +59,9 @@ function render(
               <NftMetadataProvider getCurrencyBridge={getCurrencyBridge}>
                 <StyleProvider selectedPalette="dark">
                   <FirebaseFeatureFlagsProvider getFeature={getFeature}>
-                    <MemoryRouter>{children}</MemoryRouter>
+                    <ContextMenuWrapper>
+                      <MemoryRouter>{children}</MemoryRouter>
+                    </ContextMenuWrapper>
                   </FirebaseFeatureFlagsProvider>
                 </StyleProvider>
               </NftMetadataProvider>

--- a/libs/live-nft-react/src/hooks/__tests__/useFetchOrdinalByTokenId.test.tsx
+++ b/libs/live-nft-react/src/hooks/__tests__/useFetchOrdinalByTokenId.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react";
+import { wrapper } from "../../tools/helperTests";
+import { useQuery } from "@tanstack/react-query";
+import { useFetchOrdinalByTokenId } from "../useFetchOrdinalByTokenId";
+
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useQuery: jest.fn(),
+}));
+
+const mockedInscriptionID = "51fb634f0fefa3441e1a60090d9e292ce1f0803258c2dae818410db4192c89f6i0";
+
+const mockQueryResult = {
+  data: {},
+  isLoading: false,
+  isError: false,
+  fetchNextPage: jest.fn(),
+  hasNextPage: false,
+};
+
+describe("useFetchOrdinals", () => {
+  it("calls useInfiniteQuery with correct arguments", async () => {
+    (useQuery as jest.Mock).mockReturnValue(mockQueryResult);
+
+    renderHook(() => useFetchOrdinalByTokenId(mockedInscriptionID), {
+      wrapper,
+    });
+
+    expect(useQuery).toHaveBeenCalledWith({
+      queryKey: [
+        "FectchOrdinalsByTokenId",
+        "51fb634f0fefa3441e1a60090d9e292ce1f0803258c2dae818410db4192c89f6i0",
+        ["bitcoin"],
+        "0",
+      ],
+      queryFn: expect.any(Function),
+    });
+  });
+});

--- a/libs/live-nft-react/src/hooks/useFetchOrdinalByTokenId.ts
+++ b/libs/live-nft-react/src/hooks/useFetchOrdinalByTokenId.ts
@@ -1,0 +1,21 @@
+import { fetchNftsFromSimpleHashById } from "@ledgerhq/live-nft/api/simplehash";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { OrdinalsChainsEnum } from "./types";
+import { SimpleHashNft } from "@ledgerhq/live-nft/api/types";
+import { NFTS_QUERY_KEY } from "../queryKeys";
+
+export const useFetchOrdinalByTokenId = (
+  contractAddress: string,
+): UseQueryResult<SimpleHashNft, Error> => {
+  const chain = [OrdinalsChainsEnum.INSCRIPTIONS];
+  const tokenId = "0";
+  return useQuery({
+    queryKey: [NFTS_QUERY_KEY.FectchOrdinalsByTokenId, contractAddress, chain, tokenId],
+    queryFn: () =>
+      fetchNftsFromSimpleHashById({
+        chains: chain,
+        contract_address: contractAddress,
+        token_id: tokenId,
+      }),
+  });
+};

--- a/libs/live-nft-react/src/index.ts
+++ b/libs/live-nft-react/src/index.ts
@@ -5,4 +5,5 @@ export * from "./hooks/useNftFloorPrice";
 export * from "./hooks/useRefreshMetadata";
 export * from "./hooks/useCheckSpamScore";
 export * from "./hooks/useFetchOrdinals";
+export * from "./hooks/useFetchOrdinalByTokenId";
 export * from "./hooks/helpers/ordinals";

--- a/libs/live-nft-react/src/queryKeys.ts
+++ b/libs/live-nft-react/src/queryKeys.ts
@@ -4,4 +4,5 @@ export const NFTS_QUERY_KEY = {
   FloorPrice: "FloorPrice",
   CheckSpamScore: "CheckSpamScore",
   FetchOrdinals: "FetchOrdinals",
+  FectchOrdinalsByTokenId: "FectchOrdinalsByTokenId",
 };

--- a/libs/live-nft/src/api/simplehash.ts
+++ b/libs/live-nft/src/api/simplehash.ts
@@ -1,4 +1,4 @@
-import network from "@ledgerhq/live-network/network";
+import network from "@ledgerhq/live-network";
 import {
   SimpleHashRefreshResponse,
   SimpleHashResponse,
@@ -37,7 +37,7 @@ type NftFetchOpts = {
   /**
    * wallet addresses to get NFTs from. separated by a ","
    */
-  addresses: string;
+  addresses?: string;
   /**
    * cursor used to paginate the API
    */
@@ -54,6 +54,14 @@ type NftFetchOpts = {
    * spam filtering threshold, defaults to a constant %
    */
   threshold?: number;
+  /**
+   * token id to look for
+   */
+  token_id?: string;
+  /**
+   * contract address to look for
+   */
+  contract_address?: string;
 };
 const defaultOpts = {
   limit: PAGE_SIZE,
@@ -187,6 +195,20 @@ export async function getSpamScore(opts: CheckSpamScoreOpts): Promise<SimpleHash
       accept: "application/json",
       "content-type": "application/json",
     },
+  });
+
+  return data;
+}
+
+/**
+ * Fetch NFTs for a list of token id and a specific chain
+ * using SimpleHash API.
+ */
+export async function fetchNftsFromSimpleHashById(opts: NftFetchOpts): Promise<SimpleHashResponse> {
+  const { chains, contract_address, token_id } = { ...defaultOpts, ...opts };
+  const { data } = await network<SimpleHashResponse>({
+    method: "GET",
+    url: `${getEnv("SIMPLE_HASH_API_BASE")}/nfts/${chains[0]}/${contract_address}/${token_id}`,
   });
 
   return data;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Settings
  - Ordinals
  -  ledgerhq/live-nft-react, ledgerhq/live-nft

### 📝 Description

Add hide inscription feature for ordis


https://github.com/user-attachments/assets/f89d4d65-3b85-4023-813b-44b0a251b34d


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14293](https://ledgerhq.atlassian.net/browse/LIVE-14293)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14293]: https://ledgerhq.atlassian.net/browse/LIVE-14293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ