### PR TITLE
[LIVE-7357] Feature - Decrease EIP-1559 base fee multiplier

### DIFF
--- a/.changeset/cool-cougars-push.md
+++ b/.changeset/cool-cougars-push.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-env": minor
+"@ledgerhq/coin-evm": minor
+---
+
+Decreasing the base fee multiplier to 27% for the EIP1559 fee system. Based on the spec of EIP1559, it should allow to create blocks which could be included in the next 3 blocks even in awful network situations.

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -338,7 +338,7 @@ const envDefinitions = {
     desc: "minimum priority fee percents allowed compared to network conditions allowed when EIP1559_MINIMUM_FEES_GATE is activated",
   },
   EIP1559_BASE_FEE_MULTIPLIER: {
-    def: 1.5,
+    def: 1.27,
     parser: floatParser,
     desc: "mutiplier for the base fee that is composing the maxFeePerGas property",
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Transactions using EIP-1559 will now only be sure to have enough base fee to be included in the next 3 blocks instead of the next 4 blocks before

### 📝 Description

Ledger Live is using a base fee multiplier to make sure the transactions crafted can be included in X blocks in the future based on the EIP-1559 spec.

Example of the fee system from [Blocknative](https://www.blocknative.com/blog/eip-1559-fees#4):

| Block | Base Fee   | % Full | Increase in Base Fee | Priority Fee specified | Max Fee specified | Gas Price Paid if confirmed |
|-------|------------|--------|----------------------|------------------------|-------------------|-----------------------------|
| 1     | 100.0 GWEI | 100%   | 12.5%                | 2.0                    | 202.0             | 102.0                       |
| 2     | 112.5 GWEI | 100%   | 12.5%                | 2.0                    | 202.0             | 114.5                       |
| 3     | 126.6 GWEI | 100%   | 12.5%                | 2.0                    | 202.0             | 128.6                       |
| 4     | 142.4 GWEI | 100%   | 12.5%                | 2.0                    | 202.0             | 144.4                       |
| 5     | 160.2 GWEI | 100%   | 12.5%                | 2.0                    | 202.0             | 162.2                       |
| 6     | 180.2 GWEI | 100%   | 12.5%                | 2.0                    | 202.0             | 182.2                       |
| 7     | 202.7 GWEI | -      | -                    | 2.0                    | 202.0             | Ineligible                  |

Until now we were having a 50% increase of the base fee which ensured at least 4 blocks even in the worst network conditions, we're decreasing to 27% ensuring 3 blocks now.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-7357


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
