### PR TITLE
[LIVE-14339] Support - Enforce WS version even when bundle without pnpm in the monorepo

### DIFF
--- a/.changeset/tender-icons-impress.md
+++ b/.changeset/tender-icons-impress.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-eth": patch
+---
+
+Force ws version even when bundled without pnpm from the monorepo

--- a/libs/ledgerjs/packages/hw-app-eth/package.json
+++ b/libs/ledgerjs/packages/hw-app-eth/package.json
@@ -63,5 +63,10 @@
     "source-map-support": "^0.5.21",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.4.0"
+  },
+  "overrides": {
+    "@ethersproject/providers": {
+      "ws": "7.5.10"
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no impact

### 📝 Description

`ws` lib has been forced to a `7.5.10` version to fix a CVE in the lib, but it's only enforced when bundled in Ledger Live by pnpm & the monorepo. This should enforce it as well for the simple npm package published.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-14339


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
