### PR TITLE
chore: add --verbose flag to pod install

### DIFF
--- a/.changeset/tough-owls-grin.md
+++ b/.changeset/tough-owls-grin.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+In order to easily monitor and debug futur ios build failures on the CI , we need to add --verbose in the pod install process.

--- a/apps/ledger-live-mobile/scripts/post.mjs
+++ b/apps/ledger-live-mobile/scripts/post.mjs
@@ -140,7 +140,7 @@ BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"`;
   if (os.platform() === "darwin" && !process.env["SKIP_BUNDLE_CHECK"] && !hashesAreEquals) {
     cd("ios");
     try {
-      await $`bundle exec pod install --deployment --repo-update`;
+      await $`bundle exec pod install --deployment --repo-update --verbose`;
       try {
         runHashChecks(true);
       } catch (error) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In order to easily monitor and debug futur ios build failures on the CI , we need to add --verbose in the pod install process.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-14340

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
