### PR TITLE
fix(llc): quitting apps before BLE pairing

### DIFF
--- a/.changeset/dry-socks-reflect.md
+++ b/.changeset/dry-socks-reflect.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Go back to dashboard if app is open during BLE pairing

--- a/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.test.ts
+++ b/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.test.ts
@@ -1,29 +1,52 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { from } from "rxjs";
 import { DeviceModelId } from "@ledgerhq/devices";
 import Transport from "@ledgerhq/hw-transport";
 import { withDevice } from "../../hw/deviceAccess";
 import { getVersion } from "../../device/use-cases/getVersionUseCase";
 import { useBleDevicePairing } from "./useBleDevicePairing";
+import getAppAndVersion from "../../hw/getAppAndVersion";
+import quitApp from "../../hw/quitApp";
+import { isDashboardName } from "../../hw/isDashboardName";
+import { LockedDeviceError } from "@ledgerhq/errors";
 
 jest.mock("../../hw/deviceAccess");
 jest.mock("../../device/use-cases/getVersionUseCase");
+jest.mock("../../hw/getAppAndVersion");
+jest.mock("../../hw/quitApp");
+jest.mock("../../hw/isDashboardName");
 jest.mock("@ledgerhq/hw-transport");
 jest.useFakeTimers();
 
-const mockedGetVersion = jest.mocked(getVersion);
 const mockedWithDevice = jest.mocked(withDevice);
+const mockedGetVersion = jest.mocked(getVersion);
+const mockedGetAppAndVersion = jest.mocked(getAppAndVersion);
+const mockedQuitApp = jest.mocked(quitApp);
+const mockedIsDashboardName = jest.mocked(isDashboardName);
 
-mockedWithDevice.mockReturnValue(job => from(job(new Transport())));
+const transport = new Transport();
+mockedWithDevice.mockReturnValue(job => from(job(transport)));
 
 const aFirmwareInfo = {
   isBootloader: false,
   rawVersion: "",
   targetId: 0,
   mcuVersion: "",
+  flags: Buffer.from([]),
+};
+
+const dashboardInfo = {
+  name: "BOLOS",
+  version: "1.0.0",
+  flags: Buffer.from([]),
+};
+
+const appInfo = {
+  name: "App",
+  version: "1.0.0",
   flags: Buffer.from([]),
 };
 
@@ -34,7 +57,6 @@ const aDevice = {
   wired: false,
 };
 
-// FIXME: once we have our own definition of BleError class, this won't be needed
 class BleError extends Error {
   errorCode: number;
   constructor(message: string, errorCode: number) {
@@ -46,12 +68,22 @@ class BleError extends Error {
 describe("useBleDevicePairing", () => {
   afterEach(() => {
     mockedGetVersion.mockClear();
+    mockedWithDevice.mockClear();
+    mockedGetAppAndVersion.mockClear();
+    mockedQuitApp.mockClear();
+    mockedIsDashboardName.mockClear();
     jest.clearAllTimers();
   });
 
   describe("When the request sent with the BLE transport to the device gets a success response", () => {
     beforeEach(() => {
       mockedGetVersion.mockResolvedValue(aFirmwareInfo);
+      mockedGetAppAndVersion.mockResolvedValue({
+        name: "Dashboard",
+        version: "1.0.0",
+        flags: Buffer.from([]),
+      });
+      mockedIsDashboardName.mockReturnValue(true);
     });
 
     it("should inform the hook consumer that the device is paired", async () => {
@@ -62,11 +94,13 @@ describe("useBleDevicePairing", () => {
       );
 
       await act(async () => {
-        jest.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1000);
       });
 
-      expect(result.current.isPaired).toBe(true);
-      expect(result.current.pairingError).toBeNull();
+      await waitFor(() => {
+        expect(result.current.isPaired).toBe(true);
+        expect(result.current.pairingError).toBeNull();
+      });
     });
   });
 
@@ -74,6 +108,8 @@ describe("useBleDevicePairing", () => {
     beforeEach(() => {
       const bleError = new BleError("An error during pairing", 201);
       mockedGetVersion.mockRejectedValue(bleError);
+      mockedGetAppAndVersion.mockResolvedValue(dashboardInfo);
+      mockedIsDashboardName.mockReturnValue(true);
     });
 
     it("should inform the hook consumer an error occurred", async () => {
@@ -84,11 +120,94 @@ describe("useBleDevicePairing", () => {
       );
 
       await act(async () => {
-        jest.advanceTimersByTime(1);
+        jest.advanceTimersByTime(1000);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPaired).toBe(false);
+        expect(result.current.pairingError).not.toBeNull();
+      });
+    });
+  });
+
+  describe("When the device is not in dashboard mode", () => {
+    beforeEach(() => {
+      mockedGetAppAndVersion.mockResolvedValue(appInfo);
+      mockedIsDashboardName.mockReturnValue(false);
+      mockedQuitApp.mockResolvedValue(undefined);
+      mockedGetVersion.mockResolvedValue(aFirmwareInfo);
+    });
+
+    it("should quit the current app and then check the version", async () => {
+      const { result } = renderHook(() =>
+        useBleDevicePairing({
+          deviceId: aDevice.deviceId,
+        }),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(mockedQuitApp).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(3000);
+      });
+
+      expect(mockedGetVersion).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(result.current.isPaired).toBe(true);
+        expect(result.current.pairingError).toBeNull();
+      });
+    });
+  });
+
+  describe("When the device is locked and a LockedDeviceError is thrown", () => {
+    beforeEach(() => {
+      mockedGetAppAndVersion.mockResolvedValue(dashboardInfo);
+      mockedIsDashboardName.mockReturnValue(true);
+
+      let retryAttempt = 0;
+      mockedGetVersion.mockImplementation(() => {
+        retryAttempt += 1;
+        if (retryAttempt < 3) {
+          return Promise.reject(new LockedDeviceError("Device is locked"));
+        }
+        return Promise.resolve(aFirmwareInfo);
+      });
+    });
+
+    it("should retry until the device is unlocked", async () => {
+      const { result } = renderHook(() =>
+        useBleDevicePairing({
+          deviceId: aDevice.deviceId,
+        }),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
       });
 
       expect(result.current.isPaired).toBe(false);
-      expect(result.current.pairingError).not.toBeNull();
+      expect(result.current.pairingError).toBeInstanceOf(LockedDeviceError);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      expect(result.current.isPaired).toBe(false);
+      expect(result.current.pairingError).toBeInstanceOf(LockedDeviceError);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isPaired).toBe(true);
+        expect(result.current.pairingError).toBeNull();
+      });
     });
   });
 });

--- a/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.ts
+++ b/libs/ledger-live-common/src/ble/hooks/useBleDevicePairing.ts
@@ -1,11 +1,14 @@
 import { useState, useEffect } from "react";
 import { from, throwError, timer } from "rxjs";
-import { first, retry } from "rxjs/operators";
+import { first, retry, delay, concatMap } from "rxjs/operators";
 import type { FirmwareInfo } from "@ledgerhq/types-live";
 import { LockedDeviceError } from "@ledgerhq/errors";
 import { withDevice } from "../../hw/deviceAccess";
 import { getVersion } from "../../device/use-cases/getVersionUseCase";
 import { BleError } from "../types";
+import quitApp from "../../hw/quitApp";
+import getAppAndVersion from "../../hw/getAppAndVersion";
+import { isDashboardName } from "../../hw/isDashboardName";
 
 export type useBleDevicePairingArgs = {
   deviceId: string;
@@ -33,34 +36,44 @@ export const useBleDevicePairing = ({
 }: useBleDevicePairingArgs): useBleDevicePairingResult => {
   const [isPaired, setIsPaired] = useState<boolean>(false);
   const [pairingError, setPairingError] = useState<PairingError>(null);
-
   useEffect(() => {
-    const requestObservable = withDevice(deviceId)(t => from(getVersion(t))).pipe(
-      first(),
-      retry({
-        delay: (err: BleError) => {
-          if (err instanceof LockedDeviceError) {
-            setPairingError(err);
-            return timer(1000);
+    const subscription = withDevice(deviceId)(t =>
+      from(getAppAndVersion(t).then(({ name }) => isDashboardName(name))),
+    )
+      .pipe(
+        concatMap(isInDashboard => {
+          if (isInDashboard) {
+            return withDevice(deviceId)(t => from(getVersion(t))).pipe(first());
           }
-
-          return throwError(() => err);
+          // If not in the dashboard, quit the app first, then proceed
+          return withDevice(deviceId)(t => from(quitApp(t))).pipe(
+            delay(2000),
+            concatMap(() => withDevice(deviceId)(t => from(getVersion(t))).pipe(first())),
+          );
+        }),
+        retry({
+          delay: (err: BleError) => {
+            if (err instanceof LockedDeviceError) {
+              setPairingError(err);
+              return timer(1000);
+            }
+            return throwError(() => err);
+          },
+        }),
+      )
+      .subscribe({
+        next: (_value: FirmwareInfo) => {
+          setIsPaired(true);
+          setPairingError(null);
         },
-      }),
-    );
-    const sub = requestObservable.subscribe({
-      next: (_value: FirmwareInfo) => {
-        setIsPaired(true);
-        setPairingError(null);
-      },
-      error: (error: BleError) => {
-        setIsPaired(false);
-        setPairingError(error);
-      },
-    });
+        error: (error: BleError) => {
+          setIsPaired(false);
+          setPairingError(error);
+        },
+      });
 
     return () => {
-      sub.unsubscribe();
+      subscription.unsubscribe();
     };
   }, [deviceId]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Quit any open app before BLE pairing

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13114](https://ledgerhq.atlassian.net/browse/LIVE-13114)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13114]: https://ledgerhq.atlassian.net/browse/LIVE-13114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ