### PR TITLE
[EXCHANGE] Use CHECK_ASSET_IN_NO_DISPLAY instead of CHECK_ASSET_IN

### DIFF
--- a/libs/ledgerjs/packages/hw-app-exchange/package.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/package.json
@@ -37,6 +37,7 @@
     "@ledgerhq/hw-transport-node-speculos-http": "workspace:^",
     "@types/jest": "^29.5.10",
     "@types/node": "^20.8.10",
+    "bip32-path": "^0.4.2",
     "documentation": "14.0.2",
     "jest": "^29.7.0",
     "secp256k1": "5.0.0",

--- a/libs/ledgerjs/packages/hw-app-exchange/src/Exchange.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/Exchange.ts
@@ -33,6 +33,8 @@ const CHECK_PAYOUT_ADDRESS = 0x08;
 const CHECK_ASSET_IN = 0x08;
 const CHECK_REFUND_ADDRESS = 0x09;
 const SIGN_COIN_TRANSACTION = 0x0a;
+const CHECK_ASSET_IN_AND_DISPLAY = 0x0b;
+const CHECK_ASSET_IN_NO_DISPLAY = 0x0d;
 
 // Extension for PROCESS_TRANSACTION_RESPONSE APDU
 const P2_NONE = 0x00 << 4;
@@ -280,7 +282,9 @@ export default class Exchange {
     ]);
     const result: Buffer = await this.transport.send(
       0xe0,
-      this.transactionType === ExchangeTypes.Swap ? CHECK_PAYOUT_ADDRESS : CHECK_ASSET_IN,
+      this.transactionType === ExchangeTypes.Swap || this.transactionType === ExchangeTypes.SwapNg
+        ? CHECK_PAYOUT_ADDRESS
+        : CHECK_ASSET_IN_NO_DISPLAY,
       this.transactionRate,
       this.transactionType,
       bufferToSend,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4409,6 +4409,9 @@ importers:
       '@types/node':
         specifier: ^20.8.10
         version: 20.12.12
+      bip32-path:
+        specifier: ^0.4.2
+        version: 0.4.2
       documentation:
         specifier: 14.0.2
         version: 14.0.2


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Replace the use of `CHECK_ASSET_IN` value by `CHECK_ASSET_IN_NO_DISPLAY` value in `checkPayoutAddress` call in SELL and FUND (legacy and NG) workflow.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
