### PR TITLE
Chore: pass os parameter to earn dashboard

### DIFF
--- a/.changeset/heavy-peas-cover.md
+++ b/.changeset/heavy-peas-cover.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add the platform OS to the params passed to earn to enable the correct braze environment

--- a/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/earn/index.tsx
@@ -46,6 +46,7 @@ const Earn = () => {
             locale: locale,
             currencyTicker: fiatCurrency.ticker,
             discreetMode: discreetMode ? "true" : "false",
+            OS: "web",
           }}
         />
       ) : null}

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -17,6 +17,7 @@ import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/s
 import { useSelector } from "react-redux";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { useSettings } from "~/hooks";
+import { Platform } from "react-native";
 
 export type Props = StackNavigatorProps<EarnLiveAppNavigatorParamList, ScreenName.Earn>;
 
@@ -58,6 +59,7 @@ function Earn({ route }: Props) {
           locale: language, // LLM doesn't support different locales. By doing this we don't have to have specific LLM/LLD logic in earn, and in future if LLM supports locales we will change this from `language` to `locale`
           currencyTicker,
           discreetMode: discreet ? "true" : "false",
+          OS: Platform.OS,
           ...params,
           ...Object.fromEntries(searchParams.entries()),
         }}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - no changes until braze is configured in earn dashboard. 

### 📝 Description

Braze requires a unique key for each platform os ("web", "ios", "android"). Currently there is no way to detect this from within the earn dashboard. This adds the string to the query parameters on initialising earn.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [CN-587](https://ledgerhq.atlassian.net/browse/CN-587)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-587]: https://ledgerhq.atlassian.net/browse/CN-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ