### PR TITLE
Bugfix/live 8014 llm custom button

### DIFF
--- a/.changeset/lemon-ducks-hammer.md
+++ b/.changeset/lemon-ducks-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM Custom validator button translation

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -323,7 +323,7 @@ export default function SelectValidator({ navigation, route }: Props) {
       <View style={styles.footer}>
         <Button
           type="secondary"
-          title="+ Add custom validator"
+          title={<Trans i18nKey="tezos.delegation.addCustomValidator" />}
           event="DelegationFlowAddCustom"
           onPress={enableCustomValidator}
         />

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -5402,6 +5402,9 @@
     "AccountHeader": {
       "title": "You can earn rewards by delegating your account",
       "btn": "Earn rewards"
+    },
+    "delegation": {
+      "addCustomValidator": "+ Add custom validator"
     }
   },
   "tron": {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Modified `common.json` to add "addCustomValidator": "+ Add custom validator" so it will be translated. 

<!--
| Before        | After         |
| ------------- | ------------- |
|   
![IMG_7393](https://github.com/user-attachments/assets/f9e2237f-363f-4fdd-811f-d3fa07468a50)
            |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-8014](https://ledgerhq.atlassian.net/browse/LIVE-8014) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-8014]: https://ledgerhq.atlassian.net/browse/LIVE-8014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ