### PR TITLE
fix: check if value is a number otherwise set to default gas limit li…

### DIFF
--- a/.changeset/strong-wasps-kiss.md
+++ b/.changeset/strong-wasps-kiss.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+User can enter text for Gas Limit value for ETH

--- a/apps/ledger-live-mobile/src/families/evm/ScreenEditGasLimit.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ScreenEditGasLimit.tsx
@@ -13,6 +13,7 @@ import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/typ
 import { SignTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignTransactionNavigator";
 import { SwapNavigatorParamList } from "~/components/RootNavigator/types/SwapNavigator";
 import { ScreenName } from "~/const";
+import { DEFAULT_GAS_LIMIT } from "@ledgerhq/coin-evm/lib/transaction";
 
 const options = {
   title: <Trans i18nKey="send.summary.gasLimit" />,
@@ -35,11 +36,14 @@ function EvmEditGasLimit({ navigation, route }: NavigationProps) {
   const onValidateText = useCallback(() => {
     Keyboard.dismiss();
     navigation.goBack();
-    setGasLimit(BigNumber(ownGasLimit || 0));
+    setGasLimit(new BigNumber(ownGasLimit || 0));
   }, [setGasLimit, ownGasLimit, navigation]);
 
   const onChangeText = useCallback((v: string) => {
-    const n = BigNumber(v);
+    let n = new BigNumber(v || 0);
+    if (!n.isFinite()) {
+      n = DEFAULT_GAS_LIMIT;
+    }
     setOwnGasLimit(n);
   }, []);
   return (


### PR DESCRIPTION
…ke we do in lld

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - If gas limit not a number, we set it back to `DEFAULT_GAS_LIMIT`

### 📝 Description

User can paste the content of clipboard
This results in Gas Limit value being NaN
Add checker, so if Gas limit is not a number then we set it to `DEFAULT_GAS_LIMIT` like we do in LLD.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-9561](https://ledgerhq.atlassian.net/browse/LIVE-9561)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-9561]: https://ledgerhq.atlassian.net/browse/LIVE-9561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ