### PR TITLE
feat(live-14205): add ptxSwapCoreExperiment flag

### DIFF
--- a/.changeset/pretty-penguins-hang.md
+++ b/.changeset/pretty-penguins-hang.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": patch
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+add ptxSwapCoreExperiment flag

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -1,36 +1,36 @@
-import { v4 as uuid } from "uuid";
-import invariant from "invariant";
-import { ReplaySubject } from "rxjs";
-import { getEnv } from "@ledgerhq/live-env";
-import logger from "~/renderer/logger";
-import { getParsedSystemLocale } from "~/helpers/systemLocale";
-import user from "~/helpers/user";
 import { runOnceWhen } from "@ledgerhq/live-common/utils/runOnceWhen";
-import {
-  sidebarCollapsedSelector,
-  shareAnalyticsSelector,
-  lastSeenDeviceSelector,
-  localeSelector,
-  languageSelector,
-  devicesModelListSelector,
-  sharePersonalizedRecommendationsSelector,
-  hasSeenAnalyticsOptInPromptSelector,
-  trackingEnabledSelector,
-  developerModeSelector,
-} from "~/renderer/reducers/settings";
-import { State } from "~/renderer/reducers";
-import { AccountLike, Feature, FeatureId, Features, idsToLanguage } from "@ledgerhq/types-live";
-import { accountsSelector } from "../reducers/accounts";
+import { getEnv } from "@ledgerhq/live-env";
 import {
   GENESIS_PASS_COLLECTION_CONTRACT,
   hasNftInAccounts,
   INFINITY_PASS_COLLECTION_CONTRACT,
 } from "@ledgerhq/live-nft";
-import createStore from "../createStore";
-import { currentRouteNameRef, previousRouteNameRef } from "./screenRefs";
-import { useCallback, useContext } from "react";
-import { analyticsDrawerContext } from "../drawers/Provider";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { AccountLike, Feature, FeatureId, Features, idsToLanguage } from "@ledgerhq/types-live";
+import invariant from "invariant";
+import { useCallback, useContext } from "react";
+import { ReplaySubject } from "rxjs";
+import { v4 as uuid } from "uuid";
+import { getParsedSystemLocale } from "~/helpers/systemLocale";
+import user from "~/helpers/user";
+import logger from "~/renderer/logger";
+import { State } from "~/renderer/reducers";
+import {
+  developerModeSelector,
+  devicesModelListSelector,
+  hasSeenAnalyticsOptInPromptSelector,
+  languageSelector,
+  lastSeenDeviceSelector,
+  localeSelector,
+  shareAnalyticsSelector,
+  sharePersonalizedRecommendationsSelector,
+  sidebarCollapsedSelector,
+  trackingEnabledSelector,
+} from "~/renderer/reducers/settings";
+import createStore from "../createStore";
+import { analyticsDrawerContext } from "../drawers/Provider";
+import { accountsSelector } from "../reducers/accounts";
+import { currentRouteNameRef, previousRouteNameRef } from "./screenRefs";
 
 invariant(typeof window !== "undefined", "analytics/segment must be called on renderer thread");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -87,8 +87,10 @@ const getPtxAttributes = () => {
   const ptxSwapLiveAppDemoZero = analyticsFeatureFlagMethod("ptxSwapLiveAppDemoZero")?.enabled;
   const ptxSwapLiveAppDemoOne = analyticsFeatureFlagMethod("ptxSwapLiveAppDemoOne")?.enabled;
   const ptxSwapLiveAppDemoThree = analyticsFeatureFlagMethod("ptxSwapLiveAppDemoThree")?.enabled;
-  const ptxSwapThorswapProvider = analyticsFeatureFlagMethod("ptxSwapThorswapProvider")?.enabled;
   const ptxSwapExodusProvider = analyticsFeatureFlagMethod("ptxSwapExodusProvider")?.enabled;
+  const ptxSwapCoreExperimentFlag = analyticsFeatureFlagMethod("ptxSwapCoreExperiment");
+  const ptxSwapCoreExperiment =
+    ptxSwapCoreExperimentFlag?.enabled && ptxSwapCoreExperimentFlag?.params?.variant;
 
   const isBatch1Enabled: boolean =
     !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;
@@ -113,7 +115,7 @@ const getPtxAttributes = () => {
     ptxSwapLiveAppDemoZero,
     ptxSwapLiveAppDemoOne,
     ptxSwapLiveAppDemoThree,
-    ptxSwapThorswapProvider,
+    ptxSwapCoreExperiment,
     ptxSwapExodusProvider,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebView.tsx
@@ -35,6 +35,7 @@ import { NetworkDown } from "@ledgerhq/errors";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/impl";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { SwapExchangeRateAmountTooLow } from "@ledgerhq/live-common/errors";
+import { useSwapLiveConfig } from "@ledgerhq/live-common/exchange/swap/hooks/index";
 import { getAbandonSeedAddress } from "@ledgerhq/live-common/exchange/swap/hooks/useFromState";
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import {
@@ -136,6 +137,7 @@ const SwapWebView = ({
   const { networkStatus } = useNetworkStatus();
   const isOffline = networkStatus === NetworkStatus.OFFLINE;
   const swapDefaultTrack = useGetSwapTrackingProperties();
+  const swapLiveEnabledFlag = useSwapLiveConfig();
 
   const hasSwapState = !!swapState;
   const customPTXHandlers = usePTXCustomHandlers(manifest);
@@ -471,6 +473,11 @@ const SwapWebView = ({
       toNewTokenId: swapState?.toNewTokenId,
       feeStrategy: swapState?.feeStrategy,
       customFeeConfig: swapState?.customFeeConfig,
+      ...(swapLiveEnabledFlag?.params &&
+      "variant" in swapLiveEnabledFlag.params &&
+      swapLiveEnabledFlag.params.variant === "Demo0"
+        ? { ptxSwapCoreExperiment: "Demo0" }
+        : {}),
     };
 
     Object.entries(swapParams).forEach(([key, value]) => {
@@ -484,11 +491,22 @@ const SwapWebView = ({
   }, [
     addressFrom,
     addressTo,
-    swapState,
+    swapState?.fromAmount,
+    swapState?.error,
+    swapState?.loading,
+    swapState?.fromParentAccountId,
+    swapState?.estimatedFees,
+    swapState?.provider,
+    swapState?.toAccountId,
+    swapState?.fromAccountId,
+    swapState?.toNewTokenId,
+    swapState?.feeStrategy,
+    swapState?.customFeeConfig,
     sourceCurrency?.id,
     isMaxEnabled,
     fromCurrency,
     targetCurrency?.id,
+    swapLiveEnabledFlag?.params,
   ]);
 
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/hooks/useIsSwapLiveFlagEnabled.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/hooks/useIsSwapLiveFlagEnabled.ts
@@ -3,20 +3,23 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 // used to get the value of the Swap Live App flag
 export const useIsSwapLiveFlagEnabled = (flag: string): boolean => {
   const demoZero = useFeature("ptxSwapLiveAppDemoZero");
-  const demoOne = useFeature("ptxSwapLiveAppDemoOne");
   const demoThree = useFeature("ptxSwapLiveAppDemoThree");
+  const coreExperiment = useFeature("ptxSwapCoreExperiment");
+  const coreExperimentVariant = coreExperiment?.enabled && coreExperiment?.params?.variant;
 
   if (flag === "ptxSwapLiveAppDemoThree") {
-    return !!demoThree?.enabled;
-  }
-
-  if (flag === "ptxSwapLiveAppDemoOne") {
-    return !!demoOne?.enabled;
+    return (
+      !!demoThree?.enabled || ["Demo3", "Demo3Thorswap"].includes(coreExperimentVariant as string)
+    );
   }
 
   if (flag === "ptxSwapLiveAppDemoZero") {
-    return !!demoZero?.enabled;
+    return !!demoZero?.enabled || coreExperimentVariant === "Demo0";
   }
 
-  throw new Error(`Unknown Swap Live App flag: ${flag}`);
+  if (flag === "ptxSwapLiveAppDemoOne") {
+    return false;
+  }
+
+  throw new Error(`Unknown Swap Live App flag ${flag}`);
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/index.tsx
@@ -49,6 +49,7 @@ const GlobalStyle = createGlobalStyle`
 
 const Swap2 = () => {
   const isDemo3Enabled = useIsSwapLiveFlagEnabled("ptxSwapLiveAppDemoThree");
+
   const SwapPage = isDemo3Enabled ? SwapApp : SwapForm;
 
   return (

--- a/libs/ledger-live-common/src/exchange/swap/hooks/live-app-migration/useSwapLiveConfig.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/live-app-migration/useSwapLiveConfig.test.ts
@@ -14,12 +14,15 @@ const useMockFeature = useFeature as jest.Mock;
 describe("useSwapLiveConfig", () => {
   // Setup the mock for useFeatureFlags to return an object with getFeature
   const setupFeatureFlagsMock = (
-    flags: Partial<{ enabled: boolean; params: { manifest_id: string } }>[],
+    flags: Partial<
+      { enabled: boolean; params: { manifest_id: string; variant?: string } } | undefined
+    >[],
   ) => {
     const flagsKeys = [
       "ptxSwapLiveAppDemoZero",
       "ptxSwapLiveAppDemoOne",
       "ptxSwapLiveAppDemoThree",
+      "ptxSwapCoreExperiment",
     ];
 
     useMockFeature.mockImplementation(flagName => flags[flagsKeys.indexOf(flagName)] ?? null);
@@ -40,7 +43,7 @@ describe("useSwapLiveConfig", () => {
     expect(result.current).not.toBeNull();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((result.current?.params as any)?.manifest_id).toEqual("demo_3");
+    expect((result.current?.params as any)?.manifest_id).toEqual("demo_0");
   });
 
   it("should return null if both features are disabled", () => {
@@ -96,5 +99,100 @@ describe("useSwapLiveConfig", () => {
       enabled: true,
       params: { manifest_id: "swap-live-app-demo-3" },
     });
+  });
+
+  it("should return config when ptxSwapCoreExperiment has valid variant Demo0", () => {
+    const expected = {
+      enabled: true,
+      params: { manifest_id: "swap-live-app-demo-0", variant: "Demo0" },
+    };
+    setupFeatureFlagsMock([{ enabled: false }, { enabled: false }, { enabled: false }, expected]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toEqual(expected);
+  });
+
+  it("should return config when ptxSwapCoreExperiment has valid variant Demo3", () => {
+    setupFeatureFlagsMock([
+      { enabled: false },
+      { enabled: false },
+      { enabled: false },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-3", variant: "Demo3" } },
+    ]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toEqual({
+      enabled: true,
+      params: { manifest_id: "swap-live-app-demo-3", variant: "Demo3" },
+    });
+  });
+
+  it("should return config when ptxSwapCoreExperiment has valid variant Demo3Thorswap", () => {
+    setupFeatureFlagsMock([
+      { enabled: false },
+      { enabled: false },
+      { enabled: false },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-3", variant: "Demo3Thorswap" } },
+    ]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toEqual({
+      enabled: true,
+      params: { manifest_id: "swap-live-app-demo-3", variant: "Demo3Thorswap" },
+    });
+  });
+
+  it("should return demoZero if demoThree and  are enabled", () => {
+    setupFeatureFlagsMock([
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-0" } },
+      { enabled: false },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-3" } },
+    ]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toEqual({
+      enabled: true,
+      params: { manifest_id: "swap-live-app-demo-0" },
+    });
+  });
+
+  it("should return demoZero if all demo flags are enabled", () => {
+    setupFeatureFlagsMock([
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-0" } },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-1" } },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-3" } },
+    ]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toEqual({
+      enabled: true,
+      params: { manifest_id: "swap-live-app-demo-0" },
+    });
+  });
+
+  it("should prioritize demoZero over demo flags if all are enabled", () => {
+    setupFeatureFlagsMock([
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-0" } },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-1" } },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-3" } },
+      { enabled: true, params: { manifest_id: "swap-live-app-demo-3", variant: "Demo3" } },
+    ]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toEqual({
+      enabled: true,
+      params: { manifest_id: "swap-live-app-demo-0" },
+    });
+  });
+
+  it("should return null when coreExperiment is enabled but has no variant", () => {
+    setupFeatureFlagsMock([
+      { enabled: false },
+      { enabled: false },
+      { enabled: false },
+      { enabled: true, params: { manifest_id: "core-experiment" } },
+    ]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toBeNull();
+  });
+
+  it("should return null when all flags are undefined", () => {
+    setupFeatureFlagsMock([undefined, undefined, undefined, undefined]);
+    const { result } = renderHook(() => useSwapLiveConfig());
+    expect(result.current).toBeNull();
   });
 });

--- a/libs/ledger-live-common/src/exchange/swap/hooks/live-app-migration/useSwapLiveConfig.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/live-app-migration/useSwapLiveConfig.ts
@@ -1,14 +1,38 @@
+import { Feature_PtxSwapCoreExperiment } from "@ledgerhq/types-live/lib/feature";
 import { useFeature } from "../../../../featureFlags";
+
+// check if the variant is valid for core rollout experiment
+export type CoreExperimentParams = NonNullable<Feature_PtxSwapCoreExperiment["params"]>;
+export type ValidVariant = CoreExperimentParams["variant"];
 
 // used to enable the Swap Live App globally
 export function useSwapLiveConfig() {
-  const demoZero = useFeature("ptxSwapLiveAppDemoZero");
-  const demoOne = useFeature("ptxSwapLiveAppDemoOne");
   const demoThree = useFeature("ptxSwapLiveAppDemoThree");
+  const demoOne = useFeature("ptxSwapLiveAppDemoOne");
+  const demoZero = useFeature("ptxSwapLiveAppDemoZero");
+  const coreExperiment = useFeature("ptxSwapCoreExperiment");
 
-  // Order is important in order to get the first enabled flag
-  const flags = [demoThree, demoOne, demoZero];
-  const enabledFlag = flags.find(flag => flag?.enabled);
+  // const validVariants: readonly ValidVariant[] = ["Demo0", "Demo3", "Demo3Thorswap"] as const;
 
-  return enabledFlag ?? null;
+  if (demoZero?.enabled) {
+    return demoZero;
+  }
+
+  if (demoThree?.enabled) {
+    return demoThree;
+  }
+
+  if (coreExperiment?.enabled) {
+    const variant = coreExperiment?.params?.variant;
+    if (!variant || !(variant satisfies ValidVariant)) {
+      return null;
+    }
+    return coreExperiment;
+  }
+
+  if (demoOne?.enabled) {
+    return demoOne;
+  }
+
+  return null;
 }

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useFeature } from "../../../../featureFlags";
 import { fetchAndMergeProviderData } from "../../../providers/swap";
 
@@ -9,7 +9,6 @@ export const useFilteredProviders = () => {
 
   const ptxSwapMoonpayProviderFlag = useFeature("ptxSwapMoonpayProvider");
   const ptxSwapExodusProviderFlag = useFeature("ptxSwapExodusProvider");
-  const ptxSwapThorswapProviderFlag = useFeature("ptxSwapThorswapProvider");
 
   const fetchProviders = useCallback(async () => {
     try {
@@ -22,9 +21,6 @@ export const useFilteredProviders = () => {
       if (!ptxSwapExodusProviderFlag?.enabled) {
         filteredProviders = filteredProviders.filter(provider => provider !== "exodus");
       }
-      if (!ptxSwapThorswapProviderFlag?.enabled) {
-        filteredProviders = filteredProviders.filter(provider => provider !== "thorswap");
-      }
 
       setProviders(filteredProviders);
     } catch (error) {
@@ -32,7 +28,7 @@ export const useFilteredProviders = () => {
     } finally {
       setLoading(false);
     }
-  }, [ptxSwapMoonpayProviderFlag, ptxSwapExodusProviderFlag, ptxSwapThorswapProviderFlag]);
+  }, [ptxSwapMoonpayProviderFlag, ptxSwapExodusProviderFlag]);
 
   useEffect(() => {
     fetchProviders();

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -6,8 +6,8 @@ import {
   Features,
 } from "@ledgerhq/types-live";
 import reduce from "lodash/reduce";
-import { formatToFirebaseFeatureId } from "./firebaseFeatureFlags";
 import { BUY_SELL_UI_APP_ID } from "../wallet-api/constants";
+import { formatToFirebaseFeatureId } from "./firebaseFeatureFlags";
 
 /**
  * Default disabled feature.
@@ -395,6 +395,7 @@ export const DEFAULT_FEATURES: Features = {
     enabled: false,
   },
   ptxCard: DEFAULT_FEATURE,
+
   ptxSwapLiveAppDemoZero: {
     enabled: false,
     params: {
@@ -416,9 +417,16 @@ export const DEFAULT_FEATURES: Features = {
     },
   },
 
+  ptxSwapCoreExperiment: {
+    enabled: false,
+    params: {
+      variant: "Demo0",
+      manifest_id: "swap-live-app-demo-0",
+    },
+  },
+
   ptxSwapMoonpayProvider: DEFAULT_FEATURE,
   ptxSwapExodusProvider: DEFAULT_FEATURE,
-  ptxSwapThorswapProvider: DEFAULT_FEATURE,
 
   llmAnalyticsOptInPrompt: {
     enabled: false,

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -168,9 +168,9 @@ export type Features = CurrencyFeatures & {
   ptxSwapLiveAppDemoZero: Feature_PtxSwapLiveAppDemoZero;
   ptxSwapLiveAppDemoOne: Feature_PtxSwapLiveAppDemoZero;
   ptxSwapLiveAppDemoThree: Feature_PtxSwapLiveAppDemoZero;
+  ptxSwapCoreExperiment: Feature_PtxSwapCoreExperiment;
   ptxSwapMoonpayProvider: Feature_PtxSwapMoonpayProvider;
   ptxSwapExodusProvider: Feature_PtxSwapExodusProvider;
-  ptxSwapThorswapProvider: Feature_PtxSwapThorswapProvider;
   ptxSwapReceiveTRC20WithoutTrx: Feature_PtxSwapReceiveTRC20WithoutTrx;
   flexibleContentCards: Feature_FlexibleContentCards;
   llmAnalyticsOptInPrompt: Feature_LlmAnalyticsOptInPrompt;
@@ -468,6 +468,13 @@ export type Feature_PtxSwapLiveAppDemoZero = Feature<{
   families?: string[];
 }>;
 
+export type Feature_PtxSwapCoreExperiment = Feature<{
+  variant: "Demo0" | "Demo3" | "Demo3Thorswap";
+  manifest_id: string;
+  currencies?: string[];
+  families?: string[];
+}>;
+
 export type Feature_FetchAdditionalCoins = Feature<{
   batch: number;
 }>;
@@ -532,7 +539,6 @@ export type Feature_Objkt = DefaultFeature;
 export type Feature_BrazeLearn = DefaultFeature;
 export type Feature_PtxSwapMoonpayProvider = DefaultFeature;
 export type Feature_PtxSwapExodusProvider = DefaultFeature;
-export type Feature_PtxSwapThorswapProvider = DefaultFeature;
 export type Feature_PtxSwapReceiveTRC20WithoutTrx = DefaultFeature;
 export type Feature_FlexibleContentCards = DefaultFeature;
 export type Feature_MyLedgerDisplayAppDeveloperName = DefaultFeature;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- add ptxSwapCoreExperiment flag based on this logic https://ledgerhq.atlassian.net/wiki/spaces/PTX/pages/5002821634/SWAP+AB+Test+Plan+Document+Improving+User+Flow+by+Improving+quotes+display+-+Demo+3?focusedCommentId=5089132693


https://github.com/user-attachments/assets/37ffa101-8c87-4c14-a0f0-77438be25b98




<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-14205

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
