### PR TITLE
🥅(lld): add custom errors for send flow

### DIFF
--- a/.changeset/thick-candles-visit.md
+++ b/.changeset/thick-candles-visit.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add errors handler in common to prepare the use of it in sendFlow

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -276,7 +276,8 @@
     "src/wallet-api/tracking.ts",
     "src/wallet-api/useDappLogic.ts",
     "src/wallet-api/types.ts",
-    "src/wallet-api/version.ts"
+    "src/wallet-api/version.ts",
+    "src/errors/sendFlow.ts"
   ],
   "extensions": [".ts", ".js", ".jsx", ".tsx"],
   "ignorePatterns": [

--- a/libs/ledger-live-common/src/errors/sendFlow.ts
+++ b/libs/ledger-live-common/src/errors/sendFlow.ts
@@ -1,0 +1,29 @@
+import { createCustomErrorClass } from "@ledgerhq/errors";
+
+export const TxUnderpriced = createCustomErrorClass<{ url: string }>("TxUnderpriced");
+export const AlreadySpentUTXO = createCustomErrorClass<{ url: string }>("AlreadySpendUTXO");
+export const TxnMempoolConflict = createCustomErrorClass<{ url: string }>("TxnMempoolConflict");
+
+export const createSendFlowError = (error: Error): Error => {
+  const { message } = error;
+
+  if (
+    message.includes("-25: bad-tnxs-inputs-missingorspent") ||
+    message.includes("-25: Missing inputs")
+  )
+    return new AlreadySpentUTXO(message, {
+      url: "https://support.ledger.com/article/5129526865821-zd",
+    });
+
+  if (message.includes("blobs limit in txpool is full"))
+    return new TxnMempoolConflict(message, {
+      url: "https://support.ledger.com/article/17830974229661-zd",
+    });
+
+  if (message.includes("txn-mempool-conflict"))
+    return new TxnMempoolConflict(message, {
+      url: "https://support.ledger.com/article/14593285242525-zd",
+    });
+
+  return error;
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Nothing / file created in common

### 📝 Description

For send flow we want to handle some specifics errors to return the correct support url if there is one or we will use the main support page url

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14069](https://ledgerhq.atlassian.net/browse/LIVE-14069)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14069]: https://ledgerhq.atlassian.net/browse/LIVE-14069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ