### PR TITLE
test: use playwright text locator waitFor in live app smoke tests

### DIFF
--- a/apps/ledger-live-desktop/tests/fixtures/mockFixtures.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/mockFixtures.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { test as base } from "./common";
 import { getStatusMock } from "tests/specs/services/services-api-mocks/getStatus.mock";
+import { getBitcoinToEthereumRatesMock } from "tests/specs/services/services-api-mocks/getRates.mock";
 
 type TestFixtures = {
   mockProviderSvgs: Page;
@@ -8,6 +9,9 @@ type TestFixtures = {
   mockSwapCancelledEndpoint: Page;
   mockSwapAcceptedEndpoint: Page;
   mockSwapStatusEndpoint: Page;
+  mockBitcoinToEthereumRates: Page;
+  mockSwapDogecoinToEthereumRates: Page;
+  mockProvidersCDNData: Page;
 };
 
 export const test = base.extend<TestFixtures>({
@@ -61,6 +65,43 @@ export const test = base.extend<TestFixtures>({
       console.log("Mocking swap status HTTP response");
       const mockStatusResponse = getStatusMock();
       await route.fulfill({ headers: { teststatus: "mocked" }, body: mockStatusResponse });
+    });
+    await use(page);
+  },
+
+  mockBitcoinToEthereumRates: async ({ page }, use) => {
+    await page.route("https://swap.ledger.com/v5/rate**", async route => {
+      const mockRatesResponse = getBitcoinToEthereumRatesMock();
+      await route.fulfill({ headers: { teststatus: "mocked" }, body: mockRatesResponse });
+    });
+    await use(page);
+  },
+
+  mockSwapDogecoinToEthereumRates: async ({ page }, use) => {
+    await page.route("https://swap.ledger.com/v5/currencies/to**", async route => {
+      await route.fulfill({
+        headers: { teststatus: "mocked" },
+        body: JSON.stringify({
+          currencyGroups: [
+            {
+              network: "dogecoin",
+              supportedCurrencies: ["dogecoin"],
+            },
+            {
+              network: "ethereum",
+              supportedCurrencies: ["ethereum", "ethereum/erc20/usd_tether__erc20_"],
+            },
+          ],
+        }),
+      });
+    });
+    await use(page);
+  },
+
+  mockProvidersCDNData: async ({ page }, use) => {
+    await page.route("https://cdn.live.ledger.com/swap-providers/data.json", async route => {
+      const mockProvidersResponse = getProvidersCDNDataMock();
+      await route.fulfill({ headers: { teststatus: "mocked" }, body: mockProvidersResponse });
     });
     await use(page);
   },

--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -1,6 +1,6 @@
 import { Locator, Page } from "@playwright/test";
 import { WebviewTag } from "~/renderer/components/Web3AppWebview/types";
-import { waitFor } from "../utils/waitFor";
+
 import { getLiveAppManifest, startDummyServer, stopDummyServer } from "@ledgerhq/test-utils";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 
@@ -106,11 +106,11 @@ export class LiveAppWebview {
   }
 
   async waitForCorrectTextInWebview(textToCheck: string) {
-    return waitFor(() => this.textIsPresent(textToCheck));
+    return this.page.getByText(textToCheck);
   }
 
   async waitForLoaded() {
-    return this.page.waitForLoadState("domcontentloaded");
+    return this.page.waitForLoadState("load");
   }
 
   async textIsPresent(textToCheck: string) {

--- a/apps/ledger-live-desktop/tests/specs/market/market.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/market/market.spec.ts
@@ -164,10 +164,10 @@ test("Market", async ({ page }) => {
     await expect
       .soft(page)
       .toHaveScreenshot("market-btc-buy-page.png", { mask: [page.locator("webview")] });
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBe(true);
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBe(true);
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBeVisible();
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBeVisible();
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
 
     await layout.goToMarket();
   });
@@ -188,9 +188,9 @@ test("Market", async ({ page }) => {
     await expect
       .soft(page)
       .toHaveScreenshot("market-btc-buy-page.png", { mask: [page.locator("webview")] });
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBe(true);
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBe(true);
-    await expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBeVisible();
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBeVisible();
+    await expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/services/buy.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/buy.spec.ts
@@ -57,10 +57,10 @@ test("Buy / Sell @smoke", async ({ page }) => {
   await test.step("Navigate to Buy app from portfolio banner", async () => {
     await portfolioPage.startBuyFlow();
     await liveAppWebview.waitForLoaded();
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
     await expect
       .soft(page)
       .toHaveScreenshot("buy-app-opened.png", { mask: [page.locator("webview")] });
@@ -69,16 +69,16 @@ test("Buy / Sell @smoke", async ({ page }) => {
   await test.step("Navigate to Buy app from market", async () => {
     await layout.goToMarket();
     await marketPage.openBuyPage("usdt");
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
     expect(
       await liveAppWebview.waitForCorrectTextInWebview(
         "currency: ethereum/erc20/usd_tether__erc20_",
       ),
-    ).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
+    ).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
   });
 
   await test.step("Navigate to Buy app from asset", async () => {
@@ -86,12 +86,12 @@ test("Buy / Sell @smoke", async ({ page }) => {
     await portfolioPage.navigateToAsset("ethereum");
     await assetPage.startBuyFlow();
 
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currency: ethereum")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currency: ethereum")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBeVisible();
   });
 
   await test.step("Navigate to Buy app from account", async () => {
@@ -99,15 +99,15 @@ test("Buy / Sell @smoke", async ({ page }) => {
     await accountsPage.navigateToAccountByName("Bitcoin 1 (legacy)");
     await accountPage.navigateToBuy();
 
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBeVisible();
     expect(
       await liveAppWebview.waitForCorrectTextInWebview("account: mock:1:bitcoin:true_bitcoin_0:"),
-    ).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBe(true);
+    ).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: buy")).toBeVisible();
   });
 
   await test.step("Navigate to Buy app from account", async () => {
@@ -115,15 +115,15 @@ test("Buy / Sell @smoke", async ({ page }) => {
     await accountsPage.navigateToAccountByName("Bitcoin 1 (legacy)");
     await accountPage.navigateToSell();
 
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currency: bitcoin")).toBeVisible();
     expect(
       await liveAppWebview.waitForCorrectTextInWebview("account: mock:1:bitcoin:true_bitcoin_0:"),
-    ).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: sell")).toBe(true);
+    ).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("mode: sell")).toBeVisible();
   });
 
   await test.step("Navigate to Buy app from sidebar with light theme and French Language", async () => {
@@ -132,9 +132,9 @@ test("Buy / Sell @smoke", async ({ page }) => {
     await settingsPage.changeTheme();
     await layout.goToBuyCrypto();
 
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: light")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: fr")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: light")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: fr")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/services/earn.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/earn.spec.ts
@@ -39,8 +39,10 @@ test("Earn @smoke", async ({ page }) => {
   const layout = new Layout(page);
   const liveAppWebview = new LiveAppWebview(page);
 
-  await test.step("Navigate to Buy app from portfolio banner", async () => {
+  await test.step("Navigate to Earn app from main side drawer navigation", async () => {
     await layout.goToEarn();
+    await liveAppWebview.waitForLoaded();
+
     expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
     expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
     expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);

--- a/apps/ledger-live-desktop/tests/specs/services/earn.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/earn.spec.ts
@@ -43,11 +43,11 @@ test("Earn @smoke", async ({ page }) => {
     await layout.goToEarn();
     await liveAppWebview.waitForLoaded();
 
-    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("discreetMode: false")).toBe(true);
-    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBe(true);
+    expect(await liveAppWebview.waitForCorrectTextInWebview("theme: dark")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("lang: en")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("locale: en-US")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("discreetMode: false")).toBeVisible();
+    expect(await liveAppWebview.waitForCorrectTextInWebview("currencyTicker: USD")).toBeVisible();
     await expect
       .soft(page)
       .toHaveScreenshot("earn-app-opened.png", { mask: [page.locator("webview")] });

--- a/apps/ledger-live-desktop/tests/specs/services/swap.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/swap.spec.ts
@@ -203,12 +203,12 @@ test.describe.parallel("Swap", () => {
       await swapPage.navigateToExchangeDetails();
       await swapPage.waitForExchangeDetails();
       await expect.soft(swapPage.detailsSwapId).toHaveText("12345");
-      await expect.soft(drawer.swapAmountFrom).toContainText("-1.280"); // regex /-1.280\d+ BTC/ not working with toHaveText() and value can change after the first 3 decimals so this will have to do for now - see LIVE-8642
-      await expect.soft(drawer.swapAmountTo).toContainText("+17.8943438531 ETH");
+      await expect.soft(drawer.swapAmountFrom).toContainText(/^-1.280/); // regex value can change after the first 3 decimals so this will have to do for now - see LIVE-8642
+      await expect.soft(drawer.swapAmountTo).toContainText(/^\+17[.,]+8943438531 ETH$/); // match +17,8943438531 ETH or +17.8943438531 ETH
       await expect.soft(drawer.swapAccountFrom).toHaveText("Bitcoin 2 (legacy)");
       await expect.soft(drawer.swapAccountTo).toHaveText("Ethereum 2");
 
-      // Flaky due to LIVE-8642 - the formatting is sometimes different values - therefore we are doing the above text checks
+      // Screenshot verification is flaky due to LIVE-8642 - the formatting is sometimes rounding to different values - therefore we are doing the above text checks (this seems to relate to locale formatting)
       // await expect.soft(drawer.content).toHaveScreenshot("verify-swap-details.png");
     });
 


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist


- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - CI should be less flakey on earn smoke tests like https://github.com/LedgerHQ/ledger-live/actions/runs/11213282864/job/31166142233

### 📝 Description


- wait for load state on "goToEarn()" because this is actually a "click" event that acts like a navigation event, so prefer to use the default for playwright `goTo` which is `load`. 
- Use text locator instead of custom waitfor in LiveApp web view smoke tests. As recommended by the playwright docs 
 see: 
- https://playwright.dev/docs/navigations 
- https://playwright.dev/docs/other-locators

### ❓ Context

- **JIRA or GitHub link**: [CN-776](https://ledgerhq.atlassian.net/browse/CN-776)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-776]: https://ledgerhq.atlassian.net/browse/CN-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ