### PR TITLE
EARN: hide category filter when providers' list is empty

### DIFF
--- a/.changeset/beige-planes-shake.md
+++ b/.changeset/beige-planes-shake.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": patch
+"@ledgerhq/native-ui": patch
+---
+
+On Earn's Staking Modal, it makes it so that a category filter will only show up if there's at least one provider of that category.
+Small visual fix to the gap in the options' spacing

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -48,12 +48,18 @@ export const StakeModal = ({ account, source }: Props) => {
 
   const [selected, setSelected] = useState<Option>("all");
 
+  const filteredProviders = useMemo(() => (providers ?? []).filter(x => !x.disabled), [providers]);
+  const optionValues = useMemo(
+    () => OPTION_VALUES.filter(x => x === "all" || filteredProviders.some(y => y.category === x)),
+    [filteredProviders],
+  );
+
   const formattedProviders = useMemo(
     () =>
-      (providers ?? [])
-        .filter(x => !x.disabled && (selected === "all" || selected === x.category))
+      filteredProviders
+        .filter(x => selected === "all" || selected === x.category)
         .sort(hasMinValidatorEth ? descending : ascending),
-    [providers, hasMinValidatorEth, selected],
+    [filteredProviders, hasMinValidatorEth, selected],
   );
 
   const scrollableContainerRef = useRef<HTMLDivElement>(null);
@@ -96,8 +102,8 @@ export const StakeModal = ({ account, source }: Props) => {
                 {t("ethereum.stake.title")}
               </Text>
               <Flex flexDirection="row" alignItems="center" height="24px" columnGap={2} mb={3}>
-                {OPTION_VALUES.map((x, i) => {
-                  const checked = i === OPTION_VALUES.indexOf(selected);
+                {optionValues.map((x, i) => {
+                  const checked = i === optionValues.indexOf(selected);
                   return (
                     <Button
                       borderRadius={2}

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
@@ -94,7 +94,7 @@ function Content({ accountId, has32Eth, providers }: Props) {
             activeBg={colors.primary.c80}
             activeColor={colors.neutral.c00}
             inactiveColor={colors.neutral.c100}
-            gap={4}
+            gap={8}
             inactiveBg={colors.neutral.c40}
             activeIndex={selectedIndex}
             onChange={index => {

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/index.tsx
@@ -58,20 +58,26 @@ function Content({ accountId, has32Eth, providers }: Props) {
   const { t } = useTranslation();
   const { theme: themeName, colors } = useTheme();
 
+  const filteredProviders = useMemo(() => (providers ?? []).filter(x => !x.disabled), [providers]);
+  const optionValues = useMemo(
+    () => OPTION_VALUES.filter(x => x === "all" || filteredProviders.some(y => y.category === x)),
+    [filteredProviders],
+  );
+
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const selected = OPTION_VALUES[selectedIndex];
+  const selected = optionValues[selectedIndex];
 
   const OPTION_LABELS = useMemo(
-    () => OPTION_VALUES.map(value => t(`stake.ethereum.category.${value}.name`)),
-    [t],
+    () => optionValues.map(value => t(`stake.ethereum.category.${value}.name`)),
+    [t, optionValues],
   );
 
   const listProvidersSorted: ListProvider[] = useMemo(
     () =>
-      providers
+      filteredProviders
         .sort(has32Eth ? descending : ascending)
-        .filter(x => !x.disabled && (selected === "all" || selected === x.category)),
-    [has32Eth, providers, selected],
+        .filter(x => selected === "all" || selected === x.category),
+    [has32Eth, filteredProviders, selected],
   );
 
   return (
@@ -94,7 +100,7 @@ function Content({ accountId, has32Eth, providers }: Props) {
             onChange={index => {
               setSelectedIndex(index);
               track(BUTTON_CLICKED_TRACK_EVENT, {
-                button: `filter_${OPTION_VALUES[index]}`,
+                button: `filter_${optionValues[index]}`,
               });
             }}
             stretchItems={false}

--- a/libs/ui/packages/native/src/components/Tabs/Chip/index.tsx
+++ b/libs/ui/packages/native/src/components/Tabs/Chip/index.tsx
@@ -9,7 +9,7 @@ const TabBox = styled(TouchableOpacity)<
 >`
   text-align: center;
   flex-grow: ${(p) => (p.stretchItems ? "1" : "0")};
-  margin: auto;
+  ${(p) => (p.stretchItems ? "margin: auto;" : "margin: auto 0;")}
   padding: ${(p) => p.theme.space[p.size === "small" ? 3 : 5]}px;
   border-radius: 8px;
   background-color: ${(p) =>

--- a/libs/ui/packages/native/src/components/Tabs/TemplateTabs/index.tsx
+++ b/libs/ui/packages/native/src/components/Tabs/TemplateTabs/index.tsx
@@ -35,7 +35,8 @@ export const TabsContainer = styled(FlexBox)<{ stretchItems: boolean }>`
   size: undefined;
   flex-direction: row;
   width: 100%;
-  align-items: ${(p) => (p.stretchItems ? "stretch" : "center")};
+  align-items: stretch;
+  ${(p) => (p.stretchItems ? "" : "justify-content: center;")}
 `;
 
 const TemplateTabsGroup = ({


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Hide the category filters when the providers' list for that category is empty

### 📝 Description

Hide the category filters when the providers' list for that category is empty.

Only categories with at least one provider will show:

<img width="522" alt="Screenshot 2024-10-10 at 16 39 55" src="https://github.com/user-attachments/assets/b6dee458-619b-45ea-aab1-9a5c9978ddb3">

![Simulator Screenshot - iPhone 15 Pro - 2024-10-11 at 10 46 32](https://github.com/user-attachments/assets/20b1aa4d-1275-4b36-a400-3f39e9d45441)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
