### PR TITLE
feat(web3Hub): fix state management with jotai

### DIFF
--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -154,7 +154,7 @@
     "hoist-non-react-statics": "3.3.2",
     "i18next": "20.6.1",
     "invariant": "2.2.4",
-    "jotai": "^2.7.0",
+    "jotai": "^2.10.1",
     "json-rpc-2.0": "^0.2.19",
     "lodash": "4.17.21",
     "lottie-react-native": "^6.7.0",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -154,6 +154,7 @@
     "hoist-non-react-statics": "3.3.2",
     "i18next": "20.6.1",
     "invariant": "2.2.4",
+    "jotai": "^2.7.0",
     "json-rpc-2.0": "^0.2.19",
     "lodash": "4.17.21",
     "lottie-react-native": "^6.7.0",

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/Disclaimer/useDisclaimerViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/Disclaimer/useDisclaimerViewModel.ts
@@ -1,17 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
-import { INITIAL_WEB3HUB_STATE, WEB3HUB_STORE_KEY } from "LLM/features/Web3Hub/constants";
 import { Web3HubDB } from "LLM/features/Web3Hub/types";
-import { useDB } from "~/db";
+import { useWeb3HubDB } from "LLM/features/Web3Hub/db";
 
 const dismissedManifestsSelector = (state: Web3HubDB) => state.dismissedManifests;
 
 export function useDismissedManifests() {
-  return useDB<Web3HubDB, Web3HubDB["dismissedManifests"]>(
-    WEB3HUB_STORE_KEY,
-    INITIAL_WEB3HUB_STATE,
-    dismissedManifestsSelector,
-  );
+  return useWeb3HubDB<Web3HubDB["dismissedManifests"]>(dismissedManifestsSelector);
 }
 
 export default function useDisclaimerViewModel(goToApp: (manifestId: string) => void) {
@@ -27,11 +22,6 @@ export default function useDisclaimerViewModel(goToApp: (manifestId: string) => 
       setIsChecked(false);
     }
   }, [disclaimerManifest, dismissedManifests]);
-
-  useEffect(() => {
-    setWeb3HubDB(INITIAL_WEB3HUB_STATE);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const onPressItem = useCallback(
     (manifest: AppManifest) => {

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/Disclaimer/useDisclaimerViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/components/Disclaimer/useDisclaimerViewModel.ts
@@ -3,15 +3,11 @@ import { AppManifest } from "@ledgerhq/live-common/wallet-api/types";
 import { dismissedManifestsAtom } from "LLM/features/Web3Hub/db";
 import { useAtom } from "jotai";
 
-export function useDismissedManifests() {
-  return useAtom(dismissedManifestsAtom);
-}
-
 export default function useDisclaimerViewModel(goToApp: (manifestId: string) => void) {
   const [isChecked, setIsChecked] = useState(false);
   const [disclaimerOpened, setDisclaimerOpened] = useState(false);
   const [disclaimerManifest, setDisclaimerManifest] = useState<AppManifest>();
-  const [dismissedManifests, setDismissedManifests] = useDismissedManifests();
+  const [dismissedManifests, setDismissedManifests] = useAtom(dismissedManifestsAtom);
 
   useEffect(() => {
     if (disclaimerManifest && !!dismissedManifests[disclaimerManifest.id]) {

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/constants.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/constants.ts
@@ -1,11 +1,4 @@
-import type { Web3HubDB } from "./types";
-
 export const URL_ORIGIN = "https://live-app-catalog.ledger.com";
 
-export const WEB3HUB_STORE_KEY = "web3hub";
-
-export const INITIAL_WEB3HUB_STATE: Web3HubDB = {
-  recentlyUsed: [],
-  dismissedManifests: {},
-  // localLiveApp: [],
-};
+export const RECENTLY_USED_KEY = "WEB3HUB_RECENTLY_USED";
+export const DISSMISSED_MANIFETS_KEY = "WEB3HUB_DISSMISSED_MANIFETS";

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/db.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/db.ts
@@ -1,0 +1,36 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useAtom } from "jotai";
+import { createJSONStorage } from "jotai/utils";
+import { useCallback, useMemo } from "react";
+import { Web3HubDB } from "LLM/features/Web3Hub/types";
+import { atomWithStorage } from "jotai/utils";
+import { INITIAL_WEB3HUB_STATE, WEB3HUB_STORE_KEY } from "./constants";
+
+export const storage = createJSONStorage<Web3HubDB>(() => AsyncStorage);
+
+export const web3hubAtom = atomWithStorage<Web3HubDB>(
+  WEB3HUB_STORE_KEY,
+  INITIAL_WEB3HUB_STATE,
+  storage,
+);
+
+type NewState = Web3HubDB | ((s: Web3HubDB) => Web3HubDB);
+
+export function useWeb3HubDB<Selected>(
+  selector: (state: Web3HubDB) => Selected,
+): [Selected, (v: NewState) => void] {
+  const [state, setState] = useAtom(web3hubAtom);
+
+  const setter = useCallback(
+    (newState: NewState) => {
+      const val = typeof newState === "function" ? newState(state) : newState;
+
+      setState(val);
+    },
+    // eslint-disable-next-line
+    [state],
+  );
+
+  const result = useMemo(() => selector(state), [state, selector]);
+  return [result, setter];
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/db.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/db.ts
@@ -1,36 +1,15 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useAtom } from "jotai";
-import { createJSONStorage } from "jotai/utils";
-import { useCallback, useMemo } from "react";
 import { Web3HubDB } from "LLM/features/Web3Hub/types";
-import { atomWithStorage } from "jotai/utils";
-import { INITIAL_WEB3HUB_STATE, WEB3HUB_STORE_KEY } from "./constants";
+import { atomWithStorage, createJSONStorage } from "jotai/utils";
+import { DISSMISSED_MANIFETS_KEY, RECENTLY_USED_KEY } from "./constants";
 
-export const storage = createJSONStorage<Web3HubDB>(() => AsyncStorage);
+const emptyRecentlyUsed: Web3HubDB["recentlyUsed"] = [];
+export const recentlyUseAtom = storedAtom(RECENTLY_USED_KEY, emptyRecentlyUsed);
 
-export const web3hubAtom = atomWithStorage<Web3HubDB>(
-  WEB3HUB_STORE_KEY,
-  INITIAL_WEB3HUB_STATE,
-  storage,
-);
+const emptyDismissedManifests: Web3HubDB["dismissedManifests"] = {};
+export const dismissedManifestsAtom = storedAtom(DISSMISSED_MANIFETS_KEY, emptyDismissedManifests);
 
-type NewState = Web3HubDB | ((s: Web3HubDB) => Web3HubDB);
-
-export function useWeb3HubDB<Selected>(
-  selector: (state: Web3HubDB) => Selected,
-): [Selected, (v: NewState) => void] {
-  const [state, setState] = useAtom(web3hubAtom);
-
-  const setter = useCallback(
-    (newState: NewState) => {
-      const val = typeof newState === "function" ? newState(state) : newState;
-
-      setState(val);
-    },
-    // eslint-disable-next-line
-    [state],
-  );
-
-  const result = useMemo(() => selector(state), [state, selector]);
-  return [result, setter];
+export function storedAtom<T = unknown>(key: string, defaultValue: T) {
+  const storage = createJSONStorage<T>(() => AsyncStorage);
+  return atomWithStorage<T>(key, defaultValue, storage);
 }

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -224,7 +224,7 @@
     "invariant": "^2.2.2",
     "iso-filecoin": "^4.1.0",
     "isomorphic-ws": "^4.0.1",
-    "jotai": "^2.7.0",
+    "jotai": "^2.10.1",
     "json-rpc-2.0": "^0.2.19",
     "lodash": "^4.17.21",
     "minimatch": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1053,8 +1053,8 @@ importers:
         specifier: 2.2.4
         version: 2.2.4
       jotai:
-        specifier: ^2.7.0
-        version: 2.7.1(@types/react@18.2.73)(react@18.2.0)
+        specifier: ^2.10.1
+        version: 2.10.1(@types/react@18.2.73)(react@18.2.0)
       json-rpc-2.0:
         specifier: ^0.2.19
         version: 0.2.19
@@ -3773,8 +3773,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(ws@7.5.10)
       jotai:
-        specifier: ^2.7.0
-        version: 2.7.1(@types/react@18.2.73)(react@18.2.0)
+        specifier: ^2.10.1
+        version: 2.10.1(@types/react@18.2.73)(react@18.2.0)
       json-rpc-2.0:
         specifier: ^0.2.19
         version: 0.2.19
@@ -22620,8 +22620,8 @@ packages:
   join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
 
-  jotai@2.7.1:
-    resolution: {integrity: sha512-bsaTPn02nFgWNP6cBtg/htZhCu4s0wxqoklRHePp6l/vlsypR9eLn7diRliwXYWMXDpPvW/LLA2afI8vwgFFaw==}
+  jotai@2.10.1:
+    resolution: {integrity: sha512-4FycO+BOTl2auLyF2Chvi6KTDqdsdDDtpaL/WHQMs8f3KS1E3loiUShQzAzFA/sMU5cJ0hz/RT1xum9YbG/zaA==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'
@@ -43108,7 +43108,7 @@ snapshots:
       commander: 8.3.0
       deepmerge: 4.3.1
       glob: 7.2.3
-      jotai: 2.7.1(@types/react@18.2.73)(react@18.2.0)
+      jotai: 2.10.1(@types/react@18.2.73)(react@18.2.0)
       prettier: 2.8.8
       react: 18.2.0
       react-native: 0.74.6(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.2.0)
@@ -55257,7 +55257,7 @@ snapshots:
 
   join-component@1.1.0: {}
 
-  jotai@2.7.1(@types/react@18.2.73)(react@18.2.0):
+  jotai@2.10.1(@types/react@18.2.73)(react@18.2.0):
     optionalDependencies:
       '@types/react': 18.2.73
       react: 18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,6 +1052,9 @@ importers:
       invariant:
         specifier: 2.2.4
         version: 2.2.4
+      jotai:
+        specifier: ^2.7.0
+        version: 2.7.1(@types/react@18.2.73)(react@18.2.0)
       json-rpc-2.0:
         specifier: ^0.2.19
         version: 0.2.19


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bugfix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description


#### Problem

Currently, the way we update the app storage causes issues because the data state isn't shared between instances.
Specifically, when we modify a variable with instance X, the state of instance Y isn't updated (as the state isn't shared). As a result, if two different instances update the app storage at the same time, only the last modification is applied, leading to potential data loss.

#### Solution

Ensure that the database state is shared across all instances. This way, a modification in instance Z will automatically reflect in instance Y, by using `Jotai` npm lib, a lightweight library that simplifies state management across an application.


https://github.com/user-attachments/assets/5b840552-b12b-46c2-8067-a9e91f866022


- **JIRA** : https://ledgerhq.atlassian.net/browse/LIVE-14442


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
