### PR TITLE
:bug:(lld): fix toasts issue

### DIFF
--- a/.changeset/shy-lobsters-report.md
+++ b/.changeset/shy-lobsters-report.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix toast never disappearing + fix duration bar of toast

--- a/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/TimeBasedProgressBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/TimeBasedProgressBar.tsx
@@ -1,26 +1,19 @@
 import React, { useEffect } from "react";
-import { animated, useTransition } from "react-spring";
+import { animated, useSpring } from "react-spring";
+
 type Props = {
   duration: number;
   onComplete?: () => void;
   nonce?: number;
 };
+
 export function TimeBasedProgressBar({ duration, onComplete, nonce = 1 }: Props) {
-  const config = {
-    duration,
-    tension: 125,
-    friction: 20,
-    precision: 0.1,
-  };
-  const transitions = useTransition(1, null, {
-    from: {
-      width: "0%",
-    },
-    enter: {
-      width: "100%",
-    },
-    config,
+  const style = useSpring({
+    from: { width: "0%" },
+    to: { width: "100%" },
+    config: { duration, friction: 0, tension: 125, precision: 0.1 },
   });
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (nonce && onComplete) onComplete();
@@ -29,6 +22,7 @@ export function TimeBasedProgressBar({ duration, onComplete, nonce = 1 }: Props)
       clearTimeout(timeout);
     };
   }, [duration, onComplete, nonce]);
+
   return (
     <div
       style={{
@@ -36,18 +30,14 @@ export function TimeBasedProgressBar({ duration, onComplete, nonce = 1 }: Props)
         height: 5,
       }}
     >
-      {transitions.map(({ key, props }) => (
-        <animated.div
-          key={key}
-          style={{
-            ...props,
-            height: 5,
-            width: "100%",
-            transformOrigin: "left center",
-            background: "#8a80db", // "#00000022",
-          }}
-        />
-      ))}
+      <animated.div
+        style={{
+          ...style,
+          height: 5,
+          transformOrigin: "left center",
+          background: "#8a80db",
+        }}
+      />
     </div>
   );
 }

--- a/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/Toast.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/Toast.tsx
@@ -109,24 +109,32 @@ export function Toast({
       precision: 0.1,
     },
   });
+
+  const toastListIds = id.split(",").reverse();
+
   useEffect(() => {
     async function scheduledDismiss(duration: number) {
       await delay(duration);
-      onDismiss(id);
+      toastListIds.forEach(id => {
+        onDismiss(id);
+      });
     }
     if (duration) {
       scheduledDismiss(duration);
     }
-  }, [duration, id, onDismiss]);
+  }, [duration, id, onDismiss, toastListIds]);
+
   const onClick: React.MouseEventHandler<HTMLInputElement> = useCallback(
     event => {
       if (typeof callback === "function") {
         callback();
+        toastListIds.forEach(id => {
+          onDismiss(id);
+        });
       }
-      onDismiss(id);
       event.stopPropagation();
     },
-    [callback, id, onDismiss],
+    [callback, onDismiss, toastListIds],
   );
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ToastOverlay/index.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Toast } from "./Toast";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
-import { v4 as uuidv4 } from "uuid";
 import { openInformationCenter } from "~/renderer/actions/UI";
 const Wrapper = styled.div`
   position: absolute;
@@ -43,7 +42,8 @@ export function ToastOverlay() {
         ))
       ) : (
         <Toast
-          id={uuidv4()}
+          id={toasts.map(({ id }) => id).join(",")}
+          duration={10000}
           icon="info"
           title={t("toastOverlay.groupedToast.text", {
             count: toasts.length,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - toasts

### 📝 Description

Stacked were not disappearing because we didn't delete their id of the list. Fixed ✅ 
Also add duration to toast of 10sec
Fixed the duration bar 


https://github.com/user-attachments/assets/8fc1a9ca-59ea-4940-bfe3-59302e3e8433



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:(https://ledgerhq.atlassian.net/browse/LIVE-14262)[LIVE-14262] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14262]: https://ledgerhq.atlassian.net/browse/LIVE-14262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ