### PR TITLE
Add providerTestId to test specific provider

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -102,6 +102,9 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
             ...(localManifest?.providerTestBaseUrl && {
               providerTestBaseUrl: localManifest?.providerTestBaseUrl,
             }),
+            ...(localManifest?.providerTestId && {
+              providerTestId: localManifest?.providerTestId,
+            }),
 
             ...Object.fromEntries(searchParams.entries()),
           }}

--- a/apps/ledger-live-mobile/src/screens/PTX/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/index.tsx
@@ -117,6 +117,9 @@ export function PtxScreen({ route, config }: Props) {
           ...(localManifest?.providerTestBaseUrl && {
             providerTestBaseUrl: localManifest?.providerTestBaseUrl,
           }),
+          ...(localManifest?.providerTestId && {
+            providerTestId: localManifest?.providerTestId,
+          }),
           ...customParams,
           ...Object.fromEntries(searchParams.entries()),
         }}

--- a/libs/ledger-live-common/src/platform/types.ts
+++ b/libs/ledger-live-common/src/platform/types.ts
@@ -128,6 +128,7 @@ export type LiveAppManifest = {
   visibility: Visibility;
   highlight?: boolean;
   providerTestBaseUrl?: string;
+  providerTestId?: string;
   content: {
     cta?: TranslatableString;
     subtitle?: TranslatableString;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR adds another parameter `providerTestId` which allows user to specify a specific provider (for example `revolut`, `topper`,... ) when testing using `providerTestBaseUrl`. 

In this way when on the `buy-sell-ui` just the provider indicated using this parameter will be returned by the API with the environment set by the `providerTestBaseUrl`.

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
