### PR TITLE
build: pin release workflow dependencies

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   create-hotfix:
     name: Create Hotfix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   create-release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       RELEASE_BRANCH: "release"

--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   nightly-release:
     name: Nightly Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   prepare-release:
     name: Prepare Hotfix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   prerelease:
     name: Prerelease
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:


### PR DESCRIPTION
### 📝 Description

Pins dependencies for `release-*.yml` workflows. In reality this pins only the ubuntu version, but all workflows were individually checked for versions that could drift. This includes the following custom action dependencies:
- generate-release-message
- get-package-infos
- setup-toolchain
- turborepo-s3-cache
- setup-git-user

3rd party actions were checked for having a major version pin but the pin was not extended to minor versions.

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-14091

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
