### PR TITLE
readme: fix xcode version

### DIFF
--- a/apps/ledger-live-mobile/README.md
+++ b/apps/ledger-live-mobile/README.md
@@ -25,7 +25,7 @@ We also share core business logic with Ledger Live mobile through [@ledgerhq/liv
 
 ### iOS
 
-- XCode (our CI builds run 15.4, so 15.4 is recommended)
+- XCode (our CI builds run 15.3, so 15.3 is recommended)
 - Ruby 3.3.0 or above. The macOS built-in Ruby [does not work properly for installing dependencies of the iOS app](https://jeffreymorgan.io/articles/ruby-on-macos-with-rvm/), you have to install Ruby with for instance [Homebrew](https://brew.sh/) or [rvm](https://rvm.io/rvm/install) and make sure that `which ruby` points to that newly installed Ruby.
 
 ### Android


### PR DESCRIPTION
### 📝 Description

[Our runners use Xcode 15.3](https://github.com/LedgerHQ/mac-foundry/blob/main/build/ledger-live-test/ledger-live-test.pkr.hcl#L59) not 15.4, so updating the readme accordingly

### ❓ Context

Just fixing an incorrect readme

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
