### PR TITLE
:bug:(lld): exported account name in csv

### DIFF
--- a/.changeset/lucky-otters-think.md
+++ b/.changeset/lucky-otters-think.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+when exporting account we were not displaying parent account inside account name but the coin name

--- a/libs/ledger-live-common/src/csvExport.ts
+++ b/libs/ledger-live-common/src/csvExport.ts
@@ -66,10 +66,12 @@ const fields: Field[] = [
   },
   {
     title: "Account Name",
-    cell: (account, parentAccount, _op, _counterValueCurrency, _countervalueState, walletState) =>
-      walletState
-        ? accountNameWithDefaultSelector(walletState, account)
-        : getDefaultAccountName(getMainAccount(account, parentAccount)),
+    cell: (account, parentAccount, _op, _counterValueCurrency, _countervalueState, walletState) => {
+      const main = getMainAccount(account, parentAccount);
+      return walletState
+        ? accountNameWithDefaultSelector(walletState, main)
+        : getDefaultAccountName(main);
+    },
   },
   {
     title: "Account xpub",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Export csv

### 📝 Description

There was an issue introduced with previous PR https://github.com/LedgerHQ/ledger-live/pull/7813 that uses token name as account name. 

<img width="1205" alt="Screenshot 2024-10-16 at 15 03 58" src="https://github.com/user-attachments/assets/00bd1574-c703-47c2-a8ce-413fa0336d2a">



### ❓ Context

- **JIRA or GitHub link**: [LIVE-14528](https://ledgerhq.atlassian.net/browse/LIVE-14528)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14528]: https://ledgerhq.atlassian.net/browse/LIVE-14528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ