### PR TITLE
fix attempt: wait between attempts for speculos device's screen to refresh

### DIFF
--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -376,6 +376,8 @@ export async function pressRightUntil(text: string, maxAttempts: number = 10): P
       action: "press-and-release",
     });
     attempts++;
+
+    await waitForTimeOut(200);
   }
 
   if (attempts === maxAttempts) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** Trying to fix when text isn't found on speculos device screen by waiting between 2 attempts

### 📝 Description

Trying to fix when text isn't found on speculos device screen by waiting between 2 attempts

### ❓ Context

[reporting](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/a01ebf08-a321-4c5a-a6c5-fcfb6de75d35/)
failures on Ledger sync is due to wrong CLI command returning 502 & on swap due to changelly not appearing (bit random)
unrelated to my changes

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
