### PR TITLE
:sparkles:(lld): change sync error tooltip to be more readable

### DIFF
--- a/.changeset/long-meals-laugh.md
+++ b/.changeset/long-meals-laugh.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Update the ui of the tooltip when there is some sync errors. We now display the name of the accounts that failed to sync

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/ActivityIndicator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/ActivityIndicator.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { Trans } from "react-i18next";
-import { useBridgeSync, useGlobalSyncState } from "@ledgerhq/live-common/bridge/react/index";
+import {
+  useBatchAccountsSyncState,
+  useBridgeSync,
+  useGlobalSyncState,
+} from "@ledgerhq/live-common/bridge/react/index";
 import { useCountervaluesPolling } from "@ledgerhq/live-countervalues-react";
 import { getEnv } from "@ledgerhq/live-env";
 import { track } from "~/renderer/analytics/segment";
@@ -15,18 +19,38 @@ import TranslatedError from "../TranslatedError";
 import Box from "../Box";
 import { ItemContainer } from "./shared";
 import { useWalletSyncUserState } from "LLD/features/WalletSync/components/WalletSyncContext";
+import { useBatchMaybeAccountName } from "~/renderer/reducers/wallet";
+import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { Text } from "@ledgerhq/react-ui";
 
-export default function ActivityIndicatorInner() {
+const ActivityIndicatorInner = () => {
   const wsUserState = useWalletSyncUserState();
   const bridgeSync = useBridgeSync();
   const globalSyncState = useGlobalSyncState();
-  const isUpToDate = useSelector(isUpToDateSelector);
+  const accountsWithUpToDateCheck = useSelector(isUpToDateSelector);
   const cvPolling = useCountervaluesPolling();
+
+  const allAccounts = accountsWithUpToDateCheck.map(ojb => ojb.account);
+  const allAccountsWithSyncProblem = useBatchAccountsSyncState({ accounts: allAccounts }).filter(
+    ({ syncState, account }) =>
+      !syncState.pending &&
+      (syncState.error ||
+        !accountsWithUpToDateCheck.find(obj => obj.account.id === account.id)?.isUpToDate),
+  );
+  const allMaybeAccountNames = useBatchMaybeAccountName(
+    allAccountsWithSyncProblem.map(ojb => ojb.account),
+  );
+  const allAccountNamesWithSyncError = allMaybeAccountNames.map(
+    (name, index) => name ?? getDefaultAccountName(allAccountsWithSyncProblem[index].account),
+  );
+
+  const areAllAccountsUpToDate = allAccountNamesWithSyncError.length === 0;
+
   const isPending = cvPolling.pending || globalSyncState.pending || wsUserState.visualPending;
   const syncError =
     !isPending && (cvPolling.error || globalSyncState.error || wsUserState.walletSyncError);
-  // we only show error if it's not up to date. this hide a bit error that happen from time to time
-  const isError = (!!syncError && !isUpToDate) || !!wsUserState.walletSyncError;
+
+  const isError = !!syncError || !areAllAccountsUpToDate || !!wsUserState.walletSyncError;
   const error = (syncError ? globalSyncState.error : null) || wsUserState.walletSyncError;
   const [lastClickTime, setLastclickTime] = useState(0);
   const onClick = useCallback(() => {
@@ -43,8 +67,48 @@ export default function ActivityIndicatorInner() {
   const isSpectronRun = getEnv("PLAYWRIGHT_RUN"); // we will keep 'spinning' in spectron case
   const userClickTime = isSpectronRun ? 10000 : 1000;
   const isUserClick = Date.now() - lastClickTime < userClickTime; // time to keep display the spinning on a UI click.
-  const isRotating = isPending && (!isUpToDate || isUserClick);
+  const isRotating = isPending && isUserClick;
   const isDisabled = isError || isRotating;
+
+  const getIcon = () => {
+    if (isError) return <IconExclamationCircle size={16} />;
+    if (isRotating) return <IconLoader size={16} />;
+    if (areAllAccountsUpToDate) return <IconCheckCircle size={16} />;
+    return <IconExclamationCircle size={16} />;
+  };
+
+  const getText = () => {
+    if (isRotating) return <Trans i18nKey="common.sync.syncing" />;
+    if (isError) {
+      return (
+        <>
+          <Box>
+            <Trans i18nKey="common.sync.error" />
+          </Box>
+          <Box
+            ml={2}
+            style={{
+              textDecoration: "underline",
+              pointerEvents: "all",
+              cursor: "pointer",
+            }}
+            onClick={onClick}
+          >
+            <Trans i18nKey="common.sync.refresh" />
+          </Box>
+        </>
+      );
+    }
+    if (areAllAccountsUpToDate) {
+      return (
+        <span data-testid="topbar-synchronized">
+          <Trans i18nKey="common.sync.upToDate" />
+        </span>
+      );
+    }
+    return <Trans i18nKey="common.sync.outdated" />;
+  };
+
   const content = (
     <ItemContainer
       data-testid="topbar-synchronize-button"
@@ -60,20 +124,12 @@ export default function ActivityIndicatorInner() {
             ? "alertRed"
             : isRotating
               ? "palette.text.shade60"
-              : isUpToDate
+              : areAllAccountsUpToDate
                 ? "positiveGreen"
                 : "palette.text.shade60"
         }
       >
-        {isError ? (
-          <IconExclamationCircle size={16} />
-        ) : isRotating ? (
-          <IconLoader size={16} />
-        ) : isUpToDate ? (
-          <IconCheckCircle size={16} />
-        ) : (
-          <IconExclamationCircle size={16} />
-        )}
+        {getIcon()}
       </Rotating>
       <Box
         ml={isRotating ? 2 : 1}
@@ -83,36 +139,12 @@ export default function ActivityIndicatorInner() {
         horizontal
         alignItems="center"
       >
-        {isRotating ? (
-          <Trans i18nKey="common.sync.syncing" />
-        ) : isError ? (
-          <>
-            <Box>
-              <Trans i18nKey="common.sync.error" />
-            </Box>
-            <Box
-              ml={2}
-              style={{
-                textDecoration: "underline",
-                pointerEvents: "all",
-                cursor: "pointer",
-              }}
-              onClick={onClick}
-            >
-              <Trans i18nKey="common.sync.refresh" />
-            </Box>
-          </>
-        ) : isUpToDate ? (
-          <span data-testid="topbar-synchronized">
-            <Trans i18nKey="common.sync.upToDate" />
-          </span>
-        ) : (
-          <Trans i18nKey="common.sync.outdated" />
-        )}
+        {getText()}
       </Box>
     </ItemContainer>
   );
-  if (isError && error) {
+
+  if (!areAllAccountsUpToDate || (isError && error)) {
     return (
       <Tooltip
         tooltipBg="alertRed"
@@ -124,7 +156,24 @@ export default function ActivityIndicatorInner() {
               maxWidth: 250,
             }}
           >
-            <TranslatedError error={error} />
+            {isError && error && areAllAccountsUpToDate ? (
+              <TranslatedError error={error} />
+            ) : (
+              <Box>
+                <Text mb={1} textAlign="left">
+                  <Trans
+                    i18nKey="common.sync.failingSync"
+                    count={allAccountNamesWithSyncError.length}
+                  />
+                </Text>
+
+                {allAccountNamesWithSyncError.map((accountName, index) => (
+                  <Text key={index} textAlign="left">
+                    <li>{accountName}</li>
+                  </Text>
+                ))}
+              </Box>
+            )}
           </Box>
         }
       >
@@ -132,5 +181,8 @@ export default function ActivityIndicatorInner() {
       </Tooltip>
     );
   }
+
   return content;
-}
+};
+
+export default ActivityIndicatorInner;

--- a/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/accounts.ts
@@ -117,14 +117,17 @@ export const subAccountByCurrencyOrderedSelector = createSelector(
 // FIXME we might reboot this idea later!
 export const activeAccountsSelector = accountsSelector;
 export const isUpToDateSelector = createSelector(activeAccountsSelector, accounts =>
-  accounts.every(a => {
+  accounts.map(a => {
     const { lastSyncDate } = a;
     const { blockAvgTime } = a.currency;
-    if (!blockAvgTime) return true;
-    const outdated =
-      Date.now() - (lastSyncDate.getTime() || 0) >
-      blockAvgTime * 1000 + getEnv("SYNC_OUTDATED_CONSIDERED_DELAY");
-    return !outdated;
+    let isUpToDate = true;
+    if (blockAvgTime) {
+      const outdated =
+        Date.now() - (lastSyncDate.getTime() || 0) >
+        blockAvgTime * 1000 + getEnv("SYNC_OUTDATED_CONSIDERED_DELAY");
+      isUpToDate = !outdated;
+    }
+    return { account: a, isUpToDate };
   }),
 );
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
@@ -31,14 +31,24 @@ export function latestDistantVersionSelector(state: State): number {
   return walletSyncStateSelector(walletSelector(state)).version;
 }
 
+const getAccountName = (
+  state: State,
+  account: AccountLike | null | undefined,
+): string | undefined => {
+  return !account ? undefined : accountNameWithDefaultSelector(state.wallet, account);
+};
+
 export const useMaybeAccountName = (
   account: AccountLike | null | undefined,
 ): string | undefined => {
-  return useSelector((state: State) =>
-    !account ? undefined : accountNameWithDefaultSelector(state.wallet, account),
-  );
+  return useSelector((state: State) => getAccountName(state, account));
 };
 
+export const useBatchMaybeAccountName = (
+  accounts: (AccountLike | null | undefined)[],
+): (string | undefined)[] => {
+  return useSelector((state: State) => accounts.map(account => getAccountName(state, account)));
+};
 export const useAccountName = (account: AccountLike) => {
   return useSelector((state: State) => accountNameWithDefaultSelector(state.wallet, account));
 };

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -137,7 +137,9 @@
       "outdated": "Paused",
       "error": "Synchronization error",
       "refresh": "Refresh",
-      "devTools": "Dev tools"
+      "devTools": "Dev tools",
+      "failingSync_one": "Account failing to sync:",
+      "failingSync_other": "Accounts failing to sync:"
     },
     "exchange": "Exchange",
     "info": "Info",
@@ -2256,10 +2258,10 @@
       }
     },
     "memoTag": {
-        "title": "Need a Tag/Memo?",
-        "description": "You might need a <0>Tag/Memo</0> for receiving this asset from an exchange. You can use any combination of numbers like 1234.",
-        "learnMore": "Learn more about Tag/Memo"
-      }
+      "title": "Need a Tag/Memo?",
+      "description": "You might need a <0>Tag/Memo</0> for receiving this asset from an exchange. You can use any combination of numbers like 1234.",
+      "learnMore": "Learn more about Tag/Memo"
+    }
   },
   "send": {
     "title": "Send",

--- a/libs/ledger-live-common/src/bridge/react/useAccountSyncState.ts
+++ b/libs/ledger-live-common/src/bridge/react/useAccountSyncState.ts
@@ -1,9 +1,12 @@
-import type { SyncState } from "./types";
+import { Account } from "@ledgerhq/types-live";
 import { useBridgeSyncState } from "./context";
-const nothingState = {
+import type { SyncState } from "./types";
+
+const nothingState: SyncState = {
   pending: false,
   error: null,
 };
+
 export function useAccountSyncState({
   accountId,
 }: {
@@ -11,4 +14,28 @@ export function useAccountSyncState({
 } = {}): SyncState {
   const syncState = useBridgeSyncState();
   return (accountId && syncState[accountId]) || nothingState;
+}
+
+interface AccountWithSyncState {
+  account: Account;
+  syncState: SyncState;
+}
+
+export function useBatchAccountsSyncState({
+  accounts,
+}: {
+  accounts?: (Account | null)[];
+} = {}): AccountWithSyncState[] {
+  const syncState = useBridgeSyncState();
+  if (!accounts || !accounts?.length) return [];
+
+  return accounts.reduce((acc, account) => {
+    if (account) {
+      acc.push({
+        account,
+        syncState: syncState[account.id] || nothingState,
+      });
+    }
+    return acc;
+  }, [] as AccountWithSyncState[]);
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ActivityIndicator, isUpToDateSelector, usemaybeaccountname, useaccountsyncstate

### 📝 Description

in purpose to add a more readable UI inside sync tooltips we will display all the accounts that failed to sync (not update to date / not supported ). For this I've added batch hook to find all the account names

https://github.com/user-attachments/assets/a1718467-0ca8-42fe-b02f-c401aebf28d5


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14060](https://ledgerhq.atlassian.net/browse/LIVE-14060)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14060]: https://ledgerhq.atlassian.net/browse/LIVE-14060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ