### PR TITLE
fix(iOS): Solana error after broadcast on WebSockets [LIVE-14585]

### DIFF
--- a/.changeset/breezy-deers-scream.md
+++ b/.changeset/breezy-deers-scream.md
@@ -1,0 +1,15 @@
+---
+"live-mobile": patch
+---
+
+fix(iOS): Solana error after broadcast on WebSockets
+
+We are adding a missing user-agent header on the websocket for iOS with RN
+https://github.com/facebook/react-native/issues/28450
+https://github.com/facebook/react-native/issues/30727
+We need to use the interceptor as we don't control the code initiating the websocket
+Updating the options passed in by the interceptor works fine
+https://github.com/facebook/react-native/blob/3dfe22bd27429a43b4648c597b71f7965f31ca65/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js#L148-L163
+Another solution could be to use pnpm to patch react native WebSocket linked below
+https://github.com/facebook/react-native/blob/3dfe22bd27429a43b4648c597b71f7965f31ca65/packages/react-native/Libraries/WebSocket/WebSocket.js
+But the interceptor seems lean enough and a simple hack vs patching a lib seems preferable

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -1,5 +1,6 @@
 import "./polyfill";
 import "./live-common-setup";
+import "./iosWebsocketFix";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import React, { Component, useCallback, useMemo, useEffect } from "react";
 import { StyleSheet, LogBox, Appearance, AppState } from "react-native";

--- a/apps/ledger-live-mobile/src/iosWebsocketFix.ts
+++ b/apps/ledger-live-mobile/src/iosWebsocketFix.ts
@@ -1,0 +1,25 @@
+import { Platform } from "react-native";
+// @ts-expect-error WebSocketInterceptor is not exposed by react d.ts
+import WebSocketInterceptor from "react-native/Libraries/WebSocket/WebSocketInterceptor.js";
+
+// We are adding a missing user-agent header on the websocket for iOS with RN
+// https://github.com/facebook/react-native/issues/28450
+// https://github.com/facebook/react-native/issues/30727
+// We need to use the interceptor as we don't control the code initiating the websocket
+// Updating the options passed in by the interceptor works fine
+// https://github.com/facebook/react-native/blob/3dfe22bd27429a43b4648c597b71f7965f31ca65/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js#L148-L163
+// Another solution could be to use pnpm to patch react native WebSocket linked below
+// https://github.com/facebook/react-native/blob/3dfe22bd27429a43b4648c597b71f7965f31ca65/packages/react-native/Libraries/WebSocket/WebSocket.js
+// But the interceptor seems lean enough and a simple hack vs patching a lib seems preferable
+
+if (Platform.OS === "ios") {
+  WebSocketInterceptor.enableInterception();
+  WebSocketInterceptor.setConnectCallback(
+    (_url: string, _protocols: string[] | null, options?: { headers?: Record<string, string> }) => {
+      if (options) {
+        if (!options.headers) options.headers = {};
+        if (!options.headers["User-Agent"]) options.headers["User-Agent"] = "ReactNative";
+      }
+    },
+  );
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually as it requires to broadcast the transaction
- [x] **Impact of the changes:**
  - iOS websocket usage (Solana/send)

### 📝 Description

Our proxy for Solana is blocking the connection when no user-agent is provided
We are adding the missing user-agent header on the websocket for iOS with RN
We need to use the interceptor as we don't control the code initiating the websocket
Updating the [options passed in by the interceptor](https://github.com/facebook/react-native/blob/3dfe22bd27429a43b4648c597b71f7965f31ca65/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js#L148-L163) works fine
Another solution could be to use pnpm to patch [react native WebSocket](https://github.com/facebook/react-native/blob/3dfe22bd27429a43b4648c597b71f7965f31ca65/packages/react-native/Libraries/WebSocket/WebSocket.js)
But the interceptor seems lean enough and a simple hack vs patching a lib seems preferable

Related issues:
- https://github.com/facebook/react-native/issues/28450
- https://github.com/facebook/react-native/issues/30727


### ❓ Context

- **JIRA or GitHub link**: [LIVE-14585]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14585]: https://ledgerhq.atlassian.net/browse/LIVE-14585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ