### PR TITLE
[LLM][LLD] Hide Backup section during onboarding on Flex / Stax

### DIFF
--- a/.changeset/green-rice-cheer.md
+++ b/.changeset/green-rice-cheer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Use new recover upsell redirection

--- a/.changeset/plenty-dolphins-sneeze.md
+++ b/.changeset/plenty-dolphins-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"ledger-live-desktop": patch
 ---
 
 Hide Backup section during onboarding on Flex and Stax

--- a/.changeset/slow-buses-end.md
+++ b/.changeset/slow-buses-end.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/live-common": patch
+---
+
+Add recoverUpsellRedirection feature flag

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
@@ -371,18 +371,21 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
       if (deviceOnboardingState?.currentOnboardingStep === DeviceOnboardingStep.Ready) {
         // device was just seeded
         setCompanionStepKey(
-          recoverUpsellRedirection ? CompanionStepKey.Apps : CompanionStepKey.Backup,
+          recoverUpsellRedirection?.enabled ? CompanionStepKey.Apps : CompanionStepKey.Backup,
         );
         seededDeviceHandled.current = true;
         return;
       } else if (
         deviceOnboardingState?.currentOnboardingStep === DeviceOnboardingStep.WelcomeScreen1
       ) {
-        // switch to the apps step
-        __DEV__
-          ? setCompanionStepKey(CompanionStepKey.Backup) // for ease of testing in dev mode without having to reset the device
-          : setCompanionStepKey(CompanionStepKey.Apps);
-
+        if (recoverUpsellRedirection?.enabled) {
+          // switch to the apps step
+          __DEV__
+            ? setCompanionStepKey(CompanionStepKey.Backup) // for ease of testing in dev mode without having to reset the device
+            : setCompanionStepKey(CompanionStepKey.Apps);
+        } else {
+          setCompanionStepKey(CompanionStepKey.Apps);
+        }
         seededDeviceHandled.current = true;
         return;
       }
@@ -646,8 +649,9 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
             </Flex>
           ),
         },
-        ...(!recoverUpsellRedirection?.enabled
-          ? [
+        ...(recoverUpsellRedirection?.enabled
+          ? []
+          : [
               {
                 key: CompanionStepKey.Backup,
                 title: t("syncOnboarding.backup.title"),
@@ -659,8 +663,7 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
                   />
                 ),
               },
-            ]
-          : []),
+            ]),
         ...(deviceInitialApps?.enabled
           ? [
               {
@@ -682,16 +685,6 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
           title: t("syncOnboarding.readyStep.title"),
           doneTitle: t("syncOnboarding.readyStep.doneTitle", { productName }),
         },
-        ...(recoverUpsellRedirection?.enabled
-          ? [
-              {
-                key: CompanionStepKey.Backup,
-                title: t("syncOnboarding.backup.title"),
-                doneTitle: t("syncOnboarding.backup.title"),
-                renderBody: () => <BackupStep device={device} onPressKeepManualBackup={() => {}} />,
-              },
-            ]
-          : []),
       ].map(step => ({
         ...step,
         status:

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -512,6 +512,7 @@ export const DEFAULT_FEATURES: Features = {
       warningVisible: true,
     },
   },
+  recoverUpsellRedirection: DEFAULT_FEATURE,
 };
 
 // Firebase SDK treat JSON values as strings

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -194,6 +194,7 @@ export type Features = CurrencyFeatures & {
   llmMemoTag: Feature_MemoTag;
   lldMemoTag: Feature_MemoTag;
   ldmkTransport: Feature_LdmkTransport;
+  recoverUpsellRedirection: Feature_RecoverUpsellRedirection;
 };
 
 /**
@@ -554,6 +555,7 @@ export type Feature_lldNftsGalleryNewArch = DefaultFeature;
 export type Feature_lldnewArchOrdinals = DefaultFeature;
 export type Feature_SpamFilteringTx = DefaultFeature;
 export type Feature_MemoTag = DefaultFeature;
+export type Feature_RecoverUpsellRedirection = DefaultFeature;
 
 /**
  * Utils types.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - With feature flag `feature_recover_upsell_redirection` **deactivated**, the onboarding flow keeps unchanged;
  - With feature flag `feature_recover_upsell_redirection` **activated**, the _Backup for your Secret Recovery Phrase_ step between _Secret Recovery Phrase_ and _Apps Installation_ will be hidden.

### 📝 Description

New feature flag `feature_recover_upsell_redirection` has been added to hide the _Backup for your Secret Recovery Phrase_ section in onboarding flow for Flex and Stax devices.

### ❓ Context

- **JIRA or GitHub link**: 
  - https://ledgerhq.atlassian.net/browse/PROTECT-3391
  - https://ledgerhq.atlassian.net/browse/PROTECT-3403
  - https://ledgerhq.atlassian.net/browse/PROTECT-3404

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)