### PR TITLE
chore: 🔧 Enable only AVAX & BNB NFTs support

### DIFF
--- a/.changeset/great-forks-sip.md
+++ b/.changeset/great-forks-sip.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-env": patch
+---
+
+Revert some NFTs support waiting for new API support

--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -537,7 +537,7 @@ const envDefinitions = {
     desc: "if defined, avoids bypass of the currentDevice in the store.",
   },
   NFT_CURRENCIES: {
-    def: ["arbitrum", "avalanche_c_chain", "base", "ethereum", "optimism", "polygon", "scroll"],
+    def: ["avalanche_c_chain", "bsc", "ethereum", "polygon"],
     parser: stringArrayParser,
     desc: "set the currencies where NFT is active",
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Due to some errors related to explorers, we need to rollback some NFTs support, we only activate for AVAX & BSC

Waiting for [https://ledgerhq.atlassian.net/browse/LIVE-14648 ](https://ledgerhq.atlassian.net/browse/LIVE-14648) to be done to continue activating more EVM

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
