### PR TITLE
fix(llm): 🔧 memo input on the send flow of Solana

### DIFF
--- a/.changeset/dull-plums-cheer.md
+++ b/.changeset/dull-plums-cheer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix the memo on the Solana send flow

--- a/apps/ledger-live-mobile/src/families/algorand/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/MemoTagInput.tsx
@@ -4,9 +4,9 @@ import type { Transaction as AlgorandTransaction } from "@ledgerhq/live-common/f
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<AlgorandTransaction>
+export default (props: MemoTagInputProps<AlgorandTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/cardano/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/MemoTagInput.tsx
@@ -4,9 +4,9 @@ import type { Transaction as CardanoTransaction } from "@ledgerhq/live-common/fa
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<CardanoTransaction>
+export default (props: MemoTagInputProps<CardanoTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/casper/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/MemoTagInput.tsx
@@ -5,13 +5,13 @@ import type { Transaction as CasperTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => {
+export default (props: MemoTagInputProps<CasperTransaction>) => {
   const { t } = useTranslation();
   return (
-    <GenericMemoTagInput<CasperTransaction>
+    <GenericMemoTagInput
       {...props}
       textToValue={text => text.replace(/\D/g, "")}
-      valueToTxPatch={value => ({ transferId: value || undefined })}
+      valueToTxPatch={value => tx => ({ ...tx, transferId: value || undefined })}
       placeholder={t("send.summary.transferId")}
     />
   );

--- a/apps/ledger-live-mobile/src/families/cosmos/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/MemoTagInput.tsx
@@ -4,9 +4,9 @@ import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<CosmosTransaction>
+export default (props: MemoTagInputProps<CosmosTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/crypto_org/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/crypto_org/MemoTagInput.tsx
@@ -4,9 +4,9 @@ import type { Transaction as CryptoOrgTransaction } from "@ledgerhq/live-common/
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<CryptoOrgTransaction>
+export default (props: MemoTagInputProps<CryptoOrgTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/hedera/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/MemoTagInput.tsx
@@ -4,9 +4,9 @@ import type { Transaction as HederaTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<HederaTransaction>
+export default (props: MemoTagInputProps<HederaTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/internet_computer/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/MemoTagInput.tsx
@@ -4,10 +4,10 @@ import { Transaction as ICPTransaction } from "@ledgerhq/live-common/families/in
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<ICPTransaction>
+export default (props: MemoTagInputProps<ICPTransaction>) => (
+  <GenericMemoTagInput
     {...props}
     textToValue={text => text.replace(/\D/g, "")}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
@@ -1,12 +1,15 @@
+import merge from "lodash/merge";
 import React from "react";
 
-import { Transaction as SolanaTransaction } from "@ledgerhq/live-common/generated/types";
+import { Transaction as SolanaTransaction } from "@ledgerhq/live-common/families/solana/types";
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<SolanaTransaction>
+export default (props: MemoTagInputProps<SolanaTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx =>
+      merge({}, tx, { model: { uiState: { memo: value || undefined } } })
+    }
   />
 );

--- a/apps/ledger-live-mobile/src/families/stacks/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/stacks/MemoTagInput.tsx
@@ -4,9 +4,9 @@ import type { Transaction as StacksTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => (
-  <GenericMemoTagInput<StacksTransaction>
+export default (props: MemoTagInputProps<StacksTransaction>) => (
+  <GenericMemoTagInput
     {...props}
-    valueToTxPatch={value => ({ memo: value || undefined })}
+    valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
@@ -19,7 +19,7 @@ export default ({ onChange }: MemoTagInputProps<StellarTransaction>) => {
 
   const handleChange = (type: MemoType, value: string) => {
     const error = isMemoValid(type, value) ? undefined : new StellarWrongMemoFormat();
-    const patch = { memoType: type, memoValue: value };
+    const patch = (tx: StellarTransaction) => ({ ...tx, memoType: type, memoValue: value });
     onChange({ value, patch, error });
   };
 

--- a/apps/ledger-live-mobile/src/families/ton/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/ton/MemoTagInput.tsx
@@ -5,14 +5,12 @@ import type { Transaction as TonTransaction } from "@ledgerhq/live-common/famili
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => {
+export default (props: MemoTagInputProps<TonTransaction>) => {
   const { t } = useTranslation();
   return (
-    <GenericMemoTagInput<TonTransaction>
+    <GenericMemoTagInput
       {...props}
-      valueToTxPatch={value =>
-        value ? { comment: { isEncrypted: false, text: value } } : { comment: undefined }
-      }
+      valueToTxPatch={value => tx => ({ ...tx, comment: { isEncrypted: false, text: value } })}
       placeholder={t("send.summary.comment")}
     />
   );

--- a/apps/ledger-live-mobile/src/families/xrp/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/xrp/MemoTagInput.tsx
@@ -5,13 +5,13 @@ import type { Transaction as RippleTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps) => {
+export default (props: MemoTagInputProps<RippleTransaction>) => {
   const { t } = useTranslation();
   return (
-    <GenericMemoTagInput<RippleTransaction>
+    <GenericMemoTagInput
       {...props}
       textToValue={text => text.replace(/\D/g, "")}
-      valueToTxPatch={value => ({ tag: value ? Number(value) : undefined })}
+      valueToTxPatch={value => tx => ({ ...tx, tag: value ? Number(value) : undefined })}
       placeholder={t("send.summary.tag")}
     />
   );

--- a/apps/ledger-live-mobile/src/newArch/features/MemoTag/components/GenericMemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/MemoTag/components/GenericMemoTagInput.tsx
@@ -2,11 +2,11 @@ import React from "react";
 
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { AnimatedInput } from "@ledgerhq/native-ui";
-import { MemoTagInputProps } from "../types";
+import { MemoTagInputProps, TxPatch } from "../types";
 
 type Props<T extends Transaction = Transaction> = MemoTagInputProps<T> & {
   textToValue?: (text: string) => string;
-  valueToTxPatch: (text: string) => Partial<T>;
+  valueToTxPatch: (text: string) => TxPatch<T>;
 };
 
 export function GenericMemoTagInput<T extends Transaction>({

--- a/apps/ledger-live-mobile/src/newArch/features/MemoTag/hooks/useMemoTagInput.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/MemoTag/hooks/useMemoTagInput.ts
@@ -4,17 +4,16 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import perFamily from "~/generated/MemoTagInput";
-import { MemoTagInputProps } from "../types";
+import { MemoTagInputProps, TxPatch } from "../types";
 
 export const useMemoTagInput = (
   family: CryptoCurrency["family"],
-  updateTransaction: (patch: Partial<Transaction>) => void,
+  updateTransaction: (patch: TxPatch<Transaction>) => void,
 ) => {
   const featureMemoTag = useFeature("llmMemoTag");
-  const Input: FC<MemoTagInputProps> | null =
+  const Input =
     (featureMemoTag?.enabled &&
-      family in perFamily &&
-      perFamily[family as keyof typeof perFamily]) ||
+      (perFamily[family as keyof typeof perFamily] as FC<MemoTagInputProps>)) ||
     null;
 
   const [isEmpty, setIsEmpty] = useState(true);

--- a/apps/ledger-live-mobile/src/newArch/features/MemoTag/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/MemoTag/types.ts
@@ -1,7 +1,9 @@
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AnimatedInputProps } from "@ledgerhq/native-ui/components/Form/Input/AnimatedInput";
 
+export type TxPatch<T extends Transaction> = (tx: T) => T;
+
 export type MemoTagInputProps<T extends Transaction = Transaction> = Omit<
   AnimatedInputProps,
   "value" | "onChangeText" | "onChange"
-> & { onChange: (update: { patch: Partial<T>; value: string; error?: Error }) => void };
+> & { onChange: (update: { patch: TxPatch<T>; value: string; error?: Error }) => void };

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -137,7 +137,7 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
     useCallback(
       patch => {
         const bridge = getAccountBridge(account, parentAccount);
-        setTransaction(bridge.updateTransaction(transaction, patch));
+        setTransaction(bridge.updateTransaction(transaction, patch(transaction)));
       },
       [account, parentAccount, setTransaction, transaction],
     ),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The memo wasn't set correctly on Solana's transactions. This PR fixes this by changing the "patch" parameter of the "onChange" function set on `MemoInput` from an object to a `Transaction -> Transaction` function. Allowing each coin to set more complex transaction updates to set the memo.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-9634]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-9634]: https://ledgerhq.atlassian.net/browse/LIVE-9634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ