### PR TITLE
fix(ACRE): messageSign correctly sends appName and dependencies params to the connect action [LIVE-14762]

### DIFF
--- a/.changeset/large-crabs-reply.md
+++ b/.changeset/large-crabs-reply.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+fix(ACRE): messageSign correctly sends appName and dependencies params to the connect action

--- a/.changeset/pink-candles-happen.md
+++ b/.changeset/pink-candles-happen.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+fix: ACRE withdraw message support in UI

--- a/apps/ledger-live-desktop/src/renderer/components/SignMessageConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SignMessageConfirm/index.tsx
@@ -59,12 +59,21 @@ const SignMessageConfirm = ({ device, account, parentAccount, signMessageRequest
   const { currency } = mainAccount;
   const [messageFields, setMessageFields] = useState<MessageProperties | null>(null);
 
+  const isACREWithdraw = "type" in signMessageRequested && signMessageRequested.type === "Withdraw";
+
   useEffect(() => {
     if (signMessageRequested.standard === "EIP712") {
       const specific = getLLDCoinFamily(currency.family);
       specific?.message?.getMessageProperties(signMessageRequested).then(setMessageFields);
+    } else if (isACREWithdraw) {
+      setMessageFields(
+        Object.entries(signMessageRequested.message).map(([label, value]) => ({
+          label,
+          value,
+        })),
+      );
     }
-  }, [currency, mainAccount, signMessageRequested]);
+  }, [currency, isACREWithdraw, mainAccount, signMessageRequested]);
 
   if (!device) return null;
 
@@ -88,7 +97,7 @@ const SignMessageConfirm = ({ device, account, parentAccount, signMessageRequest
         label: t("SignMessageConfirm.messageHash"),
         value: signMessageRequested.hashStruct,
       });
-    } else {
+    } else if (!isACREWithdraw) {
       fields.push({
         type: "text",
         label: t("SignMessageConfirm.message"),

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSign.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSign.tsx
@@ -28,7 +28,7 @@ export default function StepSign({
     return {
       account,
       message,
-      useApp,
+      appName: useApp,
       dependencies: appRequests,
     };
   }, [account, dependencies, message, useApp]);

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
@@ -107,12 +107,21 @@ export default function StepSummary({ account, message: messageData }: StepProps
 
   const accountName = useAccountName(account);
 
+  const isACREWithdraw = "type" in messageData && messageData.type === "Withdraw";
+
   useEffect(() => {
     if (messageData.standard === "EIP712") {
       const specific = getLLDCoinFamily(mainAccount.currency.family);
       specific?.message?.getMessageProperties(messageData).then(setMessageFields);
+    } else if (isACREWithdraw) {
+      setMessageFields(
+        Object.entries(messageData.message).map(([label, value]) => ({
+          label,
+          value,
+        })),
+      );
     }
-  }, [account.currency.family, mainAccount, messageData, setMessageFields]);
+  }, [account.currency.family, isACREWithdraw, mainAccount, messageData, setMessageFields]);
 
   return (
     <Box flow={1}>
@@ -136,7 +145,7 @@ export default function StepSummary({ account, message: messageData }: StepProps
       </Box>
       <Separator />
 
-      {messageData.standard === "EIP712" ? (
+      {messageData.standard === "EIP712" || isACREWithdraw ? (
         <MessagePropertiesComp properties={messageFields} />
       ) : (
         <MessageProperty label={"message"} value={messageData.message} />

--- a/apps/ledger-live-mobile/src/components/ValidateMessageOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateMessageOnDevice.tsx
@@ -45,11 +45,20 @@ export default function ValidateOnDevice({ device, message: messageData, account
 
   const [messageFields, setMessageFields] = useState<MessageProperties | null>(null);
 
+  const isACREWithdraw = "type" in messageData && messageData.type === "Withdraw";
+
   useEffect(() => {
     if (messageData.standard === "EIP712") {
       getMessageProperties(messageData).then(setMessageFields);
+    } else if (isACREWithdraw) {
+      setMessageFields(
+        Object.entries(messageData.message).map(([label, value]) => ({
+          label,
+          value,
+        })),
+      );
     }
-  }, [mainAccount, mainAccount.currency, messageData, setMessageFields]);
+  }, [isACREWithdraw, mainAccount, mainAccount.currency, messageData, setMessageFields]);
 
   return (
     <View style={styles.root}>
@@ -72,7 +81,7 @@ export default function ValidateOnDevice({ device, message: messageData, account
           <LText style={messageTextStyle}>{t("walletconnect.stepVerification.accountName")}</LText>
           <LText semiBold>{mainAccountName}</LText>
         </View>
-        {messageData.standard === "EIP712" ? (
+        {messageData.standard === "EIP712" || isACREWithdraw ? (
           <>
             {messageFields
               ? messageFields.map(({ label, value }) => (

--- a/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
@@ -100,11 +100,20 @@ function SignSummary({
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [messageFields, setMessageFields] = useState<MessageProperties | null>(null);
 
+  const isACREWithdraw = "type" in messageData && messageData.type === "Withdraw";
+
   useEffect(() => {
     if (messageData.standard === "EIP712") {
       getMessageProperties(messageData).then(setMessageFields);
+    } else if (isACREWithdraw) {
+      setMessageFields(
+        Object.entries(messageData.message).map(([label, value]) => ({
+          label,
+          value,
+        })),
+      );
     }
-  }, [mainAccount, mainAccount.currency, messageData, setMessageFields]);
+  }, [isACREWithdraw, mainAccount, mainAccount.currency, messageData, setMessageFields]);
 
   return (
     <SafeAreaView
@@ -151,7 +160,7 @@ function SignSummary({
           ]}
         />
         <ScrollView style={styles.scrollContainer}>
-          {messageData.standard === "EIP712" ? (
+          {messageData.standard === "EIP712" || isACREWithdraw ? (
             <MessagePropertiesComp properties={messageFields} />
           ) : (
             <View style={styles.messageContainer}>
@@ -159,7 +168,7 @@ function SignSummary({
             </View>
           )}
 
-          {messageData.standard === "EIP712" ? (
+          {messageData.standard === "EIP712" || isACREWithdraw ? (
             <>
               {messageFields ? (
                 <View>

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -119,7 +119,7 @@
     "https": false
   },
   "dependencies": {
-    "@blooo/hw-app-acre": "^1.0.1",
+    "@blooo/hw-app-acre": "^1.1.1",
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.2",
     "@celo/connect": "^3.0.1",
     "@celo/contractkit": "^3.0.1",

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -129,7 +129,7 @@ export const createAction = (
     } = txRequest;
     const mainAccount = getMainAccount(txRequest.account, txRequest.parentAccount);
     const appState = createAppAction(connectAppExec).useHook(reduxDevice, {
-      account: mainAccount,
+      account: appName ? undefined : mainAccount,
       appName,
       dependencies,
       requireLatestFirmware,

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -36,10 +36,17 @@ const signMessage: SignMessage = (transport, account, opts) => {
   const { currency } = account;
   let signMessage = perFamily[currency.family].signMessage;
   if ("type" in opts) {
-    signMessage =
-      opts.type === AcreMessageType.Withdraw
-        ? ACREMessageSigner.signWithdraw
-        : ACREMessageSigner.signMessage;
+    switch (opts.type) {
+      case AcreMessageType.Withdraw:
+        signMessage = ACREMessageSigner.signWithdraw;
+        break;
+      case AcreMessageType.SignIn:
+        signMessage = ACREMessageSigner.signIn;
+        break;
+      default:
+        signMessage = ACREMessageSigner.signMessage;
+        break;
+    }
   }
   invariant(signMessage, `signMessage is not implemented for ${currency.id}`);
   return signMessage(transport, account, opts)
@@ -103,7 +110,7 @@ export const createAction = (
     const appState: AppState = createAppAction(connectAppExec).useHook(reduxDevice, {
       appName: request.appName,
       dependencies: request.dependencies,
-      account: request.account,
+      account: request.appName ? undefined : request.account,
     });
     const { device, opened, inWrongDeviceForAccount, error } = appState;
     const [state, setState] = useState<BaseState>({

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -101,6 +101,8 @@ export const createAction = (
 ) => {
   const useHook = (reduxDevice: Device | null | undefined, request: Request): State => {
     const appState: AppState = createAppAction(connectAppExec).useHook(reduxDevice, {
+      appName: request.appName,
+      dependencies: request.dependencies,
       account: request.account,
     });
     const { device, opened, inWrongDeviceForAccount, error } = appState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3482,8 +3482,8 @@ importers:
   libs/ledger-live-common:
     dependencies:
       '@blooo/hw-app-acre':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.1
+        version: 1.1.1
       '@cardano-foundation/ledgerjs-hw-app-cardano':
         specifier: ^7.1.2
         version: 7.1.2
@@ -8658,8 +8658,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@blooo/hw-app-acre@1.0.1':
-    resolution: {integrity: sha512-lLwG2abLFks6B8rHatIfj8rOSajzjCQlT6Wa4zoZnlxWqv8o3oIZ/kQzO3Mf3CgY2i3kMk3DqNKd7yBtXyfnEg==}
+  '@blooo/hw-app-acre@1.1.1':
+    resolution: {integrity: sha512-wWYUGR0sj4Yyy3GtiFRpRuaBdIgzbg8BnXCfUeduUzjQaMWzQ66wSvaJn4pHrIAdGwmdyqJWn3UqFgb1YPq0VQ==}
 
   '@braintree/sanitize-url@6.0.4':
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
@@ -29340,6 +29340,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typical@4.0.0:
     resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
     engines: {node: '>=8'}
@@ -32999,7 +33004,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@blooo/hw-app-acre@1.0.1':
+  '@blooo/hw-app-acre@1.1.1':
     dependencies:
       '@ledgerhq/hw-transport': 6.31.3
       '@ledgerhq/logs': 6.12.0
@@ -33012,7 +33017,7 @@ snapshots:
       semver: 7.5.4
       sha.js: 2.4.11
       tiny-secp256k1: 1.1.6
-      typescript: 5.6.2
+      typescript: 5.6.3
       varuint-bitcoin: 1.1.2
 
   '@braintree/sanitize-url@6.0.4': {}
@@ -33479,14 +33484,14 @@ snapshots:
       '@commitlint/types': 17.8.1
       '@types/node': 20.5.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.6.2)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.6.2))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.6.2))(typescript@5.6.2)
+      cosmiconfig: 8.3.6(typescript@5.4.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.3))(typescript@5.4.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.6.2)
-      typescript: 5.6.2
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.4.3)
+      typescript: 5.4.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -48242,7 +48247,7 @@ snapshots:
   config-file-ts@0.2.6:
     dependencies:
       glob: 10.3.12
-      typescript: 5.6.2
+      typescript: 5.4.3
 
   confusing-browser-globals@1.0.11: {}
 
@@ -48366,12 +48371,12 @@ snapshots:
     dependencies:
       layout-base: 1.0.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.6.2))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.6.2))(typescript@5.6.2):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.4.3))(ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.3))(typescript@5.4.3):
     dependencies:
       '@types/node': 20.5.1
-      cosmiconfig: 8.3.6(typescript@5.6.2)
-      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.6.2)
-      typescript: 5.6.2
+      cosmiconfig: 8.3.6(typescript@5.4.3)
+      ts-node: 10.9.2(@types/node@20.5.1)(typescript@5.4.3)
+      typescript: 5.4.3
 
   cosmiconfig@5.2.1:
     dependencies:
@@ -48405,14 +48410,14 @@ snapshots:
     optionalDependencies:
       typescript: 4.9.5
 
-  cosmiconfig@8.3.6(typescript@5.6.2):
+  cosmiconfig@8.3.6(typescript@5.4.3):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.4.3
 
   cosmjs-types@0.2.1:
     dependencies:
@@ -64756,7 +64761,7 @@ snapshots:
     transitivePeerDependencies:
       - source-map-support
 
-  ts-node@10.9.2(@types/node@20.5.1)(typescript@5.6.2):
+  ts-node@10.9.2(@types/node@20.5.1)(typescript@5.4.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -64770,7 +64775,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.6.2
+      typescript: 5.4.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     transitivePeerDependencies:
@@ -64997,6 +65002,8 @@ snapshots:
   typescript@5.4.5: {}
 
   typescript@5.6.2: {}
+
+  typescript@5.6.3: {}
 
   typical@4.0.0: {}
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually as we cannot test connect app automatically
- [x] **Impact of the changes:**
  - ACRE messageSign

### 📝 Description

messageSign used in the custom ACRE handlers now correctly passes `appName` and `dependencies` params to the connect action

I've also updated the lib and added a missing signIn handler for ACRE while testing everything with the app

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14762]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14762]: https://ledgerhq.atlassian.net/browse/LIVE-14762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ