### PR TITLE
fix(swap): install Ethereum app if at least one evm family in the swap and not already present in the deps [LIVE-14666]

### DIFF
--- a/.changeset/tiny-cobras-refuse.md
+++ b/.changeset/tiny-cobras-refuse.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(swap): install Ethereum app if at least one evm family in the swap and not already present in the deps

--- a/libs/ledger-live-common/src/hw/actions/startExchange.ts
+++ b/libs/ledger-live-common/src/hw/actions/startExchange.ts
@@ -123,7 +123,7 @@ export const createAction = (
         ? getMainAccount(exchange.toAccount, exchange.toParentAccount)
         : null;
 
-    const request: AppRequest = useMemo(() => {
+    const request = useMemo<AppRequest>(() => {
       if (isSwapDisableAppsInstall()) {
         return {
           appName: "Exchange",
@@ -135,16 +135,28 @@ export const createAction = (
           requireLatestFirmware,
         };
       } else {
+        const shouldAddEthApp =
+          (mainFromAccount.currency.family === "evm" || mainToAccount.currency.family === "evm") &&
+          mainFromAccount.currency.managerAppName !== "Ethereum" &&
+          mainToAccount.currency.managerAppName !== "Ethereum";
+        const dependencies: AppRequest["dependencies"] = [
+          {
+            account: mainFromAccount,
+          },
+          {
+            account: mainToAccount,
+          },
+        ];
+
+        if (shouldAddEthApp) {
+          dependencies.push({
+            appName: "Ethereum",
+          });
+        }
+
         return {
           appName: "Exchange",
-          dependencies: [
-            {
-              account: mainFromAccount,
-            },
-            {
-              account: mainToAccount,
-            },
-          ],
+          dependencies,
           requireLatestFirmware,
         };
       }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually the installation of the app
- [x] **Impact of the changes:**
  - Swap eth (no regression expected as we only add the Eth app in the deps)

### 📝 Description

Install Ethereum app if at least one evm family in the swap and the app is not already present in the deps
Avalanche needs the Ethereum app for the swap but we reference the Avalanche app in the cryptoassets lib, meaning if we don't have the Ethereum app already installed we end up with an error

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14666]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14666]: https://ledgerhq.atlassian.net/browse/LIVE-14666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ