### PR TITLE
[LLM][PROTECT-3391/3392/3393/3401/3403] Auto redirection to Recover upsell at the end of Stax/Flex onboarding

### DIFF
--- a/.changeset/green-rice-cheer.md
+++ b/.changeset/green-rice-cheer.md
@@ -2,4 +2,7 @@
 "live-mobile": patch
 ---
 
-Hide Backup section during onboarding on Flex and Stax
+Stax/Flex onboarding:
+  - Hide "Backup with Recover" section
+  - Auto redirect to Recover upsell between the onboarding and the post onboarding
+

--- a/.changeset/green-rice-cheer.md
+++ b/.changeset/green-rice-cheer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Hide Backup section during onboarding on Flex and Stax

--- a/.changeset/slow-buses-end.md
+++ b/.changeset/slow-buses-end.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/live-common": patch
+---
+
+Add recoverUpsellRedirection feature flag

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -70,6 +70,7 @@ import {
   SettingsAddStarredMarketcoinsPayload,
   SettingsRemoveStarredMarketcoinsPayload,
   SettingsSetFromLedgerSyncOnboardingPayload,
+  SettingsSetHasBeenRedirectedToPostOnboardingPayload,
 } from "./types";
 import { ImageType } from "~/components/CustomImage/types";
 
@@ -263,6 +264,11 @@ export const dangerouslyOverrideState = createAction<DangerouslyOverrideStatePay
 export const setHasBeenUpsoldProtect = createAction<SettingsSetHasBeenUpsoldProtectPayload>(
   SettingsActionTypes.SET_HAS_BEEN_UPSOLD_PROTECT,
 );
+
+export const setHasBeenRedirectedToPostOnboarding =
+  createAction<SettingsSetHasBeenRedirectedToPostOnboardingPayload>(
+    SettingsActionTypes.SET_HAS_BEEN_REDIRECTED_TO_POST_ONBOARDING,
+  );
 
 export const setGeneralTermsVersionAccepted = createAction<SettingsSetGeneralTermsVersionAccepted>(
   SettingsActionTypes.SET_GENERAL_TERMS_VERSION_ACCEPTED,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -273,6 +273,7 @@ export enum SettingsActionTypes {
   SET_FEATURE_FLAGS_BANNER_VISIBLE = "SET_FEATURE_FLAGS_BANNER_VISIBLE",
   SET_DEBUG_APP_LEVEL_DRAWER_OPENED = "SET_DEBUG_APP_LEVEL_DRAWER_OPENED",
   SET_HAS_BEEN_UPSOLD_PROTECT = "SET_HAS_BEEN_UPSOLD_PROTECT",
+  SET_HAS_BEEN_REDIRECTED_TO_POST_ONBOARDING = "SET_HAS_BEEN_REDIRECTED_TO_POST_ONBOARDING",
   SET_GENERAL_TERMS_VERSION_ACCEPTED = "SET_GENERAL_TERMS_VERSION_ACCEPTED",
   SET_ONBOARDING_TYPE = "SET_ONBOARDING_TYPE",
   SET_CLOSED_NETWORK_BANNER = "SET_CLOSED_NETWORK_BANNER",
@@ -379,6 +380,8 @@ export type SettingsSetDebugAppLevelDrawerOpenedPayload =
   SettingsState["debugAppLevelDrawerOpened"];
 
 export type SettingsSetHasBeenUpsoldProtectPayload = SettingsState["hasBeenUpsoldProtect"];
+export type SettingsSetHasBeenRedirectedToPostOnboardingPayload =
+  SettingsState["hasBeenRedirectedToPostOnboarding"];
 
 export type SettingsCompleteOnboardingPayload = void | SettingsState["hasCompletedOnboarding"];
 export type SettingsSetGeneralTermsVersionAccepted = SettingsState["generalTermsVersionAccepted"];

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/index.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/index.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useSelector } from "react-redux";
+import { lastConnectedDeviceSelector } from "~/reducers/settings";
+import { useOpenPostOnboardingCallback } from "./useOpenPostOnboardingCallback";
+import { useShouldRedirect } from "./useShouldRedirect";
+import { useOpenProtectUpsellCallback } from "./useOpenProtectUpsellCallback";
+import { useIsFocused } from "@react-navigation/core";
+
+/**
+ * Redirects the user to the post onboarding or the protect (Ledger Recover) upsell if needed
+ * */
+export function useAutoRedirectToPostOnboarding() {
+  const focused = useIsFocused();
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+
+  const { shouldRedirectToProtectUpsell, shouldRedirectToPostOnboarding } = useShouldRedirect();
+
+  const openProtectUpsell = useOpenProtectUpsellCallback();
+  const openPostOnboarding = useOpenPostOnboardingCallback();
+
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (!isFocused) return;
+    if (shouldRedirectToProtectUpsell) {
+      openProtectUpsell();
+    } else if (shouldRedirectToPostOnboarding && lastConnectedDevice) {
+      openPostOnboarding(lastConnectedDevice.modelId);
+    }
+  }, [
+    lastConnectedDevice,
+    openPostOnboarding,
+    openProtectUpsell,
+    shouldRedirectToPostOnboarding,
+    shouldRedirectToProtectUpsell,
+    focused,
+    isFocused,
+  ]);
+}

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenPostOnboardingCallback.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenPostOnboardingCallback.ts
@@ -1,0 +1,19 @@
+import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/useStartPostOnboardingCallback";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useCallback } from "react";
+
+/**
+ * Returns a callback to open the post onboarding screen
+ * */
+export function useOpenPostOnboardingCallback() {
+  const startPostOnboarding = useStartPostOnboardingCallback();
+  return useCallback(
+    (deviceModelId: DeviceModelId) => {
+      startPostOnboarding({
+        deviceModelId: deviceModelId,
+        resetNavigationStack: false,
+      });
+    },
+    [startPostOnboarding],
+  );
+}

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenProtectUpsellCallback.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenProtectUpsellCallback.ts
@@ -1,0 +1,73 @@
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import {
+  Source,
+  useAlreadyOnboardedURI,
+  useHomeURI,
+  usePostOnboardingURI,
+  useTouchScreenOnboardingUpsellURI,
+} from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useIsFocused } from "@react-navigation/core";
+import { useCallback, useEffect, useState } from "react";
+import { Linking } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
+import { setHasBeenUpsoldProtect } from "~/actions/settings";
+import { internetReachable } from "~/logic/internetReachable";
+import { lastConnectedDeviceSelector, onboardingTypeSelector } from "~/reducers/settings";
+import { OnboardingType } from "~/reducers/types";
+
+/**
+ * Returns a callback to open the Protect (Ledger Recover) upsell
+ * */
+export function useOpenProtectUpsellCallback() {
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const onboardingType = useSelector(onboardingTypeSelector);
+  const protectFeature = useFeature("protectServicesMobile");
+  const recoverAlreadyOnboardedURI = useAlreadyOnboardedURI(protectFeature);
+  const recoverPostOnboardingURI = usePostOnboardingURI(protectFeature);
+  const touchScreenURI = useTouchScreenOnboardingUpsellURI(
+    protectFeature,
+    Source.LLM_ONBOARDING_24,
+  );
+  const recoverHomeURI = useHomeURI(protectFeature);
+  const dispatch = useDispatch();
+  const [redirectionStarted, setRedirectionStarted] = useState(false);
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (redirectionStarted && !isFocused) {
+      dispatch(setHasBeenUpsoldProtect(true));
+    }
+  }, [redirectionStarted, isFocused, dispatch]);
+
+  return useCallback(async () => {
+    const internetConnected = await internetReachable();
+    if (internetConnected && protectFeature?.enabled) {
+      const redirect = (url: string) => {
+        Linking.openURL(url);
+        setRedirectionStarted(true);
+      };
+      if (
+        lastConnectedDevice &&
+        touchScreenURI &&
+        [DeviceModelId.stax, DeviceModelId.europa].includes(lastConnectedDevice.modelId)
+      ) {
+        redirect(touchScreenURI);
+      } else if (recoverPostOnboardingURI && onboardingType === OnboardingType.restore) {
+        redirect(recoverPostOnboardingURI);
+      } else if (recoverHomeURI && onboardingType === OnboardingType.setupNew) {
+        redirect(recoverHomeURI);
+      } else if (recoverAlreadyOnboardedURI) {
+        redirect(recoverAlreadyOnboardedURI);
+      }
+    }
+  }, [
+    lastConnectedDevice,
+    onboardingType,
+    protectFeature?.enabled,
+    recoverAlreadyOnboardedURI,
+    recoverHomeURI,
+    recoverPostOnboardingURI,
+    touchScreenURI,
+  ]);
+}

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useShouldRedirect.test.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useShouldRedirect.test.ts
@@ -1,0 +1,226 @@
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import { useShouldRedirect } from "./useShouldRedirect";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+jest.mock("react-redux", () => ({
+  useSelector: (fn: () => void) => fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/featureFlags/index", () => ({
+  useFeature: jest.fn(),
+}));
+
+jest.mock("~/reducers/settings", () => ({
+  hasBeenUpsoldProtectSelector: jest.fn(),
+  hasBeenRedirectedToPostOnboardingSelector: jest.fn(),
+  lastConnectedDeviceSelector: jest.fn(),
+}));
+
+const { useFeature } = jest.requireMock("@ledgerhq/live-common/featureFlags/index");
+const {
+  hasBeenUpsoldProtectSelector,
+  hasBeenRedirectedToPostOnboardingSelector,
+  lastConnectedDeviceSelector,
+} = jest.requireMock("~/reducers/settings");
+
+function mockUseFeature(value: { enabled: boolean }) {
+  useFeature.mockReturnValue(value);
+}
+function mockHasBeenUpsoldProtect(value: boolean) {
+  hasBeenUpsoldProtectSelector.mockReturnValue(value);
+}
+
+function mockHasRedirectedToPostOnboarding(value: boolean) {
+  hasBeenRedirectedToPostOnboardingSelector.mockReturnValue(value);
+}
+
+function mockLastConnectedDevice(value: Device) {
+  lastConnectedDeviceSelector.mockReturnValue(value);
+}
+
+type Scenario = {
+  device: { modelId: DeviceModelId };
+  featureFlagEnabled: boolean;
+  expected: { shouldRedirectToProtectUpsell: boolean; shouldRedirectToPostOnboarding: boolean };
+};
+
+function testScenarios(scenarios: Scenario[]) {
+  it.each(scenarios)(
+    "should return $expected for $device and feature flag enabled: $featureFlagEnabled",
+    ({ device, featureFlagEnabled, expected }) => {
+      mockLastConnectedDevice(device as Device);
+      mockUseFeature({ enabled: featureFlagEnabled });
+
+      const result = useShouldRedirect();
+
+      expect(
+        [result.shouldRedirectToPostOnboarding, result.shouldRedirectToProtectUpsell].filter(
+          Boolean,
+        ).length,
+      ).toBeLessThanOrEqual(1);
+
+      expect(result).toEqual(expected);
+    },
+  );
+}
+
+describe("useShouldRedirect", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("user HAS NOT BEEN UPSOLD protect & HAS NOT BEEN REDIRECTED to post onboarding", () => {
+    beforeEach(() => {
+      mockHasBeenUpsoldProtect(false);
+      mockHasRedirectedToPostOnboarding(false);
+    });
+
+    testScenarios([
+      {
+        device: { modelId: DeviceModelId.nanoSP },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: true },
+      },
+      {
+        device: { modelId: DeviceModelId.nanoSP },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: true },
+      },
+      {
+        device: { modelId: DeviceModelId.nanoX },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.nanoX },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.stax },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: true },
+      },
+      {
+        device: { modelId: DeviceModelId.stax },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.europa },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: true },
+      },
+      {
+        device: { modelId: DeviceModelId.europa },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+    ]);
+  });
+
+  describe("user HAS BEEN UPSOLD protect & HAS NOT BEEN REDIRECTED to post onboarding", () => {
+    beforeEach(() => {
+      mockHasBeenUpsoldProtect(true);
+      mockHasRedirectedToPostOnboarding(false);
+    });
+
+    [
+      DeviceModelId.nanoS,
+      DeviceModelId.nanoSP,
+      DeviceModelId.nanoX,
+      DeviceModelId.stax,
+      DeviceModelId.europa,
+    ].forEach(modelId => {
+      [true, false].forEach(featureFlagEnabled =>
+        testScenarios([
+          {
+            device: { modelId },
+            featureFlagEnabled,
+            expected: {
+              shouldRedirectToProtectUpsell: false,
+              shouldRedirectToPostOnboarding: true,
+            },
+          },
+        ]),
+      );
+    });
+  });
+
+  describe("user HAS BEEN UPSOLD PROTECT & HAS BEEN REDIRECTED to post onboarding", () => {
+    beforeEach(() => {
+      mockHasBeenUpsoldProtect(true);
+      mockHasRedirectedToPostOnboarding(true);
+    });
+    [
+      DeviceModelId.nanoS,
+      DeviceModelId.nanoSP,
+      DeviceModelId.nanoX,
+      DeviceModelId.stax,
+      DeviceModelId.europa,
+    ].forEach(modelId => {
+      [true, false].forEach(featureFlagEnabled =>
+        testScenarios([
+          {
+            device: { modelId },
+            featureFlagEnabled,
+            expected: {
+              shouldRedirectToProtectUpsell: false,
+              shouldRedirectToPostOnboarding: false,
+            },
+          },
+        ]),
+      );
+    });
+  });
+
+  describe("user HAS NOT BEEN UPSOLD protect & HAS BEEN REDIRECTED to post onboarding", () => {
+    beforeEach(() => {
+      mockHasBeenUpsoldProtect(false);
+      mockHasRedirectedToPostOnboarding(true);
+    });
+
+    testScenarios([
+      {
+        device: { modelId: DeviceModelId.nanoSP },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.nanoSP },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.nanoX },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.nanoX },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.stax },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.stax },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.europa },
+        featureFlagEnabled: false,
+        expected: { shouldRedirectToProtectUpsell: false, shouldRedirectToPostOnboarding: false },
+      },
+      {
+        device: { modelId: DeviceModelId.europa },
+        featureFlagEnabled: true,
+        expected: { shouldRedirectToProtectUpsell: true, shouldRedirectToPostOnboarding: false },
+      },
+    ]);
+  });
+});

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useShouldRedirect.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useShouldRedirect.ts
@@ -1,0 +1,38 @@
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { useSelector } from "react-redux";
+import {
+  hasBeenRedirectedToPostOnboardingSelector,
+  hasBeenUpsoldProtectSelector,
+  lastConnectedDeviceSelector,
+} from "~/reducers/settings";
+
+/**
+ * Returns whether the user should be redirected to the Protect upsell or the post onboarding
+ * */
+export function useShouldRedirect(): {
+  shouldRedirectToProtectUpsell: boolean;
+  shouldRedirectToPostOnboarding: boolean;
+} {
+  const hasBeenUpsoldProtect = useSelector(hasBeenUpsoldProtectSelector);
+  const hasRedirectedToPostOnboarding = useSelector(hasBeenRedirectedToPostOnboardingSelector);
+  const recoverUpsellRedirection = useFeature("recoverUpsellRedirection");
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const eligibleDevicesForUpsell = recoverUpsellRedirection?.enabled
+    ? [DeviceModelId.nanoX, DeviceModelId.stax, DeviceModelId.europa]
+    : [DeviceModelId.nanoX];
+
+  const eligibleForUpsell = lastConnectedDevice?.modelId
+    ? eligibleDevicesForUpsell.includes(lastConnectedDevice.modelId)
+    : false;
+
+  const shouldRedirectToProtectUpsell = !hasBeenUpsoldProtect && eligibleForUpsell;
+
+  const shouldRedirectToPostOnboarding =
+    !shouldRedirectToProtectUpsell && !hasRedirectedToPostOnboarding;
+
+  return {
+    shouldRedirectToProtectUpsell,
+    shouldRedirectToPostOnboarding,
+  };
+}

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/useNavigateToPostOnboardingHubCallback.ts
@@ -4,11 +4,11 @@ import { RootNavigation } from "~/components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 
 export function useNavigateToPostOnboardingHubCallback() {
-  const navigation = useNavigation();
+  const navigation = useNavigation<RootNavigation>();
   return useCallback(
     (resetNavigationStack?: boolean) => {
       if (resetNavigationStack) {
-        (navigation as unknown as RootNavigation).reset({
+        navigation.reset({
           index: 0,
           routes: [
             {
@@ -34,8 +34,11 @@ export function useNavigateToPostOnboardingHubCallback() {
           ],
         });
       } else {
-        navigation.navigate(NavigatorName.PostOnboarding, {
-          screen: ScreenName.PostOnboardingHub,
+        navigation.navigate(NavigatorName.Base, {
+          screen: NavigatorName.PostOnboarding,
+          params: {
+            screen: ScreenName.PostOnboardingHub,
+          },
         });
       }
     },

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -80,6 +80,7 @@ import type {
   SettingsAddStarredMarketcoinsPayload,
   SettingsRemoveStarredMarketcoinsPayload,
   SettingsSetFromLedgerSyncOnboardingPayload,
+  SettingsSetHasBeenRedirectedToPostOnboardingPayload,
 } from "../actions/types";
 import {
   SettingsActionTypes,
@@ -165,6 +166,7 @@ export const INITIAL_STATE: SettingsState = {
   debugAppLevelDrawerOpened: false,
   dateFormat: "default",
   hasBeenUpsoldProtect: false,
+  hasBeenRedirectedToPostOnboarding: false,
   onboardingType: null,
   depositFlow: {
     hasClosedNetworkBanner: false,
@@ -601,6 +603,12 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     ...state,
     hasBeenUpsoldProtect: (action as Action<SettingsSetHasBeenUpsoldProtectPayload>).payload,
   }),
+  [SettingsActionTypes.SET_HAS_BEEN_REDIRECTED_TO_POST_ONBOARDING]: (state, action) => ({
+    ...state,
+    hasBeenRedirectedToPostOnboarding: (
+      action as Action<SettingsSetHasBeenRedirectedToPostOnboardingPayload>
+    ).payload,
+  }),
   [SettingsActionTypes.SET_GENERAL_TERMS_VERSION_ACCEPTED]: (state, action) => ({
     ...state,
     generalTermsVersionAccepted: (action as Action<SettingsSetGeneralTermsVersionAccepted>).payload,
@@ -874,6 +882,8 @@ export const featureFlagsBannerVisibleSelector = (state: State) =>
 export const debugAppLevelDrawerOpenedSelector = (state: State) =>
   state.settings.debugAppLevelDrawerOpened;
 export const hasBeenUpsoldProtectSelector = (state: State) => state.settings.hasBeenUpsoldProtect;
+export const hasBeenRedirectedToPostOnboardingSelector = (state: State) =>
+  state.settings.hasBeenRedirectedToPostOnboarding;
 export const generalTermsVersionAcceptedSelector = (state: State) =>
   state.settings.generalTermsVersionAccepted;
 export const userNpsSelector = (state: State) => state.settings.userNps;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -255,6 +255,7 @@ export type SettingsState = {
   debugAppLevelDrawerOpened: boolean;
   dateFormat: string;
   hasBeenUpsoldProtect: boolean;
+  hasBeenRedirectedToPostOnboarding: boolean;
   generalTermsVersionAccepted?: string;
   depositFlow: {
     hasClosedNetworkBanner: boolean;

--- a/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
@@ -22,6 +22,7 @@ import { MyLedgerNavigatorStackParamList } from "~/components/RootNavigator/type
 import { useManagerDeviceAction } from "~/hooks/deviceActions";
 import ContentCardsLocation from "~/dynamicContent/ContentCardsLocation";
 import { ContentCardLocation } from "~/dynamicContent/types";
+import { useAutoRedirectToPostOnboarding } from "~/hooks/useAutoRedirectToPostOnboarding";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<MyLedgerNavigatorStackParamList, ScreenName.MyLedgerChooseDevice>
@@ -45,6 +46,15 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
 
   const navigation = useNavigation<NavigationProps["navigation"]>();
   const { params } = useRoute<NavigationProps["route"]>();
+
+  /**
+   * FIXME:
+   * This is here because for now the Recover upsell redirect to this screen (My Ledger)
+   * via a deeplink, and after the Recover upsell, we are supposed to automatically redirect
+   * to the post-onboarding hub.
+   * When the Recover webpage is fixed to only redirect to the Portfolio screen, this can be removed.
+   */
+  useAutoRedirectToPostOnboarding();
 
   const onSelectDevice = (device?: Device) => {
     if (device)

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/pairNew.tsx
@@ -1,14 +1,12 @@
 import React, { useCallback, useMemo, memo } from "react";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { useDispatch } from "react-redux";
-import { DeviceModelId } from "@ledgerhq/devices";
-import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { NavigatorName, ScreenName } from "~/const";
 import BaseStepperView, { PairNew, ConnectNano } from "./setupDevice/scenes";
 import { TrackScreen } from "~/analytics";
 import SeedWarning from "../shared/SeedWarning";
 import Illustration from "~/images/illustration/Illustration";
-import { completeOnboarding } from "~/actions/settings";
+import { completeOnboarding, setHasBeenRedirectedToPostOnboarding } from "~/actions/settings";
 import { useNavigationInterceptor } from "../onboardingContext";
 import useNotifications from "~/logic/notifications";
 import {
@@ -84,8 +82,6 @@ export default memo(function () {
     [isProtectFlow],
   );
 
-  const startPostOnboarding = useStartPostOnboardingCallback();
-
   const onFinish = useCallback(() => {
     if (next && deviceModelId) {
       // only used for protect for now
@@ -105,21 +101,17 @@ export default memo(function () {
       parentNav.popToTop();
     }
 
-    startPostOnboarding({
-      deviceModelId: deviceModelId as DeviceModelId,
-      resetNavigationStack: true,
-      fallbackIfNoAction: () =>
-        navigation.replace(NavigatorName.Base, {
-          screen: NavigatorName.Main,
-        }),
+    navigation.replace(NavigatorName.Base, {
+      screen: NavigatorName.Main,
     });
+
+    dispatch(setHasBeenRedirectedToPostOnboarding(false));
 
     triggerJustFinishedOnboardingNewDevicePushNotificationModal();
   }, [
     dispatch,
     resetCurrentStep,
     navigation,
-    startPostOnboarding,
     deviceModelId,
     triggerJustFinishedOnboardingNewDevicePushNotificationModal,
     next,

--- a/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostOnboarding/PostOnboardingHub.tsx
@@ -14,25 +14,22 @@ import { TrackScreen } from "~/analytics";
 import Link from "~/components/wrappedUi/Link";
 import { useCompletePostOnboarding } from "~/logic/postOnboarding/useCompletePostOnboarding";
 import { ScrollContainer } from "@ledgerhq/native-ui";
+import { setHasBeenRedirectedToPostOnboarding } from "~/actions/settings";
 const PostOnboardingHub = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { actionsState, deviceModelId } = usePostOnboardingHubState();
   const closePostOnboarding = useCompletePostOnboarding();
 
-  const clearLastActionCompleted = useCallback(() => {
-    dispatch(clearPostOnboardingLastActionCompleted());
-  }, [dispatch]);
-
-  useEffect(
+  useEffect(() => {
     /**
      * The last action context (specific title & popup) should only be visible
      * the 1st time the hub is navigated to after that action was completed.
      * So here we clear the last action completed.
      * */
-    () => clearLastActionCompleted,
-    [clearLastActionCompleted],
-  );
+    dispatch(clearPostOnboardingLastActionCompleted());
+    dispatch(setHasBeenRedirectedToPostOnboarding(true));
+  }, [dispatch]);
 
   const navigateToMainScreen = useCallback(() => {
     closePostOnboarding();

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/RecoverUpsellRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/RecoverUpsellRow.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import SettingsRow from "~/components/SettingsRow";
+import Switch from "~/components/Switch";
+import { useFeature, useFeatureFlags } from "@ledgerhq/live-common/featureFlags/index";
+
+export function RecoverUpsellRow() {
+  const { overrideFeature, resetFeature } = useFeatureFlags();
+
+  const protectFeature = useFeature("protectServicesMobile");
+
+  if (protectFeature === null || protectFeature === undefined) return null;
+
+  const currentTarget = protectFeature?.params?.protectId;
+
+  const onChange = (enabled: boolean) => {
+    if (enabled) {
+      overrideFeature("protectServicesMobile", {
+        ...protectFeature,
+        params: { ...protectFeature?.params, protectId: "protect-prod" },
+      });
+    } else {
+      resetFeature("protectServicesMobile");
+    }
+  };
+
+  return (
+    <SettingsRow
+      title="Ledger Recover deeplinks environment"
+      desc={`Enable the production mode of Recover to have access to prod deeplinks, in dev or staging builds (current env is "${currentTarget}")`}
+    >
+      <Switch value={currentTarget === "protect-prod"} onValueChange={onChange} />
+    </SettingsRow>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ResetOnboardingStateRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/ResetOnboardingStateRow.tsx
@@ -1,7 +1,13 @@
 import React, { useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import SettingsRow from "~/components/SettingsRow";
-import { completeOnboarding, setHasOrderedNano, setReadOnlyMode } from "~/actions/settings";
+import {
+  completeOnboarding,
+  setHasBeenRedirectedToPostOnboarding,
+  setHasBeenUpsoldProtect,
+  setHasOrderedNano,
+  setReadOnlyMode,
+} from "~/actions/settings";
 import { RebootContext } from "~/context/Reboot";
 import { knownDevicesSelector } from "~/reducers/ble";
 import { removeKnownDevices } from "~/actions/ble";
@@ -22,6 +28,8 @@ export default function ResetOnboardingStateRow() {
         dispatch(setHasOrderedNano(false));
         dispatch(completeOnboarding(false));
         dispatch(removeKnownDevices(knownDevices.map(d => d.id)));
+        dispatch(setHasBeenUpsoldProtect(false));
+        dispatch(setHasBeenRedirectedToPostOnboarding(false));
         unacceptGeneralTerms();
         requestAnimationFrame(() => {
           reboot();

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Configuration/index.tsx
@@ -17,6 +17,7 @@ import ResetOnboardingStateRow from "./ResetOnboardingStateRow";
 import NftMetadataServiceRow from "./NftMetadataServiceRow";
 import HasStaxEuropaRows from "./HasStaxEuropaRows";
 import SkipOnboardingRow from "./SkipOnboardingRow";
+import { RecoverUpsellRow } from "./RecoverUpsellRow";
 
 export default function Configuration() {
   const navigation = useNavigation<StackNavigatorNavigation<SettingsNavigatorStackParamList>>();
@@ -40,6 +41,7 @@ export default function Configuration() {
       </Flex>
       <ResetOnboardingStateRow />
       <SkipOnboardingRow />
+      <RecoverUpsellRow />
       <ReadOnlyModeRow />
       <HasOrderedNanoRow />
       <HasStaxEuropaRows />

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { Flex } from "@ledgerhq/native-ui";
 import { StackScreenProps } from "@react-navigation/stack";
 import { TouchableWithoutFeedback } from "react-native-gesture-handler";
-import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/useStartPostOnboardingCallback";
 
 import { NavigatorName, ScreenName } from "~/const";
 import { SyncOnboardingStackParamList } from "~/components/RootNavigator/types/SyncOnboardingNavigator";
@@ -10,6 +9,8 @@ import { BaseComposite, RootNavigation } from "~/components/RootNavigator/types/
 import { DeviceModelId } from "@ledgerhq/devices";
 import EuropaCompletionView from "./EuropaCompletionView";
 import StaxCompletionView from "./StaxCompletionView";
+import { useDispatch } from "react-redux";
+import { setHasBeenRedirectedToPostOnboarding } from "~/actions/settings";
 
 type Props = BaseComposite<
   StackScreenProps<SyncOnboardingStackParamList, ScreenName.SyncOnboardingCompletion>
@@ -17,40 +18,41 @@ type Props = BaseComposite<
 
 const CompletionScreen = ({ navigation, route }: Props) => {
   const { device } = route.params;
-  const startPostOnboarding = useStartPostOnboardingCallback();
+  const dispatch = useDispatch();
 
-  const redirectToPostOnboarding = useCallback(() => {
-    startPostOnboarding({
-      deviceModelId: device.modelId,
-      resetNavigationStack: true,
-      fallbackIfNoAction: () =>
-        // Resets the navigation stack to avoid allowing to go back to the onboarding welcome screen
-        // FIXME: bindings to react-navigation seem to have issues with composites
-        (navigation as unknown as RootNavigation).reset({
-          index: 0,
-          routes: [
-            {
-              name: NavigatorName.Base,
-              state: {
-                routes: [
-                  {
-                    name: NavigatorName.Main,
-                  },
-                ],
+  useEffect(() => {
+    dispatch(setHasBeenRedirectedToPostOnboarding(false));
+  }, [dispatch]);
+
+  const hasRedirected = React.useRef(false);
+
+  const redirectToMainScreen = useCallback(() => {
+    if (hasRedirected.current) return;
+    hasRedirected.current = true;
+    (navigation as unknown as RootNavigation).reset({
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.Base,
+          state: {
+            routes: [
+              {
+                name: NavigatorName.Main,
               },
-            },
-          ],
-        }),
+            ],
+          },
+        },
+      ],
     });
-  }, [device.modelId, navigation, startPostOnboarding]);
+  }, [navigation]);
 
   return (
-    <TouchableWithoutFeedback onPress={redirectToPostOnboarding}>
+    <TouchableWithoutFeedback onPress={redirectToMainScreen}>
       <Flex width="100%" height="100%" alignItems="center" justifyContent="center">
         {device.modelId === DeviceModelId.europa ? (
-          <EuropaCompletionView device={device} onAnimationFinish={redirectToPostOnboarding} />
+          <EuropaCompletionView device={device} onAnimationFinish={redirectToMainScreen} />
         ) : (
-          <StaxCompletionView onAnimationFinish={redirectToPostOnboarding} />
+          <StaxCompletionView onAnimationFinish={redirectToMainScreen} />
         )}
       </Flex>
     </TouchableWithoutFeedback>

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
@@ -148,6 +148,7 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
   const { t } = useTranslation();
   const dispatchRedux = useDispatch();
   const deviceInitialApps = useFeature("deviceInitialApps");
+  const recoverUpsellRedirection = useFeature("recoverUpsellRedirection");
 
   const productName = getDeviceModel(device.modelId).productName || device.modelId;
   const deviceName = device.deviceName || productName;
@@ -369,17 +370,22 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
     if (deviceOnboardingState?.isOnboarded && !seededDeviceHandled.current) {
       if (deviceOnboardingState?.currentOnboardingStep === DeviceOnboardingStep.Ready) {
         // device was just seeded
-        setCompanionStepKey(CompanionStepKey.Backup);
+        setCompanionStepKey(
+          recoverUpsellRedirection?.enabled ? CompanionStepKey.Apps : CompanionStepKey.Backup,
+        );
         seededDeviceHandled.current = true;
         return;
       } else if (
         deviceOnboardingState?.currentOnboardingStep === DeviceOnboardingStep.WelcomeScreen1
       ) {
-        // switch to the apps step
-        __DEV__
-          ? setCompanionStepKey(CompanionStepKey.Backup) // for ease of testing in dev mode without having to reset the device
-          : setCompanionStepKey(CompanionStepKey.Apps);
-
+        if (recoverUpsellRedirection?.enabled) {
+          // switch to the apps step
+          __DEV__
+            ? setCompanionStepKey(CompanionStepKey.Backup) // for ease of testing in dev mode without having to reset the device
+            : setCompanionStepKey(CompanionStepKey.Apps);
+        } else {
+          setCompanionStepKey(CompanionStepKey.Apps);
+        }
         seededDeviceHandled.current = true;
         return;
       }
@@ -433,7 +439,12 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
       default:
         break;
     }
-  }, [deviceOnboardingState, notifyEarlySecurityCheckShouldReset, shouldRestoreApps]);
+  }, [
+    deviceOnboardingState,
+    notifyEarlySecurityCheckShouldReset,
+    recoverUpsellRedirection,
+    shouldRestoreApps,
+  ]);
 
   // When the user gets close to the seed generation step, sets the lost synchronization delay
   // and timers to a higher value. It avoids having a warning message while the connection is lost
@@ -638,17 +649,21 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
             </Flex>
           ),
         },
-        {
-          key: CompanionStepKey.Backup,
-          title: t("syncOnboarding.backup.title"),
-          doneTitle: t("syncOnboarding.backup.title"),
-          renderBody: () => (
-            <BackupStep
-              device={device}
-              onPressKeepManualBackup={() => setCompanionStepKey(CompanionStepKey.Apps)}
-            />
-          ),
-        },
+        ...(recoverUpsellRedirection?.enabled
+          ? []
+          : [
+              {
+                key: CompanionStepKey.Backup,
+                title: t("syncOnboarding.backup.title"),
+                doneTitle: t("syncOnboarding.backup.title"),
+                renderBody: () => (
+                  <BackupStep
+                    device={device}
+                    onPressKeepManualBackup={() => setCompanionStepKey(CompanionStepKey.Apps)}
+                  />
+                ),
+              },
+            ]),
         ...(deviceInitialApps?.enabled
           ? [
               {
@@ -682,13 +697,14 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
     [
       t,
       productName,
-      seedPathStatus,
+      recoverUpsellRedirection?.enabled,
       deviceInitialApps?.enabled,
       device,
+      seedPathStatus,
+      shouldRestoreApps,
       handleInstallAppsComplete,
       initialAppsToInstall,
       companionStepKey,
-      shouldRestoreApps,
     ],
   );
 

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -512,6 +512,7 @@ export const DEFAULT_FEATURES: Features = {
       warningVisible: true,
     },
   },
+  recoverUpsellRedirection: DEFAULT_FEATURE,
 };
 
 // Firebase SDK treat JSON values as strings

--- a/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
+++ b/libs/ledger-live-common/src/hooks/recoverFeatureFlag.ts
@@ -172,6 +172,8 @@ export function useCustomURI(
     if (source && deeplinkCampaign) {
       uri.searchParams.append("ajs_recover_source", source);
       uri.searchParams.append("ajs_recover_campaign", deeplinkCampaign);
+      uri.searchParams.append("ajs_prop_source", source);
+      uri.searchParams.append("ajs_prop_campaign", deeplinkCampaign);
     }
 
     return uri;
@@ -189,4 +191,17 @@ export function useCustomPath(
   const uri = useCustomURI(servicesConfig, page, source, deeplinkCampaign);
 
   return usePath(servicesConfig, uri);
+}
+
+export enum Source {
+  LLM_ONBOARDING_24 = "llm-onboarding-24",
+  LLD_ONBOARDING_24 = "lld-onboarding-24",
+}
+
+export function useTouchScreenOnboardingUpsellURI(
+  servicesConfig: Feature_ProtectServicesMobile | null,
+  source: Source,
+): string | undefined {
+  const campaign = "touchscreen-onboarding";
+  return useCustomURI(servicesConfig, "upsell", source, campaign);
 }

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
@@ -43,10 +43,8 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
       );
 
       if (actions.length === 0) {
-        if (fallbackIfNoAction) {
-          dispatch(postOnboardingSetFinished());
-          fallbackIfNoAction();
-        }
+        dispatch(postOnboardingSetFinished());
+        if (fallbackIfNoAction) fallbackIfNoAction();
         return;
       }
       navigateToPostOnboardingHub(resetNavigationStack);

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -194,6 +194,7 @@ export type Features = CurrencyFeatures & {
   llmMemoTag: Feature_MemoTag;
   lldMemoTag: Feature_MemoTag;
   ldmkTransport: Feature_LdmkTransport;
+  recoverUpsellRedirection: Feature_RecoverUpsellRedirection;
 };
 
 /**
@@ -554,6 +555,7 @@ export type Feature_lldNftsGalleryNewArch = DefaultFeature;
 export type Feature_lldnewArchOrdinals = DefaultFeature;
 export type Feature_SpamFilteringTx = DefaultFeature;
 export type Feature_MemoTag = DefaultFeature;
+export type Feature_RecoverUpsellRedirection = DefaultFeature;
 
 /**
  * Utils types.


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Flex/Stax synchronous onboarding:
    - With feature flag `recoverUpsellRedirection` deactivated, the onboarding flow is unchanged.
    - With feature flag `recoverUpsellRedirection` activated, the "Backup for your Secret Recovery Phrase" step between Secret Recovery Phrase and Apps Installation will be hidden.
  - End of the onboarding:
    - With feature flag `recoverUpsellRedirection` deactivated, the post onboarding hub is opened immediately.
    - With feature flag `recoverUpsellRedirection` activate, the Ledger Recover upsell is opened. When that upsell is dismissed, the user is redirected to the post onboarding hub.

### How to test:

**0. Prerequisite for each test**
- Reset app (Recover upsell shows only once) OR go to `Settings > Debug > Configuration` and press "Reset onboarding state".
- Go to `Settings > Debug > Configuration` & enable “Ledger Recover deeplinks environment”. This will ensure the URL Recover upsell is the production one, so it doesn't require any additional local setup (VPN etc.).

**Test 1. `recoverUpsellRedirection` FF enabled**
Onboarding Flex / Stax:
-> the "backup" step should not be in the sync onboarding.
-> at the end, it should open the Recover upsell.
-> when dismissing the Recover upsell, it should redirect to post onboarding.

**Test 2. `recoverUpsellRedirection` FF disabled**
Onboarding Flex / Stax:
-> the "backup" setup should be in the sync onboarding.
-> at the end, it should open the post onboarding.

**Test 3. Nano X onboarding (non reg)**
Onboarding Nano X:
-> at the end, it should open the Recover upsell.

**Test 4. Nano SP onboarding (non reg)**
Onboarding Nano SP:
-> at the end, it should just go to the portfolio screen.


### 📝 Description

Cf. "impact of the changes".

I had to do some refactoring to have all the post onboarding & upsell auto redirection logic in one place (the portfolio screen) to ensure its robustness for all device models.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
  - https://ledgerhq.atlassian.net/browse/PROTECT-3391
  - https://ledgerhq.atlassian.net/browse/PROTECT-3392
  - https://ledgerhq.atlassian.net/browse/PROTECT-3393
  - https://ledgerhq.atlassian.net/browse/PROTECT-3401
  - https://ledgerhq.atlassian.net/browse/PROTECT-3403 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
