### PR TITLE
:chart_with_upwards_trend: LLM - Flush analytics events when putting the app in background

### DIFF
--- a/.changeset/big-lions-refuse.md
+++ b/.changeset/big-lions-refuse.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Flushes all analytics events when the app goes in the background

--- a/apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx
+++ b/apps/ledger-live-mobile/src/analytics/SegmentSetup.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useStore } from "react-redux";
 import { start } from "./segment";
+import useFlushInBackground from "./useFlushInBackground";
 
 const SegmentSetup = (): null => {
   const store = useStore();
@@ -9,6 +10,8 @@ const SegmentSetup = (): null => {
     start(store).catch(error => console.error(`Failed to initialize Segment with error: ${error}`));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useFlushInBackground();
 
   return null;
 };

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -371,6 +371,11 @@ export const trackWithRoute = (
   };
   track(event, newProperties, mandatory);
 };
+
+export const flush = () => {
+  segmentClient?.flush();
+};
+
 export const useTrack = () => {
   const route = useRoute();
   const track = useCallback(

--- a/apps/ledger-live-mobile/src/analytics/useFlushInBackground.tsx
+++ b/apps/ledger-live-mobile/src/analytics/useFlushInBackground.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import useIsAppInBackground from "../components/useIsAppInBackground";
+import { flush } from "./segment";
+
+export default function useFlushInBackground() {
+  const isAppInBakcground = useIsAppInBackground();
+
+  useEffect(() => {
+    if (isAppInBakcground) {
+      flush();
+    }
+  }, [isAppInBakcground]);
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

We call the segment flush method when we detect that LLM goes in the background to send the events are to segment during the same session (without having to wait for the user to open the app again before sending them)

| Android        | iOS         |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/d092480a-925a-42e5-8ae4-64ad7619a756 | https://github.com/user-attachments/assets/587ed072-62fa-4db9-b80d-a9ee983cc614 |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14590]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14590]: https://ledgerhq.atlassian.net/browse/LIVE-14590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ