### PR TITLE
[DNM] add changesets-enforce workflow

### DIFF
--- a/.changeset/blue-files-train.md
+++ b/.changeset/blue-files-train.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Fix splashscreen on launch

--- a/.changeset/bright-icons-explode.md
+++ b/.changeset/bright-icons-explode.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/live-common": patch
+"@ledgerhq/live-common": minor
 ---
 
 add uniswap data

--- a/.changeset/chilly-eggs-hammer.md
+++ b/.changeset/chilly-eggs-hammer.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Fix icon for stake on Tron account screen

--- a/.changeset/cyan-experts-raise.md
+++ b/.changeset/cyan-experts-raise.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 MEV Protection

--- a/.changeset/few-owls-cross.md
+++ b/.changeset/few-owls-cross.md
@@ -1,6 +1,6 @@
 ---
-"ledger-live-desktop": patch
-"live-mobile": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
 ---
 
 Add a fallback to the provider display name from the firebase JSON if there is no translated title for the given provider. Required to add new providers like Coinbase to EVM staking.

--- a/.changeset/five-waves-promise.md
+++ b/.changeset/five-waves-promise.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Some icons on allocation screen were not well displayed. So change to use ParentCurrencyIcon component (same as the one on the portfolio)

--- a/.changeset/good-boxes-boil.md
+++ b/.changeset/good-boxes-boil.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 fix redirecting to GITHUB_ENV in fastfile for ios build and setting the build number correctly for slack notification

--- a/.changeset/long-fireants-cheer.md
+++ b/.changeset/long-fireants-cheer.md
@@ -1,7 +1,7 @@
 ---
-"@ledgerhq/types-live": patch
-"ledger-live-desktop": patch
-"@ledgerhq/live-common": patch
+"@ledgerhq/types-live": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
 ---
 
 MEV Protection feature

--- a/.changeset/loud-pumas-fix.md
+++ b/.changeset/loud-pumas-fix.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/live-common": patch
+"@ledgerhq/live-common": minor
 ---
 
 enable wallet connect for rsk

--- a/.changeset/mean-pugs-hang.md
+++ b/.changeset/mean-pugs-hang.md
@@ -1,6 +1,6 @@
 ---
-"ledger-live-desktop": patch
-"live-mobile": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
 ---
 
 Add discreetMode param for buy/sell

--- a/.changeset/metal-walls-rush.md
+++ b/.changeset/metal-walls-rush.md
@@ -1,6 +1,6 @@
 ---
 "live-mobile": minor
-"@ledgerhq/live-common": patch
+"@ledgerhq/live-common": minor
 ---
 
 Truncate some coins memo on the recipient step of the send flow

--- a/.changeset/mighty-points-hope.md
+++ b/.changeset/mighty-points-hope.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Fixes buy/sell navigation paths

--- a/.changeset/moody-deers-marry.md
+++ b/.changeset/moody-deers-marry.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": patch
+"ledger-live-desktop": minor
 ---
 
 use feature flag for send flow intermediary screen memo tag

--- a/.changeset/orange-radios-thank.md
+++ b/.changeset/orange-radios-thank.md
@@ -1,6 +1,6 @@
 ---
-"ledger-live-desktop": patch
-"live-mobile": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
 ---
 
 Persistent sync error on LLD after backup deletion from LLM

--- a/.changeset/red-bobcats-leave.md
+++ b/.changeset/red-bobcats-leave.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Remove commas from XRP summary tag

--- a/.changeset/rotten-months-glow.md
+++ b/.changeset/rotten-months-glow.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": patch
+"live-mobile": minor
 ---
 
 Fix crash on non valid memo field in Android

--- a/.changeset/seven-nails-knock.md
+++ b/.changeset/seven-nails-knock.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": patch
+"ledger-live-desktop": minor
 ---
 
 Localised URL

--- a/.changeset/shaggy-shoes-beg.md
+++ b/.changeset/shaggy-shoes-beg.md
@@ -1,6 +1,6 @@
 ---
-"ledger-live-desktop": patch
-"@ledgerhq/live-common": patch
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
 ---
 
 Add translation for troubleshooting network

--- a/.changeset/small-hairs-flow.md
+++ b/.changeset/small-hairs-flow.md
@@ -1,6 +1,6 @@
 ---
-"@ledgerhq/coin-solana": patch
-"@ledgerhq/live-common": patch
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/live-common": minor
 ---
 
 fix: solana priority fees

--- a/.changeset/smart-items-laugh.md
+++ b/.changeset/smart-items-laugh.md
@@ -1,6 +1,6 @@
 ---
-"live-mobile": patch
-"@ledgerhq/live-common": patch
+"live-mobile": minor
+"@ledgerhq/live-common": minor
 ---
 
 fix: better logic and guard against accessing null db

--- a/.changeset/sour-badgers-matter.md
+++ b/.changeset/sour-badgers-matter.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": patch
+"ledger-live-desktop": minor
 ---
 
 Optimize content card log impression based on 50% of the card seen

--- a/.changeset/sweet-needles-kiss.md
+++ b/.changeset/sweet-needles-kiss.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": patch
+"ledger-live-desktop": minor
 ---
 
 Redirect users to Recover Login if they have an account as they may be logged out

--- a/.changeset/tall-moons-invent.md
+++ b/.changeset/tall-moons-invent.md
@@ -1,7 +1,7 @@
 ---
-"@ledgerhq/types-live": patch
-"live-mobile": patch
-"@ledgerhq/live-common": patch
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
 ---
 
 Add swap live app webview behind feature flag

--- a/.changeset/ten-pigs-dress.md
+++ b/.changeset/ten-pigs-dress.md
@@ -1,7 +1,7 @@
 ---
-"@ledgerhq/coin-stacks": patch
-"live-mobile": patch
-"@ledgerhq/live-common": patch
+"@ledgerhq/coin-stacks": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
 ---
 
 support: move stacks to its own coin module

--- a/.changeset/tiny-feet-type.md
+++ b/.changeset/tiny-feet-type.md
@@ -1,6 +1,6 @@
 ---
-"@ledgerhq/types-live": patch
-"@ledgerhq/live-common": patch
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
 ---
 
 New feature flag for new add account workflow

--- a/.changeset/unlucky-boats-bow.md
+++ b/.changeset/unlucky-boats-bow.md
@@ -1,10 +1,10 @@
 ---
-"@ledgerhq/types-live": patch
-"@ledgerhq/live-countervalues-react": patch
-"ledger-live-desktop": patch
-"live-mobile": patch
-"@ledgerhq/live-common": patch
-"@ledgerhq/live-countervalues": patch
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-countervalues-react": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-countervalues": minor
 ---
 
 Add Granularity rate for Countervalues historical requests cache optimization

--- a/.changeset/wild-chefs-smash.md
+++ b/.changeset/wild-chefs-smash.md
@@ -1,8 +1,8 @@
 ---
-"@ledgerhq/coin-filecoin": patch
-"ledger-live-desktop": patch
-"live-mobile": patch
-"@ledgerhq/live-common": patch
+"@ledgerhq/coin-filecoin": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
 ---
 
 support: move filecoin to its own coin module

--- a/.github/workflows/changeset-enforce.yml
+++ b/.github/workflows/changeset-enforce.yml
@@ -1,0 +1,43 @@
+name: No patch level changesets
+on:
+  pull_request
+
+jobs:
+  check_changesets:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository (feature branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 200
+        
+      - name: Fetch develop branch
+        run: |
+          git fetch origin develop:develop --depth=1
+
+      - name: Verify develop branch
+        run: git branch --all
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+
+      - name: Install changesets
+        run: pnpm add -g @changesets/cli@2.27.7
+
+      - name: Generate changeset status
+        run: pnpm changeset status --output=changeset-status.json
+
+      - name: Check for patch level changesets
+        run: |
+          PATCH_CHANGESET_IDS=$(jq -r '.changesets[] | select(.releases[].type == "patch") | .id' changeset-status.json)
+          if [ -n "$PATCH_CHANGESET_IDS" ]; then
+            echo "Patch changesets found:"
+            echo "$PATCH_CHANGESET_IDS"
+            echo "❌ Patch level changesets are reserved for hotfixes, use major or minor only"
+            exit 1
+          else
+            echo "✅ No patch level changesets found."
+          fi


### PR DESCRIPTION
Adds workflow to enforce changesets version bumps at the `major` or `minor` level only (`patch` will cause build failure).

[Ticket here](https://ledgerhq.atlassian.net/browse/LIVE-14704)

This works on an entire-repo-snapshot basis, so if there are `patch`es in @develop and you've branched off @develop, and your commit does't create an offending changeset, your PR will still fail even though it wasn't your fault (this is currently the case for all tests and code quality checks too - I'm just being explicit). What this does mean is when we merge this all builds will go red until the changeset history is cleared on next release.

Note that the workflow fails with a useful error message: 

<img width="860" alt="image" src="https://github.com/user-attachments/assets/837290c7-8a1d-4f69-ad22-ec28cbbde32d">

The workflow is async, and typically takes 15-20s to run:

<img width="721" alt="Screenshot 2024-10-31 at 11 47 18" src="https://github.com/user-attachments/assets/02594641-7499-46fe-a26a-8275394ace30">


The checkout step was optimised to only pull in what was needed for this workflow ([more details](https://ledger.slack.com/archives/C07KP3A8CNA/p1730223516050169)). This is a practice we should roll out to the rest of the workflows.

My only concern about this is it's adding yet *another* workflow at a time where there are too many workflows.