### PR TITLE
fix(LIVE-14547) do not set `ptxSwapCoreExperiment` as `false` in analytics

### DIFF
--- a/.changeset/few-bikes-act.md
+++ b/.changeset/few-bikes-act.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Do not set `ptxSwapCoreExperiment` as `false` in analytics

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -89,8 +89,9 @@ const getPtxAttributes = () => {
   const ptxSwapLiveAppDemoThree = analyticsFeatureFlagMethod("ptxSwapLiveAppDemoThree")?.enabled;
   const ptxSwapExodusProvider = analyticsFeatureFlagMethod("ptxSwapExodusProvider")?.enabled;
   const ptxSwapCoreExperimentFlag = analyticsFeatureFlagMethod("ptxSwapCoreExperiment");
-  const ptxSwapCoreExperiment =
-    ptxSwapCoreExperimentFlag?.enabled && ptxSwapCoreExperimentFlag?.params?.variant;
+  const ptxSwapCoreExperiment = ptxSwapCoreExperimentFlag?.enabled
+    ? ptxSwapCoreExperimentFlag?.params?.variant
+    : undefined;
 
   const isBatch1Enabled: boolean =
     !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The `ptxSwapCoreExperiment` could have the following values: `false`, `Demo0`, `Demo3` or `Demo3Thorswap`, however, in the segment analytics, the false value makes no sense, by setting as `undefined` we don't send the flag.




### ❓ Context

[LIVE-14547](https://ledgerhq.atlassian.net/browse/LIVE-14547)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14547]: https://ledgerhq.atlassian.net/browse/LIVE-14547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ