### PR TITLE
[DNM] Post-"ghost"-release hotfix workflow

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -1,6 +1,18 @@
 name: "[Release](Hotfix) Create Branch"
 on:
   workflow_dispatch:
+    inputs:
+      tag_version:
+        description: the tag/release version to hotfix
+        default: latest
+        required: false
+      application:
+        description: application (LLM | LLD)
+        required: true
+        type: choice
+        options:
+          - LLM
+          - LLD
 
 jobs:
   create-hotfix:
@@ -15,10 +27,25 @@ jobs:
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+
+      - name: Checkout composite actions
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          sparse-checkout: tools/actions/composites
+
+      - name: Generate ref/tag version to use during main checkout
+        uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop
+        id: format-app-tag
+        with:
+          tag_version: ${{ github.event.inputs.tag_version }}
+          application: ${{ github.event.inputs.application }}
+        
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ steps.format-app-tag.outputs.main_ref }}
           token: ${{ steps.generate-token.outputs.token }}
+
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
       - name: create hotfix branch
@@ -61,6 +88,10 @@ jobs:
       - name: push
         run: |
           git push origin hotfix
-          gh pr create --title ":fire: Hotfix ${{ steps.date.outputs.date }}" -F ./.github/templates/hotfix.md --base main --head hotfix
+          gh pr create \
+            --title ":fire: Hotfix ${{ steps.date.outputs.date }} (targeting ${{ github.event.inputs.application }} ${{ github.event.inputs.tag_version }})"\
+            -F ./.github/templates/hotfix.md \
+            --base main \
+            --head hotfix
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -12,6 +12,10 @@ on:
           - LLD
           - LLM
           - ALL
+      ref:
+        description: "the ref (branch) to release from"
+        required: false
+        default: main
 
   workflow_run:
     workflows:
@@ -35,7 +39,7 @@ jobs:
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ inputs.ref }}
           fetch-depth: 2
           token: ${{ steps.generate-token.outputs.token }}
       - name: Setup git user
@@ -114,7 +118,7 @@ jobs:
           git tag live-mobile@${{ steps.mobile-version.outputs.version }}
       - name: push changes
         run: |
-          git push origin main --tags
+          git push origin ${{ inputs.ref }} --tags
       - name: create desktop github release
         if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
         env:
@@ -139,7 +143,7 @@ jobs:
               ref: "main",
               workflow_id: "release-desktop.yml",
               inputs: {
-                branch: "main"
+                branch: ${{ inputs.ref }}
               }
             });
       - uses: actions/github-script@v7
@@ -154,6 +158,6 @@ jobs:
               ref: "main",
               workflow_id: "release-mobile.yml",
               inputs: {
-                ref: "main"
+                ref: ${{ inputs.ref }}
               }
             });

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -7,6 +7,17 @@ on:
         description: the branch to release from
         default: hotfix
         required: true
+      tag_version:
+        description: version to hotfix (e.g. 2.91.0)
+        default: latest
+        required: false
+      application:
+        description: application (LLM | LLD)
+        required: true
+        type: choice
+        options:
+          - LLM
+          - LLD
 
 jobs:
   prepare-release:
@@ -21,11 +32,25 @@ jobs:
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
-      - name: Checkout Repo
+
+      - name: Checkout composite actions
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: tools/actions/composites
+
+      - name: Generate ref/tag version to use when running changeset status
+        uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop
+        id: format-app-tag
+        with:
+          tag_version: ${{ github.event.inputs.tag_version }}
+          application: ${{ github.event.inputs.application }}
+
+      - name: Checkout Repo (hotfix branch)
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
@@ -38,6 +63,23 @@ jobs:
 
       - name: install dependencies
         run: pnpm i -F "ledger-live"
+
+      - name: Generate changeset status
+        run: |
+          git fetch --tags
+          pnpm changeset status --since=${{ steps.format-app-tag.outputs.main_ref }} --output=changeset-status.json
+
+      - name: Enforce use of patch level changesets only for hotfixes
+        run: |
+          MINOR_MAJOR_CHANGESET_IDS=$(jq -r '.changesets[] | select(.releases[].type == "minor" or .releases[].type == "major") | .id' changeset-status.json)
+          if [ -n "$MINOR_MAJOR_CHANGESET_IDS" ]; then
+            echo "Major/minor changesets found:"
+            echo "$MINOR_MAJOR_CHANGESET_IDS"
+            echo "❌ Hotfixes must use patch level changesets only"
+            exit 1
+          else
+            echo "✅ No major/minor level changesets found."
+          fi
 
       - name: exit prerelease mode
         run: pnpm changeset pre exit
@@ -55,19 +97,21 @@ jobs:
       - name: push changes
         run: |
           git push origin ${{ inputs.ref }}
-          git fetch origin
 
       - name: fetch develop and main
+        if: ${{ github.event.inputs.tag_version == 'latest' }}
         run: |
           git fetch origin develop main
 
       - name: merge into main
+        if: ${{ github.event.inputs.tag_version == 'latest' }}
         run: |
           git checkout main
           git merge ${{ inputs.ref }} --no-ff
           git push origin main
 
       - name: create PR to develop
+        if: ${{ github.event.inputs.tag_version == 'latest' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
@@ -77,6 +121,7 @@ jobs:
           gh pr create --title ":rotating_light: Hotfix merge conflicts" -F .github/templates/hotfix-conflicts.md --base develop --head support/hotfix-merge-conflicts
 
       - name: merge into release if present
+        if: ${{ github.event.inputs.tag_version == 'latest' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -45,12 +45,11 @@ jobs:
           tag_version: ${{ github.event.inputs.tag_version }}
           application: ${{ github.event.inputs.application }}
 
-      - name: Checkout Repo (hotfix branch)
+      - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           token: ${{ steps.generate-token.outputs.token }}
-          fetch-depth: 0
 
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
@@ -63,23 +62,6 @@ jobs:
 
       - name: install dependencies
         run: pnpm i -F "ledger-live"
-
-      - name: Generate changeset status
-        run: |
-          git fetch --tags
-          pnpm changeset status --since=${{ steps.format-app-tag.outputs.main_ref }} --output=changeset-status.json
-
-      - name: Enforce use of patch level changesets only for hotfixes
-        run: |
-          MINOR_MAJOR_CHANGESET_IDS=$(jq -r '.changesets[] | select(.releases[].type == "minor" or .releases[].type == "major") | .id' changeset-status.json)
-          if [ -n "$MINOR_MAJOR_CHANGESET_IDS" ]; then
-            echo "Major/minor changesets found:"
-            echo "$MINOR_MAJOR_CHANGESET_IDS"
-            echo "❌ Hotfixes must use patch level changesets only"
-            exit 1
-          else
-            echo "✅ No major/minor level changesets found."
-          fi
 
       - name: exit prerelease mode
         run: pnpm changeset pre exit

--- a/tools/actions/composites/generate-tag/action.yml
+++ b/tools/actions/composites/generate-tag/action.yml
@@ -1,0 +1,38 @@
+name: "Format Application Tag"
+description: "Generates the ref/tag version for main checkout. Returns `main` if no tag_version supplied"
+inputs:
+  tag_version:
+    description: "The version tag to format (e.g. 2.91.0)"
+    default: "latest"
+    required: false
+  application:
+    description: "The application to use (LLM or LLD)"
+    required: true
+outputs:
+  main_ref:
+    description: "Formatted application and tag version"
+    value: ${{ steps.format-tag.outputs.main_ref }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate ref/tag version
+      id: format-tag
+      shell: bash
+      run: |
+        if [ "${{ inputs.tag_version }}" = "latest" ]; then
+          main_ref="main"
+        else
+          if [ "${{ inputs.application }}" = "LLM" ]; then
+            formatted_app="live-mobile"
+          elif [ "${{ inputs.application }}" = "LLD" ]; then
+            formatted_app="@ledgerhq/live-desktop"
+          else
+            echo "Unknown application"
+            exit 1
+          fi
+          main_ref="${formatted_app}@${{ inputs.tag_version }}"
+        fi
+
+        echo "Tag/ref generated: ${main_ref}"
+        echo "main_ref=${main_ref}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-12917)

This PR implements the new hotfix process for targeting arbitrary past releases to issue a hotfix for.

# Demo

A demo of the entire new process is [here](https://ledger.slack.com/archives/C07KP3A8CNA/p1730724401574429).

# Change 1: Create hotfix branch from any release

This modifies the *existing* create hotfix workflow to accept parameters for `version` and `application`. Specifying these values allows you to create a hotfix branch at the point of any previous release

<kbd>
  <img width="904" alt="Screenshot 2024-10-31 at 15 19 15" src="https://github.com/user-attachments/assets/f70b7371-3480-48ae-87d7-89835dd30f1c">
</kbd>

- `version` is optional, and if unspecified defaults to "latest" - a special keyword that bypasses the tag finding process (see below), instead creating the hotfix branch from `main` just as the workflow did before this PR
- `application` is mandatory and is implemented as a `choice` dropdown with LLM and LLD as the only two options

If `version` is specified it is reformatted into a tag using the specified `application`, e.g. version `2.91.0` + `LLD` will be reformatted into a the tag for the 2.91.0 release `@ledgerhq/live-desktop@2.91.0`. This is then used to checkout the repo prior to the remaining hotfix steps. This is all implemented in a new composite action in `./tools/actions/composites/generate-tag`.

Bonus: the version + application being targeted is appended to the hotfix PR title:

<kbd>
  <img width="1136" alt="Screenshot 2024-11-01 at 11 19 57" src="https://github.com/user-attachments/assets/4bdd1ddb-261d-4020-bfc7-ef0b7973a5f8">
</kbd>

### Edge case behaviour:
- when someone deletes the default value in `version` and submits it as empty: it falls back to a ref of `main` ([test run](https://github.com/LedgerHQ/ledger-live/actions/runs/11616218105/job/32348639402#step:3:22))
- when `version` is a non-existent version: `git fetch` fails during the checkout action ([test run](https://github.com/LedgerHQ/ledger-live/actions/runs/11616331415/job/32349026190#step:4:63)).


# Change 2: Implement new hotfixing process in `release-prepare-hotfix`

The PR also:
- **enforces patch changesets only on the hotfix branch** during the `release-prepare-hotfix` workflow
  - [here's a test run](https://github.com/LedgerHQ/ledger-live/actions/runs/11629980897/job/32387985117#step:10:22) of this working as expected
  - to run this workflow you must now re-specify the `application` and `tag` to target. I don't love this, but haven't thought about a slick and low complexity way to handle this automatically yet
- **removes workflow steps for merging the hotfix branch back into `main` and `develop`**

To confirm, the new process is:
1. make updates made on the hotfix branch
2. publish packages, create production build from the hotfix branch
3. (don't merge back into `main` or `develop`)