### PR TITLE
Optimise checkout action implementations

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -24,8 +24,6 @@ jobs:
     runs-on: [ledger-live-4xlarge]
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Setup git user
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
       - name: Setup the caches

--- a/.github/workflows/test-design-system-reusable.yml
+++ b/.github/workflows/test-design-system-reusable.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup the toolchain
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-toolchain@develop
         id: toolchain

--- a/.github/workflows/test-design-system-reusable.yml
+++ b/.github/workflows/test-design-system-reusable.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 1
       - name: Setup the toolchain
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-toolchain@develop
         id: toolchain

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 0
       - name: Setup the toolchain
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-toolchain@develop
         id: toolchain

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 1
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: cache
@@ -79,7 +78,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 0
       - name: Setup the toolchain
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-toolchain@develop
         id: toolchain

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -78,6 +78,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
+          fetch-depth: 2
       - name: Setup the toolchain
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-toolchain@develop
         id: toolchain

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: cache

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - uses: actions/github-script@v7
         id: clean-refs

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/github-script@v7
         id: clean-refs

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -35,9 +35,14 @@ jobs:
       packages: ${{ steps.affected.outputs.packages }}
       paths: ${{ steps.affected.outputs.paths }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout feature branch
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1 # get tip of current branch only
+  
+      - name: Fetch develop branch
+        run: |
+          git fetch origin develop:develop --depth=1
 
       - uses: actions/github-script@v7
         id: clean-refs

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -37,8 +37,6 @@ jobs:
     steps:
       - name: Checkout feature branch
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1 # get tip of current branch only
   
       - name: Fetch develop branch
         run: |


### PR DESCRIPTION
[Ticket](https://ledgerhq.atlassian.net/browse/LIVE-14752)

Streamlines our use of the [checkout](https://github.com/actions/checkout) action so it runs as fast as possible in our workflows. Typically this is because we were checking out the entire repo with all branches and complete commit history when we only need the latest snapshot of one branch.

## Results:

### PR build and test

(⭐ = on the critical path)

✅ ⭐ `turbo-affected-reusable.yml`
**before**: 50s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11632744890/job/32396487027?pr=8278))
**after**: 10s checkout (9s checkout feature branch, 1s fetch develop) ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11634052124/job/32400562112?pr=8278))
(**NOTE**: https://github.com/LedgerHQ/ledger-live/pull/8279 shaves a few extra seconds off on top of this. Not strictly part of the checkout process so different PR)

✅ `test-design-system-reusable.yml`
**before**: 52s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11666662762/job/32482186983?pr=8278#step:2:1))
**after**: 7s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11666851871/job/32482852973?pr=8278#step:2:1))

✅ `test-libs-reusable.yml`
**1. Test Libraries**
**before**: 48s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11666662762/job/32482188221?pr=8278#step:2:1))
**after**: 8s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11666851871/job/32482855073?pr=8278#step:2:1))

**2. Codecheck Libraries**
**before**: 48s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11666662762/job/32482188221?pr=8278#step:2:1))
**after**: 8s checkout ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/11666851871/job/32482855073?pr=8278#step:2:1))

### Elsewhere

These aren't in PR build and test, so less important, but I've similarly shaved ~45s off the checkout from each of these

✅ `sonar.yml`
✅ `test-integration.yml`

## Doesn't include...
There are opportunities to take off a few more seconds from most of these by using `sparse-checkout` to only download the directories of interest. This is likely to save a further ~20-40% of the remaining checkout time. Given the checkout time is now typically ~10s this means 2-4s further saved, so it isn't a high priority and we should back to this once the other massive time sinks are addressed elsewhere in PR build and test.