### PR TITLE
build: only list top level packages when checking turbo affected

### DIFF
--- a/tools/actions/turbo-affected/src/main.ts
+++ b/tools/actions/turbo-affected/src/main.ts
@@ -17,7 +17,7 @@ async function main() {
         maxBuffer: 2048 * 1024,
       },
     );
-    const pnpmOutput = execSync(`npx ${packageManager} list -r --depth=0 --json`, {
+    const pnpmOutput = execSync(`npx ${packageManager} list -r --depth=-1 --json`, {
       encoding: "utf-8",
       maxBuffer: 2048 * 1024,
     });


### PR DESCRIPTION
This is a very simple PR that shaves 2 extra seconds off the turbo-affected workflow.

The rest of the description is how it works and how I've checked that it works. But that's it.

----

One step of turbo-affected is to list the packages in the monorepo so we can get the canonical list of packages to check for changes. We do this via `pnpm list`, and currently we do so recursively (each found package is then searched for its own sub-packages, even if these are imports/not ledger-owned). This recursive step is unnecessary and adds a couple of extra seconds of pnpm searching the repo for sub-packages. We only use the top-level packages that are returned, and of those, [we only use the `name` and `path` property](https://github.com/LedgerHQ/ledger-live/blob/develop/tools/actions/turbo-affected/src/main.ts#L40) (we use nothing from the sub-modules). This PR removes the sub-package search via proper use of the `--depth` option.

https://pnpm.io/cli/list#--depth-number

Note this follows https://github.com/LedgerHQ/ledger-live/pull/8278 but is unrelated to it.

### checking it works
I'm able to confirm this has no effect on the result by running the following in a node REPL at project root. This checks that the outcome of the list of packages is identical for the `name` and `path` properties

```
const { execSync } = await import("child_process");

const pnpmOutput = execSync(`pnpm list -r --depth=0 --json`, {
  encoding: "utf-8",
  maxBuffer: 2048 * 1024,
});

const workspaceInfos = JSON.parse(pnpmOutput);

const pnpmOutputNew = execSync(`pnpm list -r --depth=-1 --json`, {
  encoding: "utf-8",
  maxBuffer: 2048 * 1024,
});

const workspaceInfosNew = JSON.parse(pnpmOutputNew);

console.log(workspaceInfosNew.length === workspaceInfos.length)
// true

// check to make sure the package list is identical at the top level
for (let i = 0; i < workspaceInfos.length; ++i) {
  if (workspaceInfos[i].name !== workspaceInfosNew[i].name) console.log(false)
  if (workspaceInfos[i].path !== workspaceInfosNew[i].path) console.log(false)
}
// no output
```