### PR TITLE
fix(PROTECT-3225): recover banner link to go to login

### DIFF
--- a/.changeset/sweet-needles-kiss.md
+++ b/.changeset/sweet-needles-kiss.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Redirect users to Recover Login if they have an account as they may be logged out


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Previously the Recover Banner was redirecting users based on they were still logged into Recover Live App, but if the user is not logged in to Recover Live app then this previous link would redirect them to the first step in the Backup flow. 

We rather expect the user to be redirected to the login screen, then we can access their data and find out where they left off of the Backup flow and redirect them to the correct step.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/PROTECT-3225
- Related `protect-frontend` PR: https://github.com/LedgerHQ/protect-frontend/pull/1182

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
