### PR TITLE
:sparkles:(lld) add default analytics for deeplinks

### DIFF
--- a/.changeset/wicked-fireants-pay.md
+++ b/.changeset/wicked-fireants-pay.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add default analytics for deeplinks

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/AnnouncementPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/AnnouncementPanel.tsx
@@ -10,7 +10,7 @@ import { openURL } from "~/renderer/linking";
 import { ScrollArea } from "~/renderer/components/Onboarding/ScrollArea";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
-import { useDeepLinkHandler } from "~/renderer/hooks/useDeeplinking";
+import { useDeepLinkHandler } from "~/renderer/hooks/useDeeplinking/useDeepLinkHandler";
 import { closeInformationCenter } from "~/renderer/actions/UI";
 import { useNotifications } from "~/renderer/hooks/useNotifications";
 import TrackPage from "~/renderer/analytics/TrackPage";

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/index.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { ipcRenderer } from "electron";
+import { useDispatch, useSelector } from "react-redux";
+import { areSettingsLoaded, deepLinkUrlSelector } from "~/renderer/reducers/settings";
+import { useDeepLinkHandler } from "./useDeepLinkHandler";
+import { setDeepLinkUrl } from "~/renderer/actions/settings";
+
+function useDeeplink() {
+  const dispatch = useDispatch();
+  const openingDeepLink = useSelector(deepLinkUrlSelector);
+  const loaded = useSelector(areSettingsLoaded);
+  const { handler } = useDeepLinkHandler();
+  useEffect(() => {
+    ipcRenderer.on("deep-linking", handler);
+    return () => {
+      ipcRenderer.removeListener("deep-linking", handler);
+    };
+  }, [handler]);
+  useEffect(() => {
+    if (openingDeepLink && loaded) {
+      handler(null, openingDeepLink);
+      dispatch(setDeepLinkUrl(null));
+    }
+  }, [loaded, openingDeepLink, dispatch, handler]);
+}
+export default useDeeplink;

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/utils.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/utils.ts
@@ -1,0 +1,74 @@
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { Account, SubAccount } from "@ledgerhq/types-live";
+import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
+import { track } from "~/renderer/analytics/segment";
+
+export const getAccountsOrSubAccountsByCurrency = (
+  currency: CryptoOrTokenCurrency,
+  accounts: Account[],
+) => {
+  const predicateFn = (account: SubAccount | Account) =>
+    getAccountCurrency(account).id === currency.id;
+  if (currency.type === "TokenCurrency") {
+    const tokenAccounts = accounts
+      .filter(acc => acc.subAccounts && acc.subAccounts.length > 0)
+      .map(acc => {
+        const found = acc.subAccounts?.find(predicateFn);
+        return found || null;
+      })
+      .filter(Boolean);
+    return tokenAccounts;
+  }
+  return accounts.filter(predicateFn);
+};
+
+type DeepLinkingEvent = {
+  ajsPropSource?: string;
+  ajsPropCampaign?: string;
+  ajsPropTrackData?: string;
+  currency?: string;
+  installApp?: string;
+  appName?: string;
+  deeplinkSource?: string;
+  deeplinkType?: string;
+  deeplinkDestination?: string;
+  deeplinkChannel?: string;
+  deeplinkMedium?: string;
+  deeplinkCampaign?: string;
+  url?: string;
+};
+
+const TRACKING_EVENT = "deeplink_clicked";
+
+export const trackDeeplinkingEvent = (event: DeepLinkingEvent) => {
+  if (event.ajsPropSource) {
+    const { ajsPropSource, ajsPropCampaign, url, currency, installApp, appName, ajsPropTrackData } =
+      event;
+    track(TRACKING_EVENT, {
+      deeplinkSource: ajsPropSource,
+      deeplinkCampaign: ajsPropCampaign,
+      url,
+      currency,
+      installApp,
+      appName,
+      ...(ajsPropTrackData ? JSON.parse(ajsPropTrackData) : {}),
+    });
+  } else {
+    const {
+      deeplinkSource,
+      deeplinkType,
+      deeplinkDestination,
+      deeplinkChannel,
+      deeplinkMedium,
+      deeplinkCampaign,
+    } = event;
+    track(TRACKING_EVENT, {
+      deeplinkSource,
+      deeplinkType,
+      deeplinkDestination,
+      deeplinkChannel,
+      deeplinkMedium,
+      deeplinkCampaign,
+    });
+  }
+};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - deeplink
  - analytics

### 📝 Description

add default analytics on deeplinks. Also little rework of the hook so it's divided in 3 files (same code as before)

https://github.com/user-attachments/assets/83b057ad-f5ce-4b5f-8905-0b1e7633c7ea


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14595](https://ledgerhq.atlassian.net/browse/LIVE-14595)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14595]: https://ledgerhq.atlassian.net/browse/LIVE-14595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ