### PR TITLE
:sparkles:(llm) add default analytics for deeplinks

### DIFF
--- a/.changeset/fuzzy-boxes-confess.md
+++ b/.changeset/fuzzy-boxes-confess.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add default deeplink analytics

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -13,11 +13,9 @@ import Config from "react-native-config";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { BUY_SELL_UI_APP_ID } from "@ledgerhq/live-common/wallet-api/constants";
-
 import Braze from "@braze/react-native-sdk";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import * as Sentry from "@sentry/react-native";
-
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
 import { navigationRef, isReadyRef } from "../rootnavigation";
 import { ScreenName, NavigatorName } from "~/const";
@@ -29,8 +27,8 @@ import { track } from "~/analytics";
 import { setEarnInfoModal } from "~/actions/earn";
 import { blockPasswordLock } from "../actions/appstate";
 import { useStorylyContext } from "~/components/StorylyStories/StorylyProvider";
-
 const routingInstrumentation = new Sentry.ReactNavigationInstrumentation();
+const TRACKING_EVENT = "deeplink_clicked";
 
 const themes: {
   [key: string]: Theme;
@@ -489,6 +487,12 @@ export const DeeplinksProvider = ({
             currency,
             installApp,
             appName,
+            deeplinkSource,
+            deeplinkType,
+            deeplinkDestination,
+            deeplinkChannel,
+            deeplinkMedium,
+            deeplinkCampaign,
           } = query;
 
           if (!ajsPropSource && !Config.MOCK) {
@@ -504,7 +508,7 @@ export const DeeplinksProvider = ({
 
           // Track deeplink only when ajsPropSource attribute exists.
           if (ajsPropSource) {
-            track("deeplink_clicked", {
+            track(TRACKING_EVENT, {
               deeplinkSource: ajsPropSource,
               deeplinkCampaign: ajsPropCampaign,
               url: hostname,
@@ -513,7 +517,16 @@ export const DeeplinksProvider = ({
               appName,
               ...(ajsPropTrackData ? JSON.parse(ajsPropTrackData) : {}),
             });
-          }
+          } else
+            track(TRACKING_EVENT, {
+              deeplinkSource,
+              deeplinkType,
+              deeplinkDestination,
+              deeplinkChannel,
+              deeplinkMedium,
+              deeplinkCampaign,
+            });
+
           const platform = pathname.split("/")[1];
 
           if (isStorylyLink(url.toString())) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Deeplink analytics LLM

### 📝 Description

Add default analytics for deeplinks (keep those for PTX)


https://github.com/user-attachments/assets/d6b6fa94-12d8-46d0-9b96-c2083bc8720e

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14594](https://ledgerhq.atlassian.net/browse/LIVE-14594)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14594]: https://ledgerhq.atlassian.net/browse/LIVE-14594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ