### PR TITLE
[LIVE-14781] Increase preload cache duration for EVMs to 1 day

### DIFF
--- a/.changeset/five-pianos-approve.md
+++ b/.changeset/five-pianos-approve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Change preload cache duration from 1 hour to 1 day in order to delay new synchronizations from block 0

--- a/libs/coin-modules/coin-evm/src/bridge/js.ts
+++ b/libs/coin-modules/coin-evm/src/bridge/js.ts
@@ -35,7 +35,7 @@ export function buildCurrencyBridge(signerContext: SignerContext<EvmSigner>): Cu
     scanAccounts,
     nftResolvers,
     getPreloadStrategy: () => ({
-      preloadMaxAge: 1 * 60 * 60 * 1000, // 1 hour cache
+      preloadMaxAge: 24 * 60 * 60 * 1000, // 1 day cache
     }),
   };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Cache duration between 2 CAL requests should now be 1 day and from scratch sync should be more spread across users

### 📝 Description

Increase preload cache duration to delay potential syncs from scratch

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-14781


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
