### PR TITLE
Feat/LIVE-10694: add webview and feature flag for swap live app view in LLM

### DIFF
--- a/.changeset/tall-moons-invent.md
+++ b/.changeset/tall-moons-invent.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Add swap live app webview behind feature flag

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SwapFormNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SwapFormNavigator.tsx
@@ -1,15 +1,17 @@
-import React, { useMemo } from "react";
+import { Text } from "@ledgerhq/native-ui";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "styled-components/native";
-import { Text } from "@ledgerhq/native-ui";
-import { SwapForm } from "~/screens/Swap";
 import { ScreenName } from "~/const";
-import History from "~/screens/Swap/History";
 import { getLineTabNavigatorConfig } from "~/navigation/tabNavigatorConfig";
-import { SwapFormNavigatorParamList } from "./types/SwapFormNavigator";
+import { SwapForm } from "~/screens/Swap";
+import History from "~/screens/Swap/History";
 import { SwapNavigatorParamList } from "../RootNavigator/types/SwapNavigator";
 import type { StackNavigatorProps } from "../RootNavigator/types/helpers";
+import { SwapFormNavigatorParamList } from "./types/SwapFormNavigator";
+import { SwapLiveApp } from "~/screens/Swap/LiveApp";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 type TabLabelProps = {
   focused: boolean;
@@ -25,24 +27,43 @@ export default function SwapFormNavigator({
   const { colors } = useTheme();
   const tabNavigationConfig = useMemo(() => getLineTabNavigatorConfig(colors), [colors]);
 
+  const ptxSwapLiveAppMobile = useFeature("ptxSwapLiveAppMobile");
+
   return (
     <Tab.Navigator {...tabNavigationConfig}>
-      <Tab.Screen
-        name={ScreenName.SwapForm}
-        component={SwapForm}
-        options={{
-          title: t("transfer.swap.form.tab"),
-          tabBarLabel: (props: TabLabelProps) => (
-            <Text variant="body" fontWeight="semiBold" {...props}>
-              {t("transfer.swap.form.tab")}
-            </Text>
-          ),
-          tabBarTestID: "swap-form-tab",
-        }}
-        initialParams={{
-          ...params,
-        }}
-      />
+      {ptxSwapLiveAppMobile?.enabled ? (
+        <Tab.Screen
+          name={ScreenName.SwapLiveApp}
+          component={SwapLiveApp}
+          options={{
+            swipeEnabled: false,
+            title: t("transfer.swap.form.tab"),
+            tabBarLabel: (props: TabLabelProps) => (
+              <Text variant="body" fontWeight="semiBold" {...props}>
+                {t("transfer.swap.form.tab")}
+              </Text>
+            ),
+            tabBarTestID: "swap-form-tab",
+          }}
+        />
+      ) : (
+        <Tab.Screen
+          name={ScreenName.SwapForm}
+          component={SwapForm}
+          options={{
+            title: t("transfer.swap.form.tab"),
+            tabBarLabel: (props: TabLabelProps) => (
+              <Text variant="body" fontWeight="semiBold" {...props}>
+                {t("transfer.swap.form.tab")}
+              </Text>
+            ),
+            tabBarTestID: "swap-form-tab",
+          }}
+          initialParams={{
+            ...params,
+          }}
+        />
+      )}
       <Tab.Screen
         name={ScreenName.SwapHistory}
         component={History}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapFormNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SwapFormNavigator.ts
@@ -13,4 +13,5 @@ export type SwapFormNavigatorParamList = {
     | SwapSelectCurrency
     | SwapPendingOperation;
   [ScreenName.SwapHistory]: undefined;
+  [ScreenName.SwapLiveApp]: undefined;
 };

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -158,6 +158,7 @@ export enum ScreenName {
   SwapFormSelectAccount = "SwapFormSelectAccount",
   SwapFormSelectCrypto = "SwapFormSelectCrypto",
   SwapFormSelectProviderRate = "SwapFormSelectProviderRate",
+  SwapLiveApp = "SwapLiveApp",
   SwapHistory = "SwapHistory",
   SwapOperationDetails = "SwapOperationDetails",
   SwapPendingOperation = "PendingOperation",

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import TabBarSafeAreaView from "~/components/TabBar/TabBarSafeAreaView";
+import { Web3AppWebview } from "~/components/Web3AppWebview";
+
+type Props = {
+  manifest: LiveAppManifest;
+};
+
+export function WebView({ manifest }: Props) {
+  return (
+    <TabBarSafeAreaView>
+      <Web3AppWebview manifest={manifest} customHandlers={{}} />
+    </TabBarSafeAreaView>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
@@ -14,7 +14,6 @@ import { WebView } from "./WebView";
 const DEFAULT_SWAP_APP_ID = "swap-live-app-demo-3";
 const APP_MANIFEST_NOT_FOUND_ERROR = new Error("Swap Live App not found");
 
-
 export function SwapLiveApp() {
   const localManifest: LiveAppManifest | undefined = useLocalLiveAppManifest(DEFAULT_SWAP_APP_ID);
   const remoteManifest: LiveAppManifest | undefined = useRemoteLiveAppManifest(DEFAULT_SWAP_APP_ID);

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+import {
+  useRemoteLiveAppContext,
+  useRemoteLiveAppManifest,
+} from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
+import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import { Flex, InfiniteLoader } from "@ledgerhq/native-ui";
+import GenericErrorView from "~/components/GenericErrorView";
+import TabBarSafeAreaView from "~/components/TabBar/TabBarSafeAreaView";
+import { WebView } from "./WebView";
+
+const DEFAULT_SWAP_APP_ID = "swap-live-app-demo-3";
+const APP_MANIFEST_NOT_FOUND_ERROR = new Error("Swap Live App not found");
+
+
+export function SwapLiveApp() {
+  const localManifest: LiveAppManifest | undefined = useLocalLiveAppManifest(DEFAULT_SWAP_APP_ID);
+  const remoteManifest: LiveAppManifest | undefined = useRemoteLiveAppManifest(DEFAULT_SWAP_APP_ID);
+  const { state: remoteLiveAppState } = useRemoteLiveAppContext();
+
+  const manifest: LiveAppManifest | undefined = !localManifest ? remoteManifest : localManifest;
+
+  if (!manifest) {
+    return (
+      <Flex flex={1} p={10} justifyContent="center" alignItems="center">
+        {remoteLiveAppState.isLoading ? (
+          <InfiniteLoader />
+        ) : (
+          <GenericErrorView error={APP_MANIFEST_NOT_FOUND_ERROR} />
+        )}
+      </Flex>
+    );
+  }
+
+  return (
+    <>
+      <TabBarSafeAreaView>
+        <WebView manifest={manifest} />
+      </TabBarSafeAreaView>
+    </>
+  );
+}

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -98,6 +98,7 @@ export const DEFAULT_FEATURES: Features = {
   ptxServiceCtaExchangeDrawer: DEFAULT_FEATURE,
   ptxServiceCtaScreens: DEFAULT_FEATURE,
   ptxSwapReceiveTRC20WithoutTrx: DEFAULT_FEATURE,
+  ptxSwapLiveAppMobile: DEFAULT_FEATURE,
   disableNftLedgerMarket: DEFAULT_FEATURE,
   disableNftRaribleOpensea: DEFAULT_FEATURE,
   disableNftSend: DEFAULT_FEATURE,

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -166,6 +166,7 @@ export type Features = CurrencyFeatures & {
   transactionsAlerts: Feature_TransactionsAlerts;
   fetchAdditionalCoins: Feature_FetchAdditionalCoins;
   ptxCard: DefaultFeature;
+  ptxSwapLiveAppMobile: DefaultFeature;
   ptxSwapLiveAppDemoZero: Feature_PtxSwapLiveAppDemoZero;
   ptxSwapLiveAppDemoOne: Feature_PtxSwapLiveAppDemoZero;
   ptxSwapLiveAppDemoThree: Feature_PtxSwapLiveAppDemoZero;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR aims to add conditional rendering of the swap live app under the feature flag `ptxSwapLiveAppMobile`.
By default this is disabled, when enabled the swap view will be redirected to the swap live app instead of native.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-10694


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
