### PR TITLE
:bug:(lld): missing translations for network troubleshooting

### DIFF
--- a/.changeset/shaggy-shoes-beg.md
+++ b/.changeset/shaggy-shoes-beg.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+Add translation for troubleshooting network

--- a/apps/ledger-live-desktop/src/renderer/modals/TroubleshootNetwork/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/TroubleshootNetwork/Body.tsx
@@ -65,19 +65,20 @@ const Status = ({ status }: { status?: TroubleshootStatus }) => {
   }
 };
 const RenderState = ({ state }: { state: TroubleshootStatus[] }) => {
+  const { t } = useTranslation();
   return (
     <Table>
       <thead>
         <tr>
-          <th>TEST</th>
-          <th>RENDERER</th>
+          <th>{t("troubleshootNetwork.test")}</th>
+          <th>{t("troubleshootNetwork.renderer")}</th>
         </tr>
       </thead>
       <tbody>
         {state.map(status => {
           return (
             <tr key={status.title}>
-              <td>{status.title}</td>
+              <td>{t(status.translationKey)}</td>
               <td>
                 <Status status={status} />
               </td>

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2375,7 +2375,7 @@
     "footer": {
       "estimatedFees": "Network fees"
     },
-    "info":{
+    "info": {
       "needMemoTag": {
         "title": "Don’t use Tag/Memo?",
         "description": "Your funds will get lost if you don’t add a Tag/Memo when sending them to any centralized exchange or custodial wallet.",
@@ -2390,7 +2390,15 @@
     "version": "Ledger Live {{versionNb}}"
   },
   "troubleshootNetwork": {
-    "title": "Troubleshoot networking"
+    "title": "Troubleshoot networking",
+    "myLedgerServices": "My Ledger services (scriptrunner)",
+    "bitcoinExplorers": "Bitcoin explorers",
+    "ethereumExplorers": "Ethereum explorers",
+    "countervaluesApi": "Countervalues API",
+    "announcements": "Announcements",
+    "status": "Status",
+    "test": "TEST",
+    "renderer": "RENDERER"
   },
   "systemLanguageAvailable": {
     "title": "Change your app's language?",

--- a/libs/ledger-live-common/src/network-troubleshooting/index.ts
+++ b/libs/ledger-live-common/src/network-troubleshooting/index.ts
@@ -11,12 +11,14 @@ export type TroubleshootStatus = {
   technicalDescription: string;
   status: "success" | "error" | "loading";
   error?: string;
+  translationKey: string;
 };
 
 type Troubleshoot = {
   title: string;
   technicalDescription: string;
   job: Promise<unknown>;
+  translationKey: string;
 };
 
 // Run all checks and return. each troubleshoot have a promise that suceed if the underlying job worked.
@@ -25,6 +27,7 @@ export function troubleshoot(): Troubleshoot[] {
   return [
     {
       title: "My Ledger services (scriptrunner)",
+      translationKey: "troubleshootNetwork.myLedgerServices",
       ...websocketConnects(
         `${getEnv(
           "BASE_SOCKET_URL",
@@ -33,23 +36,28 @@ export function troubleshoot(): Troubleshoot[] {
     },
     {
       title: "Bitcoin explorers",
+      translationKey: "troubleshootNetwork.bitcoinExplorers",
       ...httpGet(getEnv("EXPLORER") + "/blockchain/v4/btc/block/current"),
     },
     {
       title: "Ethereum explorers",
+      translationKey: "troubleshootNetwork.ethereumExplorers",
       ...httpGet(getEnv("EXPLORER") + "/blockchain/v4/eth/block/current"),
     },
     {
       title: "Countervalues API",
+      translationKey: "troubleshootNetwork.countervaluesApi",
       ...httpGet(`${getEnv("LEDGER_COUNTERVALUES_API")}/v3/spot/simple?froms=bitcoin&to=eur`),
     },
     {
       title: "Announcements",
+      translationKey: "troubleshootNetwork.announcements",
       technicalDescription: "fetching announcements",
       job: announcementsApi.fetchAnnouncements(),
     },
     {
       title: "Status",
+      translationKey: "troubleshootNetwork.status",
       technicalDescription: "fetching status",
       job: serviceStatusApi.fetchStatusSummary(),
     },
@@ -106,6 +114,7 @@ export function troubleshootOverObservable(): Observable<TroubleshootEvent> {
         type: "init",
         all: all.map(s => ({
           title: s.title,
+          translationKey: s.translationKey,
           technicalDescription: s.technicalDescription,
           status: "loading",
         })),
@@ -120,6 +129,7 @@ export function troubleshootOverObservable(): Observable<TroubleshootEvent> {
                 type: "change",
                 status: {
                   title: s.title,
+                  translationKey: s.translationKey,
                   technicalDescription: s.technicalDescription,
                   status: "success",
                 },
@@ -130,6 +140,7 @@ export function troubleshootOverObservable(): Observable<TroubleshootEvent> {
                 type: "change",
                 status: {
                   title: s.title,
+                  translationKey: s.translationKey,
                   technicalDescription: s.technicalDescription,
                   status: "error",
                   error: String(e?.message || e),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD settings

### 📝 Description

Add missing translations for network troubleshooting modal in settings

https://github.com/user-attachments/assets/5b492611-5f39-4f43-a8bb-4039db9cd121

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14829](https://ledgerhq.atlassian.net/browse/LIVE-14829)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14829]: https://ledgerhq.atlassian.net/browse/LIVE-14829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ