### PR TITLE
chore: fix redirecting to GITHUB_ENV in fastfile for ios build

### DIFF
--- a/.changeset/good-boxes-boil.md
+++ b/.changeset/good-boxes-boil.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix redirecting to GITHUB_ENV in fastfile for ios build and setting the build number correctly for slack notification

--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -187,10 +187,11 @@ platform :ios do
 
       if (options[:ci])
         sh(
-          <<-SHELL
-          echo "IOS_BUILD_NUMBER=#{build_number+1}" >> $env:GITHUB_ENV
-          SHELL
-        )
+            <<-SHELL
+              temp_ios_build_number_assignment="IOS_BUILD_NUMBER=#{build_number+1}"
+              echo $temp_ios_build_number_assignment | tee -a $GITHUB_ENV
+            SHELL
+          )
       end
     end
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
- fix build number setting to GITHUB_ENV
- The build number should be transited to slack , like android one. 
- To avoid ambiguous redirect and directory not found we need to use `tee` with a temporary variable to set the build number
<img width="737" alt="image" src="https://github.com/user-attachments/assets/0c7dc373-1a15-4880-a33a-8b035d231297">

#### Successfull build with a correct build number 
<img width="748" alt="image" src="https://github.com/user-attachments/assets/b65a7854-6989-4dfa-afa6-5150fda5b093">

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-14346
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
