### PR TITLE
fix(llm): ✂️ truncate some coins memo on the recipient step of the send flow

### DIFF
--- a/.changeset/metal-walls-rush.md
+++ b/.changeset/metal-walls-rush.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": patch
+---
+
+Truncate some coins memo on the recipient step of the send flow

--- a/apps/ledger-live-mobile/src/families/algorand/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/MemoTagInput.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { ALGORAND_MAX_MEMO_SIZE } from "@ledgerhq/live-common/families/algorand/logic";
 import type { Transaction as AlgorandTransaction } from "@ledgerhq/live-common/families/algorand/types";
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
@@ -7,6 +8,7 @@ import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemo
 export default (props: MemoTagInputProps<AlgorandTransaction>) => (
   <GenericMemoTagInput
     {...props}
+    textToValue={text => text.slice(0, ALGORAND_MAX_MEMO_SIZE)}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/internet_computer/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/MemoTagInput.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 
-import { Transaction as ICPTransaction } from "@ledgerhq/live-common/families/internet_computer/types";
+import { MAX_MEMO_VALUE } from "@ledgerhq/live-common/families/internet_computer/consts";
+import type { Transaction as ICPTransaction } from "@ledgerhq/live-common/families/internet_computer/types";
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
 export default (props: MemoTagInputProps<ICPTransaction>) => (
   <GenericMemoTagInput
     {...props}
-    textToValue={text => text.replace(/\D/g, "")}
+    textToValue={text => {
+      const value = Math.min(MAX_MEMO_VALUE, Number(text.replace(/\D/g, "")));
+      return value ? String(value) : "";
+    }}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );

--- a/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
@@ -1,15 +1,20 @@
 import merge from "lodash/merge";
 import React from "react";
 
-import { Transaction as SolanaTransaction } from "@ledgerhq/live-common/families/solana/types";
+import { MAX_MEMO_LENGTH } from "@ledgerhq/live-common/families/solana/logic";
+import type { Transaction as SolanaTransaction } from "@ledgerhq/live-common/families/solana/types";
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
+import { truncateUtf8 } from "LLM/utils/truncateUtf8";
 
-export default (props: MemoTagInputProps<SolanaTransaction>) => (
-  <GenericMemoTagInput
-    {...props}
-    valueToTxPatch={value => tx =>
-      merge({}, tx, { model: { uiState: { memo: value || undefined } } })
-    }
-  />
-);
+export default (props: MemoTagInputProps<SolanaTransaction>) => {
+  return (
+    <GenericMemoTagInput
+      {...props}
+      textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
+      valueToTxPatch={value => tx =>
+        merge({}, tx, { model: { uiState: { memo: value || undefined } } })
+      }
+    />
+  );
+};

--- a/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
@@ -7,14 +7,12 @@ import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 import { truncateUtf8 } from "LLM/utils/truncateUtf8";
 
-export default (props: MemoTagInputProps<SolanaTransaction>) => {
-  return (
-    <GenericMemoTagInput
-      {...props}
-      textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
-      valueToTxPatch={value => tx =>
-        merge({}, tx, { model: { uiState: { memo: value || undefined } } })
-      }
-    />
-  );
-};
+export default (props: MemoTagInputProps<SolanaTransaction>) => (
+  <GenericMemoTagInput
+    {...props}
+    textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
+    valueToTxPatch={value => tx =>
+      merge({}, tx, { model: { uiState: { memo: value || undefined } } })
+    }
+  />
+);

--- a/apps/ledger-live-mobile/src/newArch/utils/__tests__/truncateUtf8.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/__tests__/truncateUtf8.test.ts
@@ -1,0 +1,12 @@
+import { truncateUtf8 } from "../truncateUtf8";
+
+test("truncateUtf8", () => {
+  expect(truncateUtf8("hello world", 0)).toBe("");
+  expect(truncateUtf8("hello world", 50)).toBe("hello world");
+  expect(truncateUtf8("hello world", 1)).toBe("h");
+  expect(truncateUtf8("hello world", 5)).toBe("hello");
+  expect(truncateUtf8("👋💬🌎", 4)).toBe("👋");
+  expect(truncateUtf8("👋💬🌎", 3)).toBe("");
+  expect(truncateUtf8("👋💬🌎", 12)).toBe("👋💬🌎");
+  expect(truncateUtf8("👋💬🌎", 11)).toBe("👋💬");
+});

--- a/apps/ledger-live-mobile/src/newArch/utils/truncateUtf8.ts
+++ b/apps/ledger-live-mobile/src/newArch/utils/truncateUtf8.ts
@@ -1,0 +1,16 @@
+export function truncateUtf8(str: string, maxBytes: number) {
+  const totalBytesLength = Buffer.from(str).byteLength;
+  if (totalBytesLength <= maxBytes) return str;
+  if (totalBytesLength === str.length) return str.slice(0, maxBytes);
+
+  // NOTE in js strings characters above U+FFFF (i.e outside the Basic Multilingual Plane) are represented by two UTF-16 code units
+  // the spread operator will split these strings correctly with some "characters" being strings of length 2.
+  let byteLen = 0;
+  let charLen = 0;
+  for (const char of [...str]) {
+    byteLen += Buffer.from(char).byteLength;
+    if (byteLen > maxBytes) return str.slice(0, charLen);
+    charLen += char.length;
+  }
+  return str;
+}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -74,6 +74,7 @@
     "src/e2e/speculos.ts",
     "src/explorer.ts",
     "src/explorers.ts",
+    "src/families/algorand/logic.ts",
     "src/families/algorand/tokens.ts",
     "src/families/algorand/types.ts",
     "src/families/bitcoin/descriptor.ts",

--- a/libs/ledger-live-common/src/families/algorand/logic.ts
+++ b/libs/ledger-live-common/src/families/algorand/logic.ts
@@ -1,0 +1,2 @@
+// Encapsulate for LLD et LLM
+export * from "@ledgerhq/coin-algorand/logic";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The issue (described in the ticket) was only on Algorand. Because the error can't be caught in a consistent way (meaning if another coin threw a similar error with slightly different wording) I decided to just truncate the memo in the input directly. For consistency I applied this UX to other coins with a limit on the memo size.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-14785]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14785]: https://ledgerhq.atlassian.net/browse/LIVE-14785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ