### PR TITLE
release: make it so release-final can target the hotfix branch

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -12,6 +12,10 @@ on:
           - LLD
           - LLM
           - ALL
+      ref:
+        description: "the ref (branch) to release from"
+        required: false
+        default: main
 
   workflow_run:
     workflows:
@@ -35,7 +39,7 @@ jobs:
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ inputs.ref }}
           fetch-depth: 2
           token: ${{ steps.generate-token.outputs.token }}
       - name: Setup git user
@@ -107,7 +111,7 @@ jobs:
           git tag live-mobile@${{ steps.mobile-version.outputs.version }}
       - name: push changes
         run: |
-          git push origin main --tags
+          git push origin ${{ inputs.ref }} --tags
       - name: create desktop github release
         if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
         env:
@@ -132,7 +136,7 @@ jobs:
               ref: "main",
               workflow_id: "release-desktop.yml",
               inputs: {
-                branch: "main"
+                branch: ${{ inputs.ref }}
               }
             });
       - uses: actions/github-script@v7
@@ -147,6 +151,6 @@ jobs:
               ref: "main",
               workflow_id: "release-mobile.yml",
               inputs: {
-                ref: "main"
+                ref: ${{ inputs.ref }}
               }
             });


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-14836)

This allows us to perform the release-final workflow targeting an arbitrary branch. It defaults to `main` as before, but if we specify `hotfix` instead this will cause us to run the build and release processes from the hotfix branch instead, as part of the [new hotflix process](https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases).

This workflow is in `ledger-live` but kicks off the `release-desktop` + `release-mobile` workflows in `ledger-live-build`, which already take a ref/branch as an argument. This argument is used to specify the hotfix branch, and as such there are no changes to be made in the `ledger-live-build` repo.

This PR is based off https://github.com/LedgerHQ/ledger-live/pull/8264 