### PR TITLE
fix: fall back to firebase display name if no translated title

### DIFF
--- a/.changeset/few-owls-cross.md
+++ b/.changeset/few-owls-cross.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add a fallback to the provider display name from the firebase JSON if there is no translated title for the given provider. Required to add new providers like Coinbase to EVM staking.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -57,6 +57,10 @@ apps/ledger-live-desktop/src/renderer/screens/earn/                  @ledgerhq/p
 apps/ledger-live-desktop/src/renderer/screens/exchange/              @ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/screens/stake/                 @ledgerhq/ptx
 apps/ledger-live-desktop/src/renderer/screens/swapWeb/               @ledgerhq/ptx
+apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal	@ledgerhq/ptx
+apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal_deprecated	@ledgerhq/ptx
+apps/ledger-live-mobile/src/families/evm/StakingDrawer/              @ledgerhq/ptx
+apps/ledger-live-mobile/src/families/evm/StakingDrawer_deprecated/   @ledgerhq/ptx
 apps/ledger-live-mobile/src/actions/earn.ts                          @ledgerhq/ptx
 apps/ledger-live-mobile/src/actions/swap.ts                          @ledgerhq/ptx
 apps/ledger-live-mobile/src/components/ProviderIcon/                 @ledgerhq/ptx

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -66,7 +66,7 @@ interface Props {
 }
 
 export const ProviderItem = ({ provider, stakeOnClick }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const localManifest = useLocalLiveAppManifest(provider.liveAppId);
   const remoteManifest = useRemoteLiveAppManifest(provider.liveAppId);
@@ -78,6 +78,10 @@ export const ProviderItem = ({ provider, stakeOnClick }: Props) => {
       stakeOnClick({ provider, manifest });
     }
   }, [provider, stakeOnClick, manifest]);
+
+  const displayName = i18n.exists(`stake.ethereum.provider.${provider.id}.title`)
+    ? t(`stake.ethereum.provider.${provider.id}.title`)
+    : provider.name;
 
   return (
     <Container
@@ -91,7 +95,7 @@ export const ProviderItem = ({ provider, stakeOnClick }: Props) => {
       <StakingIcon icon={provider.icon} />
       <Flex alignItems="flex-start" flex={2} flexDirection="column">
         <Text variant="bodyLineHeight" fontSize={14} fontWeight="semiBold" mr={2}>
-          {t(`ethereum.stake.provider.${provider.id}.title`)}
+          {displayName}
         </Text>
         <Text variant="paragraph" fontSize={13} color="neutral.c70">
           {provider.lst

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerProvider.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerProvider.tsx
@@ -27,13 +27,17 @@ export function EvmStakingDrawerProvider({ provider, onProviderPress }: Props) {
 
   const theme = useTheme();
 
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const providerPress = useCallback(() => {
     if (manifest) {
       onProviderPress({ manifest, provider });
     }
   }, [manifest, provider, onProviderPress]);
+
+  const displayName = i18n.exists(`stake.ethereum.provider.${provider.id}.title`)
+    ? t(`stake.ethereum.provider.${provider.id}.title`)
+    : provider.name;
 
   return (
     <TouchableOpacity onPress={providerPress}>
@@ -52,7 +56,7 @@ export function EvmStakingDrawerProvider({ provider, onProviderPress }: Props) {
         <Flex rowGap={2} alignItems="flex-start" flex={3}>
           <Flex flexDirection="column" flex={1} alignItems="flex-start">
             <Text variant="bodyLineHeight" fontSize={14} fontWeight="semiBold" mr={2}>
-              {t(`stake.ethereum.provider.${provider.id}.title`)}
+              {displayName}
             </Text>
             <Text variant="paragraph" fontSize={13} color="neutral.c70">
               {provider.lst


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Add a new staking provider to eth_staking_providers FF in firebase
  - Add "name" field
  - Given no translated "title", name of EVM staking provider appears as is on the list, to prevent i18n key from appearing instead.

### 📝 Description


We need to add providers faster than LL release cycle. Given that provider display names are brand names therefore not translated, fallback to the JSON-serialised "name" field from Firebase for any new provider.

Example

Expected behavior:
”Coinbase” should appear in the EVM staking modal with icon

<img width="562" alt="image" src="https://github.com/user-attachments/assets/b67830cf-5940-4a21-bdde-ed90f1081d35">


Actual behavior:
i18n translation key stakingProviders.coinbase.title appears in the list

<img width="620" alt="image" src="https://github.com/user-attachments/assets/f125db65-d6eb-427f-a74f-b3ab9e2e288b">

Note that we will only release new providers in this way after the rollout of the new EVM staking modal is 100%.

### ❓ Context

- **JIRA or GitHub link**: [CN-902](https://ledgerhq.atlassian.net/browse/CN-902)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-902]: https://ledgerhq.atlassian.net/browse/CN-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ