### PR TITLE
fix: use correct refs for turbo-affected checkout + fetch

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -15,7 +15,7 @@ jobs:
   determine-affected:
     name: "Turbo Affected"
     if: ${{!github.event.pull_request.head.repo.fork }}
-    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@support/fix-turbo-affected
     with:
       head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
       base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -15,7 +15,7 @@ jobs:
   determine-affected:
     name: "Turbo Affected"
     if: ${{!github.event.pull_request.head.repo.fork }}
-    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@support/fix-turbo-affected
+    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
     with:
       head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
       base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -35,13 +35,14 @@ jobs:
       packages: ${{ steps.affected.outputs.packages }}
       paths: ${{ steps.affected.outputs.paths }}
     steps:
-      - name: Checkout feature branch
+      - name: Checkout head branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-      - name: Fetch develop branch
+          ref: ${{ inputs.head_branch }}
+  
+      - name: Fetch base branch
         run: |
-          git fetch origin develop:develop --depth=1
+          git fetch origin ${{ inputs.base_branch }}:${{ inputs.base_branch }} --depth=1
 
       - uses: actions/github-script@v7
         id: clean-refs


### PR DESCRIPTION
No ticket - this fixes an issue [encountered](https://ledger.slack.com/archives/C03MHGMAMRQ/p1731403867731049?thread_ts=1731066157.692919&cid=C03MHGMAMRQ) in the latest release. `turbo-affected` errored because the head and base branches weren't correctly handled as variables - they were hardcoded as the PR head and `develop` during the `checkout` and `fetch` stages of `turbo-affected`. When it comes to release, the relevant branches are not the head branch and `develop`, they are the head branch and `main`. Because the `fetch` step hardcoded `develop` as the branch to fetch, `main` was not available for comparison when the turbo-affected script ran, causing an error.

This PR correctly handles the head and base branch names as variables, fixing the problem