### PR TITLE
CN-908: Fix icon for staking tron on account screen

### DIFF
--- a/.changeset/chilly-eggs-hammer.md
+++ b/.changeset/chilly-eggs-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix icon for stake on Tron account screen

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -6,6 +6,7 @@ import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions
 import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { TRX } from "@ledgerhq/native-ui/assets/cryptoIcons";
 import { TokenAccount } from "@ledgerhq/types-live";
+import { IconsLegacy } from "@ledgerhq/native-ui";
 
 const getMainActions = ({
   account,
@@ -43,7 +44,7 @@ const getMainActions = ({
       id: "stake",
       navigationParams,
       label: <Trans i18nKey="account.stake" />,
-      Icon: () => <TRX />,
+      Icon: IconsLegacy.CoinsMedium,
       event: "button_clicked",
       eventProperties: {
         button: "stake",

--- a/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/tron/accountActions.tsx
@@ -4,7 +4,6 @@ import type { TronAccount } from "@ledgerhq/live-common/families/tron/types";
 import { NavigatorName, ScreenName } from "~/const";
 import { ActionButtonEvent, NavigationParamsType } from "~/components/FabActions";
 import { getMainAccount, isAccountEmpty } from "@ledgerhq/live-common/account/index";
-import { TRX } from "@ledgerhq/native-ui/assets/cryptoIcons";
 import { TokenAccount } from "@ledgerhq/types-live";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->

### 📝 Description

Icon for stake for Tron on the account screen was wrong, this PR fixes it.

<img width="514" alt="Screenshot 2024-11-14 at 13 58 54" src="https://github.com/user-attachments/assets/4e353978-b4c3-475e-960f-f97f2ee83ae1">


### ❓ Context

- [Jira CN-908](https://ledgerhq.atlassian.net/browse/CN-908)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
