### PR TITLE
feat: ✨ Countervalues historical requests cache optimization

### DIFF
--- a/.changeset/unlucky-boats-bow.md
+++ b/.changeset/unlucky-boats-bow.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/live-countervalues-react": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/live-countervalues": patch
+---
+
+Add Granularity rate for Countervalues historical requests cache optimization

--- a/apps/ledger-live-desktop/src/renderer/actions/general.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/general.ts
@@ -28,6 +28,7 @@ import { useMarketPerformanceTrackingPairs } from "./marketperformance";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { walletSelector } from "../reducers/wallet";
 import { FlattenAccountsOptions } from "@ledgerhq/live-common/account/index";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 // provide redux states via custom hook wrapper
 
@@ -129,6 +130,18 @@ export function useCalculateCountervaluesUserSettings(): CountervaluesSettings {
     [extraSessionTrackingPairs, trackingPairsForTopCoins, trPairs],
   );
 
+  const granularitiesRatesConfig = useFeature("llCounterValueGranularitiesRates");
+  const granularitiesRates = useMemo(
+    () =>
+      granularitiesRatesConfig?.enabled
+        ? {
+            daily: Number(granularitiesRatesConfig.params?.daily),
+            hourly: Number(granularitiesRatesConfig.params?.hourly),
+          }
+        : undefined,
+    [granularitiesRatesConfig],
+  );
+
   return useMemo(
     () => ({
       trackingPairs,
@@ -137,7 +150,8 @@ export function useCalculateCountervaluesUserSettings(): CountervaluesSettings {
       marketCapBatchingAfterRank: LiveConfig.getValueByKey(
         "config_countervalues_marketCapBatchingAfterRank",
       ),
+      granularitiesRates,
     }),
-    [trackingPairs],
+    [granularitiesRates, trackingPairs],
   );
 }

--- a/apps/ledger-live-mobile/src/actions/general.ts
+++ b/apps/ledger-live-mobile/src/actions/general.ts
@@ -20,6 +20,7 @@ import { clearBridgeCache } from "../bridge/cache";
 import { flushAll } from "../components/DBSave";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { walletSelector } from "~/reducers/wallet";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 const extraSessionTrackingPairsChanges: BehaviorSubject<TrackingPair[]> = new BehaviorSubject<
   TrackingPair[]
@@ -101,6 +102,19 @@ export function useCleanCache() {
 }
 export function useUserSettings() {
   const trackingPairs = useTrackingPairs();
+
+  const granularitiesRatesConfig = useFeature("llCounterValueGranularitiesRates");
+  const granularitiesRates = useMemo(
+    () =>
+      granularitiesRatesConfig?.enabled
+        ? {
+            daily: Number(granularitiesRatesConfig.params?.daily),
+            hourly: Number(granularitiesRatesConfig.params?.hourly),
+          }
+        : undefined,
+    [granularitiesRatesConfig],
+  );
+
   return useMemo(
     () => ({
       trackingPairs,
@@ -109,8 +123,9 @@ export function useUserSettings() {
       marketCapBatchingAfterRank: LiveConfig.getValueByKey(
         "config_countervalues_marketCapBatchingAfterRank",
       ),
+      granularitiesRates,
     }),
-    [trackingPairs],
+    [granularitiesRates, trackingPairs],
   );
 }
 export function addExtraSessionTrackingPair(trackingPair: TrackingPair) {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -519,6 +519,13 @@ export const DEFAULT_FEATURES: Features = {
   recoverUpsellRedirection: DEFAULT_FEATURE,
   llMevProtection: DEFAULT_FEATURE,
   llmNetworkBasedAddAccountFlow: DEFAULT_FEATURE,
+  llCounterValueGranularitiesRates: {
+    ...DEFAULT_FEATURE,
+    params: {
+      daily: 14 * 24 * 60 * 60 * 1000,
+      hourly: 2 * 24 * 60 * 60 * 1000,
+    },
+  },
 };
 
 // Firebase SDK treat JSON values as strings

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -201,6 +201,7 @@ export type Features = CurrencyFeatures & {
   recoverUpsellRedirection: Feature_RecoverUpsellRedirection;
   llMevProtection: DefaultFeature;
   llmNetworkBasedAddAccountFlow: DefaultFeature;
+  llCounterValueGranularitiesRates: Feature_LlCounterValueGranularitiesRates;
 };
 
 /**
@@ -535,6 +536,11 @@ export type Feature_LlmWalletSync = Feature<{
   environment: WalletSyncEnvironment;
   watchConfig: WalletSyncWatchConfig;
   learnMoreLink: string;
+}>;
+
+export type Feature_LlCounterValueGranularitiesRates = Feature<{
+  daily: number;
+  hourly: number;
 }>;
 
 export type Feature_CounterValue = DefaultFeature;

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -202,7 +202,12 @@ export function Countervalues({
       type: "pending",
     });
 
-    loadCountervalues(state, userSettings, batchStrategySolver).then(
+    loadCountervalues(
+      state,
+      userSettings,
+      batchStrategySolver,
+      userSettings.granularitiesRates,
+    ).then(
       state => {
         dispatch({
           type: "success",

--- a/libs/live-countervalues/src/api/index.ts
+++ b/libs/live-countervalues/src/api/index.ts
@@ -4,10 +4,10 @@ import prodAPI from "./api";
 import mockAPI from "./api.mock";
 
 const api: CounterValuesAPI = {
-  fetchHistorical: (granularity, pair) =>
+  fetchHistorical: (granularity, pair, granularitiesRates) =>
     getEnv("MOCK_COUNTERVALUES")
-      ? mockAPI.fetchHistorical(granularity, pair)
-      : prodAPI.fetchHistorical(granularity, pair),
+      ? mockAPI.fetchHistorical(granularity, pair, granularitiesRates)
+      : prodAPI.fetchHistorical(granularity, pair, granularitiesRates),
   fetchLatest: (pairs, batchStrategySolver) =>
     getEnv("MOCK_COUNTERVALUES")
       ? mockAPI.fetchLatest(pairs, batchStrategySolver)

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -147,6 +147,7 @@ export async function loadCountervalues(
   state: CounterValuesState,
   settings: CountervaluesSettings,
   batchStrategySolver?: BatchStrategySolver,
+  granularitiesRates?: Record<RateGranularity, number>,
 ): Promise<CounterValuesState> {
   const data = { ...state.data };
   const cache = { ...state.cache };
@@ -240,7 +241,7 @@ export async function loadCountervalues(
   const [histo, latest] = await Promise.all([
     promiseAllBatched(10, histoToFetch, ([granularity, pair, key]) =>
       api
-        .fetchHistorical(granularity, pair)
+        .fetchHistorical(granularity, pair, granularitiesRates)
         .then(rates => {
           // Update status infos
           const id = pairId(pair);

--- a/libs/live-countervalues/src/types.ts
+++ b/libs/live-countervalues/src/types.ts
@@ -14,6 +14,8 @@ export type CountervaluesSettings = {
   marketCapBatchingAfterRank: number;
   // throw exception in "loadCountervalues" if ANY error occurs (for test purpose)
   disableAutoRecoverErrors?: boolean;
+
+  granularitiesRates?: Record<RateGranularity, number>;
 };
 // This is the internal state of countervalues.
 export type CounterValuesState = {
@@ -49,6 +51,7 @@ export type CounterValuesAPI = {
   fetchHistorical: (
     granularity: RateGranularity,
     pair: TrackingPair,
+    granularitiesRates?: Record<RateGranularity, number>,
   ) => Promise<Record<string, number>>;
   fetchLatest: (
     pairs: TrackingPair[],


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Countervalues historical requests cache optimization

### 📝 Description

Countervalues historical requests cache optimization

Based on distribution of requested interval lengths, we can (based on current FF value):

- divide the traffic by 4 by snapping hourly requests on intervals of 2 days

- divide the traffic by 10 by snapping daily requests on intervals of 14 days

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13492]  <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13492]: https://ledgerhq.atlassian.net/browse/LIVE-13492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ