### PR TITLE
force change changeset versions during release process

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -28,6 +28,23 @@ jobs:
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-toolchain@develop
       - name: install dependencies
         run: pnpm i -F "ledger-live"
+      - name: Move minor updates to patch for hotfix branch
+        # For more info about why we do this, see this doc:
+        # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
+        if: ${{ startsWith(github.ref_name, 'hotfix') }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        with:
+          from_level: minor
+          to_level: patch
+      - name: Move major updates to patch for hotfix branch
+        # For more info about why we do this, see this doc:
+        # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
+        if: ${{ startsWith(github.ref_name, 'hotfix') }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        with:
+          from_level: major
+          to_level: patch
+
       - name: enter prerelease mode
         run: pnpm changeset pre enter hotfix
       - name: commit

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -44,6 +44,13 @@ jobs:
         run: |
           git add .
           git commit -m 'update sortByMarketcap snapshot' || echo "No changes in snapshot of sortByMarketcap.test.ts"
+      - name: Move patch updates to minor
+        # For more info about why we do this, see this doc:
+        # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        with:
+          from_level: patch
+          to_level: minor
       - name: enter prerelease mode
         run: pnpm changeset pre enter next
       - name: commit

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -61,6 +61,30 @@ jobs:
         id: post-mobile-version
         with:
           path: ${{ github.workspace }}/apps/ledger-live-mobile
+      - name: Move patch updates to minor for release branch
+        # For more info about why we do this, see this doc:
+        # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
+        if: ${{ startsWith(github.ref_name, 'release') }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        with:
+          from_level: patch
+          to_level: minor
+      - name: Move minor updates to patch for hotfix branch
+        # For more info about why we do this, see this doc:
+        # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
+        if: ${{ startsWith(github.ref_name, 'hotfix') }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        with:
+          from_level: minor
+          to_level: patch
+      - name: Move major updates to patch for hotfix branch
+        # For more info about why we do this, see this doc:
+        # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
+        if: ${{ startsWith(github.ref_name, 'hotfix') }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        with:
+          from_level: major
+          to_level: patch
       - name: commit (from release branch)
         if: ${{ startsWith(github.ref_name, 'release') }}
         env:

--- a/tools/actions/composites/adjust-changeset-level/action.yml
+++ b/tools/actions/composites/adjust-changeset-level/action.yml
@@ -1,0 +1,37 @@
+name: Adjust Changeset Level
+description: This action adjusts the changeset level from one value to another.
+inputs:
+  from_level:
+    description: 'The changeset level to target'
+    required: true
+  to_level:
+    description: 'The desired changeset level for the target'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate input levels
+      shell: bash
+      run: |
+        valid_levels=("patch" "minor" "major")
+        if [[ ! " ${valid_levels[@]} " =~ " ${{ inputs.from_level }} " ]]; then
+          echo "Invalid from_level: ${inputs.from_level}. Must be one of ${valid_levels[@]}"
+          exit 1
+        fi
+        if [[ ! " ${valid_levels[@]} " =~ " ${{ inputs.to_level }} " ]]; then
+          echo "Invalid to_level: ${inputs.to_level}. Must be one of ${valid_levels[@]}"
+          exit 1
+        fi
+
+    - name: Adjust changeset level
+      shell: bash
+      run: |
+        echo "Adjusting changeset level from ${{ inputs.from_level }} to ${{ inputs.to_level }}"
+        for file in .changeset/*.md; do
+          if grep -q ": patch" "$file"; then
+            # target the lines between the "---" yaml delimiters, replace ": patch" with ": minor"
+            sed -i '/---/,/---/s/: patch/: minor/' "$file"
+            echo "Updated $file to minor"
+          fi
+        done


### PR DESCRIPTION
- Automatically upgrade `patch` changesets to `minor` in releases
- Automatically downgrade `minor` and `major` changesets to `patch` in hotfixes

The `changeset` cli itself doesn't provide any ability to modify changeset levels, so this is done via a new action that I've written.