### PR TITLE
chore: add missing watch:es for common

### DIFF
--- a/apps/ledger-live-desktop/README.md
+++ b/apps/ledger-live-desktop/README.md
@@ -60,7 +60,7 @@ LLD is using vite and will import in priority the esm libs so we need to watch a
 
 ```bash
 # watch common
-pnpm watch:common
+pnpm watch:es:common
 
 # watch ljs
 pnpm watch:es:ljs

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -64,6 +64,7 @@
   "scripts": {
     "build": "zx ./scripts/build-ts.mjs",
     "watch": "zx ./scripts/watch-ts.mjs",
+    "watch:es": "zx ./scripts/watch-ts-es.mjs",
     "updateAppSupportsQuitApp": "node scripts/updateAppSupportsQuitApp.js",
     "prettier": "prettier --write 'src/**/*.?s'",
     "lint": "eslint src --cache",

--- a/libs/ledger-live-common/scripts/watch-ts-es.mjs
+++ b/libs/ledger-live-common/scripts/watch-ts-es.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env zx
+import "zx/globals";
+
+try {
+  cd(path.join(__dirname, ".."));
+
+  await $`zx ./scripts/sync-families-dispatch.mjs`;
+
+  await $`pnpm tsc --project src/tsconfig.json -m ES6 --outDir lib-es --watch`;
+} catch (error) {
+  console.log(chalk.red(error));
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "watch:ljs": "pnpm turbo run watch --filter=\"./libs/ledgerjs/**\" --concurrency 44",
     "watch:es:ljs": "pnpm turbo run watch:es --filter=\"./libs/ledgerjs/**\" --concurrency 44",
     "watch:common": "pnpm turbo run watch --filter=./libs/ledger-live-common",
+    "watch:es:common": "pnpm turbo run watch:es --filter=./libs/ledger-live-common",
     "dev:cli": "pnpm turbo run watch --filter=@ledgerhq/live-cli",
     "dev:lld": "pnpm turbo start --filter=ledger-live-desktop",
     "dev:lld:debug": "DEV_TOOLS=1 LEDGER_INTERNAL_ARGS=--inspect ELECTRON_ARGS=--remote-debugging-port=8315 pnpm turbo start --filter=ledger-live-desktop",


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. Only doc and scripts changes
- [ ] **Covered by automatic tests.** Tested locally as it's dev stuff
- [ ] **Impact of the changes:**
  - LLD watch for common

### 📝 Description

Follow up on https://github.com/LedgerHQ/ledger-live/pull/8365
Common watch mode would not work on common and I saw that I was also missing the watch:es for common where I thought it was not needed at first

### ❓ Context

- **JIRA or GitHub link**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
