### PR TITLE
Fix Typographical Errors in Documentation

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -114,7 +114,7 @@ Usage: ledger-live balanceHistory # Get the balance history for accounts
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -137,7 +137,7 @@ Usage: ledger-live broadcast  # Broadcast signed operation(s)
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -198,7 +198,7 @@ Usage: ledger-live estimateMaxSpendable # estimate the max spendable of an accou
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -210,7 +210,7 @@ Usage: ledger-live exportAccounts # Export given accounts to Live QR or console 
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -233,7 +233,7 @@ Usage: ledger-live generateTestScanAccounts # Generate a test for scan accounts 
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -246,7 +246,7 @@ Usage: ledger-live generateTestTransaction # Generate a test for transaction (li
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -271,7 +271,7 @@ Usage: ledger-live generateTestTransaction # Generate a test for transaction (li
      --sourceValidator <String>: for redelegate, add a source validator
      --cosmosValidator <String>: address of recipient validator that will receive the delegate
      --cosmosAmountValidator <String>: Amount that the validator will receive
-     --tokenId <String>       : determine the tokenId of an NFT (related to the --colection)
+     --tokenId <String>       : determine the tokenId of an NFT (related to the --collection)
      --gasPrice <String>      : how much gasPrice. default is 2gwei. (example format: 2gwei, 0.000001eth, in wei if no unit precised)
      --nonce <String>         : set a nonce for this transaction
      --data <String>          : set the transaction data to use for signing the ETH transaction
@@ -320,7 +320,7 @@ Usage: ledger-live getTransactionStatus # Prepare a transaction and returns 'Tra
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -345,7 +345,7 @@ Usage: ledger-live getTransactionStatus # Prepare a transaction and returns 'Tra
      --sourceValidator <String>: for redelegate, add a source validator
      --cosmosValidator <String>: address of recipient validator that will receive the delegate
      --cosmosAmountValidator <String>: Amount that the validator will receive
-     --tokenId <String>       : determine the tokenId of an NFT (related to the --colection)
+     --tokenId <String>       : determine the tokenId of an NFT (related to the --collection)
      --gasPrice <String>      : how much gasPrice. default is 2gwei. (example format: 2gwei, 0.000001eth, in wei if no unit precised)
      --nonce <String>         : set a nonce for this transaction
      --data <String>          : set the transaction data to use for signing the ETH transaction
@@ -417,7 +417,7 @@ Usage: ledger-live liveData   # utility for Ledger Live app.json file
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -435,7 +435,7 @@ Usage: ledger-live portfolio  # Get a portfolio summary for accounts
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -459,7 +459,7 @@ Usage: ledger-live receive    # Receive crypto-assets (verify on device)
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -493,7 +493,7 @@ Usage: ledger-live send       # Send crypto-assets
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -518,7 +518,7 @@ Usage: ledger-live send       # Send crypto-assets
      --sourceValidator <String>: for redelegate, add a source validator
      --cosmosValidator <String>: address of recipient validator that will receive the delegate
      --cosmosAmountValidator <String>: Amount that the validator will receive
-     --tokenId <String>       : determine the tokenId of an NFT (related to the --colection)
+     --tokenId <String>       : determine the tokenId of an NFT (related to the --collection)
      --gasPrice <String>      : how much gasPrice. default is 2gwei. (example format: 2gwei, 0.000001eth, in wei if no unit precised)
      --nonce <String>         : set a nonce for this transaction
      --data <String>          : set the transaction data to use for signing the ETH transaction
@@ -579,7 +579,7 @@ Usage: ledger-live swap       # Perform an arbitrary swap between two currencies
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -591,7 +591,7 @@ Usage: ledger-live sync       # Synchronize accounts with blockchain
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations
@@ -608,7 +608,7 @@ Usage: ledger-live testDetectOpCollision # Detect operation collisions
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
      --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
- -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
+ -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given scheme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
      --paginateOperations <Number>: if defined, will paginate operations

--- a/apps/ledger-live-mobile/README.md
+++ b/apps/ledger-live-mobile/README.md
@@ -193,7 +193,7 @@ It is possible to run Ledger Live Mobile on an emulator and connect to a Nano th
   - OR
   - First, build & run Ledger Live Mobile `pnpm mobile ios` or `pnpm mobile android`
   - Then, go to the settings tab, then _debug_ > _connectivity_ > _http transport_ and paste the IP (ex: 192.168.1.14)
-- When prompted to choose a Nano device in Ledger Live Mobile, you will see your Nano available with the adress from above, just select it and it should work normally.
+- When prompted to choose a Nano device in Ledger Live Mobile, you will see your Nano available with the address from above, just select it and it should work normally.
 
 ### Extra Docs 📄
 

--- a/apps/ledger-live-mobile/docs/theming.md
+++ b/apps/ledger-live-mobile/docs/theming.md
@@ -69,7 +69,7 @@ export default function App() {
 
 ### **_Theme conventions_**
 
-While developping we try to keep the app theme coherent by setting the same colors at the same spots:
+While developing we try to keep the app theme coherent by setting the same colors at the same spots:
 
 - use `colors.background` for background of the pages
 - use `colors.card` for foreground containers


### PR DESCRIPTION
# Pull Request: Fix Typographical Errors in Documentation

## 📝 Description

This pull request addresses various typographical errors found in the documentation files across the project. The updates ensure clarity and correctness in the provided instructions and examples.

### ✅ Checklist

- [x] Fixed typos in `README.md`.
- [x] Corrected a typo in `theming.md`.
- [x] Resolved additional errors in CLI usage documentation.
- [x] Updated `ledger-live-mobile/README.md` for improved accuracy.

---

### Changes Summary:

1. **README.md**:
   - Fixed repeated typo: "sceme" → "scheme".
   - Ensured consistency in CLI option descriptions.

2. **Theming Documentation**:
   - Corrected "developping" → "developing" to maintain a professional tone.

3. **Mobile App Documentation**:
   - Fixed "adress" → "address" to improve readability.

4. **CLI Usage Instructions**:
   - Fixed multiple instances of "sceme" → "scheme" for better accuracy.

---

### 🧐 Review Checklist for Maintainers

- Ensure no additional functionality is unintentionally affected.
- Validate that the changes improve clarity in the CLI and documentation.
- Confirm there are no missed typographical errors in related files.

---

### Additional Notes

These changes aim to enhance the quality of the documentation for developers and users, making the instructions clearer and error-free.
