### PR TITLE
🐛  LLM - Stop showing useless error message in Ledger Sync when backup has been deleted

### DIFF
--- a/.changeset/swift-pens-reply.md
+++ b/.changeset/swift-pens-reply.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+LLM - Redirect user instead of showing a Ledger Sync error message when deleting the backup and attempting to re-sync

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Manage/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Manage/index.tsx
@@ -23,6 +23,7 @@ import { TrustchainNotFound } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { useCustomTimeOut } from "../../hooks/useCustomTimeOut";
 import { useDispatch } from "react-redux";
 import { blockPasswordLock } from "~/actions/appstate";
+import { isNoTrustchainError } from "../../utils/errors";
 
 const WalletSyncManage = () => {
   const { t } = useTranslation();
@@ -100,7 +101,7 @@ const WalletSyncManage = () => {
   );
 
   const getTopContent = () => {
-    if (error) {
+    if (error && !isNoTrustchainError(error)) {
       if (isLedgerSyncError) {
         return <AlertLedgerSyncDown />;
       }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/utils/errors.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/utils/errors.ts
@@ -1,0 +1,4 @@
+import { ErrorType } from "../hooks/type.hooks";
+
+export const isNoTrustchainError = (error: Error) =>
+  error.message.includes(ErrorType.NO_TRUSTCHAIN);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Stop showing an error banner in LS

### 📝 Description

When the Ledger Sync backup is deleted by another instance, we do not show the top error banner with the error message `No such trustchain ...` that was confusing for the user as he is redirected automatically to the initialization screen of LS when this happens


https://github.com/user-attachments/assets/92a4e230-f3ca-4cad-90be-0ec541f99523


### ❓ Context

- **JIRA or GitHub link**: [LIVE-14541]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14541]: https://ledgerhq.atlassian.net/browse/LIVE-14541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ