### PR TITLE
fix: alwaysShowMemoTagInfo initial value persistence + poolish button…

### DIFF
--- a/.changeset/tough-adults-admire.md
+++ b/.changeset/tough-adults-admire.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+add margin between MemoTag info prompt ctas / make sure that alwaysShowMemoTagInfo is persisted in settings instead of applicattion store

--- a/apps/ledger-live-desktop/src/renderer/actions/application.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/application.ts
@@ -34,10 +34,3 @@ export const toggleSkeletonVisibility = createAction(
     },
   }),
 );
-
-export const toggleShouldDisplayMemoTagInfo = createAction(
-  "APPLICATION_SET_DATA",
-  (alwaysShowMemoTagInfo: boolean) => ({
-    alwaysShowMemoTagInfo,
-  }),
-);

--- a/apps/ledger-live-desktop/src/renderer/actions/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/constants.ts
@@ -1,0 +1,2 @@
+// Action types
+export const TOGGLE_MEMOTAG_INFO = "settings/toggleShouldDisplayMemoTagInfo";

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -25,6 +25,7 @@ import {
 import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 import { Language, Locale } from "~/config/languages";
 import { Layout } from "LLD/features/Collectibles/types/Layouts";
+import { TOGGLE_MEMOTAG_INFO } from "./constants";
 export type SaveSettings = (a: Partial<Settings>) => {
   type: string;
   payload: Partial<Settings>;
@@ -441,3 +442,10 @@ export const setMevProtection = (payload: boolean) => ({
   type: "SET_MEV_PROTECTION",
   payload,
 });
+
+export const toggleShouldDisplayMemoTagInfo = (payload: boolean) => {
+  return {
+    type: TOGGLE_MEMOTAG_INFO,
+    payload,
+  };
+};

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.tsx
@@ -25,8 +25,8 @@ import {
 import MemoTagSendInfo from "LLD/features/MemoTag/components/MemoTagSendInfo";
 import { Flex, Text } from "@ledgerhq/react-ui";
 import CheckBox from "~/renderer/components/CheckBox";
-import { alwaysShowMemoTagInfoSelector } from "~/renderer/reducers/application";
-import { toggleShouldDisplayMemoTagInfo } from "~/renderer/actions/application";
+import { alwaysShowMemoTagInfoSelector } from "~/renderer/reducers/settings";
+import { toggleShouldDisplayMemoTagInfo } from "~/renderer/actions/settings";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { getMemoTagValueByTransactionFamily } from "~/newArch/features/MemoTag/utils";
 
@@ -209,7 +209,7 @@ export const StepRecipientFooter = ({
           {t("send.info.needMemoTag.checkbox.label")}
         </Text>
       </Flex>
-      <Flex>
+      <Flex columnGap={2}>
         <Button secondary onClick={handleOnRefuseAddTag}>
           {t("send.info.needMemoTag.cta.not.addTag")}
         </Button>

--- a/apps/ledger-live-desktop/src/renderer/reducers/application.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/application.ts
@@ -12,7 +12,6 @@ export type ApplicationState = {
   debug: {
     alwaysShowSkeletons: boolean;
   };
-  alwaysShowMemoTagInfo: boolean;
 };
 const { language, region } = getParsedSystemLocale();
 const osLangSupported = LanguageIds.includes(language);
@@ -27,7 +26,6 @@ const state: ApplicationState = {
   debug: {
     alwaysShowSkeletons: false,
   },
-  alwaysShowMemoTagInfo: true,
 };
 
 type HandlersPayloads = {
@@ -62,9 +60,6 @@ export const osLangAndRegionSelector = (state: { application: ApplicationState }
   state.application.osLanguage;
 export const isNavigationLocked = (state: { application: ApplicationState }) =>
   state.application.navigationLocked;
-export const alwaysShowMemoTagInfoSelector = (state: { application: ApplicationState }) =>
-  state.application.alwaysShowMemoTagInfo;
-
 // Exporting reducer
 
 export default handleActions<ApplicationState, HandlersPayloads[keyof HandlersPayloads]>(

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -31,6 +31,7 @@ import { getSystemLocale } from "~/helpers/systemLocale";
 import { Handlers } from "./types";
 import { Layout, LayoutKey } from "LLD/features/Collectibles/types/Layouts";
 import { OnboardingUseCase } from "../components/Onboarding/OnboardingUseCase";
+import { TOGGLE_MEMOTAG_INFO } from "../actions/constants";
 
 /* Initial state */
 
@@ -123,6 +124,7 @@ export type SettingsState = {
   hasBeenRedirectedToPostOnboarding: boolean;
   onboardingUseCase: OnboardingUseCase | null;
   lastOnboardedDevice: Device | null;
+  alwaysShowMemoTagInfo: boolean;
 };
 
 export const getInitialLanguageAndLocale = (): { language: Language; locale: Locale } => {
@@ -225,6 +227,7 @@ export const INITIAL_STATE: SettingsState = {
   hasBeenRedirectedToPostOnboarding: true, // will be set to false at the end of an onboarding, not false by default to avoid redirection for existing users
   onboardingUseCase: null,
   lastOnboardedDevice: null,
+  alwaysShowMemoTagInfo: true,
 };
 
 /* Handlers */
@@ -294,6 +297,7 @@ type HandlersPayloads = {
   SET_LAST_ONBOARDED_DEVICE: Device | null;
 
   SET_MEV_PROTECTION: boolean;
+  [TOGGLE_MEMOTAG_INFO]: boolean;
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
 
@@ -547,6 +551,11 @@ const handlers: SettingsHandlers = {
   SET_MEV_PROTECTION: (state: SettingsState, { payload }) => ({
     ...state,
     mevProtection: payload,
+  }),
+
+  [TOGGLE_MEMOTAG_INFO]: (state: SettingsState, { payload }) => ({
+    ...state,
+    alwaysShowMemoTagInfo: payload,
   }),
 };
 
@@ -902,3 +911,5 @@ export const hasBeenRedirectedToPostOnboardingSelector = (state: State) =>
 export const lastOnboardedDeviceSelector = (state: State) => state.settings.lastOnboardedDevice;
 
 export const mevProtectionSelector = (state: State) => state.settings.mevProtection;
+
+export const alwaysShowMemoTagInfoSelector = (state: State) => state.settings.alwaysShowMemoTagInfo;


### PR DESCRIPTION
…s x-spacing

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
- scenario : when a user choose not to show memo tag prompt -> fixed by moving `alwaysShowMemoTagInfo` to settings store as it's persisted.  So when user reload or restart the app, the value will be initialized from app storage first, then merge it to redux store. 
- add a margin between 2 ctas (add memo tag , don't add tag) 

#### Preview 📹


https://github.com/user-attachments/assets/5d655cad-4b1d-48c6-89c1-07354d50de7d



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-14984

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
