### PR TITLE
fix(WebPlatformPlayer): Fixing account names in account selection in …

### DIFF
--- a/.changeset/sweet-pugs-swim.md
+++ b/.changeset/sweet-pugs-swim.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fixing the account names in webviews account selection

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
@@ -22,6 +22,8 @@ import { CurrentAccountHistDB, safeGetRefValue } from "@ledgerhq/live-common/wal
 import Wallet from "~/renderer/icons/Wallet";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import CryptoCurrencyIcon from "../CryptoCurrencyIcon";
+import { walletSelector } from "~/renderer/reducers/wallet";
+import { accountNameSelector } from "@ledgerhq/live-wallet/store";
 
 const Container = styled(Box).attrs(() => ({
   horizontal: true,
@@ -140,6 +142,8 @@ export const TopBar = ({
   webviewAPIRef,
   webviewState,
 }: Props) => {
+  const walletState = useSelector(walletSelector);
+  
   const { name, icon } = manifest;
 
   const {
@@ -182,6 +186,7 @@ export const TopBar = ({
   }, [webviewAPIRef]);
 
   const { onSelectAccount, currentAccount } = useSelectAccount({ manifest, currentAccountHistDb });
+  const currentAccountName = currentAccount && (accountNameSelector(walletState, { accountId: currentAccount.id }) || getDefaultAccountName(currentAccount));
 
   const isLoading = useDebounce(webviewState.loading, 100);
 
@@ -252,7 +257,7 @@ export const TopBar = ({
                     currency={getAccountCurrency(currentAccount)}
                     size={16}
                   />
-                  <ItemContent>{getDefaultAccountName(currentAccount)}</ItemContent>
+                  <ItemContent>{currentAccountName}</ItemContent>
                 </>
               )}
             </ItemContainer>

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
@@ -143,7 +143,7 @@ export const TopBar = ({
   webviewState,
 }: Props) => {
   const walletState = useSelector(walletSelector);
-  
+
   const { name, icon } = manifest;
 
   const {
@@ -186,7 +186,10 @@ export const TopBar = ({
   }, [webviewAPIRef]);
 
   const { onSelectAccount, currentAccount } = useSelectAccount({ manifest, currentAccountHistDb });
-  const currentAccountName = currentAccount && (accountNameSelector(walletState, { accountId: currentAccount.id }) || getDefaultAccountName(currentAccount));
+  const currentAccountName =
+    currentAccount &&
+    (accountNameSelector(walletState, { accountId: currentAccount.id }) ||
+      getDefaultAccountName(currentAccount));
 
   const isLoading = useDebounce(webviewState.loading, 100);
 


### PR DESCRIPTION
…Webviews


### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Dapp Browser Webview

### 📝 Description

The webview running the dapp-browser enables the selection of accounts.

The names of the accounts were previously gatheres using the `getDefaultAccountName` function that builds the account name by concatenating the currency of the account with an index.

This was confusing to users as the name built this way did not match the user-given names to the account.

The current fix enable users to display the selected accounts with their user-given names.



**BEFORE**
https://github.com/user-attachments/assets/73eec2b9-dcc2-42e3-8e53-c0e304da4bf9

**AFTER**
https://github.com/user-attachments/assets/6561b8ee-a288-4b9c-8947-28d872ef2950



### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-14998


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)