### PR TITLE
ci: fix old references to feature branch, re-point to @develop

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -32,7 +32,7 @@ jobs:
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
         if: ${{ startsWith(github.ref_name, 'hotfix') }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@develop
         with:
           from_level: minor
           to_level: patch
@@ -40,7 +40,7 @@ jobs:
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
         if: ${{ startsWith(github.ref_name, 'hotfix') }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@develop
         with:
           from_level: major
           to_level: patch

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Move patch updates to minor
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
-        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@develop
         with:
           from_level: patch
           to_level: minor

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -65,7 +65,7 @@ jobs:
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
         if: ${{ startsWith(github.ref_name, 'release') }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@develop
         with:
           from_level: patch
           to_level: minor
@@ -73,7 +73,7 @@ jobs:
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
         if: ${{ startsWith(github.ref_name, 'hotfix') }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@develop
         with:
           from_level: minor
           to_level: patch
@@ -81,7 +81,7 @@ jobs:
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
         if: ${{ startsWith(github.ref_name, 'hotfix') }}
-        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@support/automatic-ci-changeset-control
+        uses: LedgerHQ/ledger-live/tools/actions/composites/adjust-changeset-level@develop
         with:
           from_level: major
           to_level: patch


### PR DESCRIPTION
Fixes the error from [this comment](https://ledger.slack.com/archives/C03MHGMAMRQ/p1732551744490439?thread_ts=1732545721.321959&cid=C03MHGMAMRQ) and [associated workflow failure](https://github.com/LedgerHQ/ledger-live/actions/runs/12013943456/job/33488596218)

This was me forgetting to re-point refs to develop at the end of [the automatic changeset level control PR](https://github.com/LedgerHQ/ledger-live/pull/8406).

Unticketed