### PR TITLE
Feat/change label to dynamic for quick action menu

### DIFF
--- a/.changeset/curvy-lions-eat.md
+++ b/.changeset/curvy-lions-eat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Change label to Yield for UK and Earn for the rest on quick action market menu

--- a/apps/ledger-live-mobile/src/components/MarketQuickActions/index.tsx
+++ b/apps/ledger-live-mobile/src/components/MarketQuickActions/index.tsx
@@ -7,7 +7,9 @@ import { track } from "~/analytics";
 import { EntryOf } from "~/types/helpers";
 import useQuickActions, { QuickActionProps } from "../../hooks/useQuickActions";
 import { BaseNavigatorStackParamList } from "../RootNavigator/types/BaseNavigator";
+import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 
+const stakeLabel = getStakeLabelLocaleBased();
 export const MarketQuickActions = (quickActionsProps: Required<QuickActionProps>) => {
   const { t } = useTranslation();
   const navigation = useNavigation<StackNavigationProp<BaseNavigatorStackParamList>>();
@@ -69,7 +71,7 @@ const QUICK_ACTIONS = {
     analytics: "quick_action_swap",
   },
   STAKE: {
-    name: "portfolio.quickActions.stake",
+    name: stakeLabel,
     analytics: "quick_action_stake",
   },
 } as const;


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Change a label to Yield for UK and Earn for the rest instead of stake on quick action market menu

### 📝 Description

This PR changes the label to `Yield` for UK and `Earn` for the rest instead of `Stake` on quick action market menu
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
