### PR TITLE
[WIP] ci: add id-token permission to release-final-nightly

### DIFF
--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   nightly-release:
     name: Nightly Release


### PR DESCRIPTION
...so it can be used with setup-caches

The [release-final-nightly workflow failed](https://github.com/LedgerHQ/ledger-live/actions/runs/12042603618/job/33576546219) last night. This should fix.