### PR TITLE
[QAA] Adding speculos e2e test - User can Select a countervalue

### DIFF
--- a/.changeset/swift-islands-begin.md
+++ b/.changeset/swift-islands-begin.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+adding e2e test

--- a/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/BalanceInfos/index.tsx
@@ -46,6 +46,7 @@ export function BalanceDiff({ valueChange, unit, isAvailable, ...boxProps }: Pro
   return (
     <Box horizontal {...boxProps}>
       <Box
+        data-testid="balance-diff"
         horizontal
         alignItems="center"
         style={{

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/AssetDistribution/Row.tsx
@@ -147,6 +147,7 @@ const Row = ({ item: { currency, amount, distribution }, isVisible }: Props) => 
         <Ellipsis>
           {distribution ? (
             <CounterValue
+              data-testid={`asset-row-${currency.name.toLowerCase()}-value`}
               currency={currency}
               value={amount}
               color="palette.text.shade100"

--- a/apps/ledger-live-desktop/tests/page/portfolio.page.ts
+++ b/apps/ledger-live-desktop/tests/page/portfolio.page.ts
@@ -19,7 +19,11 @@ export class PortfolioPage extends AppPage {
   private showAllButton = this.page.getByText("Show all");
   private showMoreButton = this.page.getByText("Show more");
   private assetRow = (asset: string) => this.page.getByTestId(`asset-row-${asset.toLowerCase()}`);
+  private assetRowValue = (asset: string) =>
+    this.page.getByTestId(`asset-row-${asset.toLowerCase()}-value`);
   private operationRows = this.page.locator("[data-testid^='operation-row-']");
+  private totalBalance = this.page.getByTestId("total-balance");
+  private balanceDiff = this.page.getByTestId("balance-diff");
 
   @step("Open `Add account` modal")
   async openAddAccountModal() {
@@ -103,5 +107,51 @@ export class PortfolioPage extends AppPage {
       const numberOfOperationsAfter = await this.operationRows.count();
       expect(numberOfOperationsAfter).toBeGreaterThan(numberOfOperationsBefore);
     }
+  }
+
+  @step("Expect total balance to be visible")
+  async expectTotalBalanceToBeVisible() {
+    expect(this.totalBalance).toBeVisible();
+  }
+
+  @step("Expect total balance to have the correct counter value $0")
+  async expectTotalBalanceCounterValue(counterValue: string) {
+    await this.expectTotalBalanceToBeVisible();
+    expect(this.totalBalance).toContainText(counterValue);
+  }
+
+  @step("Expect balance diff to be visible")
+  async expectBalanceDiffToBeVisible() {
+    expect(this.balanceDiff).toBeVisible();
+  }
+
+  @step("Expect balance diff to have the correct counter value $0")
+  async expectBalanceDiffCounterValue(counterValue: string) {
+    await this.expectBalanceDiffToBeVisible();
+    expect(this.balanceDiff).toContainText(counterValue);
+  }
+
+  @step("Expect asset row $0 to be visible")
+  async expectAssetRowToBeVisible(asset: string) {
+    await this.assetRow(asset).isVisible();
+  }
+
+  @step("Expect asset row $0 to have the correct counter value $1")
+  async expectAssetRowCounterValue(asset: string, counterValue: string) {
+    await this.expectAssetRowToBeVisible(asset);
+    expect(this.assetRowValue(asset)).toContainText(counterValue);
+  }
+
+  @step("Expect operation row to be visible")
+  async expectOperationRowToBeVisible() {
+    const operationRow = this.operationRows.first();
+    await operationRow.isVisible();
+  }
+
+  @step("Expect operation to contain counter value $0")
+  async expectOperationCounterValue(counterValue: string) {
+    await this.expectOperationRowToBeVisible();
+    const operationRow = this.operationRows.first();
+    await expect(operationRow).toContainText(counterValue);
   }
 }

--- a/apps/ledger-live-desktop/tests/page/settings.page.ts
+++ b/apps/ledger-live-desktop/tests/page/settings.page.ts
@@ -1,5 +1,6 @@
 import { AppPage } from "tests/page/abstractClasses";
 import { step } from "tests/misc/reporters/step";
+import { expect } from "@playwright/test";
 
 export class SettingsPage extends AppPage {
   private manageLedgerSyncButton = this.page.getByRole("button", { name: "Manage" });
@@ -57,10 +58,16 @@ export class SettingsPage extends AppPage {
     await this.experimentalDevModeToggle.click();
   }
 
-  async changeCounterValue() {
+  @step("Change counter value to $0")
+  async changeCounterValue(currency: string) {
     await this.counterValueSelector.click();
-    await this.counterValueSearchBar.fill("euro");
+    await this.counterValueSearchBar.fill(currency);
     await this.counterValueropdownChoiceEuro.click();
+  }
+
+  @step("Expect counter value to be $0")
+  async expectCounterValue(currency: string) {
+    expect(this.counterValueSelector).toHaveText(currency);
   }
 
   async changeTheme() {

--- a/apps/ledger-live-desktop/tests/specs/general/userParametersChange.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/general/userParametersChange.spec.ts
@@ -11,8 +11,8 @@ test("User able to update currency/language/theme in settings", async ({ page })
 
   await test.step("user change currency", async () => {
     await layout.goToSettings();
-    await settingsPage.changeCounterValue();
-    await expect.soft(settingsPage.counterValueSelector).toHaveText("Euro - EUR");
+    await settingsPage.changeCounterValue("euro");
+    await settingsPage.expectCounterValue("Euro - EUR");
   });
 
   await test.step("user change language", async () => {

--- a/apps/ledger-live-desktop/tests/specs/speculos/settings.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/settings.spec.ts
@@ -83,3 +83,45 @@ test.describe("Password", () => {
     },
   );
 });
+
+test.describe("counter value selection", () => {
+  const account = Account.ETH_1;
+  test.use({
+    userdata: "skip-onboarding",
+    cliCommands: [
+      {
+        command: commandCLI.liveData,
+        args: {
+          currency: account.currency.currencyId,
+          index: account.index,
+          appjson: "",
+          add: true,
+        },
+      },
+    ],
+    speculosApp: account.currency.speculosApp,
+  });
+
+  test(
+    "User can select a counter value to display amount",
+    {
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-804",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations).split(", "));
+      await app.layout.goToSettings();
+      await app.settings.changeCounterValue("euro");
+      await app.settings.expectCounterValue("Euro - EUR");
+      await app.layout.goToPortfolio();
+
+      await app.layout.waitForAccountsSyncToBeDone();
+      await app.portfolio.expectTotalBalanceCounterValue("€");
+      await app.portfolio.expectBalanceDiffCounterValue("€");
+      await app.portfolio.expectAssetRowCounterValue(account.currency.name, "€");
+      await app.portfolio.expectOperationCounterValue("€");
+    },
+  );
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adding E2E test : User can Select a countervalue to display amount in Ledger Live
checks:
- Counter value is correct on total balance 
- Counter value is correct on balance diff
- Counter value is correct on Asset row
- Counter value is correct on Operation row

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-330](https://ledgerhq.atlassian.net/browse/QAA-330)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-330]: https://ledgerhq.atlassian.net/browse/QAA-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ