### PR TITLE
🐛 (webhid): Fix invalid channel error when using multiple apps

### DIFF
--- a/.changeset/fuzzy-cats-enjoy.md
+++ b/.changeset/fuzzy-cats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-transport-webhid": patch
+---
+
+Fix invalid channel when using multiple apps

--- a/libs/ledgerjs/packages/hw-transport-webhid/src/TransportWebHID.ts
+++ b/libs/ledgerjs/packages/hw-transport-webhid/src/TransportWebHID.ts
@@ -212,8 +212,19 @@ export default class TransportWebHID extends Transport {
       let acc;
 
       while (!(result = framing.getReducedResult(acc))) {
-        const buffer = await this.read();
-        acc = framing.reduceResponse(acc, buffer);
+        try {
+          const buffer = await this.read();
+          acc = framing.reduceResponse(acc, buffer);
+        } catch (e) {
+          if (e instanceof TransportError && e.id === "InvalidChannel") {
+            // this can happen if the device is connected
+            // on a different channel (like another app)
+            // in this case we just filter out the event
+            continue;
+          }
+
+          throw e;
+        }
       }
 
       log("apdu", "<= " + result.toString("hex"));


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When using two apps with the WebHID transport, both apps receive data from the inputreport event.
If the app is not active, it may store data with a different channel ID in the this.input cache.
When you return to the app, communication with the device can fail because of this invalid channel ID.

To fix this, don't throw an error for an InvalidChannel. Instead, ignore input events with a different channel ID.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-15039]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15039]: https://ledgerhq.atlassian.net/browse/LIVE-15039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ