### PR TITLE
Fix release-nightly by making AWS step in setup-caches optional

### DIFF
--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -35,10 +35,6 @@ jobs:
         with:
           install-proto: true
           skip-turbo-cache: "false"
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0

--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -23,10 +23,10 @@ inputs:
     default: "true"
   accountId:
     description: "aws cache account id"
-    required: true
+    required: false
   roleName:
     description: "aws cache role name"
-    required: true
+    required: false
   region:
     description: "aws cache region"
     required: false


### PR DESCRIPTION
This supersedes https://github.com/LedgerHQ/ledger-live/pull/8496 

The [release-final-nightly workflow failed](https://github.com/LedgerHQ/ledger-live/actions/runs/12042603618/job/33576546219) last night because of the migration from `setup-toolchain` to `setup-caches`, specifically [this PR](https://github.com/LedgerHQ/ledger-live/pull/8486).

In `setup-toolchain` AWS credentials inputs were optional, and their absence would cause us to skip the AWS credentials step and cache steps. In `setup-caches` these inputs are mandatory and thus AWS credentials step and cache steps are unskippable. AWS credentials step requires the `id-token: write` permission for the workflow, which wasn't in the release-final-nightly workflow - hence this all broke when we migrated.

After talking with @valpinkman we decided the solution we actually want is not to just provide the `id-token: write` permission for this workflow (that's the solution implemented in https://github.com/LedgerHQ/ledger-live/pull/8496), it is to make `setup-caches`' AWS credentials step + caching steps optional, like they were for setup-toolchain. This is done in this PR.

## testing the workflow

- see https://github.com/LedgerHQ/ledger-live/pull/8506 for a version of this branch, modified so that it targets the updated `setup-caches` action. It's based on this branch, so the diffs are useful
- see https://github.com/LedgerHQ/ledger-live/actions/runs/12053319095/job/33608706780 for a test nightly release workflow for that PR. At this line, you can see it successfully skips the AWS credentials step that was causing the failure

(Note, it's now failing at a later changeset publish step, but I'm not sure how that can be related to this change)