### PR TITLE
fix: show the transaction details on the right panel

### DIFF
--- a/.changeset/giant-jobs-whisper.md
+++ b/.changeset/giant-jobs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": minor
+---
+
+xrp fix show transaction details on the right panel

--- a/libs/coin-framework/src/account/pending.test.ts
+++ b/libs/coin-framework/src/account/pending.test.ts
@@ -2,8 +2,9 @@ import BigNumber from "bignumber.js";
 import { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import { listCryptoCurrencies } from "@ledgerhq/cryptoassets/index";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { addPendingOperation } from "./pending";
+import { addPendingOperation, shouldRetainPendingOperation } from "./pending";
 import { emptyHistoryCache } from "./balanceHistoryCache";
+import { getEnv } from "@ledgerhq/live-env";
 
 describe("addPendingOperation", () => {
   it("add the operation to the matching account Id", () => {
@@ -64,6 +65,123 @@ describe("addPendingOperation", () => {
   });
 });
 
+describe("shouldRetainPendingOperation", () => {
+  it("should retain the operation if no prior operations exist", () => {
+    // Given
+    const account = createAccount("12");
+    const date = new Date();
+    const op = createOperation("12", [], 1, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+    // Then
+    expect(shouldRetainPending).toBe(true);
+  });
+
+  it("should retain the operation with a lower transactionSequenceNumber than the last operation", () => {
+    // Given
+    const account = createAccount("12");
+    const date = new Date();
+    account.operations = [createOperation("12", [account.freshAddress], 1, date)];
+    const op = createOperation("12", [account.freshAddress], 2, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+    // Then
+    expect(shouldRetainPending).toBe(true);
+  });
+
+  it("should not retain the operation with a higher transactionSequenceNumber than the last operation", () => {
+    // Given
+    const account = createAccount("12");
+    const date = new Date();
+    account.operations = [createOperation("12", [account.freshAddress], 2, date)];
+    const op = createOperation("12", [account.freshAddress], 1, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+    // Then
+    expect(shouldRetainPending).toBe(false);
+  });
+
+  it("should not retain the operation if last operation has no matching sender", () => {
+    // Given
+    const account = createAccount("12");
+    const date = new Date(getEnv("OPERATION_OPTIMISTIC_RETENTION") + 1);
+    account.operations = [createOperation("12", [], 1, date)];
+    const op = createOperation("12", [account.freshAddress], 3, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+    // Then
+    expect(shouldRetainPending).toBe(false);
+  });
+
+  it("should not retain the operation if delay exceeds the optimistic retention threshold", () => {
+    // Given
+    const account = createAccount("12");
+    const retentionThreshold = getEnv("OPERATION_OPTIMISTIC_RETENTION");
+    const date = new Date(Date.now() - retentionThreshold - 1); // Exceeds threshold
+    const op = createOperation("12", [account.freshAddress], 1, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+
+    // Then
+    expect(shouldRetainPending).toBe(false);
+  });
+
+  it("should retain the operation if delay is within the optimistic retention threshold", () => {
+    // Given
+    const account = createAccount("12");
+    const retentionThreshold = getEnv("OPERATION_OPTIMISTIC_RETENTION");
+    const date = new Date(Date.now() - retentionThreshold + 1); // Within threshold
+    const op = createOperation("12", [account.freshAddress], 1, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+
+    // Then
+    expect(shouldRetainPending).toBe(true);
+  });
+
+  it("should retain the operation if transactionSequenceNumber is undefined in last operation", () => {
+    // Given
+    const account = createAccount("12");
+    const date = new Date();
+    account.operations = [createOperation("12", [account.freshAddress], undefined, date)];
+    const op = createOperation("12", [account.freshAddress], 1, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+
+    // Then
+    expect(shouldRetainPending).toBe(true);
+  });
+
+  it("should retain the operation if senders are empty in both the operation and last operation", () => {
+    // Given
+    const account = createAccount("12");
+    const date = new Date();
+    account.operations = [createOperation("12", [], 1, date)];
+    const op = createOperation("12", [], 1, date);
+
+    // When
+    const result = addPendingOperation(account, op);
+    const shouldRetainPending = shouldRetainPendingOperation(result, op);
+
+    // Then
+    expect(shouldRetainPending).toBe(true);
+  });
+});
+
 function createAccount(id: string): Account {
   const currency = listCryptoCurrencies(true)[0];
 
@@ -108,7 +226,12 @@ function createTokenAccount(id: string): TokenAccount {
   };
 }
 
-function createOperation(accountId: string): Operation {
+function createOperation(
+  accountId: string,
+  sender?: string[],
+  sequenceNumber?: number,
+  date?: Date,
+): Operation {
   return {
     id: "",
     hash: "",
@@ -116,12 +239,13 @@ function createOperation(accountId: string): Operation {
     value: new BigNumber(0),
     fee: new BigNumber(0),
     // senders & recipients addresses
-    senders: [],
+    senders: sender || [],
     recipients: [],
     blockHeight: undefined,
     blockHash: undefined,
+    transactionSequenceNumber: sequenceNumber,
     accountId,
-    date: new Date(),
+    date: date || new Date(),
     extra: null,
   };
 }

--- a/libs/coin-framework/src/account/pending.ts
+++ b/libs/coin-framework/src/account/pending.ts
@@ -4,7 +4,7 @@ import { getEnv } from "@ledgerhq/live-env";
 export function shouldRetainPendingOperation(account: Account, op: Operation): boolean {
   // FIXME: valueOf to compare dates in typescript
   const delay = new Date().valueOf() - op.date.valueOf();
-  const last = account.operations[0];
+  const last = account.operations.find(o => o.senders.includes(op.senders[0]));
 
   if (
     last &&


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

sent funds between two XRP accounts
When I click on "View details" at the end of the operation, the transaction details section on the right panel is empty.

This issue occurs on XRP when you perform a send transaction after receiving some funds. In this case, the **transactionSequenceNumber** of the **IN** transaction might be greater than that of the **OUT** transaction. As a result, it will be removed from **pendingTransaction** even though it hasn’t yet been added to **operations.**

<img width="1503" alt="image-20241105-093835" src="https://github.com/user-attachments/assets/e2812175-32c0-45cb-bc3e-022cfe5419c5">


### ❓ Context

- **JIRA or GitHub link**:  [LIVE-14771](https://ledgerhq.atlassian.net/browse/LIVE-14771)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14771]: https://ledgerhq.atlassian.net/browse/LIVE-14771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ