### PR TITLE
Skip AWS credentials and cache steps in setup-caches for release workflows and account-migration

### DIFF
--- a/.github/workflows/account-migration.yml
+++ b/.github/workflows/account-migration.yml
@@ -35,10 +35,6 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
       - name: install dependencies and build
         run: |

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -31,11 +31,6 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-turbo-cache: "false"
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
       - name: install dependencies
         run: pnpm i
       - name: Build libs

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -45,11 +45,6 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-turbo-cache: "false"
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -35,11 +35,6 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-turbo-cache: "false"
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
       - name: install dependencies
         run: pnpm i -F "ledger-live"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -35,11 +35,6 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-turbo-cache: "false"
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
 
       - name: install dependencies
         run: pnpm i -F "ledger-live"

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -39,11 +39,6 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-          skip-turbo-cache: "false"
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: desktop-version
         with:


### PR DESCRIPTION
Following https://github.com/LedgerHQ/ledger-live/pull/8505 and discussion with @valpinkman, this PR makes `account-migration` and release workflows all skip the actual caching steps when using `setup-caches`, essentially using just the install steps from that workflow. This is to more closely match how setup-toolchain was implemented before switching to `setup-caches`, and ensures we don't see more workflow failures (see https://github.com/LedgerHQ/ledger-live/pull/8505 description) in these other workflows.