### PR TITLE
feat(ACRE): Remove fields from the sign-message modal type withdraw

### DIFF
--- a/.changeset/lovely-glasses-study.md
+++ b/.changeset/lovely-glasses-study.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Removed message fields for sign message modal for ACRE Withdrawals

--- a/apps/ledger-live-desktop/src/renderer/components/SignMessageConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SignMessageConfirm/index.tsx
@@ -59,21 +59,12 @@ const SignMessageConfirm = ({ device, account, parentAccount, signMessageRequest
   const { currency } = mainAccount;
   const [messageFields, setMessageFields] = useState<MessageProperties | null>(null);
 
-  const isACREWithdraw = "type" in signMessageRequested && signMessageRequested.type === "Withdraw";
-
   useEffect(() => {
     if (signMessageRequested.standard === "EIP712") {
       const specific = getLLDCoinFamily(currency.family);
       specific?.message?.getMessageProperties(signMessageRequested).then(setMessageFields);
-    } else if (isACREWithdraw) {
-      setMessageFields(
-        Object.entries(signMessageRequested.message).map(([label, value]) => ({
-          label,
-          value,
-        })),
-      );
     }
-  }, [currency, isACREWithdraw, mainAccount, signMessageRequested]);
+  }, [currency, mainAccount, signMessageRequested]);
 
   if (!device) return null;
 
@@ -96,12 +87,6 @@ const SignMessageConfirm = ({ device, account, parentAccount, signMessageRequest
         type: "text",
         label: t("SignMessageConfirm.messageHash"),
         value: signMessageRequested.hashStruct,
-      });
-    } else if (!isACREWithdraw) {
-      fields.push({
-        type: "text",
-        label: t("SignMessageConfirm.message"),
-        value: signMessageRequested.message,
       });
     }
   }

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
@@ -113,13 +113,6 @@ export default function StepSummary({ account, message: messageData }: StepProps
     if (messageData.standard === "EIP712") {
       const specific = getLLDCoinFamily(mainAccount.currency.family);
       specific?.message?.getMessageProperties(messageData).then(setMessageFields);
-    } else if (isACREWithdraw) {
-      setMessageFields(
-        Object.entries(messageData.message).map(([label, value]) => ({
-          label,
-          value,
-        })),
-      );
     }
   }, [account.currency.family, isACREWithdraw, mainAccount, messageData, setMessageFields]);
 
@@ -145,11 +138,13 @@ export default function StepSummary({ account, message: messageData }: StepProps
       </Box>
       <Separator />
 
-      {messageData.standard === "EIP712" || isACREWithdraw ? (
-        <MessagePropertiesComp properties={messageFields} />
-      ) : (
-        <MessageProperty label={"message"} value={messageData.message} />
-      )}
+      {!isACREWithdraw ? (
+        messageData.standard === "EIP712" ? (
+          <MessagePropertiesComp properties={messageFields} />
+        ) : (
+          <MessageProperty label={"message"} value={messageData.message} />
+        )
+      ) : null}
 
       <MessageContainer flex="1">
         {messageFields ? (

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
@@ -114,7 +114,7 @@ export default function StepSummary({ account, message: messageData }: StepProps
       const specific = getLLDCoinFamily(mainAccount.currency.family);
       specific?.message?.getMessageProperties(messageData).then(setMessageFields);
     }
-  }, [account.currency.family, isACREWithdraw, mainAccount, messageData, setMessageFields]);
+  }, [account.currency.family, mainAccount, messageData, setMessageFields]);
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-mobile/src/components/ValidateMessageOnDevice.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateMessageOnDevice.tsx
@@ -50,15 +50,8 @@ export default function ValidateOnDevice({ device, message: messageData, account
   useEffect(() => {
     if (messageData.standard === "EIP712") {
       getMessageProperties(messageData).then(setMessageFields);
-    } else if (isACREWithdraw) {
-      setMessageFields(
-        Object.entries(messageData.message).map(([label, value]) => ({
-          label,
-          value,
-        })),
-      );
     }
-  }, [isACREWithdraw, mainAccount, mainAccount.currency, messageData, setMessageFields]);
+  }, [mainAccount, mainAccount.currency, messageData, setMessageFields]);
 
   return (
     <View style={styles.root}>
@@ -81,33 +74,35 @@ export default function ValidateOnDevice({ device, message: messageData, account
           <LText style={messageTextStyle}>{t("walletconnect.stepVerification.accountName")}</LText>
           <LText semiBold>{mainAccountName}</LText>
         </View>
-        {messageData.standard === "EIP712" || isACREWithdraw ? (
-          <>
-            {messageFields
-              ? messageFields.map(({ label, value }) => (
-                  <View key={label} style={messageContainerStyle}>
-                    <LText style={messageTextStyle}>{label}</LText>
-                    {Array.isArray(value) ? (
-                      value.map((v, i) => (
-                        <LText key={i} style={[styles.value, styles.subValue]} semiBold>
-                          {v}
+        {!isACREWithdraw ? (
+          messageData.standard === "EIP712" ? (
+            <>
+              {messageFields
+                ? messageFields.map(({ label, value }) => (
+                    <View key={label} style={messageContainerStyle}>
+                      <LText style={messageTextStyle}>{label}</LText>
+                      {Array.isArray(value) ? (
+                        value.map((v, i) => (
+                          <LText key={i} style={[styles.value, styles.subValue]} semiBold>
+                            {v}
+                          </LText>
+                        ))
+                      ) : (
+                        <LText style={styles.value} semiBold>
+                          {value}
                         </LText>
-                      ))
-                    ) : (
-                      <LText style={styles.value} semiBold>
-                        {value}
-                      </LText>
-                    )}
-                  </View>
-                ))
-              : null}
-          </>
-        ) : (
-          <View style={messageContainerStyle}>
-            <LText style={messageTextStyle}>{t("walletconnect.message")}</LText>
-            <LText semiBold>{messageData.message}</LText>
-          </View>
-        )}
+                      )}
+                    </View>
+                  ))
+                : null}
+            </>
+          ) : (
+            <View style={messageContainerStyle}>
+              <LText style={messageTextStyle}>{t("walletconnect.message")}</LText>
+              <LText semiBold>{messageData.message}</LText>
+            </View>
+          )
+        ) : null}
       </ScrollView>
     </View>
   );

--- a/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
@@ -105,13 +105,6 @@ function SignSummary({
   useEffect(() => {
     if (messageData.standard === "EIP712") {
       getMessageProperties(messageData).then(setMessageFields);
-    } else if (isACREWithdraw) {
-      setMessageFields(
-        Object.entries(messageData.message).map(([label, value]) => ({
-          label,
-          value,
-        })),
-      );
     }
   }, [isACREWithdraw, mainAccount, mainAccount.currency, messageData, setMessageFields]);
 
@@ -160,15 +153,17 @@ function SignSummary({
           ]}
         />
         <ScrollView style={styles.scrollContainer}>
-          {messageData.standard === "EIP712" || isACREWithdraw ? (
-            <MessagePropertiesComp properties={messageFields} />
-          ) : (
-            <View style={styles.messageContainer}>
-              <MessageProperty label={"message"} value={messageData.message || ""} />
-            </View>
-          )}
+          {!isACREWithdraw ? (
+            messageData.standard === "EIP712" ? (
+              <MessagePropertiesComp properties={messageFields} />
+            ) : (
+              <View style={styles.messageContainer}>
+                <MessageProperty label={"message"} value={messageData.message || ""} />
+              </View>
+            )
+          ) : null}
 
-          {messageData.standard === "EIP712" || isACREWithdraw ? (
+          {messageData.standard === "EIP712" ? (
             <>
               {messageFields ? (
                 <View>

--- a/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
@@ -106,7 +106,7 @@ function SignSummary({
     if (messageData.standard === "EIP712") {
       getMessageProperties(messageData).then(setMessageFields);
     }
-  }, [isACREWithdraw, mainAccount, mainAccount.currency, messageData, setMessageFields]);
+  }, [mainAccount, mainAccount.currency, messageData, setMessageFields]);
 
   return (
     <SafeAreaView


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Removing message fields from the sign-message modal type Withdraw, for the specific use case of ACRE withdrawals


### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-15014

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
