### PR TITLE
Fix `release-final-nightly` npm auth

### DIFF
--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -60,6 +60,10 @@ jobs:
         run: |
           git add .
           git commit -m "chore(nightly): :rocket: nightly release"
+      - name: authenticate with npm
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
       - name: publish nightly
         run: pnpm changeset publish --no-git-tag
         env:

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -60,6 +60,10 @@ jobs:
         run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
       - name: build libs
         run: pnpm run build:libs
+      - name: authenticate with npm
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
       - name: publish release
         run: pnpm changeset publish
         env:

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -111,6 +111,10 @@ jobs:
           git add .
           git commit -m "chore(prerelease): :rocket: ${{ inputs.ref }} prerelease [LLD(${{ steps.post-desktop-version.outputs.version }}), LLM(${{ steps.post-mobile-version.outputs.version }})]" ||
           echo ""
+      - name: authenticate with npm
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
       - name: publish prerelease
         run: pnpm changeset publish --no-git-tag
         env:


### PR DESCRIPTION
The nightly build was failing last night:

https://github.com/LedgerHQ/ledger-live/actions/runs/12061420704/job/33633423504

This is because authenticating with npm was inadvertently removed as part of the switch from setup-toolchain to setup-caches ([PR](https://github.com/LedgerHQ/ledger-live/pull/8486), [ticket](https://ledgerhq.atlassian.net/browse/LIVE-14750)), and that breaks the changesets package publishing step.

This PR adds a npm authentication step to the release workflows whenever we publish to npm. It uses the `setup-node` action (but only authenticates, doesn't install node), and does this in the relevant workflows, not `setup-caches`, as it's particular to release workflows.

A nightly workflow for this branch has been run [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12070900478/job/33661421843). Outcome: 🟢