### PR TITLE
Fix integration workflow failure on windows

### DIFF
--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -57,6 +57,11 @@ runs:
       shell: bash
       run: proto use
 
+    - uses: pnpm/action-setup@v4
+      if: inputs.install-proto == 'true' && startsWith(env.CI_OS, 'windows')
+      with:
+        version: 9.12.3
+
     - name: Get pnpm store directory
       shell: bash
       run: |


### PR DESCRIPTION
Fixes [this failing workflow](https://github.com/LedgerHQ/ledger-live/actions/runs/12065755570/job/33645253496?pr=8504)

Proto installing pnpm caused issues with knowing where the pnpm store is. Using the pnpm action fixes this. Seen as it adds an extra step, we only run this conditionally on the OS being windows and proto being installed as part of setup-caches.

## Workflow testing

See [this test PR](https://github.com/LedgerHQ/ledger-live/pull/8530) which initiates a workflow to run this PR's changes. Its workflow run (🟢) is [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12072768691/job/33667539378?pr=8530)