### PR TITLE
Revert "ci: remove setup-toolchain action completely"

### DIFF
--- a/tools/actions/composites/setup-toolchain/action.yml
+++ b/tools/actions/composites/setup-toolchain/action.yml
@@ -1,0 +1,111 @@
+name: "Setup Toolchain"
+description: "Setup the toolchain for an action"
+inputs:
+  upgrade_npm:
+    description: "should update npm (windows support)"
+    required: false
+  install-dotnet:
+    description: "dotnet setup for Windows"
+    required: false
+  skip-pnpm-cache:
+    description: "true to skip pnpm caching, false by default"
+    required: false
+    default: "false"
+  skip-pod-cache:
+    description: "false to get cache, true by default"
+    required: false
+    default: "true"
+  skip-turbo-cache:
+    description: "false to get cache, true by default"
+    required: false
+    default: "true"
+  accountId:
+    description: "aws cache account id"
+    required: false
+  roleName:
+    description: "aws cache role name"
+    required: false
+  region:
+    description: "aws cache region"
+    required: false
+    default: "eu-west-1"
+  turbo-server-token:
+    description: "custom token for local s3 server"
+    required: false
+    default: "yolo"
+outputs:
+  port:
+    description: "The port the local server runs on"
+    value: ${{ steps.turborepo-cache-server.outputs.port }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-dotnet@v4
+      if: inputs.install-dotnet != ''
+      with:
+        dotnet-version: 2.1.816
+
+    - uses: pnpm/action-setup@v4
+      with:
+        version: 9.12.3
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      if: inputs.accountId != '' && inputs.roleName != ''
+      id: aws
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.accountId }}:role/${{ inputs.roleName }}
+        aws-region: ${{ inputs.region }}
+
+    - name: Cache pnpm store
+      uses: tespkg/actions-cache@v1
+      if: steps.aws.conclusion == 'success' && inputs.skip-pnpm-cache != 'true'
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+        accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
+        secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
+        sessionToken: ${{ env.AWS_SESSION_TOKEN }}
+        bucket: ll-gha-s3-cache
+        region: ${{ inputs.region }}
+        use-fallback: false
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20.11.0
+        registry-url: "https://registry.npmjs.org"
+
+    - name: upgrade npm
+      if: inputs.upgrade_npm == 'true'
+      run: |
+        npm i -g npm
+      shell: bash
+
+    - name: TurboRepo local caching server
+      id: turborepo-cache-server
+      if: steps.aws.conclusion == 'success' && inputs.skip_turbo_cache != 'true'
+      uses: LedgerHQ/ledger-live/tools/actions/turborepo-s3-cache@develop
+      with:
+        server-token: "${{ inputs.turbo-server-token }}"
+        cleanup-cache-folder: "true"
+        aws-access-key: ${{ env.AWS_ACCESS_KEY_ID }}
+        aws-secret-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+        aws-session-token: ${{ env.AWS_SESSION_TOKEN }}
+        region: ${{ inputs.region }}
+
+    - name: Cache LLM pods
+      uses: actions/cache@v3
+      if: inputs.skip-pod-cache != 'true'
+      with:
+        path: |
+          apps/ledger-live-mobile/ios/Pods
+          ~/Library/Caches/CocoaPods
+          ~/.cocoapods
+        key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#8510

Other PRs and branches still rely on setup-toolchain as they were created before the migration to setup caches. Revery now with the intention of re-merging the original PR at the end of the release cycle