### PR TITLE
feat(LIVE-14855): manually instantiate the account sidebar when swap triggers `custom.requestAccount`

### DIFF
--- a/.changeset/lazy-carrots-shop.md
+++ b/.changeset/lazy-carrots-shop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Manually start the account side from swap-live

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/AccountList.tsx
@@ -36,10 +36,11 @@ const AddIconContainer = styled.div`
 type Props = {
   currency: CryptoCurrency | TokenCurrency;
   onAccountSelect: (account: AccountLike, parentAccount?: Account) => void;
+  onAddAccountClick?: () => void;
   accounts$?: Observable<WalletAPIAccount[]>;
 };
 
-export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
+export function AccountList({ currency, onAccountSelect, onAddAccountClick, accounts$ }: Props) {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const accountIds = useGetAccountIds(accounts$);
@@ -49,12 +50,16 @@ export function AccountList({ currency, onAccountSelect, accounts$ }: Props) {
     return getAccountTuplesForCurrency(currency, nestedAccounts, false, accountIds);
   }, [nestedAccounts, currency, accountIds]);
   const openAddAccounts = useCallback(() => {
+    if (onAddAccountClick) {
+      onAddAccountClick();
+    }
+
     dispatch(
       openModal("MODAL_ADD_ACCOUNTS", {
         currency,
       }),
     );
-  }, [dispatch, currency]);
+  }, [dispatch, onAddAccountClick, currency]);
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
@@ -52,6 +52,8 @@ export type SelectAccountAndCurrencyDrawerProps = {
   onClose?: () => void;
   currencies: CryptoOrTokenCurrency[];
   onAccountSelected: (account: AccountLike, parentAccount?: Account) => void;
+  onAddAccountClick?: () => void;
+  onCurrencySelected?: (currency: CryptoOrTokenCurrency) => void;
   accounts$?: Observable<WalletAPIAccount[]>;
 };
 const SearchInputContainer = styled.div`
@@ -60,7 +62,7 @@ const SearchInputContainer = styled.div`
 `;
 
 function SelectAccountAndCurrencyDrawer(props: SelectAccountAndCurrencyDrawerProps) {
-  const { currencies, onAccountSelected, onClose, accounts$ } = props;
+  const { currencies, onAccountSelected, onAddAccountClick, onClose, accounts$ } = props;
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState<string>("");
 
@@ -74,14 +76,20 @@ function SelectAccountAndCurrencyDrawer(props: SelectAccountAndCurrencyDrawerPro
     }
     return fuzzySearch(sortedCurrencies, searchValue);
   }, [searchValue, sortedCurrencies]);
+
   const handleCurrencySelected = useCallback(
     (currency: CryptoOrTokenCurrency) => {
+      if (props.onCurrencySelected) {
+        props.onCurrencySelected(currency);
+      }
+
       setDrawer(
         SelectAccountDrawer,
         {
           accounts$,
           currency,
           onAccountSelected,
+          onAddAccountClick,
           onRequestBack: () =>
             setDrawer(MemoizedSelectAccountAndCurrencyDrawer, props, {
               onRequestClose: onClose,
@@ -92,8 +100,9 @@ function SelectAccountAndCurrencyDrawer(props: SelectAccountAndCurrencyDrawerPro
         },
       );
     },
-    [onAccountSelected, props, onClose, accounts$],
+    [onAccountSelected, onAddAccountClick, props, onClose, accounts$],
   );
+
   if (currencies.length === 1) {
     return (
       <SelectAccountDrawer

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountDrawer.tsx
@@ -33,11 +33,13 @@ const HeaderContainer = styled.div`
 type SelectAccountDrawerProps = {
   currency: CryptoCurrency | TokenCurrency;
   onAccountSelected: (account: AccountLike, parentAccount?: Account) => void;
+  onAddAccountClick?: () => void;
   accounts$?: Observable<WalletAPIAccount[]>;
 };
 const SelectAccountDrawer = ({
   currency,
   onAccountSelected,
+  onAddAccountClick,
   accounts$,
 }: SelectAccountDrawerProps) => {
   const { t } = useTranslation();
@@ -47,6 +49,12 @@ const SelectAccountDrawer = ({
     },
     [onAccountSelected],
   );
+
+  const handleAddAccountClick = useCallback(() => {
+    if (onAddAccountClick) {
+      onAddAccountClick();
+    }
+  }, [onAddAccountClick]);
   return (
     <AccountSelectorDrawerContainer>
       <HeaderContainer>
@@ -66,6 +74,7 @@ const SelectAccountDrawer = ({
         <AccountList
           currency={currency}
           onAccountSelect={handleAccountSelect}
+          onAddAccountClick={handleAddAccountClick}
           accounts$={accounts$}
         />
       </SelectorContent>

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -169,7 +169,6 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
               },
               onCurrencySelected: currency => {
                 lastCurrencySelected = currency;
-                console.log("onCurrencySelected", currency);
               },
               onAddAccountClick: () => {
                 track("button_clicked", {
@@ -338,14 +337,14 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
         };
       }): Promise<
         | {
-            hash: string;
-            blockHeight: number | undefined;
-            blockHash: string | undefined;
-            nonce: number;
-            gasUsed: string;
-            gasPrice: string;
-            value: string;
-          }
+          hash: string;
+          blockHeight: number | undefined;
+          blockHash: string | undefined;
+          nonce: number;
+          gasUsed: string;
+          gasPrice: string;
+          value: string;
+        }
         | {}
       > => {
         const realFromAccountId = getAccountIdFromWalletAccountId(params.fromAccountId);
@@ -448,18 +447,18 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
         ...(isOffline ? { isOffline: "true" } : {}),
         ...(state?.defaultAccount
           ? {
-              fromAccountId: accountToWalletAPIAccount(
-                walletState,
-                state?.defaultAccount,
-                state?.defaultParentAccount,
-              ).id,
-            }
+            fromAccountId: accountToWalletAPIAccount(
+              walletState,
+              state?.defaultAccount,
+              state?.defaultParentAccount,
+            ).id,
+          }
           : {}),
         ...(state?.from ? { fromPath: simplifyFromPath(state?.from) } : {}),
         ...(swapLiveEnabledFlag?.params && "variant" in swapLiveEnabledFlag.params
           ? {
-              ptxSwapCoreExperiment: swapLiveEnabledFlag.params?.variant as string,
-            }
+            ptxSwapCoreExperiment: swapLiveEnabledFlag.params?.variant as string,
+          }
           : {}),
       }).toString(),
     [

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -165,7 +165,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
               currencies: cryptoCurrencies,
               onAccountSelected: (account, parentAccount) => {
                 track("button_clicked", {
-                  button: "Choose Account",
+                  button: `Choose Account - ${requestId === "from-account" ? "Source" : "Target"}`,
                   page: "InputSwap",
                   ...swapDefaultTrack,
                 });
@@ -175,7 +175,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
               onCurrencySelected: currency => {
                 lastCurrencySelected = currency;
                 track("button_clicked", {
-                  button: "Choose Asset",
+                  button: `Choose Asset - ${requestId === "from-account" ? "Source" : "Target"}`,
                   currency: lastCurrencySelected?.name,
                   page: "InputSwap",
                   ...swapDefaultTrack,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -337,14 +337,14 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
         };
       }): Promise<
         | {
-          hash: string;
-          blockHeight: number | undefined;
-          blockHash: string | undefined;
-          nonce: number;
-          gasUsed: string;
-          gasPrice: string;
-          value: string;
-        }
+            hash: string;
+            blockHeight: number | undefined;
+            blockHash: string | undefined;
+            nonce: number;
+            gasUsed: string;
+            gasPrice: string;
+            value: string;
+          }
         | {}
       > => {
         const realFromAccountId = getAccountIdFromWalletAccountId(params.fromAccountId);
@@ -447,18 +447,18 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
         ...(isOffline ? { isOffline: "true" } : {}),
         ...(state?.defaultAccount
           ? {
-            fromAccountId: accountToWalletAPIAccount(
-              walletState,
-              state?.defaultAccount,
-              state?.defaultParentAccount,
-            ).id,
-          }
+              fromAccountId: accountToWalletAPIAccount(
+                walletState,
+                state?.defaultAccount,
+                state?.defaultParentAccount,
+              ).id,
+            }
           : {}),
         ...(state?.from ? { fromPath: simplifyFromPath(state?.from) } : {}),
         ...(swapLiveEnabledFlag?.params && "variant" in swapLiveEnabledFlag.params
           ? {
-            ptxSwapCoreExperiment: swapLiveEnabledFlag.params?.variant as string,
-          }
+              ptxSwapCoreExperiment: swapLiveEnabledFlag.params?.variant as string,
+            }
           : {}),
       }).toString(),
     [

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -164,11 +164,22 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
             {
               currencies: cryptoCurrencies,
               onAccountSelected: (account, parentAccount) => {
+                track("button_clicked", {
+                  button: "Choose Account",
+                  page: "InputSwap",
+                  ...swapDefaultTrack,
+                });
                 setDrawer();
                 resolve(accountToWalletAPIAccount(walletState, account, parentAccount));
               },
               onCurrencySelected: currency => {
                 lastCurrencySelected = currency;
+                track("button_clicked", {
+                  button: "Choose Asset",
+                  currency: lastCurrencySelected?.name,
+                  page: "InputSwap",
+                  ...swapDefaultTrack,
+                });
               },
               onAddAccountClick: () => {
                 track("button_clicked", {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In order to trigger custom analytic events, when the user picks a currency and account in the Sidebar, manually start the sidebar with custom options, whenever the swap-live app triggers the `custom.requestAccount` method on the Wallet API

Related PR: https://github.com/LedgerHQ/swap-live-app/pull/476

https://github.com/user-attachments/assets/f993aba7-ba0d-4d0f-bbf6-18eda0591854




<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-14855


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
