### PR TITLE
FIX/LIVE-15117: exchange.swap does not have up-to-date accounts list when attempting to swap with newly created account.

### DIFF
--- a/.changeset/famous-mirrors-carry.md
+++ b/.changeset/famous-mirrors-carry.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add customPTXHandlers to list of deps for swap customHandlers

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -389,7 +389,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
       },
     }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [customPTXHandlers],
   );
 
   const hashString = useMemo(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
- When creating a new account on the swap live app interface.
- The user will attempt to swap "to" this new account.
- The user will then be unable to.

This was because the `exchangeHandlers` accounts param did not get updated when accounts were changed. Instead this PR proposes passing a getter function that will instead grab the users currents accounts when the function is run. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-15117


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
