### PR TITLE
Update `rsk` network name to `Rootstock`

### DIFF
--- a/.changeset/stale-penguins-tap.md
+++ b/.changeset/stale-penguins-tap.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+fix: updare rsk network name to rootstock

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-darwin.json
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-darwin.json
@@ -507,7 +507,7 @@
     "type": "CryptoCurrency",
     "id": "rsk",
     "ticker": "RBTC",
-    "name": "RSK",
+    "name": "Rootstock",
     "family": "ethereum",
     "color": "#FF931E",
     "decimals": 18

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-linux.json
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts-snapshots/wallet-api-currencies-linux.json
@@ -507,7 +507,7 @@
     "type": "CryptoCurrency",
     "id": "rsk",
     "ticker": "RBTC",
-    "name": "RSK",
+    "name": "Rootstock",
     "family": "ethereum",
     "color": "#FF931E",
     "decimals": 18

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -3658,7 +3658,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     type: "CryptoCurrency",
     id: "rsk",
     coinType: CoinType.ETH,
-    name: "RSK",
+    name: "Rootstock",
     managerAppName: "Ethereum",
     ticker: "RBTC",
     scheme: "rsk",
@@ -3670,9 +3670,9 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     },
     explorerViews: [
       {
-        tx: "https://explorer.rsk.co/tx/$hash",
-        address: "https://explorer.rsk.co/address/$address",
-        token: "https://explorer.rsk.co/address/$address",
+        tx: "https://explorer.rootstock.io/tx/$hash",
+        address: "https://explorer.rootstock.io/address/$address",
+        token: "https://explorer.rootstock.io/address/$address",
       },
     ],
   },


### PR DESCRIPTION
### ✅ Checklist

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR update `rsk` network name to `Rootstock`.  
Branding update: https://rootstock.io/
https://dev.rootstock.io/
Explorer: https://explorer.rootstock.io/ 


### ❓ Context

Purpose of this PR is just to change the rsk network name to Rootstock without changing underline configurations which were done using rsk as network id. So network id will remains the same. So this will not cause any breaking changes as the network id will be same. 

---

### 🧐 Checklist for the PR Reviewers


- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
