### PR TITLE
ci: checkout feature branch *including merge commit* in turbo-affected

### DIFF
--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -37,8 +37,6 @@ jobs:
     steps:
       - name: Checkout head branch
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.head_branch }}
   
       - name: Fetch base branch
         run: |


### PR DESCRIPTION
[Ticket](https://ledgerhq.atlassian.net/browse/LIVE-15121)

Fixes _part of_ a subtle bug that makes the turbo-affected workflow identify too many packages as affected.


## Explanation of fix

The `ref` that is being removed in this PR accidentally made for a bad comparison of the feature branch with `develop`: the supplied `ref` is calculated in [pr-build-and-test.yml](https://github.com/LedgerHQ/ledger-live/blob/develop/.github/workflows/build-and-test-pr.yml#L20C7-L20C18) as the latest commit in the feature branch, meaning the diffs between it and `develop` include all commits in `develop` that are not in the feature branch. That means other peoples' merged PRs.

The `ref` that we really want is the ref of the _merge commit_ github creates on creation of the pull request (`refs/pull/{PR_NUMBER}/merge`). This is exposed through the `github.ref` variable, available in the namespace of the workflow. This is what the checkout action defaults to, so this PR simply removes the `ref` parameter.

This fixes _part of_ the problem of too many workflows being triggered, however there is still some underlying issue problem on top of this, which I believe is an error in the turbo-affected node script - that will be handled in a separate PR.

The current fix preserves the turbo-affected performance improvements from 3 weeks ago.

## Testing the workflow

These 2 PRs demonstrate the fix: [after](https://github.com/LedgerHQ/ledger-live/pull/8573), [before](https://github.com/LedgerHQ/ledger-live/pull/8575)

These PRs have many identical boilerplate diffs (redirecting the PR to their respective branches' turbo-affected actions, turbo-affected scripts, turning off downstream workflows, logging commits for current git state in the workflow) - the only relevant code diff between the two PRs is in the final commit https://github.com/LedgerHQ/ledger-live/pull/8575/commits/bd684623bb51f48d0db2e1f27149506bea9a0ad6 of #8575.

In the respective workflow runs for the two:

#### No `ref` (https://github.com/LedgerHQ/ledger-live/pull/8573):
- ✅ latest commit is the merge commit [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12140230895/job/33850524756?pr=8573#step:4:7)
- ✅ small list of affected packages [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12140230895/job/33850524756?pr=8573#step:6:21)

#### With `ref` (https://github.com/LedgerHQ/ledger-live/pull/8575)
- ❌ latest commit is an edit to the feature branch [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12140243287/job/33850527999?pr=8575#step:4:7)
- ❌ very large list of affected packages [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12140243287/job/33850527999?pr=8575#step:6:21)