### PR TITLE
fix: missing names regression in staking modal

### DIFF
--- a/.changeset/heavy-worms-retire.md
+++ b/.changeset/heavy-worms-retire.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix missing names regression in staking modal

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -79,8 +79,8 @@ export const ProviderItem = ({ provider, stakeOnClick }: Props) => {
     }
   }, [provider, stakeOnClick, manifest]);
 
-  const displayName = i18n.exists(`stake.ethereum.provider.${provider.id}.title`)
-    ? t(`stake.ethereum.provider.${provider.id}.title`)
+  const displayName = i18n.exists(`ethereum.stake.provider.${provider.id}.title`)
+    ? t(`ethereum.stake.provider.${provider.id}.title`)
     : provider.name;
 
   return (


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**

### 📝 Description

Fix missing names regression in staking modal

Before:

![Screenshot 2024-12-03 at 20 50 00](https://github.com/user-attachments/assets/80184d7d-4102-4fdb-808c-cbe479cd299b)

After:

![Screenshot 2024-12-03 at 21 04 00](https://github.com/user-attachments/assets/022ee678-a43c-4f42-8aa7-3f94d1886cc9)

### ❓ Context

- **JIRA or GitHub link**: [CN-959](https://ledgerhq.atlassian.net/browse/CN-959)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-959]: https://ledgerhq.atlassian.net/browse/CN-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ