### PR TITLE
bugfix: add mev protection on swap

### DIFF
--- a/.changeset/perfect-toys-shop.md
+++ b/.changeset/perfect-toys-shop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: add mev protection on swap

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -10,8 +10,9 @@ import { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoa
 import { AccountLike, Operation, SignedOperation } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
+import { mevProtectionSelector } from "~/renderer/reducers/settings";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import { useIsSwapLiveFlagEnabled } from "~/renderer/screens/exchange/Swap2/hooks/useIsSwapLiveFlagEnabled";
 import { useRedirectToSwapHistory } from "~/renderer/screens/exchange/Swap2/utils";
@@ -112,7 +113,8 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
     return null;
   }, [toAccount, getCurrencyByAccount]);
 
-  const broadcast = useBroadcast({ account, parentAccount });
+  const mevProtected = useSelector(mevProtectionSelector);
+  const broadcast = useBroadcast({ account, parentAccount, broadcastConfig: { mevProtected } });
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();
   const [error, setError] = useState<Error>();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes [this one](https://github.com/LedgerHQ/ledger-live/pull/8375) adding mev protection for broadcasting. An issue where transactions were not being processed through Blink when MEV Protected was activated during an ETH swap.  

#### Steps to Reproduce  
1. Ensure that the MEV Protected feature is activated for a user.  
2. Initiate a swap of ETH funds.  

#### Expected Behavior  
The transaction should be processed through Blink.  

### ❓ Context

- **JIRA**:  https://ledgerhq.atlassian.net/browse/LIVE-15149


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
