### PR TITLE
fix(llm): 🐛 fix long Memo Tag issue on Cardano

### DIFF
--- a/.changeset/rare-schools-happen.md
+++ b/.changeset/rare-schools-happen.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Truncate Cardano memos in the input to prevent the transaction validation errors

--- a/apps/ledger-live-mobile/src/families/cardano/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/MemoTagInput.tsx
@@ -3,10 +3,17 @@ import React from "react";
 import type { Transaction as CardanoTransaction } from "@ledgerhq/live-common/families/cardano/types";
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
+import { truncateUtf8 } from "LLM/utils/truncateUtf8";
 
 export default (props: MemoTagInputProps<CardanoTransaction>) => (
   <GenericMemoTagInput
     {...props}
+    textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
   />
 );
+
+// From the Cardano metadata documentation:
+// > Strings must be at most 64 bytes when UTF-8 encoded.
+// https://developers.cardano.org/docs/get-started/cardano-serialization-lib/transaction-metadata/#metadata-limitations
+const MAX_MEMO_LENGTH = 64;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Truncate Cardano memos in the input to prevent the transaction validation errors.
(Follow up to #8340 and #8604).

https://github.com/user-attachments/assets/cb83d90d-281a-4afb-8967-b645a50b7e2d


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-15161]
- [LIVE-15162]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15161]: https://ledgerhq.atlassian.net/browse/LIVE-15161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-15162]: https://ledgerhq.atlassian.net/browse/LIVE-15162