### PR TITLE
Fix `setup-caches` `skip-pnpm-cache` behaviour

### DIFF
--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
     default: "false"
   skip-pnpm-cache:
-    description: "true to skip pnpm caching, false by default"
+    description: "true to skip pnpm caching, true by default"
     required: false
-    default: "false"
+    default: "true"
   skip-pod-cache:
     description: "false to get cache, true by default"
     required: false
@@ -77,7 +77,7 @@ runs:
 
     - name: Cache pnpm store
       uses: tespkg/actions-cache@v1
-      if: steps.aws.conclusion == 'success' && inputs.skip-pnpm-cache != 'false'
+      if: steps.aws.conclusion == 'success' && inputs.skip-pnpm-cache != 'true'
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}


### PR DESCRIPTION
Make setup-caches skip pnpm cache by default, respond to `skip-pnpm-cache` input correctly