### PR TITLE
fix: order the display of solana validators

### DIFF
--- a/.changeset/cyan-rabbits-return.md
+++ b/.changeset/cyan-rabbits-return.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+fix: order the display of solana validators

--- a/libs/coin-modules/coin-solana/src/utils.ts
+++ b/libs/coin-modules/coin-solana/src/utils.ts
@@ -23,9 +23,9 @@ export const LEDGER_VALIDATOR_BY_CHORUS_ONE: ValidatorsAppValidator = {
   avatarUrl:
     "https://s3.amazonaws.com/keybase_processed_uploads/3c47b62f3d28ecfd821536f69be82905_360_360.jpg",
   wwwUrl: "https://www.ledger.com/staking",
-  activeStake: 0,
+  activeStake: 10001001000098,
   commission: 7,
-  totalScore: 6,
+  totalScore: 7,
 };
 
 export const LEDGER_VALIDATOR_LIST: ValidatorsAppValidator[] = [
@@ -175,8 +175,17 @@ export function ledgerFirstValidators(
     v => LEDGER_VALIDATORS_VOTE_ACCOUNTS.includes(v.voteAccount),
     validators,
   );
+
+  const LEDGER_FIRST_VALIDATOR =
+    ledgerValidators.find(v => v.voteAccount === LEDGER_VALIDATOR_BY_CHORUS_ONE.voteAccount) ||
+    LEDGER_VALIDATOR_BY_CHORUS_ONE;
+
+  const ledgerValidatorsFiltered = ledgerValidators.filter(
+    v => v.voteAccount !== LEDGER_FIRST_VALIDATOR.voteAccount,
+  );
+
   return ledgerValidators.length === 2
-    ? ledgerValidators.concat(restValidators)
+    ? [LEDGER_FIRST_VALIDATOR, ...ledgerValidatorsFiltered].concat(restValidators)
     : LEDGER_VALIDATOR_LIST.concat(restValidators);
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In this [PR](https://github.com/LedgerHQ/ledger-live/pull/8563) we added another solana validator, but we didn't respect the order. The goal is to display `Ledger By Chorus One` first.

https://github.com/user-attachments/assets/5b1bc234-0694-43ce-bd46-95d2a4dda8d7


### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-14413

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
