### PR TITLE
fix: revalidate recipient field on account change in the send flow

### DIFF
--- a/.changeset/witty-taxis-scream.md
+++ b/.changeset/witty-taxis-scream.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+recipient field on the send flow's revalidation process is controlled by both input onChange event and watching the account.id change from the selector above

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
@@ -48,6 +48,21 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    // if the account changed, we should revalidate the recipient field
+    if (!initValue && value !== "" && value !== transaction.recipient) {
+      onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));
+    }
+  }, [
+    account.id,
+    value,
+    transaction.recipient,
+    bridge,
+    onChangeTransaction,
+    transaction,
+    initValue,
+  ]);
+
   const onChange = useCallback(
     async (recipient: string, maybeExtra?: OnChangeExtra | null) => {
       const { currency } = maybeExtra || {};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
- When a user fill the recipient field and change account, the revalidation wasn't triggered. This PR will fix this issue.

See the following video 

<b> Before </b>


https://github.com/user-attachments/assets/1535fba6-ec9f-4a60-8ddc-9c889911de5c

Note: in the end of the video, i was forced to delete and re-paste the casper address so that it can be revalidated via the input onChange event.

<b> After </b>

https://github.com/user-attachments/assets/3a2219af-f61c-4e38-9265-4b1aea763e84

Note: here the revalidation is controlled by both input onChange event and watching the account.id change from the selector above.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-14904
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
