### PR TITLE
fix(llm): ✍️ correct memo/tag drawer copy

### DIFF
--- a/.changeset/hungry-moles-yawn.md
+++ b/.changeset/hungry-moles-yawn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the memo/tag drawer copy

--- a/apps/ledger-live-mobile/src/newArch/features/MemoTag/components/MemoTagDrawer.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/MemoTag/components/MemoTagDrawer.tsx
@@ -27,11 +27,11 @@ export const MemoTagDrawer = memo(({ open, onClose, onNext }: Props) => {
       </Flex>
 
       <Text variant="h4" textAlign="center" mb={6}>
-        {t("transfer.receive.memoTag.title")}
+        {t("transfer.memoTag.title")}
       </Text>
 
       <Text variant="bodyLineHeight" textAlign="center" color="neutral.c80" mb={8}>
-        {t("transfer.receive.memoTag.description")}
+        {t("transfer.memoTag.description")}
       </Text>
 
       <Button type="primary" title={t("transfer.memoTag.cta")} onPress={onClose} mb={3} />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Copy of the memo drawer

### 📝 Description

The text of the drawer was the one of the receive flow which would have been misleading for users.

| Before        | After         |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/cd716032-5c61-4039-96e5-ecd3d7e75f77) | ![image](https://github.com/user-attachments/assets/2959f3b5-c0a7-4688-92a5-cb776fcc708f) |

[Figma for reference](https://www.figma.com/design/n5044zBaOWyNMFVYhcCZsW/Send?node-id=3097-13264)

### ❓ Context

- [LIVE-15300]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15300]: https://ledgerhq.atlassian.net/browse/LIVE-15300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ