### PR TITLE
ci: move LLM Codechecks to ledger runners

### DIFF
--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
-    runs-on: ubuntu-22.04
+    runs-on: ledger-live-4xlarge
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is the outcome of [this ticket](https://ledgerhq.atlassian.net/browse/LIVE-15198)

Moves LLM codechecks to ledger runners after I found that they consistently run quicker on the larger machines, by 29% on average. Here are the runtimes I observed:

| Runner Type   | Run 1  | Run 2  | Run 3  |
|---------------|--------|--------|--------|
| GitHub Runners| 6:47   | 7:29   | 10:06  |
| Ledger Runners| 5:22   | 6:19   | 5:45   |
