### PR TITLE
Revert "ci: move LLM Codechecks to ledger runners"

### DIFF
--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3
-    runs-on: ledger-live-4xlarge
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Code checks are failing on our self-hosting runners due to impossibility to install ruby (permission issues) .
![image](https://github.com/user-attachments/assets/acd40c25-c558-4b70-88b6-9f261d2a134a)

Reverts LedgerHQ/ledger-live#8645