### PR TITLE
fix(llm): prevent debounce causing memo change miss

### DIFF
--- a/.changeset/witty-swans-share.md
+++ b/.changeset/witty-swans-share.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Prevent debounce from causing the memo tag not being saved

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -218,6 +218,12 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
       !isConfirmedOperation(op, mainAccount, currencySettings.confirmationsNb),
   );
 
+  const isContinueDisabled =
+    debouncedBridgePending ||
+    !!status.errors.recipient ||
+    memoTag?.isDebouncePending ||
+    !!memoTag?.error;
+
   const stuckAccountAndOperation = getStuckAccountAndOperation(account, mainAccount);
   return (
     <>
@@ -341,7 +347,7 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
               testID="recipient-continue-button"
               type="primary"
               title={<Trans i18nKey="common.continue" />}
-              disabled={debouncedBridgePending || !!status.errors.recipient || !!memoTag?.error}
+              disabled={isContinueDisabled}
               pending={debouncedBridgePending}
               onPress={onPressContinue}
             />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Prevent debounce from causing the memo tag not being saved.

Here's 2 example with the debounce set to 1 second for clarity:

#### the problem:

https://github.com/user-attachments/assets/15032d30-abdb-4549-b156-0a76a69e0c3f

##### this PR's solution:

https://github.com/user-attachments/assets/0515bf4f-fdfb-46f7-bc29-575f96909e4c

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-15326]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15326]: https://ledgerhq.atlassian.net/browse/LIVE-15326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ