### PR TITLE
📌  hw-ledger-key-ring-protocol - pin tiny-secp256k1 version to 1.1.7

### DIFF
--- a/.changeset/funny-trains-speak.md
+++ b/.changeset/funny-trains-speak.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-ledger-key-ring-protocol": minor
+---
+
+HWLKRP - Pin tiny-secp256k1 version

--- a/libs/hw-ledger-key-ring-protocol/package.json
+++ b/libs/hw-ledger-key-ring-protocol/package.json
@@ -24,7 +24,7 @@
     "bip32": "^4.0.0",
     "secp256k1": "^5.0.0",
     "create-hmac": "^1.1.7",
-    "tiny-secp256k1": "1"
+    "tiny-secp256k1": "1.1.7"
   },
   "devDependencies": {
     "@types/lodash": "4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3681,8 +3681,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       tiny-secp256k1:
-        specifier: '1'
-        version: 1.1.6
+        specifier: 1.1.7
+        version: 1.1.7
     devDependencies:
       '@types/jest':
         specifier: ^29.5.10
@@ -28512,6 +28512,10 @@ packages:
 
   tiny-secp256k1@1.1.6:
     resolution: {integrity: sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==}
+    engines: {node: '>=6.0.0'}
+
+  tiny-secp256k1@1.1.7:
+    resolution: {integrity: sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==}
     engines: {node: '>=6.0.0'}
 
   tiny-typed-emitter@2.1.0:
@@ -62199,6 +62203,14 @@ snapshots:
   tiny-queue@0.2.0: {}
 
   tiny-secp256k1@1.1.6:
+    dependencies:
+      bindings: 1.5.0
+      bn.js: 4.12.0
+      create-hmac: 1.1.7
+      elliptic: 6.5.5
+      nan: 2.20.0
+
+  tiny-secp256k1@1.1.7:
     dependencies:
       bindings: 1.5.0
       bn.js: 4.12.0


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

It may fix the following Sentry error : https://ledger.sentry.io/issues/6115989813/?alert_rule_id=15006706&alert_type=issue&notification_uuid=27e565f1-802b-4dc5-88a0-906844100a0f&project=6505213&referrer=slack
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15324]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15324]: https://ledgerhq.atlassian.net/browse/LIVE-15324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ