### PR TITLE
Revert "fix(lld): use a debounce on memotag field"

### DIFF
--- a/.changeset/seven-ravens-rest.md
+++ b/.changeset/seven-ravens-rest.md
@@ -1,5 +1,0 @@
----
-"ledger-live-desktop": minor
----
-
-LLD: LIVE-15143 use a debounce on the memotag field

--- a/apps/ledger-live-desktop/src/newArch/features/MemoTag/__tests__/MemoTagField.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/MemoTag/__tests__/MemoTagField.test.tsx
@@ -7,14 +7,6 @@ import { render, screen, fireEvent } from "tests/testUtils";
 import MemoTagField from "../components/MemoTagField";
 
 describe("MemoTagField", () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
-
   it("renders MemoTagField with label and text field", () => {
     render(<MemoTagField showLabel={true} />);
     expect(screen.getByText(/Tag \/ Memo/gi)).toBeInTheDocument();
@@ -27,14 +19,12 @@ describe("MemoTagField", () => {
     expect(screen.queryByText(/Tag \/ Memo/gi)).not.toBeInTheDocument();
   });
 
-  it("should call onChange when input value changes with a debounce", () => {
+  it("should call onChange when input value changes", () => {
     const handleChange = jest.fn();
     render(<MemoTagField onChange={handleChange} />);
     fireEvent.change(screen.getByPlaceholderText(/Enter Tag \/ Memo/gi), {
       target: { value: "new memo" },
     });
-    expect(handleChange).not.toHaveBeenCalled();
-    jest.runAllTimers();
     expect(handleChange).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/ledger-live-desktop/src/newArch/features/MemoTag/components/MemoTagField.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/MemoTag/components/MemoTagField.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import Input, { Props as InputBaseProps } from "~/renderer/components/Input";
-import { useDebounce } from "@ledgerhq/live-common//hooks/useDebounce";
 import Label from "~/renderer/components/Label";
 import Box from "~/renderer/components/Box";
 import { useTranslation } from "react-i18next";
 import { Flex, Text, Tooltip } from "@ledgerhq/react-ui";
 import styled from "styled-components";
 import InfoCircle from "~/renderer/icons/InfoCircle";
+
 const TooltipContainer = styled(Box)`
   background-color: ${({ theme }) => theme.colors.palette.neutral.c100};
   padding: 10px;
@@ -30,7 +30,6 @@ type MemoTagFieldProps = InputBaseProps & {
   placeholder?: string;
   label?: string;
   tooltipText?: string;
-  validationHandler?: (newValue: string) => string;
 };
 
 const MemoTagField = ({
@@ -45,20 +44,8 @@ const MemoTagField = ({
   placeholder,
   label,
   tooltipText,
-  validationHandler,
 }: MemoTagFieldProps) => {
   const { t } = useTranslation();
-  const [memoValue, setMemoValue] = useState(value);
-  const debouncedMemoValue = useDebounce(memoValue, 300);
-
-  useEffect(() => {
-    if (debouncedMemoValue !== value) onChange?.(debouncedMemoValue || "");
-  }, [debouncedMemoValue, onChange, value]);
-
-  const handleChange = (newValue: string) => {
-    setMemoValue(validationHandler ? validationHandler(newValue) : newValue);
-  };
-
   return (
     <Box flow={1}>
       {showLabel && (
@@ -81,10 +68,10 @@ const MemoTagField = ({
         <Flex justifyContent="end">{CaracterCountComponent && <CaracterCountComponent />}</Flex>
         <Input
           placeholder={placeholder ?? t("MemoTagField.placeholder")}
-          onChange={handleChange}
+          onChange={onChange}
           warning={warning}
           error={error}
-          value={memoValue}
+          value={value}
           spellCheck="false"
           ff="Inter"
           maxMemoLength={maxMemoLength}

--- a/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/casper/MemoField.tsx
@@ -14,6 +14,7 @@ const MemoField = ({ onChange, account, transaction, status, autoFocus }: MemoTa
 
   const onTransferIdFieldChange = useCallback(
     (value: string) => {
+      value = value.replace(/\D/g, "");
       if (value !== "") onChange(bridge.updateTransaction(transaction, { transferId: value }));
       else onChange(bridge.updateTransaction(transaction, { transferId: undefined }));
     },
@@ -31,7 +32,6 @@ const MemoField = ({ onChange, account, transaction, status, autoFocus }: MemoTa
       onChange={onTransferIdFieldChange}
       spellCheck="false"
       autoFocus={autoFocus}
-      validationHandler={newValue => newValue.replace(/\D/g, "")}
     />
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/xrp/SendRecipientFields.tsx
@@ -15,7 +15,7 @@ const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
   const onChangeTag = useCallback(
     (str: string) => {
       const bridge = getAccountBridge(account);
-      const tag = BigNumber(str);
+      const tag = BigNumber(str.replace(/[^0-9]/g, ""));
       const patch = {
         tag:
           !tag.isNaN() &&
@@ -37,7 +37,6 @@ const TagField = ({ onChange, account, transaction, autoFocus }: Props) => {
       value={String(transaction.tag || "")}
       onChange={onChangeTag}
       autoFocus={autoFocus}
-      validationHandler={str => str.replace(/[^0-9]/g, "")}
     />
   );
 };


### PR DESCRIPTION
This reverts commit 3a9758f7642cea56e49b45a9e36dc5c4babc57ef.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-15143

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
