### PR TITLE
fix(llm): 🚦 do not validate empty Stellar memos

### DIFF
--- a/.changeset/small-jokes-work.md
+++ b/.changeset/small-jokes-work.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Remove invalid format error for Stellar empty hash and return type memo

--- a/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
@@ -19,7 +19,8 @@ export default ({ onChange }: MemoTagInputProps<StellarTransaction>) => {
 
   const handleChange = (type: MemoType, value: string) => {
     const error = !value || isMemoValid(type, value) ? undefined : new StellarWrongMemoFormat();
-    const patch = (tx: StellarTransaction) => ({ ...tx, memoType: type, memoValue: value });
+    const memoType = !value ? "NO_MEMO" : type;
+    const patch = (tx: StellarTransaction) => ({ ...tx, memoType, memoValue: value });
     onChange({ value, patch, error });
   };
 

--- a/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
@@ -18,7 +18,7 @@ export default ({ onChange }: MemoTagInputProps<StellarTransaction>) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleChange = (type: MemoType, value: string) => {
-    const error = isMemoValid(type, value) ? undefined : new StellarWrongMemoFormat();
+    const error = !value || isMemoValid(type, value) ? undefined : new StellarWrongMemoFormat();
     const patch = (tx: StellarTransaction) => ({ ...tx, memoType: type, memoValue: value });
     onChange({ value, patch, error });
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove invalid format error for Stellar empty hash and return type memo.

#### Before

https://github.com/user-attachments/assets/6bc4d688-5af1-4d01-95c2-f5a94e28ea17


#### After

https://github.com/user-attachments/assets/6120d850-fae5-498b-85bd-8dd175093e90


### ❓ Context

- [LIVE-15314]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15314]: https://ledgerhq.atlassian.net/browse/LIVE-15314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ