### PR TITLE
bugfix: No cryptocurrency selection available in NFT gallery 'Add New'

### DIFF
--- a/.changeset/young-jeans-sparkle.md
+++ b/.changeset/young-jeans-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Update groupCurrenciesByProvider to get Coins instead of token when it's relevant

--- a/libs/ledger-live-common/src/deposit/deposit.test.ts
+++ b/libs/ledger-live-common/src/deposit/deposit.test.ts
@@ -1,7 +1,7 @@
 import { groupCurrenciesByProvider, searchByNameOrTicker, searchByProviderId } from "./helper";
-import { MOCK } from "./mock";
+import { MOCK, MOCK_POL } from "./mock";
 import { MappedAsset } from "./type";
-import { getTokenById } from "../currencies/index";
+import { getCryptoCurrencyById, getTokenById } from "../currencies/index";
 
 const MAPPED_ASSETS = MOCK as MappedAsset[];
 
@@ -25,5 +25,20 @@ describe("Deposit logic", () => {
         currenciesByNetwork: currencies,
       },
     ]);
+    const currenciesPol = MOCK_POL.map(asset =>
+      asset.$type === "Token"
+        ? getTokenById(asset.ledgerId)
+        : getCryptoCurrencyById(asset.ledgerId),
+    );
+    const { currenciesByProvider: currenciesByProviderBis, sortedCryptoCurrencies } =
+      groupCurrenciesByProvider(MOCK_POL as MappedAsset[], currenciesPol);
+    expect(currenciesByProviderBis).toEqual([
+      {
+        providerId: "matic-network",
+        currenciesByNetwork: currenciesPol,
+      },
+    ]);
+
+    expect(sortedCryptoCurrencies).toEqual([currenciesPol[1]]);
   });
 });

--- a/libs/ledger-live-common/src/deposit/helper.ts
+++ b/libs/ledger-live-common/src/deposit/helper.ts
@@ -36,13 +36,22 @@ export const groupCurrenciesByProvider = (
           providerId: asset.providerId,
           currenciesByNetwork: [ledgerCurrency],
         });
-        // in this case, the first currency of the provider is the one we want to display
-        sortedCryptoCurrencies.push(ledgerCurrency);
       } else {
         existingEntry.currenciesByNetwork.push(ledgerCurrency);
       }
     }
   }
+
+  // in this case, the first currency of the provider is the one we want to display (Wasn't true)
+  // So we need to take the first crypto or token currency of each provider to fix that
+  for (const [, { currenciesByNetwork }] of assetsByProviderId.entries()) {
+    const firstCrypto = currenciesByNetwork.find(c => c.type === "CryptoCurrency");
+    const elem = firstCrypto || currenciesByNetwork.find(c => c.type === "TokenCurrency");
+    if (elem) {
+      sortedCryptoCurrencies.push(elem);
+    }
+  }
+
   return {
     currenciesByProvider: Array.from(assetsByProviderId.values()),
     sortedCryptoCurrencies,

--- a/libs/ledger-live-common/src/deposit/mock.ts
+++ b/libs/ledger-live-common/src/deposit/mock.ts
@@ -45,3 +45,49 @@ export const MOCK = [
     ticker: "BSC-USD",
   },
 ];
+
+export const MOCK_POL = [
+  {
+    $type: "Token",
+    ledgerId: "bsc/bep20/matic_token",
+    providerId: "matic-network",
+    name: "Matic Token",
+    ticker: "MATIC",
+    network: "bsc",
+    contract: "0xcc42724c6683b7e57334c4e856f4c9965ed682bd",
+    status: "Ok",
+    reason: null,
+    data: {
+      img: "https://proxycgassets.api.live.ledger.com/coins/images/4713/large/polygon.png",
+      marketCapRank: 121,
+    },
+  },
+  {
+    $type: "Coin",
+    ledgerId: "polygon",
+    providerId: "matic-network",
+    name: "Polygon",
+    ticker: "POL",
+    status: "Ok",
+    reason: "Overridden",
+    data: {
+      img: "https://proxycgassets.api.live.ledger.com/coins/images/4713/large/polygon.png",
+      marketCapRank: 121,
+    },
+  },
+  {
+    $type: "Token",
+    ledgerId: "ethereum/erc20/matic",
+    providerId: "matic-network",
+    name: "Matic",
+    ticker: "MATIC",
+    network: "ethereum",
+    contract: "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+    status: "Ok",
+    reason: null,
+    data: {
+      img: "https://proxycgassets.api.live.ledger.com/coins/images/4713/large/polygon.png",
+      marketCapRank: 121,
+    },
+  },
+];


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

No cryptocurrency selection available in NFT gallery 'Add New' flow except Ethereum &Polygon (ex-MATIC) missing from the receive crypto search results

So we had to update `groupCurrenciesByProvider` and  to take the first crypto or token (if no currency found) of each provider to fix that


https://github.com/user-attachments/assets/b76da7d6-5a0f-4bc2-a833-ef37a3ac160a

Good POL displayed (AFTER)

https://github.com/user-attachments/assets/964419cf-c475-42c4-908e-d0fa8d97cf34

Wrong Pol (BEFORE)

https://github.com/user-attachments/assets/7a37cc96-b334-4282-aa1a-17709ca55de0




Tests 
<img width="417" alt="Screenshot 2024-12-17 at 10 12 17" src="https://github.com/user-attachments/assets/63919b80-14f6-4927-afbf-00c9744e5d1e" />



### ❓ Context

- **JIRA or GitHub link**: [LIVE-15351] [LIVE-15381]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15351]: https://ledgerhq.atlassian.net/browse/LIVE-15351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ