### PR TITLE
treat ref as string when triggering release build

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -143,7 +143,7 @@ jobs:
               ref: "main",
               workflow_id: "release-desktop.yml",
               inputs: {
-                branch: ${{ inputs.ref }}
+                branch: "${{ inputs.ref }}"
               }
             });
       - uses: actions/github-script@v7
@@ -158,6 +158,6 @@ jobs:
               ref: "main",
               workflow_id: "release-mobile.yml",
               inputs: {
-                ref: ${{ inputs.ref }}
+                ref: "${{ inputs.ref }}"
               }
             });


### PR DESCRIPTION
[Ticket](https://ledgerhq.atlassian.net/browse/LIVE-15427)

Fixes the issue from [this failing workflow](https://github.com/LedgerHQ/ledger-live/actions/runs/12299306845/job/34324784252#step:3:3) by correctly handling the ref as a string when triggering the ledger-live-build release workflows.

This issue was introduced by the work merged 2 weeks ago to update the hotfix process ([PR](https://github.com/LedgerHQ/ledger-live/pull/8342)). This final step of the release process was not tested due to the likelihood of accidentally creating release artefacts (such as a github release or actual new app builds etc). However this time around I did figure out how to test for these changes without accidentally creating a release and the test was set up [in this testing PR](https://github.com/LedgerHQ/ledger-live/pull/8690) which ran successfully ✅. That PR explains how the testing works and links to the successful run