### PR TITLE
In `generate-screenshots` workflow, use commit action for generating signing commits

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -28,6 +28,10 @@ permissions:
 
 jobs:
   generate-screenshots-linux:
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push,
+      # for use in the update-snapshots-desktop action
+      contents: write
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       FORCE_COLOR: 3

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -29,8 +29,9 @@ permissions:
 jobs:
   generate-screenshots-linux:
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push,
-      # for use in the update-snapshots-desktop action
+      id-token: write
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
       contents: write
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -78,6 +78,7 @@ jobs:
         id: update-snapshots
         with:
           os: ubuntu-22.04
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   report-start:
     name: Report start

--- a/tools/actions/composites/update-snapshots-desktop/action.yml
+++ b/tools/actions/composites/update-snapshots-desktop/action.yml
@@ -4,6 +4,9 @@ inputs:
   os:
     description: "name of the os (same as runs-on)"
     required: true
+  token:
+    description: "GitHub token"
+    required: true
 
 runs:
   using: "composite"
@@ -42,16 +45,29 @@ runs:
         echo "changes=$(git status -s)"
       shell: bash
 
-    - name: Commit snapshots
-      if: ${{ steps.status.outputs.status != 0 || steps.status-windows.outputs.status != 0 }}
+    - name: Add changed files
       run: |
-        git add ./apps/ledger-live-desktop/tests/specs &&
-        git commit -m "test(lld): update screenshots (${{ inputs.os }}) ${{ steps.changes.outputs.changes }} lld, test, screenshot" &&
-        git restore . &&
-        git pull --rebase &&
-        git push ||
-        echo ""
+        git stash -u
+        git pull --rebase
+        git stash pop
+        git add ./apps/ledger-live-desktop/tests/specs
       shell: bash
+
+    - name: Get current branch
+      id: get_branch
+      run: echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Commit snapshots
+      uses: planetscale/ghcommit-action@v0.1.6
+      if: ${{ steps.status.outputs.status != 0 || steps.status-windows.outputs.status != 0 }}
+      with:
+        commit_message: "test(lld): update screenshots (${{ inputs.os }}) ${{ steps.changes.outputs.changes }} lld, test, screenshot"
+        repo: ${{ github.repository }}
+        branch: ${{ env.branch }}
+        file_pattern: '*'
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Upload playwright results [On Failure]
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-14389)

Uses the [ghcommit action](https://github.com/planetscale/ghcommit-action) to make a verified commit for the generated screenshots.

In this PR we replace our manual git commands for creating a commit with the ghcommit action, which makes a request to the Github API to create a commit instead. In this PR we use that action, but provide the `GITHUB_TOKEN` to authenticate the request. The `GITHUB_TOKEN` is locally scoped to just that workflow run (i.e. short lived), and is generated by Github. When Github receives the request it parses the `GITHUB_TOKEN` and recognises the commit as originating from the repo's own actions, marking it as Verified on this basis. Verification that the commit is generated within the repo's actions is sufficient because 3rd parties (people outside the Ledger organisation) cannot initiate a `generate-screenshots` run.

Test PR for this is https://github.com/LedgerHQ/ledger-live/pull/8806, with the workflow run [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12630806250/job/35191332129). 🟢, [commit generated and verified](https://github.com/LedgerHQ/ledger-live/pull/8806/commits) ✅

<img width="791" alt="Screenshot 2025-01-06 at 10 39 33" src="https://github.com/user-attachments/assets/dfdf400a-cda6-460e-a6b8-d1ab9b2ec44e" />

-----

#### During this work 2 other approaches were tried

1. **using [swinton/commit](https://github.com/swinton/commit)**, suggested in [this comment](https://ledger.slack.com/archives/C02LP0WL39P/p1733844040222729?thread_ts=1727967973.524749&cid=C02LP0WL39P). Contrary to that comment, that action is not implemented anywhere in the earn repo. I tried this action and it works fine for single-file commits but it doesn't have a documented way of adding multiple files simultaneously. It's a single-developer effort (perhaps explains the lack of support for common use cases) and isn't actively maintained. Even if I had found a hack for adding multiple files I wasn't comfortable introducing this to the team - not clean enough, high risk of it being hard to work with in the future
2. **using GPG encryption with live-github-bot's credentials**. This didn't work because live-github-bot's email address contains `[` and `]` characters, which GPG does not recognise as valid characters in an email address