### PR TITLE
TEMP - fix release final script trigger test PR

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -143,7 +143,7 @@ jobs:
               ref: "main",
               workflow_id: "release-desktop.yml",
               inputs: {
-                branch: ${{ inputs.ref }}
+                branch: "${{ inputs.ref }}"
               }
             });
       - uses: actions/github-script@v7
@@ -158,6 +158,6 @@ jobs:
               ref: "main",
               workflow_id: "release-mobile.yml",
               inputs: {
-                ref: ${{ inputs.ref }}
+                ref: "${{ inputs.ref }}"
               }
             });

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -52,112 +52,112 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.0
-      - name: Cache LLM pods
-        uses: actions/cache@v3
-        with:
-          path: |
-            apps/ledger-live-mobile/ios/Pods
-            ~/Library/Caches/CocoaPods
-            ~/.cocoapods
-          key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
-      - name: install dependencies
-        run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
-      - name: build libs
-        run: pnpm run build:libs
-      - name: authenticate with npm
-        uses: actions/setup-node@v4
-        with:
-          registry-url: "https://registry.npmjs.org"
-      - name: publish release
-        run: pnpm changeset publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
-      - name: check if desktop versions are different
-        if: ${{ github.event_name == 'workflow_run' }}
-        id: desktop-changed
-        run: |
-          echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
-      - name: check if mobile versions are different
-        if: ${{ github.event_name == 'workflow_run' }}
-        id: mobile-changed
-        run: |
-          echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: desktop-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-desktop
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: mobile-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-mobile
-      - name: generate desktop changelog
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
-        id: desktop-changelog
-        with:
-          package-path: ${{ github.workspace }}/apps/ledger-live-desktop/package.json
-          changelog-path: ${{ github.workspace }}/apps/ledger-live-desktop/CHANGELOG.md
-          output-path: ${{ github.workspace }}
-          name: desktop-changelog
-      - name: tag desktop
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        run: |
-          git tag @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }}
-      - name: generate mobile changelog
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
-        id: mobile-changelog
-        with:
-          package-path: ${{ github.workspace }}/apps/ledger-live-mobile/package.json
-          changelog-path: ${{ github.workspace }}/apps/ledger-live-mobile/CHANGELOG.md
-          output-path: ${{ github.workspace }}
-          name: mobile-changelog
-      - name: tag mobile
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        run: |
-          git tag live-mobile@${{ steps.mobile-version.outputs.version }}
-      - name: push changes
-        run: |
-          git push origin ${{ inputs.ref }} --tags
-      - name: create desktop github release
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }} -F ${{ steps.desktop-changelog.outputs.path }}
-      - name: create mobile github release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        run: |
-          gh release create live-mobile@${{ steps.mobile-version.outputs.version }} -F ${{ steps.mobile-changelog.outputs.path }}
+      # - name: Cache LLM pods
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       apps/ledger-live-mobile/ios/Pods
+      #       ~/Library/Caches/CocoaPods
+      #       ~/.cocoapods
+      #     key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
+      # - name: install dependencies
+      #   run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
+      # - name: build libs
+      #   run: pnpm run build:libs
+      # - name: authenticate with npm
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     registry-url: "https://registry.npmjs.org"
+      # - name: publish release
+      #   run: pnpm changeset publish
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      # - name: check if desktop versions are different
+      #   if: ${{ github.event_name == 'workflow_run' }}
+      #   id: desktop-changed
+      #   run: |
+      #     echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
+      # - name: check if mobile versions are different
+      #   if: ${{ github.event_name == 'workflow_run' }}
+      #   id: mobile-changed
+      #   run: |
+      #     echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
+      # - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+      #   id: desktop-version
+      #   with:
+      #     path: ${{ github.workspace }}/apps/ledger-live-desktop
+      # - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+      #   id: mobile-version
+      #   with:
+      #     path: ${{ github.workspace }}/apps/ledger-live-mobile
+      # - name: generate desktop changelog
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
+      #   id: desktop-changelog
+      #   with:
+      #     package-path: ${{ github.workspace }}/apps/ledger-live-desktop/package.json
+      #     changelog-path: ${{ github.workspace }}/apps/ledger-live-desktop/CHANGELOG.md
+      #     output-path: ${{ github.workspace }}
+      #     name: desktop-changelog
+      # - name: tag desktop
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   run: |
+      #     git tag @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }}
+      # - name: generate mobile changelog
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
+      #   id: mobile-changelog
+      #   with:
+      #     package-path: ${{ github.workspace }}/apps/ledger-live-mobile/package.json
+      #     changelog-path: ${{ github.workspace }}/apps/ledger-live-mobile/CHANGELOG.md
+      #     output-path: ${{ github.workspace }}
+      #     name: mobile-changelog
+      # - name: tag mobile
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   run: |
+      #     git tag live-mobile@${{ steps.mobile-version.outputs.version }}
+      # - name: push changes
+      #   run: |
+      #     git push origin ${{ inputs.ref }} --tags
+      # - name: create desktop github release
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh release create @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }} -F ${{ steps.desktop-changelog.outputs.path }}
+      # - name: create mobile github release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   run: |
+      #     gh release create live-mobile@${{ steps.mobile-version.outputs.version }} -F ${{ steps.mobile-changelog.outputs.path }}
       - uses: actions/github-script@v7
         name: trigger release build for desktop
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+        if: ${{ true }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             github.rest.actions.createWorkflowDispatch({
               owner: "ledgerhq",
               repo: "ledger-live-build",
-              ref: "main",
+              ref: "support/dummy-release-desktop",
               workflow_id: "release-desktop.yml",
               inputs: {
                 branch: "${{ inputs.ref }}"
               }
             });
-      - uses: actions/github-script@v7
-        name: trigger release build for mobile
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: "ledgerhq",
-              repo: "ledger-live-build",
-              ref: "main",
-              workflow_id: "release-mobile.yml",
-              inputs: {
-                ref: "${{ inputs.ref }}"
-              }
-            });
+      # - uses: actions/github-script@v7
+      #   name: trigger release build for mobile
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   with:
+      #     github-token: ${{ steps.generate-token.outputs.token }}
+      #     script: |
+      #       github.rest.actions.createWorkflowDispatch({
+      #         owner: "ledgerhq",
+      #         repo: "ledger-live-build",
+      #         ref: "main",
+      #         workflow_id: "release-mobile.yml",
+      #         inputs: {
+      #           ref: "${{ inputs.ref }}"
+      #         }
+      #       });


### PR DESCRIPTION
This is a test PR for https://github.com/LedgerHQ/ledger-live/pull/8681

It modifies the call to release-desktop in ledger-live-build to use the branch at https://github.com/LedgerHQ/ledger-live-build/pull/118 . This branch removes all functionality from that workflow temporarily, so we can call it to make sure the call works, without there being any downstream effects.

To run this test:
1. manually trigger the release-final workflow in ledger-live from this branch
2. observe that that workflow calls release-desktop in ledger-live-build
3. ensure that it calls the branch at https://github.com/LedgerHQ/ledger-live-build/pull/118 , echoing a success message
4. ensure that the calling process has not created any errors in the workflow from step # 1