### PR TITLE
fix: recipient field revalidation due to uncontrolled transaction multiple update on NFT send flow

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
@@ -49,19 +49,11 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    // if the account changed, we should revalidate the recipient field
+    // ONLY if the account changed, we should explicitly revalidate the recipient field
     if (!initValue && value !== "" && value !== transaction.recipient) {
       onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));
     }
-  }, [
-    account.id,
-    value,
-    transaction.recipient,
-    bridge,
-    onChangeTransaction,
-    transaction,
-    initValue,
-  ]);
+  }, [account.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onChange = useCallback(
     async (recipient: string, maybeExtra?: OnChangeExtra | null) => {


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When use try to send nft, the `recipient`field revalidation process wen to uncontrolled behaviour while `transaction` object reference is updated too many times and by consequence invokes the `onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));` inside the useEffect that should be used ONLY when the account change. 

- This fix will support the revalidation done in https://ledgerhq.atlassian.net/browse/LIVE-14904 as well as the current ticket

##### Before 


https://github.com/user-attachments/assets/0fbdc855-f1a3-4aaf-93e1-ac8410745862



##### After 


https://github.com/user-attachments/assets/6d774cb2-d526-4212-b5d9-7a59caf58889


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-15444

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
