### PR TITLE
change solana validators order

### DIFF
--- a/.changeset/purple-beers-report.md
+++ b/.changeset/purple-beers-report.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+change solana validators order

--- a/libs/coin-modules/coin-solana/src/utils.ts
+++ b/libs/coin-modules/coin-solana/src/utils.ts
@@ -28,12 +28,13 @@ export const LEDGER_VALIDATOR_BY_CHORUS_ONE: ValidatorsAppValidator = {
   totalScore: 7,
 };
 
-export const LEDGER_VALIDATOR_LIST: ValidatorsAppValidator[] = [
-  LEDGER_VALIDATOR_BY_CHORUS_ONE,
-  LEDGER_VALIDATOR_BY_FIGMENT,
-];
-
 export const LEDGER_VALIDATOR_DEFAULT = LEDGER_VALIDATOR_BY_FIGMENT;
+
+// default validator first
+export const LEDGER_VALIDATOR_LIST: ValidatorsAppValidator[] = [
+  LEDGER_VALIDATOR_BY_FIGMENT,
+  LEDGER_VALIDATOR_BY_CHORUS_ONE,
+];
 
 export const LEDGER_VALIDATORS_VOTE_ACCOUNTS = LEDGER_VALIDATOR_LIST.map(v => v.voteAccount);
 
@@ -177,8 +178,8 @@ export function ledgerFirstValidators(
   );
 
   const LEDGER_FIRST_VALIDATOR =
-    ledgerValidators.find(v => v.voteAccount === LEDGER_VALIDATOR_BY_CHORUS_ONE.voteAccount) ||
-    LEDGER_VALIDATOR_BY_CHORUS_ONE;
+    ledgerValidators.find(v => v.voteAccount === LEDGER_VALIDATOR_DEFAULT.voteAccount) ||
+    LEDGER_VALIDATOR_DEFAULT;
 
   const ledgerValidatorsFiltered = ledgerValidators.filter(
     v => v.voteAccount !== LEDGER_FIRST_VALIDATOR.voteAccount,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We need to reverse the changes done to the Solana validator displayed by default in the staking flow. Figment should remain 1st and Chorus one second.

![image](https://github.com/user-attachments/assets/f9521db4-61a1-4552-84bb-498f8b1e8143)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-15453


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
