### PR TITLE
ci: resolve `ref` in `release-final` across different triggers

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -31,6 +31,19 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:
+      - name: Set resolved_ref
+        id: set-resolved-ref
+        run: |
+          if [ "${{ inputs.ref }}" ]; then
+            echo "resolved_ref=${{ inputs.ref }}" >> $GITHUB_ENV
+          else
+            if ${{ contains(github.event.workflow_run.name, '(Hotfix)') }}; then
+              echo "resolved_ref=hotfix" >> $GITHUB_ENV
+            else
+              echo "resolved_ref=main" >> $GITHUB_ENV
+            fi
+          fi
+        shell: bash
       - name: generate token
         id: generate-token
         uses: tibdex/github-app-token@v1
@@ -39,7 +52,7 @@ jobs:
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ env.resolved_ref }}
           fetch-depth: 2
           token: ${{ steps.generate-token.outputs.token }}
       - name: Setup git user
@@ -118,7 +131,7 @@ jobs:
           git tag live-mobile@${{ steps.mobile-version.outputs.version }}
       - name: push changes
         run: |
-          git push origin ${{ inputs.ref }} --tags
+          git push origin ${{ env.resolved_ref }} --tags
       - name: create desktop github release
         if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
         env:
@@ -143,7 +156,7 @@ jobs:
               ref: "main",
               workflow_id: "release-desktop.yml",
               inputs: {
-                branch: "${{ inputs.ref }}"
+                branch: "${{ env.resolved_ref }}"
               }
             });
       - uses: actions/github-script@v7
@@ -158,6 +171,6 @@ jobs:
               ref: "main",
               workflow_id: "release-mobile.yml",
               inputs: {
-                ref: "${{ inputs.ref }}"
+                ref: "${{ env.resolved_ref }}"
               }
             });


### PR DESCRIPTION
...and use the resolved ref throughout

Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-15428)

This solution uses for `ref`:
- `inputs.ref` if the workflow was triggered on manual workflow dispatch
- `hotfix` if the workflow was triggered automatically on completion of the prepare hotfix workflow
- `main` if the workflow was triggered automatically on completion of the prepare release workflow

There is currently no easy way to test this (see [this thread](https://ledger.slack.com/archives/C07KP3A8CNA/p1734361634332549)), and I'm figuring out a way to do this now