### PR TITLE
Call `release-final` from `release-prepare` workflows

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -1,5 +1,12 @@
 name: "[Release] Publish packages and apps"
 on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: "the ref (branch) to release from"
+        required: false
+        default: main
   workflow_dispatch:
     inputs:
       app:
@@ -16,13 +23,6 @@ on:
         description: "the ref (branch) to release from"
         required: false
         default: main
-
-  workflow_run:
-    workflows:
-      - \[Release\] Prepare for releasing
-      - \[Release\](Hotfix) Prepare for releasing
-    types:
-      - "completed"
 
 jobs:
   release:

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -120,3 +120,11 @@ jobs:
               gh pr create --title ":rotating_light: Hotfix Release merge conflicts" -F .github/templates/hotfix-release-conflicts.md --base release --head support/hotfix-release-merge-conflicts
             fi
           fi
+
+  release-final:
+    name: "[Release] Publish packages and apps"
+    needs: prepare-release
+    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
+    with:
+      ref: hotfix
+    secrets: inherit

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -75,3 +75,11 @@ jobs:
           git checkout -b support/release-merge-conflicts
           git push origin support/release-merge-conflicts
           gh pr create --title ":rotating_light: Release merge conflicts" -F .github/templates/release-conflicts.md --base develop --head support/release-merge-conflicts
+
+  release-final:
+    name: "[Release] Publish packages and apps"
+    needs: prepare-release
+    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
+    with:
+      ref: main
+    secrets: inherit


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-15428)

This is an alternative to https://github.com/LedgerHQ/ledger-live/pull/8713 which explicitly calls `release-final` from `release-prepare` workflows, passing a `ref` input. The automatic follow-on via `workflow_run` has been removed in this PR, meaning that `inputs.ref` is guaranteed to be available in the workflow