### PR TITLE
Support/fix release ref handling call from first workflow test

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -1,5 +1,12 @@
 name: "[Release] Publish packages and apps"
 on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: "the ref (branch) to release from"
+        required: false
+        default: main
   workflow_dispatch:
     inputs:
       app:
@@ -16,13 +23,6 @@ on:
         description: "the ref (branch) to release from"
         required: false
         default: main
-
-  workflow_run:
-    workflows:
-      - \[Release\] Prepare for releasing
-      - \[Release\](Hotfix) Prepare for releasing
-    types:
-      - "completed"
 
 jobs:
   release:

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -31,6 +31,10 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:
+      - name: echo ref
+        run: |
+          echo "inputs.ref value: ${{ inputs.ref }}"
+        shell: bash
       - name: generate token
         id: generate-token
         uses: tibdex/github-app-token@v1
@@ -42,122 +46,122 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 2
           token: ${{ steps.generate-token.outputs.token }}
-      - name: Setup git user
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          install-proto: true
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 3.3.0
-      - name: Cache LLM pods
-        uses: actions/cache@v3
-        with:
-          path: |
-            apps/ledger-live-mobile/ios/Pods
-            ~/Library/Caches/CocoaPods
-            ~/.cocoapods
-          key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
-      - name: install dependencies
-        run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
-      - name: build libs
-        run: pnpm run build:libs
-      - name: authenticate with npm
-        uses: actions/setup-node@v4
-        with:
-          registry-url: "https://registry.npmjs.org"
-      - name: publish release
-        run: pnpm changeset publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
-      - name: check if desktop versions are different
-        if: ${{ github.event_name == 'workflow_run' }}
-        id: desktop-changed
-        run: |
-          echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
-      - name: check if mobile versions are different
-        if: ${{ github.event_name == 'workflow_run' }}
-        id: mobile-changed
-        run: |
-          echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: desktop-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-desktop
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: mobile-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-mobile
-      - name: generate desktop changelog
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
-        id: desktop-changelog
-        with:
-          package-path: ${{ github.workspace }}/apps/ledger-live-desktop/package.json
-          changelog-path: ${{ github.workspace }}/apps/ledger-live-desktop/CHANGELOG.md
-          output-path: ${{ github.workspace }}
-          name: desktop-changelog
-      - name: tag desktop
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        run: |
-          git tag @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }}
-      - name: generate mobile changelog
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
-        id: mobile-changelog
-        with:
-          package-path: ${{ github.workspace }}/apps/ledger-live-mobile/package.json
-          changelog-path: ${{ github.workspace }}/apps/ledger-live-mobile/CHANGELOG.md
-          output-path: ${{ github.workspace }}
-          name: mobile-changelog
-      - name: tag mobile
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        run: |
-          git tag live-mobile@${{ steps.mobile-version.outputs.version }}
-      - name: push changes
-        run: |
-          git push origin ${{ inputs.ref }} --tags
-      - name: create desktop github release
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }} -F ${{ steps.desktop-changelog.outputs.path }}
-      - name: create mobile github release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        run: |
-          gh release create live-mobile@${{ steps.mobile-version.outputs.version }} -F ${{ steps.mobile-changelog.outputs.path }}
-      - uses: actions/github-script@v7
-        name: trigger release build for desktop
-        if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: "ledgerhq",
-              repo: "ledger-live-build",
-              ref: "main",
-              workflow_id: "release-desktop.yml",
-              inputs: {
-                branch: "${{ inputs.ref }}"
-              }
-            });
-      - uses: actions/github-script@v7
-        name: trigger release build for mobile
-        if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
-        with:
-          github-token: ${{ steps.generate-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: "ledgerhq",
-              repo: "ledger-live-build",
-              ref: "main",
-              workflow_id: "release-mobile.yml",
-              inputs: {
-                ref: "${{ inputs.ref }}"
-              }
-            });
+      # - name: Setup git user
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
+      # - name: Setup the caches
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+      #   id: setup-caches
+      #   with:
+      #     install-proto: true
+      # - uses: ruby/setup-ruby@v1
+      #   with:
+      #     ruby-version: 3.3.0
+      # - name: Cache LLM pods
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       apps/ledger-live-mobile/ios/Pods
+      #       ~/Library/Caches/CocoaPods
+      #       ~/.cocoapods
+      #     key: ${{ runner.os }}-pods-${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock') }}
+      # - name: install dependencies
+      #   run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
+      # - name: build libs
+      #   run: pnpm run build:libs
+      # - name: authenticate with npm
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     registry-url: "https://registry.npmjs.org"
+      # - name: publish release
+      #   run: pnpm changeset publish
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      # - name: check if desktop versions are different
+      #   if: ${{ github.event_name == 'workflow_run' }}
+      #   id: desktop-changed
+      #   run: |
+      #     echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
+      # - name: check if mobile versions are different
+      #   if: ${{ github.event_name == 'workflow_run' }}
+      #   id: mobile-changed
+      #   run: |
+      #     echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
+      # - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+      #   id: desktop-version
+      #   with:
+      #     path: ${{ github.workspace }}/apps/ledger-live-desktop
+      # - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+      #   id: mobile-version
+      #   with:
+      #     path: ${{ github.workspace }}/apps/ledger-live-mobile
+      # - name: generate desktop changelog
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
+      #   id: desktop-changelog
+      #   with:
+      #     package-path: ${{ github.workspace }}/apps/ledger-live-desktop/package.json
+      #     changelog-path: ${{ github.workspace }}/apps/ledger-live-desktop/CHANGELOG.md
+      #     output-path: ${{ github.workspace }}
+      #     name: desktop-changelog
+      # - name: tag desktop
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   run: |
+      #     git tag @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }}
+      # - name: generate mobile changelog
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   uses: LedgerHQ/ledger-live/tools/actions/generate-release-message@develop
+      #   id: mobile-changelog
+      #   with:
+      #     package-path: ${{ github.workspace }}/apps/ledger-live-mobile/package.json
+      #     changelog-path: ${{ github.workspace }}/apps/ledger-live-mobile/CHANGELOG.md
+      #     output-path: ${{ github.workspace }}
+      #     name: mobile-changelog
+      # - name: tag mobile
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   run: |
+      #     git tag live-mobile@${{ steps.mobile-version.outputs.version }}
+      # - name: push changes
+      #   run: |
+      #     git push origin ${{ inputs.ref }} --tags
+      # - name: create desktop github release
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     gh release create @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }} -F ${{ steps.desktop-changelog.outputs.path }}
+      # - name: create mobile github release
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   run: |
+      #     gh release create live-mobile@${{ steps.mobile-version.outputs.version }} -F ${{ steps.mobile-changelog.outputs.path }}
+      # - uses: actions/github-script@v7
+      #   name: trigger release build for desktop
+      #   if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+      #   with:
+      #     github-token: ${{ steps.generate-token.outputs.token }}
+      #     script: |
+      #       github.rest.actions.createWorkflowDispatch({
+      #         owner: "ledgerhq",
+      #         repo: "ledger-live-build",
+      #         ref: "main",
+      #         workflow_id: "release-desktop.yml",
+      #         inputs: {
+      #           branch: "${{ inputs.ref }}"
+      #         }
+      #       });
+      # - uses: actions/github-script@v7
+      #   name: trigger release build for mobile
+      #   if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+      #   with:
+      #     github-token: ${{ steps.generate-token.outputs.token }}
+      #     script: |
+      #       github.rest.actions.createWorkflowDispatch({
+      #         owner: "ledgerhq",
+      #         repo: "ledger-live-build",
+      #         ref: "main",
+      #         workflow_id: "release-mobile.yml",
+      #         inputs: {
+      #           ref: "${{ inputs.ref }}"
+      #         }
+      #       });

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -26,105 +26,107 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:
-      - name: generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.GH_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+      - name: dummy step
+        run: echo "dummy step"
+      # - name: generate token
+      #   id: generate-token
+      #   uses: tibdex/github-app-token@v1
+      #   with:
+      #     app_id: ${{ secrets.GH_BOT_APP_ID }}
+      #     private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
 
-      - name: Checkout composite actions
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: tools/actions/composites
+      # - name: Checkout composite actions
+      #   uses: actions/checkout@v4
+      #   with:
+      #     sparse-checkout: tools/actions/composites
 
-      - name: Generate ref/tag version to use when running changeset status
-        uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop
-        id: format-app-tag
-        with:
-          tag_version: ${{ github.event.inputs.tag_version }}
-          application: ${{ github.event.inputs.application }}
+      # - name: Generate ref/tag version to use when running changeset status
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop
+      #   id: format-app-tag
+      #   with:
+      #     tag_version: ${{ github.event.inputs.tag_version }}
+      #     application: ${{ github.event.inputs.application }}
 
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-          token: ${{ steps.generate-token.outputs.token }}
+      # - name: Checkout Repo
+      #   uses: actions/checkout@v4
+      #   with:
+      #     ref: ${{ inputs.ref }}
+      #     token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Setup git user
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
+      # - name: Setup git user
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
 
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          install-proto: true
+      # - name: Setup the caches
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+      #   id: setup-caches
+      #   with:
+      #     install-proto: true
 
-      - name: install dependencies
-        run: pnpm i -F "ledger-live"
+      # - name: install dependencies
+      #   run: pnpm i -F "ledger-live"
 
-      - name: exit prerelease mode
-        run: pnpm changeset pre exit
+      # - name: exit prerelease mode
+      #   run: pnpm changeset pre exit
 
-      - name: versioning
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm changeset version
+      # - name: versioning
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: pnpm changeset version
 
-      - name: commit
-        run: |
-          git add .
-          git commit -m "chore(hotfix): :fire: hotfix release [skip ci]"
+      # - name: commit
+      #   run: |
+      #     git add .
+      #     git commit -m "chore(hotfix): :fire: hotfix release [skip ci]"
 
-      - name: push changes
-        run: |
-          git push origin ${{ inputs.ref }}
+      # - name: push changes
+      #   run: |
+      #     git push origin ${{ inputs.ref }}
 
-      - name: fetch develop and main
-        if: ${{ github.event.inputs.tag_version == 'latest' }}
-        run: |
-          git fetch origin develop main
+      # - name: fetch develop and main
+      #   if: ${{ github.event.inputs.tag_version == 'latest' }}
+      #   run: |
+      #     git fetch origin develop main
 
-      - name: merge into main
-        if: ${{ github.event.inputs.tag_version == 'latest' }}
-        run: |
-          git checkout main
-          git merge ${{ inputs.ref }} --no-ff
-          git push origin main
+      # - name: merge into main
+      #   if: ${{ github.event.inputs.tag_version == 'latest' }}
+      #   run: |
+      #     git checkout main
+      #     git merge ${{ inputs.ref }} --no-ff
+      #     git push origin main
 
-      - name: create PR to develop
-        if: ${{ github.event.inputs.tag_version == 'latest' }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git checkout ${{ github.event.inputs.ref }}
-          git checkout -b support/hotfix-merge-conflicts
-          git push origin support/hotfix-merge-conflicts
-          gh pr create --title ":rotating_light: Hotfix merge conflicts" -F .github/templates/hotfix-conflicts.md --base develop --head support/hotfix-merge-conflicts
+      # - name: create PR to develop
+      #   if: ${{ github.event.inputs.tag_version == 'latest' }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      #   run: |
+      #     git checkout ${{ github.event.inputs.ref }}
+      #     git checkout -b support/hotfix-merge-conflicts
+      #     git push origin support/hotfix-merge-conflicts
+      #     gh pr create --title ":rotating_light: Hotfix merge conflicts" -F .github/templates/hotfix-conflicts.md --base develop --head support/hotfix-merge-conflicts
 
-      - name: merge into release if present
-        if: ${{ github.event.inputs.tag_version == 'latest' }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          if git checkout release
-          then
-            if git merge ${{ github.event.inputs.ref }} --no-ff
-            then
-              git push origin release
-            else
-              git merge --abort
-              git checkout ${{ github.event.inputs.ref }}
-              git checkout -b support/hotfix-release-merge-conflicts
-              git push origin support/hotfix-release-merge-conflicts
-              gh pr create --title ":rotating_light: Hotfix Release merge conflicts" -F .github/templates/hotfix-release-conflicts.md --base release --head support/hotfix-release-merge-conflicts
-            fi
-          fi
+      # - name: merge into release if present
+      #   if: ${{ github.event.inputs.tag_version == 'latest' }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      #   run: |
+      #     if git checkout release
+      #     then
+      #       if git merge ${{ github.event.inputs.ref }} --no-ff
+      #       then
+      #         git push origin release
+      #       else
+      #         git merge --abort
+      #         git checkout ${{ github.event.inputs.ref }}
+      #         git checkout -b support/hotfix-release-merge-conflicts
+      #         git push origin support/hotfix-release-merge-conflicts
+      #         gh pr create --title ":rotating_light: Hotfix Release merge conflicts" -F .github/templates/hotfix-release-conflicts.md --base release --head support/hotfix-release-merge-conflicts
+      #       fi
+      #     fi
 
   release-final:
     name: "[Release] Publish packages and apps"
     needs: prepare-release
-    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@support/fix-release-ref-handling-call-from-first-workflow-test
     with:
       ref: hotfix
     secrets: inherit

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -120,3 +120,11 @@ jobs:
               gh pr create --title ":rotating_light: Hotfix Release merge conflicts" -F .github/templates/hotfix-release-conflicts.md --base release --head support/hotfix-release-merge-conflicts
             fi
           fi
+
+  release-final:
+    name: "[Release] Publish packages and apps"
+    needs: prepare-release
+    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
+    with:
+      ref: hotfix
+    secrets: inherit

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -15,71 +15,73 @@ jobs:
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:
-      - name: generate token
-        id: generate-token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.GH_BOT_APP_ID }}
-          private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
-          token: ${{ steps.generate-token.outputs.token }}
+      - name: dummy step
+        run: echo "dummy step"
+      # - name: generate token
+      #   id: generate-token
+      #   uses: tibdex/github-app-token@v1
+      #   with:
+      #     app_id: ${{ secrets.GH_BOT_APP_ID }}
+      #     private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+      # - name: Checkout Repo
+      #   uses: actions/checkout@v4
+      #   with:
+      #     ref: ${{ inputs.ref }}
+      #     token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Setup git user
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
+      # - name: Setup git user
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/setup-git-user@develop
 
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          install-proto: true
+      # - name: Setup the caches
+      #   uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+      #   id: setup-caches
+      #   with:
+      #     install-proto: true
 
-      - name: install dependencies
-        run: pnpm i -F "ledger-live"
+      # - name: install dependencies
+      #   run: pnpm i -F "ledger-live"
 
-      - name: exit prerelease mode
-        run: pnpm changeset pre exit
+      # - name: exit prerelease mode
+      #   run: pnpm changeset pre exit
 
-      - name: versioning
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm changeset version
+      # - name: versioning
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: pnpm changeset version
 
-      - name: commit
-        run: |
-          git add .
-          git commit -m "chore(release): :rocket: prepare release [skip ci]"
+      # - name: commit
+      #   run: |
+      #     git add .
+      #     git commit -m "chore(release): :rocket: prepare release [skip ci]"
 
-      - name: push changes
-        run: |
-          git push origin ${{ inputs.ref }}
-          git fetch origin
+      # - name: push changes
+      #   run: |
+      #     git push origin ${{ inputs.ref }}
+      #     git fetch origin
 
-      - name: fetch develop and main
-        run: |
-          git fetch origin develop main
+      # - name: fetch develop and main
+      #   run: |
+      #     git fetch origin develop main
 
-      - name: merge into main
-        run: |
-          git checkout main
-          git merge ${{ inputs.ref }} --no-ff
-          git push origin main
+      # - name: merge into main
+      #   run: |
+      #     git checkout main
+      #     git merge ${{ inputs.ref }} --no-ff
+      #     git push origin main
 
-      - name: create PR to develop
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git checkout ${{ github.event.inputs.ref }}
-          git checkout -b support/release-merge-conflicts
-          git push origin support/release-merge-conflicts
-          gh pr create --title ":rotating_light: Release merge conflicts" -F .github/templates/release-conflicts.md --base develop --head support/release-merge-conflicts
+      # - name: create PR to develop
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      #   run: |
+      #     git checkout ${{ github.event.inputs.ref }}
+      #     git checkout -b support/release-merge-conflicts
+      #     git push origin support/release-merge-conflicts
+      #     gh pr create --title ":rotating_light: Release merge conflicts" -F .github/templates/release-conflicts.md --base develop --head support/release-merge-conflicts
 
   release-final:
     name: "[Release] Publish packages and apps"
     needs: prepare-release
-    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@support/fix-release-ref-handling-call-from-first-workflow-test
     with:
       ref: main
     secrets: inherit

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -75,3 +75,11 @@ jobs:
           git checkout -b support/release-merge-conflicts
           git push origin support/release-merge-conflicts
           gh pr create --title ":rotating_light: Release merge conflicts" -F .github/templates/release-conflicts.md --base develop --head support/release-merge-conflicts
+
+  release-final:
+    name: "[Release] Publish packages and apps"
+    needs: prepare-release
+    uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
+    with:
+      ref: main
+    secrets: inherit


### PR DESCRIPTION
Test PR for https://github.com/LedgerHQ/ledger-live/pull/8718

Makes:
- `release-prepare` and `release-prepare-hotfix` impotent (no side-effects)
- `release-prepare` and `release-prepare-hotfix` call out to this branch's `release-final`
- `release-final` echo out the `inputs.ref` value

These workflows can now be run on this branch.