### PR TITLE
[Alpaca] Add block hash and timestamp

### DIFF
--- a/.changeset/quick-frogs-develop.md
+++ b/.changeset/quick-frogs-develop.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-stellar": minor
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/coin-xrp": minor
+"@ledgerhq/coin-framework": minor
+---
+
+Add block informations to an operation (hash, time and height of a block)

--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -1,7 +1,7 @@
 export type BlockInfo = {
   height: number;
-  hash: string;
-  time: Date;
+  hash?: string;
+  time?: Date;
 };
 
 export type Operation = {
@@ -10,8 +10,7 @@ export type Operation = {
   type: string;
   value: bigint;
   fee: bigint;
-  blockHeight: number;
-  block?: BlockInfo;
+  block: BlockInfo;
   senders: string[];
   recipients: string[];
   date: Date;

--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -11,6 +11,7 @@ export type Operation = {
   value: bigint;
   fee: bigint;
   blockHeight: number;
+  block?: BlockInfo;
   senders: string[];
   recipients: string[];
   date: Date;

--- a/libs/coin-modules/coin-polkadot/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-polkadot/src/logic/listOperations.ts
@@ -7,7 +7,11 @@ export type Operation = {
   type: string;
   value: bigint;
   fee: bigint;
-  blockHeight: number;
+  block: {
+    height: number;
+    hash?: string;
+    time?: Date;
+  };
   senders: string[];
   recipients: string[];
   date: Date;
@@ -43,7 +47,9 @@ const convertToCoreOperation = (address: string) => (operation: PolkadotOperatio
     type,
     value: BigInt(value.toString()),
     fee: BigInt(fee.toString()),
-    blockHeight: blockHeight ?? 0,
+    block: {
+      height: blockHeight ?? 0,
+    },
     senders,
     recipients,
     date,

--- a/libs/coin-modules/coin-stellar/src/bridge/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-stellar/src/bridge/buildOptimisticOperation.ts
@@ -28,6 +28,7 @@ export async function buildOptimisticOperation(
     transactionSequenceNumber: transactionSequenceNumber?.plus(1).toNumber(),
     extra: {
       ledgerOpType: type,
+      blockTime: new Date(),
     },
   };
 

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
@@ -7,10 +7,9 @@ export type Operation = {
   type: string;
   value: bigint;
   fee: bigint;
-  blockHeight: number;
-  block?: {
-    hash: string;
-    time: Date;
+  block: {
+    hash?: string;
+    time?: Date;
     height: number;
   };
   senders: string[];
@@ -46,7 +45,6 @@ const convertToCoreOperation = (address: string) => (operation: StellarOperation
     type: operation.type,
     value: BigInt(operation.value.toString()),
     fee: BigInt(operation.fee.toString()),
-    blockHeight: operation.blockHeight!,
     block: {
       hash: operation.blockHash!,
       time: operation.extra.blockTime,

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
@@ -8,6 +8,11 @@ export type Operation = {
   value: bigint;
   fee: bigint;
   blockHeight: number;
+  block?: {
+    hash: string;
+    time: Date;
+    height: number;
+  };
   senders: string[];
   recipients: string[];
   date: Date;
@@ -42,6 +47,11 @@ const convertToCoreOperation = (address: string) => (operation: StellarOperation
     value: BigInt(operation.value.toString()),
     fee: BigInt(operation.fee.toString()),
     blockHeight: operation.blockHeight!,
+    block: {
+      hash: operation.blockHash!,
+      time: operation.extra.blockTime,
+      height: operation.blockHeight!,
+    },
     senders: operation.senders,
     recipients: operation.recipients,
     date: operation.date,

--- a/libs/coin-modules/coin-stellar/src/network/horizon.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.ts
@@ -64,6 +64,14 @@ Horizon.AxiosClient.interceptors.request.use(config => {
   return config;
 });
 
+// This function allows to fix the URL, because the url returned by the Stellar SDK is not the correct one.
+// It replaces the host of the URL returned with the host of the explorer.
+function useConfigHost(url: string): string {
+  const u = new URL(url);
+  u.host = new URL(coinConfig.getCoinConfig().explorer.url).host;
+  return u.toString();
+}
+
 Horizon.AxiosClient.interceptors.response.use(response => {
   if (coinConfig.getCoinConfig().enableNetworkLogs) {
     const { url, method } = response.config;
@@ -74,21 +82,15 @@ Horizon.AxiosClient.interceptors.response.use(response => {
   // included in server responses points to the node itself instead of our reverse proxy...
   // (https://github.com/stellar/js-stellar-sdk/issues/637)
 
-  function fixURL(url: string): string {
-    const u = new URL(url);
-    u.host = new URL(coinConfig.getCoinConfig().explorer.url).host;
-    return u.toString();
-  }
-
   const next_href = response?.data?._links?.next?.href;
 
   if (next_href) {
-    response.data._links.next.href = fixURL(next_href);
+    response.data._links.next.href = useConfigHost(next_href);
   }
 
   response?.data?._embedded?.records?.forEach((r: any) => {
     const href = r.transaction?._links?.ledger?.href;
-    if (href) r.transaction._links.ledger.href = fixURL(href);
+    if (href) r.transaction._links.ledger.href = useConfigHost(href);
   });
 
   return response;

--- a/libs/coin-modules/coin-stellar/src/network/serialization.ts
+++ b/libs/coin-modules/coin-stellar/src/network/serialization.ts
@@ -79,6 +79,7 @@ async function formatOperation(
   addr: string,
 ): Promise<StellarOperation> {
   const transaction = await rawOperation.transaction();
+  const { hash: blockHash, closed_at: blockTime } = await transaction.ledger();
   const type = getOperationType(rawOperation, addr);
   const value = getValue(rawOperation, transaction, type);
   const recipients = getRecipients(rawOperation);
@@ -103,9 +104,10 @@ async function formatOperation(
     recipients,
     transactionSequenceNumber: Number(transaction.source_account_sequence),
     hasFailed: !rawOperation.transaction_successful,
-    blockHash: null,
+    blockHash: blockHash,
     extra: {
       ledgerOpType: type,
+      blockTime: new Date(blockTime),
     },
   };
 

--- a/libs/coin-modules/coin-stellar/src/types/bridge.fixture.ts
+++ b/libs/coin-modules/coin-stellar/src/types/bridge.fixture.ts
@@ -71,6 +71,7 @@ export function createFixtureOperation(operation?: Partial<StellarOperation>): S
   let extra: StellarOperationExtra = {
     assetAmount: operation?.extra?.assetAmount || undefined,
     ledgerOpType: operation?.extra?.ledgerOpType || "IN",
+    blockTime: operation?.extra?.blockTime || faker.date.past(),
   };
   if (operation?.extra?.pagingToken) {
     extra = {

--- a/libs/coin-modules/coin-stellar/src/types/bridge.ts
+++ b/libs/coin-modules/coin-stellar/src/types/bridge.ts
@@ -111,6 +111,7 @@ export type StellarOperationExtra = {
   assetAmount?: string | undefined;
   ledgerOpType: OperationType;
   memo?: string;
+  blockTime: Date;
 };
 
 export type StellarAccount = Account;

--- a/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
@@ -55,6 +55,7 @@ describe("Tezos Api", () => {
         const isSenderOrReceipt =
           operation.senders.includes(address) || operation.recipients.includes(address);
         expect(isSenderOrReceipt).toBeTruthy();
+        expect(operation.block).toBeDefined();
       });
     });
 

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -13,11 +13,10 @@ export type Operation = {
   type: string;
   value: bigint;
   fee: bigint;
-  blockHeight: number;
-  block?: {
-    hash: string;
+  block: {
+    hash?: string;
     height: number;
-    time: Date;
+    time?: Date;
   };
   senders: string[];
   recipients: string[];
@@ -58,7 +57,6 @@ function convertOperation(
     value: BigInt(amount),
     // storageFee for transaction is always present
     fee: BigInt(storageFee ?? 0),
-    blockHeight: block.level,
     block: {
       hash: block.hash,
       height: block.level,

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -1,6 +1,5 @@
 import { tzkt } from "../network";
 import {
-  APIBlock,
   type APIDelegationType,
   type APITransactionType,
   isAPIDelegationType,
@@ -29,21 +28,17 @@ export async function listOperations(
   { lastId, limit }: { lastId?: number; limit?: number },
 ): Promise<[Operation[], number]> {
   const operations = await tzkt.getAccountOperations(address, { lastId, limit });
-  const operationswithBlock = await Promise.all(
+  return [
     operations
       .filter(op => isAPITransactionType(op) || isAPIDelegationType(op))
-      .map(async op => {
-        const block = await tzkt.getBlockByHash(op.block);
-        return convertOperation(address, op, block);
-      }),
-  );
-  return [operationswithBlock, operations.slice(-1)[0].id];
+      .reduce((acc, op) => acc.concat(convertOperation(address, op)), [] as Operation[]),
+    operations.slice(-1)[0].id,
+  ];
 }
 
 function convertOperation(
   address: string,
   operation: APITransactionType | APIDelegationType,
-  block: APIBlock,
 ): Operation {
   const { amount, hash, storageFee, sender, timestamp, type, counter } = operation;
   let targetAddress = "";
@@ -58,9 +53,9 @@ function convertOperation(
     // storageFee for transaction is always present
     fee: BigInt(storageFee ?? 0),
     block: {
-      hash: block.hash,
-      height: block.level,
-      time: new Date(block.timestamp),
+      hash: operation.block,
+      height: operation.level,
+      time: new Date(operation.timestamp),
     },
     senders: [sender?.address ?? ""],
     recipients: [targetAddress],

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -27,6 +27,12 @@ const api = {
       date: new Date(data[0].timestamp),
     };
   },
+  async getBlockByHash(hash: string): Promise<APIBlock> {
+    const { data } = await network<APIBlock>({
+      url: `${getExplorerUrl()}/v1/blocks/${hash}`,
+    });
+    return data;
+  },
   async getAccountByAddress(address: string): Promise<APIAccount> {
     const { data } = await network<APIAccount>({
       url: `${getExplorerUrl()}/v1/accounts/${address}`,

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -27,12 +27,6 @@ const api = {
       date: new Date(data[0].timestamp),
     };
   },
-  async getBlockByHash(hash: string): Promise<APIBlock> {
-    const { data } = await network<APIBlock>({
-      url: `${getExplorerUrl()}/v1/blocks/${hash}`,
-    });
-    return data;
-  },
   async getAccountByAddress(address: string): Promise<APIAccount> {
     const { data } = await network<APIAccount>({
       url: `${getExplorerUrl()}/v1/accounts/${address}`,

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -112,7 +112,6 @@ describe("listOperations", () => {
           type: "Payment",
           value: expectedValue,
           fee: BigInt(10),
-          blockHeight: 1,
           block: {
             hash: "HASH_VALUE_BLOCK",
             height: 1,
@@ -129,7 +128,6 @@ describe("listOperations", () => {
           type: "Payment",
           value: expectedValue,
           fee: BigInt(10),
-          blockHeight: 1,
           block: {
             hash: "HASH_VALUE_BLOCK",
             height: 1,
@@ -149,7 +147,6 @@ describe("listOperations", () => {
           type: "Payment",
           value: expectedValue,
           fee: BigInt(10),
-          blockHeight: 1,
           block: {
             hash: "HASH_VALUE_BLOCK",
             height: 1,

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -41,12 +41,14 @@ describe("listOperations", () => {
       const fee = 10;
       mockGetTransactions.mockResolvedValue([
         {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          close_time_iso: "2000-01-01T00:00:01Z",
           meta: { delivered_amount: deliveredAmount.toString() },
-          tx: {
+          tx_json: {
             TransactionType: "Payment",
             Fee: fee.toString(),
-            hash: "HASH_VALUE",
-            inLedger: 1,
+            ledger_index: 1,
             date: 1000,
             Account: opSender,
             Destination: opDestination,
@@ -54,12 +56,14 @@ describe("listOperations", () => {
           },
         },
         {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          close_time_iso: "2000-01-01T00:00:01Z",
           meta: { delivered_amount: deliveredAmount.toString() },
-          tx: {
+          tx_json: {
             TransactionType: "Payment",
             Fee: fee.toString(),
-            hash: "HASH_VALUE",
-            inLedger: 1,
+            ledger_index: 1,
             date: 1000,
             Account: opSender,
             Destination: opDestination,
@@ -68,12 +72,14 @@ describe("listOperations", () => {
           },
         },
         {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          close_time_iso: "2000-01-01T00:00:01Z",
           meta: { delivered_amount: deliveredAmount.toString() },
-          tx: {
+          tx_json: {
             TransactionType: "Payment",
             Fee: fee.toString(),
-            hash: "HASH_VALUE",
-            inLedger: 1,
+            ledger_index: 1,
             date: 1000,
             Account: opSender,
             Destination: opDestination,
@@ -107,6 +113,11 @@ describe("listOperations", () => {
           value: expectedValue,
           fee: BigInt(10),
           blockHeight: 1,
+          block: {
+            hash: "HASH_VALUE_BLOCK",
+            height: 1,
+            time: new Date("2000-01-01T00:00:01Z"),
+          },
           senders: [opSender],
           recipients: [opDestination],
           date: new Date(1000000 + RIPPLE_EPOCH * 1000),
@@ -119,6 +130,11 @@ describe("listOperations", () => {
           value: expectedValue,
           fee: BigInt(10),
           blockHeight: 1,
+          block: {
+            hash: "HASH_VALUE_BLOCK",
+            height: 1,
+            time: new Date("2000-01-01T00:00:01Z"),
+          },
           senders: [opSender],
           recipients: [opDestination],
           date: new Date(1000000 + RIPPLE_EPOCH * 1000),
@@ -134,6 +150,11 @@ describe("listOperations", () => {
           value: expectedValue,
           fee: BigInt(10),
           blockHeight: 1,
+          block: {
+            hash: "HASH_VALUE_BLOCK",
+            height: 1,
+            time: new Date("2000-01-01T00:00:01Z"),
+          },
           senders: [opSender],
           recipients: [opDestination],
           date: new Date(1000000 + RIPPLE_EPOCH * 1000),

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -45,7 +45,7 @@ async function operations(
   address: string,
   { limit, start }: Pagination,
 ): Promise<[Operation[], number]> {
-  const [ops, index] = await listOperations(address, { limit, mostRecentIndex: start });
+  const [ops, index] = await listOperations(address, { limit, startAt: start ?? 0 });
   return [
     ops.map(op => {
       const { simpleType, blockHash, blockTime, ...rest } = op;

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -48,8 +48,15 @@ async function operations(
   const [ops, index] = await listOperations(address, { limit, mostRecentIndex: start });
   return [
     ops.map(op => {
-      const { simpleType, ...rest } = op;
-      return { ...rest } satisfies Operation;
+      const { simpleType, blockHash, blockTime, ...rest } = op;
+      return {
+        ...rest,
+        block: {
+          height: rest.blockHeight,
+          hash: blockHash,
+          time: blockTime,
+        },
+      } satisfies Operation;
     }),
     index,
   ];

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -48,11 +48,11 @@ async function operations(
   const [ops, index] = await listOperations(address, { limit, startAt: start ?? 0 });
   return [
     ops.map(op => {
-      const { simpleType, blockHash, blockTime, ...rest } = op;
+      const { simpleType, blockHash, blockTime, blockHeight, ...rest } = op;
       return {
         ...rest,
         block: {
-          height: rest.blockHeight,
+          height: blockHeight,
           hash: blockHash,
           time: blockTime,
         },

--- a/libs/coin-modules/coin-xrp/src/bridge/synchronization.test.ts
+++ b/libs/coin-modules/coin-xrp/src/bridge/synchronization.test.ts
@@ -78,12 +78,13 @@ describe("getAccountShape", () => {
     });
     mockGetTransactions.mockResolvedValue([
       {
+        ledger_hash: "HASH_VALUE_BLOCK",
+        hash: "HASH_VALUE",
         meta: { delivered_amount: "100" },
-        tx: {
+        tx_json: {
           TransactionType: "Payment",
           Fee: "10",
-          hash: "HASH_VALUE",
-          inLedger: 1,
+          ledger_index: 1,
           date: 1000,
           Account: "account_addr",
           Destination: "destination_addr",
@@ -117,7 +118,7 @@ describe("getAccountShape", () => {
       operations: [
         {
           accountId: "js:2:ripple:address:",
-          blockHash: null,
+          blockHash: "HASH_VALUE_BLOCK",
           blockHeight: 1,
           date: new Date("2000-01-01T00:16:40.000Z"),
           hash: "HASH_VALUE",

--- a/libs/coin-modules/coin-xrp/src/bridge/synchronization.ts
+++ b/libs/coin-modules/coin-xrp/src/bridge/synchronization.ts
@@ -74,7 +74,7 @@ async function filterOperations(
         type: op.simpleType,
         value: new BigNumber(op.value.toString()),
         fee: new BigNumber(op.fee.toString()),
-        blockHash: null,
+        blockHash: op.blockHash,
         blockHeight: op.blockHeight,
         senders: op.senders,
         recipients: op.recipients,

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.test.ts
@@ -39,12 +39,14 @@ describe("listOperations", () => {
       const fee = 10;
       mockGetTransactions.mockResolvedValue([
         {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          close_time_iso: "2000-01-01T00:00:01Z",
           meta: { delivered_amount: deliveredAmount.toString() },
-          tx: {
+          tx_json: {
             TransactionType: "Payment",
             Fee: fee.toString(),
-            hash: "HASH_VALUE",
-            inLedger: 1,
+            ledger_index: 1,
             date: 1000,
             Account: opSender,
             Destination: opDestination,
@@ -52,12 +54,14 @@ describe("listOperations", () => {
           },
         },
         {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          close_time_iso: "2000-01-01T00:00:01Z",
           meta: { delivered_amount: deliveredAmount.toString() },
-          tx: {
+          tx_json: {
             TransactionType: "Payment",
             Fee: fee.toString(),
-            hash: "HASH_VALUE",
-            inLedger: 1,
+            ledger_index: 1,
             date: 1000,
             Account: opSender,
             Destination: opDestination,
@@ -66,12 +70,14 @@ describe("listOperations", () => {
           },
         },
         {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          close_time_iso: "2000-01-01T00:00:01Z",
           meta: { delivered_amount: deliveredAmount.toString() },
-          tx: {
+          tx_json: {
             TransactionType: "Payment",
             Fee: fee.toString(),
-            hash: "HASH_VALUE",
-            inLedger: 1,
+            ledger_index: 1,
             date: 1000,
             Account: opSender,
             Destination: opDestination,
@@ -106,6 +112,8 @@ describe("listOperations", () => {
           value: expectedValue,
           fee: BigInt(10),
           blockHeight: 1,
+          blockHash: "HASH_VALUE_BLOCK",
+          blockTime: new Date("2000-01-01T00:00:01Z"),
           senders: [opSender],
           recipients: [opDestination],
           date: new Date(1000000 + RIPPLE_EPOCH * 1000),
@@ -119,6 +127,8 @@ describe("listOperations", () => {
           value: expectedValue,
           fee: BigInt(10),
           blockHeight: 1,
+          blockHash: "HASH_VALUE_BLOCK",
+          blockTime: new Date("2000-01-01T00:00:01Z"),
           senders: [opSender],
           recipients: [opDestination],
           date: new Date(1000000 + RIPPLE_EPOCH * 1000),
@@ -135,6 +145,8 @@ describe("listOperations", () => {
           value: expectedValue,
           fee: BigInt(10),
           blockHeight: 1,
+          blockHash: "HASH_VALUE_BLOCK",
+          blockTime: new Date("2000-01-01T00:00:01Z"),
           senders: [opSender],
           recipients: [opDestination],
           date: new Date(1000000 + RIPPLE_EPOCH * 1000),

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
@@ -58,16 +58,16 @@ export async function listOperations(
   do {
     const newTransactions = await getTransactions(address, options);
     const newPaymentsTxs = newTransactions.filter(tx => tx.tx_json.TransactionType === "Payment");
-
-    needToStop = options.limit ? newTransactions.length < options.limit : true;
-
+    if (options.limit) {
+      needToStop = newTransactions.length < options.limit;
+      options.ledger_index_max = newTransactions.slice(-1)[0].tx_json.ledger_index - 1;
+    }
     transactions = transactions.concat(newPaymentsTxs);
   } while (
     options.limit &&
     !needToStop &&
     transactions.length < options.limit &&
-    (options.limit -= transactions.length) &&
-    (options.ledger_index_max = transactions.slice(-1)[0].tx_json.ledger_index - 1)
+    (options.limit -= transactions.length)
   );
 
   return [

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
@@ -47,9 +47,9 @@ export async function listOperations(
 
   return [
     transactions
-      .filter(op => op.tx.TransactionType === "Payment")
+      .filter(op => op.tx_json.TransactionType === "Payment")
       .map(convertToCoreOperation(address)),
-    transactions.slice(-1)[0].tx.ledger_index - 1, // Returns the next index to start from for pagination
+    transactions.slice(-1)[0].tx_json.ledger_index - 1, // Returns the next index to start from for pagination
   ];
 }
 
@@ -57,18 +57,20 @@ const convertToCoreOperation =
   (address: string) =>
   (operation: XrplOperation): XrpOperation => {
     const {
+      ledger_hash,
+      hash,
+      close_time_iso,
       meta: { delivered_amount },
-      tx: {
+      tx_json: {
         TransactionType,
         Fee,
-        hash,
-        inLedger,
         date,
         Account,
         Destination,
         DestinationTag,
         Sequence,
         Memos,
+        ledger_index,
       },
     } = operation;
 
@@ -112,13 +114,15 @@ const convertToCoreOperation =
     }
 
     let op: XrpOperation = {
+      blockTime: new Date(close_time_iso),
+      blockHash: ledger_hash,
       hash,
       address,
       type: TransactionType,
       simpleType: type,
       value,
       fee,
-      blockHeight: inLedger,
+      blockHeight: ledger_index,
       senders: [Account],
       recipients: [Destination],
       date: new Date(toEpochDate),

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
@@ -39,7 +39,7 @@ export async function listOperations(
     options = {
       ...options,
       // if there is no ops, it might be after a clear and we prefer to pull from the oldest possible history
-      ledger_index_min: Math.max(startAt ?? 0, minLedgerVersion),
+      ledger_index_min: Math.max(startAt, minLedgerVersion),
     };
   }
 
@@ -47,7 +47,6 @@ export async function listOperations(
 
   return [
     transactions
-      .filter(op => op.tx_json.TransactionType === "Payment")
       .map(convertToCoreOperation(address)),
     transactions.slice(-1)[0].tx_json.ledger_index - 1, // Returns the next index to start from for pagination
   ];

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -68,12 +68,13 @@ export const getServerInfos = async (): Promise<ServerInfoResponse> => {
 
 export const getTransactions = async (
   address: string,
-  options: { ledger_index_min?: number; ledger_index_max?: number; limit?: number } | undefined,
+  options: { ledger_index_min?: number; ledger_index_max?: number; limit?: number} | undefined,
 ): Promise<XrplOperation[]> => {
   const result = await rpcCall<AccountTxResponse>("account_tx", {
     account: address,
     ledger_index: "validated",
     ...options,
+    api_version: 2,
   });
 
   return result.transactions;

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -74,7 +74,6 @@ export const getTransactions = async (
     account: address,
     ...options,
     api_version: 2,
-    tx_type: "Payment",
   });
 
   return result.transactions;

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -68,13 +68,13 @@ export const getServerInfos = async (): Promise<ServerInfoResponse> => {
 
 export const getTransactions = async (
   address: string,
-  options: { ledger_index_min?: number; ledger_index_max?: number; limit?: number} | undefined,
+  options: { ledger_index_min?: number; ledger_index_max?: number; limit?: number } | undefined,
 ): Promise<XrplOperation[]> => {
   const result = await rpcCall<AccountTxResponse>("account_tx", {
     account: address,
-    ledger_index: "validated",
     ...options,
     api_version: 2,
+    tx_type: "Payment",
   });
 
   return result.transactions;
@@ -110,7 +110,7 @@ async function rpcCall<T extends object>(
   });
 
   if (isResponseStatus(result) && result.status !== "success") {
-    throw new Error(`couldn't fetch ${method} with params ${params}`);
+    throw new Error(`couldn't fetch ${method} with params ${JSON.stringify(params)}`);
   }
 
   return result;

--- a/libs/coin-modules/coin-xrp/src/network/types.ts
+++ b/libs/coin-modules/coin-xrp/src/network/types.ts
@@ -1,4 +1,7 @@
 export type XrplOperation = {
+  ledger_hash: string;
+  hash: string;
+  close_time_iso: string;
   meta: {
     AffectedNodes: {
       ModifiedNode: {
@@ -22,7 +25,7 @@ export type XrplOperation = {
     TransactionResult: string;
     delivered_amount: string;
   };
-  tx: {
+  tx_json: {
     Account: string;
     Amount: string;
     DeliverMax: string;
@@ -44,8 +47,6 @@ export type XrplOperation = {
     TransactionType: string;
     TxnSignature: string;
     date: number;
-    hash: string;
-    inLedger: number;
     ledger_index: number;
   };
   validated: boolean;

--- a/libs/coin-modules/coin-xrp/src/types/model.ts
+++ b/libs/coin-modules/coin-xrp/src/types/model.ts
@@ -11,6 +11,8 @@ export type XrpMemo = {
   type?: string;
 };
 export type XrpOperation = {
+  blockTime: Date;
+  blockHash: string;
   hash: string;
   address: string;
   type: string;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - an extra field named `block` on the `Operation` object returned by the coin framework for `stellar`, `tezos` and `xrp`

### 📝 Description

Update `listOperations` for the coins module `stellar`, `tezos` and `xrp`. This change is needed because we need extra information about the block for each operation (the time and the hash of the block)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
