### PR TITLE
[QAA-396][Detox] Fix flaky manager/onboarding tests

### DIFF
--- a/apps/ledger-live-mobile/e2e/helpers.ts
+++ b/apps/ledger-live-mobile/e2e/helpers.ts
@@ -31,17 +31,14 @@ function sync_delay(ms: number) {
   Atomics.wait(done, 0, 0, ms); // Wait for the specified duration
 }
 
-export async function waitForElementById(id: string | RegExp, timeout: number = DEFAULT_TIMEOUT) {
-  return await waitFor(element(by.id(id)))
+export function waitForElementById(id: string | RegExp, timeout: number = DEFAULT_TIMEOUT) {
+  return waitFor(element(by.id(id)))
     .toBeVisible()
     .withTimeout(timeout);
 }
 
-export async function waitForElementByText(
-  text: string | RegExp,
-  timeout: number = DEFAULT_TIMEOUT,
-) {
-  return await waitFor(element(by.text(text)))
+export function waitForElementByText(text: string | RegExp, timeout: number = DEFAULT_TIMEOUT) {
+  return waitFor(element(by.text(text)))
     .toBeVisible()
     .withTimeout(timeout);
 }

--- a/apps/ledger-live-mobile/e2e/page/common.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/common.page.ts
@@ -31,6 +31,7 @@ export default class CommonPage {
   addDeviceButton = () => getElementById("connect-with-bluetooth");
   scannedDeviceRow = (id: string) => `device-scanned-${id}`;
   pluggedDeviceRow = (nano: DeviceUSB) => `device-item-usb|${JSON.stringify(nano)}`;
+  blePairingLoadingId = "ble-pairing-loading";
   deviceRowRegex = /device-item-.*/;
 
   @Step("Perform search")
@@ -88,8 +89,8 @@ export default class CommonPage {
     await bridge.addDevicesBT(device);
     await waitForElementById(this.scannedDeviceRow(device.id));
     await tapById(this.scannedDeviceRow(device.id));
+    await waitForElementById(this.blePairingLoadingId);
     await bridge.open();
-    await deviceAction.waitForSpinner();
     await deviceAction.accessManager();
   }
 

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/BleDevicePairing.tsx
@@ -169,7 +169,14 @@ const BleDevicePairing = ({ deviceToPair, onPaired, onRetry }: BleDevicePairingP
         <Flex width="100%" py={16} alignItems="center">
           <Flex height={100} justifyContent="center">
             <BoxedIcon
-              Icon={<InfiniteLoader color="primary.c80" size={32} mock={Config.DETOX} />}
+              Icon={
+                <InfiniteLoader
+                  color="primary.c80"
+                  size={32}
+                  mock={Config.DETOX}
+                  testID="ble-pairing-loading"
+                />
+              }
               backgroundColor={colors.opacityDefault.c05}
               size={64}
               variant="circle"

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -884,11 +884,9 @@ export function renderLoading({
   return (
     <Wrapper>
       <SpinnerContainer>
-        <InfiniteLoader mock={Config.DETOX} />
+        <InfiniteLoader mock={Config.DETOX} testID="device-action-loading" />
       </SpinnerContainer>
-      <CenteredText testID="device-action-loading">
-        {description ?? t("DeviceAction.loading")}
-      </CenteredText>
+      <CenteredText>{description ?? t("DeviceAction.loading")}</CenteredText>
       {lockModal ? <ModalLock /> : null}
     </Wrapper>
   );

--- a/libs/ui/packages/native/src/components/Loader/InfiniteLoader/index.tsx
+++ b/libs/ui/packages/native/src/components/Loader/InfiniteLoader/index.tsx
@@ -31,6 +31,7 @@ export default function InfiniteLoader({
   size = 38,
   color = "primary.c50",
   mock = false,
+  testID = "",
   ...extraProps
 }: Props): JSX.Element {
   const rotation = useSharedValue(0);
@@ -59,6 +60,7 @@ export default function InfiniteLoader({
   return (
     <Animated.View
       style={[{ display: "flex", justifyContent: "center", alignItems: "center" }, animatedStyles]}
+      testID={testID}
     >
       <Loader
         size={size}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM Manager / Onboarding Tests

### 📝 Description

_We were not waiting for the BLE Scanning loader and as react native upgrade broke iOS tests synchronisation, the open bridge message was send too soon, provoking flakiness_

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
