### PR TITLE
Updating method to get the last appVersion - Speculos e2e

### DIFF
--- a/.changeset/pink-bats-attack.md
+++ b/.changeset/pink-bats-attack.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Updating method to get Speculos app - e2e testing

--- a/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
@@ -10,7 +10,7 @@ const e2eDelegationAccounts = [
   {
     delegate: new Delegate(Account.ATOM_1, "0.001", "Ledger"),
     xrayTicket: "B2CQA-2740, B2CQA-2770",
-    bugLing: "LIVE-14501",
+    bugTicket: "LIVE-14501",
   },
   {
     delegate: new Delegate(Account.SOL_1, "0.001", "Ledger by Figment"),
@@ -38,6 +38,7 @@ const validators = [
   {
     delegate: new Delegate(Account.ADA_1, "0.01", "LBF3 - Ledger by Figment 3"),
     xrayTicket: "B2CQA-2766",
+    bugTicket: "LIVE-15536",
   },
   {
     delegate: new Delegate(Account.MULTIVERS_X_1, "1", "Ledger by Figment"),
@@ -72,12 +73,12 @@ test.describe("Delegate flows", () => {
         {
           annotation: [
             { type: "TMS", description: account.xrayTicket },
-            { type: "BUG", description: account.bugLing },
+            { type: "BUG", description: account.bugTicket },
           ],
         },
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-          if (account.bugLing) {
+          if (account.bugTicket) {
             await addBugLink(getDescription(test.info().annotations, "BUG").split(", "));
           }
 
@@ -133,10 +134,16 @@ test.describe("Delegate flows", () => {
       test(
         `[${validator.delegate.account.currency.name}] - Select validator`,
         {
-          annotation: { type: "TMS", description: validator.xrayTicket },
+          annotation: [
+            { type: "TMS", description: validator.xrayTicket },
+            { type: "BUG", description: validator.bugTicket },
+          ],
         },
         async ({ app }) => {
           await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+          if (validator.bugTicket) {
+            await addBugLink(getDescription(test.info().annotations, "BUG").split(", "));
+          }
 
           await app.layout.goToAccounts();
           await app.accounts.navigateToAccountByName(validator.delegate.account.accountName);

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -277,7 +277,11 @@ export async function startSpeculos(
   const { model } = appQuery;
   const { dependencies } = spec;
   const newAppQuery = dependencies?.map(dep => {
-    return findLatestAppCandidate(appCandidates, { model, appName: dep.name });
+    return findLatestAppCandidate(appCandidates, {
+      model,
+      appName: dep.name,
+      firmware: appCandidate?.firmware,
+    });
   });
   const appVersionMap = new Map(newAppQuery?.map(app => [app?.appName, app?.appVersion]));
   dependencies?.forEach(dependency => {

--- a/libs/ledger-live-common/src/load/speculos.ts
+++ b/libs/ledger-live-common/src/load/speculos.ts
@@ -132,8 +132,7 @@ export const findLatestAppCandidate = (
   if (apps.length === 0) {
     return null;
   }
-
-  apps = apps.sort((a, b) => semver.rcompare(a.appVersion, b.appVersion));
+  apps = apps.sort((a, b) => semver.compare(b.appVersion, a.appVersion));
   return apps[0];
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR updates the method for retrieving the latest version of the app. The new implementation now takes into account the firmware version, ensuring that the app version corresponds correctly with the firmware in use.

This update fixes the timeout issue.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-368](https://ledgerhq.atlassian.net/browse/QAA-368)
- ci run: [Run](https://github.com/LedgerHQ/ledger-live/actions/runs/12464979636)
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-368]: https://ledgerhq.atlassian.net/browse/QAA-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ