### PR TITLE
fix :bug:(llm) ios splashscreen

### DIFF
--- a/.changeset/loud-masks-relate.md
+++ b/.changeset/loud-masks-relate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Restore IOS launchscreen

--- a/apps/ledger-live-mobile/ios/LaunchScreen.storyboard
+++ b/apps/ledger-live-mobile/ios/LaunchScreen.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,7 +11,7 @@
         <!--View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" sceneMemberID="viewController">
+                <viewController useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/AppDelegate.mm
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/AppDelegate.mm
@@ -1,14 +1,11 @@
 #import "AppDelegate.h"
-
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTLinkingManager.h>
 #import <React/RCTRootView.h>
 #import "RNCConfig.h"
-#import "RNSplashScreen.h"  // here
 #import <BrazeKit/BrazeKit-Swift.h>
 #import "BrazeReactUtils.h"
 #import "BrazeReactBridge.h"
-
 #import <Firebase.h>
 
 
@@ -26,20 +23,18 @@ static NSString *const iOSPushAutoEnabledKey = @"iOSPushAutoEnabled";
   // Retrieve the correct GoogleService-Info.plist file name for a given environment
   NSString *googleServiceInfoEnvName = [RNCConfig envFor:@"GOOGLE_SERVICE_INFO_NAME"];
   NSString *googleServiceInfoName = googleServiceInfoEnvName;
-  
   if ([googleServiceInfoName length] == 0) {
     googleServiceInfoName = @"GoogleService-Info";
   }
-  
+
   // Initialize Firebase with the correct GoogleService-Info.plist file
   NSString *filePath = [[NSBundle mainBundle] pathForResource:googleServiceInfoName ofType:@"plist"];
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
   [FIRApp configureWithOptions:options];
-  
+
   // Setup Braze
   NSString *brazeApiKeyFromEnv = [RNCConfig envFor:@"BRAZE_IOS_API_KEY"];
   NSString *brazeCustomEndpointFromEnv = [RNCConfig envFor:@"BRAZE_CUSTOM_ENDPOINT"];
-
   BRZConfiguration *configuration = [[BRZConfiguration alloc] initWithApiKey:brazeApiKeyFromEnv endpoint:brazeCustomEndpointFromEnv];
   configuration.triggerMinimumTimeInterval = 1;
   configuration.logger.level = BRZLoggerLevelInfo;
@@ -51,8 +46,7 @@ static NSString *const iOSPushAutoEnabledKey = @"iOSPushAutoEnabled";
   }
   if (pushAutoEnabled) {
     NSLog(@"iOS Push Auto enabled.");
-    configuration.push.automation =
-        [[BRZConfigurationPushAutomation alloc] initEnablingAllAutomations:YES];
+    configuration.push.automation = [[BRZConfigurationPushAutomation alloc] initEnablingAllAutomations:YES];
     configuration.push.automation.requestAuthorizationAtLaunch = NO;
   }
 
@@ -66,7 +60,7 @@ static NSString *const iOSPushAutoEnabledKey = @"iOSPushAutoEnabled";
   }
 
   [[BrazeReactUtils sharedInstance] populateInitialUrlFromLaunchOptions:launchOptions];
-    
+
   BOOL appLaunched = [super application:application didFinishLaunchingWithOptions:launchOptions];
   // This condition is needed to prevent a crash since upgrading to React Native 0.75.4
   // It may be fixed in a later version of React Native
@@ -76,14 +70,20 @@ static NSString *const iOSPushAutoEnabledKey = @"iOSPushAutoEnabled";
   }
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                               moduleName:@"ledgerlivemobile"
-                                               initialProperties:nil];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"ledgerlivemobile" initialProperties:nil];
+
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  self.window.rootViewController = [UIViewController new];
   [self.window makeKeyAndVisible];
-  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
+
+  UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:[NSBundle mainBundle]];
   UIViewController *vc = [sb instantiateInitialViewController];
+
   rootView.loadingView = vc.view;
-  
+
+
+  self.window.rootViewController.view = rootView;
 
   return YES;
 }
@@ -152,23 +152,23 @@ static Braze *_braze;
   blurEffectView.frame = [self.window bounds];
   blurEffectView.tag = 12345;
   logoView.tag = 12346;
-  
+
   blurEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
   [self.window addSubview:blurEffectView];
   [self.window addSubview:logoView];
   [self.window bringSubviewToFront:logoView];
-  
+
   [logoView setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisHorizontal];
   [logoView setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisVertical];
   logoView.frame = CGRectMake(0, 0, 128, 128);
-  
+
   logoView.center = CGPointMake(self.window.frame.size.width  / 2,self.window.frame.size.height / 2);
 }
 
 - (void) hideOverlay{
   UIView *blurEffectView = [self.window viewWithTag:12345];
   UIView *logoView = [self.window viewWithTag:12346];
-  
+
   [UIView animateWithDuration:0.5 animations:^{
     blurEffectView.alpha = 0;
     logoView.alpha = 0;

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/Info.plist
@@ -118,7 +118,7 @@
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen.storyboard</string>
+	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - IOS config

### 📝 Description

Fix IOS splashscreen. It wasn't working due to missconfig. 
In dev there is a little white/black screen after the launchscreen due to metro loading

We can't use RNSplashScreen since there is known issue with detox. Also it looks quite better to handle this in the native part. 



It doesn't look perfect but this will be reworked a day. So for the moment I leave the existing one what it's better than just a white or black screen

https://github.com/user-attachments/assets/de0a66d2-9ca3-48a5-8a04-bb18954fbacb


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-13154](https://ledgerhq.atlassian.net/browse/LIVE-13154)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-13154]: https://ledgerhq.atlassian.net/browse/LIVE-13154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ