### PR TITLE
chore: tests

### DIFF
--- a/libs/ledger-live-common/src/exchange/providers/swap.integration.test.ts
+++ b/libs/ledger-live-common/src/exchange/providers/swap.integration.test.ts
@@ -188,7 +188,7 @@ describe("fetchAndMergeProviderData", () => {
         useInExchangeApp: false,
         mainUrl: "https://uniswap.org/",
         needsKYC: false,
-        supportUrl: "mailto:support@uniswap.org",
+        supportUrl: "https://support.uniswap.org/hc/en-us/requests/new",
         termsOfUseUrl:
           "https://support.uniswap.org/hc/en-us/articles/30935100859661-Uniswap-Labs-Terms-of-Service",
         type: "DEX",

--- a/libs/ledger-services/cal/src/partners/default.ts
+++ b/libs/ledger-services/cal/src/partners/default.ts
@@ -83,7 +83,7 @@ export const SWAP_DATA_CDN: Record<string, AdditionalProviderConfig> = {
     displayName: "Uniswap",
     termsOfUseUrl:
       "https://support.uniswap.org/hc/en-us/articles/30935100859661-Uniswap-Labs-Terms-of-Service",
-    supportUrl: "mailto:support@uniswap.org",
+    supportUrl: "https://support.uniswap.org/hc/en-us/requests/new",
     mainUrl: "https://uniswap.org/",
     needsKYC: false,
   },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
