### PR TITLE
fix: wait for providers parsing process before pressing on crypto item in receive flow

### DIFF
--- a/.changeset/wicked-camels-joke.md
+++ b/.changeset/wicked-camels-joke.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+the fix (like Add account v2) is using a loading mechanism with 4 state and plug it to the state so that we will be having the right screen order: SelectCrypto -> SelectNetwork -> SelectAccount


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Deeplinks entrypoint for receive flow is a SelectCrypto component that intercepts the currency, fetch for a potential network provider via `useGroupedCurrenciesByProvider` common hook  and then perform an explicit navigation to the network page if there is more than 1 network. 
This processing occurs actually on a useEffect level: 

```
  useEffect(() => {
    if (paramsCurrency) {
      const selectedCurrency = findCryptoCurrencyByKeyword(paramsCurrency.toUpperCase());

      if (selectedCurrency) {
        onPressItem(selectedCurrency);
      }
    }
  }, [onPressItem, paramsCurrency]);

````

What's happening is if the user has already scanned a network based currency before, the first effect that will trigger the `onPressItem(selectedCurrency)` wont wait for  `useGroupedCurrenciesByProvider` result, and while `useGroupedCurrenciesByProvider` processing is a little bit costly, it will return the providers after the first effect and trigger a second one.  

So we got SelectCrypto -> SelectAccount page and then SelectNetwork.


https://github.com/user-attachments/assets/67a981b0-4aad-4e6a-8174-a3ed193409c5



While the effect has no idea about the completion of the `useGroupedCurrenciesByProvider` business logic, it will be triggered twice. So the fix (like Add account v2)  is using a loading mechanism with 4 state and plug it to the state so that we will be having the right screen order: SelectCrypto -> SelectNetwork -> SelectAccount. 


https://github.com/user-attachments/assets/764ad5e8-e59f-4923-a943-cc9503de593c

This solution is adapted to the way the navigator configuration and Deeplink single entrypoint. 

See DeeplinkProviders configuration. 

We can't perform a fetch of network at deeplink provider level as it will be costly for all other deeplinks. 

For reviewer testing: you need to build the common lib via `pnpm common build` before performing tests.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-15385
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
