### PR TITLE
Support/chang hardfork bis

### DIFF
--- a/.changeset/perfect-schools-pretend.md
+++ b/.changeset/perfect-schools-pretend.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": minor
+---
+
+Disable auto withdrawal of rewards as a workaround for the upcoming Cardano hard fork

--- a/libs/coin-modules/coin-cardano/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-cardano/src/buildTransaction.ts
@@ -5,13 +5,11 @@ import {
 } from "@stricahq/typhonjs";
 import BigNumber from "bignumber.js";
 import type { TokenAccount } from "@ledgerhq/types-live";
-import { RewardAddress } from "@stricahq/typhonjs/dist/address";
 import {
   getAccountStakeCredential,
   getBaseAddress,
   getTTL,
   mergeTokens,
-  isTestnet,
   isProtocolParamsValid,
 } from "./logic";
 import { decodeTokenAssetId, decodeTokenCurrencyId, getTokenAssetId } from "./buildSubAccounts";
@@ -44,28 +42,34 @@ function getTyphonInputFromUtxo(utxo: CardanoOutput): TyphonTypes.Input {
   };
 }
 
-function getRewardWithdrawalCertificate(account: CardanoAccount): TyphonTypes.Withdrawal | null {
-  if (!account.cardanoResources.delegation?.rewards.gt(0)) {
-    return null;
-  }
+function getRewardWithdrawalCertificate(_account: CardanoAccount): TyphonTypes.Withdrawal | null {
+  return null;
 
-  const stakeCredential = getAccountStakeCredential(account.xpub as string, account.index);
-  const stakeKeyHashCredential: TyphonTypes.HashCredential = {
-    hash: Buffer.from(stakeCredential.key, "hex"),
-    type: TyphonTypes.HashType.ADDRESS,
-    bipPath: stakeCredential.path,
-  };
+  /**
+   * Disable rewards withdraw certificate, as a work around for Chang 2 hard fork
+   */
 
-  const networkId = isTestnet(account.currency)
-    ? TyphonTypes.NetworkId.TESTNET
-    : TyphonTypes.NetworkId.MAINNET;
-  const rewardAddress = new RewardAddress(networkId, stakeKeyHashCredential);
-  const rewardsWithdrawalCertificate: TyphonTypes.Withdrawal = {
-    rewardAccount: rewardAddress,
-    amount: account.cardanoResources.delegation.rewards,
-  };
+  // if (!account.cardanoResources.delegation?.rewards.gt(0)) {
+  //   return null;
+  // }
 
-  return rewardsWithdrawalCertificate;
+  // const stakeCredential = getAccountStakeCredential(account.xpub as string, account.index);
+  // const stakeKeyHashCredential: TyphonTypes.HashCredential = {
+  //   hash: Buffer.from(stakeCredential.key, "hex"),
+  //   type: TyphonTypes.HashType.ADDRESS,
+  //   bipPath: stakeCredential.path,
+  // };
+
+  // const networkId = isTestnet(account.currency)
+  //   ? TyphonTypes.NetworkId.TESTNET
+  //   : TyphonTypes.NetworkId.MAINNET;
+  // const rewardAddress = new RewardAddress(networkId, stakeKeyHashCredential);
+  // const rewardsWithdrawalCertificate: TyphonTypes.Withdrawal = {
+  //   rewardAccount: rewardAddress,
+  //   amount: account.cardanoResources.delegation.rewards,
+  // };
+
+  // return rewardsWithdrawalCertificate;
 }
 
 const buildSendTokenTransaction = async ({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Original PR: https://github.com/LedgerHQ/ledger-live/pull/8770

With the upcoming Cardano hard fork every Cardano wallet will be required to participate in governance by selecting a DRep and without doing so they won't be able to withdraw the rewards.

The current implementation has auto withdrawal of the rewards, which will break after the hard fork. This is a work around PR so users can continue using their wallet as normal with their rewards being locked until the DRep feature gets implemented to Ledger Live.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: LIVE-15541


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
