### PR TITLE
[Coin-Module] Fix XRP pagination issue

### DIFF
--- a/libs/coin-modules/coin-xrp/package.json
+++ b/libs/coin-modules/coin-xrp/package.json
@@ -134,6 +134,7 @@
     "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --cache",
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
+    "test-watch": "jest --watch",
     "test-integ": "DOTENV_CONFIG_PATH=.env.integ.test jest --config=jest.integ.config.js",
     "typecheck": "tsc --noEmit",
     "unimported": "unimported"

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -45,7 +45,12 @@ async function operations(
   address: string,
   { limit, start }: Pagination,
 ): Promise<[Operation[], number]> {
-  const [ops, index] = await listOperations(address, { limit, startAt: start ?? 0 });
+  const options: {
+    limit?: number;
+    minHeight?: number;
+  } = { limit: limit };
+  if (start) options.minHeight = start;
+  const [ops, index] = await listOperations(address, options);
   return [
     ops.map(op => {
       const { simpleType, blockHash, blockTime, blockHeight, ...rest } = op;

--- a/libs/coin-modules/coin-xrp/src/bridge/synchronization.ts
+++ b/libs/coin-modules/coin-xrp/src/bridge/synchronization.ts
@@ -63,7 +63,7 @@ async function filterOperations(
   address: string,
   blockHeight: number,
 ): Promise<Operation[]> {
-  const [operations, _] = await listOperations(address, { startAt: blockHeight });
+  const [operations, _] = await listOperations(address, { minHeight: blockHeight });
 
   return operations.map(
     op =>

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -72,10 +72,12 @@ export const getTransactions = async (
 ): Promise<XrplOperation[]> => {
   const result = await rpcCall<AccountTxResponse>("account_tx", {
     account: address,
+    // newest first
+    // note that order within the results is not guaranteed (see documentation of account_tx)
+    forward: false,
     ...options,
     api_version: 2,
   });
-
   return result.transactions;
 };
 
@@ -91,7 +93,7 @@ export async function getLedgerIndex(): Promise<number> {
 
 async function rpcCall<T extends object>(
   method: string,
-  params: Record<string, string | number>,
+  params: Record<string, string | number | boolean> = {},
 ): Promise<T> {
   const {
     data: { result },


### PR DESCRIPTION
Follow up of [@ae713b20c1da18ef33beb730f41fb3ea2990e44](https://github.com/LedgerHQ/ledger-live/commit/2ae713b20c1da18ef33beb730f41fb3ea2990e44)

Fix 2 issues:
1. gracefully handle case where no results are returned (npe)
2. iterate properly over pages (some txs were skipped)

Refactored the code to be a bit less mutable.