### PR TITLE
feat :lipstick:(llm): change add accounts button logic

### DIFF
--- a/.changeset/five-waves-attend.md
+++ b/.changeset/five-waves-attend.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Change logic on portfolio assets to display add account button

--- a/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/PortfolioAssets.tsx
@@ -94,8 +94,7 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
     [startNavigationTTITimer, showAssets, isAccountListUIEnabled, navigation],
   );
 
-  const showAddAccountButton =
-    isAccountListUIEnabled && showAccounts && distribution.list.length >= maxItemsToDysplay;
+  const showAddAccountButton = isAccountListUIEnabled && showAccounts;
 
   return (
     <>
@@ -119,20 +118,24 @@ const PortfolioAssets = ({ hideEmptyTokenAccount, openAddModal }: Props) => {
       ) : (
         <Assets assets={assetsToDisplay} />
       )}
-      {showAddAccountButton ? <AddAccountButton sourceScreenName="Wallet" /> : null}
-      {distribution.list.length < maxItemsToDysplay ? (
-        <Button
-          type="shade"
-          size="large"
-          outline
-          mt={6}
-          iconPosition="left"
-          Icon={IconsLegacy.PlusMedium}
-          onPress={openAddModal}
-        >
-          {t("account.emptyState.addAccountCta")}
-        </Button>
+      {showAddAccountButton ? (
+        <AddAccountButton sourceScreenName="Wallet" />
       ) : (
+        distribution.list.length === 0 && (
+          <Button
+            type="shade"
+            size="large"
+            outline
+            mt={6}
+            iconPosition="left"
+            Icon={IconsLegacy.PlusMedium}
+            onPress={openAddModal}
+          >
+            {t("account.emptyState.addAccountCta")}
+          </Button>
+        )
+      )}
+      {distribution.list.length >= maxItemsToDysplay && (
         <Button type="shade" size="large" outline onPress={onPressButton}>
           {showAssets ? t("portfolio.seeAllAssets") : t("portfolio.seeAllAccounts")}
         </Button>

--- a/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/portfolioAssets.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Portfolio/__integrations__/portfolioAssets.integration.test.tsx
@@ -56,7 +56,7 @@ describe("portfolioAssets", () => {
     // FIXME this is not visible in the test after the animation. It seems that the useSharedValue are not updated in the test environment so cronos 2 is always not visible even if it should be visible.
   });
 
-  it("should hide see all button and display add account button because there is less than 5 assets", async () => {
+  it("should hide see all button because there is less than 5 assets", async () => {
     const { user } = render(
       <TestNavigator>
         <PortfolioAssets hideEmptyTokenAccount={false} openAddModal={() => null} />
@@ -71,7 +71,8 @@ describe("portfolioAssets", () => {
 
     expect(await screen.getByTestId("AssetsList")).toBeVisible();
     expect(screen.queryByText(/see all assets/i)).toBeNull();
-    expect(screen.getByText(/add account/i)).toBeVisible();
+    expect(screen.queryByText(/add account/i)).toBeNull();
+    expect(screen.queryByText(/add new or existing account/i)).toBeNull();
 
     await user.press(screen.getByText(/accounts/i));
 
@@ -81,6 +82,8 @@ describe("portfolioAssets", () => {
     });
 
     expect(screen.queryByText(/see all accounts/i)).toBeNull();
+    expect(screen.queryByText(/add account/i)).toBeNull();
+    expect(screen.queryByText(/add new or existing account/i)).toBeVisible();
 
     await user.press(screen.getByText(/assets/i));
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - new accounts list add account

### 📝 Description

Change add account button apparition on portfolio screen with the new accounts list
Update inte test in consequence 

No button on assets list if less than 5 assets 
See all assets if equal or more than 5 assets
Add account button on accounts list
See all accounts button if equal or more than 5 accounts
If nothing default add account button
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15678](https://ledgerhq.atlassian.net/browse/LIVE-15678) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15678]: https://ledgerhq.atlassian.net/browse/LIVE-15678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ