### PR TITLE
Run pr-build-and-test on merge queue

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -1,5 +1,7 @@
 name: "[PR] Build and Test"
 on:
+  merge_group:
+    types: [checks_requested]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Part of https://ledgerhq.atlassian.net/browse/LIVE-14748

Updates our workflows so that ~`build-and-test-pr` workflows are run on Github runners if the triggering event is a merge queue group.~ the `build-and-test-pr` job runs on merge group, clearing the merge queue. 

This anticipates the activation of a merge queue on `develop`, as has been done in the device-sdk-ts repo.

There is no easy way to test this - I recommend we do a live switchover late in the evening at the end of a workday, announcing to #live-engineering in advance, or at a weekend. Therefore, merge strategy is to merge at the end of a workday, in advance of an end-of-workday session where we turn on the merge queue and validate that it works.