### PR TITLE
[QAA-415][Detox][Speculos] Account name persist after restart

### DIFF
--- a/apps/ledger-live-mobile/e2e/page/accounts/account.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/accounts/account.page.ts
@@ -1,4 +1,11 @@
-import { getElementById, getTextOfElement, scrollToId, tapByElement, tapById } from "../../helpers";
+import {
+  getElementById,
+  getTextOfElement,
+  scrollToId,
+  tapByElement,
+  typeTextById,
+  tapById,
+} from "../../helpers";
 import { expect } from "detox";
 import jestExpect from "expect";
 
@@ -17,6 +24,8 @@ export default class AccountPage {
   receiveButton = () => getElementById("account-quick-action-button-receive");
   sendButton = () => getElementById("account-quick-action-button-send");
   earnButtonId = "account-quick-action-button-earn";
+  accountRenameRow = () => getElementById("account-settings-rename-row");
+  accountRenameTextInputId = "account-rename-text-input";
 
   @Step("Open account settings")
   async openAccountSettings() {
@@ -36,6 +45,16 @@ export default class AccountPage {
   @Step("Confirm account deletion")
   async confirmAccountDelete() {
     await tapByElement(this.accountDeleteConfirm());
+  }
+
+  @Step("Select account edit name")
+  async selectAccountRename() {
+    await tapByElement(this.accountRenameRow());
+  }
+
+  @Step("Enter new account name and submit")
+  async enterNewAccountName(name: string) {
+    await typeTextById(this.accountRenameTextInputId, name);
   }
 
   @Step("Expect operation history to be visible")

--- a/apps/ledger-live-mobile/e2e/specs/speculos/account/accountRename.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/account/accountRename.spec.ts
@@ -1,0 +1,45 @@
+import { launchApp } from "../../../helpers";
+import { Application } from "../../../page";
+import { CLI } from "../../../utils/cliUtils";
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { device } from "detox";
+
+const app = new Application();
+const account = Account.BTC_NATIVE_SEGWIT_1;
+const newAccountName = "New Account Name";
+
+$TmsLink("B2CQA-2996");
+describe("Account name change", () => {
+  beforeAll(async () => {
+    await app.init({
+      speculosApp: account.currency.speculosApp,
+      cliCommands: [
+        async () => {
+          return CLI.liveData({
+            currency: account.currency.currencyId,
+            index: account.index,
+            appjson: app.userdataPath,
+            add: true,
+          });
+        },
+      ],
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  it("should persist Account name change after app restart", async () => {
+    await app.accounts.openViaDeeplink();
+    await app.common.expectAccountName(account.accountName);
+    await app.common.goToAccountByName(account.accountName);
+    await app.account.openAccountSettings();
+    await app.account.selectAccountRename();
+    await app.account.enterNewAccountName(newAccountName);
+    await app.accounts.openViaDeeplink();
+    await app.common.expectAccountName(newAccountName);
+    await device.terminateApp();
+    await launchApp();
+    await app.portfolio.waitForPortfolioPageToLoad();
+    await app.accounts.openViaDeeplink();
+    await app.common.expectAccountName(newAccountName);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/AccountSettings/AccountNameRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/AccountSettings/AccountNameRow.tsx
@@ -24,6 +24,7 @@ function AccountNameRow({ navigation, account }: Props) {
       event="AccountNameRow"
       title={<Trans i18nKey="account.settings.accountName.title" />}
       desc={<Trans i18nKey="account.settings.accountName.desc" />}
+      testID="account-settings-rename-row"
       arrowRight
       onPress={onPress}
     >

--- a/apps/ledger-live-mobile/src/screens/AccountSettings/EditAccountName.tsx
+++ b/apps/ledger-live-mobile/src/screens/AccountSettings/EditAccountName.tsx
@@ -91,6 +91,7 @@ class EditAccountName extends PureComponent<
             onSubmitEditing={this.onNameEndEditing}
             clearButtonMode="while-editing"
             placeholder={i18next.t("account.settings.accountName.placeholder")}
+            testID="account-rename-text-input"
           />
         </Box>
         <Button


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached. (no need)
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLM Rename account test

### 📝 Description

Add test to check that account name change persists after app kill

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [Test Mobile E2E Speculos](https://github.com/LedgerHQ/ledger-live/actions/runs/13026789815)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
