### PR TITLE
fix(llm): ⚡️ fix braze related performance issues

### DIFF
--- a/.changeset/poor-students-kick.md
+++ b/.changeset/poor-students-kick.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix braze related performance issues

--- a/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/brazeContentCard.ts
@@ -1,14 +1,12 @@
 import Braze from "@braze/react-native-sdk";
 import { useCallback, useRef } from "react";
-import { useSelector, useDispatch, shallowEqual } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { track } from "~/analytics";
 import { setDismissedContentCard } from "~/actions/settings";
 import { trackingEnabledSelector } from "~/reducers/settings";
-import { mobileCardsSelector } from "~/reducers/dynamicContent";
 
-export const useBrazeContentCard = () => {
+export const useBrazeContentCard = (mobileCards: Braze.ContentCard[]) => {
   const isTrackedUser = useSelector(trackingEnabledSelector);
-  const mobileCards = useSelector(mobileCardsSelector, shallowEqual);
   const mobileCardRef = useRef(mobileCards);
   const dispatch = useDispatch();
 

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContent.tsx
@@ -24,8 +24,6 @@ import { setDynamicContentMobileCards } from "~/actions/dynamicContent";
 
 const useDynamicContent = () => {
   const dispatch = useDispatch();
-  const { logClickCard, logDismissCard, logImpressionCard, refreshDynamicContent } =
-    useBrazeContentCard();
   const notificationCards = useSelector(notificationsCardsSelector);
   const assetsCards = useSelector(assetsCardsSelector);
   const walletCards = useSelector(walletCardsSelector);
@@ -34,6 +32,9 @@ const useDynamicContent = () => {
   const landingPageStickyCtaCards = useSelector(landingPageStickyCtaCardsSelector);
   const mobileCards = useSelector(mobileCardsSelector);
   const hiddenCards: string[] = useSelector(dismissedDynamicCardsSelector);
+
+  const { logClickCard, logDismissCard, logImpressionCard, refreshDynamicContent } =
+    useBrazeContentCard(mobileCards);
 
   const walletCardsDisplayed = useMemo(
     () => walletCards.filter((wc: WalletContentCard) => !hiddenCards.includes(wc.id)),

--- a/apps/ledger-live-mobile/src/dynamicContent/useDynamicContentLogic.ts
+++ b/apps/ledger-live-mobile/src/dynamicContent/useDynamicContentLogic.ts
@@ -1,3 +1,4 @@
+import Braze from "@braze/react-native-sdk";
 import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -10,7 +11,6 @@ import {
   setIsDynamicContentLoading,
   setDynamicContentLandingPageStickyCtaCards,
 } from "../actions/dynamicContent";
-import { useBrazeContentCard } from "./brazeContentCard";
 import {
   filterByPage,
   filterByType,
@@ -31,7 +31,7 @@ import { clearDismissedContentCards } from "~/actions/settings";
 
 export const useDynamicContentLogic = () => {
   const dispatch = useDispatch();
-  const { Braze, refreshDynamicContent } = useBrazeContentCard();
+  const refreshDynamicContent = useCallback(() => Braze.requestContentCardsRefresh(), []);
   const dismissedContentCards = useSelector(dismissedContentCardsSelector) || {};
   const dismissedContentCardsIds = Object.keys(dismissedContentCards);
 
@@ -90,7 +90,7 @@ export const useDynamicContentLogic = () => {
     dispatch(setDynamicContentLearnCards(learnCards));
     dispatch(setDynamicContentLandingPageStickyCtaCards(landingPageStickyCtaCards));
     dispatch(setIsDynamicContentLoading(false));
-  }, [Braze, dismissedContentCardsIds, dispatch]);
+  }, [dismissedContentCardsIds, dispatch]);
 
   const clearOldDismissedContentCards = () => {
     const oldCampaignIds = getOldCampaignIds(dismissedContentCards || {});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix the braze related performance issue introduced by #8576.
This fix was already merged into the release branch by #8870.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- [LIVE-15674](https://ledgerhq.atlassian.net/browse/LIVE-15674)
- [LIVE-15681](https://ledgerhq.atlassian.net/browse/LIVE-15681)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15674]: https://ledgerhq.atlassian.net/browse/LIVE-15674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-15681]: https://ledgerhq.atlassian.net/browse/LIVE-15681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ