### PR TITLE
[QAA] adding checks - B2CQA-2073

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/OperationDetails/index.tsx
@@ -424,6 +424,7 @@ const OperationD = (props: Props) => {
               <Box mr={2}>
                 {hasFailed ? null : (
                   <CounterValue
+                    data-testid="operation-amount"
                     alwaysShowSign
                     color="palette.text.shade60"
                     fontSize={3}
@@ -615,7 +616,9 @@ const OperationD = (props: Props) => {
               </Box>
 
               <TextEllipsis>
-                <Link onClick={goToMainAccount}>{name}</Link>
+                <Link data-testId="account-name" onClick={goToMainAccount}>
+                  {name}
+                </Link>
               </TextEllipsis>
               <AccountTagDerivationMode account={account} />
             </Box>
@@ -640,13 +643,13 @@ const OperationD = (props: Props) => {
       {isNftOperation ? <NFTOperationDetails operation={operation} /> : null}
       <OpDetailsSection>
         <OpDetailsTitle>{t("operationDetails.date")}</OpDetailsTitle>
-        <OpDetailsData>{dateFormatted}</OpDetailsData>
+        <OpDetailsData data-testid="operation-date">{dateFormatted}</OpDetailsData>
       </OpDetailsSection>
       <B />
       <OpDetailsSection>
         <OpDetailsTitle>{t("operationDetails.identifier")}</OpDetailsTitle>
         <OpDetailsData>
-          <HashContainer>
+          <HashContainer data-testid="operation-id">
             <SplitAddress value={hash} />
           </HashContainer>
           <GradientHover>

--- a/apps/ledger-live-desktop/tests/component/drawer.component.ts
+++ b/apps/ledger-live-desktop/tests/component/drawer.component.ts
@@ -35,7 +35,7 @@ export class Drawer extends Component {
   }
 
   @step("Close drawer")
-  async close() {
+  async closeDrawer() {
     await this.closeButton.click();
   }
 

--- a/apps/ledger-live-desktop/tests/page/drawer/operation.drawer.ts
+++ b/apps/ledger-live-desktop/tests/page/drawer/operation.drawer.ts
@@ -1,0 +1,34 @@
+import { step } from "tests/misc/reporters/step";
+import { Drawer } from "tests/component/drawer.component";
+import { expect } from "@playwright/test";
+
+export class OperationDrawer extends Drawer {
+  readonly transactionIdLabel = this.page.getByText("Transaction ID");
+  readonly transactionIdValue = this.page.getByTestId("operation-id");
+  readonly dateLabel = this.page.getByText("Date");
+  readonly dateValue = this.page.getByTestId("operation-date");
+  readonly amountLabel = this.page.getByText("Amount", { exact: true });
+  readonly amountValue = this.page.getByTestId("operation-amount");
+  readonly transactionType = this.page.getByTestId("transaction-type");
+  readonly accountName = this.page.getByTestId("account-name");
+
+  @step("Verify drawer information")
+  async expectDrawerInfos(accountName: string) {
+    await this.waitForDrawerToBeVisible();
+    const transactionType = await this.transactionType.textContent();
+    await expect(this.accountName).toHaveText(accountName);
+    await expect(this.dateLabel).toBeVisible();
+    expect(await this.dateValue.textContent()).toMatch(
+      /^\d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2} (AM|PM)$/,
+    );
+    await expect(this.transactionIdLabel).toBeVisible();
+    expect(await this.transactionIdValue.textContent()).toMatch(/^[a-zA-Z0-9+/=]{40,}$/);
+    if (transactionType !== "NFT Received") {
+      await expect(this.amountLabel).toBeVisible();
+      expect(await this.amountValue.textContent()).toMatch(/^[+-]?\$\d+\.\d{2}$/);
+    } else {
+      await expect(this.amountLabel).not.toBeVisible();
+      expect(this.amountValue).not.toBeVisible();
+    }
+  }
+}

--- a/apps/ledger-live-desktop/tests/page/index.ts
+++ b/apps/ledger-live-desktop/tests/page/index.ts
@@ -25,6 +25,7 @@ import { NftGallery } from "./nftGallery.page";
 import { AssetPage } from "./asset.page";
 import { SettingsModal } from "tests/page/modal/settings.modal";
 import { OnboardingPage } from "tests/page/onboarding.page";
+import { OperationDrawer } from "./drawer/operation.drawer";
 
 export class Application extends PageHolder {
   public account = new AccountPage(this.page);
@@ -53,4 +54,5 @@ export class Application extends PageHolder {
   public assetPage = new AssetPage(this.page);
   public settingsModal = new SettingsModal(this.page);
   public onboarding = new OnboardingPage(this.page);
+  public operationDrawer = new OperationDrawer(this.page);
 }

--- a/apps/ledger-live-desktop/tests/specs/services/ethereumStaking.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/ethereumStaking.spec.ts
@@ -151,7 +151,7 @@ test("Ethereum staking flows via portfolio, asset page and market page @smoke", 
     await assetPage.startStakeFlow();
     await drawer.waitForDrawerToBeVisible();
     await expect.soft(page).toHaveScreenshot("stake-drawer-opened-from-asset-page.png");
-    await drawer.close();
+    await drawer.closeDrawer();
   });
 
   await test.step("start stake flow via Account page", async () => {
@@ -181,7 +181,7 @@ test("Ethereum staking flows via portfolio, asset page and market page @smoke", 
     await expect
       .soft(page)
       .toHaveScreenshot("stake-drawer-opened-from-market-page.png", maskPartOfItemsInMarket);
-    await drawer.close();
+    await drawer.closeDrawer();
   });
 
   await test.step("Go back to Market page and start stake from ETH coin detail page", async () => {

--- a/apps/ledger-live-desktop/tests/specs/speculos/add.account.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/add.account.spec.ts
@@ -4,7 +4,10 @@ import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "../../utils/customJsonReporter";
 
 const currencies = [
-  { currency: Currency.BTC, xrayTicket: "B2CQA-2499, B2CQA-2644, B2CQA-2672, B2CQA-786" },
+  {
+    currency: Currency.BTC,
+    xrayTicket: "B2CQA-2499, B2CQA-2644, B2CQA-2672, B2CQA-786, B2CQA-2073",
+  },
   { currency: Currency.ETH, xrayTicket: "B2CQA-2503, B2CQA-929, B2CQA-2645, B2CQA-2673" },
   { currency: Currency.ETC, xrayTicket: "B2CQA-2502, B2CQA-2646, B2CQA-2674" },
   { currency: Currency.XRP, xrayTicket: "B2CQA-2505, B2CQA-2647, B2CQA-2675" },
@@ -53,6 +56,9 @@ for (const currency of currencies) {
         await app.account.expectAccountVisibility(firstAccountName);
         await app.account.expectAccountBalance();
         await app.account.expectLastOperationsVisibility();
+        await app.account.clickOnLastOperation();
+        await app.operationDrawer.expectDrawerInfos(firstAccountName);
+        await app.operationDrawer.closeDrawer();
         await app.account.expectAddressIndex(0);
         await app.account.expectShowMoreButton();
       },

--- a/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
@@ -105,7 +105,7 @@ test.describe("Delegate flows", () => {
           await app.delegateDrawer.transactionTypeIsVisible();
           await app.delegateDrawer.providerIsVisible(account.delegate);
           await app.delegateDrawer.amountValueIsVisible();
-          await app.drawer.close();
+          await app.drawer.closeDrawer();
 
           if (!getEnv("DISABLE_TRANSACTION_BROADCAST")) {
             await app.layout.syncAccounts();

--- a/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
@@ -96,7 +96,7 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
       await app.settings.openManageLedgerSync();
       await app.ledgerSync.destroyTrustchain();
       await app.ledgerSync.expectBackupDeletion();
-      await app.drawer.close();
+      await app.drawer.closeDrawer();
     },
   );
 });

--- a/apps/ledger-live-desktop/tests/specs/speculos/nft.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/nft.spec.ts
@@ -51,7 +51,7 @@ test.describe("send NFT to ENS address", () => {
       await app.speculos.signSendNFTTransaction(transaction);
       await app.send.expectTxSent();
       await app.account.navigateToViewDetails();
-      await app.drawer.close();
+      await app.drawer.closeDrawer();
       await app.layout.goToAccounts();
       await app.accounts.navigateToAccountByName(transaction.accountToDebit.accountName);
       await app.account.navigateToNFTOperation();

--- a/apps/ledger-live-desktop/tests/specs/speculos/send.tx.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/send.tx.spec.ts
@@ -276,7 +276,7 @@ test.describe("Send flows", () => {
           await app.sendDrawer.addressValueIsVisible(
             transaction.transaction.accountToCredit.address,
           );
-          await app.drawer.close();
+          await app.drawer.closeDrawer();
           if (!getEnv("DISABLE_TRANSACTION_BROADCAST")) {
             await app.layout.goToAccounts();
             await app.accounts.clickSyncBtnForAccount(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [Ticket to automate](https://ledgerhq.atlassian.net/browse/B2CQA-2073)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
