### PR TITLE
[LIVE-14648] Feature - Prevent ERC-1155 calls for Blockscout explorer & authorize node-only sync

### DIFF
--- a/.changeset/clean-moose-kick.md
+++ b/.changeset/clean-moose-kick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+Prevent request on blockscout for ERC1155 NFTs as unsupported yet and add a `none` option for explorer's config to allow for node-only synchronization (will make token accounts disappear though)

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/indexer.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/indexer.ts
@@ -727,7 +727,7 @@ export const initMswHandlers = (currencyConfig: EvmConfigInfo) => {
         return HttpResponse.json(response);
       }),
     );
-  } else {
+  } else if (currencyConfig.explorer.type !== "none") {
     handlers.push(
       http.get(currencyConfig.explorer.uri, async ({ request }) => {
         const uri = new URL(request.url).searchParams;

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/synchronization.unit.test.ts
@@ -1,15 +1,17 @@
 import { AssertionError, fail } from "assert";
 import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
+import { TokenAccount } from "@ledgerhq/types-live";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { decodeAccountId } from "@ledgerhq/coin-framework/account/accountId";
 import { AccountShapeInfo } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { TokenAccount } from "@ledgerhq/types-live";
 import { makeTokenAccount } from "../fixtures/common.fixtures";
 import * as etherscanAPI from "../../api/explorer/etherscan";
+import { UnknownExplorer, UnknownNode } from "../../errors";
 import * as synchronization from "../../synchronization";
 import * as noneExplorer from "../../api/explorer/none";
 import * as nodeApi from "../../api/node/rpc.common";
+import { createSwapHistoryMap } from "../../logic";
 import {
   account,
   coinOperations,
@@ -24,10 +26,8 @@ import {
   internalOperations,
   swapHistory,
 } from "../fixtures/synchronization.fixtures";
-import { UnknownNode } from "../../errors";
-import * as logic from "../../logic";
 import { getCoinConfig } from "../../config";
-import { createSwapHistoryMap } from "../../logic";
+import * as logic from "../../logic";
 
 jest.mock("../../api/node/rpc.common");
 jest.useFakeTimers().setSystemTime(new Date("2014-04-21"));
@@ -182,6 +182,8 @@ describe("EVM Family", () => {
 
       describe("With no transactions fetched", () => {
         beforeAll(() => {
+          // @ts-expect-error reseting cache
+          etherscanAPI?.default.getLastOperations.reset();
           jest.spyOn(etherscanAPI, "getLastOperations").mockImplementation(() =>
             Promise.resolve({
               lastCoinOperations: [],
@@ -310,6 +312,8 @@ describe("EVM Family", () => {
 
       describe("With transactions fetched", () => {
         beforeAll(() => {
+          // @ts-expect-error reseting cache
+          etherscanAPI?.default.getLastOperations.reset();
           jest
             .spyOn(etherscanAPI, "getLastCoinOperations")
             .mockImplementation(() =>
@@ -567,6 +571,84 @@ describe("EVM Family", () => {
           );
 
           expect(accountShape.operations).toEqual([coinOperations[0]]);
+        });
+      });
+
+      describe("With Blockscout", () => {
+        beforeAll(() => {
+          // @ts-expect-error reseting cache
+          etherscanAPI?.default.getLastOperations.reset();
+          jest
+            .spyOn(etherscanAPI, "getLastCoinOperations")
+            .mockImplementation(() =>
+              Promise.resolve([{ ...coinOperations[0] }, { ...coinOperations[1] }]),
+            );
+          jest
+            .spyOn(etherscanAPI, "getLastTokenOperations")
+            .mockImplementation(() =>
+              Promise.resolve([{ ...tokenOperations[0] }, { ...tokenOperations[1] }]),
+            );
+
+          jest
+            .spyOn(etherscanAPI, "getLastERC721Operations")
+            .mockImplementation(() =>
+              Promise.resolve([
+                { ...erc721Operations[0] },
+                { ...erc721Operations[1] },
+                { ...erc721Operations[2] },
+              ]),
+            );
+          jest
+            .spyOn(etherscanAPI, "getLastInternalOperations")
+            .mockImplementation(() =>
+              Promise.resolve([
+                { ...internalOperations[0] },
+                { ...internalOperations[1] },
+                { ...internalOperations[2] },
+              ]),
+            );
+          jest
+            .spyOn(nodeApi, "getTokenBalance")
+            .mockImplementation(async (a, b, contractAddress) => {
+              if (contractAddress === tokenCurrencies[0].contractAddress) {
+                return new BigNumber(10000);
+              }
+              throw new Error("Shouldn't be trying to fetch this token balance");
+            });
+        });
+
+        afterAll(() => {
+          jest.restoreAllMocks();
+        });
+
+        it("should never call ERC1155 endpoint", async () => {
+          mockGetConfig.mockImplementation((): any => {
+            return {
+              info: {
+                node: {
+                  type: "external",
+                  uri: "https://my-rpc.com",
+                },
+                explorer: {
+                  type: "blockscout",
+                  uri: "https://api.com",
+                },
+              },
+            };
+          });
+          console.log(etherscanAPI?.default.getLastOperations);
+          const spy = jest.spyOn(etherscanAPI, "getLastERC1155Operations");
+
+          await synchronization.getAccountShape(
+            {
+              ...getAccountShapeParameters,
+              initialAccount: account,
+            },
+            {} as any,
+          );
+
+          expect(spy).toHaveBeenCalledTimes(1);
+          expect(spy).toHaveReturnedWith(Promise.resolve([]));
         });
       });
     });

--- a/libs/coin-modules/coin-evm/src/api/explorer/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/api/explorer/etherscan.ts
@@ -211,6 +211,11 @@ export const getLastERC1155Operations = async (
     throw new EtherscanLikeExplorerUsedIncorrectly();
   }
 
+  // Blockscout has no ERC1155 support yet
+  if (explorer.type === "blockscout") {
+    return [];
+  }
+
   const ops = await fetchWithRetries<EtherscanERC1155Event[]>({
     method: "GET",
     url: `${explorer.uri}?module=account&action=token1155tx&address=${address}`,

--- a/libs/coin-modules/coin-evm/src/api/explorer/index.ts
+++ b/libs/coin-modules/coin-evm/src/api/explorer/index.ts
@@ -4,6 +4,7 @@ import { getCoinConfig } from "../../config";
 import etherscanLikeApi from "./etherscan";
 import ledgerExplorerApi from "./ledger";
 import { ExplorerApi } from "./types";
+import noExplorerAPI from "./none";
 
 /**
  * Switch to select one of the compatible explorer
@@ -20,6 +21,8 @@ export const getExplorerApi = (currency: CryptoCurrency): ExplorerApi => {
       return etherscanLikeApi;
     case "ledger":
       return ledgerExplorerApi;
+    case "none":
+      return noExplorerAPI;
 
     default:
       throw new UnknownExplorer(`Unknown explorer for currency: ${currency.id}`);

--- a/libs/coin-modules/coin-evm/src/api/explorer/none.ts
+++ b/libs/coin-modules/coin-evm/src/api/explorer/none.ts
@@ -1,0 +1,19 @@
+import { ExplorerApi } from "./types";
+
+/**
+ * Returns all operation types from an address
+ */
+export const getLastOperations: ExplorerApi["getLastOperations"] = async () => {
+  return {
+    lastCoinOperations: [],
+    lastTokenOperations: [],
+    lastNftOperations: [],
+    lastInternalOperations: [],
+  };
+};
+
+const noExplorerAPI: ExplorerApi = {
+  getLastOperations,
+};
+
+export default noExplorerAPI;

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -19,6 +19,11 @@ type EvmConfig = {
     | {
         type: "ledger";
         explorerId: LedgerExplorerId;
+      }
+    | {
+        type: "none";
+        uri?: never;
+        explorerId?: never;
       };
   gasTracker?: {
     type: "ledger";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Prevent non supported requests on blockscout for ERC-1155 NFTs leading to errors during sync
  - Allow for `none` explorer type in coin config to allow for node-only sync

### 📝 Description

Now prevents requests to Blockscout for ERC-1155 transfer events as the endpoint isn't supported for now. Also adds a new explorer type for coin-config `none`, allowing to sync an account with purely a node (although, all token accounts will disappear for the user).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  https://ledgerhq.atlassian.net/browse/LIVE-14648


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
