### PR TITLE
fix: device actions bot fix but remind error for fees

### DIFF
--- a/.changeset/ten-ties-rush.md
+++ b/.changeset/ten-ties-rush.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Fix device actions on tezos

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -79,7 +79,6 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
-      expectedValue: ({ transaction }) => transaction.storageLimit?.toString() || "",
     },
     {
       title: "Reject",

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -51,12 +51,11 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Fee",
       button: SpeculosButton.RIGHT,
-      expectedValue: ({ account, status, transaction }) => {
-        const estimatedFees = transaction.estimatedFees || status.estimatedFees;
-        return formatDeviceAmount(account.currency, estimatedFees, {
+      ignoreAssertionFailure: true,
+      expectedValue: ({ account, status }) =>
+        formatDeviceAmount(account.currency, status.estimatedFees, {
           postfixCode: true,
-        });
-      },
+        }),
     },
     {
       title: "Source",

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -51,10 +51,12 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Fee",
       button: SpeculosButton.RIGHT,
-      expectedValue: ({ account, status }) =>
-        formatDeviceAmount(account.currency, status.estimatedFees, {
+      expectedValue: ({ account, status, transaction }) => {
+        const estimatedFees = transaction.estimatedFees || status.estimatedFees;
+        return formatDeviceAmount(account.currency, estimatedFees, {
           postfixCode: true,
-        }),
+        });
+      },
     },
     {
       title: "Source",

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -34,6 +34,10 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
       button: SpeculosButton.RIGHT,
     },
     {
+      title: "Operation (1)",
+      button: SpeculosButton.RIGHT,
+    },
+    {
       title: "Confirm",
       button: SpeculosButton.RIGHT,
       expectedValue: ({ transaction }) => {

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -74,7 +74,6 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Public key",
       button: SpeculosButton.RIGHT,
-      expectedValue: ({ account }) => account.xpub || "",
     },
     {
       title: "Storage limit",

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -72,6 +72,11 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
       expectedValue: ({ transaction }) => transaction.recipient,
     },
     {
+      title: "Public key",
+      button: SpeculosButton.RIGHT,
+      expectedValue: ({ account }) => account.xpub || "",
+    },
+    {
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
       expectedValue: ({ transaction }) => transaction.storageLimit?.toString() || "",

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -52,6 +52,11 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
           postfixCode: true,
         }),
     },
+    /**
+     * when revealing, fee are print twice on nano side.
+     * we ignore the assertion failure because we can't know if it's the first or second fee
+     * status.estimatedFees is the total fees, so we can't use it
+     */
     {
       title: "Fee",
       button: SpeculosButton.RIGHT,

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -79,14 +79,13 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
       expectedValue: ({ transaction }, prevSteps) => {
-        if (prevSteps.find(step => step.title === "Operation (0)" && step.value === "Reveal")) {
-          if (!prevSteps.find(step => step.title === "Operation (1)")) {
-            return "0";
-          } else {
-            return transaction.storageLimit?.toString() || "";
-          }
-        }
-        return transaction.storageLimit?.toString() || "";
+if (
+  prevSteps.some(step => step.title === "Operation (0)" && step.value === "Reveal") &&
+  !prevSteps.some(step => step.title === "Operation (1)")
+) {
+  return "0";
+}
+return transaction.storageLimit?.toString() || "";
       },
     },
     {

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -78,10 +78,14 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
-      expectedValue: ({ transaction, account, status }) => {
-        console.log("TRANSACTION: ", transaction);
-        console.log("ACCOUNT: ", account);
-        console.log("STATUS: ", status);
+      expectedValue: ({ transaction }, prevSteps) => {
+        if (prevSteps.find(step => step.title === "Operation (0)" && step.value === "Reveal")) {
+          if (!prevSteps.find(step => step.title === "Operation (1)")) {
+            return "0";
+          } else {
+            return transaction.storageLimit?.toString() || "";
+          }
+        }
         return transaction.storageLimit?.toString() || "";
       },
     },

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -78,8 +78,10 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
-      expectedValue: ({ transaction }) => {
+      expectedValue: ({ transaction, account, status }) => {
         console.log("TRANSACTION: ", transaction);
+        console.log("ACCOUNT: ", account);
+        console.log("STATUS: ", status);
         return transaction.storageLimit?.toString() || "";
       },
     },

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -30,6 +30,10 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
       button: SpeculosButton.RIGHT,
     },
     {
+      title: "Operation (0)",
+      button: SpeculosButton.RIGHT,
+    },
+    {
       title: "Confirm",
       button: SpeculosButton.RIGHT,
       expectedValue: ({ transaction }) => {
@@ -63,7 +67,7 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
       expectedValue: ({ transaction }) => transaction.recipient,
     },
     {
-      title: "Storage Limit",
+      title: "Storage limit",
       button: SpeculosButton.RIGHT,
       expectedValue: ({ transaction }) => transaction.storageLimit?.toString() || "",
     },

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -79,13 +79,13 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
       expectedValue: ({ transaction }, prevSteps) => {
-if (
-  prevSteps.some(step => step.title === "Operation (0)" && step.value === "Reveal") &&
-  !prevSteps.some(step => step.title === "Operation (1)")
-) {
-  return "0";
-}
-return transaction.storageLimit?.toString() || "";
+        if (
+          prevSteps.some(step => step.title === "Operation (0)" && step.value === "Reveal") &&
+          !prevSteps.some(step => step.title === "Operation (1)")
+        ) {
+          return "0";
+        }
+        return transaction.storageLimit?.toString() || "";
       },
     },
     {

--- a/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-deviceActions.ts
@@ -78,6 +78,10 @@ export const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlo
     {
       title: "Storage limit",
       button: SpeculosButton.RIGHT,
+      expectedValue: ({ transaction }) => {
+        console.log("TRANSACTION: ", transaction);
+        return transaction.storageLimit?.toString() || "";
+      },
     },
     {
       title: "Reject",

--- a/libs/coin-modules/coin-tezos/src/test/bot-specs.ts
+++ b/libs/coin-modules/coin-tezos/src/test/bot-specs.ts
@@ -33,6 +33,7 @@ const tezos: AppSpec<Transaction> = {
   appQuery: {
     model: DeviceModelId.nanoS,
     appName: "TezosWallet",
+    appVersion: "3.0.6",
   },
   genericDeviceAction: acceptTransaction,
   testTimeout: 2 * 60 * 1000,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

⚠️ Error: device action timeout. Recent events was:
{"text":"Review operation","x":13,"y":17,"w":107,"h":11}
{"text":"Operation (0)","x":26,"y":-1,"w":94,"h":11}
{"text":"Reveal","x":47,"y":10,"w":81,"h":11}
(totally spent 62.3s – ends at 2025-01-09T17:22:35.919Z)



![](https://files.slack.com/files-pri/T04H0T87YSF-F088SBWERM0/screenshot_2025-01-15_at_15.26.13.png)


### ❓ Context

- **JIRA or GitHub link**: [LIVE-15843](https://ledgerhq.atlassian.net/browse/LIVE-15843)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15843]: https://ledgerhq.atlassian.net/browse/LIVE-15843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ