### PR TITLE
Feat/track stake programs

### DIFF
--- a/.changeset/sharp-cheetahs-tell.md
+++ b/.changeset/sharp-cheetahs-tell.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+track all stake programs in analytics

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -99,6 +99,7 @@ const getPtxAttributes = () => {
   if (!analyticsFeatureFlagMethod) return {};
   const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
   const stakingProviders = analyticsFeatureFlagMethod("ethStakingProviders");
+  const stakePrograms = analyticsFeatureFlagMethod("stakePrograms");
   const ptxCard = analyticsFeatureFlagMethod("ptxCard");
 
   const isBatch1Enabled: boolean =
@@ -113,6 +114,15 @@ const getPtxAttributes = () => {
     stakingProviders?.params?.listProvider?.length > 0
       ? stakingProviders?.params?.listProvider.length
       : "flag not loaded";
+  const stakingCurrenciesEnabled =
+    !stakePrograms?.params?.list?.length || !stakePrograms?.enabled
+      ? {}
+      : Object.fromEntries(
+          stakePrograms?.params?.list?.map((currencyId: string) => [
+            `feature_earn_${currencyId}_enabled`,
+            true,
+          ]),
+        );
 
   return {
     isBatch1Enabled,
@@ -120,6 +130,7 @@ const getPtxAttributes = () => {
     isBatch3Enabled,
     stakingProvidersEnabled,
     ptxCard,
+    ...stakingCurrenciesEnabled,
   };
 };
 

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -114,15 +114,16 @@ const getPtxAttributes = () => {
     stakingProviders?.params?.listProvider?.length > 0
       ? stakingProviders?.params?.listProvider.length
       : "flag not loaded";
+
   const stakingCurrenciesEnabled =
-    !stakePrograms?.params?.list?.length || !stakePrograms?.enabled
-      ? {}
-      : Object.fromEntries(
-          stakePrograms?.params?.list?.map((currencyId: string) => [
+    stakePrograms?.enabled && stakePrograms?.params?.list?.length
+      ? Object.fromEntries(
+          stakePrograms.params.list.map((currencyId: string) => [
             `feature_earn_${currencyId}_enabled`,
             true,
           ]),
-        );
+        )
+      : {};
 
   return {
     isBatch1Enabled,

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -76,6 +76,7 @@ const getFeatureFlagProperties = () => {
   (async () => {
     const fetchAdditionalCoins = analyticsFeatureFlagMethod("fetchAdditionalCoins");
     const stakingProviders = analyticsFeatureFlagMethod("ethStakingProviders");
+    const stakePrograms = analyticsFeatureFlagMethod("stakePrograms");
 
     const isBatch1Enabled =
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;
@@ -85,12 +86,22 @@ const getFeatureFlagProperties = () => {
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 3;
     const stakingProvidersEnabled =
       stakingProviders?.enabled && stakingProviders?.params?.listProvider.length;
+    const stakingCurrenciesEnabled =
+      !stakePrograms?.params?.list?.length || !stakePrograms?.enabled
+        ? {}
+        : Object.fromEntries(
+            stakePrograms?.params?.list?.map((currencyId: string) => [
+              `feature_earn_${currencyId}_enabled`,
+              true,
+            ]),
+          );
 
     updateIdentify({
       isBatch1Enabled,
       isBatch2Enabled,
       isBatch3Enabled,
       stakingProvidersEnabled,
+      ...stakingCurrenciesEnabled,
     });
   })();
 };

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -86,15 +86,16 @@ const getFeatureFlagProperties = () => {
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 3;
     const stakingProvidersEnabled =
       stakingProviders?.enabled && stakingProviders?.params?.listProvider.length;
+
     const stakingCurrenciesEnabled =
-      !stakePrograms?.params?.list?.length || !stakePrograms?.enabled
-        ? {}
-        : Object.fromEntries(
-            stakePrograms?.params?.list?.map((currencyId: string) => [
+      stakePrograms?.enabled && stakePrograms?.params?.list?.length
+        ? Object.fromEntries(
+            stakePrograms.params.list.map((currencyId: string) => [
               `feature_earn_${currencyId}_enabled`,
               true,
             ]),
-          );
+          )
+        : {};
 
     updateIdentify({
       isBatch1Enabled,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist


- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Analytics events with `feature_earn_${currencyId}_enabled` set to `true` for where `currencyId` includes:
      "mantra",
      "xion",
      "ethereum",
      "solana",
etc.

### 📝 Description

- Ensure we track all enabled "stake" (i.e. yield-earning) programs before release of stablecoin yield
- Aside: If we need to treat them differently then we will create a 2nd flag or a new param in this flag for just `stablecoins` or `defi`, then merge them together where "yield" is the suitable usage. In this case we want to track both. 

### ❓ Context

- **JIRA or GitHub link**: [CN-851](https://ledgerhq.atlassian.net/browse/CN-851)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-851]: https://ledgerhq.atlassian.net/browse/CN-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ