### PR TITLE
Authenticate with docker before running ghcommit action

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -39,6 +39,11 @@ jobs:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     runs-on: [ledger-live-4xlarge]
     steps:
+      - name: Docker Hub Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: generate token
         id: generate-token
         uses: tibdex/github-app-token@v1

--- a/tools/actions/composites/update-snapshots-desktop/action.yml
+++ b/tools/actions/composites/update-snapshots-desktop/action.yml
@@ -11,12 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Docker Hub Login
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
     - name: Update playwright snapshots [Linux => xvfb-run]
       if: ${{ startsWith(inputs.os, 'ubuntu') }}
       run: |

--- a/tools/actions/composites/update-snapshots-desktop/action.yml
+++ b/tools/actions/composites/update-snapshots-desktop/action.yml
@@ -11,6 +11,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Docker Hub Login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
     - name: Update playwright snapshots [Linux => xvfb-run]
       if: ${{ startsWith(inputs.os, 'ubuntu') }}
       run: |


### PR DESCRIPTION
To fix [this issue](https://ledger.slack.com/archives/C05J8CKP88G/p1736960394684999), this PR adds a docker authentication step prior to calling the ghcommit verified commits action during generate-screenshots.

This PR is tested in [this test branch](https://github.com/LedgerHQ/ledger-live/pull/8920), which has the successful workflow run [here](https://github.com/LedgerHQ/ledger-live/actions/runs/12807237858/job/35707513011) 🟢.