### PR TITLE
FIX: LIVE-15628 Fix app crashing when selecting EVM accounts

### DIFF
--- a/.changeset/pretty-boats-cry.md
+++ b/.changeset/pretty-boats-cry.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix crash happening when selecting EVM account from account screen, missing walletState passed to decorator

--- a/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/hooks/useAccountActions.tsx
@@ -21,6 +21,7 @@ import { ActionButtonEvent } from "~/components/FabActions";
 import { useCanShowStake } from "./useCanShowStake";
 import { PtxToast } from "~/components/Toast/PtxToast";
 import { useFetchCurrencyAll } from "@ledgerhq/live-common/exchange/swap/hooks/index";
+import { walletSelector } from "~/reducers/wallet";
 
 type Props = {
   account: AccountLike;
@@ -39,6 +40,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const route = useRoute();
   const { t } = useTranslation();
+  const walletState = useSelector(walletSelector);
 
   const ptxServiceCtaScreens = useFeature("ptxServiceCtaScreens");
 
@@ -191,6 +193,7 @@ export default function useAccountActions({ account, parentAccount, colors }: Pr
     (decorators &&
       decorators.getMainActions &&
       decorators.getMainActions({
+        walletState,
         account,
         parentAccount,
         colors,


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - walletState passed from useAccountActions to decorator

### 📝 Description

This PR fixes a bug where the walletState that was introduced on the accountActions was not passed from the account screen.


https://github.com/user-attachments/assets/6c17e324-29dc-461e-b6eb-4a382e7e50b9



### ❓ Context

- **JIRA or GitHub link**: [JIRA-15628](https://ledgerhq.atlassian.net/browse/LIVE-15786)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
