### PR TITLE
ci: Enabling CI to return success when no desktop changes occur

### DIFF
--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -59,7 +59,9 @@ jobs:
       - name: commit
         run: |
           git add .
-          git commit -m "chore(nightly): :rocket: nightly release"
+          if [ "$(git status --porcelain --untracked-files=no)" ]; then 
+            git commit -m "chore(nightly): :rocket: nightly release"
+          fi
       - name: authenticate with npm
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Wrapping the release commit in a git status (porcelain to remove human readable elements and no untracked files to avoid dotfiles impacting)

The steps following this should either auto skip or complete quickly allowing the workflow to finish quickly

https://ledgerhq.atlassian.net/browse/LIVE-12391

Success with changes present: https://github.com/LedgerHQ/ledger-live/actions/runs/12870060269/job/35880244698
Success with no changes present: https://github.com/LedgerHQ/ledger-live/actions/runs/12870214117/job/35880740006