### PR TITLE
feat: Add final steps (succes,warning, quickActions, emptyState UI) for add account v2 workflow

### DIFF
--- a/.changeset/sharp-items-nail.md
+++ b/.changeset/sharp-items-nail.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-wallet": minor
+---
+
+feat: Add final steps (succes,warning, quickActions, emptyState UI) for add account v2 workflow

--- a/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
@@ -30,7 +30,7 @@ import AccountItem from "LLM/features/Accounts/components/AccountsListView/compo
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { BaseComposite, StackNavigatorProps } from "./RootNavigator/types/helpers";
 
-const ANIMATION_DURATION = 200;
+import useAnimatedStyle from "LLM/features/Accounts/screens/ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
 
 const selectAllHitSlop = {
   top: 16,
@@ -89,57 +89,23 @@ const SelectableAccountsList = ({
   }, [accounts, onUnselectAllProp]);
 
   const areAllSelected = accounts.every(a => selectedIds.indexOf(a.id) > -1);
-  const translateY = useRef(new Animated.Value(50)).current;
-  const opacity = useRef(new Animated.Value(0)).current;
-  const scale = useRef(new Animated.Value(0.8)).current;
   const llmNetworkBasedAddAccountFlow = useFeature("llmNetworkBasedAddAccountFlow");
-
-  useEffect(() => {
-    if (!llmNetworkBasedAddAccountFlow?.enabled) return;
-    Animated.parallel([
-      Animated.timing(translateY, {
-        toValue: 0,
-        duration: ANIMATION_DURATION,
-        useNativeDriver: true,
-      }),
-      Animated.timing(opacity, {
-        toValue: 1,
-        duration: ANIMATION_DURATION,
-        useNativeDriver: true,
-      }),
-      Animated.timing(scale, {
-        toValue: 1,
-        duration: ANIMATION_DURATION,
-        useNativeDriver: true,
-      }),
-    ]).start();
-  }, [translateY, opacity, scale, llmNetworkBasedAddAccountFlow?.enabled]);
-
-  const animatedSelectableAccount = useMemo(
-    () => ({
-      transform: [{ translateY }, { scale }],
-      opacity,
-    }),
-    [translateY, scale, opacity],
-  );
 
   const renderSelectableAccount = useCallback(
     ({ item, index }: { index: number; item: Account }) =>
       llmNetworkBasedAddAccountFlow?.enabled ? (
-        <Animated.View style={[animatedSelectableAccount]}>
-          <SelectableAccount
-            navigation={navigation}
-            showHint={!index && showHint}
-            rowIndex={index}
-            listIndex={listIndex}
-            account={item}
-            onAccountNameChange={onAccountNameChange}
-            isSelected={forceSelected || selectedIds.indexOf(item.id) > -1}
-            isDisabled={isDisabled}
-            onPress={onPressAccount}
-            useFullBalance={useFullBalance}
-          />
-        </Animated.View>
+        <SelectableAccount
+          navigation={navigation}
+          showHint={!index && showHint}
+          rowIndex={index}
+          listIndex={listIndex}
+          account={item}
+          onAccountNameChange={onAccountNameChange}
+          isSelected={forceSelected || selectedIds.indexOf(item.id) > -1}
+          isDisabled={isDisabled}
+          onPress={onPressAccount}
+          useFullBalance={useFullBalance}
+        />
       ) : (
         <SelectableAccount
           navigation={navigation}
@@ -164,7 +130,6 @@ const SelectableAccountsList = ({
       onAccountNameChange,
       onPressAccount,
       useFullBalance,
-      animatedSelectableAccount,
       llmNetworkBasedAddAccountFlow?.enabled,
     ],
   );
@@ -325,64 +290,66 @@ const SelectableAccount = ({
 
   const subAccountCount = account.subAccounts && account.subAccounts.length;
   const isToken = listTokenTypesForCryptoCurrency(account.currency).length > 0;
-
+  const { animatedSelectableAccount } = useAnimatedStyle();
   const inner = (
-    <Flex
-      marginTop={3}
-      marginBottom={3}
-      marginLeft={6}
-      marginRight={6}
-      paddingLeft={6}
-      paddingRight={6}
-      paddingTop={3}
-      paddingBottom={3}
-      flexDirection="row"
-      alignItems="center"
-      borderRadius={4}
-      opacity={isDisabled ? 0.4 : 1}
-      backgroundColor="neutral.c30"
-    >
-      {llmNetworkBasedAddAccountFlow?.enabled ? (
-        <Flex
-          flex={1}
-          flexDirection="row"
-          height={56}
-          alignItems="center"
-          backgroundColor="neutral.c30"
-          borderRadius="12px"
-          padding="8px"
-          columnGap={8}
-        >
-          <AccountItem account={account} balance={account.spendableBalance} />
-        </Flex>
-      ) : (
-        <Flex flex={1}>
-          <AccountCard
-            useFullBalance={useFullBalance}
-            account={account}
-            AccountSubTitle={
-              subAccountCount && !isDisabled ? (
-                <Flex marginTop={2}>
-                  <Text fontWeight="semiBold" variant="small" color="pillActiveForeground">
-                    <Trans
-                      i18nKey={`selectableAccountsList.${isToken ? "tokenCount" : "subaccountCount"}`}
-                      count={subAccountCount}
-                      values={{ count: subAccountCount }}
-                    />
-                  </Text>
-                </Flex>
-              ) : null
-            }
-          />
-        </Flex>
-      )}
+    <Animated.View style={[animatedSelectableAccount]}>
+      <Flex
+        marginTop={3}
+        marginBottom={3}
+        marginLeft={6}
+        marginRight={6}
+        paddingLeft={6}
+        paddingRight={6}
+        paddingTop={3}
+        paddingBottom={3}
+        flexDirection="row"
+        alignItems="center"
+        borderRadius={4}
+        opacity={isDisabled ? 0.4 : 1}
+        backgroundColor="neutral.c30"
+      >
+        {llmNetworkBasedAddAccountFlow?.enabled ? (
+          <Flex
+            flex={1}
+            flexDirection="row"
+            height={56}
+            alignItems="center"
+            backgroundColor="neutral.c30"
+            borderRadius="12px"
+            padding="8px"
+            columnGap={8}
+          >
+            <AccountItem account={account as Account} balance={account.spendableBalance} />
+          </Flex>
+        ) : (
+          <Flex flex={1}>
+            <AccountCard
+              useFullBalance={useFullBalance}
+              account={account}
+              AccountSubTitle={
+                subAccountCount && !isDisabled ? (
+                  <Flex marginTop={2}>
+                    <Text fontWeight="semiBold" variant="small" color="pillActiveForeground">
+                      <Trans
+                        i18nKey={`selectableAccountsList.${isToken ? "tokenCount" : "subaccountCount"}`}
+                        count={subAccountCount}
+                        values={{ count: subAccountCount }}
+                      />
+                    </Text>
+                  </Flex>
+                ) : null
+              }
+            />
+          </Flex>
+        )}
 
-      {!isDisabled && (
-        <Flex marginLeft={4}>
-          <CheckBox onChange={handlePress} isChecked={!!isSelected} />
-        </Flex>
-      )}
-    </Flex>
+        {!isDisabled && (
+          <Flex marginLeft={4}>
+            <CheckBox onChange={handlePress} isChecked={!!isSelected} />
+          </Flex>
+        )}
+      </Flex>
+    </Animated.View>
   );
 
   if (isDisabled) return inner;

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -542,6 +542,7 @@ export enum ScreenName {
   SelectAccounts = "SelectAccounts",
   ScanDeviceAccounts = "ScanDeviceAccounts",
   AddAccountsWarning = "AddAccountsWarning",
+  NoAssociatedAccounts = "NoAssociatedAccounts",
 }
 
 export enum NavigatorName {

--- a/apps/ledger-live-mobile/src/families/hedera/NoAssociatedAccounts.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/NoAssociatedAccounts.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback } from "react";
 import i18next from "i18next";
-import { useTheme } from "@react-navigation/native";
-import { StyleSheet, Linking, Text } from "react-native";
+import { StyleSheet, Linking } from "react-native";
 import { urls } from "~/utils/urls";
 import Touchable, { Props as TouchableProps } from "~/components/Touchable";
 import LText from "~/components/LText";
 import ExternalLink from "~/icons/ExternalLink";
+import { Flex, Icons, Text, Button } from "@ledgerhq/native-ui";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useTheme } from "styled-components/native";
+import { useTranslation } from "react-i18next";
 
 type Props = {
   style?: {
@@ -16,23 +19,44 @@ type Props = {
 // "no associated accounts" text when adding/importing accounts
 function NoAssociatedAccounts({ style }: Props) {
   const { colors } = useTheme();
-  const c = colors.live;
+  const { t } = useTranslation();
+  const mainColor = colors.primary.c100;
+  const llmNetworkBasedAddAccountFlow = useFeature("llmNetworkBasedAddAccountFlow");
   const fontSize = 13;
   const onPress = useCallback(() => Linking.openURL(urls.hedera.supportArticleLink), []);
-  return (
+  return llmNetworkBasedAddAccountFlow?.enabled ? (
+    <>
+      <Flex flex={1} alignSelf="stretch" alignItems="center">
+        <Text style={styles.title}> {t("hedera.createHederaAccountHelp.title")}</Text>
+
+        <Text style={styles.desc} color="neutral.c70">
+          {t("hedera.createHederaAccountHelp.description")}
+        </Text>
+      </Flex>
+      <Button
+        size="large"
+        type="shade"
+        testID="button-create-account"
+        Icon={() => <Icons.ExternalLink color={colors.neutral.c20} size="S" />}
+        onPress={onPress}
+      >
+        {t("hedera.createHederaAccountHelp.link")}
+      </Button>
+    </>
+  ) : (
     <Touchable onPress={onPress} style={[style?.paddingHorizontal, styles.root]}>
       <Text>{i18next.t("hedera.createHederaAccountHelp.text") as React.ReactNode}</Text>
       <LText
         style={[
           {
             fontSize,
-            color: c,
+            color: mainColor,
           },
         ]}
       >
-        {i18next.t("hedera.createHederaAccountHelp.link") as React.ReactNode}
+        {t("hedera.createHederaAccountHelp.link") as React.ReactNode}
       </LText>
-      <ExternalLink size={fontSize + 2} color={c} />
+      <ExternalLink size={fontSize + 2} color={mainColor} />
     </Touchable>
   );
 }
@@ -43,6 +67,29 @@ const styles = StyleSheet.create({
     justifyContent: "flex-start",
     alignItems: "center",
     flexWrap: "wrap",
+  },
+  title: {
+    marginTop: 32,
+    fontSize: 24,
+    textAlign: "center",
+    width: "100%",
+    fontWeight: 600,
+    fontStyle: "normal",
+    lineHeight: 32.4,
+    letterSpacing: 0.75,
+  },
+  desc: {
+    marginTop: 16,
+    marginBottom: 32,
+    fontSize: 14,
+    width: "100%",
+    lineHeight: 23.8,
+    fontWeight: 500,
+    textAlign: "center",
+    alignSelf: "stretch",
+  },
+  cta: {
+    textTransform: "capitalize",
   },
 });
 export default NoAssociatedAccounts;

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -99,7 +99,8 @@
       "id": "ID {{ value }}",
       "times": "x{{ value }}"
     },
-    "quote": "Quote"
+    "quote": "Quote",
+    "tryAgain": "Try again"
   },
   "errors": {
     "ReplacementTransactionUnderpriced": {
@@ -4066,18 +4067,29 @@
           "title": "New account"
         },
         "imported": {
-          "title": "Account already in the Portfolio ({{length}})",
-          "title_plural": "Accounts already in the Portfolio ({{length}})"
+          "title": "Account already in the Portfolio ({{count}})",
+          "title_plural": "Accounts already in the Portfolio ({{count}})"
         },
         "migrate": {
           "title": "Accounts to update"
         }
-      }
+      },
+      "retryScanning": "Try Again"
     },
     "addAccountsSuccess": {
       "ctaAddFunds": "Add funds to my account",
       "ctaClose": "Close"
-    }
+    },
+    "addAccountsWarning": {
+      "cantCreateAccount": {
+        "title": "We can’t add a new account",
+        "body": "A new account cannot be added before receiving assets on your {{accountName}} account."
+      },
+      "noAccountToCreate": {
+        "title": "We couldn’t add a new {{currency}} account"
+      }
+    },
+    "chooseAccountToFund": "Choose an account to add funds"
   },
   "DeviceAction": {
     "stayInTheAppPlz": "Stay in the Ledger Live app and keep your Ledger nearby.",
@@ -6560,7 +6572,9 @@
     "name": "hedera",
     "createHederaAccountHelp": {
       "text": "Please refer to this support article for",
-      "link": "how to create a Hedera account"
+      "link": "How to create a Hedera account ?",
+      "title": "We can’t create a new Hedera account",
+      "description": "In the Hedera ecosystem, only a select number of services can create new accounts. While Ledger does not currently offer this onboarding service, alternatives are available. You will be able to add your Hedera account on Ledger Live once it’s created."
     },
     "currentAddress": {
       "messageIfVirtual": "Your {{name}} address cannot be confirmed on your Ledger device. Use at your own risk."

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/Navigator.tsx
@@ -15,6 +15,8 @@ import AccountsList from "LLM/features/Accounts/screens/AccountsList";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import AddAccountsSuccess from "./screens/AddAccountSuccess";
 import SelectAccounts from "./screens/SelectAccounts";
+import AddAccountsWarning from "./screens/AddAccountWarning";
+import NoAssociatedAccountsView from "./screens/NoAssociatedAccountsView";
 
 export default function Navigator() {
   const { colors } = useTheme();
@@ -58,6 +60,7 @@ export default function Navigator() {
         component={ScanDeviceAccounts}
         options={{
           headerTitle: "",
+          headerTransparent: true,
         }}
       />
       {/* Select Accounts */}
@@ -85,6 +88,25 @@ export default function Navigator() {
         options={{
           headerTitle: "",
           headerLeft: () => null,
+          headerTransparent: true,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.AddAccountsWarning}
+        component={AddAccountsWarning}
+        options={{
+          headerTitle: "",
+          headerLeft: () => null,
+          headerTransparent: true,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.NoAssociatedAccounts}
+        component={NoAssociatedAccountsView}
+        options={{
+          headerTitle: "",
+          headerLeft: () => null,
+          headerTransparent: true,
         }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/CustomHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/CustomHeader/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Flex, Icons, Text } from "@ledgerhq/native-ui";
+import { TouchableOpacity } from "react-native";
+
+type Props = {
+  onClose: () => void;
+  backgroundColor: string;
+  iconColor: string;
+  title: string;
+};
+
+const CustomHeader = ({ onClose, backgroundColor, iconColor, title }: Props) => {
+  return (
+    <Flex
+      flexDirection="row"
+      width="100%"
+      p={16}
+      borderBottom={5}
+      borderBottomColor={"neutral.c30"}
+      justifyContent="space-between"
+      alignItems="center"
+    >
+      <Text fontSize="18px" fontWeight="semiBold" textTransform="none">
+        {title}
+      </Text>
+      <Flex alignItems="flex-end">
+        <TouchableOpacity onPress={onClose}>
+          <Flex
+            justifyContent="center"
+            alignItems="center"
+            p={3}
+            borderRadius={32}
+            backgroundColor={backgroundColor}
+          >
+            <Icons.Close size="XS" color={iconColor} />
+          </Flex>
+        </TouchableOpacity>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default CustomHeader;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/index.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback } from "react";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { Flex } from "@ledgerhq/native-ui";
+import { FlatList, ListRenderItemInfo, TouchableOpacity, View } from "react-native";
+import { Account, TokenAccount } from "@ledgerhq/types-live";
+import AccountItem from "../AccountsListView/components/AccountItem";
+import CustomHeader from "./CustomHeader";
+import { useTheme } from "styled-components/native";
+import getAccountListKeyExtractor from "../../utils/getAccountListKeyExtractor";
+import AccountListEmpty from "../AccountListEmpty";
+import { useTranslation } from "react-i18next";
+
+type AccountListDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onBack: () => void;
+  data: (Account | TokenAccount)[];
+  onPressAccount: (account: Account | TokenAccount) => void;
+};
+
+const AccountListDrawer = ({
+  isOpen,
+  onClose,
+  onBack,
+  data,
+  onPressAccount,
+}: AccountListDrawerProps) => {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  const renderItem = useCallback(
+    ({ item: account }: ListRenderItemInfo<Account | TokenAccount>) => {
+      return (
+        <TouchableOpacity key={account.id} onPress={() => onPressAccount(account)}>
+          <Flex flexDirection="row" alignItems="center" padding={3} width={343}>
+            <AccountItem account={account} balance={account.spendableBalance} showUnit />
+          </Flex>
+        </TouchableOpacity>
+      );
+    },
+    [onPressAccount],
+  );
+
+  const keyExtractor = useCallback(getAccountListKeyExtractor, []);
+
+  return (
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      onBack={onBack}
+      CustomHeader={() => (
+        <CustomHeader
+          onClose={onClose}
+          backgroundColor={colors.opacityDefault.c10}
+          iconColor={colors.neutral.c100}
+          title={t("addAccounts.chooseAccountToFund")}
+        />
+      )}
+    >
+      <Flex justifyContent="center" alignItems="centers" width="100%">
+        <FlatList
+          testID="added-accounts-list"
+          data={data}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          showsVerticalScrollIndicator={false}
+          ItemSeparatorComponent={() => <View style={{ height: 16 }} />}
+          style={{ paddingHorizontal: 16 }}
+          ListEmptyComponent={<AccountListEmpty />}
+        />
+      </Flex>
+    </QueuedDrawer>
+  );
+};
+
+export default AccountListDrawer;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListEmpty/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListEmpty/index.tsx
@@ -1,0 +1,11 @@
+import { Text } from "@ledgerhq/native-ui";
+import React from "react";
+import { Trans } from "react-i18next";
+
+export default function AccountListEmpty() {
+  return (
+    <Text color="neutral.c100">
+      <Trans i18nKey="transfer.receive.noAccount" />
+    </Text>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/CustomHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/CustomHeader/index.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Flex, Icons } from "@ledgerhq/native-ui";
+import { TouchableOpacity } from "react-native";
+import AccountItem from "../../AccountsListView/components/AccountItem";
+import { AccountLike } from "@ledgerhq/types-live";
+
+type Props = {
+  account: AccountLike | null;
+  onClose: () => void;
+  backgroundColor: string;
+  iconColor: string;
+};
+
+const CustomHeader = ({ account, onClose, backgroundColor, iconColor }: Props) =>
+  !account ? null : (
+    <Flex
+      flexDirection="row"
+      width="100%"
+      p={16}
+      borderBottom={5}
+      borderBottomColor={"neutral.c30"}
+    >
+      <AccountItem account={account} balance={account.spendableBalance} hideBalanceInfo />
+      <Flex alignItems="flex-end">
+        <TouchableOpacity onPress={onClose}>
+          <Flex
+            justifyContent="center"
+            alignItems="center"
+            p={3}
+            borderRadius={32}
+            backgroundColor={backgroundColor}
+          >
+            <Icons.Close size={"XS"} color={iconColor} />
+          </Flex>
+        </TouchableOpacity>
+      </Flex>
+    </Flex>
+  );
+
+export default CustomHeader;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/index.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { Box, Flex } from "@ledgerhq/native-ui";
+import { Account, TokenAccount } from "@ledgerhq/types-live";
+
+import useAccountQuickActionDrawerViewModel from "./useAccountQuickActionDrawerViewModel";
+import TransferButton from "~/components/TransferButton";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import CustomHeader from "./CustomHeader";
+import { useTheme } from "styled-components/native";
+
+type AccountListDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onBack: () => void;
+  account: Account | TokenAccount | null;
+  currency: CryptoOrTokenCurrency;
+};
+
+const AccountQuickActionsDrawer = ({
+  isOpen,
+  onClose,
+  onBack,
+  account,
+  currency,
+}: AccountListDrawerProps) => {
+  const { actions } = useAccountQuickActionDrawerViewModel({
+    accounts: account ? [account as Account] : [],
+    currency,
+  });
+  const { colors } = useTheme();
+
+  return (
+    <QueuedDrawer
+      isRequestingToBeOpened={isOpen}
+      onClose={onClose}
+      onBack={onBack}
+      CustomHeader={() => (
+        <CustomHeader
+          account={account}
+          onClose={onClose}
+          backgroundColor={colors.opacityDefault.c10}
+          iconColor={colors.neutral.c100}
+        />
+      )}
+    >
+      <Flex width="100%" rowGap={6}>
+        {actions.map((button, index) => (
+          <Box mb={index === actions.length - 1 ? 0 : 8} key={button?.title as string}>
+            <TransferButton {...button} testID={button?.testID as string} />
+          </Box>
+        ))}
+      </Flex>
+    </QueuedDrawer>
+  );
+};
+
+export default AccountQuickActionsDrawer;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/useAccountQuickActionDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/useAccountQuickActionDrawerViewModel.ts
@@ -1,0 +1,73 @@
+import { Account, TokenAccount } from "@ledgerhq/types-live";
+
+import useQuickActions from "~/hooks/useQuickActions";
+import { useNavigation } from "@react-navigation/core";
+import { useTranslation } from "react-i18next";
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
+import { IconType } from "@ledgerhq/native-ui/components/Icon/type";
+import { StyleProp, ViewStyle } from "react-native";
+import { track } from "~/analytics";
+
+type ActionItem = {
+  title: string;
+  description: string;
+  tag?: string;
+  Icon: IconType;
+  onPress?: (() => void) | null;
+  onDisabledPress?: () => void;
+  disabled?: boolean;
+  event?: string;
+  eventProperties?: Parameters<typeof track>[1];
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+export default function useAccountQuickActionDrawerViewModel({
+  currency,
+  accounts,
+}: {
+  currency: CryptoOrTokenCurrency;
+  accounts: Account[] | TokenAccount[];
+}) {
+  const {
+    quickActionsList: { RECEIVE, BUY },
+  } = useQuickActions({ currency, accounts });
+  const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
+  const { t } = useTranslation();
+
+  const actions: ActionItem[] = [
+    RECEIVE && {
+      eventProperties: {
+        button: "transfer_receive",
+        //page, TODO: add it in the analytics ticket
+        drawer: "trade",
+      },
+      title: t("transfer.receive.title"),
+      description: t("transfer.receive.description"),
+      onPress: () =>
+        navigation.navigate<keyof BaseNavigatorStackParamList>(...(RECEIVE && RECEIVE.route)),
+      Icon: RECEIVE.icon,
+      disabled: RECEIVE.disabled,
+      testID: "transfer-receive-button",
+    },
+    BUY && {
+      eventProperties: {
+        button: "transfer_buy",
+        //page, TODO: add it in the analytics ticket
+        drawer: "trade",
+      },
+      title: t("transfer.buy.title"),
+      description: t("transfer.buy.description"),
+      Icon: BUY.icon,
+      onPress: () => navigation.navigate<keyof BaseNavigatorStackParamList>(...BUY.route),
+      disabled: BUY.disabled,
+      testID: "transfer-buy-button",
+    },
+  ].filter(<T extends ActionItem>(v: T | undefined): v is T => !!v);
+
+  return {
+    actions,
+  };
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountsListView/components/AccountItem/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountsListView/components/AccountItem/index.tsx
@@ -3,10 +3,21 @@ import useAccountItemModel, { AccountItemProps } from "./useAccountItemModel";
 import { Flex, Tag, Text } from "@ledgerhq/native-ui";
 import CounterValue from "~/components/CounterValue";
 import ParentCurrencyIcon from "~/components/ParentCurrencyIcon";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
+import { Unit } from "@ledgerhq/types-cryptoassets";
 
 type ViewProps = ReturnType<typeof useAccountItemModel>;
 
-const View: React.FC<ViewProps> = ({ accountName, balance, formattedAddress, tag, currency }) => (
+const View: React.FC<ViewProps> = ({
+  accountName,
+  balance,
+  formattedAddress,
+  tag,
+  currency,
+  unit,
+  showUnit,
+  hideBalanceInfo,
+}) => (
   <>
     <Flex flex={1} rowGap={2} flexShrink={1} testID={`accountItem-${accountName}`}>
       <Flex flexDirection="row" columnGap={8} alignItems="center" maxWidth="70%">
@@ -32,11 +43,18 @@ const View: React.FC<ViewProps> = ({ accountName, balance, formattedAddress, tag
         <ParentCurrencyIcon forceIconScale={2} currency={currency} size={20} />
       </Flex>
     </Flex>
-    <Flex justifyContent="center" alignItems="flex-end">
-      <Text variant="large" fontWeight="semiBold" color="neutral.c100" testID="asset-balance">
-        <CounterValue currency={currency} value={balance} joinFragmentsSeparator="" />
-      </Text>
-    </Flex>
+    {!hideBalanceInfo && (
+      <Flex justifyContent="center" alignItems="flex-end">
+        <Text variant="large" fontWeight="semiBold" color="neutral.c100" testID="asset-balance">
+          <CounterValue currency={currency} value={balance} joinFragmentsSeparator="" />
+        </Text>
+        {showUnit && (
+          <Text variant="body" fontWeight="medium" color="neutral.c70">
+            <CurrencyUnitValue showCode unit={unit as Unit} value={balance} />
+          </Text>
+        )}
+      </Flex>
+    )}
   </>
 );
 

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountsListView/components/AccountItem/useAccountItemModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountsListView/components/AccountItem/useAccountItemModel.ts
@@ -6,6 +6,7 @@ import {
 import { Account, DerivationMode, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { useSelector } from "react-redux";
+import { useMaybeAccountUnit } from "~/hooks";
 import { formatAddress } from "~/newArch/features/Accounts/utils/formatAddress";
 import { accountsSelector } from "~/reducers/accounts";
 import { useMaybeAccountName } from "~/reducers/wallet";
@@ -13,13 +14,17 @@ import { useMaybeAccountName } from "~/reducers/wallet";
 export interface AccountItemProps {
   account: Account | TokenAccount;
   balance: BigNumber;
+  showUnit?: boolean;
+  hideBalanceInfo?: boolean;
 }
 
-const useAccountItemModel = ({ account, balance }: AccountItemProps) => {
+const useAccountItemModel = ({ account, balance, showUnit, hideBalanceInfo }: AccountItemProps) => {
   const allAccount = useSelector(accountsSelector);
   const isTokenAccount = isTokenAccountChecker(account);
   const currency = isTokenAccount ? account.token.parentCurrency : account.currency;
   const accountName = useMaybeAccountName(account);
+  const unit = useMaybeAccountUnit(account);
+
   const parentAccount = getParentAccount(account, allAccount);
   const formattedAddress = formatAddress(
     isTokenAccount ? parentAccount.freshAddress : account.freshAddress,
@@ -37,6 +42,9 @@ const useAccountItemModel = ({ account, balance }: AccountItemProps) => {
     formattedAddress,
     tag,
     currency,
+    unit,
+    showUnit,
+    hideBalanceInfo,
   };
 };
 

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AddFundsButton/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AddFundsButton/index.tsx
@@ -1,0 +1,71 @@
+import React, { useCallback, useState } from "react";
+
+import { Button } from "@ledgerhq/native-ui";
+import { useTranslation } from "react-i18next";
+import { track } from "~/analytics";
+import { Account, AccountLike } from "@ledgerhq/types-live";
+
+import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import AccountListDrawer from "../AccountListDrawer";
+import AccountQuickActionsDrawer from "../AccountQuickActionsDrawer";
+
+export default function AddFundsButton({
+  accounts,
+  currency,
+}: {
+  accounts: Account[];
+  currency: CryptoOrTokenCurrency;
+}) {
+  const { t } = useTranslation();
+  const [isAccountListDrawerOpen, setIsAccountListDrawerOpen] = useState<boolean>(false);
+  const [isAccountQuickActionsDrawerOpen, setIsAccountQuickActionsDrawerOpen] =
+    useState<boolean>(false);
+  const [selectedAccount, setSelectedAccount] = useState<AccountLike | null>(
+    accounts.length === 1 ? accounts[0] : null,
+  );
+  const openFundOrAccountListDrawer = () => {
+    track("button_clicked", { button: "Add a new account" });
+    if (accounts.length === 1) {
+      setIsAccountQuickActionsDrawerOpen(true);
+    } else setIsAccountListDrawerOpen(true);
+  };
+
+  const closeAccountListDrawer = () => setIsAccountListDrawerOpen(false);
+
+  const handleOnSelectAccoount = useCallback((account: AccountLike) => {
+    closeAccountListDrawer();
+    setSelectedAccount(account);
+    setIsAccountQuickActionsDrawerOpen(true);
+  }, []);
+
+  const handleOnCloseQuickActions = () => {
+    setIsAccountQuickActionsDrawerOpen(false);
+  };
+
+  return (
+    <>
+      <Button
+        size="large"
+        type="shade"
+        testID="button-create-account"
+        onPress={openFundOrAccountListDrawer}
+      >
+        {t("addAccounts.addAccountsSuccess.ctaAddFunds")}
+      </Button>
+      <AccountListDrawer
+        isOpen={isAccountListDrawerOpen}
+        onClose={closeAccountListDrawer}
+        onBack={closeAccountListDrawer}
+        data={accounts}
+        onPressAccount={handleOnSelectAccoount}
+      />
+      <AccountQuickActionsDrawer
+        isOpen={isAccountQuickActionsDrawerOpen}
+        onClose={handleOnCloseQuickActions}
+        onBack={handleOnCloseQuickActions}
+        account={selectedAccount}
+        currency={currency}
+      />
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/VerticalGradientBackground/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/VerticalGradientBackground/index.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import Svg, { Rect, Defs, LinearGradient, Stop } from "react-native-svg";
+
+export default function VerticalGradientBackground({ stopColor }: { stopColor: string }) {
+  return (
+    <Svg
+      style={{
+        ...StyleSheet.absoluteFillObject,
+        top: 0,
+        flexShrink: 0,
+      }}
+      width="100%"
+      height="395px"
+    >
+      <Defs>
+        <LinearGradient id="verticalGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+          <Stop offset="0%" stopOpacity={0.3} stopColor={stopColor} />
+          <Stop offset="100%" stopOpacity={0} stopColor={stopColor} />
+        </LinearGradient>
+      </Defs>
+      <Rect x="0" y="0" width="100%" height="100%" fill="url(#verticalGradient)" />
+    </Svg>
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
@@ -1,8 +1,8 @@
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { ScreenName } from "~/const";
 import { Device } from "@ledgerhq/types-devices";
-import { AccountLikeEnhanced } from "../ScanDeviceAccounts/types";
 import { Account } from "@ledgerhq/types-live";
+import { Props as TouchableProps } from "~/components/Touchable";
 
 type CommonParams = {
   context?: "addAccounts" | "receiveFunds";
@@ -19,8 +19,21 @@ export type NetworkBasedAddAccountNavigator = {
   [ScreenName.SelectAccounts]: CommonParams & {
     createTokenAccount?: boolean;
   };
+
   [ScreenName.AddAccountsSuccess]: CommonParams & {
-    fundedAccounts: AccountLikeEnhanced[];
-    accountsWithZeroBalance: AccountLikeEnhanced[];
+    accountsToAdd: Account[];
+  };
+  [ScreenName.AddAccountsWarning]: CommonParams & {
+    emptyAccount?: Account;
+    emptyAccountName?: string;
+  };
+  [ScreenName.NoAssociatedAccounts]: {
+    CustomNoAssociatedAccounts: ({
+      style,
+    }: {
+      style?: {
+        paddingHorizontal?: TouchableProps["style"];
+      };
+    }) => JSX.Element;
   };
 };

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
@@ -1,10 +1,16 @@
-import { Button, Flex, Icons, Text } from "@ledgerhq/native-ui";
+import { Button, Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { FlatList, ListRenderItemInfo, StyleSheet, TouchableOpacity, View } from "react-native";
-import { useTheme } from "@react-navigation/native";
+import {
+  Animated,
+  FlatList,
+  ListRenderItemInfo,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
-import { rgba } from "../../../../../colors";
 import { TrackScreen } from "~/analytics";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import AccountItem from "../../components/AccountsListView/components/AccountItem";
@@ -14,8 +20,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import SafeAreaView from "~/components/SafeAreaView";
 import Circle from "~/components/Circle";
 import { NetworkBasedAddAccountNavigator } from "../AddAccount/types";
-
-// TODO: Add business logic (0 funded account warning section) and Poolish (UI + gradient like figma design) & add integration tests in the following ticket https://ledgerhq.atlassian.net/browse/LIVE-13983
+import VerticalGradientBackground from "../../components/VerticalGradientBackground";
+import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
+import { useNavigation } from "@react-navigation/core";
+import useAnimatedStyle from "../ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
+import AddFundsButton from "../../components/AddFundsButton";
 
 type Props = BaseComposite<
   StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.AddAccountsSuccess>
@@ -25,56 +34,70 @@ export default function AddAccountsSuccess({ route }: Props) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
+  const { animatedSelectableAccount } = useAnimatedStyle();
 
-  const { currency, fundedAccounts } = route.params || {};
+  const goToAccounts = useCallback(
+    (accountId: string) => () => {
+      navigation.navigate(ScreenName.Account, {
+        accountId,
+      });
+    },
+    [navigation],
+  );
+
+  const { currency, accountsToAdd } = route.params || {};
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<AccountLikeEnhanced>) => (
-      <TouchableOpacity>
-        <Flex
-          flex={1}
-          flexDirection="row"
-          height={56}
-          alignItems="center"
-          backgroundColor="neutral.c30"
-          borderRadius={"12px"}
-          padding={"12px"}
-          columnGap={12}
-        >
-          <AccountItem account={item as Account} balance={item.spendableBalance} />
-          <Icons.ChevronRight size="M" color={colors.primary} />
-        </Flex>
-      </TouchableOpacity>
+      <Animated.View style={[animatedSelectableAccount]}>
+        <TouchableOpacity onPress={goToAccounts(item.id)}>
+          <Flex
+            flexDirection="row"
+            alignItems="center"
+            backgroundColor="neutral.c30"
+            borderRadius="12px"
+            padding="12px"
+            width={343}
+          >
+            <AccountItem account={item as Account} balance={item.spendableBalance} />
+            <Icons.ChevronRight size="M" color={colors.primary.c100} />
+          </Flex>
+        </TouchableOpacity>
+      </Animated.View>
     ),
-    [colors.primary],
+    [colors.primary, goToAccounts, animatedSelectableAccount],
   );
 
   const keyExtractor = useCallback((item: AccountLikeEnhanced) => item?.id, []);
 
+  const statusColor = colors.neutral.c100;
+
   return (
     <SafeAreaView edges={["left", "right"]} isFlex>
       <TrackScreen category="AddAccounts" name="Success" currencyName={currency?.name} />
+      <VerticalGradientBackground stopColor={getCurrencyColor(currency)} />
       <Flex alignItems={"center"} style={styles.root}>
-        <View style={[styles.iconWrapper, { backgroundColor: rgba(colors.success, 0.1) }]}>
+        <View style={[styles.iconWrapper, { backgroundColor: rgba(statusColor, 0.1) }]}>
           <Circle size={24}>
-            <Icons.CheckmarkCircleFill size="L" color={colors.success} />
+            <Icons.CheckmarkCircleFill size="L" color={statusColor} />
           </Circle>
         </View>
-        <Text style={styles.title}>{t("addAccounts.added", { count: fundedAccounts.length })}</Text>
+        <Text style={styles.title}>{t("addAccounts.added", { count: accountsToAdd.length })}</Text>
       </Flex>
-      <FlatList
-        testID="receive-header-step2-accounts"
-        data={fundedAccounts}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        showsVerticalScrollIndicator={false}
-        style={{ paddingHorizontal: 16 }}
-      />
-
+      <Flex flex={1} justifyContent="center" alignItems="center">
+        <FlatList
+          testID="added-accounts-list"
+          data={accountsToAdd}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          showsVerticalScrollIndicator={false}
+          ItemSeparatorComponent={() => <View style={{ height: 16 }} />}
+          style={{ paddingHorizontal: 16 }}
+        />
+      </Flex>
       <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
-        <Button size="large" type="shade" testID="button-create-account">
-          {t("addAccounts.addAccountsSuccess.ctaAddFunds")}
-        </Button>
+        <AddFundsButton accounts={accountsToAdd} currency={currency} />
         <Button size="large" testID="button-create-account">
           {t("addAccounts.addAccountsSuccess.ctaClose")}
         </Button>
@@ -85,53 +108,14 @@ export default function AddAccountsSuccess({ route }: Props) {
 
 const styles = StyleSheet.create({
   root: {
-    flex: 1,
-    paddingHorizontal: 20,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  currencySuccess: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  outer: {
-    position: "absolute",
-    top: -5,
-    right: -5,
-    width: 34,
-    height: 34,
-    borderRadius: 100,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  inner: {
-    width: 26,
-    height: 26,
-    borderRadius: 100,
-    flexDirection: "row",
+    marginTop: 100,
+    marginBottom: 20,
     alignItems: "center",
     justifyContent: "center",
   },
   title: {
     marginTop: 32,
     fontSize: 24,
-  },
-  desc: {
-    marginTop: 16,
-    marginBottom: 32,
-    marginHorizontal: 32,
-    textAlign: "center",
-    fontSize: 14,
-  },
-  buttonsContainer: {
-    alignSelf: "stretch",
-  },
-  button: {
-    marginBottom: 16,
   },
   iconWrapper: {
     height: 72,

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
@@ -1,0 +1,127 @@
+import React, { useCallback } from "react";
+import { Button, Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
+import { useTranslation } from "react-i18next";
+import { Animated, StyleSheet, TouchableOpacity, View } from "react-native";
+import { useTheme } from "styled-components/native";
+import { ScreenName } from "~/const";
+import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import AccountItem from "../../components/AccountsListView/components/AccountItem";
+import { Account } from "@ledgerhq/types-live";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
+import Circle from "~/components/Circle";
+import { NetworkBasedAddAccountNavigator } from "../AddAccount/types";
+import VerticalGradientBackground from "../../components/VerticalGradientBackground";
+import BigNumber from "bignumber.js";
+import { useNavigation } from "@react-navigation/core";
+import useAnimatedStyle from "../ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
+import AddFundsButton from "../../components/AddFundsButton";
+type Props = BaseComposite<
+  StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.AddAccountsWarning>
+>;
+
+export default function AddAccountsWarning({ route }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
+
+  const { animatedSelectableAccount } = useAnimatedStyle();
+
+  const goToAccounts = useCallback(
+    (accountId: string) => () => {
+      navigation.navigate(ScreenName.Account, {
+        accountId,
+      });
+    },
+    [navigation],
+  );
+  const { emptyAccount, emptyAccountName, currency } = route.params || {};
+
+  const statusColor = colors.warning.c70;
+
+  return (
+    <SafeAreaView edges={["left", "right"]} isFlex>
+      <VerticalGradientBackground stopColor={statusColor} />
+      <Flex alignItems={"center"} flex={1} style={styles.root}>
+        <View style={[styles.iconWrapper, { backgroundColor: rgba(statusColor, 0.1) }]}>
+          <Circle size={24}>
+            <Icons.WarningFill size="L" color={statusColor} />
+          </Circle>
+        </View>
+        <>
+          <Text style={styles.title}>
+            {t("addAccounts.addAccountsWarning.cantCreateAccount.title", {
+              accountName: emptyAccountName,
+            })}
+          </Text>
+
+          <Text style={styles.desc}>
+            {t("addAccounts.addAccountsWarning.cantCreateAccount.body", {
+              accountName: emptyAccountName,
+            })}
+          </Text>
+        </>
+      </Flex>
+      <Flex flex={1} p={6} flexDirection="row" justifyContent="center">
+        <Animated.View style={[animatedSelectableAccount]}>
+          <TouchableOpacity onPress={goToAccounts(emptyAccount?.id as string)}>
+            <Flex
+              flexDirection="row"
+              alignItems="center"
+              backgroundColor="neutral.c30"
+              borderRadius="12px"
+              padding="12px"
+              width={343}
+            >
+              <AccountItem
+                account={emptyAccount as Account}
+                balance={emptyAccount?.spendableBalance as BigNumber}
+              />
+              <Icons.ChevronRight size="M" color={colors.primary.c100} />
+            </Flex>
+          </TouchableOpacity>
+        </Animated.View>
+      </Flex>
+      <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
+        <AddFundsButton accounts={[emptyAccount as Account]} currency={currency} />
+        <Button size="large" testID="button-create-account">
+          {t("addAccounts.addAccountsSuccess.ctaClose")}
+        </Button>
+      </Flex>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: 20,
+    alignItems: "center",
+    justifyContent: "center",
+    marginTop: 50,
+  },
+  title: {
+    marginTop: 32,
+    fontSize: 24,
+    textAlign: "center",
+    width: "100%",
+    fontWeight: 600,
+    fontStyle: "normal",
+    lineHeight: 32.4,
+    letterSpacing: 0.75,
+  },
+  desc: {
+    marginTop: 16,
+    marginBottom: 32,
+    marginHorizontal: 32,
+    textAlign: "center",
+    fontSize: 14,
+  },
+  iconWrapper: {
+    height: 72,
+    width: 72,
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/NoAssociatedAccountsView/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/NoAssociatedAccountsView/index.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Flex, Icons, rgba, Button } from "@ledgerhq/native-ui";
+import { StyleSheet, View } from "react-native";
+import { useTheme } from "styled-components/native";
+import SafeAreaView from "~/components/SafeAreaView";
+import Circle from "~/components/Circle";
+import VerticalGradientBackground from "LLM/features/Accounts/components/VerticalGradientBackground";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTranslation } from "react-i18next";
+import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import { NetworkBasedAddAccountNavigator } from "../AddAccount/types";
+import { ScreenName } from "~/const";
+
+type Props = BaseComposite<
+  StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.NoAssociatedAccounts>
+>;
+export default function NoAssociatedAccountsView({ route }: Props) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { t } = useTranslation();
+  const { CustomNoAssociatedAccounts } = route.params || {};
+
+  const statusColor = colors.primary.c70;
+  return (
+    <SafeAreaView edges={["left", "right"]} isFlex style={{ justifyContent: "center" }}>
+      <VerticalGradientBackground stopColor={statusColor} />
+      <View
+        style={[
+          styles.iconWrapper,
+          {
+            backgroundColor: rgba(statusColor, 0.1),
+            borderColor: colors.primary.c70,
+            alignSelf: "center",
+            marginTop: 150,
+          },
+        ]}
+      >
+        <Circle size={24}>
+          <Icons.InformationFill size="L" color={statusColor} />
+        </Circle>
+      </View>
+      <Flex
+        alignItems="center"
+        justifyContent={"center"}
+        style={styles.famillyComponentContainer}
+        flex={1}
+      >
+        {<CustomNoAssociatedAccounts />}
+      </Flex>
+      <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
+        <Button size="large" testID="button-create-account">
+          {t("addAccounts.addAccountsSuccess.ctaClose")}
+        </Button>
+      </Flex>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  famillyComponentContainer: {
+    paddingHorizontal: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconWrapper: {
+    height: 72,
+    width: 72,
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+    display: "flex",
+  },
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/components/CanCreateAccountAlert/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/components/CanCreateAccountAlert/index.tsx
@@ -1,0 +1,59 @@
+import { Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Animated, StyleSheet } from "react-native";
+import { View } from "react-native-animatable";
+import { useTheme } from "styled-components/native";
+import Circle from "~/components/Circle";
+import VerticalGradientBackground from "LLM/features/Accounts/components/VerticalGradientBackground";
+import useAnimatedStyle from "../ScanDeviceAccountsFooter/useAnimatedStyle";
+
+export function CantCreateAccountAlert({ currencyName }: { currencyName: string }) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const { animatedSelectableAccount: animatedContainer } = useAnimatedStyle();
+  return (
+    <Animated.View style={[animatedContainer, styles.cantCreateAccount]}>
+      <VerticalGradientBackground stopColor={colors.warning.c70} />
+      <Flex alignItems={"center"} style={styles.cantCreateAccount}>
+        <View style={[styles.iconWrapper, { backgroundColor: rgba(colors.warning.c70, 0.1) }]}>
+          <Circle size={24}>
+            <Icons.WarningFill size="L" color={colors.warning.c70} />
+          </Circle>
+        </View>
+
+        <Text style={styles.cantCreateAccountTitle}>
+          {t("addAccounts.addAccountsWarning.noAccountToCreate.title", {
+            replace: {
+              currency: currencyName,
+            },
+          })}
+        </Text>
+      </Flex>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cantCreateAccountTitle: {
+    marginTop: 32,
+    fontSize: 24,
+    textAlign: "center",
+    width: "100%",
+    fontWeight: 600,
+    fontStyle: "normal",
+    lineHeight: 32.4,
+    letterSpacing: 0.75,
+  },
+  iconWrapper: {
+    height: 72,
+    width: 72,
+    borderRadius: 50,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cantCreateAccount: {
+    flex: 1,
+    justifyContent: "center",
+  },
+});

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/components/ScanDeviceAccountsFooter/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/components/ScanDeviceAccountsFooter/index.tsx
@@ -34,7 +34,7 @@ const ScanDeviceAccountsFooter = ({
         <Button
           event="AddAccountsRetryScan"
           type="primary"
-          title={<Trans i18nKey="addAccounts.retryScanning" />}
+          title={<Trans i18nKey="addAccounts.scanDeviceAccounts.retryScanning" />}
           onPress={onRetry}
         />
       ) : canDone ? (

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/index.tsx
@@ -14,7 +14,6 @@ import { TrackScreen } from "~/analytics";
 
 import Button from "~/components/Button";
 import PreventNativeBack from "~/components/PreventNativeBack";
-import LText from "~/components/LText";
 import RetryButton from "~/components/RetryButton";
 import CancelButton from "~/components/CancelButton";
 import GenericErrorBottomModal from "~/components/GenericErrorBottomModal";
@@ -26,6 +25,7 @@ import AnimatedGradient from "./components/AnimatedGradient";
 import ScanDeviceAccountsFooter from "./components/ScanDeviceAccountsFooter";
 import AddressTypeTooltip from "./components/AddressTypeTooltip";
 import ScannedAccountsSection from "./components/ScannedAccountsSection";
+import { CantCreateAccountAlert } from "./components/CanCreateAccountAlert";
 
 function ScanDeviceAccounts() {
   const { colors } = useTheme();
@@ -37,7 +37,6 @@ function ScanDeviceAccounts() {
 
   const {
     alreadyEmptyAccount,
-    alreadyEmptyAccountName,
     cantCreateAccount,
     CustomNoAssociatedAccounts,
     error,
@@ -66,26 +65,9 @@ function ScanDeviceAccounts() {
     blacklistedTokenIds,
   });
 
-  // Empty state same UI as ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
   const emptyTexts = {
-    creatable: alreadyEmptyAccount ? (
-      <LText style={styles.paddingHorizontal}>
-        <Trans i18nKey="addAccounts.cantCreateAccount">
-          {"PLACEHOLDER-1"}
-          <LText semiBold>{alreadyEmptyAccountName}</LText>
-          {"PLACEHOLDER-2"}
-        </Trans>
-      </LText>
-    ) : CustomNoAssociatedAccounts ? (
-      <CustomNoAssociatedAccounts style={styles} />
-    ) : (
-      <LText style={styles.paddingHorizontal}>
-        <Trans i18nKey="addAccounts.noAccountToCreate">
-          {"PLACEHOLDER-1"}
-          <LText semiBold>{currency.name}</LText>
-          {"PLACEHOLDER-2"}
-        </Trans>
-      </LText>
+    creatable: alreadyEmptyAccount ? null : CustomNoAssociatedAccounts ? null : (
+      <CantCreateAccountAlert currencyName={currency.name} />
     ),
   };
 
@@ -100,8 +82,9 @@ function ScanDeviceAccounts() {
     >
       <TrackScreen category="AddAccounts" name="Accounts" currencyName={currency.name} />
       <PreventNativeBack />
-      <Flex px={6}>
-        {scanning || !scannedAccounts.length ? (
+
+      {scanning || !scannedAccounts.length ? (
+        <Flex px={6} style={styles.headerTitle}>
           <Text
             variant="h4"
             testID="receive-header-step2-title"
@@ -110,17 +93,21 @@ function ScanDeviceAccounts() {
           >
             <Trans i18nKey="addAccounts.scanDeviceAccounts.scanningTitle" />
           </Text>
-        ) : (
-          <Text
-            variant="h4"
-            testID="receive-header-step2-title"
-            fontSize="24px"
-            color="neutral.c100"
-          >
-            <Trans i18nKey="addAccounts.scanDeviceAccounts.title" />
-          </Text>
-        )}
-      </Flex>
+        </Flex>
+      ) : (
+        !cantCreateAccount && (
+          <Flex px={6} style={styles.headerTitle}>
+            <Text
+              variant="h4"
+              testID="receive-header-step2-title"
+              fontSize="24px"
+              color="neutral.c100"
+            >
+              <Trans i18nKey="addAccounts.scanDeviceAccounts.title" />
+            </Text>
+          </Flex>
+        )
+      )}
 
       {scanning ? <AnimatedGradient /> : null}
       <NavigationScrollView style={styles.inner} contentContainerStyle={styles.innerContent}>
@@ -225,26 +212,19 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: "transparent",
+    marginTop: 50,
   },
-  paddingHorizontal: {
-    paddingHorizontal: 16,
+  headerTitle: {
+    marginTop: 50,
+    marginBottom: 16,
   },
   inner: {
-    paddingTop: 24,
     backgroundColor: "transparent",
   },
   innerContent: {
     paddingBottom: 24,
     backgroundColor: "transparent",
-  },
-  descText: {
-    paddingHorizontal: 16,
-    marginBottom: 16,
-    textAlign: "center",
-  },
-  addAccountsError: {
-    marginHorizontal: 16,
-    marginBottom: 16,
+    flex: 1,
   },
   button: {
     flex: 1,

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -8,10 +8,10 @@ import uniq from "lodash/uniq";
 import type { Account } from "@ledgerhq/types-live";
 import { getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { isTokenCurrency } from "@ledgerhq/live-common/currencies/index";
-import logger from "../../../../../logger";
+import logger from "~/logger";
 import { NavigatorName, ScreenName } from "~/const";
 import { prepareCurrency } from "~/bridge/cache";
-import noAssociatedAccountsByFamily from "../../../../../generated/NoAssociatedAccounts";
+import noAssociatedAccountsByFamily from "~/generated/NoAssociatedAccounts";
 import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { groupAddAccounts } from "@ledgerhq/live-wallet/addAccounts";
@@ -34,6 +34,7 @@ export default function useScanDeviceAccountsViewModel({
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [cancelled, setCancelled] = useState(false);
   const scanSubscription = useRef<Subscription | null>(null);
+  const [isAddingAccounts, setIsAddinAccounts] = useState<boolean>(false);
   const dispatch = useDispatch();
 
   const route = useRoute<ScanDeviceAccountsNavigationProps["route"]>();
@@ -130,31 +131,17 @@ export default function useScanDeviceAccountsViewModel({
     [selectedIds],
   );
   const importAccounts = useCallback(() => {
-    const selectedAccounts = scannedAccounts.filter(a => selectedIds.includes(a.id));
-    const { accountsWithZeroBalance, fundedAccounts } = selectedAccounts.reduce(
-      (acc, account) => {
-        if (account.balance.isZero()) {
-          acc.accountsWithZeroBalance.push(account);
-        } else {
-          acc.fundedAccounts.push(account);
-        }
-        return acc;
-      },
-      { accountsWithZeroBalance: [], fundedAccounts: [] } as {
-        accountsWithZeroBalance: Account[];
-        fundedAccounts: Account[];
-      },
+    setIsAddinAccounts(true);
+    const accountsToAdd = scannedAccounts.filter(a => selectedIds.includes(a.id));
+
+    dispatch(
+      addAccountsAction({
+        existingAccounts,
+        scannedAccounts,
+        selectedIds,
+        renamings: {}, // renaming was done in scannedAccounts directly.. (see if we want later to change this paradigm)
+      }),
     );
-    if (fundedAccounts.length > 0) {
-      dispatch(
-        addAccountsAction({
-          existingAccounts,
-          scannedAccounts,
-          selectedIds: fundedAccounts.map(a => a.id),
-          renamings: {}, // renaming was done in scannedAccounts directly.. (see if we want later to change this paradigm)
-        }),
-      );
-    }
 
     if (inline) {
       navigation.goBack();
@@ -163,14 +150,13 @@ export default function useScanDeviceAccountsViewModel({
       if (onSuccess)
         onSuccess({
           scannedAccounts,
-          selected: scannedAccounts.filter(a => selectedIds.includes(a.id)),
+          selected: accountsToAdd,
         });
       else
         navigation.replace(ScreenName.AddAccountsSuccess, {
           ...route.params,
           currency,
-          fundedAccounts,
-          accountsWithZeroBalance,
+          accountsToAdd: accountsToAdd,
         });
     }
   }, [
@@ -256,6 +242,30 @@ export default function useScanDeviceAccountsViewModel({
     }
   }, [existingAccounts, latestScannedAccount, onlyNewAccounts, scannedAccounts, selectedIds]);
 
+  useEffect(() => {
+    if (!cantCreateAccount && !isAddingAccounts && !scanning) {
+      if (alreadyEmptyAccount) {
+        navigation.replace(ScreenName.AddAccountsWarning, {
+          emptyAccount: alreadyEmptyAccount,
+          emptyAccountName: alreadyEmptyAccountName,
+          currency,
+        });
+      } else if (CustomNoAssociatedAccounts) {
+        navigation.replace(ScreenName.NoAssociatedAccounts, {
+          CustomNoAssociatedAccounts,
+        });
+      }
+    }
+  }, [
+    cantCreateAccount,
+    isAddingAccounts,
+    alreadyEmptyAccount,
+    alreadyEmptyAccountName,
+    scanning,
+    navigation,
+    currency,
+    CustomNoAssociatedAccounts,
+  ]);
   return {
     alreadyEmptyAccount,
     alreadyEmptyAccountName,

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/utils/getAccountListKeyExtractor.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/utils/getAccountListKeyExtractor.ts
@@ -1,0 +1,5 @@
+import { AccountLike } from "@ledgerhq/types-live";
+
+export default function getAccountListKeyExtractor(account: AccountLike) {
+  return account.id;
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/utils/tests/getAccountListKeyExtractor.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/utils/tests/getAccountListKeyExtractor.test.ts
@@ -1,0 +1,13 @@
+import getAccountListKeyExtractor from "../getAccountListKeyExtractor";
+import { Account } from "@ledgerhq/types-live";
+
+describe("getAccountListKeyExtractor", () => {
+  it("should return the id of an Account", () => {
+    const account = {
+      id: "account1",
+      seedIdentifier: "Account 1",
+    } as Account;
+    const result = getAccountListKeyExtractor(account);
+    expect(result).toBe("account1");
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/SkipSelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SkipSelectDevice.tsx
@@ -10,7 +10,7 @@ import { ReceiveFundsStackParamList } from "~/components/RootNavigator/types/Rec
 import { ScreenName } from "~/const";
 import { useDebouncedRequireBluetooth } from "~/components/RequiresBLE/hooks/useRequireBluetooth";
 import RequiresBluetoothDrawer from "~/components/RequiresBLE/RequiresBluetoothDrawer";
-import { DeviceSelectionNavigatorParamsList } from "~/newArch/features/DeviceSelection/types";
+import { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
 
 type Navigation =
   | StackNavigatorProps<AddAccountsNavigatorParamList, ScreenName.AddAccountsSelectDevice>

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -190,7 +190,7 @@ export const accountNameSelector = (
 ): string | undefined => state.accountNames.get(accountId);
 
 export const accountNameWithDefaultSelector = (state: WalletState, account: AccountLike): string =>
-  state.accountNames.get(account.id) || getDefaultAccountName(account);
+  state?.accountNames?.get(account.id) || getDefaultAccountName(account);
 
 export const isStarredAccountSelector = (
   state: WalletState,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR will cover the following use cases: 

1.  Show a success screen with one or more added account with a currency color based gradient.
-> When user clicks on an account item , a redirection to account details page
-> when user clicks on add funds to my accounts -> a first drawer suggest the account list to select -> a second drawer will appear  with buy/receive cta once an account is selected. 


https://github.com/user-attachments/assets/fec7a199-f521-47fe-81a7-a149d835c675



2.  Show a warning screen one single 0$ balance existing account.
-> Here when you click on Add funds to my accounts -> a drawer with buy/receive (no account list drawer in this case)


https://github.com/user-attachments/assets/9e4a9cc1-9d66-415f-b88b-c6a82fbd4517


3. Show a specific empty state screen for Hedera with a custom NoAssociatedAccount component (secured with a feature flag ) 


https://github.com/user-attachments/assets/0eadb96e-2554-4b93-840a-4e14b58ed96e


4. Show a generic empty state when the account cannot be added. (this use case can happen when there is no funded accounts found on the scan process and the creation of the 0 $ balance account failed) an edge case that needs a specific backend simulation. 

The following component should be seen: 
![image](https://github.com/user-attachments/assets/8a7c8f30-bb26-4070-b0f1-c90036f108fd)


### 👩🏼‍🎨 Resources

[Figma for add account full process](https://www.figma.com/design/CRZc2rIqb9dbV7eOt9rhXt/Add-accounts?node-id=1303-15413&p=f&m=dev)
[Figma for additional screen](https://www.figma.com/design/CRZc2rIqb9dbV7eOt9rhXt/Add-accounts?node-id=2806-4508&m=dev)
[My test case testing ](https://ledgerhq.atlassian.net/browse/LIVE-15607?focusedCommentId=511743)

### 📣 📣 🚨 Details to keep in mind while reviewing/testing this PR 

- The close CTA for the current state of developpement will be fixed in this [ticket](https://ledgerhq.atlassian.net/browse/LIVE-15606)
- Animation are not finalised , pending animation keys from the design team -> will be done in this [ticket](https://ledgerhq.atlassian.net/browse/LIVE-15721) 
- Analytics cleanup are not in the scope of this PR. There is a dedicated [taks](https://ledgerhq.atlassian.net/browse/LIVE-15722) 
- Do not test this flow starting by Receive, Buy or Swap. An adjusting plug-in is expected in this [task](https://ledgerhq.atlassian.net/browse/LIVE-14645)



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-15607

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
