### PR TITLE
fix(wallet-api): only bypass derivation check on LL for ACRE flows [LIVE-15787]

### DIFF
--- a/.changeset/kind-buttons-lay.md
+++ b/.changeset/kind-buttons-lay.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+fix(wallet-api): only bypass derivation check on LL for ACRE flows

--- a/.changeset/kind-buttons-lay.md
+++ b/.changeset/kind-buttons-lay.md
@@ -1,7 +1,7 @@
 ---
-"ledger-live-desktop": patch
-"live-mobile": patch
-"@ledgerhq/live-common": patch
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
 ---
 
 fix(wallet-api): only bypass derivation check on LL for ACRE flows

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/CustomHandlers.ts
@@ -62,6 +62,7 @@ export function useACRECustomHandlers(manifest: WebviewProps["manifest"], accoun
             ipcRenderer.send("show-app", {});
             dispatch(
               openModal("MODAL_SIGN_MESSAGE", {
+                isACRE: true,
                 account,
                 message,
                 useApp: options?.hwAppId,

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/Body.tsx
@@ -15,6 +15,7 @@ export type Data = {
   onClose: () => void;
   useApp?: string;
   dependencies?: string[];
+  isACRE?: boolean;
 };
 
 type OwnProps = {
@@ -56,6 +57,7 @@ const Body = ({ onClose, data }: Props) => {
     onStepChange: handleStepChange,
     stepId,
     steps,
+    isACRE: data.isACRE,
     useApp: data.useApp,
     dependencies: data.dependencies,
     message: data.message,

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSign.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSign.tsx
@@ -21,6 +21,7 @@ export default function StepSign({
   dependencies,
   onConfirmationHandler,
   onFailHandler,
+  isACRE,
 }: StepProps) {
   const dispatch = useDispatch();
   const request = useMemo(() => {
@@ -30,8 +31,9 @@ export default function StepSign({
       message,
       appName: useApp,
       dependencies: appRequests,
+      isACRE,
     };
-  }, [account, dependencies, message, useApp]);
+  }, [account, dependencies, isACRE, message, useApp]);
   return (
     <DeviceAction
       action={action}

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/types.ts
@@ -14,6 +14,7 @@ export type StepProps = {
   dependencies?: string[];
   onConfirmationHandler: (arg: string) => void;
   onFailHandler: (arg: Error) => void;
+  isACRE?: boolean;
 };
 
 export type St = Step<StepId, StepProps>;

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/SignMessageNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/SignMessageNavigator.ts
@@ -10,6 +10,7 @@ export type CommonParams = {
   dependencies?: string[];
   onConfirmationHandler?: (_: string) => void;
   onFailHandler?: (_: Error) => void;
+  isACRE?: boolean;
 };
 
 export type SignMessageNavigatorStackParamList = {

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/CustomHandlers.ts
@@ -53,6 +53,7 @@ export function useACRECustomHandlers(manifest: WebviewProps["manifest"], accoun
                 dependencies: options?.dependencies,
                 onConfirmationHandler: onSuccess,
                 onFailHandler: onError,
+                isACRE: true,
               },
               onClose: onCancel,
             });

--- a/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.tsx
@@ -48,8 +48,15 @@ export default function ConnectDevice({
       appName: route.params.appName,
       message: route.params.message,
       dependencies: appRequests,
+      isACRE: route.params.isACRE,
     };
-  }, [mainAccount, route.params.appName, route.params.dependencies, route.params.message]);
+  }, [
+    mainAccount,
+    route.params.appName,
+    route.params.dependencies,
+    route.params.isACRE,
+    route.params.message,
+  ]);
 
   return useMemo(
     () => (

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -129,7 +129,7 @@ export const createAction = (
     } = txRequest;
     const mainAccount = getMainAccount(txRequest.account, txRequest.parentAccount);
     const appState = createAppAction(connectAppExec).useHook(reduxDevice, {
-      account: appName ? undefined : mainAccount,
+      account: isACRE ? undefined : mainAccount, // Bypass derivation check with ACRE as we can use other addresses than the freshest
       appName,
       dependencies,
       requireLatestFirmware,

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -78,6 +78,7 @@ type BaseState = {
 export type State = AppState & BaseState;
 export type Request = AppRequest & {
   message: AnyMessage;
+  isACRE?: boolean;
 };
 
 export type Input = {
@@ -110,7 +111,7 @@ export const createAction = (
     const appState: AppState = createAppAction(connectAppExec).useHook(reduxDevice, {
       appName: request.appName,
       dependencies: request.dependencies,
-      account: request.appName ? undefined : request.account,
+      account: request.isACRE ? undefined : request.account, // Bypass derivation check with ACRE as we can use other addresses than the freshest
     });
     const { device, opened, inWrongDeviceForAccount, error } = appState;
     const [state, setState] = useState<BaseState>({


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Not sure if we can test this with speculos
- [x] **Impact of the changes:**
  - wallet-api ACRE flows

### 📝 Description

Added back the account for the connect action even with an appName present as we should still keep it
And only bypass the derivation check on LL for ACRE flows

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15787]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15787]: https://ledgerhq.atlassian.net/browse/LIVE-15787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ