### PR TITLE
:bug: (lld): Fix scroll on change device language

### DIFF
--- a/.changeset/bright-turkeys-compete.md
+++ b/.changeset/bright-turkeys-compete.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix windows scroll on change device language

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceLanguageInstallation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceLanguageInstallation.tsx
@@ -97,7 +97,7 @@ const DeviceLanguageInstallation: React.FC<Props> = ({
       <Text alignSelf="center" variant="h5Inter" mb={12}>
         {t("deviceLocalization.deviceLanguage")}
       </Text>
-      <Flex px={12} flex={1}>
+      <Flex px={12} flex={1} overflowY="scroll" height="100%">
         {availableLanguages?.length ? (
           installing ? (
             <ChangeDeviceLanguageAction


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix scroll on change device language


https://github.com/user-attachments/assets/0643c18a-cb6e-4533-96c6-4beaecfce647


https://github.com/user-attachments/assets/de4a77ec-7b27-4b8f-803f-55c4af5caa8c



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-14690] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14690]: https://ledgerhq.atlassian.net/browse/LIVE-14690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ