### PR TITLE
feat: close add account v2 multiple navigator via a confirmation drawer

### DIFF
--- a/.changeset/hungry-bobcats-sneeze.md
+++ b/.changeset/hungry-bobcats-sneeze.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add account v2 close process management

--- a/apps/ledger-live-mobile/src/components/ConfirmationModal.tsx
+++ b/apps/ledger-live-mobile/src/components/ConfirmationModal.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from "react";
 import { Trans } from "react-i18next";
-import { View, StyleSheet, Image } from "react-native";
+import { View, StyleSheet, Image, StyleProp, ViewStyle } from "react-native";
 import { rgba, Theme, withTheme } from "../colors";
 import QueuedDrawer from "./QueuedDrawer";
 import LText from "./LText";
@@ -25,6 +25,8 @@ type Props = {
   preventBackdropClick?: boolean;
   iconMarginBottom?: number;
   testID?: string;
+  customTitleStyle?: StyleProp<ViewStyle>;
+  customDescriptionStyle?: StyleProp<ViewStyle>;
 };
 
 class ConfirmationModal extends PureComponent<Props> {
@@ -48,6 +50,8 @@ class ConfirmationModal extends PureComponent<Props> {
       hideRejectButton,
       colors,
       iconMarginBottom,
+      customTitleStyle,
+      customDescriptionStyle,
       ...rest
     } = this.props;
     const iColor = iconColor || colors.live;
@@ -77,12 +81,12 @@ class ConfirmationModal extends PureComponent<Props> {
           </View>
         )}
         {confirmationTitle && (
-          <LText secondary semiBold style={styles.confirmationTitle}>
+          <LText secondary semiBold style={[styles.confirmationTitle, customTitleStyle]}>
             {confirmationTitle}
           </LText>
         )}
         {confirmationDesc && (
-          <LText style={styles.confirmationDesc} color="smoke">
+          <LText style={[styles.confirmationDesc, customDescriptionStyle]} color="smoke">
             {confirmationDesc}
           </LText>
         )}

--- a/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
@@ -1,4 +1,4 @@
-import { Flex, IconsLegacy } from "@ledgerhq/native-ui";
+import { Button, Flex, IconsLegacy } from "@ledgerhq/native-ui";
 import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import React, { useCallback, useState } from "react";
@@ -78,6 +78,9 @@ type AdvancedProps = {
   confirmationDesc?: React.ReactNode;
   onClose?: () => void;
   rounded?: boolean;
+  showButton?: boolean;
+  buttonText?: string;
+  customDrawerStyle?: Record<string, unknown>;
 };
 
 /**
@@ -96,6 +99,9 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
     confirmationDesc,
     onClose = emptyFunction,
     rounded = false,
+    showButton = false,
+    buttonText,
+    customDrawerStyle,
   }) => {
     const navigation = useNavigation();
     const [isConfirmationModalOpened, setIsConfirmationModalOpened] = useState(false);
@@ -157,13 +163,21 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
       setIsConfirmationModalOpened(false);
     }, [close]);
 
+    const renderCloseElement = useCallback(() => {
+      if (showButton && buttonText)
+        return (
+          <Button size="large" testID="button-create-account" onPress={onPress}>
+            {buttonText}
+          </Button>
+        );
+
+      if (rounded) return <NavigationHeaderCloseButtonRounded onPress={onPress} color={color} />;
+      else return <NavigationHeaderCloseButton onPress={onPress} color={color} />;
+    }, [buttonText, showButton, onPress, rounded, color]);
+
     return (
       <>
-        {rounded ? (
-          <NavigationHeaderCloseButtonRounded onPress={onPress} color={color} />
-        ) : (
-          <NavigationHeaderCloseButton onPress={onPress} color={color} />
-        )}
+        {renderCloseElement()}
 
         {withConfirmation && (
           <ConfirmationModal
@@ -173,6 +187,8 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
             confirmationTitle={confirmationTitle}
             confirmationDesc={confirmationDesc}
             onModalHide={onModalHide}
+            customTitleStyle={customDrawerStyle?.title ?? {}}
+            customDescriptionStyle={customDrawerStyle?.description ?? {}}
           />
         )}
       </>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3991,7 +3991,11 @@
     },
     "quitConfirmation": {
       "title": "Cancel add account",
-      "desc": "Are you sure you want to cancel adding accounts?"
+      "desc": "Are you sure you want to cancel adding accounts?",
+      "v2": {
+        "title": "Cancel adding account?",
+        "desc": "No account wll be added to Ledger Live."
+      }
     },
     "imported": "Asset added successfully",
     "added": "Account added to your portfolio",

--- a/apps/ledger-live-mobile/src/newArch/components/CloseWithConfirmation/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/CloseWithConfirmation/index.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Trans } from "react-i18next";
+import { useRoute } from "@react-navigation/native";
+import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
+import { ScreenName } from "~/const";
+
+const routesWithConfirmation: string[] = [
+  ScreenName.SelectDevice,
+  ScreenName.SelectNetwork,
+  ScreenName.AddAccountsSelectCrypto,
+  ScreenName.ScanDeviceAccounts,
+  ScreenName.NoAssociatedAccounts,
+];
+export default function CloseWithConfirmation({
+  onClose,
+  showButton,
+  buttonText,
+}: {
+  onClose?: () => void;
+  showButton?: boolean;
+  buttonText?: string;
+}) {
+  const route = useRoute();
+  return (
+    <NavigationHeaderCloseButtonAdvanced
+      withConfirmation={routesWithConfirmation.includes(route.name)}
+      confirmationTitle={<Trans i18nKey="addAccounts.quitConfirmation.v2.title" />}
+      confirmationDesc={<Trans i18nKey="addAccounts.quitConfirmation.v2.desc" />}
+      {...(onClose && { onClose })}
+      {...(showButton && { showButton })}
+      {...(buttonText && { buttonText })}
+      customDrawerStyle={{
+        title: {
+          textAlign: "left",
+          fontSize: 24,
+          fontWeight: 600,
+          lineHeight: 32.4,
+          letterSpacing: -0.72,
+        },
+        description: {
+          textAlign: "left",
+          paddingHorizontal: 0,
+          fontSize: 14,
+          fontWeight: 500,
+          lineHeight: 21,
+        },
+      }}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/Navigator.tsx
@@ -7,7 +7,6 @@ import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { track } from "~/analytics";
 import type { NetworkBasedAddAccountNavigator } from "LLM/features/Accounts/screens/AddAccount/types";
-import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
 import ScanDeviceAccounts from "LLM/features/Accounts/screens/ScanDeviceAccounts";
 import { AccountsListNavigator } from "./screens/AccountsList/types";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
@@ -17,24 +16,30 @@ import AddAccountsSuccess from "./screens/AddAccountSuccess";
 import SelectAccounts from "./screens/SelectAccounts";
 import AddAccountsWarning from "./screens/AddAccountWarning";
 import NoAssociatedAccountsView from "./screens/NoAssociatedAccountsView";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
+import { StackNavigatorNavigation } from "~/components/RootNavigator/types/helpers";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 
 export default function Navigator() {
   const { colors } = useTheme();
   const route = useRoute();
   const accountListUIFF = useFeature("llmAccountListUI");
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
 
   const onClose = useCallback(() => {
     track("button_clicked", {
       button: "Close",
       screen: route.name,
     });
-  }, [route]);
+    const rootParent = navigation.getParent();
+    // this is the only way to go back to the root navigator
+    navigation.replace(rootParent?.getState().routeNames[0] as keyof BaseNavigatorStackParamList);
+  }, [route, navigation]);
 
   const stackNavigationConfig = useMemo(
     () => ({
       ...getStackNavigatorConfig(colors, true),
-      headerRight: () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} />,
+      headerRight: () => <CloseWithConfirmation onClose={onClose} />,
     }),
     [colors, onClose],
   );
@@ -90,6 +95,9 @@ export default function Navigator() {
           headerLeft: () => null,
           headerTransparent: true,
         }}
+        initialParams={{
+          onCloseNavigation: onClose,
+        }}
       />
       <Stack.Screen
         name={ScreenName.AddAccountsWarning}
@@ -99,14 +107,20 @@ export default function Navigator() {
           headerLeft: () => null,
           headerTransparent: true,
         }}
+        initialParams={{
+          onCloseNavigation: onClose,
+        }}
       />
       <Stack.Screen
         name={ScreenName.NoAssociatedAccounts}
         component={NoAssociatedAccountsView}
         options={{
           headerTitle: "",
-          headerLeft: () => null,
+          headerLeft: () => <NavigationHeaderBackButton onPress={onPressBack} />,
           headerTransparent: true,
+        }}
+        initialParams={{
+          onCloseNavigation: onClose,
         }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
@@ -7,6 +7,7 @@ import { Props as TouchableProps } from "~/components/Touchable";
 type CommonParams = {
   context?: "addAccounts" | "receiveFunds";
   onSuccess?: () => void;
+  onCloseNavigation?: () => void;
   currency: CryptoOrTokenCurrency;
 };
 export type NetworkBasedAddAccountNavigator = {
@@ -27,7 +28,7 @@ export type NetworkBasedAddAccountNavigator = {
     emptyAccount?: Account;
     emptyAccountName?: string;
   };
-  [ScreenName.NoAssociatedAccounts]: {
+  [ScreenName.NoAssociatedAccounts]: Pick<CommonParams, "onCloseNavigation"> & {
     CustomNoAssociatedAccounts: ({
       style,
     }: {

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
+import { Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -25,6 +25,7 @@ import { getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { useNavigation } from "@react-navigation/core";
 import useAnimatedStyle from "../ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
 import AddFundsButton from "../../components/AddFundsButton";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 
 type Props = BaseComposite<
   StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.AddAccountsSuccess>
@@ -46,7 +47,7 @@ export default function AddAccountsSuccess({ route }: Props) {
     [navigation],
   );
 
-  const { currency, accountsToAdd } = route.params || {};
+  const { currency, accountsToAdd, onCloseNavigation } = route.params || {};
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<AccountLikeEnhanced>) => (
@@ -98,9 +99,11 @@ export default function AddAccountsSuccess({ route }: Props) {
       </Flex>
       <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
         <AddFundsButton accounts={accountsToAdd} currency={currency} />
-        <Button size="large" testID="button-create-account">
-          {t("addAccounts.addAccountsSuccess.ctaClose")}
-        </Button>
+        <CloseWithConfirmation
+          showButton
+          buttonText={t("addAccounts.addAccountsSuccess.ctaClose")}
+          onClose={onCloseNavigation}
+        />
       </Flex>
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Button, Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
+import { Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { Animated, StyleSheet, TouchableOpacity, View } from "react-native";
 import { useTheme } from "styled-components/native";
@@ -16,6 +16,7 @@ import BigNumber from "bignumber.js";
 import { useNavigation } from "@react-navigation/core";
 import useAnimatedStyle from "../ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
 import AddFundsButton from "../../components/AddFundsButton";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 type Props = BaseComposite<
   StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.AddAccountsWarning>
 >;
@@ -36,7 +37,7 @@ export default function AddAccountsWarning({ route }: Props) {
     },
     [navigation],
   );
-  const { emptyAccount, emptyAccountName, currency } = route.params || {};
+  const { emptyAccount, emptyAccountName, currency, onCloseNavigation } = route.params || {};
 
   const statusColor = colors.warning.c70;
 
@@ -85,9 +86,11 @@ export default function AddAccountsWarning({ route }: Props) {
       </Flex>
       <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
         <AddFundsButton accounts={[emptyAccount as Account]} currency={currency} />
-        <Button size="large" testID="button-create-account">
-          {t("addAccounts.addAccountsSuccess.ctaClose")}
-        </Button>
+        <CloseWithConfirmation
+          showButton
+          buttonText={t("addAccounts.addAccountsSuccess.ctaClose")}
+          onClose={onCloseNavigation}
+        />
       </Flex>
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/NoAssociatedAccountsView/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/NoAssociatedAccountsView/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, Icons, rgba, Button } from "@ledgerhq/native-ui";
+import { Flex, Icons, rgba } from "@ledgerhq/native-ui";
 import { StyleSheet, View } from "react-native";
 import { useTheme } from "styled-components/native";
 import SafeAreaView from "~/components/SafeAreaView";
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { NetworkBasedAddAccountNavigator } from "../AddAccount/types";
 import { ScreenName } from "~/const";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 
 type Props = BaseComposite<
   StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.NoAssociatedAccounts>
@@ -18,7 +19,7 @@ export default function NoAssociatedAccountsView({ route }: Props) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
-  const { CustomNoAssociatedAccounts } = route.params || {};
+  const { CustomNoAssociatedAccounts, onCloseNavigation } = route.params || {};
 
   const statusColor = colors.primary.c70;
   return (
@@ -48,9 +49,11 @@ export default function NoAssociatedAccountsView({ route }: Props) {
         {<CustomNoAssociatedAccounts />}
       </Flex>
       <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
-        <Button size="large" testID="button-create-account">
-          {t("addAccounts.addAccountsSuccess.ctaClose")}
-        </Button>
+        <CloseWithConfirmation
+          showButton
+          buttonText={t("addAccounts.addAccountsSuccess.ctaClose")}
+          onClose={onCloseNavigation}
+        />
       </Flex>
     </SafeAreaView>
   );

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -43,6 +43,7 @@ export default function useScanDeviceAccountsViewModel({
     device: { deviceId },
     inline,
     returnToSwap,
+    onCloseNavigation,
   } = route.params || {};
 
   const newAccountSchemes = useMemo(() => {
@@ -292,5 +293,6 @@ export default function useScanDeviceAccountsViewModel({
     viewAllCreatedAccounts,
     returnToSwap,
     currency,
+    onCloseNavigation,
   };
 }

--- a/apps/ledger-live-mobile/src/newArch/features/AssetSelection/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/AssetSelection/Navigator.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo } from "react";
 import { Platform } from "react-native";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
-import { useRoute } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { track } from "~/analytics";
@@ -13,10 +13,10 @@ import { hasClosedNetworkBannerSelector } from "~/reducers/settings";
 import { urls } from "~/utils/urls";
 import SelectCrypto from "LLM/features/AssetSelection/screens/SelectCrypto";
 import SelectNetwork from "LLM/features/AssetSelection/screens/SelectNetwork";
-import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import { AssetSelectionNavigatorParamsList } from "./types";
 import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<AssetSelectionNavigatorParamsList, NavigatorName.AssetSelection>
@@ -28,20 +28,22 @@ export default function Navigator() {
   const hasClosedNetworkBanner = useSelector(hasClosedNetworkBannerSelector);
 
   const { token, currency } = route.params || {};
+  const navigation = useNavigation();
 
-  const onClose = useCallback(() => {
+  const handleOnCloseAssetSelectionNavigator = useCallback(() => {
     track("button_clicked", {
       button: "Close",
       screen: route.name,
     });
-  }, [route]);
+    navigation.getParent()?.goBack();
+  }, [route, navigation]);
 
   const stackNavigationConfig = useMemo(
     () => ({
       ...getStackNavigatorConfig(colors, true),
-      headerRight: () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} />,
+      headerRight: () => <CloseWithConfirmation onClose={handleOnCloseAssetSelectionNavigator} />,
     }),
-    [colors, onClose],
+    [colors, handleOnCloseAssetSelectionNavigator],
   );
 
   return (
@@ -60,7 +62,6 @@ export default function Navigator() {
         options={{
           headerLeft: () => <NavigationHeaderBackButton />,
           title: "",
-          headerRight: () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} />,
         }}
         initialParams={route.params}
       />
@@ -76,7 +77,7 @@ export default function Navigator() {
               {hasClosedNetworkBanner && (
                 <HelpButton eventButton="Choose a network article" url={urls.chooseNetwork} />
               )}
-              <NavigationHeaderCloseButtonAdvanced onClose={onClose} />
+              {stackNavigationConfig.headerRight()}
             </Flex>
           ),
         }}

--- a/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/Navigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/Navigator.tsx
@@ -3,33 +3,33 @@ import { Platform } from "react-native";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
 import { useTranslation } from "react-i18next";
-import { useRoute } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
 import { ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import { track } from "~/analytics";
-import SelectDevice, {
-  addAccountsSelectDeviceHeaderOptions,
-} from "LLM/features/DeviceSelection/screens/SelectDevice";
+import SelectDevice from "LLM/features/DeviceSelection/screens/SelectDevice";
 import StepHeader from "~/components/StepHeader";
-import { NavigationHeaderCloseButtonAdvanced } from "~/components/NavigationHeaderCloseButton";
 import { DeviceSelectionNavigatorParamsList } from "./types";
+import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
 
 export default function Navigator() {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const route = useRoute();
+  const navigation = useNavigation();
 
   const onClose = useCallback(() => {
     track("button_clicked", {
       button: "Close",
       screen: route.name,
     });
-  }, [route]);
+    navigation.getParent()?.goBack();
+  }, [route, navigation]);
 
   const stackNavigationConfig = useMemo(
     () => ({
       ...getStackNavigatorConfig(colors, true),
-      headerRight: () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} />,
+      headerRight: () => <CloseWithConfirmation onClose={onClose} />,
     }),
     [colors, onClose],
   );
@@ -55,7 +55,6 @@ export default function Navigator() {
               title={t("transfer.receive.stepperHeader.connectDevice")}
             />
           ),
-          ...addAccountsSelectDeviceHeaderOptions(onClose),
         }}
         initialParams={route.params}
       />

--- a/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/types.ts
@@ -7,6 +7,7 @@ import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 type CommonParams = {
   context?: "addAccounts" | "receiveFunds";
   onSuccess?: () => void;
+  onCloseNavigation?: () => void;
 };
 
 export type SelectDeviceRouteParams = CommonParams & {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Simply when a user is in an Add account process and try to quit there are 2 possibilities: 
- A confirmation dialog will appear in the following screens:  Crypto and Network and Device Selection, ScanDeviceAccoun screen & Hedera no associated account screen.
- Direct exit from warning/success screen 

The close process will get back to the main wallet page. 

![image](https://github.com/user-attachments/assets/56435489-cc79-4667-9c0c-614d6e1e806c)



https://github.com/user-attachments/assets/db7016fb-7546-4d99-972a-2fa5779e2abf


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-15606

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
