### PR TITLE
fix(wallet-api): add missing cosmos walletApiAdapter [LIVE-15822]

### DIFF
--- a/.changeset/silent-poets-check.md
+++ b/.changeset/silent-poets-check.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(wallet-api): add missing cosmos walletApiAdapter

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
 [
   {
-    "balance": "1612686",
+    "balance": "5739320",
     "currencyId": "cosmos",
     "derivationMode": "",
     "freshAddress": "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
@@ -12,7 +12,7 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
-    "spendableBalance": "315704",
+    "spendableBalance": "4442338",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,
@@ -257,6 +257,25 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": 32,
       "type": "IN",
       "value": "1000",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 24046706,
+      "extra": {},
+      "fee": "1729",
+      "hasFailed": false,
+      "hash": "146D033842F4637F5FA2F13AC4D7888EEA8935F1D5822B955562ED685E7E8A78",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-146D033842F4637F5FA2F13AC4D7888EEA8935F1D5822B955562ED685E7E8A78-IN",
+      "recipients": [
+        "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
+      ],
+      "senders": [
+        "cosmos125me68y8fx88wyqwa4mp4q2cmglrnetsa2kr68",
+      ],
+      "transactionSequenceNumber": 22364,
+      "type": "IN",
+      "value": "4639888",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -1139,6 +1158,29 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": 87,
       "type": "DELEGATE",
       "value": "10650",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 23976580,
+      "extra": {
+        "memo": "LedgerLiveBot",
+        "validators": [
+          {
+            "address": "cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn",
+            "amount": "5210",
+          },
+        ],
+      },
+      "fee": "17390",
+      "hasFailed": false,
+      "hash": "7706B2098FBB961FED169FE177276EFE1C85C7FCA216B61A9F9FD54DEDD6B81A",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-7706B2098FBB961FED169FE177276EFE1C85C7FCA216B61A9F9FD54DEDD6B81A-REWARD",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": 157,
+      "type": "REWARD",
+      "value": "5210",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -2180,6 +2222,25 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": 67,
       "type": "DELEGATE",
       "value": "11254",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 24063617,
+      "extra": {},
+      "fee": "1074",
+      "hasFailed": false,
+      "hash": "CEF4B772F7E12B048A8903146DDC06FB769813B0A6AB475EC455CE6BBAF9BAEB",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-CEF4B772F7E12B048A8903146DDC06FB769813B0A6AB475EC455CE6BBAF9BAEB-OUT",
+      "recipients": [
+        "osmo10a3k4hvk37cc4hnxctw4p95fhscd2z6h2rmx0aukc6rm8u9qqx9smfsh7u",
+      ],
+      "senders": [
+        "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
+      ],
+      "transactionSequenceNumber": 158,
+      "type": "OUT",
+      "value": "501074",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",

--- a/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.test.ts
@@ -1,0 +1,58 @@
+import { Account } from "@ledgerhq/types-live";
+import { WalletAPICosmosTransaction } from "@ledgerhq/wallet-api-core";
+import BigNumber from "bignumber.js";
+import { Transaction } from "@ledgerhq/coin-cosmos/types/index";
+import cosmos from "./walletApiAdapter";
+
+describe("getWalletAPITransactionSignFlowInfos", () => {
+  describe("should properly get infos for Cosmos platform tx", () => {
+    it("without fees provided", () => {
+      const cosmosPlatformTx: WalletAPICosmosTransaction = {
+        family: "cosmos",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        mode: "send",
+      };
+
+      const expectedLiveTx: Partial<Transaction> = {
+        ...cosmosPlatformTx,
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = cosmos.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: cosmosPlatformTx,
+        account: {} as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(false);
+
+      expect(liveTx).toEqual(expectedLiveTx);
+    });
+
+    it("with fees provided", () => {
+      const cosmosPlatformTx: WalletAPICosmosTransaction = {
+        family: "cosmos",
+        amount: new BigNumber(100000),
+        recipient: "0xABCDEF",
+        fees: new BigNumber(300),
+        mode: "send",
+      };
+
+      const expectedLiveTx: Partial<Transaction> = {
+        ...cosmosPlatformTx,
+      };
+
+      const { canEditFees, hasFeesProvided, liveTx } = cosmos.getWalletAPITransactionSignFlowInfos({
+        walletApiTransaction: cosmosPlatformTx,
+        account: {} as Account,
+      });
+
+      expect(canEditFees).toBe(true);
+
+      expect(hasFeesProvided).toBe(true);
+
+      expect(liveTx).toEqual(expectedLiveTx);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.test.ts
@@ -1,5 +1,5 @@
 import { Account } from "@ledgerhq/types-live";
-import { WalletAPICosmosTransaction } from "@ledgerhq/wallet-api-core";
+import { CosmosTransaction as WalletAPICosmosTransaction } from "@ledgerhq/wallet-api-core";
 import BigNumber from "bignumber.js";
 import { Transaction } from "@ledgerhq/coin-cosmos/types/index";
 import cosmos from "./walletApiAdapter";

--- a/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.test.ts
@@ -16,6 +16,13 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
 
       const expectedLiveTx: Partial<Transaction> = {
         ...cosmosPlatformTx,
+        fees: null,
+        gas: null,
+        useAllAmount: false,
+        networkInfo: null,
+        memo: null,
+        sourceValidator: null,
+        validators: [],
       };
 
       const { canEditFees, hasFeesProvided, liveTx } = cosmos.getWalletAPITransactionSignFlowInfos({
@@ -41,6 +48,12 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
 
       const expectedLiveTx: Partial<Transaction> = {
         ...cosmosPlatformTx,
+        gas: null,
+        useAllAmount: false,
+        networkInfo: null,
+        memo: null,
+        sourceValidator: null,
+        validators: [],
       };
 
       const { canEditFees, hasFeesProvided, liveTx } = cosmos.getWalletAPITransactionSignFlowInfos({

--- a/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.ts
@@ -1,0 +1,66 @@
+import createTransaction from "@ledgerhq/coin-cosmos/createTransaction";
+import { WalletAPICosmosTransaction } from "@ledgerhq/wallet-api-core";
+import {
+  AreFeesProvided,
+  ConvertToLiveTransaction,
+  GetWalletAPITransactionSignFlowInfos,
+} from "../../wallet-api/types";
+import { Transaction } from "@ledgerhq/coin-cosmos/types/index";
+
+const CAN_EDIT_FEES = true;
+
+const areFeesProvided: AreFeesProvided<WalletAPICosmosTransaction> = tx => !!tx.fees;
+
+const convertToLiveTransaction: ConvertToLiveTransaction<
+  WalletAPICosmosTransaction,
+  Transaction
+> = ({ account, walletApiTransaction }) => {
+  const liveTx: Transaction = createTransaction(account);
+
+  if (walletApiTransaction.amount) {
+    liveTx.amount = walletApiTransaction.amount;
+  }
+
+  if (walletApiTransaction.recipient) {
+    liveTx.recipient = walletApiTransaction.recipient;
+  }
+
+  if (walletApiTransaction.mode) {
+    liveTx.mode = walletApiTransaction.mode;
+  }
+
+  if (walletApiTransaction.fees) {
+    liveTx.fees = walletApiTransaction.fees;
+  }
+
+  if (walletApiTransaction.gas) {
+    liveTx.gas = walletApiTransaction.gas;
+  }
+
+  if (walletApiTransaction.memo) {
+    liveTx.memo = walletApiTransaction.memo;
+  }
+
+  if (walletApiTransaction.sourceValidator) {
+    liveTx.sourceValidator = walletApiTransaction.sourceValidator;
+  }
+
+  if (walletApiTransaction.validators) {
+    liveTx.validators = walletApiTransaction.validators;
+  }
+
+  return liveTx;
+};
+
+const getWalletAPITransactionSignFlowInfos: GetWalletAPITransactionSignFlowInfos<
+  WalletAPICosmosTransaction,
+  Transaction
+> = ({ walletApiTransaction, account }) => {
+  return {
+    canEditFees: CAN_EDIT_FEES,
+    liveTx: convertToLiveTransaction({ walletApiTransaction, account }),
+    hasFeesProvided: areFeesProvided(walletApiTransaction),
+  };
+};
+
+export default { getWalletAPITransactionSignFlowInfos };

--- a/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/families/cosmos/walletApiAdapter.ts
@@ -1,5 +1,5 @@
 import createTransaction from "@ledgerhq/coin-cosmos/createTransaction";
-import { WalletAPICosmosTransaction } from "@ledgerhq/wallet-api-core";
+import { CosmosTransaction as WalletAPICosmosTransaction } from "@ledgerhq/wallet-api-core";
 import {
   AreFeesProvided,
   ConvertToLiveTransaction,

--- a/libs/ledger-live-common/src/generated/walletApiAdapter.ts
+++ b/libs/ledger-live-common/src/generated/walletApiAdapter.ts
@@ -1,10 +1,12 @@
 import bitcoin from "../families/bitcoin/walletApiAdapter";
+import cosmos from "../families/cosmos/walletApiAdapter";
 import evm from "../families/evm/walletApiAdapter";
 import polkadot from "../families/polkadot/walletApiAdapter";
 import xrp from "../families/xrp/walletApiAdapter";
 
 export default {
   bitcoin,
+  cosmos,
   evm,
   polkadot,
   xrp,


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-api cosmos flows

### 📝 Description

Fixes root cause issue where `validators` in cosmos transactions could be `undefined` when coming from the wallet-api

We still have an issue trying to swap, where it requires `Expert mode` but enabling it in the cosmos app doesn't work for the exchange app

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15822]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15822]: https://ledgerhq.atlassian.net/browse/LIVE-15822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ