### PR TITLE
fix: double broadcast on exchange flow [LIVE-15840]

### DIFF
--- a/.changeset/tiny-hornets-beg.md
+++ b/.changeset/tiny-hornets-beg.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: double broadcast on exchange flow

--- a/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
@@ -135,6 +135,10 @@ export const LiveAppDrawer = () => {
     }
   }, [dismissDisclaimerChecked, dispatch, payload]);
 
+  const onCloseExchangeComplete = useCallback(() => {
+    dispatch(closePlatformAppDrawer());
+  }, [dispatch]);
+
   const drawerContent = useMemo(() => {
     if (!payload) {
       return null;
@@ -238,17 +242,20 @@ export const LiveAppDrawer = () => {
       }
       case "EXCHANGE_COMPLETE":
         return data && isCompleteExchangeData(data) ? (
-          <CompleteExchange
-            data={data}
-            onClose={() => {
-              dispatch(closePlatformAppDrawer());
-            }}
-          />
+          <CompleteExchange data={data} onClose={onCloseExchangeComplete} />
         ) : null;
       default:
         return null;
     }
-  }, [payload, t, dismissDisclaimerChecked, onContinue, device?.modelId, dispatch]);
+  }, [
+    payload,
+    t,
+    dismissDisclaimerChecked,
+    onContinue,
+    onCloseExchangeComplete,
+    device?.modelId,
+    dispatch,
+  ]);
 
   return (
     <SideDrawer

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -114,7 +114,8 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
   }, [toAccount, getCurrencyByAccount]);
 
   const mevProtected = useSelector(mevProtectionSelector);
-  const broadcast = useBroadcast({ account, parentAccount, broadcastConfig: { mevProtected } });
+  const broadcastConfig = useMemo(() => ({ mevProtected }), [mevProtected]);
+  const broadcast = useBroadcast({ account, parentAccount, broadcastConfig });
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();
   const [error, setError] = useState<Error>();

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/GenericStepConnectDevice.tsx
@@ -58,10 +58,11 @@ export default function StepConnectDevice({
 }) {
   const mevProtected = useSelector(mevProtectionSelector);
   const dispatch = useDispatch();
+  const broadcastConfig = useMemo(() => ({ mevProtected }), [mevProtected]);
   const broadcast = useBroadcast({
     account,
     parentAccount,
-    broadcastConfig: { mevProtected },
+    broadcastConfig,
   });
   const tokenCurrency = (account && account.type === "TokenAccount" && account.token) || undefined;
   const request = useMemo(


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** We still need to manually test swaps
- [x] **Impact of the changes:**
  - Swap live-app

### 📝 Description

Fix double broadcast that could happen on the exchange flow as the useEffect deps could change

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15840]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15840]: https://ledgerhq.atlassian.net/browse/LIVE-15840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ