### PR TITLE
[QAA] Adding currencies for E2E delegation test

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/SuccessDisplay.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SuccessDisplay.tsx
@@ -37,7 +37,7 @@ function SuccessDisplay({
       >
         <IconCheckCircle size={43} />
       </span>
-      <Title>{title}</Title>
+      <Title data-testid="success-message-label">{title}</Title>
 
       <Text
         style={{

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepSummary.tsx
@@ -46,7 +46,13 @@ function StepSummary(props: StepProps) {
               <Ellipsis mt={2}>
                 <Box horizontal alignItems="center">
                   <CardanoLedgerPoolIcon validator={selectedPool} />
-                  <Text ff="Inter" color="palette.text.shade100" fontSize={4} ml={2}>
+                  <Text
+                    ff="Inter"
+                    color="palette.text.shade100"
+                    fontSize={4}
+                    ml={2}
+                    data-testid="validator-name-label"
+                  >
                     {`${selectedPool.name} [${selectedPool.ticker}]`}
                   </Text>
                 </Box>
@@ -107,6 +113,7 @@ function StepSummary(props: StepProps) {
           </Text>
           <Box>
             <FormattedVal
+              data-testid="fees-amount-step-summary"
               color={feeTooHigh ? "warning" : "palette.text.shade80"}
               disableRounding
               unit={feesUnit}

--- a/apps/ledger-live-desktop/tests/component/modal.component.ts
+++ b/apps/ledger-live-desktop/tests/component/modal.component.ts
@@ -30,7 +30,9 @@ export class Modal extends Component {
 
   @step("Click Continue button")
   async continue() {
-    await this.continueButton.click();
+    if (await this.continueButton.isVisible()) {
+      await this.continueButton.click();
+    }
   }
 
   async save() {

--- a/apps/ledger-live-desktop/tests/page/drawer/delegate.drawer.ts
+++ b/apps/ledger-live-desktop/tests/page/drawer/delegate.drawer.ts
@@ -10,6 +10,7 @@ export class DelegateDrawer extends Drawer {
     this.page.getByTestId("drawer-content").locator(`text=${provider}`);
   private amountValue = this.page.getByTestId("amountReceived-drawer");
   private transactionType = this.page.getByTestId("transaction-type");
+  private operationType = this.page.getByTestId("operation-type");
   private addressValue = (address: string) =>
     this.page.locator('[data-testid="drawer-content"]').locator(`text=${address}`);
 
@@ -33,6 +34,18 @@ export class DelegateDrawer extends Drawer {
   @step("Verify transaction type is correct")
   async transactionTypeIsVisible() {
     await expect(this.transactionType).toBeVisible();
+  }
+
+  @step("Verify transaction type corresond to $0")
+  async transactionTypeIsCorrect(transactionType: string) {
+    const transaction = await this.transactionType.allInnerTexts();
+    expect(transaction).toContain(transactionType);
+  }
+
+  @step("Verify operation type corresond to $0")
+  async operationTypeIsCorrect(operationType: string) {
+    const operation = await this.operationType.allInnerTexts();
+    expect(operation).toContain(operationType);
   }
 
   @step("Verify that the information of the transaction is visible")

--- a/apps/ledger-live-desktop/tests/page/index.ts
+++ b/apps/ledger-live-desktop/tests/page/index.ts
@@ -26,6 +26,7 @@ import { AssetPage } from "./asset.page";
 import { SettingsModal } from "tests/page/modal/settings.modal";
 import { OnboardingPage } from "tests/page/onboarding.page";
 import { OperationDrawer } from "./drawer/operation.drawer";
+import { LiveApp } from "tests/page/liveApp.page";
 
 export class Application extends PageHolder {
   public account = new AccountPage(this.page);
@@ -55,4 +56,5 @@ export class Application extends PageHolder {
   public settingsModal = new SettingsModal(this.page);
   public onboarding = new OnboardingPage(this.page);
   public operationDrawer = new OperationDrawer(this.page);
+  public liveApp = new LiveApp(this.page);
 }

--- a/apps/ledger-live-desktop/tests/page/liveApp.page.ts
+++ b/apps/ledger-live-desktop/tests/page/liveApp.page.ts
@@ -1,0 +1,13 @@
+import { AppPage } from "tests/page/abstractClasses";
+import { step } from "tests/misc/reporters/step";
+import { expect } from "@playwright/test";
+
+export class LiveApp extends AppPage {
+  readonly liveAppTitle = this.page.getByTestId("live-app-title");
+
+  @step("Verify live app title contains $0")
+  async verifyLiveAppTitle(provider: string) {
+    const liveApp = await this.liveAppTitle.textContent();
+    expect(liveApp?.toLowerCase()).toContain(provider);
+  }
+}

--- a/apps/ledger-live-desktop/tests/page/modal/delegate.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/delegate.modal.ts
@@ -14,6 +14,9 @@ export class delegateModal extends Modal {
     this.page.getByTestId(`stake-provider-container-${stakeProviderID}`);
   private detailsButton = this.page.getByRole("button", { name: "View details" });
   private validatorTC = this.page.getByTestId("ledger-validator-tc");
+  private validatorName = this.page.getByTestId("validator-name-label");
+  private feesSummaryStep = this.page.getByTestId("fees-amount-step-summary");
+  private successMessageLabel = this.page.getByTestId("success-message-label");
   private checkIcon = this.page
     .getByTestId("check-icon")
     .locator('path[fill]:not([fill="transparent"])');
@@ -123,5 +126,21 @@ export class delegateModal extends Modal {
     } else {
       await this.cryptoAmountField.fill(amount);
     }
+  }
+
+  @step("Verify success message")
+  async verifySuccessMessage() {
+    await expect(this.successMessageLabel).toBeVisible();
+  }
+
+  @step("Verify validator name is $0")
+  async verifyValidatorName(validatorName: string) {
+    const validator = await this.validatorName.allInnerTexts();
+    expect(validator).toContain(validatorName);
+  }
+
+  @step("Verify fees summary step")
+  async verifyFeesVisible() {
+    await expect(this.feesSummaryStep).toBeVisible();
   }
 }

--- a/apps/ledger-live-desktop/tests/page/speculos.page.ts
+++ b/apps/ledger-live-desktop/tests/page/speculos.page.ts
@@ -8,6 +8,7 @@ import {
   signDelegationTransaction,
   verifyAmountsAndAcceptSwap,
   verifyAmountsAndRejectSwap,
+  activateExpertMode,
 } from "@ledgerhq/live-common/e2e/speculos";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 import { NFTTransaction, Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
@@ -48,5 +49,10 @@ export class SpeculosPage extends AppPage {
   @step("Verify amounts and reject swap")
   async verifyAmountsAndRejectSwap(swap: Swap) {
     await verifyAmountsAndRejectSwap(swap);
+  }
+
+  @step("Activate expert mode")
+  async activateExpertMode() {
+    await activateExpertMode();
   }
 }

--- a/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
@@ -7,6 +7,20 @@ import { CLI } from "tests/utils/cliUtils";
 import { Currency } from "@ledgerhq/live-common/e2e/enum/Currency";
 import { getEnv } from "@ledgerhq/live-env";
 
+function setupEnv(disableBroadcast?: boolean) {
+  const originalBroadcastValue = process.env.DISABLE_TRANSACTION_BROADCAST;
+  test.beforeAll(async () => {
+    if (disableBroadcast) process.env.DISABLE_TRANSACTION_BROADCAST = "1";
+  });
+  test.afterAll(async () => {
+    if (originalBroadcastValue !== undefined) {
+      process.env.DISABLE_TRANSACTION_BROADCAST = originalBroadcastValue;
+    } else {
+      delete process.env.DISABLE_TRANSACTION_BROADCAST;
+    }
+  });
+}
+
 const e2eDelegationAccounts = [
   {
     delegate: new Delegate(Account.ATOM_1, "0.001", "Ledger"),
@@ -19,6 +33,25 @@ const e2eDelegationAccounts = [
   {
     delegate: new Delegate(Account.NEAR_1, "0.01", "ledgerbyfigment.poolv1.near"),
     xrayTicket: "B2CQA-2741",
+  },
+  {
+    delegate: new Delegate(Account.INJ_1, "0.0000001", "Ledger by Chorus One"),
+    xrayTicket: "B2CQA-3021",
+  },
+  {
+    delegate: new Delegate(Account.OSMO_1, "0.0001", "Ledger by Figment"),
+    xrayTicket: "B2CQA-3022",
+  },
+];
+
+const e2eDelegationAccountsWithoutBroadcast = [
+  {
+    delegate: new Delegate(Account.ADA_1, "0.01", "LBF3 - Ledger by Figment 3"),
+    xrayTicket: "B2CQA-3023",
+  },
+  {
+    delegate: new Delegate(Account.MULTIVERS_X_1, "1", "Ledger by Figment"),
+    xrayTicket: "B2CQA-3020",
   },
 ];
 
@@ -36,136 +69,44 @@ const validators = [
     xrayTicket: "B2CQA-2732, B2CQA-2765",
   },
   {
-    delegate: new Delegate(Account.ADA_1, "0.01", "LBF3 - Ledger by Figment 3"),
+    delegate: new Delegate(Account.ADA_2, "0.01", "LBF3 - Ledger by Figment 3"),
     xrayTicket: "B2CQA-2766",
   },
   {
-    delegate: new Delegate(Account.MULTIVERS_X_1, "1", "Ledger by Figment"),
+    delegate: new Delegate(Account.MULTIVERS_X_2, "1", "Ledger by Figment"),
     xrayTicket: "B2CQA-2767",
   },
   {
-    delegate: new Delegate(Account.OSMO_1, "1", "Ledger by Figment"),
+    delegate: new Delegate(Account.OSMO_2, "1", "Ledger by Figment"),
     xrayTicket: "B2CQA-2768",
   },
 ];
 
-test.describe("Delegate flows", () => {
-  for (const account of e2eDelegationAccounts) {
-    test.describe("Delegate", () => {
-      test.use({
-        userdata: "skip-onboarding",
-        speculosApp: account.delegate.account.currency.speculosApp,
-        cliCommands: [
-          (appjsonPath: string) => {
-            return CLI.liveData({
-              currency: account.delegate.account.currency.ticker,
-              index: account.delegate.account.index,
-              add: true,
-              appjson: appjsonPath,
-            });
-          },
-        ],
-      });
+const liveApps = [
+  {
+    delegate: new Delegate(Account.ETH_1, "0.01", "lido"),
+    xrayTicket: "B2CQA-3024",
+  },
+  {
+    delegate: new Delegate(Account.TRX_1, "1", "stakekit"),
+    xrayTicket: "B2CQA-3025", //todo: Add split from when parent ticket is available
+  },
+  {
+    delegate: new Delegate(Account.DOT_1, "1", "stakekit"),
+    xrayTicket: "B2CQA-3026", //todo: Add split from when parent ticket is available
+  },
+];
 
-      test(
-        `[${account.delegate.account.currency.name}] Delegate`,
-        {
-          annotation: { type: "TMS", description: account.xrayTicket },
-        },
-        async ({ app }) => {
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-          await app.layout.goToAccounts();
-          await app.accounts.navigateToAccountByName(account.delegate.account.accountName);
-
-          await app.account.clickBannerCTA();
-          await app.delegate.verifyFirstProviderName(account.delegate.provider);
-          if (account.delegate.account.currency.name == Currency.SOL.name) {
-            await app.delegate.verifyContinueDisabled();
-            await app.delegate.selectProviderByName(account.delegate.provider);
-            await app.delegate.verifyProviderTC(account.delegate.provider);
-            await app.delegate.verifyProvider(1);
-          }
-          await app.delegate.continueDelegate();
-          await app.delegate.fillAmount(account.delegate.amount);
-          await app.modal.countinueSendAmount();
-
-          await app.speculos.signDelegationTransaction(account.delegate);
-          await app.delegate.clickViewDetailsButton();
-
-          await app.drawer.waitForDrawerToBeVisible();
-          await app.delegateDrawer.transactionTypeIsVisible();
-          await app.delegateDrawer.providerIsVisible(account.delegate);
-          await app.delegateDrawer.amountValueIsVisible();
-          await app.drawer.closeDrawer();
-
-          if (!getEnv("DISABLE_TRANSACTION_BROADCAST")) {
-            await app.layout.syncAccounts();
-            await app.account.clickOnLastOperation();
-            await app.delegateDrawer.expectDelegationInfos(account.delegate);
-          }
-        },
-      );
-    });
-  }
-
-  for (const validator of validators) {
-    test.describe("Select a validator", () => {
-      test.use({
-        userdata: "skip-onboarding",
-        speculosApp: validator.delegate.account.currency.speculosApp,
-        cliCommands: [
-          (appjsonPath: string) => {
-            return CLI.liveData({
-              currency: validator.delegate.account.currency.ticker,
-              index: validator.delegate.account.index,
-              add: true,
-              appjson: appjsonPath,
-            });
-          },
-        ],
-      });
-
-      test(
-        `[${validator.delegate.account.currency.name}] - Select validator`,
-        {
-          annotation: { type: "TMS", description: validator.xrayTicket },
-        },
-        async ({ app }) => {
-          await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-          await app.layout.goToAccounts();
-          await app.accounts.navigateToAccountByName(validator.delegate.account.accountName);
-
-          await app.account.startStakingFlowFromMainStakeButton();
-          await app.modal.continue();
-
-          await app.delegate.verifyFirstProviderName(validator.delegate.provider);
-          if (validator.delegate.account.currency.name == Currency.SOL.name) {
-            await app.delegate.verifyContinueDisabled();
-            await app.delegate.selectProviderByName(validator.delegate.provider);
-            await app.delegate.verifyProviderTC(validator.delegate.provider);
-          } else await app.delegate.verifyContinueEnabled();
-          await app.delegate.verifyProvider(1);
-          await app.delegate.openSearchProviderModal();
-          await app.delegate.checkValidatorListIsVisible();
-          await app.delegate.selectProviderOnRow(2);
-          await app.delegate.closeProviderList(2);
-        },
-      );
-    });
-  }
-
-  test.describe("Staking flow from different entry point", () => {
-    const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger");
+for (const account of e2eDelegationAccounts) {
+  test.describe("Delegate", () => {
     test.use({
       userdata: "skip-onboarding",
-      speculosApp: delegateAccount.account.currency.speculosApp,
+      speculosApp: account.delegate.account.currency.speculosApp,
       cliCommands: [
         (appjsonPath: string) => {
           return CLI.liveData({
-            currency: delegateAccount.account.currency.ticker,
-            index: delegateAccount.account.index,
+            currency: account.delegate.account.currency.ticker,
+            index: account.delegate.account.index,
             add: true,
             appjson: appjsonPath,
           });
@@ -174,47 +115,266 @@ test.describe("Delegate flows", () => {
     });
 
     test(
-      "Staking flow from portfolio entry point",
+      `[${account.delegate.account.currency.name}] Delegate`,
       {
-        annotation: {
-          type: "TMS",
-          description: "B2CQA-2769",
-        },
+        annotation: { type: "TMS", description: account.xrayTicket },
       },
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await app.layout.goToPortfolio();
-        await app.portfolio.startStakeFlow();
+        await app.layout.goToAccounts();
+        await app.accounts.navigateToAccountByName(account.delegate.account.accountName);
 
-        await app.assetDrawer.selectAsset(delegateAccount.account.currency);
-        await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
+        if (account.delegate.account.currency.name == Currency.INJ.name) {
+          await app.speculos.activateExpertMode();
+        }
 
-        await app.delegate.verifyFirstProviderName(delegateAccount.provider);
+        await app.account.startStakingFlowFromMainStakeButton();
+        await app.modal.continue();
+        await app.delegate.verifyFirstProviderName(account.delegate.provider);
+        if (account.delegate.account.currency.name == Currency.SOL.name) {
+          await app.delegate.verifyContinueDisabled();
+          await app.delegate.selectProviderByName(account.delegate.provider);
+          await app.delegate.verifyProviderTC(account.delegate.provider);
+          await app.delegate.verifyProvider(1);
+        }
         await app.delegate.continueDelegate();
-      },
-    );
+        await app.delegate.fillAmount(account.delegate.amount);
+        await app.modal.countinueSendAmount();
 
-    test(
-      "Staking flow from market entry point",
-      {
-        annotation: {
-          type: "TMS",
-          description: "B2CQA-2771",
-        },
-      },
-      async ({ app }) => {
-        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        await app.speculos.signDelegationTransaction(account.delegate);
+        await app.delegate.verifySuccessMessage();
+        await app.delegate.clickViewDetailsButton();
 
-        await app.layout.goToMarket();
-        await app.market.search(delegateAccount.account.currency.name);
-        await app.market.stakeButtonClick(delegateAccount.account.currency.ticker);
+        await app.drawer.waitForDrawerToBeVisible();
+        await app.delegateDrawer.transactionTypeIsVisible();
 
-        await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
+        const transactionType =
+          account.delegate.account.currency.name === Currency.NEAR.name ? "Staked" : "Delegated";
+        await app.delegateDrawer.transactionTypeIsCorrect(transactionType);
 
-        await app.delegate.verifyFirstProviderName(delegateAccount.provider);
-        await app.delegate.continueDelegate();
+        await app.delegateDrawer.providerIsVisible(account.delegate);
+        await app.delegateDrawer.amountValueIsVisible();
+        await app.delegateDrawer.operationTypeIsCorrect(transactionType);
+        await app.drawer.closeDrawer();
+
+        if (!getEnv("DISABLE_TRANSACTION_BROADCAST")) {
+          await app.layout.syncAccounts();
+          await app.account.clickOnLastOperation();
+          await app.delegateDrawer.expectDelegationInfos(account.delegate);
+          await app.delegateDrawer.transactionTypeIsCorrect(transactionType);
+          await app.delegateDrawer.operationTypeIsCorrect(transactionType);
+        }
       },
     );
   });
+}
+
+for (const account of e2eDelegationAccountsWithoutBroadcast) {
+  test.describe("Delegate without Broadcasting", () => {
+    setupEnv(true);
+    test.use({
+      userdata: "skip-onboarding",
+      speculosApp: account.delegate.account.currency.speculosApp,
+      cliCommands: [
+        (appjsonPath: string) => {
+          return CLI.liveData({
+            currency: account.delegate.account.currency.ticker,
+            index: account.delegate.account.index,
+            add: true,
+            appjson: appjsonPath,
+          });
+        },
+      ],
+    });
+
+    test(
+      `[${account.delegate.account.currency.name}] Delegate without broadcasting`,
+      {
+        annotation: { type: "TMS", description: account.xrayTicket },
+      },
+      async ({ app }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+        await app.layout.goToAccounts();
+        await app.accounts.navigateToAccountByName(account.delegate.account.accountName);
+
+        await app.account.startStakingFlowFromMainStakeButton();
+        await app.modal.continue();
+        await app.delegate.verifyFirstProviderName(account.delegate.provider);
+        await app.delegate.continueDelegate();
+
+        if (account.delegate.account.currency.name == Currency.ADA.name) {
+          await app.delegate.verifyValidatorName("Ledger by Figment 3 [LBF3]");
+          await app.delegate.verifyFeesVisible();
+          await app.delegate.continueDelegate();
+        } else {
+          await app.delegate.fillAmount(account.delegate.amount);
+          await app.modal.countinueSendAmount();
+        }
+
+        await app.speculos.signDelegationTransaction(account.delegate);
+        await app.delegate.verifySuccessMessage();
+
+        if (account.delegate.account.currency.name !== Currency.ADA.name) {
+          await app.delegate.clickViewDetailsButton();
+
+          await app.drawer.waitForDrawerToBeVisible();
+          await app.delegateDrawer.transactionTypeIsVisible();
+          await app.delegateDrawer.transactionTypeIsCorrect("Delegated");
+          await app.delegateDrawer.providerIsVisible(account.delegate);
+          await app.delegateDrawer.amountValueIsVisible();
+          await app.delegateDrawer.operationTypeIsCorrect("Delegated");
+          await app.drawer.closeDrawer();
+        }
+      },
+    );
+  });
+}
+
+for (const validator of validators) {
+  test.describe("Select a validator", () => {
+    test.use({
+      userdata: "skip-onboarding",
+      speculosApp: validator.delegate.account.currency.speculosApp,
+      cliCommands: [
+        (appjsonPath: string) => {
+          return CLI.liveData({
+            currency: validator.delegate.account.currency.ticker,
+            index: validator.delegate.account.index,
+            add: true,
+            appjson: appjsonPath,
+          });
+        },
+      ],
+    });
+
+    test(
+      `[${validator.delegate.account.currency.name}] - Select validator`,
+      {
+        annotation: { type: "TMS", description: validator.xrayTicket },
+      },
+      async ({ app }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+        await app.layout.goToAccounts();
+        await app.accounts.navigateToAccountByName(validator.delegate.account.accountName);
+
+        await app.account.startStakingFlowFromMainStakeButton();
+        await app.modal.continue();
+
+        await app.delegate.verifyFirstProviderName(validator.delegate.provider);
+        if (validator.delegate.account.currency.name == Currency.SOL.name) {
+          await app.delegate.verifyContinueDisabled();
+          await app.delegate.selectProviderByName(validator.delegate.provider);
+          await app.delegate.verifyProviderTC(validator.delegate.provider);
+        } else await app.delegate.verifyContinueEnabled();
+        await app.delegate.verifyProvider(1);
+        await app.delegate.openSearchProviderModal();
+        await app.delegate.checkValidatorListIsVisible();
+        await app.delegate.selectProviderOnRow(2);
+        await app.delegate.closeProviderList(2);
+      },
+    );
+  });
+}
+
+test.describe("Staking flow from different entry point", () => {
+  const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger");
+  test.use({
+    userdata: "skip-onboarding",
+    speculosApp: delegateAccount.account.currency.speculosApp,
+    cliCommands: [
+      (appjsonPath: string) => {
+        return CLI.liveData({
+          currency: delegateAccount.account.currency.ticker,
+          index: delegateAccount.account.index,
+          add: true,
+          appjson: appjsonPath,
+        });
+      },
+    ],
+  });
+
+  test(
+    "Staking flow from portfolio entry point",
+    {
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-2769",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.layout.goToPortfolio();
+      await app.portfolio.startStakeFlow();
+
+      await app.assetDrawer.selectAsset(delegateAccount.account.currency);
+      await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
+
+      await app.delegate.verifyFirstProviderName(delegateAccount.provider);
+      await app.delegate.continueDelegate();
+    },
+  );
+
+  test(
+    "Staking flow from market entry point",
+    {
+      annotation: {
+        type: "TMS",
+        description: "B2CQA-2771",
+      },
+    },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+      await app.layout.goToMarket();
+      await app.market.search(delegateAccount.account.currency.name);
+      await app.market.stakeButtonClick(delegateAccount.account.currency.ticker);
+
+      await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
+
+      await app.delegate.verifyFirstProviderName(delegateAccount.provider);
+      await app.delegate.continueDelegate();
+    },
+  );
 });
+
+for (const currency of liveApps) {
+  test.describe("LiveApp delegate", () => {
+    test.use({
+      userdata: "skip-onboarding",
+      speculosApp: currency.delegate.account.currency.speculosApp,
+      cliCommands: [
+        (appjsonPath: string) => {
+          return CLI.liveData({
+            currency: currency.delegate.account.currency.ticker,
+            index: currency.delegate.account.index,
+            add: true,
+            appjson: appjsonPath,
+          });
+        },
+      ],
+    });
+
+    test(
+      `[${currency.delegate.account.currency.name}] - Select validator`,
+      {
+        annotation: { type: "TMS", description: currency.xrayTicket },
+      },
+      async ({ app }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+        await app.layout.goToAccounts();
+        await app.accounts.navigateToAccountByName(currency.delegate.account.accountName);
+
+        await app.account.startStakingFlowFromMainStakeButton();
+        if (currency.delegate.account.currency.name == Currency.ETH.name) {
+          await app.delegate.chooseStakeProvider(currency.delegate.provider);
+        }
+        await app.liveApp.verifyLiveAppTitle(currency.delegate.provider);
+      },
+    );
+  });
+}

--- a/libs/ledger-live-common/src/e2e/enum/Account.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Account.ts
@@ -14,6 +14,14 @@ export class Account {
     public readonly nft?: Nft[],
   ) {}
 
+  static readonly INJ_1 = new Account(
+    Currency.INJ,
+    "Injective 1",
+    "inj1hyz3lqavdc28jfph0wlwh5d2026r5elkmxxpwr",
+    undefined,
+    0,
+  );
+
   static readonly APTOS_1 = new Account(
     Currency.APT,
     "Aptos 1",
@@ -573,11 +581,27 @@ export class Account {
     0,
   );
 
+  static readonly MULTIVERS_X_2 = new Account(
+    Currency.MULTIVERS_X,
+    "MultiversX 2",
+    "erd10nxfga5uavl7pr8k5qptk49h2983erxznj7z3kpw28937z7gmf5sc7shug",
+    undefined,
+    1,
+  );
+
   static readonly OSMO_1 = new Account(
     Currency.OSMO,
     "Osmosis 1",
     "osmo1w7v2v6v8z3r3d8x8h7yjv6w2k3c5w3z7w6v8v8",
     undefined,
     0,
+  );
+
+  static readonly OSMO_2 = new Account(
+    Currency.OSMO,
+    "Osmosis 2",
+    "osmo12d854g9mut943gu5ncyhalapukttkddnyy4dkg",
+    undefined,
+    1,
   );
 }

--- a/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
+++ b/libs/ledger-live-common/src/e2e/enum/AppInfos.ts
@@ -3,6 +3,8 @@ export class AppInfos {
 
   static readonly BITCOIN = new AppInfos("Bitcoin");
 
+  static readonly INJECTIVE = new AppInfos("Injective");
+
   static readonly APTOS = new AppInfos("Aptos");
 
   static readonly BITCOIN_TESTNET = new AppInfos("Bitcoin Test");

--- a/libs/ledger-live-common/src/e2e/enum/Currency.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Currency.ts
@@ -8,6 +8,8 @@ export class Currency {
     public readonly speculosApp: AppInfos,
   ) {}
 
+  static readonly INJ = new Currency("Injective", "INJ", "injective", AppInfos.INJECTIVE);
+
   static readonly BTC = new Currency("Bitcoin", "BTC", "bitcoin", AppInfos.BITCOIN);
 
   static readonly APT = new Currency("Aptos", "APT", "aptos", AppInfos.APTOS);

--- a/libs/ledger-live-common/src/e2e/enum/DeviceLabels.ts
+++ b/libs/ledger-live-common/src/e2e/enum/DeviceLabels.ts
@@ -42,4 +42,8 @@ export enum DeviceLabels {
   SEND_TO_ADDRESS_2 = "Send to address (2/2)",
   CONFIRM_TRANSACTION = "Confirm transaction",
   REVIEW_TRANSACTION = "Review transaction",
+  EXPERT_MODE = "Expert mode",
+  REGISTER = "Register",
+  STAKE_KEY = "Stake key",
+  DELEGATE_STAKE = "Delegate stake",
 }

--- a/libs/ledger-live-common/src/e2e/families/cardano.ts
+++ b/libs/ledger-live-common/src/e2e/families/cardano.ts
@@ -20,3 +20,24 @@ export async function sendCardano(tx: Transaction) {
   const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
   expect(isAddressCorrect).toBeTruthy();
 }
+
+export async function delegateCardano() {
+  await waitFor(DeviceLabels.NEW_ORDINARY_TRANSACTION);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.TRANSACTION_FEE);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.REGISTER);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.STAKE_KEY);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.CONFIRM);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.DELEGATE_STAKE);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.STAKE_KEY);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.CONFIRM);
+  await pressBoth();
+  await pressUntilTextFound(DeviceLabels.CONFIRM);
+  await pressBoth();
+}

--- a/libs/ledger-live-common/src/e2e/families/multiversX.ts
+++ b/libs/ledger-live-common/src/e2e/families/multiversX.ts
@@ -1,0 +1,8 @@
+import { pressBoth, pressUntilTextFound, waitFor } from "../speculos";
+import { DeviceLabels } from "../enum/DeviceLabels";
+
+export async function delegateMultiversX() {
+  await waitFor(DeviceLabels.RECEIVER);
+  await pressUntilTextFound(DeviceLabels.SIGN);
+  await pressBoth();
+}

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -24,12 +24,13 @@ import { sendPolkadot } from "./families/polkadot";
 import { sendAlgorand } from "./families/algorand";
 import { sendTron } from "./families/tron";
 import { sendStellar } from "./families/stellar";
-import { sendCardano } from "./families/cardano";
+import { sendCardano, delegateCardano } from "./families/cardano";
 import { sendXRP } from "./families/xrp";
 import { sendAptos } from "./families/aptos";
 import { delegateNear } from "./families/near";
 import { delegateCosmos, sendCosmos } from "./families/cosmos";
 import { delegateSolana, sendSolana } from "./families/solana";
+import { delegateMultiversX } from "./families/multiversX";
 import { NFTTransaction, Transaction } from "./models/Transaction";
 import { Delegate } from "./models/Delegate";
 import { Swap } from "./models/Swap";
@@ -275,6 +276,14 @@ export const specs: Specs = {
     },
     dependency: "",
   },
+  Injective: {
+    currency: getCryptoCurrencyById("injective"),
+    appQuery: {
+      model: DeviceModelId.nanoSP,
+      appName: "Cosmos",
+    },
+    dependency: "",
+  },
 };
 
 export async function startSpeculos(
@@ -470,6 +479,11 @@ export async function activateLedgerSync() {
   await pressBoth();
 }
 
+export async function activateExpertMode() {
+  await pressUntilTextFound(DeviceLabels.EXPERT_MODE);
+  await pressBoth();
+}
+
 export async function expectValidAddressDevice(account: Account, addressDisplayed: string) {
   let deviceLabels: string[];
 
@@ -558,7 +572,15 @@ export async function signDelegationTransaction(delegatingAccount: Delegate) {
       await delegateNear(delegatingAccount);
       break;
     case Account.ATOM_1.currency.name:
+    case Account.INJ_1.currency.name:
+    case Account.OSMO_1.currency.name:
       await delegateCosmos(delegatingAccount);
+      break;
+    case Account.MULTIVERS_X_1.currency.name:
+      await delegateMultiversX();
+      break;
+    case Account.ADA_1.currency.name:
+      await delegateCardano();
       break;
     default:
       throw new Error(`Unsupported currency: ${currencyName}`);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- e2e delegation:
   - Injective
   - OSMOS
- e2e delegation without broadcast:
   - Ada Cardano
   - Multivers X
- 'liveApp' Flow:
   - Ethereum
   - Tron
   - Polkadot

🚨 Tezos and Celo not done yet, Waiting for information about the new delegation flow. cc @mcoursier-ledger 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-438](https://ledgerhq.atlassian.net/browse/QAA-438)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-438]: https://ledgerhq.atlassian.net/browse/QAA-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ