### PR TITLE
Check for version differences on `workflow_call` not `workflow_run`

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -7,6 +7,10 @@ on:
         description: "the ref (branch) to release from"
         required: false
         default: main
+      caller:
+        type: string
+        description: "the workflow that called this one"
+        required: true
   workflow_dispatch:
     inputs:
       app:
@@ -73,12 +77,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       - name: check if desktop versions are different
-        if: ${{ github.event_name == 'workflow_call' }}
+        if: ${{ inputs.caller == 'release-prepare' || inputs.caller == 'release-prepare-hotfix' }}
         id: desktop-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
       - name: check if mobile versions are different
-        if: ${{ github.event_name == 'workflow_call' }}
+        if: ${{ inputs.caller == 'release-prepare' || inputs.caller == 'release-prepare-hotfix' }}
         id: mobile-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -73,12 +73,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       - name: check if desktop versions are different
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_call' }}
         id: desktop-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
       - name: check if mobile versions are different
-        if: ${{ github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'workflow_call' }}
         id: mobile-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -127,4 +127,5 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
       ref: hotfix
+      caller: release-prepare-hotfix
     secrets: inherit

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -82,4 +82,5 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
       ref: main
+      caller: release-prepare
     secrets: inherit


### PR DESCRIPTION
Fixes the (unticketed) issue from [this comment](https://ledger.slack.com/archives/C03MHGMAMRQ/p1737535147677199) where the "publish apps" workflow did not execute all the expected steps when triggered by the "prepare release" workflow.

This issue stems from this PR - https://github.com/LedgerHQ/ledger-live/pull/8718, which introduced a new mechanism for chaining the workflows together (`workflow_call` chaining technique introduced, `workflow_run` deprecated). Although this was tested and worked well during development, we turned off many of the steps of the downstream "publish" workflow so that we wouldn't create actual releases during testing, therefore only testing the workflow chaining. It turns out 2 of these deacticated steps were affected by the workflow call type, and are now having issues. This is fixed in this PR.

There is a test PR that runs the code path of the changed code here https://github.com/LedgerHQ/ledger-live/pull/8979. This test has passed 🟢: it correctly runs the "Check if desktop versions are different" step that failed to run in [Desire's run last night](https://github.com/LedgerHQ/ledger-live/actions/runs/12897870296/job/35963915760), and I believe is the cause of the problem he saw.