### PR TITLE
fix: remove incorrect indentation in desktop readme

### DIFF
--- a/apps/ledger-live-desktop/README.md
+++ b/apps/ledger-live-desktop/README.md
@@ -13,7 +13,7 @@ Minimum system requirements can be found on [Ledger Support website](https://sup
   <p align="center">
     <img src="./docs/screenshot.png" width="550"/>
   </p>
- </a>
+</a>
 
 ## Architecture
 


### PR DESCRIPTION
Inconsequential PR that removes a stray extra space in the desktop readme. Really this PR is to see the CI working following the switch to the merge queue setup, which was just turned on.