### PR TITLE
feat(coin:xrp): apply api change on operations

### DIFF
--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -27,11 +27,12 @@ export type Transaction = {
   supplement?: unknown;
 };
 
-// FIXME rename start to minHeight
+// TODO rename start to minHeight
 //       and add a `token: string` field to the pagination if we really need to support pagination
 //       (which is not the case for now)
 //       for now start is used as a minHeight from which we want to fetch ALL operations
 //       limit is unused for now
+//       see design document at https://ledgerhq.atlassian.net/wiki/spaces/BE/pages/5446205788/coin-modules+lama-adapter+APIs+refinements
 export type Pagination = { limit?: number; start?: number };
 export type Api = {
   broadcast: (tx: string) => Promise<string>;

--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -27,7 +27,12 @@ export type Transaction = {
   supplement?: unknown;
 };
 
-export type Pagination = { limit: number; start?: number };
+// FIXME rename start to minHeight
+//       and add a `token: string` field to the pagination if we really need to support pagination
+//       (which is not the case for now)
+//       for now start is used as a minHeight from which we want to fetch ALL operations
+//       limit is unused for now
+export type Pagination = { limit?: number; start?: number };
 export type Api = {
   broadcast: (tx: string) => Promise<string>;
   combine: (tx: string, signature: string, pubkey?: string) => string;
@@ -35,13 +40,5 @@ export type Api = {
   estimateFees: (addr: string, amount: bigint) => Promise<bigint>;
   getBalance: (address: string) => Promise<bigint>;
   lastBlock: () => Promise<BlockInfo>;
-  /**
-   *
-   * @param address
-   * @param pagination The max number of operation to receive and the "id" or "index" to start from (see returns value).
-   * @returns Operations found and the next "id" or "index" to use for pagination (i.e. `start` property).\
-   * If `0` is returns, no pagination needed.
-   * This "id" or "index" value, thus it has functional meaning, is different for each blockchain.
-   */
-  listOperations: (address: string, pagination: Pagination) => Promise<[Operation[], number]>;
+  listOperations: (address: string, pagination: Pagination) => Promise<[Operation[], string]>;
 };

--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -33,7 +33,7 @@ export type Transaction = {
 //       for now start is used as a minHeight from which we want to fetch ALL operations
 //       limit is unused for now
 //       see design document at https://ledgerhq.atlassian.net/wiki/spaces/BE/pages/5446205788/coin-modules+lama-adapter+APIs+refinements
-export type Pagination = { limit?: number; start?: number };
+export type Pagination = { minHeight: number };
 export type Api = {
   broadcast: (tx: string) => Promise<string>;
   combine: (tx: string, signature: string, pubkey?: string) => string;

--- a/libs/coin-modules/coin-module-boilerplate/src/common-logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/common-logic/history/listOperations.ts
@@ -11,11 +11,12 @@ import { getTransactions } from "../../network/indexer";
  */
 export async function listOperations(
   address: string,
-  { limit, start }: Pagination,
-): Promise<[Operation[], number]> {
-  const transactions = await getTransactions(address, { from: start || 0, size: limit });
-
-  return [transactions.map(convertToCoreOperation(address)), transactions.length];
+  page: Pagination,
+): Promise<[Operation[], string]> {
+  let options: { from: number; size?: number } = { from: page.start || 0 };
+  if (page.limit) options = { ...options, size: page.limit };
+  const transactions = await getTransactions(address, options);
+  return [transactions.map(convertToCoreOperation(address)), ""];
 }
 
 const convertToCoreOperation = (address: string) => (operation: any) => {

--- a/libs/coin-modules/coin-module-boilerplate/src/common-logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/common-logic/history/listOperations.ts
@@ -13,9 +13,7 @@ export async function listOperations(
   address: string,
   page: Pagination,
 ): Promise<[Operation[], string]> {
-  let options: { from: number; size?: number } = { from: page.start || 0 };
-  if (page.limit) options = { ...options, size: page.limit };
-  const transactions = await getTransactions(address, options);
+  const transactions = await getTransactions(address, { from: page.minHeight });
   return [transactions.map(convertToCoreOperation(address)), ""];
 }
 

--- a/libs/coin-modules/coin-module-boilerplate/src/network/indexer.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/network/indexer.ts
@@ -4,7 +4,7 @@ import { getEnv } from "@ledgerhq/live-env";
 
 export const getTransactions = async (
   address: string,
-  params: { from: number; size: number },
+  params: { from: number; size?: number },
 ): Promise<AccountTxResponse["transactions"]> => {
   const { data } = await network<AccountTxResponse>({
     // NOTE: add INDEXER_BOILERPLATE to libs/env/src/env.ts

--- a/libs/coin-modules/coin-polkadot/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.integ.test.ts
@@ -42,7 +42,7 @@ describe("Polkadot Api", () => {
   describe("listOperations", () => {
     it("returns a list regarding address parameter", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, { limit: 100 });
+      const [tx, _] = await module.listOperations(address, { minHeight: 0 });
 
       // Then
       expect(tx.length).toBeGreaterThanOrEqual(1);
@@ -56,7 +56,7 @@ describe("Polkadot Api", () => {
 
     it("returns all operations", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, {});
+      const [tx, _] = await module.listOperations(address, { minHeight: 0 });
 
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));

--- a/libs/coin-modules/coin-polkadot/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.integ.test.ts
@@ -54,11 +54,9 @@ describe("Polkadot Api", () => {
       });
     }, 20000);
 
-    it("returns paginated operations", async () => {
+    it("returns all operations", async () => {
       // When
-      const [tx, idx] = await module.listOperations(address, { limit: 100 });
-      const [tx2, _] = await module.listOperations(address, { limit: 100, start: idx });
-      tx.push(...tx2);
+      const [tx, _] = await module.listOperations(address, {});
 
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));

--- a/libs/coin-modules/coin-polkadot/src/api/index.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.ts
@@ -1,6 +1,7 @@
 import type {
   Api,
   Transaction as ApiTransaction,
+  Operation,
   Pagination,
 } from "@ledgerhq/coin-framework/api/index";
 import coinConfig, { type PolkadotConfig } from "../config";
@@ -47,5 +48,10 @@ async function estimate(addr: string, amount: bigint): Promise<bigint> {
   return estimateFees(tx);
 }
 
-const operations = async (addr: string, { limit, start }: Pagination) =>
-  listOperations(addr, { limit, startAt: start });
+async function operations(
+  address: string,
+  { limit, start }: Pagination,
+): Promise<[Operation[], string]> {
+  const [ops, nextHeight] = await listOperations(address, { limit: limit || 0, startAt: start });
+  return [ops, JSON.stringify(nextHeight)];
+}

--- a/libs/coin-modules/coin-polkadot/src/api/index.ts
+++ b/libs/coin-modules/coin-polkadot/src/api/index.ts
@@ -50,8 +50,8 @@ async function estimate(addr: string, amount: bigint): Promise<bigint> {
 
 async function operations(
   address: string,
-  { limit, start }: Pagination,
+  { minHeight }: Pagination,
 ): Promise<[Operation[], string]> {
-  const [ops, nextHeight] = await listOperations(address, { limit: limit || 0, startAt: start });
+  const [ops, nextHeight] = await listOperations(address, { limit: 0, startAt: minHeight });
   return [ops, JSON.stringify(nextHeight)];
 }

--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -32,7 +32,7 @@ describe("Stellar Api", () => {
   describe.only("listOperations", () => {
     it("returns a list regarding address parameter", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, { limit: 100 });
+      const [tx, _] = await module.listOperations(address, { minHeight: 0 });
 
       // Then
       expect(tx.length).toBeGreaterThanOrEqual(100);
@@ -46,7 +46,7 @@ describe("Stellar Api", () => {
 
     it("returns all operations", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, {});
+      const [tx, _] = await module.listOperations(address, { minHeight: 0 });
 
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));

--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -44,11 +44,9 @@ describe("Stellar Api", () => {
       });
     });
 
-    it("returns paginated operations", async () => {
+    it("returns all operations", async () => {
       // When
-      const [tx, idx] = await module.listOperations(address, { limit: 200 });
-      const [tx2, _] = await module.listOperations(address, { limit: 200, start: idx });
-      tx.push(...tx2);
+      const [tx, _] = await module.listOperations(address, {});
 
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -67,7 +67,42 @@ function compose(tx: string, signature: string, pubkey?: string): string {
   return combine(tx, signature, pubkey);
 }
 
-const operations = async (
+type PaginationState = {
+  pageSize?: number;
+  heightLimit: number;
+  continueIterations: boolean;
+  apiNextCursor?: string;
+  accumulator: Operation[];
+};
+
+async function operationsFromHeight(
   address: string,
-  { limit, start }: Pagination,
-): Promise<[Operation[], number]> => listOperations(address, { limit, cursor: start });
+  start: number,
+): Promise<[Operation[], string]> {
+  const state: PaginationState = {
+    pageSize: 100,
+    heightLimit: start,
+    continueIterations: true,
+    accumulator: [],
+  };
+
+  while (state.continueIterations) {
+    const options: { limit?: number; cursor?: string } = {};
+    if (state.apiNextCursor) {
+      options.cursor = state.apiNextCursor;
+    }
+    if (state.pageSize) {
+      options.limit = state.pageSize;
+    }
+    const [operations, nextCursor] = await listOperations(address, options);
+    const filteredOperations = operations.filter(op => op.block.height >= state.heightLimit);
+    state.accumulator.push(...filteredOperations);
+    state.apiNextCursor = nextCursor;
+    state.continueIterations = operations.length === filteredOperations.length;
+  }
+
+  return [state.accumulator, state.apiNextCursor ?? ""];
+}
+
+const operations = async (address: string, { start }: Pagination): Promise<[Operation[], string]> =>
+  operationsFromHeight(address, start ?? 0);

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -67,7 +67,10 @@ function compose(tx: string, signature: string, pubkey?: string): string {
   return combine(tx, signature, pubkey);
 }
 
-async function operations(address: string, { limit }: Pagination): Promise<[Operation[], string]> {
+async function operations(
+  address: string,
+  _pagination: Pagination,
+): Promise<[Operation[], string]> {
   // TODO will be fixed with https://github.com/LedgerHQ/ledger-live/pull/8898/files
-  return listOperations(address, { limit: limit ?? 200 });
+  return listOperations(address, { limit: 200 });
 }

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -67,42 +67,7 @@ function compose(tx: string, signature: string, pubkey?: string): string {
   return combine(tx, signature, pubkey);
 }
 
-type PaginationState = {
-  pageSize?: number;
-  heightLimit: number;
-  continueIterations: boolean;
-  apiNextCursor?: string;
-  accumulator: Operation[];
-};
-
-async function operationsFromHeight(
-  address: string,
-  start: number,
-): Promise<[Operation[], string]> {
-  const state: PaginationState = {
-    pageSize: 100,
-    heightLimit: start,
-    continueIterations: true,
-    accumulator: [],
-  };
-
-  while (state.continueIterations) {
-    const options: { limit?: number; cursor?: string } = {};
-    if (state.apiNextCursor) {
-      options.cursor = state.apiNextCursor;
-    }
-    if (state.pageSize) {
-      options.limit = state.pageSize;
-    }
-    const [operations, nextCursor] = await listOperations(address, options);
-    const filteredOperations = operations.filter(op => op.block.height >= state.heightLimit);
-    state.accumulator.push(...filteredOperations);
-    state.apiNextCursor = nextCursor;
-    state.continueIterations = operations.length === filteredOperations.length;
-  }
-
-  return [state.accumulator, state.apiNextCursor ?? ""];
+async function operations(address: string, { limit }: Pagination): Promise<[Operation[], string]> {
+  // TODO will be fixed with https://github.com/LedgerHQ/ledger-live/pull/8898/files
+  return listOperations(address, { limit: limit ?? 200 });
 }
-
-const operations = async (address: string, { start }: Pagination): Promise<[Operation[], string]> =>
-  operationsFromHeight(address, start ?? 0);

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
@@ -20,8 +20,8 @@ export type Operation = {
 
 export async function listOperations(
   address: string,
-  { limit, cursor }: { limit: number; cursor?: number | undefined },
-): Promise<[Operation[], number]> {
+  { limit, cursor }: { limit?: number; cursor?: string },
+): Promise<[Operation[], string]> {
   // Fake accountId
   const accountId = "";
   const operations = await fetchOperations({
@@ -29,12 +29,12 @@ export async function listOperations(
     addr: address,
     order: "asc",
     limit,
-    cursor: cursor?.toString(),
+    cursor: cursor,
   });
 
   return [
     operations.map(convertToCoreOperation(address)),
-    parseInt(operations.slice(-1)[0].extra.pagingToken ?? "0"),
+    operations.slice(-1)[0].extra.pagingToken ?? "",
   ];
 }
 

--- a/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
@@ -46,7 +46,7 @@ describe("Tezos Api", () => {
   describe.only("listOperations", () => {
     it("returns a list regarding address parameter", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, { limit: 100 });
+      const [tx, _] = await module.listOperations(address, { minHeight: 0 });
 
       // Then
       expect(tx.length).toBeGreaterThanOrEqual(1);
@@ -61,7 +61,7 @@ describe("Tezos Api", () => {
 
     it("returns all operations", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, {});
+      const [tx, _] = await module.listOperations(address, { minHeight: 0 });
 
       // Then
       // Find a way to create a unique id. In Tezos, the same hash may represent different operations in case of delegation.

--- a/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
@@ -59,11 +59,9 @@ describe("Tezos Api", () => {
       });
     });
 
-    it("returns paginated operations", async () => {
+    it("returns all operations", async () => {
       // When
-      const [tx, idx] = await module.listOperations(address, { limit: 100 });
-      const [tx2, _] = await module.listOperations(address, { limit: 100, start: idx });
-      tx.push(...tx2);
+      const [tx, _] = await module.listOperations(address, {});
 
       // Then
       // Find a way to create a unique id. In Tezos, the same hash may represent different operations in case of delegation.

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -65,7 +65,7 @@ async function estimate(addr: string, amount: bigint): Promise<bigint> {
   return estimatedFees.estimatedFees;
 }
 
-function operations(address: string, { limit }: Pagination) {
+function operations(address: string, _pagination: Pagination) {
   //TODO implement properly with https://github.com/LedgerHQ/ledger-live/pull/8875
-  return listOperations(address, { limit });
+  return listOperations(address, {});
 }

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -25,14 +25,20 @@ export type Operation = {
 
 export async function listOperations(
   address: string,
-  { lastId, limit }: { lastId?: number; limit?: number },
-): Promise<[Operation[], number]> {
-  const operations = await tzkt.getAccountOperations(address, { lastId, limit });
+  { token, limit }: { limit?: number; token?: string },
+): Promise<[Operation[], string]> {
+  let options: { lastId?: number; limit?: number } = { limit: limit };
+  if (token) {
+    options = { ...options, lastId: JSON.parse(token) };
+  }
+  const operations = await tzkt.getAccountOperations(address, options);
+  const lastOperation = operations.slice(-1)[0];
+  const nextId = lastOperation ? JSON.stringify(lastOperation?.id) : "";
   return [
     operations
       .filter(op => isAPITransactionType(op) || isAPIDelegationType(op))
       .reduce((acc, op) => acc.concat(convertOperation(address, op)), [] as Operation[]),
-    operations.slice(-1)[0].id,
+    nextId,
   ];
 }
 

--- a/libs/coin-modules/coin-xrp/package.json
+++ b/libs/coin-modules/coin-xrp/package.json
@@ -105,6 +105,7 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
+    "@ledgerhq/logs": "workspace:^",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.4",
     "ripple-address-codec": "^5.0.0",

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -31,7 +31,7 @@ describe("Xrp Api", () => {
   describe("listOperations", () => {
     it("returns a list regarding address parameter", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, { limit: 200 });
+      const [tx, _] = await module.listOperations(address, { minHeight: 200 });
 
       // Then
       expect(tx.length).toBe(200);
@@ -45,7 +45,7 @@ describe("Xrp Api", () => {
 
     it("returns all operations", async () => {
       // When
-      const [tx, _] = await module.listOperations(bigAddress, { start: 0 });
+      const [tx, _] = await module.listOperations(bigAddress, { minHeight: 0 });
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));
       expect(checkSet.size).toEqual(tx.length);

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -51,6 +51,9 @@ describe("Xrp Api", () => {
       expect(checkSet.size).toEqual(tx.length);
       // the first transaction is returned
       expect(tx[0].block.height).toEqual(73126713);
+      expect(tx[0].hash.toUpperCase).toEqual(
+        "0FC3792449E5B1E431D45E3606017D10EC1FECC8EDF988A98E36B8FE0C33ACAE",
+      );
       // 200 is the default XRP explorer hard limit,
       // so here we are checking that this limit is bypassed
       expect(tx.length).toBeGreaterThan(200);

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -6,6 +6,7 @@ import { sign } from "ripple-keypairs";
 describe("Xrp Api", () => {
   let module: Api;
   const address = "rh1HPuRVsYYvThxG2Bs1MfjmrVC73S16Fb";
+  const bigAddress = "rUxSkt6hQpWxXQwTNRUCYYRQ7BC2yRA3F8"; // An account with more that 4000 txs
   const emptyAddress = "rKtXXTVno77jhu6tto1MAXjepyuaKaLcqB"; // Account with no transaction (at the time of this writing)
   const xrpPubKey = process.env["PUB_KEY"]!;
   const xrpSecretKey = process.env["SECRET_KEY"]!;
@@ -44,10 +45,15 @@ describe("Xrp Api", () => {
 
     it("returns all operations", async () => {
       // When
-      const [tx, _] = await module.listOperations(address, {});
+      const [tx, _] = await module.listOperations(bigAddress, { start: 0 });
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));
       expect(checkSet.size).toEqual(tx.length);
+      // the first transaction is returned
+      expect(tx[0].block.height).toEqual(73126713);
+      // 200 is the default XRP explorer hard limit,
+      // so here we are checking that this limit is bypassed
+      expect(tx.length).toBeGreaterThan(200);
     });
   });
 

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -42,12 +42,9 @@ describe("Xrp Api", () => {
       });
     });
 
-    it("returns paginated operations", async () => {
+    it("returns all operations", async () => {
       // When
-      const [tx, idx] = await module.listOperations(address, { limit: 200 });
-      const [tx2, _] = await module.listOperations(address, { limit: 200, start: idx });
-      tx.push(...tx2);
-
+      const [tx, _] = await module.listOperations(address, {});
       // Then
       const checkSet = new Set(tx.map(elt => elt.hash));
       expect(checkSet.size).toEqual(tx.length);

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -34,6 +34,84 @@ describe("listOperations", () => {
     };
   }
 
+  function givenTxs(
+    fee: number,
+    deliveredAmount: number,
+    opSender: string,
+    opDestination: string,
+  ): unknown[] {
+    return [
+      {
+        ledger_hash: "HASH_VALUE_BLOCK",
+        hash: "HASH_VALUE",
+        close_time_iso: "2000-01-01T00:00:01Z",
+        meta: { delivered_amount: deliveredAmount.toString() },
+        tx_json: {
+          TransactionType: "Payment",
+          Fee: fee.toString(),
+          ledger_index: 1,
+          date: 1000,
+          Account: opSender,
+          Destination: opDestination,
+          Sequence: 1,
+        },
+      },
+      {
+        ledger_hash: "HASH_VALUE_BLOCK",
+        hash: "HASH_VALUE",
+        close_time_iso: "2000-01-01T00:00:01Z",
+        meta: { delivered_amount: deliveredAmount.toString() },
+        tx_json: {
+          TransactionType: "Payment",
+          Fee: fee.toString(),
+          ledger_index: 1,
+          date: 1000,
+          Account: opSender,
+          Destination: opDestination,
+          DestinationTag: 509555,
+          Sequence: 1,
+        },
+      },
+      {
+        ledger_hash: "HASH_VALUE_BLOCK",
+        hash: "HASH_VALUE",
+        close_time_iso: "2000-01-01T00:00:01Z",
+        meta: { delivered_amount: deliveredAmount.toString() },
+        tx_json: {
+          TransactionType: "Payment",
+          Fee: fee.toString(),
+          ledger_index: 1,
+          date: 1000,
+          Account: opSender,
+          Destination: opDestination,
+          Memos: [
+            {
+              Memo: {
+                MemoType: "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963",
+                MemoData: "72656e74",
+              },
+            },
+          ],
+          Sequence: 1,
+        },
+      },
+    ];
+  }
+
+  it("should kill the loop after 10 iterations", async () => {
+    const txs = givenTxs(10, 10, "src", "dest");
+    // each time it's called it returns a marker, so in theory it would loop forever
+    mockGetTransactions.mockResolvedValue(mockNetworkTxs(txs, defaultMarker));
+    const [results, _] = await api.listOperations("src", { limit: 100 });
+
+    // called 10 times because there is a hard limit of 10 iterations in case something goes wrong
+    // with interpretation of the token (bug / explorer api changed ...)
+    expect(mockGetServerInfos).toHaveBeenCalledTimes(10);
+    expect(mockGetTransactions).toHaveBeenCalledTimes(10);
+
+    expect(results.length).toBe(txs.length * 10);
+  });
+
   it.each([
     {
       address: "WHATEVER_ADDRESS",

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -54,65 +54,7 @@ describe("listOperations", () => {
       const deliveredAmount = 100;
       const fee = 10;
       mockGetTransactions.mockResolvedValueOnce(
-        mockNetworkTxs(
-          [
-            {
-              ledger_hash: "HASH_VALUE_BLOCK",
-              hash: "HASH_VALUE",
-              close_time_iso: "2000-01-01T00:00:01Z",
-              meta: { delivered_amount: deliveredAmount.toString() },
-              tx_json: {
-                TransactionType: "Payment",
-                Fee: fee.toString(),
-                ledger_index: 1,
-                date: 1000,
-                Account: opSender,
-                Destination: opDestination,
-                Sequence: 1,
-              },
-            },
-            {
-              ledger_hash: "HASH_VALUE_BLOCK",
-              hash: "HASH_VALUE",
-              close_time_iso: "2000-01-01T00:00:01Z",
-              meta: { delivered_amount: deliveredAmount.toString() },
-              tx_json: {
-                TransactionType: "Payment",
-                Fee: fee.toString(),
-                ledger_index: 1,
-                date: 1000,
-                Account: opSender,
-                Destination: opDestination,
-                DestinationTag: 509555,
-                Sequence: 1,
-              },
-            },
-            {
-              ledger_hash: "HASH_VALUE_BLOCK",
-              hash: "HASH_VALUE",
-              close_time_iso: "2000-01-01T00:00:01Z",
-              meta: { delivered_amount: deliveredAmount.toString() },
-              tx_json: {
-                TransactionType: "Payment",
-                Fee: fee.toString(),
-                ledger_index: 1,
-                date: 1000,
-                Account: opSender,
-                Destination: opDestination,
-                Memos: [
-                  {
-                    Memo: {
-                      MemoType: "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963",
-                      MemoData: "72656e74",
-                    },
-                  },
-                ],
-                Sequence: 1,
-              },
-            },
-          ],
-          defaultMarker,
-        ),
+        mockNetworkTxs(givenTxs(fee, deliveredAmount, opSender, opDestination), defaultMarker),
       );
 
       // second call to kill the loop

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -102,7 +102,7 @@ describe("listOperations", () => {
     const txs = givenTxs(10, 10, "src", "dest");
     // each time it's called it returns a marker, so in theory it would loop forever
     mockGetTransactions.mockResolvedValue(mockNetworkTxs(txs, defaultMarker));
-    const [results, _] = await api.listOperations("src", { limit: 100 });
+    const [results, _] = await api.listOperations("src", { minHeight: 0 });
 
     // called 10 times because there is a hard limit of 10 iterations in case something goes wrong
     // with interpretation of the token (bug / explorer api changed ...)
@@ -139,7 +139,7 @@ describe("listOperations", () => {
       mockGetTransactions.mockResolvedValue(mockNetworkTxs([], undefined));
 
       // When
-      const [results, _] = await api.listOperations(address, { limit: 100 });
+      const [results, _] = await api.listOperations(address, { minHeight: 0 });
 
       // Then
       // called twice because the marker is set the first time

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -67,7 +67,7 @@ async function operationsFromHeight(address: string, minHeight: number): Promise
   }
 
   const firstState: PaginationState = {
-    pageSize: 200,
+    pageSize: 400, // must be large enough to avoid unnecessary calls to the underlying explorer
     minHeight: minHeight,
     continueIterations: true,
     accumulator: [],

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -61,6 +61,7 @@ async function operationsFromHeight(
     const [operations, apiNextCursor] = await listOperations(address, {
       limit: state.pageSize,
       minHeight: state.minHeight,
+      order: "desc",
     });
     const newCurrentIteration = state.currentIteration + 1;
     let continueIteration = true;

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -96,8 +96,10 @@ async function operationsFromHeight(
   return [state.accumulator, state.apiNextCursor ?? ""];
 }
 
-async function operations(address: string, { start }: Pagination): Promise<[Operation[], string]> {
-  const minHeight = start ? start : 0;
+async function operations(
+  address: string,
+  { minHeight }: Pagination,
+): Promise<[Operation[], string]> {
   const [ops, token] = await operationsFromHeight(address, minHeight);
   // TODO token must be implemented properly (waiting ack from the design document)
   return [

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -61,7 +61,7 @@ async function operationsFromHeight(
     const [operations, apiNextCursor] = await listOperations(address, {
       limit: state.pageSize,
       minHeight: state.minHeight,
-      order: "desc",
+      order: "asc",
     });
     const newCurrentIteration = state.currentIteration + 1;
     let continueIteration = true;

--- a/libs/coin-modules/coin-xrp/src/bridge/synchronization.test.ts
+++ b/libs/coin-modules/coin-xrp/src/bridge/synchronization.test.ts
@@ -68,6 +68,20 @@ describe("getAccountShape", () => {
     });
   });
 
+  const someMarker = { ledger: 1, seq: 1 };
+  function mockNetworkTxs(txs: unknown): unknown {
+    return {
+      account: "account",
+      ledger_index_max: 1,
+      ledger_index_min: 1,
+      limit: 1,
+      validated: false,
+      transactions: txs,
+      marker: someMarker,
+      error: "",
+    };
+  }
+
   it("convert correctly operations", async () => {
     // Given
     mockGetAccountInfo.mockResolvedValue({
@@ -76,22 +90,24 @@ describe("getAccountShape", () => {
       ownerCount: 0,
       sequence: 0,
     });
-    mockGetTransactions.mockResolvedValue([
-      {
-        ledger_hash: "HASH_VALUE_BLOCK",
-        hash: "HASH_VALUE",
-        meta: { delivered_amount: "100" },
-        tx_json: {
-          TransactionType: "Payment",
-          Fee: "10",
-          ledger_index: 1,
-          date: 1000,
-          Account: "account_addr",
-          Destination: "destination_addr",
-          Sequence: 1,
+    mockGetTransactions.mockResolvedValue(
+      mockNetworkTxs([
+        {
+          ledger_hash: "HASH_VALUE_BLOCK",
+          hash: "HASH_VALUE",
+          meta: { delivered_amount: "100" },
+          tx_json: {
+            TransactionType: "Payment",
+            Fee: "10",
+            ledger_index: 1,
+            date: 1000,
+            Account: "account_addr",
+            Destination: "destination_addr",
+            Sequence: 1,
+          },
         },
-      },
-    ]);
+      ]),
+    );
 
     // When
     const account = await getAccountShape(
@@ -135,3 +151,4 @@ describe("getAccountShape", () => {
     });
   });
 });
+  

--- a/libs/coin-modules/coin-xrp/src/bridge/synchronization.test.ts
+++ b/libs/coin-modules/coin-xrp/src/bridge/synchronization.test.ts
@@ -151,4 +151,3 @@ describe("getAccountShape", () => {
     });
   });
 });
-  

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.test.ts
@@ -1,6 +1,7 @@
 import { assert } from "console";
 import { listOperations } from "./listOperations";
 import { RIPPLE_EPOCH } from "./utils";
+import { Marker } from "../network/types";
 
 const maxHeight = 2;
 const minHeight = 1;
@@ -21,33 +22,48 @@ describe("listOperations", () => {
     mockGetTransactions.mockClear();
   });
 
+  const someMarker: Marker = { ledger: 1, seq: 1 };
+  function mockNetworkTxs(txs: unknown): unknown {
+    return {
+      account: "account",
+      ledger_index_max: 1,
+      ledger_index_min: 1,
+      limit: 1,
+      validated: false,
+      transactions: txs,
+      marker: someMarker,
+      error: "",
+    };
+  }
+
   it("when there are no transactions then the result is empty", async () => {
     // Given
-    mockGetTransactions.mockResolvedValue([]);
+    mockGetTransactions.mockResolvedValue(mockNetworkTxs([]));
     // When
     const [results, token] = await listOperations("any address", { minHeight: 0 });
     // Then
     expect(mockGetServerInfos).toHaveBeenCalledTimes(1);
     expect(mockGetTransactions).toHaveBeenCalledTimes(1);
     expect(results).toEqual([]);
-    expect(token).toEqual(minHeight);
+    expect(JSON.parse(token)).toEqual(someMarker);
   });
 
   it("when there are no transactions and a limit then the result is empty", async () => {
     // Given
-    mockGetTransactions.mockResolvedValue([]);
+    mockGetTransactions.mockResolvedValue(mockNetworkTxs([]));
     // When
     const [results, token] = await listOperations("any address", { minHeight: 0, limit: 1 });
     // Then
     expect(mockGetServerInfos).toHaveBeenCalledTimes(1);
     expect(mockGetTransactions).toHaveBeenCalledTimes(1);
     expect(results).toEqual([]);
-    expect(token).toEqual(minHeight);
+    expect(JSON.parse(token)).toEqual(someMarker);
   });
 
   const paymentTx = {
     ledger_hash: "HASH_VALUE_BLOCK",
     hash: "HASH_VALUE",
+    validated: true,
     close_time_iso: "2000-01-01T00:00:01Z",
     meta: { delivered_amount: "100" },
     tx_json: {
@@ -65,8 +81,9 @@ describe("listOperations", () => {
   it("should only list operations of type payment", async () => {
     // Given
     const lastTransaction = paymentTx;
-    mockGetTransactions.mockResolvedValueOnce([paymentTx, otherTx, lastTransaction]);
-    mockGetTransactions.mockResolvedValue([]); // subsequent calls
+    const txs = [paymentTx, otherTx, lastTransaction];
+    mockGetTransactions.mockResolvedValueOnce(mockNetworkTxs(txs));
+    mockGetTransactions.mockResolvedValue(mockNetworkTxs([])); // subsequent calls
 
     // When
     const [results, token] = await listOperations("any address", { minHeight: 0, limit: 3 });
@@ -76,14 +93,13 @@ describe("listOperations", () => {
     // it's called twice because first call yields only 2 transactions, and 3 are asked
     expect(mockGetTransactions).toHaveBeenCalledTimes(2);
     expect(results.length).toEqual(2);
-    expect(token).toEqual(lastTransaction.tx_json.ledger_index - 1);
+    expect(JSON.parse(token)).toEqual(someMarker);
   });
 
   it("should make enough calls so that the limit requested is satified", async () => {
-    const lastTransaction = otherTx;
     const txs = [paymentTx, paymentTx, otherTx, otherTx, otherTx, otherTx, otherTx, otherTx];
     assert(txs.length === 8);
-    mockGetTransactions.mockResolvedValue(txs);
+    mockGetTransactions.mockResolvedValue(mockNetworkTxs(txs));
 
     const [results, token] = await listOperations("any address", { minHeight: 0, limit: 8 });
 
@@ -91,14 +107,13 @@ describe("listOperations", () => {
     // it's called 4 times because each call yields only 2 transactions, and 8 are asked
     expect(mockGetTransactions).toHaveBeenCalledTimes(4);
     expect(results.length).toEqual(8);
-    expect(token).toEqual(lastTransaction.tx_json.ledger_index - 1);
+    expect(JSON.parse(token)).toEqual(someMarker);
   });
 
   it("should make enough calls, even if there is not enough txs to satisfy the limit", async () => {
-    mockGetTransactions.mockResolvedValueOnce([otherTx, otherTx, otherTx, otherTx]);
-    mockGetTransactions.mockResolvedValueOnce([paymentTx, paymentTx]);
+    mockGetTransactions.mockResolvedValueOnce(mockNetworkTxs([otherTx, otherTx, otherTx, otherTx]));
+    mockGetTransactions.mockResolvedValueOnce(mockNetworkTxs([paymentTx, paymentTx]));
     mockGetTransactions.mockResolvedValue([]); // subsequent calls
-    const lastTransaction = paymentTx;
 
     const [results, token] = await listOperations("any address", { minHeight: 0, limit: 4 });
 
@@ -106,7 +121,7 @@ describe("listOperations", () => {
     // it's called 2 times because the second call is a shortage of txs
     expect(mockGetTransactions).toHaveBeenCalledTimes(2);
     expect(results.length).toEqual(2);
-    expect(token).toEqual(lastTransaction.tx_json.ledger_index - 1);
+    expect(JSON.parse(token)).toEqual(someMarker);
   });
 
   it.each([
@@ -128,62 +143,64 @@ describe("listOperations", () => {
       // Given
       const deliveredAmount = 100;
       const fee = 10;
-      mockGetTransactions.mockResolvedValue([
-        {
-          ledger_hash: "HASH_VALUE_BLOCK",
-          hash: "HASH_VALUE",
-          close_time_iso: "2000-01-01T00:00:01Z",
-          meta: { delivered_amount: deliveredAmount.toString() },
-          tx_json: {
-            TransactionType: "Payment",
-            Fee: fee.toString(),
-            ledger_index: 1,
-            date: 1000,
-            Account: opSender,
-            Destination: opDestination,
-            Sequence: 1,
+      mockGetTransactions.mockResolvedValue(
+        mockNetworkTxs([
+          {
+            ledger_hash: "HASH_VALUE_BLOCK",
+            hash: "HASH_VALUE",
+            close_time_iso: "2000-01-01T00:00:01Z",
+            meta: { delivered_amount: deliveredAmount.toString() },
+            tx_json: {
+              TransactionType: "Payment",
+              Fee: fee.toString(),
+              ledger_index: 1,
+              date: 1000,
+              Account: opSender,
+              Destination: opDestination,
+              Sequence: 1,
+            },
           },
-        },
-        {
-          ledger_hash: "HASH_VALUE_BLOCK",
-          hash: "HASH_VALUE",
-          close_time_iso: "2000-01-01T00:00:01Z",
-          meta: { delivered_amount: deliveredAmount.toString() },
-          tx_json: {
-            TransactionType: "Payment",
-            Fee: fee.toString(),
-            ledger_index: 1,
-            date: 1000,
-            Account: opSender,
-            Destination: opDestination,
-            DestinationTag: 509555,
-            Sequence: 1,
+          {
+            ledger_hash: "HASH_VALUE_BLOCK",
+            hash: "HASH_VALUE",
+            close_time_iso: "2000-01-01T00:00:01Z",
+            meta: { delivered_amount: deliveredAmount.toString() },
+            tx_json: {
+              TransactionType: "Payment",
+              Fee: fee.toString(),
+              ledger_index: 1,
+              date: 1000,
+              Account: opSender,
+              Destination: opDestination,
+              DestinationTag: 509555,
+              Sequence: 1,
+            },
           },
-        },
-        {
-          ledger_hash: "HASH_VALUE_BLOCK",
-          hash: "HASH_VALUE",
-          close_time_iso: "2000-01-01T00:00:01Z",
-          meta: { delivered_amount: deliveredAmount.toString() },
-          tx_json: {
-            TransactionType: "Payment",
-            Fee: fee.toString(),
-            ledger_index: 1,
-            date: 1000,
-            Account: opSender,
-            Destination: opDestination,
-            Memos: [
-              {
-                Memo: {
-                  MemoType: "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963",
-                  MemoData: "72656e74",
+          {
+            ledger_hash: "HASH_VALUE_BLOCK",
+            hash: "HASH_VALUE",
+            close_time_iso: "2000-01-01T00:00:01Z",
+            meta: { delivered_amount: deliveredAmount.toString() },
+            tx_json: {
+              TransactionType: "Payment",
+              Fee: fee.toString(),
+              ledger_index: 1,
+              date: 1000,
+              Account: opSender,
+              Destination: opDestination,
+              Memos: [
+                {
+                  Memo: {
+                    MemoType: "687474703a2f2f6578616d706c652e636f6d2f6d656d6f2f67656e65726963",
+                    MemoData: "72656e74",
+                  },
                 },
-              },
-            ],
-            Sequence: 1,
+              ],
+              Sequence: 1,
+            },
           },
-        },
-      ]);
+        ]),
+      );
 
       // When
       const [results, _] = await listOperations(address, { minHeight: 0 });

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
@@ -52,7 +52,7 @@ export async function listOperations(
     };
   }
 
-  if (minHeight) {
+  if (minHeight !== undefined) {
     options = {
       ...options,
       // if there is no ops, it might be after a clear and we prefer to pull from the oldest possible history

--- a/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/listOperations.ts
@@ -1,5 +1,5 @@
 import { getServerInfos, getTransactions, GetTransactionsOptions } from "../network";
-import type { Marker, XrplOperation } from "../network/types";
+import type { XrplOperation } from "../network/types";
 import { XrpMemo, XrpOperation } from "../types";
 import { RIPPLE_EPOCH } from "./utils";
 
@@ -37,6 +37,7 @@ export async function listOperations(
   const ledgers = serverInfo.info.complete_ledgers.split("-");
   const minLedgerVersion = Number(ledgers[0]);
 
+  // by default the explorer queries the transactions in descending order (newest first)
   let forward = false;
   if (order && order === "asc") {
     forward = true;
@@ -99,7 +100,8 @@ export async function listOperations(
     transactions = transactions.concat(newTransactions);
   }
 
-  transactions.reverse();
+  // the order is reversed so that the results are always sorted by newest tx first element of the list
+  if (order === "asc") transactions.reverse();
 
   // the next index to start the pagination from
   const next = nextOptions.marker ? JSON.stringify(nextOptions.marker) : "";

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -4,13 +4,13 @@ import type { AccountInfo } from "../types/model";
 import {
   isErrorResponse,
   isResponseStatus,
+  Marker,
   type AccountInfoResponse,
   type AccountTxResponse,
   type ErrorResponse,
   type LedgerResponse,
   type ServerInfoResponse,
   type SubmitReponse,
-  type XrplOperation,
 } from "./types";
 
 const getNodeUrl = () => coinConfig.getCoinConfig().node;
@@ -68,17 +68,18 @@ export const getServerInfos = async (): Promise<ServerInfoResponse> => {
 
 export const getTransactions = async (
   address: string,
-  options: { ledger_index_min?: number; ledger_index_max?: number; limit?: number } | undefined,
-): Promise<XrplOperation[]> => {
+  options:
+    | { ledger_index_min?: number; ledger_index_max?: number; limit?: number; marker?: Marker }
+    | undefined,
+): Promise<AccountTxResponse> => {
   const result = await rpcCall<AccountTxResponse>("account_tx", {
     account: address,
-    // newest first
-    // note that order within the results is not guaranteed (see documentation of account_tx)
+    // oldest first
     forward: false,
     ...options,
     api_version: 2,
   });
-  return result.transactions;
+  return result;
 };
 
 export async function getLedger(): Promise<LedgerResponse> {
@@ -93,7 +94,7 @@ export async function getLedgerIndex(): Promise<number> {
 
 async function rpcCall<T extends object>(
   method: string,
-  params: Record<string, string | number | boolean> = {},
+  params: Record<string, unknown> = {},
 ): Promise<T> {
   const {
     data: { result },

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -66,6 +66,7 @@ export const getServerInfos = async (): Promise<ServerInfoResponse> => {
   return rpcCall<ServerInfoResponse>("server_info", { ledger_index: "validated" });
 };
 
+// https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx
 export const getTransactions = async (
   address: string,
   options:
@@ -75,7 +76,7 @@ export const getTransactions = async (
   const result = await rpcCall<AccountTxResponse>("account_tx", {
     account: address,
     // oldest first
-    forward: false,
+    forward: true,
     ...options,
     api_version: 2,
   });

--- a/libs/coin-modules/coin-xrp/src/network/index.ts
+++ b/libs/coin-modules/coin-xrp/src/network/index.ts
@@ -67,16 +67,27 @@ export const getServerInfos = async (): Promise<ServerInfoResponse> => {
 };
 
 // https://xrpl.org/docs/references/http-websocket-apis/public-api-methods/account-methods/account_tx
+export type GetTransactionsOptions = {
+  ledger_index_min?: number;
+  ledger_index_max?: number;
+  limit?: number;
+  marker?: Marker;
+  // this property controls the order of the transactions
+  // true: oldest first
+  // false: newest first
+  forward: boolean;
+};
+
 export const getTransactions = async (
   address: string,
-  options:
-    | { ledger_index_min?: number; ledger_index_max?: number; limit?: number; marker?: Marker }
-    | undefined,
+  options: GetTransactionsOptions | undefined,
 ): Promise<AccountTxResponse> => {
   const result = await rpcCall<AccountTxResponse>("account_tx", {
     account: address,
-    // oldest first
-    forward: true,
+    // this property controls the order of the transactions
+    // looks like there is a bug in LL (https://ledgerhq.atlassian.net/browse/LIVE-16705)
+    // so we need to set it to false (newest first) to get the transactions in the right order
+    // for lama-adapter we need to set it to true (oldest first)
     ...options,
     api_version: 2,
   });

--- a/libs/coin-modules/coin-xrp/src/network/types.ts
+++ b/libs/coin-modules/coin-xrp/src/network/types.ts
@@ -168,6 +168,11 @@ export type ServerInfoResponse = {
   };
 } & ResponseStatus;
 
+export type Marker = {
+  ledger: number;
+  seq: number;
+};
+
 export type AccountTxResponse = {
   account: string;
   ledger_index_max: number;
@@ -175,6 +180,7 @@ export type AccountTxResponse = {
   limit: number;
   transactions: XrplOperation[];
   validated: boolean;
+  marker?: Marker;
 } & ResponseStatus;
 
 export type LedgerResponse = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3545,6 +3545,9 @@ importers:
       '@ledgerhq/live-network':
         specifier: workspace:^
         version: link:../../live-network
+      '@ledgerhq/logs':
+        specifier: workspace:^
+        version: link:../../ledgerjs/packages/logs
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/types-live
@@ -21005,13 +21008,10 @@ packages:
     resolution: {integrity: sha512-06OKXQmKI0vuje++6lm7w1kO3rKsZAHio/4d9hwQuVAtExJ6RM92BnpzkDAV16ZheVN/FHKzNyY1BYLqXfujMw==}
     peerDependencies:
       expo: '*'
-      expo-constants: '*'
       expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
-      expo-constants:
-        optional: true
       expo-modules-core:
         optional: true
       react:
@@ -21023,13 +21023,10 @@ packages:
     resolution: {integrity: sha512-9tNY3OVO0jfiMzl7ngb6IOyR5VFzNoN5OOazUWoeGfmMqVB5kltTemRvKraK9JRbBKIw+SOYLEmF0sEqgFZ6OQ==}
     peerDependencies:
       expo: '*'
-      expo-constants: '*'
       expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
-      expo-constants:
-        optional: true
       expo-modules-core:
         optional: true
       react:
@@ -21227,13 +21224,10 @@ packages:
     resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
     peerDependencies:
       expo-constants: '*'
-      expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
       expo-constants:
-        optional: true
-      expo-modules-core:
         optional: true
       react:
         optional: true
@@ -52530,7 +52524,6 @@ snapshots:
       expo: 51.0.39(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(expo-constants@14.5.1)(expo-modules-core@1.12.26)(metro-core@0.80.12)(metro@0.80.12)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       uuid: 3.4.0
     optionalDependencies:
-      expo-constants: 14.5.1(expo-modules-core@1.12.26)(expo@51.0.39)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       expo-modules-core: 1.12.26(expo-constants@14.5.1)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3)
@@ -52543,7 +52536,6 @@ snapshots:
       '@expo/env': 0.3.0
       expo: 51.0.39(@babel/core@7.24.3)(expo-modules-autolinking@1.11.2(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
     optionalDependencies:
-      expo-constants: 16.0.2(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(expo@51.0.39(@babel/core@7.24.3)(expo-modules-autolinking@1.11.2(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       expo-modules-core: 1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3)
@@ -52556,7 +52548,6 @@ snapshots:
       '@expo/env': 0.3.0
       expo: 51.0.39(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(expo-constants@14.5.1)(expo-modules-core@1.12.26)(metro-core@0.80.12)(metro@0.80.12)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
     optionalDependencies:
-      expo-constants: 16.0.2(expo-modules-core@1.12.26)(expo@51.0.39)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       expo-modules-core: 1.12.26(expo-constants@14.5.1)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3)
@@ -52568,8 +52559,6 @@ snapshots:
       '@expo/config': 9.0.4
       '@expo/env': 0.3.0
       expo: 51.0.39
-    optionalDependencies:
-      expo-constants: 16.0.2(expo@51.0.39)
     transitivePeerDependencies:
       - supports-color
 
@@ -52711,7 +52700,6 @@ snapshots:
       invariant: 2.2.4
     optionalDependencies:
       expo-constants: 14.5.1(expo-modules-core@1.12.26)(expo@51.0.39)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
-      expo-modules-core: 1.12.26(expo-constants@14.5.1)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3)
 
@@ -52719,7 +52707,6 @@ snapshots:
     dependencies:
       invariant: 2.2.4
     optionalDependencies:
-      expo-modules-core: 1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21008,10 +21008,13 @@ packages:
     resolution: {integrity: sha512-06OKXQmKI0vuje++6lm7w1kO3rKsZAHio/4d9hwQuVAtExJ6RM92BnpzkDAV16ZheVN/FHKzNyY1BYLqXfujMw==}
     peerDependencies:
       expo: '*'
+      expo-constants: '*'
       expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
+      expo-constants:
+        optional: true
       expo-modules-core:
         optional: true
       react:
@@ -21023,10 +21026,13 @@ packages:
     resolution: {integrity: sha512-9tNY3OVO0jfiMzl7ngb6IOyR5VFzNoN5OOazUWoeGfmMqVB5kltTemRvKraK9JRbBKIw+SOYLEmF0sEqgFZ6OQ==}
     peerDependencies:
       expo: '*'
+      expo-constants: '*'
       expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
+      expo-constants:
+        optional: true
       expo-modules-core:
         optional: true
       react:
@@ -21224,10 +21230,13 @@ packages:
     resolution: {integrity: sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==}
     peerDependencies:
       expo-constants: '*'
+      expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
       expo-constants:
+        optional: true
+      expo-modules-core:
         optional: true
       react:
         optional: true
@@ -52524,6 +52533,7 @@ snapshots:
       expo: 51.0.39(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(expo-constants@14.5.1)(expo-modules-core@1.12.26)(metro-core@0.80.12)(metro@0.80.12)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       uuid: 3.4.0
     optionalDependencies:
+      expo-constants: 14.5.1(expo-modules-core@1.12.26)(expo@51.0.39)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       expo-modules-core: 1.12.26(expo-constants@14.5.1)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3)
@@ -52536,6 +52546,7 @@ snapshots:
       '@expo/env': 0.3.0
       expo: 51.0.39(@babel/core@7.24.3)(expo-modules-autolinking@1.11.2(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
     optionalDependencies:
+      expo-constants: 16.0.2(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(expo@51.0.39(@babel/core@7.24.3)(expo-modules-autolinking@1.11.2(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(expo-modules-core@1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1))(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       expo-modules-core: 1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3)
@@ -52548,6 +52559,7 @@ snapshots:
       '@expo/env': 0.3.0
       expo: 51.0.39(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(expo-constants@14.5.1)(expo-modules-core@1.12.26)(metro-core@0.80.12)(metro@0.80.12)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
     optionalDependencies:
+      expo-constants: 16.0.2(expo-modules-core@1.12.26)(expo@51.0.39)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       expo-modules-core: 1.12.26(expo-constants@14.5.1)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3)
@@ -52559,6 +52571,8 @@ snapshots:
       '@expo/config': 9.0.4
       '@expo/env': 0.3.0
       expo: 51.0.39
+    optionalDependencies:
+      expo-constants: 16.0.2(expo@51.0.39)
     transitivePeerDependencies:
       - supports-color
 
@@ -52700,6 +52714,7 @@ snapshots:
       invariant: 2.2.4
     optionalDependencies:
       expo-constants: 14.5.1(expo-modules-core@1.12.26)(expo@51.0.39)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
+      expo-modules-core: 1.12.26(expo-constants@14.5.1)(react-native@0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@babel/preset-env@7.24.3(@babel/core@7.24.3))(@types/react@18.2.73)(metro-resolver@0.80.12)(metro-transform-worker@0.80.12)(react@18.3.1)(typescript@5.4.3)
 
@@ -52707,6 +52722,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
     optionalDependencies:
+      expo-modules-core: 1.12.26(react-native@0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3))(react@18.3.1)
       react: 18.3.1
       react-native: 0.75.4(@babel/core@7.24.3)(@types/react@18.2.73)(react@18.3.1)(typescript@5.4.3)
 


### PR DESCRIPTION
Sorry, this is a big PR.

I changed the API of "operations" so, it impacted the code on all coins that implements the coin framework. Specifically I changed the semantic of "operations" so that it returns all operations, without pagination. In the future we may paginate using a proper token described in this document https://ledgerhq.atlassian.net/wiki/x/XIGeRAE


For stellar/tezos/xrp coins: I also changed signature of "logic" layer so that the token used for iteration is string not a number. The value of the token is a stringified json representation of the token returned by the underlying "network" layer. It's returned by the listOperations so that it could be reused as input in future implementation.

For stellar and tezos, the "api" is adapted for compilation but not yet ready to use, we'll have 2 respective separate PR for that:
- https://github.com/LedgerHQ/ledger-live/pull/8898
- https://github.com/LedgerHQ/ledger-live/pull/8875

For XRP specifically, 
- the "api" loop over the "logic" using the dedicated token provided by the explorer instead of the block height (that was buggy). There is a hard coded limit over the number of iteration to avoid infinite loop (if there is a bug or something) that could result in freezing users. There is a log when that limit is reached.
- introduced a `order` parameter as a workaroud for LIVE-16705

integrations tests: https://github.com/LedgerHQ/ledger-live/actions/runs/13056449704