### PR TITLE
Normalise refs before passing to turbo-affected

### DIFF
--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -58,4 +58,4 @@ jobs:
       - uses: LedgerHQ/ledger-live/tools/actions/turbo-affected@develop
         id: affected
         with:
-          ref: ${{ format('origin/{0}', inputs.base_branch) }}
+          ref: ${{ format('origin/{0}', env.base_branch) }}


### PR DESCRIPTION
Part of https://ledgerhq.atlassian.net/browse/LIVE-16491

This was a (hopefully the) missing piece from yesterday's merge queue switch-on. Git refs need to normalised, i.e. the `refs/heads/` substring needs to be removed, before passing to turbo. This PR implements that.

[Here's a PR](https://github.com/LedgerHQ/merge-queue-test/pull/11/files) that shows this working. The `clean-refs` step is mostly copy-pasted from the `clean-refs` step that is already in this repo's `turbo-affected-reusable` workflow (it adds  in variable definitions that this repo's `turbo-affected-reusable` workflow receives when it is run).

[Here's the check](https://github.com/LedgerHQ/merge-queue-test/actions/runs/12932759419/job/36069739445?pr=11) that runs during the PR CI. [Here's the check](https://github.com/LedgerHQ/merge-queue-test/actions/runs/12932791625/job/36069849382) that runs on the merge group. It helps to get those 2 runs up side by side. You want to compare the "echo vars" and the "echo sanitized vars" steps for each run. This shows both that
- github passes different format refs for PRs and Merge Groups
- sanitization function correctly normalises them

This is what we need to fix the [ambiguous refs issue from yesterday's merge group check](https://github.com/LedgerHQ/ledger-live/actions/runs/12915046500/job/36017734231#step:5:18).

There's a test PR [here](https://github.com/LedgerHQ/ledger-live/pull/8994) that logs out the calculated value for `env.base_branch` that is passed into the turbo-affected action. It appears as expected 🟢
