### PR TITLE
Support/normalise refs test

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -17,7 +17,7 @@ jobs:
   determine-affected:
     name: "Turbo Affected"
     if: ${{!github.event.pull_request.head.repo.fork }}
-    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@support/normalise-refs-test
     with:
       head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
       base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -58,4 +58,4 @@ jobs:
       - uses: LedgerHQ/ledger-live/tools/actions/turbo-affected@develop
         id: affected
         with:
-          ref: ${{ format('origin/{0}', inputs.base_branch) }}
+          ref: ${{ format('origin/{0}', env.base_branch) }}

--- a/.github/workflows/turbo-affected-reusable.yml
+++ b/.github/workflows/turbo-affected-reusable.yml
@@ -55,6 +55,12 @@ jobs:
             core.exportVariable("head_branch", newHeadBranch);
             core.exportVariable("base_branch", newBaseBranch);
 
+      - name: Echo env.base_branch
+        run: |
+            echo "env.base_branch: ${{ env.base_branch }}"
+            echo "format('origin/{0}', env.base_branch): ${{ format('origin/{0}', env.base_branch) }}"
+
+
       - uses: LedgerHQ/ledger-live/tools/actions/turbo-affected@develop
         id: affected
         with:


### PR DESCRIPTION
Test PR for https://github.com/LedgerHQ/ledger-live/pull/8991

In this test we want to see calculated value for `env.base_branch` is valid in turbo-affected

**Update**: that's a pass 🟢. [Workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/12948078895/job/36115971607?pr=8994#step:5:9)