### PR TITLE
fix: add account v2 redirection from receive when no account found / add account v1 is OK

### DIFF
--- a/.changeset/new-bulldogs-hope.md
+++ b/.changeset/new-bulldogs-hope.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix redirection to add account v2 when the user try to receive on 0 accounts based currency

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
@@ -6,9 +6,9 @@ import {
 } from "@ledgerhq/types-cryptoassets";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { AccountLike } from "@ledgerhq/types-live";
-import { NavigatorScreenParams } from "@react-navigation/core";
+import { NavigatorScreenParams } from "@react-navigation/native";
 import type { NavigatorName, ScreenName } from "~/const";
-import { DeviceSelectionNavigatorParamsList } from "~/newArch/features/DeviceSelection/types";
+import { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
 
 export type ReceiveFundsStackParamList = {
   [ScreenName.ReceiveSelectCrypto]:

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/ReceiveFundsNavigator.ts
@@ -6,7 +6,9 @@ import {
 } from "@ledgerhq/types-cryptoassets";
 import { Device, DeviceModelId } from "@ledgerhq/types-devices";
 import { AccountLike } from "@ledgerhq/types-live";
-import type { ScreenName } from "~/const";
+import { NavigatorScreenParams } from "@react-navigation/core";
+import type { NavigatorName, ScreenName } from "~/const";
+import { DeviceSelectionNavigatorParamsList } from "~/newArch/features/DeviceSelection/types";
 
 export type ReceiveFundsStackParamList = {
   [ScreenName.ReceiveSelectCrypto]:
@@ -76,4 +78,7 @@ export type ReceiveFundsStackParamList = {
     onSuccess?: (_?: string) => void;
     onError?: () => void;
   };
+  [NavigatorName.DeviceSelection]?: Partial<
+    NavigatorScreenParams<DeviceSelectionNavigatorParamsList>
+  >;
 };

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AccountsList/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AccountsList/index.tsx
@@ -26,6 +26,7 @@ import { LoadingBasedGroupedCurrencies, LoadingStatus } from "@ledgerhq/live-com
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { TrackingEvent } from "../../enums";
 import { parseBoolean } from "LLM/utils/parseBoolean";
+import { AddAccountContexts } from "../AddAccount/enums";
 type Props = StackNavigatorProps<AccountsListNavigator, ScreenName.AccountsList>;
 
 export default function AccountsList({ route }: Props) {
@@ -85,7 +86,7 @@ export default function AccountsList({ route }: Props) {
           screen: ScreenName.SelectNetwork,
           params: {
             currency: currency.id,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
           },
         });
       } else {
@@ -93,7 +94,7 @@ export default function AccountsList({ route }: Props) {
           screen: ScreenName.SelectDevice,
           params: {
             currency: currency as CryptoCurrency,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
           },
         });
       }

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/SelectAddAccountMethod/useSelectAddAccountMethodViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/SelectAddAccountMethod/useSelectAddAccountMethodViewModel.ts
@@ -7,6 +7,7 @@ import { useCallback, useMemo } from "react";
 import { track } from "~/analytics";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { AddAccountContexts } from "../../enums";
 
 type AddAccountScreenProps = {
   currency?: CryptoCurrency | TokenCurrency | null;
@@ -31,16 +32,22 @@ const useSelectAddAccountMethodViewModel = ({
       if (currency?.type === "TokenCurrency") {
         return {
           token: currency,
-          ...(llmNetworkBasedAddAccountFlow?.enabled && { context: "addAccounts" }),
+          ...(llmNetworkBasedAddAccountFlow?.enabled && {
+            context: AddAccountContexts.AddAccounts,
+          }),
         };
       } else {
         return {
           currency,
-          ...(llmNetworkBasedAddAccountFlow?.enabled && { context: "addAccounts" }),
+          ...(llmNetworkBasedAddAccountFlow?.enabled && {
+            context: AddAccountContexts.AddAccounts,
+          }),
         };
       }
     } else {
-      return llmNetworkBasedAddAccountFlow?.enabled ? { context: "addAccounts" } : {};
+      return llmNetworkBasedAddAccountFlow?.enabled
+        ? { context: AddAccountContexts.AddAccounts }
+        : {};
     }
   }, [hasCurrency, currency, llmNetworkBasedAddAccountFlow?.enabled]);
 

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/enums.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/enums.ts
@@ -1,0 +1,4 @@
+export enum AddAccountContexts {
+  AddAccounts = "addAccounts",
+  ReceiveFunds = "receiveFunds",
+}

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/types.ts
@@ -3,9 +3,12 @@ import { ScreenName } from "~/const";
 import { Device } from "@ledgerhq/types-devices";
 import { Account } from "@ledgerhq/types-live";
 import { Props as TouchableProps } from "~/components/Touchable";
+import { AddAccountContexts } from "./enums";
+
+export type AddAccountContextType = `${AddAccountContexts}`;
 
 type CommonParams = {
-  context?: "addAccounts" | "receiveFunds";
+  context?: AddAccountContextType;
   onSuccess?: () => void;
   onCloseNavigation?: () => void;
   currency: CryptoOrTokenCurrency;

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
@@ -10,7 +10,7 @@ import {
   View,
 } from "react-native";
 import { useTheme } from "styled-components/native";
-import { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import AccountItem from "../../components/AccountsListView/components/AccountItem";
@@ -26,6 +26,7 @@ import { useNavigation } from "@react-navigation/core";
 import useAnimatedStyle from "../ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
 import AddFundsButton from "../../components/AddFundsButton";
 import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
+import { AddAccountContexts } from "../AddAccount/enums";
 
 type Props = BaseComposite<
   StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.AddAccountsSuccess>
@@ -37,17 +38,25 @@ export default function AddAccountsSuccess({ route }: Props) {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const { animatedSelectableAccount } = useAnimatedStyle();
+  const { currency, accountsToAdd, onCloseNavigation, context } = route.params || {};
 
   const goToAccounts = useCallback(
     (accountId: string) => () => {
-      navigation.navigate(ScreenName.Account, {
-        accountId,
-      });
+      if (context === AddAccountContexts.AddAccounts)
+        navigation.navigate(ScreenName.Account, {
+          accountId,
+        });
+      else
+        navigation.navigate(NavigatorName.ReceiveFunds, {
+          screen: ScreenName.ReceiveConfirmation,
+          params: {
+            ...route.params,
+            accountId,
+          },
+        });
     },
-    [navigation],
+    [navigation, route.params, context],
   );
-
-  const { currency, accountsToAdd, onCloseNavigation } = route.params || {};
 
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<AccountLikeEnhanced>) => (

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
@@ -3,7 +3,7 @@ import { Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { Animated, StyleSheet, TouchableOpacity, View } from "react-native";
 import { useTheme } from "styled-components/native";
-import { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import AccountItem from "../../components/AccountsListView/components/AccountItem";
 import { Account } from "@ledgerhq/types-live";
@@ -17,6 +17,7 @@ import { useNavigation } from "@react-navigation/core";
 import useAnimatedStyle from "../ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
 import AddFundsButton from "../../components/AddFundsButton";
 import CloseWithConfirmation from "LLM/components/CloseWithConfirmation";
+import { AddAccountContexts } from "../AddAccount/enums";
 type Props = BaseComposite<
   StackNavigatorProps<NetworkBasedAddAccountNavigator, ScreenName.AddAccountsWarning>
 >;
@@ -29,17 +30,27 @@ export default function AddAccountsWarning({ route }: Props) {
 
   const { animatedSelectableAccount } = useAnimatedStyle();
 
-  const goToAccounts = useCallback(
-    (accountId: string) => () => {
-      navigation.navigate(ScreenName.Account, {
-        accountId,
-      });
-    },
-    [navigation],
-  );
-  const { emptyAccount, emptyAccountName, currency } = route.params || {};
+  const { emptyAccount, emptyAccountName, currency, context } = route.params || {};
 
   const statusColor = colors.warning.c70;
+
+  const goToAccounts = useCallback(
+    (accountId: string) => () => {
+      if (context === AddAccountContexts.AddAccounts)
+        navigation.navigate(ScreenName.Account, {
+          accountId,
+        });
+      else
+        navigation.navigate(NavigatorName.ReceiveFunds, {
+          screen: ScreenName.ReceiveConfirmation,
+          params: {
+            ...route.params,
+            accountId,
+          },
+        });
+    },
+    [navigation, route.params, context],
+  );
 
   const handleOnCloseWarningScreen = useCallback(() => {
     navigation.goBack();

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
@@ -36,11 +36,11 @@ export default function AddAccountsWarning({ route }: Props) {
 
   const goToAccounts = useCallback(
     (accountId: string) => () => {
-      if (context === AddAccountContexts.AddAccounts)
+      if (context === AddAccountContexts.AddAccounts) {
         navigation.navigate(ScreenName.Account, {
           accountId,
         });
-      else
+      } else {
         navigation.navigate(NavigatorName.ReceiveFunds, {
           screen: ScreenName.ReceiveConfirmation,
           params: {
@@ -48,6 +48,7 @@ export default function AddAccountsWarning({ route }: Props) {
             accountId,
           },
         });
+      }
     },
     [navigation, route.params, context],
   );

--- a/apps/ledger-live-mobile/src/newArch/features/AssetSelection/__integrations__/assetSelection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/AssetSelection/__integrations__/assetSelection.integration.test.tsx
@@ -7,6 +7,7 @@ import {
   mockGroupedCurrenciesBySingleProviderData,
   mockGroupedCurrenciesWithMultipleProviderData,
 } from "./mockData";
+import { AddAccountContexts } from "../../Accounts/screens/AddAccount/enums";
 
 const MockUseRoute = useRoute as jest.Mock;
 const MockUseGroupedCurrenciesByProvider = useGroupedCurrenciesByProvider as jest.Mock;
@@ -39,7 +40,7 @@ describe("Asset Selection test suite", () => {
   it("should render crypto selection screen when no currency is defined in the navigation route showing a loader", () => {
     MockUseRoute.mockReturnValue({
       params: {
-        context: "addAccounts",
+        context: AddAccountContexts.AddAccounts,
       },
     });
 
@@ -62,7 +63,7 @@ describe("Asset Selection test suite", () => {
   it("should render crypto selection screen with empty list when useGroupedCurrenciesByProvider finish loading with empty result", () => {
     MockUseRoute.mockReturnValue({
       params: {
-        context: "addAccounts",
+        context: AddAccountContexts.AddAccounts,
       },
     });
 
@@ -79,7 +80,7 @@ describe("Asset Selection test suite", () => {
   it("should display a list of cryptocurrencies when useGroupedCurrenciesByProvider successfully loads data", () => {
     MockUseRoute.mockReturnValue({
       params: {
-        context: "addAccounts",
+        context: AddAccountContexts.AddAccounts,
       },
     });
 
@@ -98,7 +99,7 @@ describe("Asset Selection test suite", () => {
   it("should navigate to network selection when currency has more than one network provider", () => {
     MockUseRoute.mockReturnValue({
       params: {
-        context: "addAccounts",
+        context: AddAccountContexts.AddAccounts,
         currency: "ethereum",
       },
     });

--- a/apps/ledger-live-mobile/src/newArch/features/AssetSelection/screens/SelectCrypto/useSelectCryptoViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/AssetSelection/screens/SelectCrypto/useSelectCryptoViewModel.ts
@@ -15,6 +15,7 @@ import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets
 import { AssetSelectionNavigationProps, CommonParams } from "../../types";
 import { useGroupedCurrenciesByProvider } from "@ledgerhq/live-common/deposit/index";
 import { LoadingBasedGroupedCurrencies } from "@ledgerhq/live-common/deposit/type";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 type SelectCryptoViewModelProps = Pick<CommonParams, "context"> & {
   filterCurrencyIds?: string[];
@@ -58,7 +59,7 @@ export default function useSelectCryptoViewModel({
         navigation.navigate(ScreenName.SelectNetwork, {
           context,
           currency: curr.id,
-          ...(context === "receiveFunds" && { filterCurrencyIds }),
+          ...(context === AddAccountContexts.AddAccounts && { filterCurrencyIds }),
         });
         return;
       }
@@ -66,7 +67,7 @@ export default function useSelectCryptoViewModel({
       const isToken = curr.type === "TokenCurrency";
       const currency = isToken ? curr.parentCurrency : curr;
       const currencyAccounts = findAccountByCurrency(accounts, currency);
-      const isAddAccountContext = context === "addAccounts";
+      const isAddAccountContext = context === AddAccountContexts.AddAccounts;
 
       if (currencyAccounts.length > 0 && !isAddAccountContext) {
         // If we found one or more accounts of the currency then we select account
@@ -113,12 +114,12 @@ export default function useSelectCryptoViewModel({
   );
   const { titleText, titleTestId } = useMemo(() => {
     switch (context) {
-      case "addAccounts":
+      case AddAccountContexts.AddAccounts:
         return {
           titleText: t("assetSelection.selectCrypto.title"),
           titleTestId: "select-crypto-header-step1-title",
         };
-      case "receiveFunds":
+      case AddAccountContexts.ReceiveFunds:
         return {
           titleText: t("transfer.receive.selectCrypto.title"),
           titleTestId: "receive-header-step1-title",

--- a/apps/ledger-live-mobile/src/newArch/features/AssetSelection/screens/SelectNetwork/useSelectNetworkViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/AssetSelection/screens/SelectNetwork/useSelectNetworkViewModel.ts
@@ -17,6 +17,7 @@ import { AssetSelectionNavigationProps, SelectNetworkRouteParams } from "../../t
 import { CryptoWithAccounts } from "./types";
 import { LoadingBasedGroupedCurrencies } from "@ledgerhq/live-common/deposit/type";
 import { useGroupedCurrenciesByProvider } from "@ledgerhq/live-common/deposit/index";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 export default function useSelectNetworkViewModel({
   filterCurrencyIds,
@@ -124,7 +125,7 @@ export default function useSelectNetworkViewModel({
       );
 
       if (!cryptoToSend) return;
-      const isAddAccountContext = context === "addAccounts";
+      const isAddAccountContext = context === AddAccountContexts.AddAccounts;
 
       const accs = findAccountByCurrency(accounts, cryptoToSend);
 
@@ -191,7 +192,7 @@ export default function useSelectNetworkViewModel({
     string
   > => {
     switch (context) {
-      case "receiveFunds":
+      case AddAccountContexts.ReceiveFunds:
         return {
           titleText: t("selectNetwork.swap.title"),
           titleTestId: "receive-header-step2-title",
@@ -199,7 +200,7 @@ export default function useSelectNetworkViewModel({
           subTitleTestId: "transfer.receive.selectNetwork.subtitle",
           listTestId: "receive-header-step2-networks",
         };
-      case "addAccounts":
+      case AddAccountContexts.AddAccounts:
         return {
           titleText: t("assetSelection.selectNetwork.title"),
           titleTestId: "addAccounts-header-step2-title",

--- a/apps/ledger-live-mobile/src/newArch/features/AssetSelection/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/AssetSelection/types.ts
@@ -1,10 +1,13 @@
 import { NavigatorScreenParams } from "@react-navigation/core";
 import { NavigatorName, ScreenName } from "~/const";
 import { DeviceSelectionNavigatorParamsList } from "../DeviceSelection/types";
-import { NetworkBasedAddAccountNavigator } from "../Accounts/screens/AddAccount/types";
+import {
+  AddAccountContextType,
+  NetworkBasedAddAccountNavigator,
+} from "../Accounts/screens/AddAccount/types";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 export type CommonParams = {
-  context?: "addAccounts" | "receiveFunds";
+  context?: AddAccountContextType;
   onSuccess?: () => void;
   currency?: string;
   inline?: boolean;

--- a/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/__integrations__/deviceSelection.integration.test.tsx
@@ -5,6 +5,7 @@ import { useRoute, useNavigation } from "@react-navigation/native";
 import { discoverDevices } from "@ledgerhq/live-common/hw/index";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { of } from "rxjs";
+import { AddAccountContexts } from "../../Accounts/screens/AddAccount/enums";
 
 const MockUseRoute = useRoute as jest.Mock;
 const mockNavigate = jest.fn();
@@ -34,7 +35,7 @@ describe("Device Selection feature integration test", () => {
   beforeAll(() => {
     MockUseRoute.mockReturnValue({
       params: {
-        context: "addAccounts",
+        context: AddAccountContexts.AddAccounts,
         currency: {
           type: "CryptoCurrency",
           id: "bitcoin",

--- a/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/DeviceSelection/types.ts
@@ -1,11 +1,14 @@
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { NavigatorScreenParams } from "@react-navigation/core";
 import { NavigatorName, ScreenName } from "~/const";
-import { NetworkBasedAddAccountNavigator } from "../Accounts/screens/AddAccount/types";
+import {
+  AddAccountContextType,
+  NetworkBasedAddAccountNavigator,
+} from "../Accounts/screens/AddAccount/types";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 
 type CommonParams = {
-  context?: "addAccounts" | "receiveFunds";
+  context?: AddAccountContextType;
   onSuccess?: () => void;
   onCloseNavigation?: () => void;
 };

--- a/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Modals/InstalledAppModal.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerDevice/Modals/InstalledAppModal.tsx
@@ -18,6 +18,7 @@ import QueuedDrawer from "~/components/QueuedDrawer";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { MyLedgerNavigatorStackParamList } from "~/components/RootNavigator/types/MyLedgerNavigator";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { AddAccountContexts } from "~/newArch/features/Accounts/screens/AddAccount/enums";
 
 type NavigationProps = BaseComposite<
   StackNavigatorProps<MyLedgerNavigatorStackParamList, ScreenName.MyLedgerDevice>
@@ -54,7 +55,7 @@ const InstallSuccessBar = ({ state, navigation, disable }: Props) => {
   const onAddAccount = useCallback(() => {
     if (llmNetworkBasedAddAccountFlow?.enabled)
       navigation.navigate(NavigatorName.AssetSelection, {
-        context: "addAccounts",
+        context: AddAccountContexts.AddAccounts,
       });
     else navigation.navigate(NavigatorName.AddAccounts);
 

--- a/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/ReceiveFunds/02-SelectAccount.tsx
@@ -21,6 +21,7 @@ import { walletSelector } from "~/reducers/wallet";
 import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 type SubAccountEnhanced = SubAccount & {
   parentAccount: Account;
@@ -133,7 +134,7 @@ function ReceiveSelectAccount({
         screen: ScreenName.SelectDevice,
         params: {
           currency: currency as CryptoCurrency,
-          context: "addAccounts",
+          context: AddAccountContexts.AddAccounts,
           inline: true,
         },
       });

--- a/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
@@ -26,6 +26,7 @@ import { Flex } from "@ledgerhq/native-ui";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useGroupedCurrenciesByProvider } from "@ledgerhq/live-common/deposit/index";
 import { LoadingBasedGroupedCurrencies } from "@ledgerhq/live-common/deposit/type";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 const SEARCH_KEYS = [
   "name",
@@ -143,7 +144,7 @@ function SelectAccount({ navigation, route }: Props) {
           params: {
             currency: currency.id,
             inline: true,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
             onSuccess: () =>
               navigation.navigate(ScreenName.RequestAccountsSelectAccount, route.params),
           },
@@ -153,7 +154,7 @@ function SelectAccount({ navigation, route }: Props) {
           screen: ScreenName.SelectDevice,
           params: {
             currency: currency as CryptoCurrency,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
             inline: true,
             onSuccess: () =>
               navigation.navigate(ScreenName.RequestAccountsSelectAccount, route.params),

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Summary/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Summary/index.tsx
@@ -30,6 +30,7 @@ import { EDITABLE_FEE_FAMILIES } from "@ledgerhq/live-common/exchange/swap/const
 import { useMaybeAccountName } from "~/reducers/wallet";
 import { useMaybeAccountUnit } from "~/hooks/useAccountUnit";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 interface Props {
   provider?: string;
@@ -90,7 +91,7 @@ export function Summary({ provider, swapTx: { swap, status, transaction } }: Pro
         navigation.navigate(NavigatorName.AssetSelection, {
           token: to.currency.id,
           currency: to.currency.parentCurrency.id,
-          context: "addAccounts",
+          context: AddAccountContexts.AddAccounts,
         });
       } else {
         navigation.navigate(NavigatorName.AddAccounts, {
@@ -108,7 +109,7 @@ export function Summary({ provider, swapTx: { swap, status, transaction } }: Pro
           params: {
             ...params,
             currency: to.currency,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
             inline: true,
           },
         });

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SelectAccount.tsx
@@ -22,6 +22,7 @@ import { sharedSwapTracking } from "../utils";
 import { walletSelector } from "~/reducers/wallet";
 import { accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 export function SelectAccount({ navigation, route: { params } }: SelectAccountParamList) {
   const { provider, target, selectableCurrencyIds, selectedCurrency } = params;
@@ -157,7 +158,7 @@ export function SelectAccount({ navigation, route: { params } }: SelectAccountPa
             navigation.navigate(ScreenName.SwapSelectAccount, params);
           },
           analyticsPropertyFlow: "swap",
-          context: "addAccounts",
+          context: AddAccountContexts.AddAccounts,
         },
       });
     } else {

--- a/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricAsset/index.tsx
@@ -40,6 +40,7 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { useGroupedCurrenciesByProvider } from "@ledgerhq/live-common/deposit/index";
 import { LoadingBasedGroupedCurrencies, LoadingStatus } from "@ledgerhq/live-common/deposit/type";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
 
 const AnimatedFlatListWithRefreshControl = Animated.createAnimatedComponent(
   accountSyncRefreshControl(FlatList),
@@ -115,7 +116,7 @@ const AssetScreen = ({ route }: NavigationProps) => {
           screen: ScreenName.SelectNetwork,
           params: {
             currency: currency.id,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
           },
         });
       } else {
@@ -123,7 +124,7 @@ const AssetScreen = ({ route }: NavigationProps) => {
           screen: ScreenName.SelectDevice,
           params: {
             currency: currency as CryptoCurrency,
-            context: "addAccounts",
+            context: AddAccountContexts.AddAccounts,
           },
         });
       }


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Issue analysis:

After reviewing the scenario in detail, it appears the account selection screen displayed in this particular use case is the "add account v1" version (designed for receiving), even the screen preceding the scan is the "add account v1" (intended for receiving). Therefore, when you select an account from the list, it will be added.

Essentially, on the production environment, this isn't a bug, because it's a logical sequence:

I initiate a "receive" operation.

I select an asset for which I don't have an existing account.

The scan that launches is the "add account v1" version.

The displayed list is the "add account v1" list for receiving (since it's a single selection).

Normally, if the "add account v2" feature flag is activated, we should go through (in this specific case) the "add account v2" device scan -> then a success or warning screen -> when we choose an account -> redirection to the address/QR code page. This case should be part of the receive plugin, however, I only handled the case where the "add account" button is on the account selection screen in cases of accounts already existing on the receive.

Solution: 

When the user try to receive funds on currency where there is no persisted account, the redirection should be done to Add account v2 flow (FF ON) and on the success/warning page when an account is selected , the redirection should be to the receive confirmation page with QR code. 

Full scenario here ⬇️

https://github.com/user-attachments/assets/0a8cb91a-b94a-4e7a-b419-f2df29eff4b6

I also made a refactor for the use of string literal `"addAccounts"` or `"receiveFunds"` across the codebase and replaced it with common enum based type. 

Please make sure your review covers the scope of the changes. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-16522
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
