### PR TITLE
[QAA] Refacto modal class - e2e tests

### DIFF
--- a/apps/ledger-live-desktop/tests/component/modal.component.ts
+++ b/apps/ledger-live-desktop/tests/component/modal.component.ts
@@ -13,10 +13,6 @@ export class Modal extends Component {
   protected closeButton = this.page.getByTestId("modal-close-button");
   protected maxAmountCheckbox = this.page.getByTestId("modal-max-checkbox");
 
-  constructor(page: any) {
-    super(page);
-  }
-
   @step("Click Continue button")
   async continue() {
     await this.continueButton.click();
@@ -27,15 +23,18 @@ export class Modal extends Component {
     await this.closeButton.click();
   }
 
+  @step("Wait for modal to appear")
   async waitForModalToAppear() {
     await this.container.waitFor({ state: "attached" });
     await this.backdrop.waitFor({ state: "attached" });
   }
 
+  @step("Wait for modal to disappear")
   async waitForModalToDisappear() {
     await this.container.waitFor({ state: "detached" });
   }
 
+  @step("Toggle Max Amount")
   async toggleMaxAmount() {
     await this.maxAmountCheckbox.click();
   }
@@ -45,10 +44,12 @@ export class Modal extends Component {
     await this.continueButton.click();
   }
 
+  @step("Continue to sign transaction")
   async continueToSignTransaction() {
     await this.continueButton.click({ force: true });
   }
 
+  @step("continue until option is displayed")
   async scrollUntilOptionIsDisplayed(dropdown: Locator, element: Locator) {
     let isVisible = await element.isVisible();
 

--- a/apps/ledger-live-desktop/tests/component/modal.component.ts
+++ b/apps/ledger-live-desktop/tests/component/modal.component.ts
@@ -9,20 +9,9 @@ export class Modal extends Component {
   readonly title = this.page.getByTestId("modal-title");
   readonly content = this.page.getByTestId("modal-content");
   protected backdrop = this.page.getByTestId("modal-backdrop");
-  protected continueButton = this.page.getByTestId("modal-continue-button");
-  protected saveButton = this.page.getByTestId("modal-save-button");
-  protected cancelButton = this.page.getByTestId("modal-cancel-button");
-  protected confirmButton = this.page.getByTestId("modal-confirm-button");
+  readonly continueButton = this.page.getByRole("button", { name: "continue" });
   protected closeButton = this.page.getByTestId("modal-close-button");
-  protected backButton = this.page.getByTestId("modal-back-button");
-  protected spendableBanner = this.page.getByTestId("modal-spendable-banner");
   protected maxAmountCheckbox = this.page.getByTestId("modal-max-checkbox");
-  protected cryptoAmountField = this.page.getByTestId("modal-amount-field");
-  protected continueAmountButton = this.page.locator("id=send-amount-continue-button");
-  protected signContinueButton = this.page.locator("text=Continue");
-  protected confirmText = this.page.locator(
-    "text=Please confirm the operation on your device to finalize it",
-  );
 
   constructor(page: any) {
     super(page);
@@ -30,25 +19,7 @@ export class Modal extends Component {
 
   @step("Click Continue button")
   async continue() {
-    if (await this.continueButton.isVisible()) {
-      await this.continueButton.click();
-    }
-  }
-
-  async save() {
-    await this.saveButton.click();
-  }
-
-  async cancel() {
-    await this.cancelButton.click();
-  }
-
-  async confirm() {
-    await this.confirmButton.click();
-  }
-
-  async back() {
-    await this.backButton.click();
+    await this.continueButton.click();
   }
 
   @step("Close modal")
@@ -65,32 +36,17 @@ export class Modal extends Component {
     await this.container.waitFor({ state: "detached" });
   }
 
-  async getSpendableBannerValue() {
-    const amountValue = await this.spendableBanner.textContent();
-    // removing non numerical values
-    return parseInt(amountValue!.replace(/[^0-9.]/g, ""));
-  }
-
   async toggleMaxAmount() {
     await this.maxAmountCheckbox.click();
   }
 
-  async getCryptoAmount() {
-    const valueAmount = await this.cryptoAmountField.inputValue();
-    return parseInt(valueAmount);
-  }
-
   @step("Click Continue button")
-  async countinueSendAmount() {
-    await this.continueAmountButton.click();
+  async continueAmountModal() {
+    await this.continueButton.click();
   }
 
   async continueToSignTransaction() {
-    await this.signContinueButton.click({ force: true });
-  }
-
-  async waitForConfirmationScreenToBeDisplayed() {
-    await this.confirmText.waitFor({ state: "visible" });
+    await this.continueButton.click({ force: true });
   }
 
   async scrollUntilOptionIsDisplayed(dropdown: Locator, element: Locator) {

--- a/apps/ledger-live-desktop/tests/page/drawer/delegate.drawer.ts
+++ b/apps/ledger-live-desktop/tests/page/drawer/delegate.drawer.ts
@@ -36,13 +36,13 @@ export class DelegateDrawer extends Drawer {
     await expect(this.transactionType).toBeVisible();
   }
 
-  @step("Verify transaction type corresond to $0")
+  @step("Verify transaction type corresponds to $0")
   async transactionTypeIsCorrect(transactionType: string) {
     const transaction = await this.transactionType.allInnerTexts();
     expect(transaction).toContain(transactionType);
   }
 
-  @step("Verify operation type corresond to $0")
+  @step("Verify operation type corresponds to $0")
   async operationTypeIsCorrect(operationType: string) {
     const operation = await this.operationType.allInnerTexts();
     expect(operation).toContain(operationType);

--- a/apps/ledger-live-desktop/tests/page/drawer/firmwareUpdate.drawer.ts
+++ b/apps/ledger-live-desktop/tests/page/drawer/firmwareUpdate.drawer.ts
@@ -1,12 +1,20 @@
+import { step } from "tests/misc/reporters/step";
+import { Drawer } from "tests/component/drawer.component";
 import { deviceInfo155 as deviceInfo } from "@ledgerhq/live-common/apps/mock";
-import { Modal } from "../../component/modal.component";
 
-export class FirmwareUpdateModal extends Modal {
+export class FirmwareUpdate extends Drawer {
   readonly downloadProgress = this.page.getByTestId("firmware-update-download-progress");
   readonly flashProgress = this.page.getByTestId("firmware-update-flash-mcu-progress");
   readonly updateDone = this.page.getByTestId("firmware-update-done");
   readonly drawerClose = this.page.getByTestId("drawer-close-button");
+  readonly installUpdateButton = this.page.getByRole("button", { name: "Install update" });
 
+  @step("Install update")
+  async installUpdate() {
+    await this.installUpdateButton.click();
+  }
+
+  @step("Wait for device info")
   async waitForDeviceInfo() {
     await this.page.evaluate(
       args => {

--- a/apps/ledger-live-desktop/tests/page/modal/add.account.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/add.account.modal.ts
@@ -14,6 +14,7 @@ export class AddAccountModal extends Modal {
   private stopButton = this.page.getByTestId("add-accounts-import-stop-button");
   private doneButton = this.page.getByTestId("add-accounts-finish-close-button");
   private infoBox = this.page.getByTestId("add-token-infoBox");
+  private addSubAccountButton = this.page.getByTestId("modal-continue-button");
   private successAddLabel = this.page.locator("text=Account added successfully");
   private selectAccountInList = (Currency: Currency) =>
     this.page.getByRole("option", {
@@ -46,7 +47,7 @@ export class AddAccountModal extends Modal {
     }
     await expect(this.closeButton).toBeVisible();
     await expect(this.infoBox).toBeVisible();
-    await this.continue();
+    await this.addSubAccountButton.click();
   }
 
   @step("Select account by scrolling: {0}")

--- a/apps/ledger-live-desktop/tests/page/modal/delegate.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/delegate.modal.ts
@@ -4,7 +4,6 @@ import { step } from "tests/misc/reporters/step";
 
 export class delegateModal extends Modal {
   private titleProvider = this.page.getByTestId("modal-provider-title");
-  private delegateContinueButton = this.page.getByText("Continue");
   private rowProvider = this.page.getByTestId("modal-provider-row");
   private searchOpenButton = this.page.getByText("Show all");
   private searchCloseButton = this.page.getByText("Show less");
@@ -20,6 +19,8 @@ export class delegateModal extends Modal {
   private checkIcon = this.page
     .getByTestId("check-icon")
     .locator('path[fill]:not([fill="transparent"])');
+  private spendableBanner = this.page.getByTestId("modal-spendable-banner");
+  readonly cryptoAmountField = this.page.getByTestId("modal-amount-field");
 
   @step("Get title provider on row $0")
   async getTitleProvider(row: number): Promise<string> {
@@ -27,6 +28,18 @@ export class delegateModal extends Modal {
     const titleProvider = await this.titleProvider.nth(row - 1).textContent();
     expect(titleProvider).not.toBeNull();
     return titleProvider!;
+  }
+
+  @step("Get spendable banner value")
+  async getSpendableBannerValue() {
+    const amountValue = await this.spendableBanner.textContent();
+    return parseInt(amountValue!.replace(/[^0-9.]/g, ""));
+  }
+
+  @step("Get crypto amount")
+  async getCryptoAmount() {
+    const valueAmount = await this.cryptoAmountField.inputValue();
+    return parseInt(valueAmount);
   }
 
   @step("Verify first provider name is $0")
@@ -59,23 +72,18 @@ export class delegateModal extends Modal {
 
   @step("Verify continue button is disabled")
   async verifyContinueDisabled() {
-    await expect(this.delegateContinueButton).toBeDisabled();
+    await expect(this.continueButton).toBeDisabled();
   }
 
   @step("Verify continue button is enabled")
   async verifyContinueEnabled() {
-    await expect(this.delegateContinueButton).toBeEnabled();
+    await expect(this.continueButton).toBeEnabled();
   }
 
   @step("Verify provider TC contains $0")
   async verifyProviderTC(provider: string) {
     const providerTC = await this.validatorTC.textContent();
     expect(providerTC).toContain(provider);
-  }
-
-  @step("Click on continue button - delegate")
-  async continueDelegate() {
-    await this.delegateContinueButton.click();
   }
 
   @step("Click on search provider button")

--- a/apps/ledger-live-desktop/tests/page/modal/delegate.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/delegate.modal.ts
@@ -19,7 +19,7 @@ export class delegateModal extends Modal {
   private checkIcon = this.page
     .getByTestId("check-icon")
     .locator('path[fill]:not([fill="transparent"])');
-  private spendableBanner = this.page.getByTestId("modal-spendable-banner");
+  readonly spendableBanner = this.page.getByTestId("modal-spendable-banner");
   readonly cryptoAmountField = this.page.getByTestId("modal-amount-field");
 
   @step("Get title provider on row $0")

--- a/apps/ledger-live-desktop/tests/page/modal/passwordlock.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/passwordlock.modal.ts
@@ -8,6 +8,8 @@ export class PasswordlockModal extends Modal {
   private confirmPasswordInput = this.page.getByTestId("confirm-password-input");
   private currentPasswordInput = this.page.getByTestId("current-password-input");
   private disablePasswordInput = this.page.getByTestId("disable-password-input");
+  private saveButton = this.page.getByTestId("modal-save-button");
+  private cancelButton = this.page.getByTestId("modal-cancel-button");
 
   @step("Toggle password lock")
   async toggle() {
@@ -34,5 +36,10 @@ export class PasswordlockModal extends Modal {
     await this.newPasswordInput.fill(newPassword);
     await this.confirmPasswordInput.fill(confirmPassword);
     await this.saveButton.click();
+  }
+
+  @step("Click Cancel button")
+  async clickCancel() {
+    await this.cancelButton.click();
   }
 }

--- a/apps/ledger-live-desktop/tests/page/modal/passwordlock.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/passwordlock.modal.ts
@@ -8,7 +8,7 @@ export class PasswordlockModal extends Modal {
   private confirmPasswordInput = this.page.getByTestId("confirm-password-input");
   private currentPasswordInput = this.page.getByTestId("current-password-input");
   private disablePasswordInput = this.page.getByTestId("disable-password-input");
-  private saveButton = this.page.getByTestId("modal-save-button");
+  readonly saveButton = this.page.getByTestId("modal-save-button");
   private cancelButton = this.page.getByTestId("modal-cancel-button");
 
   @step("Toggle password lock")

--- a/apps/ledger-live-desktop/tests/page/modal/send.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/send.modal.ts
@@ -7,7 +7,6 @@ export class SendModal extends Modal {
   private drowdownAccount = this.page.locator('[data-testid="modal-content"] svg').nth(1);
   readonly recipientInput = this.page.getByTestId("send-recipient-input");
   readonly tagInput = this.page.getByTestId("memo-tag-input");
-  readonly continueButton = this.page.getByRole("button", { name: "continue" });
   private checkDeviceLabel = this.page.locator(
     "text=Double-check the transaction details on your Ledger device before signing.",
   );
@@ -23,6 +22,7 @@ export class SendModal extends Modal {
   readonly inputError = this.page.locator("id=input-error"); // no data-testid because css style is applied
   readonly insufficientFundsWarning = this.page.getByTestId("insufficient-funds-warning");
   readonly inputWarning = this.page.locator("id=input-warning");
+  readonly cryptoAmountField = this.page.getByTestId("modal-amount-field");
 
   async selectAccount(name: string) {
     await this.drowdownAccount.click();
@@ -35,7 +35,7 @@ export class SendModal extends Modal {
 
   @step("Click `Continue` button")
   async clickContinueToDevice() {
-    await this.continueButton.click();
+    await this.continue();
     await expect(this.checkDeviceLabel).toBeVisible();
   }
 
@@ -73,15 +73,15 @@ export class SendModal extends Modal {
     await this.fillRecipient(tx.accountToCredit.ensName || tx.accountToCredit.address);
     const displayedAddress = await this.ENSAddressLabel.innerText();
     expect(displayedAddress).toEqual(tx.accountToCredit.address);
-    await this.continueButton.click();
+    await this.continue();
     await this.chooseFeeStrategy(tx.speed);
-    await this.continueButton.click();
+    await this.continue();
   }
 
   @step("Fill tx information")
   async craftTx(tx: Transaction) {
     await this.fillRecipientInfo(tx);
-    await this.continueButton.click();
+    await this.continue();
 
     if (tx.memoTag === "noTag") {
       await this.noTagButton.click();
@@ -104,7 +104,7 @@ export class SendModal extends Modal {
 
     const displayedNftName = await this.nftNameDisplayed.innerText();
     expect(displayedNftName).toEqual(expect.stringContaining(tx.nft.nftName));
-    await this.continueButton.click();
+    await this.continue();
   }
 
   @step("Verify tx information before confirming")
@@ -128,11 +128,6 @@ export class SendModal extends Modal {
   @step("Check continue button enable")
   async checkContinueButtonEnable() {
     await expect(this.continueButton).toBeEnabled();
-  }
-
-  @step("Click `Continue` button")
-  async clickContinue() {
-    await this.continueButton.click();
   }
 
   @step("Check continue button disabled")

--- a/apps/ledger-live-desktop/tests/page/modal/settings.modal.ts
+++ b/apps/ledger-live-desktop/tests/page/modal/settings.modal.ts
@@ -4,6 +4,7 @@ import { step } from "tests/misc/reporters/step";
 
 export class SettingsModal extends Modal {
   readonly warningMessage = this.page.getByTestId("warning-message");
+  readonly confirmButton = this.page.getByTestId("modal-confirm-button");
 
   @step("Check Reset Modal")
   async checkResetModal() {

--- a/apps/ledger-live-desktop/tests/specs/accounts/delegate.smoke.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/accounts/delegate.smoke.spec.ts
@@ -27,16 +27,16 @@ test("Delegate flow using max amount", async () => {
   });
 
   await test.step("Check Ledger is the provider by default", async () => {
-    await modalPage.continue();
+    await delegate.continue();
     const defaultprovider = await delegate.getTitleProvider(1);
     expect(defaultprovider).toEqual("Ledger");
   });
 
   await test.step("Toggle max amount to be filled in the amount field", async () => {
-    await delegate.continueDelegate();
-    await modalPage.toggleMaxAmount();
-    const availableMaxAmount = await modalPage.getSpendableBannerValue();
-    const filledMaxAmount = await modalPage.getCryptoAmount();
+    await delegate.continue();
+    await delegate.toggleMaxAmount();
+    const availableMaxAmount = await delegate.getSpendableBannerValue();
+    const filledMaxAmount = await delegate.getCryptoAmount();
     expect(filledMaxAmount).toEqual(availableMaxAmount);
     await expect.soft(modalPage.container).toHaveScreenshot(`staking-max-amount-page.png`);
   });
@@ -44,7 +44,7 @@ test("Delegate flow using max amount", async () => {
 
 test("The user search and select a provider", async () => {
   await test.step("open the provider search modal", async () => {
-    await modalPage.continue();
+    await delegate.continue();
     await expect.soft(modalPage.container).toHaveScreenshot(`provider-search-page.png`);
   });
 

--- a/apps/ledger-live-desktop/tests/specs/general/passwordlock.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/general/passwordlock.spec.ts
@@ -55,7 +55,7 @@ test("Enable password lock", async ({ page, userdataFile }) => {
   await test.step("I lost my password", async () => {
     await lockscreenPage.lostPassword();
     await expect.soft(modal.container).toHaveScreenshot("lockscreen-reset-app-modal.png");
-    await modal.cancel();
+    await passwordlockModal.clickCancel();
   });
 
   await test.step("Unlock with wrong password", async () => {

--- a/apps/ledger-live-desktop/tests/specs/manager/firmwareupdate.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/manager/firmwareupdate.spec.ts
@@ -1,7 +1,7 @@
 import test from "../../fixtures/common";
 import { expect } from "@playwright/test";
 import { ManagerPage } from "../../page/manager.page";
-import { FirmwareUpdateModal } from "../../page/modal/firmware.update.modal";
+import { FirmwareUpdate } from "../../page/drawer/firmwareUpdate.drawer";
 import { DeviceAction } from "../../models/DeviceAction";
 import { Layout } from "../../component/layout.component";
 
@@ -11,7 +11,7 @@ test.use({ userdata: "skip-onboarding" });
 // this e2e is only testing the very old firmware update path.
 test("Firmware Update @smoke", async ({ page }) => {
   const managerPage = new ManagerPage(page);
-  const firmwareUpdateModal = new FirmwareUpdateModal(page);
+  const firmwareUpdateDrawer = new FirmwareUpdate(page);
   const deviceAction = new DeviceAction(page);
   const layout = new Layout(page);
 
@@ -31,27 +31,27 @@ test("Firmware Update @smoke", async ({ page }) => {
   });
 
   await test.step("MCU download step", async () => {
-    await firmwareUpdateModal.continue();
-    await firmwareUpdateModal.downloadProgress.waitFor({ state: "visible" });
+    await firmwareUpdateDrawer.installUpdate();
+    await firmwareUpdateDrawer.downloadProgress.waitFor({ state: "visible" });
     // await expect.soft(firmwareUpdateModal.container).toHaveScreenshot("download-mcu-progress.png");
   });
 
   await test.step("MCU flash step", async () => {
     await deviceAction.complete(); // .complete() install full firmware -> flash mcu
-    await firmwareUpdateModal.flashProgress.waitFor({ state: "visible" });
+    await firmwareUpdateDrawer.flashProgress.waitFor({ state: "visible" });
     // await expect.soft(firmwareUpdateModal.container).toHaveScreenshot("flash-mcu-progress.png");
   });
 
   await test.step("Firmware update done", async () => {
     await deviceAction.complete(); // .complete() flash mcu -> completed
-    await firmwareUpdateModal.waitForDeviceInfo(); // 2nd step to get the latest device info
-    await firmwareUpdateModal.updateDone.waitFor({ state: "visible" });
+    await firmwareUpdateDrawer.waitForDeviceInfo(); // 2nd step to get the latest device info
+    await firmwareUpdateDrawer.updateDone.waitFor({ state: "visible" });
     // await expect.soft(firmwareUpdateModal.container).toHaveScreenshot("flash-mcu-done.png");
   });
 
   await test.step("Modal is closed", async () => {
     // TODO rewrite this to fit a drawer model, not a modal one.
-    await firmwareUpdateModal.drawerClose.click();
+    await firmwareUpdateDrawer.drawerClose.click();
     await expect.soft(page).toHaveScreenshot("modal-closed.png");
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
@@ -130,7 +130,6 @@ for (const account of e2eDelegationAccounts) {
         }
 
         await app.account.startStakingFlowFromMainStakeButton();
-        await app.modal.continue();
         await app.delegate.verifyFirstProviderName(account.delegate.provider);
         if (account.delegate.account.currency.name == Currency.SOL.name) {
           await app.delegate.verifyContinueDisabled();
@@ -138,9 +137,9 @@ for (const account of e2eDelegationAccounts) {
           await app.delegate.verifyProviderTC(account.delegate.provider);
           await app.delegate.verifyProvider(1);
         }
-        await app.delegate.continueDelegate();
+        await app.delegate.continue();
         await app.delegate.fillAmount(account.delegate.amount);
-        await app.modal.countinueSendAmount();
+        await app.delegate.continue();
 
         await app.speculos.signDelegationTransaction(account.delegate);
         await app.delegate.verifySuccessMessage();
@@ -200,17 +199,17 @@ for (const account of e2eDelegationAccountsWithoutBroadcast) {
         await app.accounts.navigateToAccountByName(account.delegate.account.accountName);
 
         await app.account.startStakingFlowFromMainStakeButton();
-        await app.modal.continue();
+        await app.delegate.continue();
         await app.delegate.verifyFirstProviderName(account.delegate.provider);
-        await app.delegate.continueDelegate();
+        await app.delegate.continue();
 
         if (account.delegate.account.currency.name == Currency.ADA.name) {
           await app.delegate.verifyValidatorName("Ledger by Figment 3 [LBF3]");
           await app.delegate.verifyFeesVisible();
-          await app.delegate.continueDelegate();
+          await app.delegate.continue();
         } else {
           await app.delegate.fillAmount(account.delegate.amount);
-          await app.modal.countinueSendAmount();
+          await app.delegate.continue();
         }
 
         await app.speculos.signDelegationTransaction(account.delegate);
@@ -261,7 +260,7 @@ for (const validator of validators) {
         await app.accounts.navigateToAccountByName(validator.delegate.account.accountName);
 
         await app.account.startStakingFlowFromMainStakeButton();
-        await app.modal.continue();
+        await app.delegate.continue();
 
         await app.delegate.verifyFirstProviderName(validator.delegate.provider);
         if (validator.delegate.account.currency.name == Currency.SOL.name) {
@@ -314,7 +313,7 @@ test.describe("Staking flow from different entry point", () => {
       await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
 
       await app.delegate.verifyFirstProviderName(delegateAccount.provider);
-      await app.delegate.continueDelegate();
+      await app.delegate.continue();
     },
   );
 
@@ -336,7 +335,7 @@ test.describe("Staking flow from different entry point", () => {
       await app.assetDrawer.selectAccountByIndex(delegateAccount.account);
 
       await app.delegate.verifyFirstProviderName(delegateAccount.provider);
-      await app.delegate.continueDelegate();
+      await app.delegate.continue();
     },
   );
 });

--- a/apps/ledger-live-desktop/tests/specs/speculos/receive.address.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/receive.address.spec.ts
@@ -64,7 +64,7 @@ for (const account of accounts) {
             await app.receive.verifySendCurrencyTokensWarningMessage(account.account, "BEP20");
             break;
         }
-        await app.modal.continue();
+        await app.receive.continue();
         const displayedAddress = await app.receive.getAddressDisplayed();
         await app.receive.expectValidReceiveAddress(displayedAddress);
 
@@ -106,7 +106,7 @@ test.describe("Receive", () => {
       await app.accounts.navigateToAccountByName(account.accountName);
       await app.account.expectAccountVisibility(account.accountName);
       await app.account.clickReceive();
-      await app.modal.continue();
+      await app.receive.continue();
       await app.receive.verifyTronAddressActivationWarningMessage();
     },
   );

--- a/apps/ledger-live-desktop/tests/specs/speculos/send.tx.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/send.tx.spec.ts
@@ -259,7 +259,7 @@ test.describe("Send flows", () => {
 
           await app.account.clickSend();
           await app.send.craftTx(transaction.transaction);
-          await app.send.countinueSendAmount();
+          await app.send.continueAmountModal();
           await app.send.expectTxInfoValidity(transaction.transaction);
           await app.send.clickContinueToDevice();
 
@@ -367,7 +367,7 @@ test.describe("Send flows", () => {
           await app.account.navigateToTokenInAccount(transaction.transaction.accountToDebit);
           await app.account.clickSend();
           await app.send.fillRecipient(transaction.transaction.accountToCredit.address);
-          await app.send.clickContinue();
+          await app.send.continue();
           await app.send.fillAmount(transaction.transaction.amount);
           await app.send.checkContinueButtonDisabled();
           await app.send.checkAmountWarningMessage(transaction.expectedWarningMessage);
@@ -418,7 +418,7 @@ test.describe("Send flows", () => {
         await app.send.fillRecipient(tokenTransactionValid.accountToCredit.address);
         await app.send.checkContinueButtonEnable();
         await app.send.checkInputErrorVisibility("hidden");
-        await app.send.clickContinue();
+        await app.send.continue();
         await app.send.fillAmount(tokenTransactionValid.amount);
         await app.send.checkContinueButtonEnable();
       },
@@ -505,7 +505,7 @@ test.describe("Send flows", () => {
 
         await app.account.clickSend();
         await app.send.fillRecipient(transactionInputValid.accountToCredit.address);
-        await app.send.clickContinue();
+        await app.send.continue();
         await app.send.fillAmount(transactionInputValid.amount);
         await app.send.checkContinueButtonEnable();
         await app.send.checkInputErrorVisibility("hidden");
@@ -652,7 +652,7 @@ test.describe("Send flows", () => {
 
         await app.account.clickSend();
         await app.send.craftTx(transactionEnsAddress);
-        await app.send.countinueSendAmount();
+        await app.send.continueAmountModal();
         await app.send.expectTxInfoValidity(transactionEnsAddress);
         await app.send.clickContinueToDevice();
 

--- a/apps/ledger-live-desktop/tests/specs/speculos/subAccount.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/subAccount.spec.ts
@@ -83,7 +83,7 @@ for (const token of subAccountReceive) {
         await app.account.clickAddToken();
         await app.receive.selectToken(token.account);
 
-        await app.modal.continue();
+        await app.receive.continue();
 
         const displayedAddress = await app.receive.getAddressDisplayed();
         await app.receive.expectValidReceiveAddress(displayedAddress);

--- a/apps/ledger-live-desktop/tests/specs/speculos/swap.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/swap.spec.ts
@@ -157,7 +157,7 @@ test.describe("Swap - Rejected on device", () => {
   test(
     `Swap ${rejectedSwap.accountToDebit.currency.name} to ${rejectedSwap.accountToCredit.currency.name}`,
     {
-      annotation: { type: "TMS", description: "B2CQA-600, B2CQA-2212" },
+      annotation: { type: "TMS", description: "B2CQA-2212" },
     },
     async ({ app, electronApp }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));

--- a/apps/ledger-live-desktop/tests/specs/speculos/swap.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/swap.spec.ts
@@ -190,7 +190,7 @@ const tooLowAmountForQuoteSwaps = [
     xrayTicket: "B2CQA-2759",
   },
   {
-    swap: new Swap(Account.TRX_1, Account.ETH_1, "77", Fee.MEDIUM),
+    swap: new Swap(Account.TRX_1, Account.ETH_1, "70", Fee.MEDIUM),
     xrayTicket: "B2CQA-2739",
   },
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Refacto modal class for e2e tests
Fix Xray integration by removing B2CQA-600

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
[QAA-79](https://ledgerhq.atlassian.net/browse/QAA-79)
[QAA-445](https://ledgerhq.atlassian.net/browse/QAA-445)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-79]: https://ledgerhq.atlassian.net/browse/QAA-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QAA-445]: https://ledgerhq.atlassian.net/browse/QAA-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ