### PR TITLE
ci: Improving reliability of tests during mobile upgrades

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Create iOS simulator
         id: simulator
         run: |
-          ID=$(xcrun simctl create "ios" "iPhone 15")
+          ID=$(xcrun simctl create "iOS Simulator" "iPhone 15")
           echo "id=$ID" >> $GITHUB_OUTPUT
       - name: Build iOS app for Detox test run
         if: steps.detox-build.outputs.cache-hit != 'true'
@@ -205,7 +205,7 @@ jobs:
       AVD_ARCH: x86_64
       AVD_PROFILE: pixel_7_pro
       AVD_TARGET: google_apis
-      AVD_NAME: "android"
+      AVD_NAME: "Android_Emulator"
       AVD_CORES: 4
       AVD_RAM_SIZE: 4096M
       AVD_OPTIONS: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Create iOS simulator
         id: simulator
         run: |
-          ID=$(xcrun simctl create "iPhone 15" "iPhone 15")
+          ID=$(xcrun simctl create "ios" "iPhone 15")
           echo "id=$ID" >> $GITHUB_OUTPUT
       - name: Build iOS app for Detox test run
         if: steps.detox-build.outputs.cache-hit != 'true'
@@ -205,7 +205,7 @@ jobs:
       AVD_ARCH: x86_64
       AVD_PROFILE: pixel_7_pro
       AVD_TARGET: google_apis
-      AVD_NAME: "Pixel_7_Pro_API_35"
+      AVD_NAME: "android"
       AVD_CORES: 4
       AVD_RAM_SIZE: 4096M
       AVD_OPTIONS: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/apps/ledger-live-mobile/detox.config.d.ts
+++ b/apps/ledger-live-mobile/detox.config.d.ts
@@ -13,7 +13,8 @@ declare let detoxConfig: {
     simulator: {
       type: string;
       device: {
-        type: string;
+        type?: string;
+        name: string;
       };
     };
     emulator: {

--- a/apps/ledger-live-mobile/detox.config.js
+++ b/apps/ledger-live-mobile/detox.config.js
@@ -73,13 +73,13 @@ module.exports = {
     simulator: {
       type: "ios.simulator",
       device: {
-        type: "iPhone 15",
+        type: "ios",
       },
     },
     emulator: {
       type: "android.emulator",
       device: {
-        avdName: "Pixel_7_Pro_API_35",
+        avdName: "android",
       },
       gpuMode: "swiftshader_indirect",
       headless: process.env.CI ? true : false,

--- a/apps/ledger-live-mobile/detox.config.js
+++ b/apps/ledger-live-mobile/detox.config.js
@@ -73,13 +73,13 @@ module.exports = {
     simulator: {
       type: "ios.simulator",
       device: {
-        type: "ios",
+        name: "iOS Simulator",
       },
     },
     emulator: {
       type: "android.emulator",
       device: {
-        avdName: "android",
+        avdName: "Android_Emulator",
       },
       gpuMode: "swiftshader_indirect",
       headless: process.env.CI ? true : false,

--- a/apps/ledger-live-mobile/docs/llm_e2e_testing.md
+++ b/apps/ledger-live-mobile/docs/llm_e2e_testing.md
@@ -41,7 +41,7 @@ Most of the setup is taken care of in the React Native docs, but you will have t
 
 - XCode and XCode command line tools - run `xcode-select -v` and `xcrun --version` to make sure these are working
 - Latest `ruby` is installed with brew, make sure `$PATH` is updated - `which ruby` points to `/opt/homebrew/opt/ruby/bin/ruby`, not `usr/bin/ruby`.
-- An iPhone simulator for iPhone 15 - open Xcode > Window > Devices and Simulators > Simulators > Add a new device from the '+' sign in the bottom right corner.
+- An iPhone simulator for iPhone 15 named 'iOS Simulator' - open Xcode > Window > Devices and Simulators > Simulators > Add a new device from the '+' sign in the bottom right corner.
 - `applesimutils` is installed via npm.
 
 ### Tips for Android setup
@@ -50,7 +50,7 @@ The Android toolkit can be more complex than the iOS one. Once you've done the R
 
 - Java version 17 installed. Check with `java -version`
 - Android 15 (API Level 35) is installed.
-- An Android Virtual Device (AVD) named 'Pixel 7 Pro API 35'
+- An Android Virtual Device (AVD) for Pixel 7 Pro named 'Android_Emulator'
 - Android SDK Build Tools, SDK Platform Tools, SDK Command Line Tools, Android Emulator, CMake 3.10.2 and NDK 21.4.7075529 are installed. You can do this through Android Studio > Tools > SDK Tools, or via the [command line](https://wix.github.io/Detox/docs/guide/android-dev-env#heres-how-to-install-them-using-the-command-line).
 - Your shell profile (for example `~/.zshrc`) should have environmental variables setup something like this:
 


### PR DESCRIPTION
When the simulators are updated, the naming inside detox vs the workflow causes the tests to fail. This change provides an alias for the simulators which does not change. When upgrading the simulators, it needs only be upgraded in the pipeline.

Demonstration of the problem: https://github.com/LedgerHQ/ledger-live/actions/runs/12994666080
Passed Run: https://github.com/LedgerHQ/ledger-live/actions/runs/13008738541