### PR TITLE
Release from `main` if the hotfix has been done from latest version

### DIFF
--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -126,6 +126,9 @@ jobs:
     needs: prepare-release
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
+      # release from main if hotfixing the latest version, otherwise from the hotfix branch
+      # For more info about why we do this, see this doc:
+      # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
       ref: ${{ github.event.inputs.tag_version == 'latest' && 'main' || 'hotfix' }}
       caller: release-prepare-hotfix
     secrets: inherit

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -126,6 +126,6 @@ jobs:
     needs: prepare-release
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
-      ref: hotfix
+      ref: ${{ github.event.inputs.tag_version == 'latest' && 'main' || 'hotfix' }}
       caller: release-prepare-hotfix
     secrets: inherit


### PR DESCRIPTION
We've just found an issue with https://github.com/LedgerHQ/ledger-live/pull/8718.

At the end of the release-prepare-hotfix workflow we automatically call the release-final workflow (simply as a matter of convenience so Desire doesn't have to manually trigger the final release).

A problem with this implementation was that even though you're releasing a hotfix, you want to do it from:
- `main` if the hotfix was created from the "latest" version of the app
- `hotfix` if the hotfix was created from a previous version

Documentation explaining this is [here](https://github.com/LedgerHQ/ledger-live/pull/9044/files). IMO this is a bit confusing and the chaining of "if"s is getting a bit wild, so I think that we may be due a rethink of how we manage this. But for now this PR fixes the issue and kicks off the release process from the correct branch.

A test PR is [here](https://github.com/LedgerHQ/ledger-live/pull/9080), I'm satisfied this solves the problem 🟢.