### PR TITLE
fix: check account balance or spedable is zero in front

### DIFF
--- a/.changeset/ninety-radios-suffer.md
+++ b/.changeset/ninety-radios-suffer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix solana delegationDisabled condition on LLM

--- a/apps/ledger-live-mobile/src/families/solana/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/accountActions.tsx
@@ -17,7 +17,8 @@ const getMainActions = ({
   parentAccount: Account;
   parentRoute: RouteProp<ParamListBase, ScreenName>;
 }): ActionButtonEvent[] => {
-  const delegationDisabled = account.balance.isZero() || account.spendableBalance.isZero() ? true : false;
+  const delegationDisabled =
+    account.balance.isZero() || account.spendableBalance.isZero() ? true : false;
   const label = getStakeLabelLocaleBased();
 
   const navigationParams: NavigationParamsType = delegationDisabled

--- a/apps/ledger-live-mobile/src/families/solana/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/accountActions.tsx
@@ -17,7 +17,7 @@ const getMainActions = ({
   parentAccount: Account;
   parentRoute: RouteProp<ParamListBase, ScreenName>;
 }): ActionButtonEvent[] => {
-  const delegationDisabled = account.solanaResources?.stakes.length > 1;
+  const delegationDisabled = account.balance.isZero() || account.spendableBalance.isZero() ? true : false;
   const label = getStakeLabelLocaleBased();
 
   const navigationParams: NavigationParamsType = delegationDisabled


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Have over 1 SOL available to spend
Go to Earn on LLM
Try to stake your SOL
Given the amount of SOL available in my wallet, I should be able to stake and not getting redirected to the screen with CTAs to Buy and Swap.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15273](https://ledgerhq.atlassian.net/browse/LIVE-15273)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15273]: https://ledgerhq.atlassian.net/browse/LIVE-15273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ