### PR TITLE
Run build-and-test-external on merge group

### DIFF
--- a/.github/workflows/build-and-test-external.yml
+++ b/.github/workflows/build-and-test-external.yml
@@ -1,6 +1,8 @@
 name: Build and Test External
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name != 'develop' && github.ref || github.run_id }}


### PR DESCRIPTION
Part of https://ledgerhq.atlassian.net/browse/LIVE-16491

Fixes the issue described in [this message](https://ledger.slack.com/archives/C0308JT8WS2/p1738090132410689?thread_ts=1738074868.453619&cid=C0308JT8WS2).

"OK external", the final job from [build-and-test-external](https://github.com/LedgerHQ/ledger-live/blob/develop/.github/workflows/build-and-test-external.yml), is a required check for this repo - that means it must be run on `merge_group` trigger otherwise the merge group checks will hang indefinitely (waiting for a required check which is never triggered). This PR ads the `on: merge_group` condition to handle this.