### PR TITLE
[QAA - DETOX] Adding fee strategie + Implement invalid Amount - USDT

### DIFF
--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -244,11 +244,12 @@ jobs:
     if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule' )}}
     steps:
       - uses: actions/github-script@v7
-        if: ${{ !cancelled() && (inputs.slack_notif || github.event_name == 'schedule' )}}
         name: prepare status
         id: status
         env:
           STATUS_EMOJI: ${{ needs.report-to-allure.outputs.status_emoji }}
+          EXPORT_TO_XRAY: ${{ inputs.export_to_xray }}
+          TEST_EXECUTION: ${{ github.event.inputs.test_execution }}
         with:
           script: |
             const fs = require("fs");
@@ -375,13 +376,13 @@ jobs:
               ]
             };
 
-            if (${{ inputs.export_to_xray }}) {
+            if (process.env.EXPORT_TO_XRAY === 'true') {
               slackPayload.attachments[0].blocks.push({
                 "type": "section",
                 "fields": [
                   {
                     "type": "mrkdwn",
-                    "text": "*Xray Link*\n<https://ledgerhq.atlassian.net/browse/${{ github.event.inputs.test_execution }}|Test Execution>"
+                    "text": `*Xray Link*\n<https://ledgerhq.atlassian.net/browse/${process.env.TEST_EXECUTION}|Test Execution>`
                   }
                 ]
               });

--- a/apps/ledger-live-mobile/e2e/page/trade/send.page.ts
+++ b/apps/ledger-live-mobile/e2e/page/trade/send.page.ts
@@ -8,6 +8,7 @@ import {
   tapByElement,
   IsIdVisible,
   getTextOfElement,
+  getElementByText,
 } from "../../helpers";
 import { expect } from "detox";
 import jestExpect from "expect";
@@ -38,6 +39,7 @@ export default class SendPage {
   summaryWarning = () => getElementById("send-summary-warning");
   summaryContinueButton = () => getElementById("summary-continue-button");
   highFreeConfirmButtonID = "confirmation-modal-confirm-button";
+  feeStrategy = (fee: string) => getElementByText(fee);
 
   async openViaDeeplink() {
     await openDeeplink(baseLink);
@@ -196,5 +198,12 @@ export default class SendPage {
   async expectValidationEnsName(ensName: string) {
     await waitForElementById(this.validationEnsId);
     await expect(getElementById(this.validationEnsId)).toHaveText(ensName);
+  }
+
+  @Step("choose fee startegy")
+  async chooseFeeStrategy(fee: string | undefined) {
+    if (fee) {
+      await tapByElement(this.feeStrategy(fee));
+    }
   }
 }

--- a/apps/ledger-live-mobile/e2e/specs/speculos/send/send.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/send/send.ts
@@ -48,7 +48,8 @@ export async function runSendTest(transaction: Transaction, tmsLink: string) {
       const amountWithCode = transaction.amount + " " + transaction.accountToCredit.currency.ticker;
       await app.send.expectSummaryAmount(amountWithCode);
       await app.send.expectSummaryRecipient(addressToCredit);
-      await app.send.expectSummaryMemoTag(transaction.memoTag);
+      await app.send.expectSummaryMemoTag(transaction.memoTag); // inverser ici ?
+      await app.send.chooseFeeStrategy(transaction.speed); // Inverser ici ?
       await app.send.summaryContinue();
       await app.send.dismissHighFeeModal();
 
@@ -170,6 +171,7 @@ export async function runSendInvalidTokenAmountTest(
           transaction.amount + " " + transaction.accountToCredit.currency.ticker;
         await app.send.expectSummaryAmount(amountWithCode);
         await app.send.expectSummaryRecipient(transaction.accountToCredit.address);
+        await app.send.chooseFeeStrategy(transaction.speed);
         await app.send.expectSendSummaryError(expectedErrorMessage);
       } else {
         await app.send.expectSendAmountError(expectedErrorMessage);

--- a/apps/ledger-live-mobile/e2e/specs/speculos/send/send.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/send/send.ts
@@ -48,8 +48,8 @@ export async function runSendTest(transaction: Transaction, tmsLink: string) {
       const amountWithCode = transaction.amount + " " + transaction.accountToCredit.currency.ticker;
       await app.send.expectSummaryAmount(amountWithCode);
       await app.send.expectSummaryRecipient(addressToCredit);
-      await app.send.expectSummaryMemoTag(transaction.memoTag); // inverser ici ?
-      await app.send.chooseFeeStrategy(transaction.speed); // Inverser ici ?
+      await app.send.expectSummaryMemoTag(transaction.memoTag);
+      await app.send.chooseFeeStrategy(transaction.speed);
       await app.send.summaryContinue();
       await app.send.dismissHighFeeModal();
 

--- a/apps/ledger-live-mobile/e2e/specs/speculos/send/send.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/send/send.ts
@@ -146,7 +146,7 @@ export async function runSendInvalidAmountTest(
 
 export async function runSendInvalidTokenAmountTest(
   transaction: Transaction,
-  expectedErrorMessage: RegExp,
+  expectedErrorMessage: RegExp | string,
   tmsLink: string,
 ) {
   const app = new Application();
@@ -162,14 +162,18 @@ export async function runSendInvalidTokenAmountTest(
       await navigateToSendScreen(app, transaction.accountToDebit.currency.name);
       await app.send.setRecipientAndContinue(addressToCredit, transaction.memoTag);
       await app.send.setAmount(transaction.amount);
-      await app.send.expectSendAmountSuccess();
-      await app.send.amountContinue();
+      if (expectedErrorMessage instanceof RegExp) {
+        await app.send.expectSendAmountSuccess();
+        await app.send.amountContinue();
 
-      const amountWithCode = transaction.amount + " " + transaction.accountToCredit.currency.ticker;
-      await app.send.expectSummaryAmount(amountWithCode);
-      await app.send.expectSummaryRecipient(addressToCredit);
-      await app.send.expectSummaryMemoTag(transaction.memoTag);
-      await app.send.expectSendSummaryError(expectedErrorMessage);
+        const amountWithCode =
+          transaction.amount + " " + transaction.accountToCredit.currency.ticker;
+        await app.send.expectSummaryAmount(amountWithCode);
+        await app.send.expectSummaryRecipient(transaction.accountToCredit.address);
+        await app.send.expectSendSummaryError(expectedErrorMessage);
+      } else {
+        await app.send.expectSendAmountError(expectedErrorMessage);
+      }
     });
   });
 }

--- a/apps/ledger-live-mobile/e2e/specs/speculos/send/sendInvalid/sendInvalidTokenAmountBSC_BUSD.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/send/sendInvalid/sendInvalidTokenAmountBSC_BUSD.spec.ts
@@ -3,7 +3,7 @@ import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { runSendInvalidTokenAmountTest } from "../send";
 import { Fee } from "@ledgerhq/live-common/e2e/enum/Fee";
 
-const transaction = new Transaction(Account.BSC_BUSD_1, Account.BSC_BUSD_2, "1", Fee.MEDIUM);
+const transaction = new Transaction(Account.BSC_BUSD_1, Account.BSC_BUSD_2, "1", Fee.FAST);
 runSendInvalidTokenAmountTest(
   transaction,
   new RegExp(

--- a/apps/ledger-live-mobile/e2e/specs/speculos/send/sendInvalid/sendInvalidTokenAmountETH_USDT.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/send/sendInvalid/sendInvalidTokenAmountETH_USDT.spec.ts
@@ -3,7 +3,7 @@ import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
 import { runSendInvalidTokenAmountTest } from "../send";
 import { Fee } from "@ledgerhq/live-common/e2e/enum/Fee";
 
-const transaction = new Transaction(Account.ETH_USDT_2, Account.ETH_USDT_1, "1", Fee.MEDIUM);
+const transaction = new Transaction(Account.ETH_USDT_2, Account.ETH_USDT_1, "1", Fee.FAST);
 runSendInvalidTokenAmountTest(
   transaction,
   new RegExp(

--- a/apps/ledger-live-mobile/e2e/specs/speculos/send/sendInvalid/sendInvalidTokenAmountETH_USDT_2.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/send/sendInvalid/sendInvalidTokenAmountETH_USDT_2.spec.ts
@@ -1,0 +1,6 @@
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Transaction } from "@ledgerhq/live-common/e2e/models/Transaction";
+import { runSendInvalidTokenAmountTest } from "../send";
+
+const transaction = new Transaction(Account.ETH_USDT_1, Account.ETH_USDT_2, "10000");
+runSendInvalidTokenAmountTest(transaction, "Sorry, insufficient funds", "B2CQA-3043");

--- a/libs/ledger-live-common/src/e2e/enum/Fee.ts
+++ b/libs/ledger-live-common/src/e2e/enum/Fee.ts
@@ -1,5 +1,5 @@
 export enum Fee {
-  FAST = "fast",
-  MEDIUM = "medium",
-  SLOW = "slow",
+  FAST = "Fast",
+  MEDIUM = "Medium",
+  SLOW = "Slow",
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Implement invalid transaction - USDT (Amount > Balance)
Implement Fees for Send Tests

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- [QAA-448](https://ledgerhq.atlassian.net/browse/QAA-448)
- [QAA-455](https://ledgerhq.atlassian.net/browse/QAA-455)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-448]: https://ledgerhq.atlassian.net/browse/QAA-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-455]: https://ledgerhq.atlassian.net/browse/QAA-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ