### PR TITLE
chore: add changeset about coin-framework and impacted coin modules

### DIFF
--- a/.changeset/loud-comics-remember.md
+++ b/.changeset/loud-comics-remember.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-framework": major
+"@ledgerhq/coin-module-boilerplate": major
+"@ledgerhq/coin-polkadot": major
+"@ledgerhq/coin-stellar": major
+"@ledgerhq/coin-tezos": major
+"@ledgerhq/coin-xrp": major
+---
+
+Change coin-framework/api types for list operations


### PR DESCRIPTION
I bump to `major` following the semantic versioning because I broke the coin-framework/api types (not forward compatible)

Is that ok ? Since that's the very first major, maybe you're not using semantic versioning ?