### PR TITLE
fix(cryptoassets): update TOMO magnitude to 18

### DIFF
--- a/.changeset/pink-apes-pump.md
+++ b/.changeset/pink-apes-pump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+fix(cryptoassets): update TOMO magnitude to 18

--- a/libs/coin-framework/src/currencies/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/coin-framework/src/currencies/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -300,7 +300,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Thundercore unit (TT) 1`] = `"0,012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format TomoChain unit (TOMO) 1`] = `"123.456.789,00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format TomoChain unit (TOMO) 1`] = `"0,012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Tron unit (TRX) 1`] = `"12.345.678.900,000000- -TRX"`;
 
@@ -640,7 +640,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Thundercore unit (TT) 1`] = `"0.012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format TomoChain unit (TOMO) 1`] = `"123,456,789.00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format TomoChain unit (TOMO) 1`] = `"0.012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Tron unit (TRX) 1`] = `"12,345,678,900.000000- -TRX"`;
 
@@ -980,7 +980,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Thundercore unit (TT) 1`] = `"0,012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format TomoChain unit (TOMO) 1`] = `"123.456.789,00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format TomoChain unit (TOMO) 1`] = `"0,012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Tron unit (TRX) 1`] = `"12.345.678.900,000000- -TRX"`;
 
@@ -1320,7 +1320,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Thundercore unit (TT) 1`] = `"0,012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format TomoChain unit (TOMO) 1`] = `"123 456 789,00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format TomoChain unit (TOMO) 1`] = `"0,012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Tron unit (TRX) 1`] = `"12 345 678 900,000000- -TRX"`;
 
@@ -1660,7 +1660,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Thundercore unit (TT) 1`] = `"0.012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format TomoChain unit (TOMO) 1`] = `"123,456,789.00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format TomoChain unit (TOMO) 1`] = `"0.012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Tron unit (TRX) 1`] = `"12,345,678,900.000000- -TRX"`;
 
@@ -2000,7 +2000,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Thundercore unit (TT) 1`] = `"0.012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format TomoChain unit (TOMO) 1`] = `"123,456,789.00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format TomoChain unit (TOMO) 1`] = `"0.012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Tron unit (TRX) 1`] = `"12,345,678,900.000000- -TRX"`;
 
@@ -2340,7 +2340,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Thundercore unit (TT) 1`] = `"0,012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format TomoChain unit (TOMO) 1`] = `"123.456.789,00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format TomoChain unit (TOMO) 1`] = `"0,012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Tron unit (TRX) 1`] = `"12.345.678.900,000000- -TRX"`;
 
@@ -2680,7 +2680,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Thundercore unit (TT) 1`] = `"0,012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format TomoChain unit (TOMO) 1`] = `"123 456 789,00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format TomoChain unit (TOMO) 1`] = `"0,012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Tron unit (TRX) 1`] = `"12 345 678 900,000000- -TRX"`;
 
@@ -3020,7 +3020,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Thundercore unit (TT) 1`] = `"0,012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format TomoChain unit (TOMO) 1`] = `"123.456.789,00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format TomoChain unit (TOMO) 1`] = `"0,012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Tron unit (TRX) 1`] = `"12.345.678.900,000000- -TRX"`;
 
@@ -3360,7 +3360,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Thundercore unit (TT) 1`] = `"0.012345678900000000- -TT"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format TomoChain unit (TOMO) 1`] = `"123,456,789.00000000- -TOMO"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format TomoChain unit (TOMO) 1`] = `"0.012345678900000000- -TOMO"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Tron unit (TRX) 1`] = `"12,345,678,900.000000- -TRX"`;
 
@@ -3700,7 +3700,7 @@ exports[`formatCurrencyUnit with default options should correctly format Tezos u
 
 exports[`formatCurrencyUnit with default options should correctly format Thundercore unit (TT) 1`] = `"0.0123456"`;
 
-exports[`formatCurrencyUnit with default options should correctly format TomoChain unit (TOMO) 1`] = `"123,456,789"`;
+exports[`formatCurrencyUnit with default options should correctly format TomoChain unit (TOMO) 1`] = `"0.0123456"`;
 
 exports[`formatCurrencyUnit with default options should correctly format Tron unit (TRX) 1`] = `"12,345,678,900"`;
 

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/editTransaction/__snapshots__/getFormattedFeeFields.test.ts.snap
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/editTransaction/__snapshots__/getFormattedFeeFields.test.ts.snap
@@ -506,8 +506,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1.050.000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0,000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -1064,8 +1064,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1,050,000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0.000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -1622,8 +1622,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1.050.000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0,000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -2180,8 +2180,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1 050 000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0,000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -2738,8 +2738,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1,050,000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0.000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -3296,8 +3296,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1,050,000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0.000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -3854,8 +3854,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1.050.000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0,000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -4412,8 +4412,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1 050 000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0,000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -4970,8 +4970,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1.050.000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0,000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -5528,8 +5528,8 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "1,050,000 TOMO",
-  "formattedGasPrice": "50 TOMO",
+  "formattedFeeValue": "0.000105 TOMO",
+  "formattedGasPrice": "0 TOMO",
   "formattedMaxFeePerGas": "0 TOMO",
   "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
@@ -6086,10 +6086,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420.000 TOMO",
+  "formattedFeeValue": "0,000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -6644,10 +6644,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420,000 TOMO",
+  "formattedFeeValue": "0.000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -7202,10 +7202,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420.000 TOMO",
+  "formattedFeeValue": "0,000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -7760,10 +7760,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420 000 TOMO",
+  "formattedFeeValue": "0,000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -8318,10 +8318,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420,000 TOMO",
+  "formattedFeeValue": "0.000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -8876,10 +8876,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420,000 TOMO",
+  "formattedFeeValue": "0.000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -9434,10 +9434,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420.000 TOMO",
+  "formattedFeeValue": "0,000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -9992,10 +9992,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420 000 TOMO",
+  "formattedFeeValue": "0,000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -10550,10 +10550,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420.000 TOMO",
+  "formattedFeeValue": "0,000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 
@@ -11108,10 +11108,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for TomoChain unit 1`] = `
 {
-  "formattedFeeValue": "420,000 TOMO",
+  "formattedFeeValue": "0.000042 TOMO",
   "formattedGasPrice": "0 TOMO",
-  "formattedMaxFeePerGas": "20 TOMO",
-  "formattedMaxPriorityFeePerGas": "10 TOMO",
+  "formattedMaxFeePerGas": "0 TOMO",
+  "formattedMaxPriorityFeePerGas": "0 TOMO",
 }
 `;
 

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -2836,7 +2836,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
       {
         name: "TOMO",
         code: "TOMO",
-        magnitude: 8,
+        magnitude: 18,
       },
     ],
     explorerViews: [


### PR DESCRIPTION
Sounds like `TOMO` is not properly aligned with `LedgerHQ/crypto-assets` repo (see [here](https://github.com/LedgerHQ/crypto-assets/blob/0ad6155f0ecb61a036e9866b672993a8d1e0c8c8/outputs/update/coins/tomo.asset.json#L7-L13)).

Causing some trouble on Ledger Enterprise side (see TSD-4669).