### PR TITLE
feat: don't display Accounts already in the Portfolio

### DIFF
--- a/.changeset/loud-llamas-try.md
+++ b/.changeset/loud-llamas-try.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Hide account already in the portfolio in add account v2 scan process

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4025,9 +4025,6 @@
       "creatable": {
         "title": "Add new account"
       },
-      "imported": {
-        "title": "Accounts already in the Portfolio ({{length}})"
-      },
       "migrate": {
         "title": "Accounts to update"
       }

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -240,6 +240,9 @@ export default function useScanDeviceAccountsViewModel({
   const noImportableAccounts = !sections.some(
     s => s.id === "importable" || s.id === "creatable" || s.id === "migrate",
   );
+  // We don't show already imported accounts in the UI
+  const sanitizedSections = sections.filter(s => s.id !== "imported");
+
   const CustomNoAssociatedAccounts =
     currency.type === "CryptoCurrency"
       ? noAssociatedAccountsByFamily[currency.family as keyof typeof noAssociatedAccountsByFamily]
@@ -315,7 +318,7 @@ export default function useScanDeviceAccountsViewModel({
     restartSubscription,
     scannedAccounts,
     scanning,
-    sections,
+    sections: sanitizedSections,
     selectAll,
     selectedIds,
     showAllCreatedAccounts,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The aim of this fix/feat is to not show the "imported" section in the scan section of the add account v2. 

#### Before 


https://github.com/user-attachments/assets/204fc035-a9e6-4dba-9f9c-8515244eb539



#### After 


https://github.com/user-attachments/assets/467d5e3f-4440-4cdd-8f17-1940d8a90aec



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-16637

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
