### PR TITLE
fix: add missing error strings [LIVE-16703]

### DIFF
--- a/.changeset/odd-shoes-promise.md
+++ b/.changeset/odd-shoes-promise.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix: add missing error strings

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6247,6 +6247,9 @@
     "SolanaTokenAccounNotInitialized": {
       "title": "Account not initialized"
     },
+    "SolanaTokenRecipientIsSenderATA": {
+      "title": "Recipient address is the same as the sender token address"
+    },
     "SolanaMemoIsTooLong": {
       "title": "Memo is too long. Max length is {{maxLength}}"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -809,6 +809,12 @@
     "SolanaTokenAccountFrozen": {
       "title": "Token account assets are frozen"
     },
+    "SolanaTokenAccounNotInitialized": {
+      "title": "Account not initialized"
+    },
+    "SolanaTokenRecipientIsSenderATA": {
+      "title": "Recipient address is the same as the sender token address"
+    },
     "SolanaAddressOfEd25519": {
       "title": "Address off ed25519 curve"
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** We don't test i18n, we probably could have a linter for this
- [x] **Impact of the changes:**
  - Solana send token error message 

### 📝 Description

Add missing error messages

<img width="583" alt="Screenshot 2025-02-04 at 09 03 54" src="https://github.com/user-attachments/assets/1610cc84-58d1-44ef-b02f-32469a2a0c7c" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-16703]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16703]: https://ledgerhq.atlassian.net/browse/LIVE-16703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ