### PR TITLE
CN-1076: change the button action earn rewards to open stakekit

### DIFF
--- a/.changeset/calm-planes-train.md
+++ b/.changeset/calm-planes-train.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+DOT stake eearn more reward button redirecting to stakekit

--- a/.changeset/calm-planes-train.md
+++ b/.changeset/calm-planes-train.md
@@ -3,4 +3,4 @@
 "live-mobile": minor
 ---
 
-DOT stake eearn more reward button redirecting to stakekit
+DOT stake earn more reward button redirecting to stakekit

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/Nomination/index.tsx
@@ -44,6 +44,7 @@ import {
 } from "@ledgerhq/live-common/families/polkadot/types";
 import { SubAccount } from "@ledgerhq/types-live";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import { useHistory } from "react-router";
 
 type Props = {
   account: PolkadotAccount | SubAccount;
@@ -64,6 +65,8 @@ export type NominationValidator =
   | PolkadotUnlocking;
 
 const Nomination = ({ account }: { account: PolkadotAccount }) => {
+  const history = useHistory();
+
   const discreet = useDiscreetMode();
   const locale = useSelector(localeSelector);
   const unit = useAccountUnit(account);
@@ -115,12 +118,15 @@ const Nomination = ({ account }: { account: PolkadotAccount }) => {
     };
   }, [unlockings, unlockedBalance]);
   const onEarnRewards = useCallback(() => {
-    dispatch(
-      openModal("MODAL_POLKADOT_REWARDS_INFO", {
-        account,
-      }),
-    );
-  }, [account, dispatch]);
+    history.push({
+      pathname: "/platform/stakekit",
+      state: {
+        yieldId: "polkadot-dot-validator-staking",
+        accountId: account.id,
+        returnTo: `/account/${account.id}`,
+      },
+    });
+  }, [account, history]);
   const onNominate = useCallback(() => {
     dispatch(
       openModal("MODAL_POLKADOT_NOMINATE", {

--- a/apps/ledger-live-mobile/src/families/polkadot/Nominations/index.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/Nominations/index.tsx
@@ -9,7 +9,6 @@ import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getDefaultExplorerView, getAddressExplorer } from "@ledgerhq/live-common/explorers";
 import {
   canNominate,
-  isStash,
   hasExternalController,
   hasExternalStash,
   hasPendingOperationType,
@@ -144,15 +143,16 @@ export default function Nominations(props: Props) {
   );
 
   const onEarnRewards = useCallback(() => {
-    isStash(account)
-      ? onNavigate({
-          route: NavigatorName.PolkadotNominateFlow,
-          screen: ScreenName.PolkadotNominateSelectValidators,
-        })
-      : onNavigate({
-          route: NavigatorName.PolkadotBondFlow,
-          screen: ScreenName.PolkadotBondStarted,
-        });
+    onNavigate({
+      route: NavigatorName.Base,
+      screen: ScreenName.PlatformApp,
+      params: {
+        platform: "stakekit",
+        name: "StakeKit",
+        accountId: account.id,
+        yieldId: "polkadot-dot-validator-staking",
+      },
+    });
   }, [account, onNavigate]);
 
   const onNominate = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Earn rewards button opening stakekit live app

### 📝 Description

This PR replaces the action on the "earn rewards" button into the account screen to open stakekit rather than the native staking modal.

### ❓ Context

- **JIRA or GitHub link**: [CN-1076](https://ledgerhq.atlassian.net/browse/CN-1076)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[CN-1076]: https://ledgerhq.atlassian.net/browse/CN-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ