### PR TITLE
🧐  LLD - Fix clicks tracking for Portfolio cards

### DIFF
--- a/.changeset/dull-pianos-wave.md
+++ b/.changeset/dull-pianos-wave.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LLD - Fix tracking of clicks on new Portfolio cards

--- a/apps/ledger-live-desktop/src/newArch/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -107,7 +107,10 @@ describe("PortfolioContentCards", () => {
     expect(track).not.toHaveBeenCalledWith("contentcard_clicked", expect.any(Object));
     act(() => cta0.click());
     expect(logContentCardClick).toHaveBeenCalledTimes(1);
-    expect(logContentCardClick).toHaveBeenCalledWith(asBrazeCard(Cards[0]));
+    expect(logContentCardClick).toHaveBeenCalledWith({
+      ...asBrazeCard(Cards[0]),
+      url: Cards[0].id,
+    });
     expect(track).toHaveBeenCalledWith("contentcard_clicked", {
       contentcard: "Foo",
       link: "ledger-live://deep-link",

--- a/apps/ledger-live-desktop/src/newArch/features/DynamicContent/hooks/usePortfolioCards.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/DynamicContent/hooks/usePortfolioCards.ts
@@ -67,8 +67,12 @@ export function usePortfolioCards(): UsePortfolioCards {
 
       const currentCard = cachedContentCards.find(card => card.id === cardId);
       if (!currentCard) return;
-
-      braze.logContentCardClick(currentCard);
+      // For some reason braze won't log the click event if the card url is empty
+      // Setting it as the card id just to have a dummy non empty value
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      currentCard.url = currentCard.id;
+      braze.logContentCardClick(currentCard as braze.ClassicCard);
     },
     [portfolioCards, cachedContentCards, isTrackedUser],
   );


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

With the Braze Web SDK, clicks are not tracked if the url field is empty so we need to set it to a dumb value as it isn't used for anything else
We also need to dismiss the typescript error as they have an error in their typing and the Braze.Card class doesn't declare a url property
![Screenshot 2025-02-04 at 11 33 53](https://github.com/user-attachments/assets/56babe5b-a131-42e1-97ae-cf14a9805afd)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-16763] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16763]: https://ledgerhq.atlassian.net/browse/LIVE-16763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ