### PR TITLE
fix: 🐞 allow user to add funded account when 0$ account exist on his …

### DIFF
--- a/.changeset/few-hats-repair.md
+++ b/.changeset/few-hats-repair.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: 🐞 allow user to add funded account when 0$ account exist on his wallet (add account v2)

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4027,6 +4027,9 @@
       "creatable": {
         "title": "Add new account"
       },
+      "imported": {
+        "title": "Accounts already in the Portfolio ({{length}})"
+      },
       "migrate": {
         "title": "Accounts to update"
       }
@@ -4086,10 +4089,6 @@
         },
         "creatable": {
           "title": "New account"
-        },
-        "imported": {
-          "title": "Account already in the Portfolio ({{count}})",
-          "title_plural": "Accounts already in the Portfolio ({{count}})"
         },
         "migrate": {
           "title": "Accounts to update"

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -243,6 +243,7 @@ export default function useScanDeviceAccountsViewModel({
   );
   // We don't show already imported accounts in the UI
   const sanitizedSections = sections.filter(s => s.id !== "imported");
+  const hasImportableAccounts = sections.find(s => s.id === "importable" && s.data.length > 0);
 
   const CustomNoAssociatedAccounts =
     currency.type === "CryptoCurrency"
@@ -280,7 +281,7 @@ export default function useScanDeviceAccountsViewModel({
 
   useEffect(() => {
     if (!cantCreateAccount && !isAddingAccounts && !scanning) {
-      if (alreadyEmptyAccount) {
+      if (alreadyEmptyAccount && !hasImportableAccounts) {
         navigation.replace(ScreenName.AddAccountsWarning, {
           emptyAccount: alreadyEmptyAccount,
           emptyAccountName: alreadyEmptyAccountName,
@@ -293,6 +294,7 @@ export default function useScanDeviceAccountsViewModel({
       }
     }
   }, [
+    hasImportableAccounts,
     cantCreateAccount,
     isAddingAccounts,
     alreadyEmptyAccount,
@@ -301,6 +303,7 @@ export default function useScanDeviceAccountsViewModel({
     navigation,
     currency,
     CustomNoAssociatedAccounts,
+    scannedAccounts,
   ]);
   return {
     alreadyEmptyAccount,


### PR DESCRIPTION
…wallet (add account v2)

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This change will fix the fact that the user cannot add a funded account after adding an empty one. The next video will visit the following scenarios: 

- Add new empty account 
- Add a funded account from the same currency 
- Try to add a new empty account -> warning screen

Video [here](https://drive.google.com/file/d/1-XmorW6hGm0Inc5kaX7MwpHCU93CafiF/view?usp=sharing)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-16644


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
