### PR TITLE
fix: update ethereum testnet units to match nano app

### DIFF
--- a/.changeset/fast-doors-mix.md
+++ b/.changeset/fast-doors-mix.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+Fix ethereum testnet units

--- a/.changeset/fast-doors-mix.md
+++ b/.changeset/fast-doors-mix.md
@@ -1,5 +1,7 @@
 ---
 "@ledgerhq/cryptoassets": patch
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/coin-framework": patch
 ---
 
 Fix ethereum testnet units

--- a/libs/coin-framework/src/currencies/__snapshots__/formatCurrencyUnit.test.ts.snap
+++ b/libs/coin-framework/src/currencies/__snapshots__/formatCurrencyUnit.test.ts.snap
@@ -10,7 +10,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Aptos unit (APT) 1`] = `"123.456.789,00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Arbitrum unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -26,7 +26,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Banano unit (BANANO) 1`] = `"123.456.789,00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Base unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -46,7 +46,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Blast unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -102,9 +102,9 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Ethereum Classic unit (ETC) 1`] = `"0,012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Ethereum unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -170,7 +170,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format LBRY unit (LBRY) 2`] = `"123.456.789,00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Linea unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -216,7 +216,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format OP Mainnet unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Onomy unit (Onomy) 1`] = `"0,012345678900000000- -NOM"`;
 
@@ -238,7 +238,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Polygon unit (POL) 1`] = `"0,012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Polygon zkEVM unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -260,7 +260,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Rootstock unit (RBTC) 1`] = `"0,012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format Scroll unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -324,7 +324,7 @@ exports[`formatCurrencyUnit with custom options with locale de-DE should correct
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format ZCoin unit (XZC) 1`] = `"123.456.789,00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale de-DE should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -350,7 +350,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Aptos unit (APT) 1`] = `"123,456,789.00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Arbitrum unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -366,7 +366,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Banano unit (BANANO) 1`] = `"123,456,789.00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Base unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -386,7 +386,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Blast unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -442,9 +442,9 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Ethereum Classic unit (ETC) 1`] = `"0.012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Ethereum unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -510,7 +510,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format LBRY unit (LBRY) 2`] = `"123,456,789.00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Linea unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -556,7 +556,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format OP Mainnet unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Onomy unit (Onomy) 1`] = `"0.012345678900000000- -NOM"`;
 
@@ -578,7 +578,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Polygon unit (POL) 1`] = `"0.012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Polygon zkEVM unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -600,7 +600,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Rootstock unit (RBTC) 1`] = `"0.012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format Scroll unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -664,7 +664,7 @@ exports[`formatCurrencyUnit with custom options with locale en-US should correct
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ZCoin unit (XZC) 1`] = `"123,456,789.00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale en-US should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -690,7 +690,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Aptos unit (APT) 1`] = `"123.456.789,00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Arbitrum unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -706,7 +706,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Banano unit (BANANO) 1`] = `"123.456.789,00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Base unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -726,7 +726,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Blast unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -782,9 +782,9 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Ethereum Classic unit (ETC) 1`] = `"0,012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Ethereum unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -850,7 +850,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format LBRY unit (LBRY) 2`] = `"123.456.789,00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Linea unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -896,7 +896,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format OP Mainnet unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Onomy unit (Onomy) 1`] = `"0,012345678900000000- -NOM"`;
 
@@ -918,7 +918,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Polygon unit (POL) 1`] = `"0,012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Polygon zkEVM unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -940,7 +940,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Rootstock unit (RBTC) 1`] = `"0,012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format Scroll unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1004,7 +1004,7 @@ exports[`formatCurrencyUnit with custom options with locale es-ES should correct
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format ZCoin unit (XZC) 1`] = `"123.456.789,00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale es-ES should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1030,7 +1030,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Aptos unit (APT) 1`] = `"123 456 789,00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Arbitrum unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1046,7 +1046,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Banano unit (BANANO) 1`] = `"123 456 789,00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Base unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1066,7 +1066,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Blast unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1122,9 +1122,9 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Ethereum Classic unit (ETC) 1`] = `"0,012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Ethereum unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1190,7 +1190,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format LBRY unit (LBRY) 2`] = `"123 456 789,00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Linea unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1236,7 +1236,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format OP Mainnet unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Onomy unit (Onomy) 1`] = `"0,012345678900000000- -NOM"`;
 
@@ -1258,7 +1258,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Polygon unit (POL) 1`] = `"0,012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Polygon zkEVM unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1280,7 +1280,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Rootstock unit (RBTC) 1`] = `"0,012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format Scroll unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1344,7 +1344,7 @@ exports[`formatCurrencyUnit with custom options with locale fr-FR should correct
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ZCoin unit (XZC) 1`] = `"123 456 789,00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale fr-FR should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -1370,7 +1370,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Aptos unit (APT) 1`] = `"123,456,789.00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Arbitrum unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1386,7 +1386,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Banano unit (BANANO) 1`] = `"123,456,789.00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Base unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1406,7 +1406,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Blast unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1462,9 +1462,9 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Ethereum Classic unit (ETC) 1`] = `"0.012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Ethereum unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1530,7 +1530,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format LBRY unit (LBRY) 2`] = `"123,456,789.00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Linea unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1576,7 +1576,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format OP Mainnet unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Onomy unit (Onomy) 1`] = `"0.012345678900000000- -NOM"`;
 
@@ -1598,7 +1598,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Polygon unit (POL) 1`] = `"0.012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Polygon zkEVM unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1620,7 +1620,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Rootstock unit (RBTC) 1`] = `"0.012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format Scroll unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1684,7 +1684,7 @@ exports[`formatCurrencyUnit with custom options with locale ja-JP should correct
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format ZCoin unit (XZC) 1`] = `"123,456,789.00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ja-JP should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1710,7 +1710,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Aptos unit (APT) 1`] = `"123,456,789.00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Arbitrum unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1726,7 +1726,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Banano unit (BANANO) 1`] = `"123,456,789.00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Base unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1746,7 +1746,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Blast unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1802,9 +1802,9 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Ethereum Classic unit (ETC) 1`] = `"0.012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Ethereum unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1870,7 +1870,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format LBRY unit (LBRY) 2`] = `"123,456,789.00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Linea unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1916,7 +1916,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format OP Mainnet unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Onomy unit (Onomy) 1`] = `"0.012345678900000000- -NOM"`;
 
@@ -1938,7 +1938,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Polygon unit (POL) 1`] = `"0.012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Polygon zkEVM unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -1960,7 +1960,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Rootstock unit (RBTC) 1`] = `"0.012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format Scroll unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -2024,7 +2024,7 @@ exports[`formatCurrencyUnit with custom options with locale ko-KR should correct
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ZCoin unit (XZC) 1`] = `"123,456,789.00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ko-KR should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -2050,7 +2050,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Aptos unit (APT) 1`] = `"123.456.789,00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Arbitrum unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2066,7 +2066,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Banano unit (BANANO) 1`] = `"123.456.789,00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Base unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2086,7 +2086,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Blast unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2142,9 +2142,9 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Ethereum Classic unit (ETC) 1`] = `"0,012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Ethereum unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2210,7 +2210,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format LBRY unit (LBRY) 2`] = `"123.456.789,00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Linea unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2256,7 +2256,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format OP Mainnet unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Onomy unit (Onomy) 1`] = `"0,012345678900000000- -NOM"`;
 
@@ -2278,7 +2278,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Polygon unit (POL) 1`] = `"0,012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Polygon zkEVM unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2300,7 +2300,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Rootstock unit (RBTC) 1`] = `"0,012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format Scroll unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2364,7 +2364,7 @@ exports[`formatCurrencyUnit with custom options with locale pt-BR should correct
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format ZCoin unit (XZC) 1`] = `"123.456.789,00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale pt-BR should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2390,7 +2390,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Aptos unit (APT) 1`] = `"123 456 789,00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Arbitrum unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2406,7 +2406,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Banano unit (BANANO) 1`] = `"123 456 789,00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Base unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2426,7 +2426,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Blast unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2482,9 +2482,9 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Ethereum Classic unit (ETC) 1`] = `"0,012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Ethereum unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2550,7 +2550,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format LBRY unit (LBRY) 2`] = `"123 456 789,00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Linea unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2596,7 +2596,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format OP Mainnet unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Onomy unit (Onomy) 1`] = `"0,012345678900000000- -NOM"`;
 
@@ -2618,7 +2618,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Polygon unit (POL) 1`] = `"0,012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Polygon zkEVM unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2640,7 +2640,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Rootstock unit (RBTC) 1`] = `"0,012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format Scroll unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2704,7 +2704,7 @@ exports[`formatCurrencyUnit with custom options with locale ru-RU should correct
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ZCoin unit (XZC) 1`] = `"123 456 789,00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale ru-RU should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2730,7 +2730,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Aptos unit (APT) 1`] = `"123.456.789,00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Arbitrum unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2746,7 +2746,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Banano unit (BANANO) 1`] = `"123.456.789,00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Base Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Base unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2766,7 +2766,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Bittorent Chain unit (BTT) 1`] = `"0,012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Blast Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Blast unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2822,9 +2822,9 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Ethereum Classic unit (ETC) 1`] = `"0,012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Ethereum Holesky unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Ethereum Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Ethereum unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2890,7 +2890,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format LBRY unit (LBRY) 2`] = `"123.456.789,00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Linea Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Linea unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2936,7 +2936,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format OP Mainnet unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format OP Sepolia unit (ether) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Onomy unit (Onomy) 1`] = `"0,012345678900000000- -NOM"`;
 
@@ -2958,7 +2958,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Polygon unit (POL) 1`] = `"0,012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Polygon zkEVM unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -2980,7 +2980,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Rootstock unit (RBTC) 1`] = `"0,012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Scroll Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format Scroll unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -3044,7 +3044,7 @@ exports[`formatCurrencyUnit with custom options with locale tr-TR should correct
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format ZCoin unit (XZC) 1`] = `"123.456.789,00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale tr-TR should correctly format ZKsync unit (ETH) 1`] = `"0,012345678900000000- -ETH"`;
 
@@ -3070,7 +3070,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Aptos unit (APT) 1`] = `"123,456,789.00000000- -APT"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Arbitrum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Arbitrum unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3086,7 +3086,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Banano unit (BANANO) 1`] = `"123,456,789.00000000- -BANANO"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Base Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Base unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3106,7 +3106,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Bittorent Chain unit (BTT) 1`] = `"0.012345678900000000- -BTT"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Blast Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Blast unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3162,9 +3162,9 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Ethereum Classic unit (ETC) 1`] = `"0.012345678900000000- -ETC"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Ethereum Holesky unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Ethereum Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Ethereum unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3230,7 +3230,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format LBRY unit (LBRY) 2`] = `"123,456,789.00000000- -LBRY"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Linea Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Linea unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3276,7 +3276,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format OP Mainnet unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format OP Sepolia unit (ether) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Onomy unit (Onomy) 1`] = `"0.012345678900000000- -NOM"`;
 
@@ -3298,7 +3298,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Polygon unit (POL) 1`] = `"0.012345678900000000- -POL"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Polygon zkEVM Testnet unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Polygon zkEVM unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3320,7 +3320,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Rootstock unit (RBTC) 1`] = `"0.012345678900000000- -RBTC"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Scroll Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format Scroll unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
@@ -3384,7 +3384,7 @@ exports[`formatCurrencyUnit with custom options with locale zh-CN should correct
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format ZCoin unit (XZC) 1`] = `"123,456,789.00000000- -XZC"`;
 
-exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -𝚝ETH"`;
+exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format ZKsync Sepolia unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 
 exports[`formatCurrencyUnit with custom options with locale zh-CN should correctly format ZKsync unit (ETH) 1`] = `"0.012345678900000000- -ETH"`;
 

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/editTransaction/__snapshots__/getFormattedFeeFields.test.ts.snap
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/editTransaction/__snapshots__/getFormattedFeeFields.test.ts.snap
@@ -11,10 +11,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -56,10 +56,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -92,10 +92,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -191,19 +191,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -290,10 +290,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -380,10 +380,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -416,10 +416,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -452,10 +452,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -542,10 +542,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale de-DE should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -569,10 +569,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -614,10 +614,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -650,10 +650,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -749,19 +749,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -848,10 +848,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -938,10 +938,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -974,10 +974,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1010,10 +1010,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1100,10 +1100,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale en-US should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1127,10 +1127,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1172,10 +1172,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1208,10 +1208,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1307,19 +1307,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1406,10 +1406,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1496,10 +1496,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1532,10 +1532,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1568,10 +1568,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1658,10 +1658,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale es-ES should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1685,10 +1685,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1730,10 +1730,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1766,10 +1766,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1865,19 +1865,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -1964,10 +1964,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2054,10 +2054,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2090,10 +2090,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2126,10 +2126,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2216,10 +2216,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale fr-FR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2243,10 +2243,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2288,10 +2288,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2324,10 +2324,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2423,19 +2423,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2522,10 +2522,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2612,10 +2612,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2648,10 +2648,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2684,10 +2684,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2774,10 +2774,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ja-JP should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2801,10 +2801,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2846,10 +2846,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2882,10 +2882,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -2981,19 +2981,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3080,10 +3080,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3170,10 +3170,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3206,10 +3206,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3242,10 +3242,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3332,10 +3332,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ko-KR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3359,10 +3359,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3404,10 +3404,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3440,10 +3440,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3539,19 +3539,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3638,10 +3638,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3728,10 +3728,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3764,10 +3764,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3800,10 +3800,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3890,10 +3890,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale pt-BR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3917,10 +3917,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3962,10 +3962,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -3998,10 +3998,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4097,19 +4097,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4196,10 +4196,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4286,10 +4286,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4322,10 +4322,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4358,10 +4358,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4448,10 +4448,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale ru-RU should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4475,10 +4475,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4520,10 +4520,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4556,10 +4556,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4655,19 +4655,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4754,10 +4754,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4844,10 +4844,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4880,10 +4880,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -4916,10 +4916,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5006,10 +5006,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale tr-TR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0,000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5033,10 +5033,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5078,10 +5078,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5114,10 +5114,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5213,19 +5213,19 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5312,10 +5312,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5402,10 +5402,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5438,10 +5438,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5474,10 +5474,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5564,10 +5564,10 @@ exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 0 with locale zh-CN should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000105 𝚝ETH",
-  "formattedGasPrice": "5 𝚝Gwei",
-  "formattedMaxFeePerGas": "0 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "0 𝚝Gwei",
+  "formattedFeeValue": "0.000105 ETH",
+  "formattedGasPrice": "5 Gwei",
+  "formattedMaxFeePerGas": "0 Gwei",
+  "formattedMaxPriorityFeePerGas": "0 Gwei",
 }
 `;
 
@@ -5591,10 +5591,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -5636,10 +5636,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -5672,10 +5672,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -5771,19 +5771,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -5870,10 +5870,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -5960,10 +5960,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -5996,10 +5996,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6032,10 +6032,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6122,10 +6122,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale de-DE should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6149,10 +6149,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6194,10 +6194,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6230,10 +6230,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6329,19 +6329,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6428,10 +6428,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6518,10 +6518,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6554,10 +6554,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6590,10 +6590,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6680,10 +6680,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale en-US should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6707,10 +6707,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6752,10 +6752,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6788,10 +6788,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6887,19 +6887,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -6986,10 +6986,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7076,10 +7076,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7112,10 +7112,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7148,10 +7148,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7238,10 +7238,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale es-ES should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7265,10 +7265,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7310,10 +7310,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7346,10 +7346,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7445,19 +7445,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7544,10 +7544,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7634,10 +7634,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7670,10 +7670,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7706,10 +7706,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7796,10 +7796,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale fr-FR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7823,10 +7823,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7868,10 +7868,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -7904,10 +7904,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8003,19 +8003,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8102,10 +8102,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8192,10 +8192,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8228,10 +8228,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8264,10 +8264,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8354,10 +8354,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ja-JP should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8381,10 +8381,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8426,10 +8426,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8462,10 +8462,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8561,19 +8561,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8660,10 +8660,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8750,10 +8750,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8786,10 +8786,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8822,10 +8822,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8912,10 +8912,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ko-KR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8939,10 +8939,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -8984,10 +8984,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9020,10 +9020,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9119,19 +9119,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9218,10 +9218,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9308,10 +9308,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9344,10 +9344,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9380,10 +9380,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9470,10 +9470,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale pt-BR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9497,10 +9497,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9542,10 +9542,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9578,10 +9578,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9677,19 +9677,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9776,10 +9776,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9866,10 +9866,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9902,10 +9902,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -9938,10 +9938,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10028,10 +10028,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale ru-RU should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10055,10 +10055,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10100,10 +10100,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10136,10 +10136,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10235,19 +10235,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10334,10 +10334,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10424,10 +10424,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10460,10 +10460,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10496,10 +10496,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10586,10 +10586,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale tr-TR should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0,000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0,000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10613,10 +10613,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Arbitrum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10658,10 +10658,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Base Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10694,10 +10694,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Blast Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10793,19 +10793,19 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Ethereum Holesky unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Ethereum Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10892,10 +10892,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Linea Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -10982,10 +10982,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for OP Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -11018,10 +11018,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Polygon zkEVM Testnet unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -11054,10 +11054,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for Scroll Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 
@@ -11144,10 +11144,10 @@ exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly
 
 exports[`getFormattedFeeFields with tx type 2 with locale zh-CN should correctly format fee fields for ZKsync Sepolia unit 1`] = `
 {
-  "formattedFeeValue": "0.000042 𝚝ETH",
-  "formattedGasPrice": "0 𝚝Gwei",
-  "formattedMaxFeePerGas": "2 𝚝Gwei",
-  "formattedMaxPriorityFeePerGas": "1 𝚝Gwei",
+  "formattedFeeValue": "0.000042 ETH",
+  "formattedGasPrice": "0 Gwei",
+  "formattedMaxFeePerGas": "2 Gwei",
+  "formattedMaxPriorityFeePerGas": "1 Gwei",
 }
 `;
 

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -3254,7 +3254,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     deviceTicker: "ETH",
     scheme: "eth_sepolia",
     color: "#ff0000",
-    units: ethereumUnits("ether", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ether", "ETH"),
     isTestnetFor: "ethereum",
     disableCountervalue: true,
     family: "evm",
@@ -3280,7 +3280,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     deviceTicker: "ETH",
     scheme: "eth_holesky",
     color: "#00ff00",
-    units: ethereumUnits("ether", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ether", "ETH"),
     isTestnetFor: "ethereum",
     disableCountervalue: true,
     family: "evm",
@@ -3568,7 +3568,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "arbitrum_sepolia",
     color: "#ff0000",
     family: "evm",
-    units: ethereumUnits("ether", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ether", "ETH"),
     isTestnetFor: "arbitrum",
     disableCountervalue: true,
     ethereumLikeInfo: {
@@ -3780,7 +3780,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "optimism_sepolia",
     color: "#FF0000",
     family: "evm",
-    units: ethereumUnits("ether", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ether", "ETH"),
     isTestnetFor: "optimism",
     ethereumLikeInfo: {
       chainId: 11155420,
@@ -4002,7 +4002,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "polygon_zk_evm_testnet",
     color: "#E58247",
     family: "evm",
-    units: ethereumUnits("ETH", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ETH", "ETH"),
     disableCountervalue: true,
     isTestnetFor: "polygon_zk_evm",
     ethereumLikeInfo: {
@@ -4049,7 +4049,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "base_sepolia",
     color: "#FF0000",
     family: "evm",
-    units: ethereumUnits("ETH", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ETH", "ETH"),
     disableCountervalue: true,
     isTestnetFor: "base",
     ethereumLikeInfo: {
@@ -4163,7 +4163,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "linea_sepolia",
     color: "#ff0000",
     family: "evm",
-    units: ethereumUnits("ETH", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ETH", "ETH"),
     disableCountervalue: false,
     isTestnetFor: "linea",
     ethereumLikeInfo: {
@@ -4210,7 +4210,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "blast_sepolia",
     color: "#ff0000",
     family: "evm",
-    units: ethereumUnits("ETH", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ETH", "ETH"),
     disableCountervalue: false,
     isTestnetFor: "blast",
     ethereumLikeInfo: {
@@ -4257,7 +4257,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "scroll_sepolia",
     color: "#ff0000",
     family: "evm",
-    units: ethereumUnits("ETH", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ETH", "ETH"),
     disableCountervalue: false,
     isTestnetFor: "scroll",
     ethereumLikeInfo: {
@@ -4325,7 +4325,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "zksync_sepolia",
     color: "#ff0000",
     family: "evm",
-    units: ethereumUnits("ETH", "ETH").map(makeTestnetUnit),
+    units: ethereumUnits("ETH", "ETH"),
     ethereumLikeInfo: {
       chainId: 300,
     },


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Some testnet tickers are not the same on nano app and LL
for exemple on nano app we have `ETH` and on LL we have `tETH`

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-16797](https://ledgerhq.atlassian.net/browse/LIVE-16797)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16797]: https://ledgerhq.atlassian.net/browse/LIVE-16797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ