### PR TITLE
fix(coin:tezos): api iterates over all results

### DIFF
--- a/.changeset/strange-mirrors-wink.md
+++ b/.changeset/strange-mirrors-wink.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+api iterates over all operations

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -1,0 +1,67 @@
+import { Operation } from "@ledgerhq/coin-framework/lib/api/types";
+import { createApi } from "./index";
+
+const logicGetTransactions = jest.fn();
+jest.mock("../logic", () => ({
+  listOperations: async () => {
+    return logicGetTransactions();
+  },
+}));
+
+const api = createApi({
+  baker: {
+    url: "https://baker.example.com",
+  },
+  explorer: {
+    url: "foo",
+    maxTxQuery: 1,
+  },
+  node: {
+    url: "bar",
+  },
+  fees: {
+    minGasLimit: 1,
+    minRevealGasLimit: 1,
+    minStorageLimit: 1,
+    minFees: 1,
+    minEstimatedFees: 2,
+  },
+});
+
+describe("get operations", () => {
+  afterEach(() => {
+    logicGetTransactions.mockClear();
+  });
+
+  it("could return no operation", async () => {
+    logicGetTransactions.mockResolvedValue([[], ""]);
+    const [operations, token] = await api.listOperations("addr", { minHeight: 100 });
+    expect(operations).toEqual([]);
+    expect(token).toEqual("");
+  });
+
+  const op: Operation = {
+    hash: "opHash",
+    address: "tz1...",
+    type: "transaction",
+    value: BigInt(1000),
+    fee: BigInt(100),
+    block: {
+      hash: "blockHash",
+      height: 123456,
+      time: new Date(),
+    },
+    senders: ["tz1Sender"],
+    recipients: ["tz1Recipient"],
+    date: new Date(),
+    transactionSequenceNumber: 1,
+  };
+
+  it("stops iterating after 10 iterations", async () => {
+    logicGetTransactions.mockResolvedValue([[op], "888"]);
+    const [operations, token] = await api.listOperations("addr", { minHeight: 100 });
+    expect(logicGetTransactions).toHaveBeenCalledTimes(10);
+    expect(operations.length).toBe(10);
+    expect(token).toEqual("888");
+  });
+});

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -1,5 +1,6 @@
 import {
   IncorrectTypeError,
+  Operation,
   Pagination,
   type Api,
   type Transaction as ApiTransaction,
@@ -16,6 +17,7 @@ import {
   rawEncode,
 } from "../logic";
 import api from "../network/tzkt";
+import { log } from "@ledgerhq/logs";
 
 export function createApi(config: TezosConfig): Api {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
@@ -65,7 +67,62 @@ async function estimate(addr: string, amount: bigint): Promise<bigint> {
   return estimatedFees.estimatedFees;
 }
 
-function operations(address: string, _pagination: Pagination) {
-  //TODO implement properly with https://github.com/LedgerHQ/ledger-live/pull/8875
-  return listOperations(address, {});
+type PaginationState = {
+  readonly pageSize: number;
+  readonly maxIterations: number; // a security to avoid infinite loop
+  currentIteration: number;
+  readonly minHeight: number;
+  continueIterations: boolean;
+  nextCursor?: string;
+  accumulator: Operation[];
+};
+
+async function fetchNextPage(address: string, state: PaginationState): Promise<PaginationState> {
+  const [operations, newNextCursor] = await listOperations(address, {
+    limit: state.pageSize,
+    token: state.nextCursor,
+    sort: "Ascending",
+    minHeight: state.minHeight,
+  });
+  const newCurrentIteration = state.currentIteration + 1;
+  let continueIteration = newNextCursor !== "";
+  if (newCurrentIteration >= state.maxIterations) {
+    log("coin:tezos", "(api/operations): max iterations reached", state.maxIterations);
+    continueIteration = false;
+  }
+  const accumulated = operations.concat(state.accumulator);
+  return {
+    ...state,
+    continueIterations: continueIteration,
+    currentIteration: newCurrentIteration,
+    nextCursor: newNextCursor,
+    accumulator: accumulated,
+  };
+}
+
+async function operationsFromHeight(
+  address: string,
+  start: number,
+): Promise<[Operation[], string]> {
+  const firstState: PaginationState = {
+    pageSize: 200,
+    maxIterations: 10,
+    currentIteration: 0,
+    minHeight: start,
+    continueIterations: true,
+    accumulator: [],
+  };
+
+  let state = await fetchNextPage(address, firstState);
+  while (state.continueIterations) {
+    state = await fetchNextPage(address, state);
+  }
+  return [state.accumulator, state.nextCursor || ""];
+}
+
+async function operations(
+  address: string,
+  { minHeight }: Pagination,
+): Promise<[Operation[], string]> {
+  return operationsFromHeight(address, minHeight);
 }

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -10,6 +10,11 @@ jest.mock("../network", () => ({
   },
 }));
 
+const options: { sort: "Ascending" | "Descending"; minHeight: number } = {
+  sort: "Ascending",
+  minHeight: 0,
+};
+
 describe("listOperations", () => {
   afterEach(() => {
     mockNetworkGetTransactions.mockClear();
@@ -19,7 +24,7 @@ describe("listOperations", () => {
     // Given
     mockNetworkGetTransactions.mockResolvedValue([]);
     // When
-    const [results, token] = await listOperations("any address", {});
+    const [results, token] = await listOperations("any address", options);
     // Then
     expect(results).toEqual([]);
     expect(token).toEqual("");
@@ -65,7 +70,7 @@ describe("listOperations", () => {
       // Given
       mockNetworkGetTransactions.mockResolvedValue([operation]);
       // When
-      const [results, token] = await listOperations("any address", {});
+      const [results, token] = await listOperations("any address", options);
       // Then
       expect(results.length).toEqual(1);
       expect(results[0].recipients).toEqual([someDestinationAddress]);
@@ -80,7 +85,7 @@ describe("listOperations", () => {
     // Given
     mockNetworkGetTransactions.mockResolvedValue([operation]);
     // When
-    const [results, token] = await listOperations("any address", {});
+    const [results, token] = await listOperations("any address", options);
     // Then
     expect(results.length).toEqual(1);
     expect(results[0].recipients).toEqual([]);
@@ -92,10 +97,18 @@ describe("listOperations", () => {
     const operation = { ...undelegate, sender: null };
     mockNetworkGetTransactions.mockResolvedValue([operation]);
     // When
-    const [results, token] = await listOperations("any address", {});
+    const [results, token] = await listOperations("any address", options);
     // Then
     expect(results.length).toEqual(1);
     expect(results[0].senders).toEqual([]);
     expect(token).toEqual(JSON.stringify(operation.id));
+  });
+
+  it("should order the results in descending order even if the sort option is set to ascending", async () => {
+    const op1 = { ...undelegate, level: "1" };
+    const op2 = { ...undelegate, level: "2" };
+    mockNetworkGetTransactions.mockResolvedValue([op1, op2]);
+    const [results, _] = await listOperations("any address", options);
+    expect(results.map(op => op.block.height)).toEqual(["2", "1"]);
   });
 });

--- a/libs/coin-modules/coin-tezos/src/network/types.ts
+++ b/libs/coin-modules/coin-tezos/src/network/types.ts
@@ -61,6 +61,16 @@ export type APIDelegationType = CommonOperationType & {
 export function isAPIDelegationType(op: APIOperation): op is APIDelegationType {
   return op.type === "delegation";
 }
+
+// https://api.tzkt.io/#operation/Accounts_GetOperations
+export type AccountsGetOperationsOptions = {
+  lastId?: number; // used as a pagination cursor to fetch more transactions
+  limit?: number;
+  sort?: "Descending" | "Ascending";
+  // the minimum height of the block the operation is in
+  "level.ge": number;
+};
+
 export type APIOperation =
   | APITransactionType
   | (CommonOperationType & {

--- a/libs/coin-modules/coin-tezos/src/network/tzkt.ts
+++ b/libs/coin-modules/coin-tezos/src/network/tzkt.ts
@@ -2,7 +2,7 @@ import URL from "url";
 import { log } from "@ledgerhq/logs";
 import network from "@ledgerhq/live-network";
 import coinConfig from "../config";
-import { APIAccount, APIBlock, APIOperation } from "./types";
+import { APIAccount, APIBlock, APIOperation, AccountsGetOperationsOptions } from "./types";
 
 const getExplorerUrl = () => coinConfig.getCoinConfig().explorer.url;
 
@@ -36,11 +36,7 @@ const api = {
   // https://api.tzkt.io/#operation/Accounts_GetOperations
   async getAccountOperations(
     address: string,
-    query: {
-      lastId?: number;
-      sort?: number;
-      limit?: number;
-    },
+    query: AccountsGetOperationsOptions,
   ): Promise<APIOperation[]> {
     // Remove undefined from query
     Object.entries(query).forEach(
@@ -56,10 +52,7 @@ const api = {
   },
 };
 
-const sortOperation = {
-  ascending: 0,
-  descending: 1,
-};
+// TODO this has same purpose as api/listOperations
 export const fetchAllTransactions = async (
   address: string,
   lastId?: number,
@@ -69,7 +62,8 @@ export const fetchAllTransactions = async (
   do {
     const newOps = await api.getAccountOperations(address, {
       lastId,
-      sort: sortOperation.ascending,
+      sort: "Ascending",
+      "level.ge": 0,
     });
     if (newOps.length === 0) return ops;
     ops = ops.concat(newOps);

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -44,10 +44,10 @@ async function estimate(_addr: string, _amount: bigint): Promise<bigint> {
 }
 
 type PaginationState = {
-  pageSize: number; // must be large enough to avoid unnecessary calls to the underlying explorer
-  maxIterations: number; // a security to avoid infinite loop
+  readonly pageSize: number; // must be large enough to avoid unnecessary calls to the underlying explorer
+  readonly maxIterations: number; // a security to avoid infinite loop
   currentIteration: number;
-  minHeight: number;
+  readonly minHeight: number;
   continueIterations: boolean;
   apiNextCursor?: string;
   accumulator: XrpOperation[];


### PR DESCRIPTION
Changes:
- the api retrieves operations from oldest to newest, bypassing explorer limit with iteration over pages 

integration tests: https://github.com/LedgerHQ/ledger-live/actions/runs/13366400373
integration tests (old): https://github.com/LedgerHQ/ledger-live/actions/runs/13200265887