### PR TITLE
feat: add explicit error message for LNS users swapping Cosmos [LIVE-16786]

### DIFF
--- a/.changeset/chilled-apes-begin.md
+++ b/.changeset/chilled-apes-begin.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: add explicit error message for LNS users swapping Cosmos

--- a/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
@@ -29,11 +29,11 @@ import CompleteExchange, {
   isCompleteExchangeData,
 } from "~/renderer/modals/Platform/Exchange/CompleteExchange/Body";
 import { ExchangeType } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import { getIncompatibleCurrencyKeys } from "@ledgerhq/live-common/exchange/swap/index";
 import { Exchange, isExchangeSwap } from "@ledgerhq/live-common/exchange/types";
 import { HardwareUpdate, renderLoading } from "./DeviceAction/rendering";
 import { createCustomErrorClass } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
-import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 
 const Divider = styled(Box)`
   border: 1px solid ${p => p.theme.colors.palette.divider};
@@ -64,51 +64,6 @@ export function isStartExchangeData(data: unknown): data is StartExchangeData {
 }
 
 const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
-
-type Keys = Record<string, { title: string; description: string }>;
-
-const INCOMPATIBLE_NANO_S_TOKENS_KEYS: Keys = {
-  solana: {
-    title: "swap.incompatibility.spl_tokens_title",
-    description: "swap.incompatibility.spl_tokens_description",
-  },
-};
-
-const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {
-  ton: {
-    title: "swap.incompatibility.ton_title",
-    description: "swap.incompatibility.ton_description",
-  },
-  cardano: {
-    title: "swap.incompatibility.ada_title",
-    description: "swap.incompatibility.ada_description",
-  },
-  aptos: {
-    title: "swap.incompatibility.apt_title",
-    description: "swap.incompatibility.apt_description",
-  },
-  near: {
-    title: "swap.incompatibility.near_title",
-    description: "swap.incompatibility.near_description",
-  },
-};
-const getIncompatibleCurrencyKeys = (exchange: ExchangeSwap) => {
-  const parentFrom =
-    (exchange?.fromAccount?.type === "TokenAccount" && exchange?.fromParentAccount?.currency?.id) ||
-    "";
-  const parentTo =
-    (exchange?.toAccount?.type === "TokenAccount" && exchange?.toParentAccount?.currency?.id) || "";
-  const from =
-    (exchange?.fromAccount.type === "Account" && exchange?.fromAccount?.currency?.id) || "";
-  const to = (exchange?.toAccount.type === "Account" && exchange?.toAccount?.currency?.id) || "";
-
-  return (
-    INCOMPATIBLE_NANO_S_TOKENS_KEYS[parentFrom] ||
-    INCOMPATIBLE_NANO_S_TOKENS_KEYS[parentTo] ||
-    INCOMPATIBLE_NANO_S_CURRENCY_KEYS[from] ||
-    INCOMPATIBLE_NANO_S_CURRENCY_KEYS[to]
-  );
-};
 
 export const LiveAppDrawer = () => {
   const [dismissDisclaimerChecked, setDismissDisclaimerChecked] = useState<boolean>(false);

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -454,7 +454,9 @@
       "ada_title": "Ledger Nano S™ does not support swapping Cardano",
       "ada_description": "To swap Cardano, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
       "apt_title": "Ledger Nano S™ does not support swapping Aptos",
-      "apt_description": "To swap Aptos, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
+      "apt_description": "To swap Aptos, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
+      "cosmos_title": "Ledger Nano S™ does not support swapping Cosmos",
+      "cosmos_description": "To swap Cosmos, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
     },
     "providers": {
       "title": "Choose a provider to swap crypto",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -3518,7 +3518,9 @@
         "ada_title": "Ledger Nano S™ does not support swapping Cardano",
         "ada_description": "To swap Cardano, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
         "apt_title": "Ledger Nano S™ does not support swapping Aptos",
-        "apt_description": "To swap Aptos, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
+        "apt_description": "To swap Aptos, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
+        "cosmos_title": "Ledger Nano S™ does not support swapping Cosmos",
+        "cosmos_description": "To swap Cosmos, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
       }
     },
     "lending": {

--- a/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/Form/Modal/Confirmation.tsx
@@ -23,7 +23,11 @@ import {
   SignedOperation,
 } from "@ledgerhq/types-live";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { postSwapAccepted, postSwapCancelled } from "@ledgerhq/live-common/exchange/swap/index";
+import {
+  getIncompatibleCurrencyKeys,
+  postSwapAccepted,
+  postSwapCancelled,
+} from "@ledgerhq/live-common/exchange/swap/index";
 import { InstalledItem } from "@ledgerhq/live-common/apps/types";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { HardwareUpdate, renderLoading } from "~/components/DeviceAction/rendering";
@@ -57,51 +61,6 @@ interface Props {
 }
 
 type NavigationProp = StackNavigatorNavigation<SwapNavigatorParamList>;
-type Keys = Record<string, { title: string; description: string }>;
-
-const INCOMPATIBLE_NANO_S_TOKENS_KEYS: Keys = {
-  solana: {
-    title: "transfer.swap2.incompatibility.spl_tokens_title",
-    description: "transfer.swap2.incompatibility.spl_tokens_description",
-  },
-};
-
-const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {
-  ton: {
-    title: "transfer.swap2.incompatibility.ton_title",
-    description: "transfer.swap2.incompatibility.ton_description",
-  },
-  cardano: {
-    title: "transfer.swap2.incompatibility.ada_title",
-    description: "transfer.swap2.incompatibility.ada_description",
-  },
-  aptos: {
-    title: "transfer.swap2.incompatibility.apt_title",
-    description: "transfer.swap2.incompatibility.apt_description",
-  },
-  near: {
-    title: "transfer.swap2.incompatibility.near_title",
-    description: "transfer.swap2.incompatibility.near_description",
-  },
-};
-
-const getIncompatibleCurrencyKeys = (exchange: ExchangeSwap) => {
-  const parentFrom =
-    (exchange?.fromAccount?.type === "TokenAccount" && exchange?.fromParentAccount?.currency?.id) ||
-    "";
-  const parentTo =
-    (exchange?.toAccount?.type === "TokenAccount" && exchange?.toParentAccount?.currency?.id) || "";
-  const from =
-    (exchange?.fromAccount.type === "Account" && exchange?.fromAccount?.currency?.id) || "";
-  const to = (exchange?.toAccount.type === "Account" && exchange?.toAccount?.currency?.id) || "";
-
-  return (
-    INCOMPATIBLE_NANO_S_TOKENS_KEYS[parentFrom] ||
-    INCOMPATIBLE_NANO_S_TOKENS_KEYS[parentTo] ||
-    INCOMPATIBLE_NANO_S_CURRENCY_KEYS[from] ||
-    INCOMPATIBLE_NANO_S_CURRENCY_KEYS[to]
-  );
-};
 
 export function Confirmation({
   swapTx: swapTxProp,

--- a/libs/ledger-live-common/src/exchange/swap/getIncompatibleCurrencyKeys.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getIncompatibleCurrencyKeys.ts
@@ -1,0 +1,75 @@
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { ExchangeSwap } from "./types";
+
+type Keys = Partial<Record<CryptoCurrency["id"], { title: string; description: string }>>;
+
+const INCOMPATIBLE_NANO_S_TOKENS_KEYS: Keys = {
+  solana: {
+    title: "swap.incompatibility.spl_tokens_title",
+    description: "swap.incompatibility.spl_tokens_description",
+  },
+  solana_testnet: {
+    title: "swap.incompatibility.spl_tokens_title",
+    description: "swap.incompatibility.spl_tokens_description",
+  },
+  solana_devnet: {
+    title: "swap.incompatibility.spl_tokens_title",
+    description: "swap.incompatibility.spl_tokens_description",
+  },
+};
+
+const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {
+  ton: {
+    title: "swap.incompatibility.ton_title",
+    description: "swap.incompatibility.ton_description",
+  },
+  cardano: {
+    title: "swap.incompatibility.ada_title",
+    description: "swap.incompatibility.ada_description",
+  },
+  cardano_testnet: {
+    title: "swap.incompatibility.ada_title",
+    description: "swap.incompatibility.ada_description",
+  },
+  aptos: {
+    title: "swap.incompatibility.apt_title",
+    description: "swap.incompatibility.apt_description",
+  },
+  aptos_testnet: {
+    title: "swap.incompatibility.apt_title",
+    description: "swap.incompatibility.apt_description",
+  },
+  near: {
+    title: "swap.incompatibility.near_title",
+    description: "swap.incompatibility.near_description",
+  },
+  cosmos: {
+    title: "swap.incompatibility.cosmos_title",
+    description: "swap.incompatibility.cosmos_description",
+  },
+  cosmos_testnet: {
+    title: "swap.incompatibility.cosmos_title",
+    description: "swap.incompatibility.cosmos_description",
+  },
+};
+
+export const getIncompatibleCurrencyKeys = (exchange: ExchangeSwap) => {
+  const parentFrom =
+    exchange.fromAccount.type === "TokenAccount"
+      ? INCOMPATIBLE_NANO_S_TOKENS_KEYS[exchange.fromAccount.token.parentCurrency.id]
+      : undefined;
+  const parentTo =
+    exchange.toAccount.type === "TokenAccount"
+      ? INCOMPATIBLE_NANO_S_TOKENS_KEYS[exchange.toAccount.token.parentCurrency.id]
+      : undefined;
+  const from =
+    exchange.fromAccount.type === "Account"
+      ? INCOMPATIBLE_NANO_S_CURRENCY_KEYS[exchange.fromAccount.currency.id]
+      : undefined;
+  const to =
+    exchange.toAccount.type === "Account"
+      ? INCOMPATIBLE_NANO_S_CURRENCY_KEYS[exchange.toAccount.currency.id]
+      : undefined;
+
+  return parentFrom || parentTo || from || to;
+};

--- a/libs/ledger-live-common/src/exchange/swap/index.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.ts
@@ -1,4 +1,5 @@
 import { getEnv } from "@ledgerhq/live-env";
+import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import {
   AccessDeniedError,
   CurrencyDisabledAsInputError,
@@ -22,6 +23,7 @@ import getExchangeRates from "./getExchangeRates";
 import { maybeTezosAccountUnrevealedAccount } from "./maybeTezosAccountUnrevealedAccount";
 import { maybeTronEmptyAccount } from "./maybeTronEmptyAccount";
 import { maybeKeepTronAccountAlive } from "./maybeKeepTronAccountAlive";
+import { ExchangeSwap } from "./types";
 
 export { getAvailableProviders } from "../providers";
 
@@ -134,6 +136,79 @@ export const getSwapAPIError = (errorCode: number, errorMessage?: string) => {
   return new Error(errorMessage);
 };
 
+type Keys = Partial<Record<CryptoCurrency["id"], { title: string; description: string }>>;
+
+const INCOMPATIBLE_NANO_S_TOKENS_KEYS: Keys = {
+  solana: {
+    title: "swap.incompatibility.spl_tokens_title",
+    description: "swap.incompatibility.spl_tokens_description",
+  },
+  solana_testnet: {
+    title: "swap.incompatibility.spl_tokens_title",
+    description: "swap.incompatibility.spl_tokens_description",
+  },
+  solana_devnet: {
+    title: "swap.incompatibility.spl_tokens_title",
+    description: "swap.incompatibility.spl_tokens_description",
+  },
+};
+
+const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {
+  ton: {
+    title: "swap.incompatibility.ton_title",
+    description: "swap.incompatibility.ton_description",
+  },
+  cardano: {
+    title: "swap.incompatibility.ada_title",
+    description: "swap.incompatibility.ada_description",
+  },
+  cardano_testnet: {
+    title: "swap.incompatibility.ada_title",
+    description: "swap.incompatibility.ada_description",
+  },
+  aptos: {
+    title: "swap.incompatibility.apt_title",
+    description: "swap.incompatibility.apt_description",
+  },
+  aptos_testnet: {
+    title: "swap.incompatibility.apt_title",
+    description: "swap.incompatibility.apt_description",
+  },
+  near: {
+    title: "swap.incompatibility.near_title",
+    description: "swap.incompatibility.near_description",
+  },
+  cosmos: {
+    title: "swap.incompatibility.cosmos_title",
+    description: "swap.incompatibility.cosmos_description",
+  },
+  cosmos_testnet: {
+    title: "swap.incompatibility.cosmos_title",
+    description: "swap.incompatibility.cosmos_description",
+  },
+};
+
+const getIncompatibleCurrencyKeys = (exchange: ExchangeSwap) => {
+  const parentFrom =
+    exchange.fromAccount.type === "TokenAccount"
+      ? INCOMPATIBLE_NANO_S_TOKENS_KEYS[exchange.fromAccount.token.parentCurrency.id]
+      : undefined;
+  const parentTo =
+    exchange.toAccount.type === "TokenAccount"
+      ? INCOMPATIBLE_NANO_S_TOKENS_KEYS[exchange.toAccount.token.parentCurrency.id]
+      : undefined;
+  const from =
+    exchange.fromAccount.type === "Account"
+      ? INCOMPATIBLE_NANO_S_CURRENCY_KEYS[exchange.fromAccount.currency.id]
+      : undefined;
+  const to =
+    exchange.toAccount.type === "Account"
+      ? INCOMPATIBLE_NANO_S_CURRENCY_KEYS[exchange.toAccount.currency.id]
+      : undefined;
+
+  return parentFrom || parentTo || from || to;
+};
+
 export {
   getSwapAPIBaseURL,
   getSwapUserIP,
@@ -148,4 +223,5 @@ export {
   initSwap,
   USStates,
   countries,
+  getIncompatibleCurrencyKeys,
 };

--- a/libs/ledger-live-common/src/exchange/swap/index.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.ts
@@ -1,5 +1,4 @@
 import { getEnv } from "@ledgerhq/live-env";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import {
   AccessDeniedError,
   CurrencyDisabledAsInputError,
@@ -23,7 +22,7 @@ import getExchangeRates from "./getExchangeRates";
 import { maybeTezosAccountUnrevealedAccount } from "./maybeTezosAccountUnrevealedAccount";
 import { maybeTronEmptyAccount } from "./maybeTronEmptyAccount";
 import { maybeKeepTronAccountAlive } from "./maybeKeepTronAccountAlive";
-import { ExchangeSwap } from "./types";
+import { getIncompatibleCurrencyKeys } from "./getIncompatibleCurrencyKeys";
 
 export { getAvailableProviders } from "../providers";
 
@@ -134,79 +133,6 @@ const swapBackendErrorCodes = {
 export const getSwapAPIError = (errorCode: number, errorMessage?: string) => {
   if (errorCode in swapBackendErrorCodes) return new swapBackendErrorCodes[errorCode](errorMessage);
   return new Error(errorMessage);
-};
-
-type Keys = Partial<Record<CryptoCurrency["id"], { title: string; description: string }>>;
-
-const INCOMPATIBLE_NANO_S_TOKENS_KEYS: Keys = {
-  solana: {
-    title: "swap.incompatibility.spl_tokens_title",
-    description: "swap.incompatibility.spl_tokens_description",
-  },
-  solana_testnet: {
-    title: "swap.incompatibility.spl_tokens_title",
-    description: "swap.incompatibility.spl_tokens_description",
-  },
-  solana_devnet: {
-    title: "swap.incompatibility.spl_tokens_title",
-    description: "swap.incompatibility.spl_tokens_description",
-  },
-};
-
-const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {
-  ton: {
-    title: "swap.incompatibility.ton_title",
-    description: "swap.incompatibility.ton_description",
-  },
-  cardano: {
-    title: "swap.incompatibility.ada_title",
-    description: "swap.incompatibility.ada_description",
-  },
-  cardano_testnet: {
-    title: "swap.incompatibility.ada_title",
-    description: "swap.incompatibility.ada_description",
-  },
-  aptos: {
-    title: "swap.incompatibility.apt_title",
-    description: "swap.incompatibility.apt_description",
-  },
-  aptos_testnet: {
-    title: "swap.incompatibility.apt_title",
-    description: "swap.incompatibility.apt_description",
-  },
-  near: {
-    title: "swap.incompatibility.near_title",
-    description: "swap.incompatibility.near_description",
-  },
-  cosmos: {
-    title: "swap.incompatibility.cosmos_title",
-    description: "swap.incompatibility.cosmos_description",
-  },
-  cosmos_testnet: {
-    title: "swap.incompatibility.cosmos_title",
-    description: "swap.incompatibility.cosmos_description",
-  },
-};
-
-const getIncompatibleCurrencyKeys = (exchange: ExchangeSwap) => {
-  const parentFrom =
-    exchange.fromAccount.type === "TokenAccount"
-      ? INCOMPATIBLE_NANO_S_TOKENS_KEYS[exchange.fromAccount.token.parentCurrency.id]
-      : undefined;
-  const parentTo =
-    exchange.toAccount.type === "TokenAccount"
-      ? INCOMPATIBLE_NANO_S_TOKENS_KEYS[exchange.toAccount.token.parentCurrency.id]
-      : undefined;
-  const from =
-    exchange.fromAccount.type === "Account"
-      ? INCOMPATIBLE_NANO_S_CURRENCY_KEYS[exchange.fromAccount.currency.id]
-      : undefined;
-  const to =
-    exchange.toAccount.type === "Account"
-      ? INCOMPATIBLE_NANO_S_CURRENCY_KEYS[exchange.toAccount.currency.id]
-      : undefined;
-
-  return parentFrom || parentTo || from || to;
 };
 
 export {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually as we don't usually e2e test messages like that
- [x] **Impact of the changes:** 
  - Swap live-app LNS

### 📝 Description

Add explicit error message for LNS users swapping Cosmos
Move the duplicated logic to common
I can avoid the multiple duplication in translated strings too IMO and use a param for the currency name instead

### ❓ Context

- **JIRA or GitHub link**: [LIVE-16786]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16786]: https://ledgerhq.atlassian.net/browse/LIVE-16786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ