### PR TITLE
:bug: fix(llm) accounts list wrong order with staked

### DIFF
--- a/.changeset/lucky-snakes-serve.md
+++ b/.changeset/lucky-snakes-serve.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": minor
+---
+
+Add a props to order by spendable or full balance

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -476,10 +476,11 @@ export const orderAccountsByFiatValue = (
   accounts: Account[] | TokenAccount[],
   counterValueState: CounterValuesState,
   to: Currency,
+  fullBalance: boolean = true,
 ) => {
   const accountsWithValue = accounts.map(account => {
     const value = calculate(counterValueState, {
-      value: account.spendableBalance.toNumber(),
+      value: (fullBalance ? account.balance : account.spendableBalance).toNumber(),
       from: getAccountCurrency(account),
       to,
       disableRounding: true,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - countervalues

### 📝 Description

Add a props to order the accounts by fullbalance or spendable balance. By default it's the full balance
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15501](https://ledgerhq.atlassian.net/browse/LIVE-15501)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15501]: https://ledgerhq.atlassian.net/browse/LIVE-15501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ