### PR TITLE
fix: legacy transaction support in rpc call of getFeeData [LIVE-15313]

### DIFF
--- a/.changeset/thick-apes-sleep.md
+++ b/.changeset/thick-apes-sleep.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix: legacy transaction support in rpc call of getFeeData

--- a/libs/coin-modules/coin-evm/src/api/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/api/node/rpc.common.ts
@@ -149,12 +149,12 @@ export const getGasEstimation: NodeApi["getGasEstimation"] = (account, transacti
 /**
  * Get an estimation of fees on the network
  */
-export const getFeeData: NodeApi["getFeeData"] = currency =>
+export const getFeeData: NodeApi["getFeeData"] = (currency, transaction) =>
   withApi(currency, async api => {
     const block = await api.getBlock("latest");
     const currencySupports1559 = getEnv("EVM_FORCE_LEGACY_TRANSACTIONS")
       ? false
-      : Boolean(block.baseFeePerGas);
+      : transaction.type === 2 && Boolean(block.baseFeePerGas);
 
     const feeData = await (async (): Promise<
       | {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**
  - send transaction using networks not supported by our explorer or where we use rpc calls directly (optimism or base for example) and where a dapp would use a legacy transaction (like paraswap does)

### 📝 Description

Fix legacy transaction support in rpc call of getFeeData

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15313]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
