### PR TITLE
:lipstick: (llm) add account polish

### DIFF
--- a/.changeset/four-pigs-bathe.md
+++ b/.changeset/four-pigs-bathe.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Polish ui of the add account v2 flow

--- a/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, IconsLegacy } from "@ledgerhq/native-ui";
+import { Button, Flex, Icons, IconsLegacy } from "@ledgerhq/native-ui";
 import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack";
 import React, { useCallback, useState } from "react";
@@ -40,7 +40,7 @@ export const NavigationHeaderCloseButton: React.FC<Props> = React.memo(({ onPres
       onPress={() => (onPress ? onPress() : navigation.popToTop())}
     >
       <Flex p={6}>
-        <IconsLegacy.CloseMedium size={24} color={color || "neutral.c100"} />
+        <Icons.Close color={color || "neutral.c100"} />
       </Flex>
     </Touchable>
   );

--- a/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectableAccountsList.tsx
@@ -9,6 +9,7 @@ import {
   StyleProp,
   ViewStyle,
   LayoutChangeEvent,
+  TextStyle,
 } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/currencies/index";
@@ -31,6 +32,8 @@ import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { BaseComposite, StackNavigatorProps } from "./RootNavigator/types/helpers";
 
 import useAnimatedStyle from "LLM/features/Accounts/screens/ScanDeviceAccounts/components/ScanDeviceAccountsFooter/useAnimatedStyle";
+import { useTheme } from "styled-components/native";
+import { TextVariants } from "@ledgerhq/native-ui/lib/styles/theme";
 
 const selectAllHitSlop = {
   top: 16,
@@ -59,6 +62,36 @@ type Props = FlexBoxProps & {
 type NavigationProps = BaseComposite<
   StackNavigatorProps<AccountSettingsNavigatorParamList, ScreenName.EditAccountName>
 >["navigation"];
+
+// This will need to be removed once isNetworkBasedAddAccountFlowEnabled is removed
+type SelectAllTextColorFn = (areAllSelected: boolean) => string;
+
+const getConditionalStyles = (isNetworkBasedAddAccountFlowEnabled?: boolean, space?: number[]) => ({
+  selectableAccount: {
+    marginTop: isNetworkBasedAddAccountFlowEnabled ? space?.[6] : 3,
+    marginX: 6,
+    paddingX: isNetworkBasedAddAccountFlowEnabled ? space?.[6] : 6,
+    paddingY: isNetworkBasedAddAccountFlowEnabled ? space?.[6] : 3,
+    columnGap: isNetworkBasedAddAccountFlowEnabled ? space?.[4] : 4,
+    borderRadius: isNetworkBasedAddAccountFlowEnabled ? space?.[4] : 4,
+    backgroundColor: isNetworkBasedAddAccountFlowEnabled ? "opacityDefault.c05" : "neutral.c30",
+  },
+  header: {
+    paddingX: isNetworkBasedAddAccountFlowEnabled ? 16 : 22,
+    paddingBottom: isNetworkBasedAddAccountFlowEnabled ? 0 : 8,
+  },
+  headerText: {
+    variant: isNetworkBasedAddAccountFlowEnabled ? "paragraph" : ("small" as TextVariants),
+    textTransform: (!isNetworkBasedAddAccountFlowEnabled
+      ? "uppercase"
+      : undefined) as TextStyle["textTransform"],
+  },
+  selectAllText: {
+    getColor: (isNetworkBasedAddAccountFlowEnabled
+      ? (areAllSelected: boolean) => (areAllSelected ? "neutral.c80" : "constant.purple")
+      : () => "neutral.c70") as SelectAllTextColorFn,
+  },
+});
 
 const SelectableAccountsList = ({
   accounts,
@@ -184,7 +217,8 @@ const SelectableAccount = ({
   useFullBalance,
 }: SelectableAccountProps) => {
   const [stopAnimation, setStopAnimation] = useState<boolean>(false);
-  const llmNetworkBasedAddAccountFlow = useFeature("llmNetworkBasedAddAccountFlow");
+  const isNetworkBasedAddAccountFlowEnabled = useFeature("llmNetworkBasedAddAccountFlow")?.enabled;
+  const { space } = useTheme();
 
   const swipeableRow = useRef<Swipeable>(null);
 
@@ -244,7 +278,7 @@ const SelectableAccount = ({
     if (!onAccountNameChange) return;
 
     swipedAccountSubject.next({ row: -1, list: -1 });
-    if (llmNetworkBasedAddAccountFlow?.enabled) {
+    if (isNetworkBasedAddAccountFlowEnabled) {
       navigation.navigate(NavigatorName.AccountSettings, {
         screen: ScreenName.EditAccountName,
         params: {
@@ -258,7 +292,7 @@ const SelectableAccount = ({
         account,
       });
     }
-  }, [account, navigation, onAccountNameChange, llmNetworkBasedAddAccountFlow?.enabled]);
+  }, [account, navigation, onAccountNameChange, isNetworkBasedAddAccountFlowEnabled]);
 
   const renderLeftActions = useCallback(
     (
@@ -291,34 +325,18 @@ const SelectableAccount = ({
   const subAccountCount = account.subAccounts && account.subAccounts.length;
   const isToken = listTokenTypesForCryptoCurrency(account.currency).length > 0;
   const { animatedSelectableAccount } = useAnimatedStyle();
+  const styles = getConditionalStyles(isNetworkBasedAddAccountFlowEnabled, space);
+
   const inner = (
     <Animated.View style={[animatedSelectableAccount]}>
       <Flex
-        marginTop={3}
-        marginBottom={3}
-        marginLeft={6}
-        marginRight={6}
-        paddingLeft={6}
-        paddingRight={6}
-        paddingTop={3}
-        paddingBottom={3}
+        {...styles.selectableAccount}
         flexDirection="row"
         alignItems="center"
-        borderRadius={4}
         opacity={isDisabled ? 0.4 : 1}
-        backgroundColor="neutral.c30"
       >
-        {llmNetworkBasedAddAccountFlow?.enabled ? (
-          <Flex
-            flex={1}
-            flexDirection="row"
-            height={56}
-            alignItems="center"
-            backgroundColor="neutral.c30"
-            borderRadius="12px"
-            padding="8px"
-            columnGap={8}
-          >
+        {isNetworkBasedAddAccountFlowEnabled ? (
+          <Flex flex={1} flexDirection="row" alignItems="center">
             <AccountItem
               account={account as Account}
               balance={useFullBalance ? account.balance : account.spendableBalance}
@@ -347,7 +365,7 @@ const SelectableAccount = ({
         )}
 
         {!isDisabled && (
-          <Flex marginLeft={4}>
+          <Flex marginLeft={isNetworkBasedAddAccountFlowEnabled ? 0 : 4}>
             <CheckBox onChange={handlePress} isChecked={!!isSelected} />
           </Flex>
         )}
@@ -386,20 +404,15 @@ type HeaderProps = {
 
 const Header = ({ text, areAllSelected, onSelectAll, onUnselectAll }: HeaderProps) => {
   const shouldDisplaySelectAll = !!onSelectAll && !!onUnselectAll;
-  const llmNetworkBasedAddAccountFlow = useFeature("llmNetworkBasedAddAccountFlow");
+  const llmNetworkBasedAddAccountFlowEnabled = useFeature("llmNetworkBasedAddAccountFlow")?.enabled;
+  const styles = getConditionalStyles(llmNetworkBasedAddAccountFlowEnabled);
 
   return (
-    <Flex
-      paddingX={llmNetworkBasedAddAccountFlow?.enabled ? 16 : 22}
-      flexDirection="row"
-      alignItems="center"
-      paddingBottom={llmNetworkBasedAddAccountFlow?.enabled ? 16 : 8}
-    >
+    <Flex {...styles.header} flexDirection="row" alignItems="center">
       <Text
+        {...styles.headerText}
         fontWeight="semiBold"
         flexShrink={1}
-        variant="small"
-        {...(!llmNetworkBasedAddAccountFlow?.enabled && { textTransform: "uppercase" })}
         color="neutral.c70"
         numberOfLines={1}
       >
@@ -413,7 +426,7 @@ const Header = ({ text, areAllSelected, onSelectAll, onUnselectAll }: HeaderProp
           >
             <Text
               fontSize={14}
-              color="neutral.c70"
+              color={styles.selectAllText.getColor(areAllSelected)}
               testID={`add-accounts-${areAllSelected ? "deselect" : "select"}-all`}
               numberOfLines={1}
             >

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/CustomHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/CustomHeader/index.tsx
@@ -12,17 +12,14 @@ type Props = {
 const CustomHeader = ({ onClose, backgroundColor, iconColor, title }: Props) => {
   return (
     <Flex
-      flexDirection="row"
+      flexDirection="column"
       width="100%"
       p={16}
       borderBottom={5}
-      borderBottomColor={"neutral.c30"}
+      borderBottomColor="neutral.c30"
+      rowGap={16}
       justifyContent="space-between"
-      alignItems="center"
     >
-      <Text fontSize="18px" fontWeight="semiBold" textTransform="none">
-        {title}
-      </Text>
       <Flex alignItems="flex-end">
         <TouchableOpacity onPress={onClose}>
           <Flex
@@ -36,6 +33,9 @@ const CustomHeader = ({ onClose, backgroundColor, iconColor, title }: Props) => 
           </Flex>
         </TouchableOpacity>
       </Flex>
+      <Text variant="h3Inter" fontSize={24}>
+        {title}
+      </Text>
     </Flex>
   );
 };

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountListDrawer/index.tsx
@@ -29,7 +29,7 @@ const AccountListDrawer = ({ isOpen, onClose, data, onPressAccount }: AccountLis
     ({ item: account }: ListRenderItemInfo<Account | TokenAccount>) => {
       return (
         <TouchableOpacity key={account.id} onPress={() => onPressAccount(account)}>
-          <Flex flexDirection="row" alignItems="center" padding={3} width={343}>
+          <Flex flexDirection="row" alignItems="center" padding={3}>
             <AccountItem account={account} balance={account.balance} showUnit />
           </Flex>
         </TouchableOpacity>
@@ -65,8 +65,8 @@ const AccountListDrawer = ({ isOpen, onClose, data, onPressAccount }: AccountLis
             renderItem={renderItem}
             keyExtractor={keyExtractor}
             showsVerticalScrollIndicator={false}
-            ItemSeparatorComponent={() => <View style={{ height: 16 }} />}
-            style={{ paddingHorizontal: 16 }}
+            ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+            style={{ width: "100%" }}
             ListEmptyComponent={<AccountListEmpty />}
           />
         </Flex>

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/CustomHeader/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/CustomHeader/index.tsx
@@ -18,7 +18,8 @@ const CustomHeader = ({ account, onClose, backgroundColor, iconColor }: Props) =
       width="100%"
       p={16}
       borderBottom={5}
-      borderBottomColor={"neutral.c30"}
+      borderBottomColor="opacityDefault.c10"
+      borderBottomWidth={1}
     >
       <AccountItem account={account} balance={account.balance} hideBalanceInfo />
       <Flex alignItems="flex-end">

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountQuickActionsDrawer/index.tsx
@@ -29,7 +29,7 @@ const AccountQuickActionsDrawer = ({
     accounts: account ? [account as Account] : [],
     currency,
   });
-  const { colors } = useTheme();
+  const { colors, space } = useTheme();
   const { analyticsMetadata } = useAnalytics(AnalyticContexts.AddAccounts);
   const pageTrackingEvent = analyticsMetadata.AddFunds?.onQuickActionOpen;
 
@@ -44,15 +44,15 @@ const AccountQuickActionsDrawer = ({
           <CustomHeader
             account={account}
             onClose={onClose}
-            backgroundColor={colors.opacityDefault.c10}
+            backgroundColor={colors.neutral.c30}
             iconColor={colors.neutral.c100}
           />
         )}
       >
-        <Flex width="100%" rowGap={6}>
-          {actions.map((button, index) => (
-            <Box mb={index === actions.length - 1 ? 0 : 8} key={button?.title as string}>
-              <TransferButton {...button} testID={button?.testID as string} />
+        <Flex width="100%" rowGap={space[8]} pb={space[8]}>
+          {actions.map(button => (
+            <Box key={button?.title}>
+              <TransferButton {...button} testID={button?.testID} />
             </Box>
           ))}
         </Flex>

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountSuccess/index.tsx
@@ -16,7 +16,6 @@ import type { BaseComposite, StackNavigatorProps } from "~/components/RootNaviga
 import AccountItem from "../../components/AccountsListView/components/AccountItem";
 import { AccountLikeEnhanced } from "../ScanDeviceAccounts/types";
 import { Account } from "@ledgerhq/types-live";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import SafeAreaView from "~/components/SafeAreaView";
 import Circle from "~/components/Circle";
 import { NetworkBasedAddAccountNavigator } from "../AddAccount/types";
@@ -33,9 +32,8 @@ type Props = BaseComposite<
 >;
 
 export default function AddAccountsSuccess({ route }: Props) {
-  const { colors } = useTheme();
+  const { colors, space } = useTheme();
   const { t } = useTranslation();
-  const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const { animatedSelectableAccount } = useAnimatedStyle();
   const { currency, accountsToAdd, onCloseNavigation, context } = route.params || {};
@@ -65,10 +63,10 @@ export default function AddAccountsSuccess({ route }: Props) {
           <Flex
             flexDirection="row"
             alignItems="center"
-            backgroundColor="neutral.c30"
-            borderRadius="12px"
-            padding="12px"
-            width={343}
+            borderRadius={space[4]}
+            padding={space[6]}
+            backgroundColor="opacityDefault.c05"
+            width="100%"
           >
             <AccountItem account={item as Account} balance={item.balance} />
             <Icons.ChevronRight size="M" color={colors.primary.c100} />
@@ -76,7 +74,7 @@ export default function AddAccountsSuccess({ route }: Props) {
         </TouchableOpacity>
       </Animated.View>
     ),
-    [colors.primary, goToAccounts, animatedSelectableAccount],
+    [animatedSelectableAccount, goToAccounts, space, colors.primary.c100],
   );
 
   const keyExtractor = useCallback((item: AccountLikeEnhanced) => item?.id, []);
@@ -84,16 +82,18 @@ export default function AddAccountsSuccess({ route }: Props) {
   const statusColor = colors.neutral.c100;
 
   return (
-    <SafeAreaView edges={["left", "right"]} isFlex>
+    <SafeAreaView edges={["left", "right", "bottom"]} isFlex>
       <TrackScreen category="AddAccounts" name="Success" currencyName={currency?.name} />
       <VerticalGradientBackground stopColor={getCurrencyColor(currency)} />
-      <Flex alignItems={"center"} style={styles.root}>
+      <Flex alignItems="center" style={styles.root} pt={space[7]}>
         <View style={[styles.iconWrapper, { backgroundColor: rgba(statusColor, 0.1) }]}>
           <Circle size={24}>
             <Icons.CheckmarkCircleFill size="L" color={statusColor} />
           </Circle>
         </View>
-        <Text style={styles.title}>{t("addAccounts.added", { count: accountsToAdd.length })}</Text>
+        <Text style={styles.title} textAlign="center" width="60%">
+          {t("addAccounts.added", { count: accountsToAdd.length })}
+        </Text>
       </Flex>
       <Flex flex={1} justifyContent="center" alignItems="center">
         <FlatList
@@ -102,11 +102,11 @@ export default function AddAccountsSuccess({ route }: Props) {
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           showsVerticalScrollIndicator={false}
-          ItemSeparatorComponent={() => <View style={{ height: 16 }} />}
-          style={{ paddingHorizontal: 16 }}
+          ItemSeparatorComponent={() => <View style={{ height: space[4] }} />}
+          style={{ paddingHorizontal: space[4], width: "100%" }}
         />
       </Flex>
-      <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
+      <Flex px={6} rowGap={6}>
         <AddFundsButton
           accounts={accountsToAdd}
           currency={currency}
@@ -130,7 +130,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   title: {
-    marginTop: 32,
+    marginTop: 16,
     fontSize: 24,
   },
   iconWrapper: {

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccountWarning/index.tsx
@@ -1,13 +1,12 @@
 import React, { useCallback } from "react";
 import { Flex, Icons, rgba, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
-import { Animated, StyleSheet, TouchableOpacity, View } from "react-native";
+import { Animated, StyleSheet, TouchableOpacity } from "react-native";
 import { useTheme } from "styled-components/native";
 import { NavigatorName, ScreenName } from "~/const";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import AccountItem from "../../components/AccountsListView/components/AccountItem";
 import { Account } from "@ledgerhq/types-live";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import SafeAreaView from "~/components/SafeAreaView";
 import Circle from "~/components/Circle";
 import { NetworkBasedAddAccountNavigator } from "../AddAccount/types";
@@ -23,9 +22,8 @@ type Props = BaseComposite<
 >;
 
 export default function AddAccountsWarning({ route }: Props) {
-  const { colors } = useTheme();
+  const { colors, space } = useTheme();
   const { t } = useTranslation();
-  const insets = useSafeAreaInsets();
   const navigation = useNavigation();
 
   const { animatedSelectableAccount } = useAnimatedStyle();
@@ -58,38 +56,33 @@ export default function AddAccountsWarning({ route }: Props) {
   }, [navigation]);
 
   return (
-    <SafeAreaView edges={["left", "right"]} isFlex>
+    <SafeAreaView edges={["left", "right", "bottom"]} isFlex>
       <VerticalGradientBackground stopColor={statusColor} />
-      <Flex alignItems={"center"} flex={1} style={styles.root}>
-        <View style={[styles.iconWrapper, { backgroundColor: rgba(statusColor, 0.1) }]}>
-          <Circle size={24}>
-            <Icons.WarningFill size="L" color={statusColor} />
-          </Circle>
-        </View>
-        <>
-          <Text style={styles.title}>
-            {t("addAccounts.addAccountsWarning.cantCreateAccount.title", {
-              accountName: emptyAccountName,
-            })}
-          </Text>
-
-          <Text style={styles.desc}>
-            {t("addAccounts.addAccountsWarning.cantCreateAccount.body", {
-              accountName: emptyAccountName,
-            })}
-          </Text>
-        </>
+      <Flex alignItems="center" pt={space[14]}>
+        <Circle size={24} bg={rgba(statusColor, 0.05)} style={styles.iconWrapper}>
+          <Icons.WarningFill size="L" color={statusColor} />
+        </Circle>
+        <Text style={styles.title}>
+          {t("addAccounts.addAccountsWarning.cantCreateAccount.title", {
+            accountName: emptyAccountName,
+          })}
+        </Text>
+        <Text style={styles.desc} variant="bodyLineHeight" color="neutral.c70">
+          {t("addAccounts.addAccountsWarning.cantCreateAccount.body", {
+            accountName: emptyAccountName,
+          })}
+        </Text>
       </Flex>
-      <Flex flex={1} p={6} flexDirection="row" justifyContent="center">
-        <Animated.View style={[animatedSelectableAccount]}>
+      <Flex flex={1} px={space[6]} flexDirection="row" justifyContent="center">
+        <Animated.View style={[{ width: "100%" }, animatedSelectableAccount]}>
           <TouchableOpacity onPress={goToAccounts(emptyAccount?.id as string)}>
             <Flex
               flexDirection="row"
               alignItems="center"
-              backgroundColor="neutral.c30"
-              borderRadius="12px"
-              padding="12px"
-              width={343}
+              borderRadius={space[4]}
+              padding={space[6]}
+              backgroundColor="opacityDefault.c05"
+              width="100%"
             >
               <AccountItem
                 account={emptyAccount as Account}
@@ -100,7 +93,7 @@ export default function AddAccountsWarning({ route }: Props) {
           </TouchableOpacity>
         </Animated.View>
       </Flex>
-      <Flex mb={insets.bottom + 2} px={6} rowGap={6}>
+      <Flex px={6} rowGap={6}>
         <AddFundsButton
           accounts={[emptyAccount as Account]}
           currency={currency}
@@ -117,14 +110,8 @@ export default function AddAccountsWarning({ route }: Props) {
 }
 
 const styles = StyleSheet.create({
-  root: {
-    paddingHorizontal: 20,
-    alignItems: "center",
-    justifyContent: "center",
-    marginTop: 50,
-  },
   title: {
-    marginTop: 32,
+    marginTop: 16,
     fontSize: 24,
     textAlign: "center",
     width: "100%",

--- a/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
+++ b/apps/ledger-live-mobile/src/screens/AddAccounts/03-Accounts.tsx
@@ -369,7 +369,7 @@ function AddAccountsAccounts({
                 emptyState={emptyTexts[id as keyof typeof emptyTexts]}
                 isDisabled={!selectable}
                 forceSelected={id === "existing"}
-                style={hasMultipleSchemes ? styles.smallMarginBottom : {}}
+                style={(hasMultipleSchemes ? styles.smallMarginBottom : {}, { flex: 1 })}
               />
               {hasMultipleSchemes ? (
                 <View style={styles.moreAddressTypesContainer}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - UI of add account flow

### 📝 Description

Polish of the add account flow UI + fix a old layout issue when an account wasn't created because of empty account on the old UI. I've added the video of the before to ensure that all is still working well even if it's not really relevant in the context
For some styles it can be a bit a mess because I'd to change the style depending of the ff
I've used space[] to ensure that we have the correct value in px and I am not sure why space[6] doesn't render the same as "16px" for borderRadius but 16px doesn't seem working well (not sure)

| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/98018b86-b739-49e0-af97-babad141a4bf|https://github.com/user-attachments/assets/b599b74a-b1a6-4c48-8199-c05835bb5846|

| Screen | Description |
|--------|-------------|
| <img src="https://github.com/user-attachments/assets/205262a6-9b69-4ac9-ad9b-c1d4d1b23a8a" width="200"/> | fund account drawer |
| <img src="https://github.com/user-attachments/assets/29e10219-efc0-417b-8d86-3438dd8177c9" width="200"/> | error screen because of an existing empty account |
| <img src="https://github.com/user-attachments/assets/fd93690b-f2f5-4815-b75a-08985b0dc042" width="200"/> | fund account quickActions drawer |
| <img src="https://github.com/user-attachments/assets/71e784f7-01e8-44ca-809b-b19b29bf4d50" width="200"/> | selectable accounts to add screen |
| <img src="https://github.com/user-attachments/assets/b6946ed2-519f-41b0-be1a-257d2c9ae50b" width="200"/> | list of accounts added screen |




Some different renders depending on the crypto added : 
![Simulator Screenshot - iPhone 15 Pro - 2025-02-10 at 17 18 09](https://github.com/user-attachments/assets/60dbb43a-cafe-41a3-9b11-d0bab1db8b52)

![Simulator Screenshot - iPhone 15 Pro - 2025-02-10 at 17 21 16](https://github.com/user-attachments/assets/ab37f66e-4993-4ec3-afb5-f80db94791b9)
![Simulator Screenshot - iPhone 15 Pro - 2025-02-10 at 17 22 42](https://github.com/user-attachments/assets/ddccca2c-36b8-4d04-a52b-3e681026e628)

for btc (multiple address types) 

https://github.com/user-attachments/assets/b4a67f32-534a-470e-b05e-245ddba18c05




### ❓ Context

- **JIRA or GitHub link**: [LIVE-16655](https://ledgerhq.atlassian.net/browse/LIVE-16655)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16655]: https://ledgerhq.atlassian.net/browse/LIVE-16655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ