### PR TITLE
Revert "skip build-and-test-pr if already run on this file set"

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -12,28 +12,11 @@ permissions:
   id-token: write
   contents: read
   pull-requests: write
-  actions: write
 
 jobs:
-  pre_job:
-    # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          # All of these options are optional, so you can remove them if you are happy with the defaults
-          concurrent_skipping: 'never'
-          skip_after_successful_duplicate: 'true'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
-
   determine-affected:
     name: "Turbo Affected"
-    needs: pre_job
-    if: ${{!github.event.pull_request.head.repo.fork && needs.pre_job.outputs.should_skip != 'true'}}
+    if: ${{!github.event.pull_request.head.repo.fork }}
     uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
     with:
       head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#9141

Wasn't able to add a test PR to the merge queue out-of-hours without a reviewer present.
Of course, I could skip the branch protections but as I have just learned, this would also have skipped the merge queue which is what I'm trying to test. Will have to be another night 😮‍💨