### PR TITLE
feat: add dropdown drawer menu for managing an Earn position

### DIFF
--- a/.changeset/gorgeous-teachers-tap.md
+++ b/.changeset/gorgeous-teachers-tap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add a new modal, that can be triggered from Earn, that shows a list of options to select from. These will re-direct the user to different dynamic links specified from Earn.

--- a/apps/ledger-live-mobile/src/actions/earn.ts
+++ b/apps/ledger-live-mobile/src/actions/earn.ts
@@ -1,7 +1,11 @@
 import { createAction } from "redux-actions";
 import { EarnActionTypes } from "./types";
-import type { EarnSetInfoModalPayload } from "./types";
+import type { EarnSetInfoModalPayload, EarnSetMenuModalPayload } from "./types";
 
-export const setEarnInfoModal = createAction<EarnSetInfoModalPayload>(
+export const makeSetEarnInfoModalAction = createAction<EarnSetInfoModalPayload>(
   EarnActionTypes.EARN_INFO_MODAL,
+);
+
+export const makeSetEarnMenuModalAction = createAction<EarnSetMenuModalPayload>(
+  EarnActionTypes.EARN_MENU_MODAL,
 );

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -491,11 +491,14 @@ export type SwapPayload = UpdateProvidersPayload | UpdateTransactionPayload | Up
 // === EARN ACTIONS ==
 export enum EarnActionTypes {
   EARN_INFO_MODAL = "EARN_INFO_MODAL",
+  EARN_MENU_MODAL = "EARN_MENU_MODAL",
 }
 
 export type EarnSetInfoModalPayload = EarnState["infoModal"] | undefined;
 
-export type EarnPayload = EarnSetInfoModalPayload;
+export type EarnSetMenuModalPayload = EarnState["menuModal"] | undefined;
+
+export type EarnPayload = EarnSetInfoModalPayload | EarnSetMenuModalPayload;
 
 // === PROTECT ACTIONS ===
 export enum ProtectActionTypes {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -14,6 +14,7 @@ import { EarnScreen } from "~/screens/PTX/Earn";
 import { shallowAccountsSelector } from "~/reducers/accounts";
 import { EarnInfoDrawer } from "~/screens/PTX/Earn/EarnInfoDrawer";
 import { useStakingDrawer } from "../Stake/useStakingDrawer";
+import { EarnMenuDrawer } from "~/screens/PTX/Earn/EarnMenuDrawer";
 
 const Stack = createStackNavigator<EarnLiveAppNavigatorParamList>();
 
@@ -120,6 +121,7 @@ const Earn = (props: NavigationProps) => {
         }}
       />
       <EarnInfoDrawer />
+      <EarnMenuDrawer />
     </>
   );
 };

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/EarnLiveAppNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/EarnLiveAppNavigator.ts
@@ -3,7 +3,7 @@ import { ScreenName } from "~/const";
 export type EarnLiveAppNavigatorParamList = {
   [ScreenName.Earn]: {
     accountId?: string;
-    action?: "get-funds" | "stake" | "stake-account" | "info-modal";
+    action?: "get-funds" | "stake" | "stake-account" | "info-modal" | "menu-modal";
     currencyId?: string;
     learnMore?: string;
     message?: string;

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -23,10 +23,11 @@ import { useGeneralTermsAccepted } from "~/logic/terms";
 import { Writeable } from "~/types/helpers";
 import { lightTheme, darkTheme, Theme } from "../colors";
 import { track } from "~/analytics";
-import { setEarnInfoModal } from "~/actions/earn";
+import { makeSetEarnInfoModalAction, makeSetEarnMenuModalAction } from "~/actions/earn";
 import { blockPasswordLock } from "../actions/appstate";
 import { useStorylyContext } from "~/components/StorylyStories/StorylyProvider";
 import { navigationIntegration } from "../sentry";
+import { OptionMetadata } from "~/reducers/types";
 const TRACKING_EVENT = "deeplink_clicked";
 
 const themes: {
@@ -597,10 +598,25 @@ export const DeeplinksProvider = ({
               const learnMoreLink = searchParams.get("learnMoreLink") ?? "";
 
               dispatch(
-                setEarnInfoModal({
+                makeSetEarnInfoModalAction({
                   message,
                   messageTitle,
                   learnMoreLink,
+                }),
+              );
+              return;
+            }
+            if (searchParams.get("action") === "menu-modal") {
+              const title = searchParams.get("title") ?? "";
+              const options = searchParams.get("options") ?? "";
+
+              dispatch(
+                makeSetEarnMenuModalAction({
+                  title,
+                  options: JSON.parse(options) as {
+                    label: string;
+                    metadata: OptionMetadata;
+                  }[],
                 }),
               );
               return;

--- a/apps/ledger-live-mobile/src/reducers/earn.ts
+++ b/apps/ledger-live-mobile/src/reducers/earn.ts
@@ -1,17 +1,27 @@
-import { handleActions } from "redux-actions";
 import type { Action, ReducerMap } from "redux-actions";
+import { handleActions } from "redux-actions";
 import { createSelector } from "reselect";
+import {
+  EarnActionTypes,
+  EarnPayload,
+  EarnSetInfoModalPayload,
+  EarnSetMenuModalPayload,
+} from "../actions/types";
 import type { EarnState, State } from "./types";
-import { EarnActionTypes, EarnPayload, EarnSetInfoModalPayload } from "../actions/types";
 
 export const INITIAL_STATE: EarnState = {
   infoModal: {},
+  menuModal: undefined,
 };
 
 const handlers: ReducerMap<EarnState, EarnPayload> = {
-  [EarnActionTypes.EARN_INFO_MODAL]: (state, action: Action<EarnSetInfoModalPayload>) => ({
+  [EarnActionTypes.EARN_INFO_MODAL]: (state, action): EarnState => ({
     ...state,
-    infoModal: action.payload || {},
+    infoModal: (action as Action<EarnSetInfoModalPayload>).payload ?? {},
+  }),
+  [EarnActionTypes.EARN_MENU_MODAL]: (state, action): EarnState => ({
+    ...state,
+    menuModal: (action as Action<EarnSetMenuModalPayload>).payload,
   }),
 };
 
@@ -24,4 +34,9 @@ export default handleActions<EarnState, EarnPayload>(handlers, INITIAL_STATE);
 export const earnInfoModalSelector = createSelector(
   storeSelector,
   (state: EarnState) => state.infoModal,
+);
+
+export const earnMenuModalSelector = createSelector(
+  storeSelector,
+  (state: EarnState) => state.menuModal,
 );

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -304,11 +304,17 @@ export type SwapStateType = {
 
 // === EARN STATE ===
 
+export type OptionMetadata = { button: string; live_app: string; flow: string; link?: string };
+
 export type EarnState = {
   infoModal: {
     message?: string;
     messageTitle?: string;
     learnMoreLink?: string;
+  };
+  menuModal?: {
+    title?: string;
+    options: { label: string; metadata: OptionMetadata }[];
   };
 };
 

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Linking } from "react-native";
 import { useDispatch, useSelector } from "react-redux";
 import { useTheme } from "styled-components/native";
-import { setEarnInfoModal } from "~/actions/earn";
+import { makeSetEarnInfoModalAction } from "~/actions/earn";
 import { Track } from "~/analytics";
 import Circle from "~/components/Circle";
 import QueuedDrawer from "~/components/QueuedDrawer";
@@ -18,7 +18,7 @@ export function EarnInfoDrawer() {
   const openModal = useCallback(() => setModalOpened(true), []);
 
   const closeModal = useCallback(async () => {
-    await dispatch(setEarnInfoModal({}));
+    await dispatch(makeSetEarnInfoModalAction(undefined));
     await setModalOpened(false);
   }, [dispatch]);
   const { message, messageTitle, learnMoreLink } = useSelector(earnInfoModalSelector);

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -16,7 +16,7 @@ export function EarnMenuDrawer() {
   const openModal = useCallback(() => setModalOpened(true), []);
   const modal = useSelector(earnMenuModalSelector);
 
-  const closeDrawer = useCallback(async () => {
+  const closeDrawer = useCallback(() => {
     setModalOpened(false);
     dispatch(makeSetEarnMenuModalAction(undefined));
   }, [dispatch]);
@@ -35,7 +35,7 @@ export function EarnMenuDrawer() {
             {modal?.title}
           </Text>
         ) : null}
-        <Flex rowGap={8}>
+        <Flex rowGap={16}>
           {modal?.options.map(({ label, metadata: { link, button, ...tracked } }) =>
             link ? (
               <OptionButton

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -37,7 +37,7 @@ export function EarnMenuDrawer() {
             {modal?.title}
           </Text>
         ) : null}
-        <Flex rowGap={6}>
+        <Flex rowGap={8}>
           {modal?.options.map(({ label, metadata: { link, button, ...tracked } }) =>
             link ? (
               <OptionButton
@@ -70,6 +70,7 @@ const OptionButton = styled(Button)<{
   justify-content: left;
   max-width: 100%;
   overflow: hidden;
+  padding: 16px;
   text-overflow: ellipsis;
   white-space: nowrap;
   &:active {

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, rgba, Text } from "@ledgerhq/native-ui";
+import { Button, Flex, Text } from "@ledgerhq/native-ui";
 import { Theme } from "@ledgerhq/native-ui/lib/styles/theme";
 import React, { useCallback, useEffect, useState } from "react";
 import { Linking } from "react-native";

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -27,8 +27,6 @@ export function EarnMenuDrawer() {
     }
   }, [openModal, modalOpened]);
 
-  // const { colors } = useTheme();
-
   return (
     <QueuedDrawer isRequestingToBeOpened={Boolean(modal)} onClose={closeDrawer}>
       <Flex rowGap={48}>
@@ -73,12 +71,8 @@ const OptionButton = styled(Button)<{
   padding: 16px;
   text-overflow: ellipsis;
   white-space: nowrap;
-  &:active {
-    box-shadow: 0 0 0 4px ${p => rgba(p.theme.colors.primary.c50, 0.4)};
-  }
   &:focus,
   &:hover {
-    box-shadow: 0 0 0 2px ${p => rgba(p.theme.colors.primary.c50, 0.4)};
     background-color: ${p => p.theme.colors.neutral.c50};
   }
 `;

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -1,0 +1,83 @@
+import { Button, Flex, rgba, Text } from "@ledgerhq/native-ui";
+import { Theme } from "@ledgerhq/native-ui/lib/styles/theme";
+import React, { useCallback, useEffect, useState } from "react";
+import { Linking } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components/native";
+import { makeSetEarnMenuModalAction } from "~/actions/earn";
+import { track } from "~/analytics";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { earnMenuModalSelector } from "~/reducers/earn";
+
+export function EarnMenuDrawer() {
+  const dispatch = useDispatch();
+  const [modalOpened, setModalOpened] = useState(false);
+
+  const openModal = useCallback(() => setModalOpened(true), []);
+  const modal = useSelector(earnMenuModalSelector);
+
+  const closeDrawer = useCallback(async () => {
+    setModalOpened(false);
+    dispatch(makeSetEarnMenuModalAction(undefined));
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!modalOpened) {
+      openModal();
+    }
+  }, [openModal, modalOpened]);
+
+  // const { colors } = useTheme();
+
+  return (
+    <QueuedDrawer isRequestingToBeOpened={Boolean(modal)} onClose={closeDrawer}>
+      <Flex rowGap={48}>
+        {modal?.title ? (
+          <Text variant="h4" fontFamily="Inter" textAlign="center" fontWeight="bold">
+            {modal?.title}
+          </Text>
+        ) : null}
+        <Flex rowGap={6}>
+          {modal?.options.map(({ label, metadata: { link, button, ...tracked } }) =>
+            link ? (
+              <OptionButton
+                key={label}
+                onPress={() => {
+                  Linking.openURL(link);
+                  track(button, tracked);
+                  closeDrawer();
+                }}
+              >
+                {label}
+              </OptionButton>
+            ) : null,
+          )}
+        </Flex>
+      </Flex>
+    </QueuedDrawer>
+  );
+}
+
+const OptionButton = styled(Button)<{
+  theme: Theme;
+}>`
+  color: ${p => p.theme.colors.neutral.c100};
+  background-color: ${p => p.theme.colors.neutral.c40};
+  border-color: transparent;
+  border-radius: 16px;
+  display: inline-flex;
+  font-weight: 600;
+  justify-content: left;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  &:active {
+    box-shadow: 0 0 0 4px ${p => rgba(p.theme.colors.primary.c50, 0.4)};
+  }
+  &:focus,
+  &:hover {
+    box-shadow: 0 0 0 2px ${p => rgba(p.theme.colors.primary.c50, 0.4)};
+    background-color: ${p => p.theme.colors.neutral.c50};
+  }
+`;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New modal component added.

### 📝 Description

Add a new modal, that can be triggered from Earn, that shows a list of options to select from. These will re-direct the user to different dynamic links specified from Earn.

After:

![Simulator Screenshot - iPhone 15 Pro - 2025-02-11 at 06 43 08](https://github.com/user-attachments/assets/bbd17b41-3c5c-44e3-a10b-b915700c9f97)

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15861](https://ledgerhq.atlassian.net/browse/LIVE-15861)
- **Design**: [Figma](https://www.figma.com/design/ZOf1hLXmO4BtdcEWP8XyKX/Stablecoin-integration?node-id=537-32658&t=io8NVNtxtUREorFb-4)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15861]: https://ledgerhq.atlassian.net/browse/LIVE-15861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ