### PR TITLE
fix(coin:tezos): compute operation fees

### DIFF
--- a/.changeset/tasty-eggs-retire.md
+++ b/.changeset/tasty-eggs-retire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": patch
+---
+
+Tesos tx fee is now the sum of storageFee + bakerFee + allocationFee

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -47,6 +47,9 @@ describe("listOperations", () => {
       address: someDestinationAddress,
     },
     newDelegate: null,
+    storageFee: 1,
+    bakerFee: 2,
+    allocationFee: 3,
   };
 
   const undelegate: APIDelegationType = {
@@ -90,6 +93,20 @@ describe("listOperations", () => {
     expect(results.length).toEqual(1);
     expect(results[0].recipients).toEqual([]);
     expect(token).toEqual(JSON.stringify(operation.id));
+  });
+
+  it.each([
+    { ...undelegate, storageFee: 1, bakerFee: 2, allocationFee: 3 },
+    { ...delegate, storageFee: 1, bakerFee: 2, allocationFee: 3 },
+    { ...transfer, storageFee: 1, bakerFee: 2, allocationFee: 3 },
+  ])("should compute the fees properly", async operation => {
+    // Given
+    mockNetworkGetTransactions.mockResolvedValue([operation]);
+    // When
+    const [results, _] = await listOperations("any address", options);
+    // Then
+    expect(results.length).toEqual(1);
+    expect(results[0].fee).toEqual(BigInt(6));
   });
 
   it("should return empty sender list when no sender can be found", async () => {

--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.ts
@@ -70,7 +70,7 @@ function convertOperation(
   address: string,
   operation: APITransactionType | APIDelegationType,
 ): Operation {
-  const { amount, hash, storageFee, sender, timestamp, type, counter } = operation;
+  const { amount, hash, sender, timestamp, type, counter } = operation;
 
   let targetAddress = undefined;
   if (isAPITransactionType(operation)) {
@@ -89,6 +89,11 @@ function convertOperation(
 
   const senders = sender?.address ? [sender.address] : [];
 
+  const fee =
+    BigInt(operation.storageFee ?? 0) +
+    BigInt(operation.bakerFee ?? 0) +
+    BigInt(operation.allocationFee ?? 0);
+
   return {
     // hash id defined nullable in the tzkt API, but I wonder when it would be null ?
     hash: hash ?? "",
@@ -96,7 +101,7 @@ function convertOperation(
     type: type,
     value: BigInt(amount),
     // storageFee for transaction is always present
-    fee: BigInt(storageFee ?? 0),
+    fee: fee,
     block: {
       hash: operation.block,
       height: operation.level,


### PR DESCRIPTION
Tezos tx fee is now the sum of storageFee + bakerFee + allocationFee
instead of just storageFee

tests: https://github.com/LedgerHQ/ledger-live/actions/runs/13541173128
