### PR TITLE
fix: add guardrails when mainAccount does not have nearResources

### DIFF
--- a/.changeset/real-guests-fly.md
+++ b/.changeset/real-guests-fly.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+add guardrail when nearResources is undefined

--- a/apps/ledger-live-desktop/src/renderer/families/near/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/near/AccountHeaderManageActions.ts
@@ -17,7 +17,7 @@ const AccountHeaderActions: NearFamily["accountHeaderManageActions"] = ({
   const mainAccount = getMainAccount(account, parentAccount);
   const { nearResources } = mainAccount;
   const stakingEnabled = canStake(mainAccount);
-  const hasStakingPositions = nearResources.stakingPositions.length > 0;
+  const hasStakingPositions = nearResources?.stakingPositions.length > 0;
 
   const onClick = useCallback(() => {
     if (!stakingEnabled) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Fixes the issues reported from Sentry

### 📝 Description

Adds a guardrail when `nearResources` from mainAccount is undefined, which will make`hasStakingPositions` falsy

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

[- **JIRA**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->](https://ledgerhq.atlassian.net/browse/LIVE-16957)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
