### PR TITLE
feat(LIVE-16730): enable Swap deeplinks on LLM

### DIFF
--- a/.changeset/empty-spies-rhyme.md
+++ b/.changeset/empty-spies-rhyme.md
@@ -1,5 +1,6 @@
 ---
 "live-mobile": minor
+"@ledgerhq/live-common": minor
 ---
 
 Support deeplinks for Swap in LLM

--- a/.changeset/empty-spies-rhyme.md
+++ b/.changeset/empty-spies-rhyme.md
@@ -1,6 +1,5 @@
 ---
 "live-mobile": minor
-"@ledgerhq/live-common": minor
 ---
 
 Support deeplinks for Swap in LLM

--- a/.changeset/empty-spies-rhyme.md
+++ b/.changeset/empty-spies-rhyme.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Support deeplinks for Swap in LLM

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -156,6 +156,7 @@
     "i18next": "20.6.1",
     "invariant": "2.2.4",
     "jotai": "2.10.1",
+    "jotai-scope": "0.7.3",
     "json-rpc-2.0": "0.2.19",
     "lodash": "4.17.21",
     "lottie-react-native": "6.7.0",

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -117,6 +117,7 @@ export type BaseNavigatorStackParamList = {
     defaultCurrencyId?: string;
     defaultTicker?: string;
     customDappURL?: string;
+    customDappUrl?: string;
     uri?: string;
     requestId?: string;
     sessionTopic?: string;

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/index.tsx
@@ -2,11 +2,13 @@ import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, SafeAreaView, BackHandler, Platform } from "react-native";
 import { useSelector } from "react-redux";
+import { ScopeProvider } from "jotai-scope";
 
 import { useNavigation } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
 import { CurrentAccountHistDB, safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { handlers as loggerHandlers } from "@ledgerhq/live-common/wallet-api/CustomLogger/server";
+import { currentAccountAtom } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { WebviewAPI, WebviewState } from "../Web3AppWebview/types";
 
 import { Web3AppWebview } from "../Web3AppWebview";
@@ -94,31 +96,33 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   }, [customACREHandlers, customPTXHandlers]);
 
   return (
-    <SafeAreaView style={[styles.root]}>
-      <Web3AppWebview
-        ref={webviewAPIRef}
-        manifest={manifest}
-        currentAccountHistDb={currentAccountHistDb}
-        inputs={inputs}
-        onStateChange={setWebviewState}
-        customHandlers={customHandlers}
-      />
-      <BottomBar
-        manifest={manifest}
-        currentAccountHistDb={currentAccountHistDb}
-        webviewAPIRef={webviewAPIRef}
-        webviewState={webviewState}
-      />
-      <InfoPanel
-        name={manifest.name}
-        icon={manifest.icon}
-        url={manifest.homepageUrl}
-        uri={webviewState.url.toString()}
-        description={manifest.content.description}
-        isOpened={isInfoPanelOpened}
-        setIsOpened={setIsInfoPanelOpened}
-      />
-    </SafeAreaView>
+    <ScopeProvider atoms={[currentAccountAtom]}>
+      <SafeAreaView style={[styles.root]}>
+        <Web3AppWebview
+          ref={webviewAPIRef}
+          manifest={manifest}
+          currentAccountHistDb={currentAccountHistDb}
+          inputs={inputs}
+          onStateChange={setWebviewState}
+          customHandlers={customHandlers}
+        />
+        <BottomBar
+          manifest={manifest}
+          currentAccountHistDb={currentAccountHistDb}
+          webviewAPIRef={webviewAPIRef}
+          webviewState={webviewState}
+        />
+        <InfoPanel
+          name={manifest.name}
+          icon={manifest.icon}
+          url={manifest.homepageUrl}
+          uri={webviewState.url.toString()}
+          description={manifest.content.description}
+          isOpened={isInfoPanelOpened}
+          setIsOpened={setIsInfoPanelOpened}
+        />
+      </SafeAreaView>
+    </ScopeProvider>
   );
 };
 

--- a/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
+++ b/apps/ledger-live-mobile/src/components/WebRecoverPlayer/index.tsx
@@ -2,9 +2,11 @@ import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { StyleSheet, SafeAreaView, BackHandler, Platform } from "react-native";
 import { useDispatch } from "react-redux";
+import { ScopeProvider } from "jotai-scope";
 
 import { useNavigation } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
+import { currentAccountAtom } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { WebviewAPI, WebviewState } from "../Web3AppWebview/types";
 
 import { Web3AppWebview } from "../Web3AppWebview";
@@ -100,24 +102,26 @@ const WebRecoverPlayer = ({ manifest, inputs }: Props) => {
   }, [handleBypassOnboarding, webviewState]);
 
   return (
-    <SafeAreaView style={[styles.root, { paddingTop: !headerShown ? extraStatusBarPadding : 0 }]}>
-      <Web3AppWebview
-        ref={webviewAPIRef}
-        manifest={manifest}
-        inputs={inputs}
-        onStateChange={setWebviewState}
-        allowsBackForwardNavigationGestures={false}
-      />
-      <InfoPanel
-        name={manifest.name}
-        icon={manifest.icon}
-        url={manifest.homepageUrl}
-        uri={webviewState.url.toString()}
-        description={manifest.content.description}
-        isOpened={isInfoPanelOpened}
-        setIsOpened={setIsInfoPanelOpened}
-      />
-    </SafeAreaView>
+    <ScopeProvider atoms={[currentAccountAtom]}>
+      <SafeAreaView style={[styles.root, { paddingTop: !headerShown ? extraStatusBarPadding : 0 }]}>
+        <Web3AppWebview
+          ref={webviewAPIRef}
+          manifest={manifest}
+          inputs={inputs}
+          onStateChange={setWebviewState}
+          allowsBackForwardNavigationGestures={false}
+        />
+        <InfoPanel
+          name={manifest.name}
+          icon={manifest.icon}
+          url={manifest.homepageUrl}
+          uri={webviewState.url.toString()}
+          description={manifest.content.description}
+          isOpened={isInfoPanelOpened}
+          setIsOpened={setIsInfoPanelOpened}
+        />
+      </SafeAreaView>
+    </ScopeProvider>
   );
 };
 

--- a/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Web3Player/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Web3Hub/screens/Web3HubApp/components/Web3Player/index.tsx
@@ -2,9 +2,11 @@ import React, { ComponentProps, useCallback, useEffect, useMemo, useRef, useStat
 import { StyleSheet, View, BackHandler, Platform } from "react-native";
 import { SharedValue } from "react-native-reanimated";
 import { useSelector } from "react-redux";
+import { ScopeProvider } from "jotai-scope";
 import { CurrentAccountHistDB, safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
 import { handlers as loggerHandlers } from "@ledgerhq/live-common/wallet-api/CustomLogger/server";
 import { AppManifest, WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import { currentAccountAtom } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { WebviewAPI, WebviewState } from "~/components/Web3AppWebview/types";
 import { Web3AppWebview } from "~/components/Web3AppWebview";
 import { useACRECustomHandlers } from "~/components/WebPlatformPlayer/CustomHandlers";
@@ -71,33 +73,35 @@ const WebPlatformPlayer = ({
   }, [customACREHandlers, customPTXHandlers]);
 
   return (
-    <View style={styles.root}>
-      <Web3AppWebview
-        ref={webviewAPIRef}
-        onScroll={onScroll}
-        manifest={manifest}
-        currentAccountHistDb={currentAccountHistDb}
-        inputs={inputs}
-        onStateChange={setWebviewState}
-        customHandlers={customHandlers}
-      />
-      <BottomBar
-        manifest={manifest}
-        currentAccountHistDb={currentAccountHistDb}
-        webviewAPIRef={webviewAPIRef}
-        webviewState={webviewState}
-        layoutY={layoutY}
-      />
-      <InfoPanel
-        name={manifest.name}
-        icon={manifest.icon}
-        url={manifest.homepageUrl}
-        uri={webviewState.url.toString()}
-        description={manifest.content.description}
-        isOpened={isInfoPanelOpened}
-        setIsOpened={setIsInfoPanelOpened}
-      />
-    </View>
+    <ScopeProvider atoms={[currentAccountAtom]}>
+      <View style={styles.root}>
+        <Web3AppWebview
+          ref={webviewAPIRef}
+          onScroll={onScroll}
+          manifest={manifest}
+          currentAccountHistDb={currentAccountHistDb}
+          inputs={inputs}
+          onStateChange={setWebviewState}
+          customHandlers={customHandlers}
+        />
+        <BottomBar
+          manifest={manifest}
+          currentAccountHistDb={currentAccountHistDb}
+          webviewAPIRef={webviewAPIRef}
+          webviewState={webviewState}
+          layoutY={layoutY}
+        />
+        <InfoPanel
+          name={manifest.name}
+          icon={manifest.icon}
+          url={manifest.homepageUrl}
+          uri={webviewState.url.toString()}
+          description={manifest.content.description}
+          isOpened={isInfoPanelOpened}
+          setIsOpened={setIsInfoPanelOpened}
+        />
+      </View>
+    </ScopeProvider>
   );
 };
 

--- a/apps/ledger-live-mobile/src/screens/Platform/LiveApp.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/LiveApp.tsx
@@ -21,7 +21,8 @@ type Props = StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.Platfor
 
 export function LiveApp({ route }: Props) {
   const { theme } = useTheme();
-  const { platform: appId, ...params } = route.params || {};
+  // For consistency with LLD, customDappUrl casing should be allowed for Swap
+  const { platform: appId, customDappURL, customDappUrl, ...params } = route.params || {};
   const { setParams } = useNavigation<Props["navigation"]>();
   const localManifest = useLocalLiveAppManifest(appId);
   const remoteManifest = useRemoteLiveAppManifest(appId);
@@ -35,22 +36,21 @@ export function LiveApp({ route }: Props) {
     });
   }, [manifest, setParams]);
 
-  // For consistency with LLD, customDappUrl casing should be allowed for Swap
-  const customDappUrl = params.customDappURL || params.customDappUrl;
+  const dappUrl = customDappURL || customDappUrl;
 
-  if (customDappUrl && manifest && manifest.params && "dappUrl" in manifest.params) {
+  if (dappUrl && manifest && manifest.params && "dappUrl" in manifest.params) {
     manifest = {
       ...manifest,
       params: {
         ...manifest.params,
-        dappUrl: customDappUrl,
+        dappUrl,
       },
     };
   }
-  if (customDappUrl && manifest && manifest.dapp) {
+  if (dappUrl && manifest && manifest.dapp) {
     manifest = {
       ...manifest,
-      url: customDappUrl,
+      url: dappUrl,
     };
   }
   return manifest ? (

--- a/apps/ledger-live-mobile/src/screens/Platform/LiveApp.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/LiveApp.tsx
@@ -21,7 +21,7 @@ type Props = StackNavigatorProps<BaseNavigatorStackParamList, ScreenName.Platfor
 
 export function LiveApp({ route }: Props) {
   const { theme } = useTheme();
-  const { platform: appId, customDappURL, ...params } = route.params || {};
+  const { platform: appId, ...params } = route.params || {};
   const { setParams } = useNavigation<Props["navigation"]>();
   const localManifest = useLocalLiveAppManifest(appId);
   const remoteManifest = useRemoteLiveAppManifest(appId);
@@ -35,19 +35,22 @@ export function LiveApp({ route }: Props) {
     });
   }, [manifest, setParams]);
 
-  if (route.params.customDappURL && manifest && manifest.params && "dappUrl" in manifest.params) {
+  // For consistency with LLD, customDappUrl casing should be allowed for Swap
+  const customDappUrl = params.customDappURL || params.customDappUrl;
+
+  if (customDappUrl && manifest && manifest.params && "dappUrl" in manifest.params) {
     manifest = {
       ...manifest,
       params: {
         ...manifest.params,
-        dappUrl: route.params.customDappURL,
+        dappUrl: customDappUrl,
       },
     };
   }
-  if (route.params.customDappURL && manifest && manifest.dapp) {
+  if (customDappUrl && manifest && manifest.dapp) {
     manifest = {
       ...manifest,
-      url: route.params.customDappURL,
+      url: customDappUrl,
     };
   }
   return manifest ? (

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
@@ -39,8 +39,8 @@ export function WebView({ manifest, setWebviewState }: Props) {
 
   // ScopeProvider required to prevent conflicts between Swap's Webview instance and deeplink instances
   return (
-    <Flex flex={1}>
-      <ScopeProvider atoms={[currentAccountAtom]}>
+    <ScopeProvider atoms={[currentAccountAtom]}>
+      <Flex flex={1}>
         <Web3AppWebview
           manifest={manifest}
           customHandlers={customHandlers}
@@ -60,7 +60,7 @@ export function WebView({ manifest, setWebviewState }: Props) {
             platform: "LLM", // need consitent format with LLD, Platform doesn't work
           }}
         />
-      </ScopeProvider>
-    </Flex>
+      </Flex>
+    </ScopeProvider>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
@@ -1,10 +1,12 @@
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { currentAccountAtom } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { Flex } from "@ledgerhq/native-ui";
 import React from "react";
 import { Platform } from "react-native";
 import { useSelector } from "react-redux";
 import { useTheme } from "styled-components/native";
+import { ScopeProvider } from "jotai-scope";
 import { Web3AppWebview } from "~/components/Web3AppWebview";
 import { WebviewState } from "~/components/Web3AppWebview/types";
 import { getCountryLocale } from "~/helpers/getStakeLabelLocaleBased";
@@ -35,27 +37,30 @@ export function WebView({ manifest, setWebviewState }: Props) {
   const devMode = exportSettings.developerModeEnabled.toString();
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
 
+  // ScopeProvider required to prevent conflicts between Swap's Webview instance and deeplink instances
   return (
     <Flex flex={1}>
-      <Web3AppWebview
-        manifest={manifest}
-        customHandlers={customHandlers}
-        onStateChange={setWebviewState}
-        inputs={{
-          swapApiBase: SWAP_API_BASE,
-          swapUserIp: SWAP_USER_IP,
-          devMode,
-          theme,
-          lang: language,
-          locale: language, // LLM doesn't support different locales. By doing this we don't have to have specific LLM/LLD logic in earn, and in future if LLM supports locales we will change this from `language` to `locale`
-          countryLocale,
-          currencyTicker,
-          lastSeenDevice: lastSeenDevice?.modelId,
-          discreetMode: discreet ? "true" : "false",
-          OS: Platform.OS,
-          platform: "LLM", // need consitent format with LLD, Platform doesn't work
-        }}
-      />
+      <ScopeProvider atoms={[currentAccountAtom]}>
+        <Web3AppWebview
+          manifest={manifest}
+          customHandlers={customHandlers}
+          onStateChange={setWebviewState}
+          inputs={{
+            swapApiBase: SWAP_API_BASE,
+            swapUserIp: SWAP_USER_IP,
+            devMode,
+            theme,
+            lang: language,
+            locale: language, // LLM doesn't support different locales. By doing this we don't have to have specific LLM/LLD logic in earn, and in future if LLM supports locales we will change this from `language` to `locale`
+            countryLocale,
+            currencyTicker,
+            lastSeenDevice: lastSeenDevice?.modelId,
+            discreetMode: discreet ? "true" : "false",
+            OS: Platform.OS,
+            platform: "LLM", // need consitent format with LLD, Platform doesn't work
+          }}
+        />
+      </ScopeProvider>
     </Flex>
   );
 }

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -107,6 +107,10 @@ function useDappAccountLogic({
   }, [currentAccount, accounts]);
 
   const firstAccountAvailable = useMemo(() => {
+    // Return an account for manifests with wildcard currencyIds
+    // Prevents infinite useEffect loop seen on Swap deep links
+    if (currencyIds.includes("**")) return accounts[0];
+
     const account = accounts.find(account => {
       if (account.type === "Account" && currencyIds.includes(account.currency.id)) {
         return account;

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -107,10 +107,6 @@ function useDappAccountLogic({
   }, [currentAccount, accounts]);
 
   const firstAccountAvailable = useMemo(() => {
-    // Return an account for manifests with wildcard currencyIds
-    // Prevents infinite useEffect loop seen on Swap deep links
-    if (currencyIds.includes("**")) return accounts[0];
-
     const account = accounts.find(account => {
       if (account.type === "Account" && currencyIds.includes(account.currency.id)) {
         return account;

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -107,6 +107,10 @@ function useDappAccountLogic({
   }, [currentAccount, accounts]);
 
   const firstAccountAvailable = useMemo(() => {
+    // Return an account for manifests with wildcard currencyIds
+    if (currencyIds.includes("**") && accounts.length)
+      return getParentAccount(accounts[0], accounts);
+
     const account = accounts.find(account => {
       if (account.type === "Account" && currencyIds.includes(account.currency.id)) {
         return account;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1097,6 +1097,9 @@ importers:
       jotai:
         specifier: 2.10.1
         version: 2.10.1(@types/react@18.2.73)(react@18.3.1)
+      jotai-scope:
+        specifier: 0.7.3
+        version: 0.7.3(jotai@2.10.1(@types/react@18.2.73)(react@18.3.1))
       json-rpc-2.0:
         specifier: 0.2.19
         version: 0.2.19
@@ -23654,6 +23657,12 @@ packages:
 
   join-component@1.1.0:
     resolution: {integrity: sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==}
+
+  jotai-scope@0.7.3:
+    resolution: {integrity: sha512-8MSlj62XwWE/AHXU0MKpNjvrl7ZBx38B4p/3474uayljrYIQEHgZDTTjTRZqvPeG/1H+4Owod7l0OTA4ztvA+g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      jotai: '>=2.9.3'
 
   jotai@2.10.1:
     resolution: {integrity: sha512-4FycO+BOTl2auLyF2Chvi6KTDqdsdDDtpaL/WHQMs8f3KS1E3loiUShQzAzFA/sMU5cJ0hz/RT1xum9YbG/zaA==}
@@ -56823,6 +56832,10 @@ snapshots:
       '@sideway/pinpoint': 2.0.0
 
   join-component@1.1.0: {}
+
+  jotai-scope@0.7.3(jotai@2.10.1(@types/react@18.2.73)(react@18.3.1)):
+    dependencies:
+      jotai: 2.10.1(@types/react@18.2.73)(react@18.3.1)
 
   jotai@2.10.1(@types/react@18.2.73)(react@18.3.1):
     optionalDependencies:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

To enable swap app LLM deeplinks, two problems needed to be fixed:
- an infinite useEffect loop within the useDappAccountLogic function
- the deeplink parameter has different casing on LLM (`customDappURL`) compared to LLD (`customDappUrl`) 

![Kapture 2025-02-17 at 10 14 12](https://github.com/user-attachments/assets/5c4c332f-f1b5-4eaa-8de3-d2d4fae3968e)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
[LIVE-16730](https://ledgerhq.atlassian.net/browse/LIVE-16730) Prevent infinite useEffect loop on Swap deeplinks 

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
