### PR TITLE
add coin-modules on affected files

### DIFF
--- a/.changeset/tasty-guests-suffer.md
+++ b/.changeset/tasty-guests-suffer.md
@@ -1,0 +1,5 @@
+---
+"@actions/live-common-affected": minor
+---
+
+add coin-modules on affected files

--- a/tools/actions/live-common-affected/build/main.js
+++ b/tools/actions/live-common-affected/build/main.js
@@ -18895,13 +18895,13 @@ function main(ref) {
       const list = [
         ...new Set(
           stdout.split("\n").map((line) => {
-            const m = line.match(/live-common\/src\/([^/]+)\/([^/]+)/);
+            const m = line.match(/(live-common\/src\/([^/]+)\/([^/]+))|(coin-modules\/([^/]+))/);
             if (m) {
-              const [, first, second] = m;
-              if (first === "families") {
-                return `${first}/${second}`;
+              const [first, second, third] = m;
+              if (second === "families") {
+                return `${second}/${third}`;
               } else {
-                return first;
+                return second || first;
               }
             }
           }).filter(Boolean)

--- a/tools/actions/live-common-affected/src/main.ts
+++ b/tools/actions/live-common-affected/src/main.ts
@@ -26,21 +26,22 @@ function main(ref: string) {
           stdout
             .split("\n")
             .map(line => {
-              const m = line.match(/live-common\/src\/([^/]+)\/([^/]+)/);
+              const m = line.match(/(live-common\/src\/([^/]+)\/([^/]+))|(coin-modules\/([^/]+))/);
               if (m) {
-                const [, first, second] = m;
-                if (first === "families") {
+                const [first, second, third] = m;
+                if (second === "families") {
                   // in case of coin implementations, we will stop at the coin family level
-                  return `${first}/${second}`;
+                  return `${second}/${third}`;
                 } else {
-                  // in any other case, we consider the first src/* folder level to be relevant filter
-                  return first;
+                  // in any other case, we consider the second src/* folder level to be relevant filter
+                  return second || first;
                 }
               }
             })
             .filter(Boolean),
         ),
       ];
+
       core.setOutput("is-affected", String(list.length > 0));
       core.setOutput("paths", list.join(" "));
       if (list.length > 0) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
