### PR TITLE
turbo caching for iOS E2E tests

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -61,7 +61,7 @@ jobs:
     # needs: determine-affected
     # if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
     if: true
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-reusable.yml@support/turbo-e2e-ios
     secrets: inherit
 
   # Tests

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -14,77 +14,86 @@ permissions:
   pull-requests: write
 
 jobs:
-  determine-affected:
-    name: "Turbo Affected"
-    if: ${{!github.event.pull_request.head.repo.fork }}
-    uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
-    with:
-      head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
-      base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+  # determine-affected:
+  #   name: "Turbo Affected"
+  #   if: ${{!github.event.pull_request.head.repo.fork }}
+  #   uses: LedgerHQ/ledger-live/.github/workflows/turbo-affected-reusable.yml@develop
+  #   with:
+  #     head_branch: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
+  #     base_branch: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
 
   # LLD
   build-desktop:
     name: "Build Desktop"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork }}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork }}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/build-desktop-reusable.yml@develop
     secrets: inherit
 
   test-desktop:
     name: "Test Desktop"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
     secrets: inherit
 
   # LLM
   build-mobile:
     name: "Build Mobile"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/build-mobile-reusable.yml@develop
     secrets: inherit
 
   test-mobile:
     name: "Test Mobile"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
     secrets: inherit
 
   test-mobile-e2e:
     name: "Test Mobile E2E"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    if: true
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-reusable.yml@develop
     secrets: inherit
 
   # Tests
   test-libraries:
     name: "Test Libraries"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'libs') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'libs') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop
     secrets: inherit
 
   test-design-system:
     name: "Test Design System"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'libs/ui') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'libs/ui') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/test-design-system-reusable.yml@develop
     secrets: inherit
 
   build-web-tools:
     name: "Build Web Tools"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'apps/web-tools') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'apps/web-tools') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/build-web-tools-reusable.yml@develop
     secrets: inherit
 
   test-cli:
     name: "Test CLI"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'apps/cli') && !github.event.pull_request.head.repo.fork}}
+    # needs: determine-affected
+    # if: ${{contains(needs.determine-affected.outputs.paths, 'apps/cli') && !github.event.pull_request.head.repo.fork}}
+    if: false
     uses: LedgerHQ/ledger-live/.github/workflows/test-cli-reusable.yml@develop
     secrets: inherit
 

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -148,7 +148,8 @@ jobs:
       - name: Test iOS app
         id: detox
         timeout-minutes: 75
-        run: pnpm mobile e2e:ci -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
+          # run: pnpm mobile e2e:ci -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
+        run: pnpm test-e2e:llm:ios
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -149,7 +149,7 @@ jobs:
         id: detox
         timeout-minutes: 75
           # run: pnpm mobile e2e:ci -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
-        run: pnpm test-e2e:llm:ios
+        run: pnpm test-e2e:llm:ios --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -148,8 +148,7 @@ jobs:
       - name: Test iOS app
         id: detox
         timeout-minutes: 75
-          # run: pnpm mobile e2e:ci -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
-        run: pnpm test-e2e:llm:ios --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
+        run: pnpm test:llm:ios:e2e --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -167,7 +167,8 @@ jobs:
   allure-report-ios:
     name: "Allure Reports Export on Server"
     runs-on: [ledger-live-medium]
-    if: ${{ !inputs.speculos_tests && (inputs.slack_notif || github.event_name == 'push') }}
+    # if: ${{ !inputs.speculos_tests && (inputs.slack_notif || github.event_name == 'push') }}
+    if: false
     needs: [detox-tests-ios]
     outputs:
       report-url: ${{ steps.upload.outputs.report-url }}
@@ -194,6 +195,7 @@ jobs:
 
   detox-tests-android:
     name: "Ledger Live Mobile - Android Detox Tests"
+    if: false
     runs-on: [ledger-live-linux-8CPU-32RAM]
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
@@ -342,7 +344,8 @@ jobs:
   allure-report-android:
     name: "Allure Reports Export on Server"
     runs-on: [ledger-live-medium]
-    if: ${{ always() && (inputs.slack_notif || github.event_name == 'push' || github.event_name == 'schedule') }}
+    # if: ${{ always() && (inputs.slack_notif || github.event_name == 'push' || github.event_name == 'schedule') }}
+    if: false
     outputs:
       report-url: ${{ steps.upload.outputs.report-url }}
       result: ${{ steps.summary.outputs.test_result }}
@@ -449,7 +452,8 @@ jobs:
   report-on-slack:
     runs-on: ubuntu-22.04
     needs: [allure-report-android, allure-report-ios]
-    if: ${{ (failure() && github.event_name == 'push') || (always() && (inputs.slack_notif || github.event_name == 'schedule')) }}
+    # if: ${{ (failure() && github.event_name == 'push') || (always() && (inputs.slack_notif || github.event_name == 'schedule')) }}
+    if: false
     env:
       IOS_STATUS: ${{ needs.allure-report-ios.outputs.status }}
       IOS_REPORT_URL: ${{ needs.allure-report-ios.outputs.report-url }}

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -20,6 +20,7 @@
     "e2e:build": "pnpm detox build",
     "e2e:ci": "zx ./scripts/e2e-ci.mjs",
     "e2e:test": "export MOCK=1 && pnpm detox test",
+    "e2e:test-with-turbo": "export MOCK=1 && pnpm detox test -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --forceExit --headless --retries 1 --runInBand --cleanup",
     "e2e:test:speculos": "export MOCK=0 && pnpm detox test --testMatch \"$(pwd)/e2e/specs/speculos/{,**/,**/**/,**/**/**/}*.spec.ts\" --testTimeout=300000",
     "prebeta": "bundle install",
     "debug:detox": "pnpm detox test -c ios.manual currencies.spec.ts",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -20,7 +20,7 @@
     "e2e:build": "pnpm detox build",
     "e2e:ci": "zx ./scripts/e2e-ci.mjs",
     "e2e:test": "export MOCK=1 && pnpm detox test",
-    "e2e:test-with-turbo": "export MOCK=1 && pnpm detox test -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --forceExit --headless --retries 1 --runInBand --cleanup",
+    "e2e:test:ios": "export MOCK=1 && pnpm detox test -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --forceExit --headless --retries 1 --runInBand --cleanup",
     "e2e:test:speculos": "export MOCK=0 && pnpm detox test --testMatch \"$(pwd)/e2e/specs/speculos/{,**/,**/**/,**/**/**/}*.spec.ts\" --testTimeout=300000",
     "prebeta": "bundle install",
     "debug:detox": "pnpm detox test -c ios.manual currencies.spec.ts",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
-    "test-e2e:llm:ios": "pnpm turbo e2e:test-with-turbo --filter=live-mobile",
+    "test:llm:ios:e2e": "pnpm turbo e2e:test-with-turbo --filter=live-mobile",
     "test": "pnpm turbo test --concurrency=50%",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
-    "test-e2e:llm:ios": "pnpm turbo e2e:test --filter=live-mobile -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --forceExit --headless --retries 1 --runInBand --cleanup`;",
+    "test-e2e:llm:ios": "pnpm turbo e2e:test-with-turbo --filter=live-mobile",
     "test": "pnpm turbo test --concurrency=50%",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
+    "test-e2e:llm:ios": "pnpm turbo e2e:test --filter=live-mobile -c ios.sim.release --loglevel error --record-logs all --take-screenshots all --forceExit --headless --retries 1 --runInBand --cleanup`;",
     "test": "pnpm turbo test --concurrency=50%",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",

--- a/turbo.json
+++ b/turbo.json
@@ -190,11 +190,10 @@
       "dependsOn": ["build"],
       "env": ["CI_OS"]
     },
-    "live-mobile#e2e:test-with-turbo": {
+    "live-mobile#e2e:test:ios": {
       "cache": true,
-      "outputs": [".detox-artifacts/junit.xml"],
-      "dependsOn": [],
-      "inputs": ["src/**/*.ts", "e2e/**/*.test.js", "package.json", "pnpm-lock.yaml"]
+      "dependsOn": ["^build"],
+      "inputs": []
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -190,7 +190,7 @@
       "dependsOn": ["build"],
       "env": ["CI_OS"]
     },
-    "live-mobile#e2e:test": {
+    "live-mobile#e2e:test-with-turbo": {
       "cache": true,
       "outputs": [".detox-artifacts/junit.xml"],
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -189,6 +189,12 @@
       "outputs": [],
       "dependsOn": ["build"],
       "env": ["CI_OS"]
+    },
+    "live-mobile#e2e:test": {
+      "cache": true,
+      "outputs": [".detox-artifacts/junit.xml"],
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "e2e/**/*.test.js", "package.json", "pnpm-lock.yaml"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -193,7 +193,7 @@
     "live-mobile#e2e:test-with-turbo": {
       "cache": true,
       "outputs": [".detox-artifacts/junit.xml"],
-      "dependsOn": ["^build"],
+      "dependsOn": [],
       "inputs": ["src/**/*.ts", "e2e/**/*.test.js", "package.json", "pnpm-lock.yaml"]
     }
   }


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-16986)

WIP for adding turbo caching for iOS E2E tests.

[As mentioned in the ticket](https://ledgerhq.atlassian.net/browse/LIVE-16986?focusedCommentId=521951) the iOS E2E tests already has some caching implemented, for the iOS build. This is not implemented via turbo though - separate caching mechanism. For now this PR won't cover the refactor we should make to unify the caching approach.