### PR TITLE
ci: Revert test libs to self hosting

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -27,7 +27,7 @@ jobs:
       FORCE_COLOR: 3
       CI_OS: ubuntu-22.04
 
-    runs-on: [ubuntu-latest]
+    runs-on: [ledger-live-4xlarge]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Moving library tests back to self hosted runners following resource management updates to deal with high CPU/memory 

Passing test: https://github.com/LedgerHQ/ledger-live/actions/runs/13308587669/job/37165178308