### PR TITLE
ci: Adjust concurrency to 25% to avoid memory issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
-    "test": "pnpm turbo test --concurrency=50%",
+    "test": "pnpm turbo test --concurrency=25%",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",
     "lint:fix": "pnpm turbo lint:fix",


### PR DESCRIPTION
Reducing memory pressure on runners during test to avoid inside-container flakes (such as https://github.com/LedgerHQ/ledger-live/actions/runs/13310399962/job/37171255396)