### PR TITLE
ci: Move iOS PR builds to Linux due to limited macOS runners

### DIFF
--- a/.github/workflows/build-mobile-reusable.yml
+++ b/.github/workflows/build-mobile-reusable.yml
@@ -82,7 +82,7 @@ jobs:
           path: ${{ github.workspace }}/apps/ledger-live-mobile/android/app/build/outputs/apk/stagingRelease
 
   build-mobile-app-ios:
-    runs-on: [ledger-live-medium]
+    runs-on: [ledger-live-large]
     name: "Build LLM | iOS"
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"

--- a/.github/workflows/build-mobile-reusable.yml
+++ b/.github/workflows/build-mobile-reusable.yml
@@ -82,7 +82,7 @@ jobs:
           path: ${{ github.workspace }}/apps/ledger-live-mobile/android/app/build/outputs/apk/stagingRelease
 
   build-mobile-app-ios:
-    runs-on: [ledger-live-large]
+    runs-on: [ledger-live-4xlarge]
     name: "Build LLM | iOS"
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"

--- a/.github/workflows/build-mobile-reusable.yml
+++ b/.github/workflows/build-mobile-reusable.yml
@@ -82,7 +82,7 @@ jobs:
           path: ${{ github.workspace }}/apps/ledger-live-mobile/android/app/build/outputs/apk/stagingRelease
 
   build-mobile-app-ios:
-    runs-on: [m1, ARM64]
+    runs-on: [ledger-live-medium]
     name: "Build LLM | iOS"
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"


### PR DESCRIPTION
Move JS bundle builds on PR to linux due to increased scaling flexability