### PR TITLE
LIVE-15869: Earn eth staking modal text issues if ll in some languages

### DIFF
--- a/.changeset/wicked-doors-search.md
+++ b/.changeset/wicked-doors-search.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix staking modal text overlap when too many words

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/component/ProviderItem.tsx
@@ -87,13 +87,13 @@ export const ProviderItem = ({ provider, stakeOnClick }: Props) => {
     <Container
       alignItems="center"
       borderRadius={2}
-      columnGap={4}
+      columnGap={3}
       data-testid={`stake-provider-container-${provider.id}`}
       onClick={handleClick}
       p={3}
     >
       <StakingIcon icon={provider.icon} />
-      <Flex alignItems="flex-start" flex={2} flexDirection="column">
+      <Flex alignItems="flex-start" flex={1} flexDirection="column">
         <Text variant="bodyLineHeight" fontSize={14} fontWeight="semiBold" mr={2}>
           {displayName}
         </Text>
@@ -107,8 +107,14 @@ export const ProviderItem = ({ provider, stakeOnClick }: Props) => {
               : t("ethereum.stake.noMinimum")}
         </Text>
       </Flex>
-      <Flex flex={1} flexWrap="wrap" justifyContent="right">
-        <Text variant="paragraph" fontSize={13} color="neutral.c70" textAlign="right">
+      <Flex flex={1.1} flexWrap="wrap" justifyContent="right">
+        <Text
+          variant="paragraph"
+          fontSize={13}
+          color="neutral.c70"
+          textAlign="right"
+          width={"100%"}
+        >
           {t(`ethereum.stake.rewardsStrategy.${provider.rewardsStrategy}`)}
         </Text>
       </Flex>

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -95,7 +95,7 @@ export const StakeModal = ({ account, source }: Props) => {
           flex={1}
           flexDirection="column"
           height="100%"
-          px={3}
+          px={2}
         >
           <Header p={3} pt={5} pb={0} width="100%" position="relative" isScrollable={isScrollable}>
             <Flex flexDirection="column" alignItems="center">


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Visualisation of text

### 📝 Description

Fix staking modal text overlap when too many words

Before:

<img width="516" alt="Screenshot 2025-02-13 at 18 34 37" src="https://github.com/user-attachments/assets/04a00a49-f44d-496a-ac65-bc39b6b81391" />

After:

<img width="520" alt="Screenshot 2025-02-13 at 18 34 07" src="https://github.com/user-attachments/assets/ef3a97c6-0113-471d-b978-c32f8617fa2a" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15869](https://ledgerhq.atlassian.net/browse/LIVE-15869)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15869]: https://ledgerhq.atlassian.net/browse/LIVE-15869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ