### PR TITLE
ci: Limit max workers in gradle builds

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -481,6 +481,7 @@ platform :android do
           "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASS"],
           "android.injected.signing.key.alias" => ENV["ANDROID_KEY_ALIAS"],
           "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASS"],
+          "org.gradle.workers.max" => 13
         },
         project_dir: 'android/'
       )


### PR DESCRIPTION
Manually setting number of Gradle workers to ensure jobs complete successfully within CI