### PR TITLE
ci: adjust concurrency to 1 fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
-    "test": "pnpm turbo test --concurrency=4",
+    "test": "pnpm turbo test --concurrency=1",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",
     "lint:fix": "pnpm turbo lint:fix",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
-    "test": "pnpm turbo test --concurrency=25%",
+    "test": "pnpm turbo test --concurrency=10",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",
     "lint:fix": "pnpm turbo lint:fix",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pre:lld": "pnpm turbo pre-build --filter=ledger-live-desktop",
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
-    "test": "pnpm turbo test --concurrency=10",
+    "test": "pnpm turbo test --concurrency=4",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",
     "lint:fix": "pnpm turbo lint:fix",


### PR DESCRIPTION
Reducing the concurrency of turbo to 1 due to parallelism in jest eating up resources

This PR's run show a run with caching enabled

The issue is a bi-product of reducing resource allocation to prevent runner crashes https://ledgerhq.atlassian.net/browse/LIVE-16834