### PR TITLE
ci: Adjust gradle concurrency

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -481,9 +481,9 @@ platform :android do
           "android.injected.signing.store.password" => ENV["ANDROID_KEYSTORE_PASS"],
           "android.injected.signing.key.alias" => ENV["ANDROID_KEY_ALIAS"],
           "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASS"],
-          "org.gradle.workers.max" => 13
         },
-        project_dir: 'android/'
+        project_dir: 'android/',
+        flags: ' -Dorg.gradle.workers.max=3 -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=1g"'
       )
     end
   end


### PR DESCRIPTION
On the back of performance testing, 3 workers appears to be an adequate fit for the CI runners to improve consistency.

This issue was borne out of the reduction of runner resources which caused crashes https://ledgerhq.atlassian.net/browse/LIVE-16834