### PR TITLE
fix(llm): 🩹 do not re-count devices multiple time after upgrades

### DIFF
--- a/.changeset/quick-items-burn.md
+++ b/.changeset/quick-items-burn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Do not re-count devices multiple times after devices upgrades

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -171,9 +171,10 @@ const extraProperties = async (store: AppStore) => {
   const language = sensitiveAnalytics ? null : languageSelector(state);
   const region = sensitiveAnalytics ? null : localeSelector(state);
   const devices = seenDevicesSelector(state);
+  const bleDevices = bleDevicesSelector(state);
   const satisfaction = satisfactionSelector(state);
   const accounts = accountsSelector(state);
-  const lastDevice = devices.at(-1) || bleDevicesSelector(state).at(-1);
+  const lastDevice = devices.at(-1) || bleDevices.at(-1);
   const deviceInfo = lastDevice
     ? {
         deviceVersion: lastDevice.deviceInfo?.version,
@@ -227,6 +228,14 @@ const extraProperties = async (store: AppStore) => {
   const rebornAttributes = getRebornAttributes();
   const mevProtectionAtributes = getMEVAttributes(state);
 
+  // NOTE: Currently there no reliable way to uniquely identify devices from DeviceModelInfo.
+  // So device counts is approximated as follows:
+  // Each model of device seen which was not connected in Bluetooth is counted as a 1 device.
+  const seenBleModels = bleDevices.map(d => d.modelId);
+  const usbDeviceModelSeen = devices.filter(d => !seenBleModels.includes(d.modelId));
+  const devicesCount = bleDevices.length + usbDeviceModelSeen.length;
+  const modelIdQtyList = { ...aggregateData(bleDevices), ...aggregateData(usbDeviceModelSeen) };
+
   return {
     ...mandatoryProperties,
     appVersion,
@@ -240,8 +249,8 @@ const extraProperties = async (store: AppStore) => {
     platformOS: Platform.OS,
     platformVersion: Platform.Version,
     sessionId,
-    devicesCount: devices.length,
-    modelIdQtyList: aggregateData(devices),
+    devicesCount,
+    modelIdQtyList,
     modelIdList: getUniqueModelIdList(devices),
     isReborn,
     onboardingHasDevice,

--- a/apps/ledger-live-mobile/src/logic/modelIdList.ts
+++ b/apps/ledger-live-mobile/src/logic/modelIdList.ts
@@ -1,6 +1,6 @@
 import type { DeviceModelInfo } from "@ledgerhq/types-live";
 
-export const aggregateData = (devices: DeviceModelInfo[]) => {
+export const aggregateData = (devices: Pick<DeviceModelInfo, "modelId">[]) => {
   const aggregatedData = new Map<string, number>();
 
   devices.forEach(device => {

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -452,7 +452,7 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     return {
       ...state,
       seenDevices: state.seenDevices
-        .filter(d => d.deviceInfo.targetId !== payload.deviceInfo.targetId)
+        .filter(d => d.modelId !== payload.modelId)
         .concat({ ...state.seenDevices.at(-1), ...payload }),
       knownDeviceModelIds: {
         ...state.knownDeviceModelIds,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

#### Context

In #9109 devices are added to the store in `settings.seenDevices` which is supposed to be a uniq device array. However to identify the devices uniquely the reducer uses `DeviceModelInfo["deviceInfo"]["targetId"]` which actually identifies the firmware version. While discussing the issue the device team pointed out that there is no way to uniquely identify a device.

#### Fix

As an approximation this PR stores **for each model** only the last connected device into `settings.seenDevices`. Then devices are counted based on:
- `ble.knownDevices` + (each model in `settings.seenDevices` but not in `ble.knownDevices`)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-16680]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16680]: https://ledgerhq.atlassian.net/browse/LIVE-16680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ