### PR TITLE
turbo caching for iOS E2E tests

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Test iOS app
         id: detox
         timeout-minutes: 75
-        run: pnpm mobile e2e:ci -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
+        run: pnpm test:llm:ios:e2e --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" -- -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
     "test": "pnpm turbo test --concurrency=1",
+    "test:llm:ios:e2e": "pnpm turbo run e2e:ci --filter=live-mobile",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",
     "lint:fix": "pnpm turbo lint:fix",

--- a/turbo.json
+++ b/turbo.json
@@ -189,6 +189,11 @@
       "outputs": [],
       "dependsOn": ["build"],
       "env": ["CI_OS"]
+    },
+    "live-mobile#e2e:ci": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": []
     }
   }
 }


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-16986)

Runs iOS E2E tests with turbo, using cache if available.

[As mentioned in the ticket](https://ledgerhq.atlassian.net/browse/LIVE-16986?focusedCommentId=521951) the iOS E2E test workflow already has some caching implemented, for the iOS build. This is not implemented via turbo though - separate caching mechanism. For now this PR won't cover the refactor we should make to unify the caching approach.

-----------

## Implementation and test details

Testing has been done against this in [this PR](https://github.com/LedgerHQ/ledger-live/pull/9240)

- ✅ `dependsOn` LLM dependencies' builds via turbo.json (you can see we retrieve these builds from cache [here](https://github.com/LedgerHQ/ledger-live/actions/runs/13334150255/job/37245375356?pr=9240#step:13:23))
- ✅ test run has shown that the E2E test step itself hits the cache when re-run with identical repo state ([workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/13334150255/job/37248573630?pr=9240#step:13:831))
- ✅ if there’s an update in an internal package LLM depends on, it triggers a rerun of E2E. Here's [a commit](https://github.com/LedgerHQ/ledger-live/pull/9240/commits/3244e983040f12410a4bfb33b04184622b3995d9) where that was done in the test PR, here's the [workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/13366988029/job/37326838573?pr=9240), showing a cache miss in the build [here](https://github.com/LedgerHQ/ledger-live/actions/runs/13366988029/job/37326838573?pr=9240#step:7:663) and in the E2E test run [here](https://github.com/LedgerHQ/ledger-live/actions/runs/13366988029/job/37326838573?pr=9240#step:13:22)
- as a result of this PR the E2E test run step itself tries to rebuild dependencies, but it’s a redundant rebuild because it's already been done in the build dependencies step a few steps prior. The build dependencies step is run by turbo with caching enabled, that means the E2E test run step always hits cache. This IMO is a bit of a messy setup where we are repeating turbo calls, but this is the simplest implementation for now, and I think we should go further with turbo to remove explicit build steps in the workflow and let turbo manage it all via its dependency graph and caching setup
- ~here I'm calling the e2e tests independent of the e2e-ci.mjs script. I want to move away from that script - it seems like a one-off attempt to abstract away some parts of the pnpm/turbo call chain, but it's not clear why the abstraction is like it is. For me that script has always made the actual chain of pnpm/turbo calls harder to follow. Maybe one to discuss?~