### PR TITLE
fix (coin-tester): stop EVM coin tester smoothly

### DIFF
--- a/.changeset/mighty-mirrors-relate.md
+++ b/.changeset/mighty-mirrors-relate.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/coin-tester": patch
+---
+
+fix (coin-tester): stop EVM coin tester smoothly

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/anvil.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/anvil.ts
@@ -56,6 +56,7 @@ export const killAnvil = async (): Promise<void> => {
     cwd,
     log: Boolean(process.env.DEBUG),
     env: process.env,
+    commandOptions: ["--remove-orphans"],
   });
 };
 

--- a/libs/coin-tester/src/main.ts
+++ b/libs/coin-tester/src/main.ts
@@ -133,7 +133,7 @@ export async function executeScenario<T extends TransactionCommon, A extends Acc
         );
       }
 
-      console.log(" → ", "🪲  ", chalk.bold("No status errors detected"), "✓");
+      console.log(" → ", "🪲 ", chalk.bold("No status errors detected"), "✓");
 
       const { signedOperation } = await firstValueFrom(
         accountBridge

--- a/libs/coin-tester/src/signers/speculos.ts
+++ b/libs/coin-tester/src/signers/speculos.ts
@@ -116,6 +116,7 @@ export async function killSpeculos() {
     cwd,
     log: Boolean(process.env.DEBUG),
     env: process.env,
+    commandOptions: ["--remove-orphans"],
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Running the EVM coin tester is failing, even all the tests pass. That is because, in some cases, old containers remain and make docker network removal impossible.

Now using `--remove-orphans` to exit cointaners in a clean way to avoid the behavior described above.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
