### PR TITLE
doc (coin-evm): fix misleading doc on SVG naming convention

### DIFF
--- a/.changeset/sharp-llamas-begin.md
+++ b/.changeset/sharp-llamas-begin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+doc (coin-evm): fix misleading doc on SVG naming convention

--- a/libs/coin-modules/coin-evm/docs/evm-family-integration-process/README.md
+++ b/libs/coin-modules/coin-evm/docs/evm-family-integration-process/README.md
@@ -40,7 +40,7 @@ _Common steps for all new EVM currency integration_
    1. run `pnpm doc` under `libs/ledgerjs/packages/types-live` to update the doc
    2. run `pnpm test:jest` under `apps/ledger-live-desktop` to update the snapshots
 7. Add the related currency icon as SVG format under the [`libs/ui/packages/crypto-icons/src/svg`](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/crypto-icons/src/svg) folder within the [@ledgerhq/icons-ui](https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ui/packages/crypto-icons) package
-   1. the file name should follow the `{currency_id}.svg` naming convention
+   1. the file name should follow the `{currency_ticker}.svg` naming convention
    2. the SVG icon should follow Ledger Live currency icon guideline (you can use [this tool](https://live.ledger.tools/svg-icons) for validation)
 
 ### Optional steps


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The documentation claims that the naming convention for SVGs representing cryptoassets is `<currency_id>.svg`, when it is actually `<currency_ticker>.svg`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
