### PR TITLE
ci: e2e ios depends on dependency builds via turbo

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Test iOS app
         id: detox
         timeout-minutes: 75
-        run: pnpm mobile e2e:ci -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
+        run: pnpm test:llm:ios:e2e --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" -- -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos')
         env:
           SEED: ${{ secrets.SEED_QAA_B2C }}
           INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "nightly": "pnpm turbo nightly",
     "nightly:lld": "pnpm turbo nightly --filter=ledger-live-desktop",
     "test": "pnpm turbo test --concurrency=1",
+    "test:llm:ios:e2e": "pnpm turbo run e2e:ci --filter=live-mobile",
     "run:cli": "./apps/cli/bin/index.js",
     "lint": "pnpm turbo lint",
     "lint:fix": "pnpm turbo lint:fix",

--- a/turbo.json
+++ b/turbo.json
@@ -189,6 +189,11 @@
       "outputs": [],
       "dependsOn": ["build"],
       "env": ["CI_OS"]
+    },
+    "live-mobile#e2e:ci": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": []
     }
   }
 }


### PR DESCRIPTION
Identical to https://github.com/LedgerHQ/ledger-live/pull/9247

The part that's relevant to the release process is that it updates package.json to include the E2E iOS test command that `develop`'s E2E mobile test workflow now uses. This fixes [the error in the latest workflow run during release](https://github.com/LedgerHQ/ledger-live/actions/runs/13392188207/job/37402276124?pr=9266)