### PR TITLE
CI: reliable build desktop failures

### DIFF
--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -43,7 +43,6 @@ jobs:
       win: ${{ steps.status.outputs.win }}
       mac: ${{ steps.status.outputs.mac }}
 
-    continue-on-error: true
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:
@@ -113,14 +112,17 @@ jobs:
           private_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
 
       - uses: actions/download-artifact@v4
+        if: ${{ needs.build-desktop-app.outputs.linux == 'success' }}
         with:
           name: linux-js-bundle-metafiles
           path: linux-js-bundle-metafiles
       - uses: actions/download-artifact@v4
+        if: ${{ needs.build-desktop-app.outputs.win == 'success' }}
         with:
           name: win-js-bundle-metafiles
           path: win-js-bundle-metafiles
       - uses: actions/download-artifact@v4
+        if: ${{ needs.build-desktop-app.outputs.mac == 'success' }}
         with:
           name: mac-js-bundle-metafiles
           path: mac-js-bundle-metafiles


### PR DESCRIPTION
Currently successful mac builds are being misreported in certain cases. This fix ensures that the individual build steps fail and the reporting step passes

Partial failure (linux) https://github.com/LedgerHQ/ledger-live/actions/runs/13397330840
Partial failure (mac) https://github.com/LedgerHQ/ledger-live/actions/runs/13397562809
Timeout: https://github.com/LedgerHQ/ledger-live/actions/runs/13397620348/job/37420477018

Problem job: https://github.com/LedgerHQ/ledger-live/actions/runs/13291952727/job/37145026465?pr=9209