### PR TITLE
fix: casper bot specs min safe value

### DIFF
--- a/.changeset/brave-dancers-kick.md
+++ b/.changeset/brave-dancers-kick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": patch
+---
+
+fix casper bot specs

--- a/libs/coin-modules/coin-casper/src/test/bot-specs.ts
+++ b/libs/coin-modules/coin-casper/src/test/bot-specs.ts
@@ -10,7 +10,7 @@ import { acceptTransaction } from "./speculos-deviceActions";
 import { CASPER_MINIMUM_VALID_AMOUNT_MOTES, MayBlockAccountError } from "../consts";
 import { getRandomTransferID } from "../common-logic";
 
-const MIN_SAFE = new BigNumber(CASPER_MINIMUM_VALID_AMOUNT_MOTES);
+const MIN_SAFE = new BigNumber(CASPER_MINIMUM_VALID_AMOUNT_MOTES * 2);
 const maxAccount = 6;
 
 const casperSpecs: AppSpec<Transaction> = {
@@ -22,9 +22,9 @@ const casperSpecs: AppSpec<Transaction> = {
   },
   genericDeviceAction: acceptTransaction,
   testTimeout: 6 * 60 * 1000,
-  minViableAmount: MIN_SAFE * 2,
+  minViableAmount: MIN_SAFE,
   transactionCheck: ({ maxSpendable }) => {
-    invariant(maxSpendable.gt(MIN_SAFE * 2), "balance is too low");
+    invariant(maxSpendable.gt(MIN_SAFE), "balance is too low");
   },
   mutations: [
     {
@@ -33,7 +33,7 @@ const casperSpecs: AppSpec<Transaction> = {
       maxRun: 1,
       testDestination: genericTestDestination,
       transaction: ({ account, siblings, bridge, maxSpendable }) => {
-        invariant(maxSpendable.gt(MIN_SAFE * 2), "balance is too low");
+        invariant(maxSpendable.gt(MIN_SAFE), "balance is too low");
         const sibling = pickSiblings(siblings, maxAccount);
         const recipient = sibling.freshAddress;
         const amount = maxSpendable.div(2).integerValue();

--- a/libs/coin-modules/coin-casper/src/test/bot-specs.ts
+++ b/libs/coin-modules/coin-casper/src/test/bot-specs.ts
@@ -22,9 +22,9 @@ const casperSpecs: AppSpec<Transaction> = {
   },
   genericDeviceAction: acceptTransaction,
   testTimeout: 6 * 60 * 1000,
-  minViableAmount: MIN_SAFE,
+  minViableAmount: MIN_SAFE * 2,
   transactionCheck: ({ maxSpendable }) => {
-    invariant(maxSpendable.gt(MIN_SAFE), "balance is too low");
+    invariant(maxSpendable.gt(MIN_SAFE * 2), "balance is too low");
   },
   mutations: [
     {
@@ -33,7 +33,7 @@ const casperSpecs: AppSpec<Transaction> = {
       maxRun: 1,
       testDestination: genericTestDestination,
       transaction: ({ account, siblings, bridge, maxSpendable }) => {
-        invariant(maxSpendable.gt(MIN_SAFE), "balance is too low");
+        invariant(maxSpendable.gt(MIN_SAFE * 2), "balance is too low");
         const sibling = pickSiblings(siblings, maxAccount);
         const recipient = sibling.freshAddress;
         const amount = maxSpendable.div(2).integerValue();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

test send ~50% was failing cause the `MIN_SAFE = 2.6` and the minimum amout that a user can send on Casper is `2.5`.
I Change the value to `MIN_SAFE * 2` so test send ~50% while work.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
