### PR TITLE
Track `ios-test-artifacts` in turbo outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -194,7 +194,7 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": [],
-      "outputs": ["apps/ledger-live-mobile/artifacts/**"]
+      "outputs": ["artifacts/**"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -193,7 +193,8 @@
     "live-mobile#e2e:ci": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": []
+      "inputs": [],
+      "outputs": ["apps/ledger-live-mobile/artifacts/ios-test-artifacts**"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -194,7 +194,7 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": [],
-      "outputs": ["apps/ledger-live-mobile/artifacts/ios-test-artifacts**"]
+      "outputs": ["apps/ledger-live-mobile/artifacts/**"]
     }
   }
 }


### PR DESCRIPTION
Ticket [here](https://ledgerhq.atlassian.net/browse/LIVE-17169)

This should fix the issue from [this run](https://github.com/LedgerHQ/ledger-live/actions/runs/13400303219/job/37429985231).

Hypothesis is that we never saw the above failure in testing because during testing the [allure report step was disabled](https://github.com/LedgerHQ/ledger-live/pull/9240/files#diff-83652d5bf6180c5f87f3117471e890d655448ca914458c7ed9c560937a4b7c63R170). You can see in the test run that the upload of the test artefacts [failed because they did not exist](https://github.com/LedgerHQ/ledger-live/actions/runs/13400303219/job/37429305277#step:15:24).

Therefore, adding that directory to outputs Full description and test PR incoming.

The CI run for this PR indicated that [artefacts were uploaded successfully](https://github.com/LedgerHQ/ledger-live/actions/runs/13440567335/job/37553765208?pr=9291#step:15:42) ✅