### PR TITLE
Update auto-close target to Smartling Github app

### DIFF
--- a/tools/github-bot/src/features/autoClose/index.ts
+++ b/tools/github-bot/src/features/autoClose/index.ts
@@ -13,7 +13,7 @@ export function autoClose(app: Probot) {
 
     if (
       repository.repo !== "ledger-live" ||
-      login !== "ldg-smartling-sa" ||
+      login !== "app/smartling-github-connector" ||
       !/^smartling-(content-updated|translation-completed)-.+/.test(branch)
     ) {
       return;


### PR DESCRIPTION
[Ticket](https://ledgerhq.atlassian.net/browse/LIVE-17102)

When I migrated Smartling's connector to the Github App it revealed that we had an extra process auto-closing all automatic PRs from Smartling. This process is [here](https://github.com/LedgerHQ/ledger-live/pull/6289) ([original ticket/context for that](https://ledgerhq.atlassian.net/browse/LIVE-11383)).

I have learned from @desirendr that our ideal setup is to dispatch translation jobs at the point of PR creation, but not get any PRs back from Smartling until he dispatches an export PR "on demand". Smartling appears to have no way to support this flow - the "PR" smartling connection mode, which dispatches translation jobs for every new PR, also creates a PR back into the original PR with the translations that result from the dispatched job. These are ignored by the eng team and accumulate over time. There appears to be no way to disable PR creation in the "PR" smartling connection mode.

Our way around this has been to create an extra task for the ledger live github bot, which auto-closes all these PRs issued from Smartling (but targeting the branch names such that the on-demand PR is not auto-closed).

This PR updates the config here, but I have questions about whether this is a good setup! I am double checking with our Smartling account manager whether there's a way to stop Smartling from auto-issuing these PRs in the first place, which would bring down the overall amount of moving parts.