### PR TITLE
fix: Setup Ledger by Figment two as the default validator

### DIFF
--- a/.changeset/pretty-dolls-marry.md
+++ b/.changeset/pretty-dolls-marry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cardano": patch
+---
+
+Setup Ledger by Figment two as the default validator

--- a/libs/coin-modules/coin-cardano/src/utils.ts
+++ b/libs/coin-modules/coin-cardano/src/utils.ts
@@ -1,4 +1,4 @@
 // the IDs of ledger stake pools to shows in lld and llm
 export const LEDGER_POOL_IDS: Array<string> = [
-  "c726c9da5615d5f9f6858c25bb13f81c4741eccd08ce32f3414f323f",
+  "4a9c9902c9538da900b10b716d5d1b214487455fdb06028b32ffa180",
 ];


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Right now Ledger by Figment 3 is the default validator, but it will be full soon.
We put Ledger by Figment 2 as the default one.


![Screenshot 2025-02-24 at 11 31 23](https://github.com/user-attachments/assets/934cf6f5-4228-4fd5-8e38-0e1449ca0791)


### ❓ Context

- **JIRA or GitHub link**:  [LIVE-17216](https://ledgerhq.atlassian.net/browse/LIVE-17216)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17216]: https://ledgerhq.atlassian.net/browse/LIVE-17216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ