### PR TITLE
:thread: (llm): optimize launch

### DIFF
--- a/.changeset/soft-kangaroos-call.md
+++ b/.changeset/soft-kangaroos-call.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Promise Concurrency during app start to reduce the llm startup time

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -1,6 +1,6 @@
-import React, { Component } from "react";
+import React, { useEffect, useState, ReactNode, useCallback } from "react";
 import { Provider } from "react-redux";
-import { type StoreType } from "./store";
+import { Store } from "redux";
 import { importPostOnboardingState } from "@ledgerhq/live-common/postOnboarding/actions";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
@@ -26,57 +26,83 @@ import { importMarket } from "~/actions/market";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { importWalletState } from "@ledgerhq/live-wallet/store";
 
-export default class LedgerStoreProvider extends Component<
-  {
-    onInitFinished: () => void;
-    children: (ready: boolean, initialCountervalues?: CounterValuesStateRaw) => JSX.Element;
-    store: StoreType;
-  },
-  {
-    ready: boolean;
-    initialCountervalues?: CounterValuesStateRaw;
+interface Props {
+  onInitFinished: () => void;
+  children: (ready: boolean, initialCountervalues?: CounterValuesStateRaw) => ReactNode;
+  store: Store;
+}
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY = 500;
+
+async function retry<T>(fn: () => Promise<T>, retries: number, delay: number): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries > 0) {
+      await new Promise(res => setTimeout(res, delay));
+      return retry(fn, retries - 1, delay);
+    } else {
+      throw new Error(`Max retries reached for ${fn.name}`);
+    }
   }
-> {
-  state = {
-    ready: false,
-    initialCountervalues: undefined,
-  };
+}
 
-  componentDidMount() {
-    return this.init();
-  }
+const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store }) => {
+  const [ready, setReady] = useState(false);
+  const [initialCountervalues, setInitialCountervalues] = useState<
+    CounterValuesStateRaw | undefined
+  >(undefined);
 
-  componentDidCatch(e: Error) {
-    console.error(e);
-    throw e;
-  }
+  const init = useCallback(async () => {
+    try {
+      const [
+        bleData,
+        settingsData,
+        cachedCurrencyIds,
+        supportedFiats,
+        accountsData,
+        postOnboardingState,
+        marketState,
+        trustchainStore,
+        walletStore,
+        protect,
+        initialCountervalues,
+      ] = await Promise.all([
+        retry(getBle, MAX_RETRIES, RETRY_DELAY),
+        retry(getSettings, MAX_RETRIES, RETRY_DELAY),
+        retry(listCachedCurrencyIds, MAX_RETRIES, RETRY_DELAY),
+        retry(listSupportedFiats, MAX_RETRIES, RETRY_DELAY),
+        retry(getAccounts, MAX_RETRIES, RETRY_DELAY),
+        retry(getPostOnboardingState, MAX_RETRIES, RETRY_DELAY),
+        retry(getMarketState, MAX_RETRIES, RETRY_DELAY),
+        retry(getTrustchainState, MAX_RETRIES, RETRY_DELAY),
+        retry(getWalletExportState, MAX_RETRIES, RETRY_DELAY),
+        retry(getProtect, MAX_RETRIES, RETRY_DELAY),
+        retry(getCountervalues, MAX_RETRIES, RETRY_DELAY),
+      ]);
 
-  async init() {
-    const bleData = await getBle();
-    this.props.store.dispatch(importBle(bleData));
-    const settingsData = await getSettings();
+      store.dispatch(importBle(bleData));
 
-    const cachedCurrencyIds = await listCachedCurrencyIds();
-    // hydrate the store with the bridge/cache
-    // Promise.allSettled doesn't exist in RN
-    await Promise.all(
-      cachedCurrencyIds
-        .map(id => {
-          const currency = findCryptoCurrencyById?.(id);
-          return currency ? hydrateCurrency(currency) : Promise.reject();
-        })
-        .map(promise =>
-          promise
-            .then((value: unknown) => ({ status: "fulfilled", value }))
-            .catch((reason: unknown) => ({ status: "rejected", reason })),
-        ),
-    );
-    const bitcoin = getCryptoCurrencyById("bitcoin");
-    const ethereum = getCryptoCurrencyById("ethereum");
-    const possibleIntermediaries = [bitcoin, ethereum];
+      // hydrate the store with the bridge/cache
+      // Promise.allSettled doesn't exist in RN
+      await Promise.all(
+        cachedCurrencyIds
+          .map(id => {
+            const currency = findCryptoCurrencyById?.(id);
+            return currency ? hydrateCurrency(currency) : Promise.reject();
+          })
+          .map(promise =>
+            promise
+              .then((value: unknown) => ({ status: "fulfilled", value }))
+              .catch((reason: unknown) => ({ status: "rejected", reason })),
+          ),
+      );
 
-    const getsupportedCountervalues = async () => {
-      const supportedFiats = await listSupportedFiats();
+      const bitcoin = getCryptoCurrencyById("bitcoin");
+      const ethereum = getCryptoCurrencyById("ethereum");
+      const possibleIntermediaries = [bitcoin, ethereum];
+
       const supportedCounterValues = [...supportedFiats, ...possibleIntermediaries]
         .map(currency => ({
           value: currency.ticker,
@@ -86,70 +112,57 @@ export default class LedgerStoreProvider extends Component<
         }))
         .sort((a, b) => (a.currency.name < b.currency.name ? -1 : 1));
 
-      if (this.props?.store?.dispatch) {
-        this.props.store.dispatch(setSupportedCounterValues(supportedCounterValues));
+      store.dispatch(setSupportedCounterValues(supportedCounterValues));
+
+      if (
+        settingsData &&
+        settingsData.counterValue &&
+        !supportedCounterValues.find(({ ticker }) => ticker === settingsData.counterValue)
+      ) {
+        settingsData.counterValue = settingsState.counterValue;
       }
 
-      return supportedCounterValues || [];
-    };
+      store.dispatch(importSettings(settingsData));
+      store.dispatch(importAccountsRaw(accountsData));
 
-    const supportedCV = await getsupportedCountervalues();
-    if (settingsData && supportedCV.length > 0) {
-      settingsData.supportedCounterValues = supportedCV;
+      if (postOnboardingState) {
+        store.dispatch(importPostOnboardingState({ newState: postOnboardingState }));
+      }
+
+      if (marketState) {
+        store.dispatch(importMarket(marketState));
+      }
+
+      if (trustchainStore) {
+        store.dispatch(importTrustchainStoreState(trustchainStore));
+      }
+
+      if (walletStore) {
+        store.dispatch(importWalletState(walletStore));
+      }
+
+      if (protect) {
+        store.dispatch(updateProtectData(protect.data));
+        store.dispatch(updateProtectStatus(protect.protectStatus));
+      }
+
+      setInitialCountervalues(initialCountervalues);
+      setReady(true);
+      onInitFinished();
+    } catch (error) {
+      console.error(
+        error instanceof Error
+          ? error.message
+          : "An unknown error occurred during the StoreProvider initialization",
+      );
     }
-    if (
-      settingsData &&
-      settingsData.counterValue &&
-      !supportedCV.find(({ ticker }) => ticker === settingsData.counterValue)
-    ) {
-      settingsData.counterValue = settingsState.counterValue;
-    }
+  }, [store, onInitFinished]);
 
-    this.props.store.dispatch(importSettings(settingsData));
-    const accountsData = await getAccounts();
-    this.props.store.dispatch(importAccountsRaw(accountsData));
+  useEffect(() => {
+    init();
+  }, [init]);
 
-    const postOnboardingState = await getPostOnboardingState();
-    if (postOnboardingState) {
-      this.props.store.dispatch(importPostOnboardingState({ newState: postOnboardingState }));
-    }
+  return <Provider store={store}>{children(ready, initialCountervalues)}</Provider>;
+};
 
-    const marketState = await getMarketState();
-    if (marketState) {
-      this.props.store.dispatch(importMarket(marketState));
-    }
-
-    const trustchainStore = await getTrustchainState();
-    if (trustchainStore) {
-      this.props.store.dispatch(importTrustchainStoreState(trustchainStore));
-    }
-
-    const walletStore = await getWalletExportState();
-    if (walletStore) {
-      this.props.store.dispatch(importWalletState(walletStore));
-    }
-
-    const protect = await getProtect();
-    if (protect) {
-      this.props.store.dispatch(updateProtectData(protect.data));
-      this.props.store.dispatch(updateProtectStatus(protect.protectStatus));
-    }
-
-    const initialCountervalues = await getCountervalues();
-    this.setState(
-      {
-        ready: true,
-        initialCountervalues,
-      },
-      () => {
-        this.props.onInitFinished();
-      },
-    );
-  }
-
-  render() {
-    const { children, store } = this.props;
-    const { ready, initialCountervalues } = this.state;
-    return <Provider store={store}>{children(ready, initialCountervalues)}</Provider>;
-  }
-}
+export default LedgerStoreProvider;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ledger store

### 📝 Description

Rework the way we initialise the ledger store to make it faster. 

#### Today 
Previously, the code was executing promises sequentially using await statements one after another:

```
const bleData = await getBle();
const settingsData = await getSettings();
const cachedCurrencyIds = await listCachedCurrencyIds();
```

This approach was slower as each promise had to complete before the next one could start.

#### Promise concurrency 

The new implementation uses promise concurrency by starting all promises simultaneously:

```
const {getBle, getSettings, listCachedCurrencyIds} = await Promise.all([
        retry(getBle, MAX_RETRIES, RETRY_DELAY),
        retry(getSettings, MAX_RETRIES, RETRY_DELAY),
        retry(listCachedCurrencyIds, MAX_RETRIES, RETRY_DELAY),
])
```

This way we parallelise promise execution and reduce init time.  Also a retry function is added so we ensure to retry the init if needed max 3 times until an error is send


documentation : https://www.builder.io/blog/promises

first POC : https://github.com/LedgerHQ/ledger-live/pull/8866

#### TLDR
```
// Sequential approach
const bleData = await getBle();          // Wait 100ms
const settings = await getSettings();     // Wait another 100ms
const accounts = await getAccounts();     // Wait another 100ms
// Total time: ~300ms

// Concurrent approach
const blePromise = getBle();             // Start immediately
const settingsPromise = getSettings();    // Start immediately
const accountsPromise = getAccounts();    // Start immediately
// Total time: ~100ms
``` 

#### Results

The start up time will of course differs on accounts number but we can expect a reduction of ~30% on the initialisation of the Store Provider. In the videos below I've used the same accounts and as we can see promise concurrency is quite faster. 

The risks should be minor since we only parallelise execution but we still do all of them before starting the app

How did I measure ? => by adding a start time at the beginning of the init method and a stop time at the end. For more precision we could do as it's done in the POC https://github.com/LedgerHQ/ledger-live/pull/8866

This measurement will depends on many conditions to be fully reliable (accounts number etc...) but it's still an improvement

| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/bfdd583a-134f-46b0-a8bc-04ee18297d02|https://github.com/user-attachments/assets/2dfb4db2-650f-4869-8306-cb7d4567fcdc|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17265](https://ledgerhq.atlassian.net/browse/LIVE-17265)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17265]: https://ledgerhq.atlassian.net/browse/LIVE-17265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ