### PR TITLE
fix accidental level hardcoding in adjust-changeset-level

### DIFF
--- a/tools/actions/composites/adjust-changeset-level/action.yml
+++ b/tools/actions/composites/adjust-changeset-level/action.yml
@@ -30,7 +30,7 @@ runs:
         echo "Adjusting changeset level from ${{ inputs.from_level }} to ${{ inputs.to_level }}"
         for file in .changeset/*.md; do
           if grep -q ": ${{ inputs.from_level }}" "$file"; then
-            # target the lines between the "---" yaml delimiters, replace ": patch" with ": minor"
+            # target the lines between the "---" yaml delimiters, replace e.g. ": patch" with ": minor"
             sed -i '/---/,/---/s/: ${{ inputs.from_level }}/: ${{ inputs.to_level }}/' "$file"
             echo "Updated $file to ${{ inputs.to_level }}"
           fi

--- a/tools/actions/composites/adjust-changeset-level/action.yml
+++ b/tools/actions/composites/adjust-changeset-level/action.yml
@@ -29,9 +29,9 @@ runs:
       run: |
         echo "Adjusting changeset level from ${{ inputs.from_level }} to ${{ inputs.to_level }}"
         for file in .changeset/*.md; do
-          if grep -q ": patch" "$file"; then
+          if grep -q ": ${{ inputs.from_level }}" "$file"; then
             # target the lines between the "---" yaml delimiters, replace ": patch" with ": minor"
-            sed -i '/---/,/---/s/: patch/: minor/' "$file"
-            echo "Updated $file to minor"
+            sed -i '/---/,/---/s/: ${{ inputs.from_level }}/: ${{ inputs.to_level }}/' "$file"
+            echo "Updated $file to ${{ inputs.to_level }}"
           fi
         done


### PR DESCRIPTION
[Ticket](https://ledgerhq.atlassian.net/browse/LIVE-17338)

Fixes accidental level hardcoding in the `adjust-changeset-level` internal action that stopped the downgrading of minor ➡️ patch changesets during hotfixes.

This has been tested in [this temporary PR](https://github.com/LedgerHQ/ledger-live/pull/9354), which introduces a [(temporary) test workflow](https://github.com/LedgerHQ/ledger-live/pull/9354/files#diff-6f074678577ec9a56edcf2bf29f9ee5cadd2c4f5dbce2ce862599d6e75e83ef0) that runs the action against several test cases.

When we point the tests to the version of the action on `develop` they fail ([this run](https://github.com/LedgerHQ/ledger-live/actions/runs/13543467439/job/37849584591?pr=9354)), but when we point to the version on this branch they pass ([this run](https://github.com/LedgerHQ/ledger-live/actions/runs/13543598561/job/37850002655?pr=9354)).