### PR TITLE
:bug: fix(lld) add a check before size and position events

### DIFF
--- a/.changeset/heavy-papayas-confess.md
+++ b/.changeset/heavy-papayas-confess.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a check during debounce on LLD resize and move events

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -150,6 +150,7 @@ app.on("ready", async () => {
   window.on(
     "resize",
     debounce(() => {
+      if (!window || window.isDestroyed()) return;
       const [width, height] = window.getSize();
       db.setKey("windowParams", `${window.name}.dimensions`, {
         width,
@@ -160,6 +161,7 @@ app.on("ready", async () => {
   window.on(
     "move",
     debounce(() => {
+      if (!window || window.isDestroyed()) return;
       const [x, y] = window.getPosition();
       db.setKey("windowParams", `${window.name}.positions`, {
         x,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - window events

### 📝 Description

We need to ensure that the app well exists before checking its size or position to avoid typeError in the case the user closes the app during the debounce effect

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17339](https://ledgerhq.atlassian.net/browse/LIVE-17339)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17339]: https://ledgerhq.atlassian.net/browse/LIVE-17339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ