### PR TITLE
fix: aptos derivation path account metadata

### DIFF
--- a/.changeset/gentle-icons-shave.md
+++ b/.changeset/gentle-icons-shave.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/hw-app-aptos": minor
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-aptos": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-framework": minor
+---
+
+Fix Aptos derivation path account metadata

--- a/libs/coin-framework/src/derivation.ts
+++ b/libs/coin-framework/src/derivation.ts
@@ -208,6 +208,7 @@ const legacyDerivations: Partial<Record<CryptoCurrency["id"], DerivationMode[]>>
   solana: ["solanaMain", "solanaSub"],
   solana_devnet: ["solanaMain", "solanaSub"],
   solana_testnet: ["solanaMain", "solanaSub"],
+  aptos: ["aptos"],
 };
 
 export const asDerivationMode = (derivationMode: string): DerivationMode => {
@@ -321,6 +322,7 @@ export const runAccountDerivationScheme = (
   }).replace(/[_/]+$/, "");
 const disableBIP44: Record<string, boolean> = {
   aeternity: true,
+  aptos: true,
   tezos: true,
   // current workaround, device app does not seem to support bip44
   stellar: true,

--- a/libs/coin-modules/coin-aptos/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-aptos/src/test/bridgeDatasetTest.ts
@@ -28,7 +28,7 @@ const aptos: CurrenciesData<Transaction> = {
         derivationMode: "",
         index: 0,
         freshAddress: "0x445fa0013887abd1a0c14acdec6e48090e0ad3fed3e08202aac15ca14f3be26b",
-        freshAddressPath: "44'/637'/0'/0/0",
+        freshAddressPath: "44'/637'/0'/0'/0'",
         blockHeight: 286066372,
         creationDate: "2024-12-18T12:26:31.070Z",
         operationsCount: 5,

--- a/libs/ledger-live-common/src/DataModel.test.ts
+++ b/libs/ledger-live-common/src/DataModel.test.ts
@@ -1,0 +1,61 @@
+import { Account, AccountRaw, AccountUserData, Operation } from "@ledgerhq/types-live";
+import { createDataModel } from "./DataModel";
+import { fromAccountRaw, toAccountRaw } from "./account";
+import { accountRawToAccountUserData } from "@ledgerhq/live-wallet/lib/store";
+import {
+  APTOS_HARDENED_DERIVATION_PATH,
+  APTOS_NON_HARDENED_DERIVATION_PATH,
+} from "./families/aptos/consts";
+
+const opRetentionStategy =
+  (maxDaysOld: number, keepFirst: number) =>
+  (op: Operation, index: number): boolean =>
+    index < keepFirst || Date.now() - op.date.getTime() < 1000 * 60 * 60 * 24 * maxDaysOld;
+
+const schema = {
+  migrations: [raw => raw],
+  decode: (raw: AccountRaw) => [fromAccountRaw(raw), accountRawToAccountUserData(raw)],
+  encode: ([account, userData]: [Account, AccountUserData]): AccountRaw =>
+    toAccountRaw(
+      {
+        ...account,
+        operations: account.operations.filter(opRetentionStategy(366, 500)),
+      },
+      userData,
+    ),
+};
+
+const cryptoOrgAccount = {
+  data: {
+    currencyId: "crypto_org",
+  } as AccountRaw,
+  version: 1,
+};
+
+const aptosAccount = {
+  data: {
+    currencyId: "aptos",
+    freshAddressPath: APTOS_NON_HARDENED_DERIVATION_PATH,
+  } as AccountRaw,
+  version: 1,
+};
+
+describe("DataModel", () => {
+  test("createDataModel for crypto.org account", () => {
+    const migratedCryptoOrgAccount = createDataModel(schema).decode(cryptoOrgAccount);
+    expect(migratedCryptoOrgAccount.length).toBeGreaterThan(0);
+
+    const migratedCryptoOrgAccountRaw = migratedCryptoOrgAccount.at(0) as Account & {
+      cosmosResources: Record<string, unknown>;
+    };
+    expect(migratedCryptoOrgAccountRaw.cosmosResources).toBeDefined();
+  });
+
+  test("createDataModel for aptos account", () => {
+    const migratedAptosAccount = createDataModel(schema).decode(aptosAccount);
+    expect(migratedAptosAccount.length).toBeGreaterThan(0);
+
+    const migratedAptosAccountRaw = migratedAptosAccount.at(0) as Account;
+    expect(migratedAptosAccountRaw.freshAddressPath).toEqual(APTOS_HARDENED_DERIVATION_PATH);
+  });
+});

--- a/libs/ledger-live-common/src/families/aptos/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/aptos/__snapshots__/bridge.integration.test.ts.snap
@@ -5,10 +5,10 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 1`] = `
   {
     "balance": "30100",
     "currencyId": "aptos",
-    "derivationMode": "",
+    "derivationMode": "aptos",
     "freshAddress": "0x445fa0013887abd1a0c14acdec6e48090e0ad3fed3e08202aac15ca14f3be26b",
-    "freshAddressPath": "44'/637'/0'/0/0",
-    "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:",
+    "freshAddressPath": "44'/637'/0'/0'/0'",
+    "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos",
     "index": 0,
     "operationsCount": 5,
     "pendingOperations": [],
@@ -22,10 +22,10 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 1`] = `
   {
     "balance": "20000",
     "currencyId": "aptos",
-    "derivationMode": "",
+    "derivationMode": "aptos",
     "freshAddress": "0xd20fa44192f94ba086ab16bfdf57e43ff118ada69b4c66fa9b9a9223cbc068c1",
-    "freshAddressPath": "44'/637'/1'/0/0",
-    "id": "js:2:aptos:6a7712fdac0cb4ed27076c707e7798be52cf6c93a2d43d5cf9b874d0a45a111e:",
+    "freshAddressPath": "44'/637'/1'/0'/0'",
+    "id": "js:2:aptos:6a7712fdac0cb4ed27076c707e7798be52cf6c93a2d43d5cf9b874d0a45a111e:aptos",
     "index": 1,
     "operationsCount": 1,
     "pendingOperations": [],
@@ -39,10 +39,10 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 1`] = `
   {
     "balance": "0",
     "currencyId": "aptos",
-    "derivationMode": "",
+    "derivationMode": "aptos",
     "freshAddress": "0xf4bf78be42e07959793c98c7e8345bb948bf10b8e6baac5e368eab66d09a9671",
-    "freshAddressPath": "44'/637'/2'/0/0",
-    "id": "js:2:aptos:8ffc0c2e141ead220f05b30fa01ce9a3783c5a157219f922b02ec194308b1b45:",
+    "freshAddressPath": "44'/637'/2'/0'/0'",
+    "id": "js:2:aptos:8ffc0c2e141ead220f05b30fa01ce9a3783c5a157219f922b02ec194308b1b45:aptos",
     "index": 2,
     "operationsCount": 0,
     "pendingOperations": [],
@@ -60,7 +60,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
 [
   [
     {
-      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:",
+      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos",
       "blockHash": "0x4c000b55c435dc0d1040d26a7ee782fb7e151748d41ea9126ebe6bbbf2e95111",
       "blockHeight": 266342014,
       "extra": {
@@ -69,7 +69,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "fee": "900",
       "hasFailed": false,
       "hash": "0x1e85342da3a81f9c3a30c585677d3e50101d5731dcaf31cc157a3c694e6aece8",
-      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:-0x1e85342da3a81f9c3a30c585677d3e50101d5731dcaf31cc157a3c694e6aece8-IN",
+      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos-0x1e85342da3a81f9c3a30c585677d3e50101d5731dcaf31cc157a3c694e6aece8-IN",
       "recipients": [
         "0x445fa0013887abd1a0c14acdec6e48090e0ad3fed3e08202aac15ca14f3be26b",
       ],
@@ -81,7 +81,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "value": "100000",
     },
     {
-      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:",
+      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos",
       "blockHash": "0x46de657932759f16ffcda6ef6ace41996f263287e538d3e0f5cbf85994695247",
       "blockHeight": 266316843,
       "extra": {
@@ -90,7 +90,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "fee": "900",
       "hasFailed": false,
       "hash": "0x3c586d8c15c76848fbd3c84ddfbf11a1a07c92734da4dd8d530c9f23a0e7744c",
-      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:-0x3c586d8c15c76848fbd3c84ddfbf11a1a07c92734da4dd8d530c9f23a0e7744c-IN",
+      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos-0x3c586d8c15c76848fbd3c84ddfbf11a1a07c92734da4dd8d530c9f23a0e7744c-IN",
       "recipients": [
         "0x445fa0013887abd1a0c14acdec6e48090e0ad3fed3e08202aac15ca14f3be26b",
       ],
@@ -102,7 +102,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "value": "20000",
     },
     {
-      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:",
+      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos",
       "blockHash": "0xc546b75fd87fb75a2f328bebffade4ccf3345844eec4d2b6cf82e042fe9a7661",
       "blockHeight": 266313878,
       "extra": {
@@ -111,7 +111,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "fee": "99900",
       "hasFailed": false,
       "hash": "0x5f2c2f597ab912dff9fe413b503036edbcc5488c03a4606f11eef868ed68258e",
-      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:-0x5f2c2f597ab912dff9fe413b503036edbcc5488c03a4606f11eef868ed68258e-IN",
+      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos-0x5f2c2f597ab912dff9fe413b503036edbcc5488c03a4606f11eef868ed68258e-IN",
       "recipients": [
         "0x445fa0013887abd1a0c14acdec6e48090e0ad3fed3e08202aac15ca14f3be26b",
       ],
@@ -123,7 +123,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "value": "20000",
     },
     {
-      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:",
+      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos",
       "blockHash": "0x1bbe17059abba7dc500aca2eb174c217e71f3dcd7486cd4b27dc6136cce8a60a",
       "blockHeight": 266315762,
       "extra": {
@@ -132,7 +132,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "fee": "900",
       "hasFailed": false,
       "hash": "0xb74e3ab13f7a00faeb51c0e251602f53d387a64ac9fea7c76a8be3d0bf6f7a19",
-      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:-0xb74e3ab13f7a00faeb51c0e251602f53d387a64ac9fea7c76a8be3d0bf6f7a19-IN",
+      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos-0xb74e3ab13f7a00faeb51c0e251602f53d387a64ac9fea7c76a8be3d0bf6f7a19-IN",
       "recipients": [
         "0x445fa0013887abd1a0c14acdec6e48090e0ad3fed3e08202aac15ca14f3be26b",
       ],
@@ -144,7 +144,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "value": "10000",
     },
     {
-      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:",
+      "accountId": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos",
       "blockHash": "0xf37ce698cf2e6d9e4a0048cd6d09fb3f19f417ab8251a3cc1f19b8d0e503538f",
       "blockHeight": 266342506,
       "extra": {
@@ -153,7 +153,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "fee": "99900",
       "hasFailed": false,
       "hash": "0xf980601fe40ad1dab0cc68fe08d2bc95c73e2a21c6d257475e0879394638058e",
-      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:-0xf980601fe40ad1dab0cc68fe08d2bc95c73e2a21c6d257475e0879394638058e-OUT",
+      "id": "js:2:aptos:d1a8c6a1cdd52dd40c7ea61ee4571fb51fcae440a594c1eca18636928f1d3956:aptos-0xf980601fe40ad1dab0cc68fe08d2bc95c73e2a21c6d257475e0879394638058e-OUT",
       "recipients": [
         "0xd20fa44192f94ba086ab16bfdf57e43ff118ada69b4c66fa9b9a9223cbc068c1",
       ],
@@ -167,7 +167,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
   ],
   [
     {
-      "accountId": "js:2:aptos:6a7712fdac0cb4ed27076c707e7798be52cf6c93a2d43d5cf9b874d0a45a111e:",
+      "accountId": "js:2:aptos:6a7712fdac0cb4ed27076c707e7798be52cf6c93a2d43d5cf9b874d0a45a111e:aptos",
       "blockHash": "0xf37ce698cf2e6d9e4a0048cd6d09fb3f19f417ab8251a3cc1f19b8d0e503538f",
       "blockHeight": 266342506,
       "extra": {
@@ -176,7 +176,7 @@ exports[`aptos currency bridge scanAccounts aptos seed 1 2`] = `
       "fee": "99900",
       "hasFailed": false,
       "hash": "0xf980601fe40ad1dab0cc68fe08d2bc95c73e2a21c6d257475e0879394638058e",
-      "id": "js:2:aptos:6a7712fdac0cb4ed27076c707e7798be52cf6c93a2d43d5cf9b874d0a45a111e:-0xf980601fe40ad1dab0cc68fe08d2bc95c73e2a21c6d257475e0879394638058e-IN",
+      "id": "js:2:aptos:6a7712fdac0cb4ed27076c707e7798be52cf6c93a2d43d5cf9b874d0a45a111e:aptos-0xf980601fe40ad1dab0cc68fe08d2bc95c73e2a21c6d257475e0879394638058e-IN",
       "recipients": [
         "0xd20fa44192f94ba086ab16bfdf57e43ff118ada69b4c66fa9b9a9223cbc068c1",
       ],

--- a/libs/ledger-live-common/src/families/aptos/consts.ts
+++ b/libs/ledger-live-common/src/families/aptos/consts.ts
@@ -1,0 +1,3 @@
+export const APTOS_NON_HARDENED_DERIVATION_PATH_REGEX = /^44'\/637'\/[0-9]+'\/[0-9]+\/[0-9]+$/;
+export const APTOS_NON_HARDENED_DERIVATION_PATH = "44'/637'/0'/0/0";
+export const APTOS_HARDENED_DERIVATION_PATH = "44'/637'/0'/0'/0'";

--- a/libs/ledgerjs/packages/hw-app-aptos/README.md
+++ b/libs/ledgerjs/packages/hw-app-aptos/README.md
@@ -36,6 +36,7 @@ For a smooth and quick integration:
     *   [signTransaction](#signtransaction)
         *   [Parameters](#parameters-2)
         *   [Examples](#examples-2)
+*   [bippath](#bippath)
 
 ### Aptos
 
@@ -113,3 +114,12 @@ const signature = await aptos.signTransaction("44'/144'/0'/0/0", "12000022800000
 ```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<{signature: [Buffer](https://nodejs.org/api/buffer.html)}>** a signature as hex string
+
+### bippath
+
+BIP32 Path Handling for Aptos Wallets
+
+This file provides utility functions to handle BIP32 paths,
+which are commonly used in hierarchical deterministic (HD) wallets.
+It includes functions to convert BIP32 paths to and from different formats,
+extract components from extended public keys (xpubs), and manipulate path elements.

--- a/libs/ledgerjs/packages/hw-app-aptos/src/bip32.ts
+++ b/libs/ledgerjs/packages/hw-app-aptos/src/bip32.ts
@@ -1,0 +1,29 @@
+/**
+ * @file bip32.ts
+ * @description BIP32 Path Handling for Aptos Wallets
+ *
+ * This file provides utility functions to handle BIP32 paths,
+ * which are commonly used in hierarchical deterministic (HD) wallets.
+ * It includes functions to convert BIP32 paths to and from different formats,
+ * extract components from extended public keys (xpubs), and manipulate path elements.
+ */
+
+import bippath from "bip32-path";
+
+export function pathElementsToBuffer(paths: number[]): Buffer {
+  const buffer = Buffer.alloc(1 + paths.length * 4);
+  buffer[0] = paths.length;
+  paths.forEach((element, index) => {
+    buffer.writeUInt32BE(element, 1 + 4 * index);
+  });
+  return buffer;
+}
+
+export function bip32asBuffer(path: string): Buffer {
+  const pathElements = !path ? [] : pathStringToArray(path);
+  return pathElementsToBuffer(pathElements);
+}
+
+export function pathStringToArray(path: string): number[] {
+  return bippath.fromString(path).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-aptos/tests/bip32.test.ts
+++ b/libs/ledgerjs/packages/hw-app-aptos/tests/bip32.test.ts
@@ -1,0 +1,27 @@
+import { pathElementsToBuffer, bip32asBuffer } from "../src/bip32";
+
+describe("Aptos bip32asBuffer", () => {
+  test("pathElementsToBuffer", () => {
+    const arg = [44, 637, 1, 0, 0];
+    const expected = Buffer.from([
+      0x05, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x00, 0x02, 0x7d, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    expect(pathElementsToBuffer(arg)).toStrictEqual(expected);
+  });
+
+  test("bip32asBuffer", () => {
+    const arg = "44'/637'/1'/0'/0'";
+    const expected = Buffer.from([
+      0x05, 0x80, 0x00, 0x00, 0x2c, 0x80, 0x00, 0x02, 0x7d, 0x80, 0x00, 0x00, 0x01, 0x80, 0x00,
+      0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
+    ]);
+    expect(bip32asBuffer(arg)).toStrictEqual(expected);
+  });
+
+  test("bip32asBuffer with empty string", () => {
+    const arg = "";
+    const expected = Buffer.from([0x00]);
+    expect(bip32asBuffer(arg)).toStrictEqual(expected);
+  });
+});

--- a/libs/ledgerjs/packages/types-live/src/derivation.ts
+++ b/libs/ledgerjs/packages/types-live/src/derivation.ts
@@ -31,4 +31,5 @@ export type DerivationMode =
   | "internet_computer"
   | "stacks_wallet"
   | "icon"
-  | "ton";
+  | "ton"
+  | "aptos";


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** bridge integration tests
- [x] **Impact of the changes:**  account metadata

### 📝 Description

Fix aptos derivation path to match nano app behavior

Path was previously unhardened in metadata, now it's hardened (actual device app derivation)

![image](https://github.com/user-attachments/assets/b3dbb4c0-ca9a-4715-aa1b-5345cb3e06dd)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [https://ledgerhq.atlassian.net/browse/LIVE-17309](https://ledgerhq.atlassian.net/browse/LIVE-17309)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
