### PR TITLE
Revert "Verified commits in all remaining parts of the release workflows"

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -51,7 +51,6 @@ jobs:
       - name: create hotfix branch
         run: |
           git checkout -b hotfix
-          git push -u origin hotfix
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -78,23 +77,17 @@ jobs:
 
       - name: enter prerelease mode
         run: pnpm changeset pre enter hotfix
-      - name: git add
+      - name: commit
         run: |
           git add .
-      - name: commit changes
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(hotfix) :rocket: entering hotfix mode"
-          repo: ${{ github.repository }}
-          branch: hotfix
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git commit -m "chore(hotfix) :rocket: entering hotfix mode"
       - name: Get date
         id: date
         run: |
           echo "date=$(date +%F)" >> $GITHUB_OUTPUT
-      - name: create PR to main
+      - name: push
         run: |
+          git push origin hotfix
           gh pr create \
             --title ":fire: Hotfix ${{ steps.date.outputs.date }} (targeting ${{ github.event.inputs.application }} ${{ github.event.inputs.tag_version }})"\
             -F ./.github/templates/hotfix.md \

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -26,7 +26,6 @@ jobs:
       - name: create release branch
         run: |
           git checkout -b $RELEASE_BRANCH
-          git push -u origin $RELEASE_BRANCH
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -38,34 +37,16 @@ jobs:
         run: pnpm build:libs
       - name: import CAL tokens
         run: pnpm import:cal-tokens
-      - name: Add changed files
+      - name: commit new tokens
         run: |
           git add .
-      - name: commit new tokens
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(prerelease) update cryptoassets"
-          repo: ${{ github.repository }}
-          branch: ${{ env.RELEASE_BRANCH }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          git commit -m 'chore(prerelease) update cryptoassets' || echo "No new tokens added"
       - name: update sortByMarketcap snapshot
         run: pnpm common jest --runTestsByPath src/currencies/sortByMarketcap.test.ts -u
-      - name: Add changed files
-        run: |
-          git stash
-          git fetch origin $RELEASE_BRANCH          # make sure previous commit is included
-          git pull --rebase origin $RELEASE_BRANCH  # make sure previous commit is included
-          git stash pop
-          git add .
       - name: commit sortByMarketcap.test.ts
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "update sortByMarketcap snapshot"
-          repo: ${{ github.repository }}
-          branch: ${{ env.RELEASE_BRANCH }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add .
+          git commit -m 'update sortByMarketcap snapshot' || echo "No changes in snapshot of sortByMarketcap.test.ts"
       - name: Move patch updates to minor
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
@@ -75,27 +56,17 @@ jobs:
           to_level: minor
       - name: enter prerelease mode
         run: pnpm changeset pre enter next
-      - name: Add changed files
-        run: |
-          git stash
-          git fetch origin $RELEASE_BRANCH          # make sure previous commit is included
-          git pull --rebase origin $RELEASE_BRANCH  # make sure previous commit is included
-          git stash pop
-          git add .
       - name: commit
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(prerelease): :rocket: entering prerelease mode"
-          repo: ${{ github.repository }}
-          branch: ${{ env.RELEASE_BRANCH }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add .
+          git commit -m "chore(prerelease): :rocket: entering prerelease mode"
       - name: Get date
         id: date
         run: |
           echo "date=$(date +%F)" >> $GITHUB_OUTPUT
-      - name: create PR
+      - name: push
         run: |
+          git push origin $RELEASE_BRANCH
           gh pr create --title ":rocket: Release ${{ steps.date.outputs.date }}" -F .github/templates/release.md --base main --head $RELEASE_BRANCH
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -71,23 +71,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm changeset version
 
-      - name: git add
+      - name: commit
         run: |
           git add .
+          git commit -m "chore(hotfix): :fire: hotfix release [skip ci]"
 
-      - name: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(hotfix): :fire: hotfix release [skip ci]"
-          repo: ${{ github.repository }}
-          branch: ${{ inputs.ref }}
-
-      - name: pull commit
+      - name: push changes
         run: |
-          git stash
-          git pull
+          git push origin ${{ inputs.ref }}
 
       - name: fetch develop and main
         if: ${{ github.event.inputs.tag_version == 'latest' }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -47,23 +47,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm changeset version
 
-      - name: git add
+      - name: commit
         run: |
           git add .
+          git commit -m "chore(release): :rocket: prepare release [skip ci]"
 
-      - name: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(release): :rocket: prepare release [skip ci]"
-          repo: ${{ github.repository }}
-          branch: ${{ inputs.ref }}
-
-      - name: pull commit
+      - name: push changes
         run: |
-          git stash
-          git pull origin ${{ inputs.ref }}
+          git push origin ${{ inputs.ref }}
+          git fetch origin
 
       - name: fetch develop and main
         run: |

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -87,42 +87,30 @@ jobs:
         with:
           from_level: major
           to_level: patch
-      - name: Add changed files
-        run: |
-          git add .
       - name: commit (from release branch)
         if: ${{ startsWith(github.ref_name, 'release') }}
         env:
           LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
           LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
-          repo: ${{ github.repository }}
-          branch: ${{ github.ref_name }}
+        run: |
+          git add . &&
+          git commit -m "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}]" ||
+          echo ""
       - name: commit (from hotfix branch)
         if: ${{ startsWith(github.ref_name, 'hotfix') }}
         env:
           LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
           LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(hotfix): :fire: hotfix prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
-          repo: ${{ github.repository }}
-          branch: ${{ github.ref_name }}
+        run: |
+          git add . &&
+          git commit -m "chore(hotfix): :fire: hotfix prerelease [${{ env.LLD }}, ${{ env.LLM }}]" ||
+          echo ""
       - name: commit (from ${{ inputs.ref }} branch) workflow dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
-          LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "chore(prerelease): :rocket: ${{ inputs.ref }} prerelease [LLD(${{ steps.post-desktop-version.outputs.version }}), LLM(${{ steps.post-mobile-version.outputs.version }})]"
-          repo: ${{ github.repository }}
-          branch: ${{ inputs.ref }}
+        run: |
+          git add .
+          git commit -m "chore(prerelease): :rocket: ${{ inputs.ref }} prerelease [LLD(${{ steps.post-desktop-version.outputs.version }}), LLM(${{ steps.post-mobile-version.outputs.version }})]" ||
+          echo ""
       - name: authenticate with npm
         uses: actions/setup-node@v4
         with:
@@ -131,6 +119,16 @@ jobs:
         run: pnpm changeset publish --no-git-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+      - name: push changes (push event)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          git pull --rebase
+          git push origin ${{ github.ref_name }}
+      - name: push changes (other events)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          git pull --rebase
+          git push origin ${{ inputs.ref }}
       - uses: actions/github-script@v7
         name: trigger prerelease build for desktop
         if: ${{ steps.desktop-version.outputs.version != steps.post-desktop-version.outputs.version }}


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#9335 - we are seeing an issue where branch protection rules on the `release` branch prevent signed commits being created (all testing was not done on the real `release` branch, so this issue is only coming up now). This is blocking the current release, so reverting until we have figured out a workaround