### PR TITLE
fix: when no associated account error is trigger on the scan process,…

### DIFF
--- a/.changeset/swift-plants-visit.md
+++ b/.changeset/swift-plants-visit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Navigate to CustomNoAssociatedAccounts if exists and if no scanned accounts on add account v2

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/ScanDeviceAccounts/useScanDeviceAccountsViewModel.ts
@@ -288,7 +288,7 @@ export default function useScanDeviceAccountsViewModel({
           currency,
           context,
         });
-      } else if (CustomNoAssociatedAccounts) {
+      } else if (!scannedAccounts.length && CustomNoAssociatedAccounts) {
         navigation.replace(ScreenName.NoAssociatedAccounts, {
           CustomNoAssociatedAccounts,
         });


### PR DESCRIPTION
… verify whether there is a scanned account | hedera case

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This issue is initiated by a Hedera test case, when a currency have a `CustomNoAssociatedAccounts` implementation screen, the error is triggered even if the scanned accounts are > 1 and then the user cannot add an existing account. 

The fix is, whe no_importable accounts is trigger and fall into the CustomNoAssociatedAccounts exception, it should verify whether the scanned accounts are > 1 before blocking the user to the custo screen. 


https://github.com/user-attachments/assets/8e70cc99-ecbc-41f7-970f-62d4cb978e44

 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://ledgerhq.atlassian.net/browse/LIVE-17379
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
