### PR TITLE
feat(LIVE-17291): navigate to quotes on drawer cancel

### DIFF
--- a/.changeset/selfish-meals-stare.md
+++ b/.changeset/selfish-meals-stare.md
@@ -2,4 +2,4 @@
 "live-mobile": minor
 ---
 
-Start Exchange drawer onclose should only be called once
+Start and Complete Exchange drawer onclose should only be called once

--- a/.changeset/selfish-meals-stare.md
+++ b/.changeset/selfish-meals-stare.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Start Exchange drawer onclose should only be called once

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet } from "react-native";
 import { useSelector } from "react-redux";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -34,6 +34,7 @@ const PlatformCompleteExchange: React.FC<Props> = ({
   const [transaction, setTransaction] = useState<Transaction>();
   const [signedOperation, setSignedOperation] = useState<SignedOperation>();
   const [error, setError] = useState<Error>();
+  const hasPopped = useRef(false);
 
   useEffect(() => {
     if (signedOperation) {
@@ -50,7 +51,11 @@ const PlatformCompleteExchange: React.FC<Props> = ({
   }, [onResult, error]);
 
   const onClose = useCallback(() => {
-    navigation.pop();
+    // Prevent onClose being called twice
+    if (!hasPopped.current) {
+      navigation.pop();
+    }
+    hasPopped.current = true;
   }, [navigation]);
 
   const onCompleteExchange = useCallback(

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -1,7 +1,7 @@
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useIsFocused } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import DeviceActionModal from "~/components/DeviceActionModal";
@@ -23,9 +23,14 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   const action = useStartExchangeDeviceAction();
   const [device, setDevice] = useState<Device>();
   const isFocused = useIsFocused();
+  const hasPopped = useRef(false);
 
   const onClose = useCallback(() => {
-    navigation.pop();
+    // Prevent onClose being called twice
+    if (!hasPopped.current) {
+      navigation.pop();
+    }
+    hasPopped.current = true;
   }, [navigation]);
 
   const onResult = useCallback(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Prevent navigation.pop called twice on exchange drawer onClose, so close navigates back to Swap

![gif2](https://github.com/user-attachments/assets/c3a8f146-a143-4204-8a49-43dd31c7c5a1) 


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17291](https://ledgerhq.atlassian.net/browse/LIVE-17291)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17291]: https://ledgerhq.atlassian.net/browse/LIVE-17291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ