### PR TITLE
Re-implement verified commits in all remaining parts of the release workflows

### DIFF
--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -51,6 +51,7 @@ jobs:
       - name: create hotfix branch
         run: |
           git checkout -b hotfix
+          git push -u origin hotfix
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -77,17 +78,23 @@ jobs:
 
       - name: enter prerelease mode
         run: pnpm changeset pre enter hotfix
-      - name: commit
+      - name: git add
         run: |
           git add .
-          git commit -m "chore(hotfix) :rocket: entering hotfix mode"
+      - name: commit changes
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(hotfix) :rocket: entering hotfix mode"
+          repo: ${{ github.repository }}
+          branch: hotfix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get date
         id: date
         run: |
           echo "date=$(date +%F)" >> $GITHUB_OUTPUT
-      - name: push
+      - name: create PR to main
         run: |
-          git push origin hotfix
           gh pr create \
             --title ":fire: Hotfix ${{ steps.date.outputs.date }} (targeting ${{ github.event.inputs.application }} ${{ github.event.inputs.tag_version }})"\
             -F ./.github/templates/hotfix.md \

--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -88,7 +88,7 @@ jobs:
           repo: ${{ github.repository }}
           branch: hotfix
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Get date
         id: date
         run: |

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -26,6 +26,7 @@ jobs:
       - name: create release branch
         run: |
           git checkout -b $RELEASE_BRANCH
+          git push -u origin $RELEASE_BRANCH
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -37,16 +38,34 @@ jobs:
         run: pnpm build:libs
       - name: import CAL tokens
         run: pnpm import:cal-tokens
-      - name: commit new tokens
+      - name: Add changed files
         run: |
           git add .
-          git commit -m 'chore(prerelease) update cryptoassets' || echo "No new tokens added"
+      - name: commit new tokens
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(prerelease) update cryptoassets"
+          repo: ${{ github.repository }}
+          branch: ${{ env.RELEASE_BRANCH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: update sortByMarketcap snapshot
         run: pnpm common jest --runTestsByPath src/currencies/sortByMarketcap.test.ts -u
-      - name: commit sortByMarketcap.test.ts
+      - name: Add changed files
         run: |
+          git stash
+          git fetch origin $RELEASE_BRANCH          # make sure previous commit is included
+          git pull --rebase origin $RELEASE_BRANCH  # make sure previous commit is included
+          git stash pop
           git add .
-          git commit -m 'update sortByMarketcap snapshot' || echo "No changes in snapshot of sortByMarketcap.test.ts"
+      - name: commit sortByMarketcap.test.ts
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "update sortByMarketcap snapshot"
+          repo: ${{ github.repository }}
+          branch: ${{ env.RELEASE_BRANCH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Move patch updates to minor
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
@@ -56,17 +75,27 @@ jobs:
           to_level: minor
       - name: enter prerelease mode
         run: pnpm changeset pre enter next
-      - name: commit
+      - name: Add changed files
         run: |
+          git stash
+          git fetch origin $RELEASE_BRANCH          # make sure previous commit is included
+          git pull --rebase origin $RELEASE_BRANCH  # make sure previous commit is included
+          git stash pop
           git add .
-          git commit -m "chore(prerelease): :rocket: entering prerelease mode"
+      - name: commit
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(prerelease): :rocket: entering prerelease mode"
+          repo: ${{ github.repository }}
+          branch: ${{ env.RELEASE_BRANCH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get date
         id: date
         run: |
           echo "date=$(date +%F)" >> $GITHUB_OUTPUT
-      - name: push
+      - name: create PR
         run: |
-          git push origin $RELEASE_BRANCH
           gh pr create --title ":rocket: Release ${{ steps.date.outputs.date }}" -F .github/templates/release.md --base main --head $RELEASE_BRANCH
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -48,7 +48,7 @@ jobs:
           repo: ${{ github.repository }}
           branch: ${{ env.RELEASE_BRANCH }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: update sortByMarketcap snapshot
         run: pnpm common jest --runTestsByPath src/currencies/sortByMarketcap.test.ts -u
       - name: Add changed files
@@ -65,7 +65,7 @@ jobs:
           repo: ${{ github.repository }}
           branch: ${{ env.RELEASE_BRANCH }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Move patch updates to minor
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
@@ -89,7 +89,7 @@ jobs:
           repo: ${{ github.repository }}
           branch: ${{ env.RELEASE_BRANCH }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Get date
         id: date
         run: |

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -76,13 +76,13 @@ jobs:
           git add .
 
       - name: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: planetscale/ghcommit-action@v0.1.6
         with:
           commit_message: "chore(hotfix): :fire: hotfix release [skip ci]"
           repo: ${{ github.repository }}
           branch: ${{ inputs.ref }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: pull commit
         run: |

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -71,14 +71,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm changeset version
 
-      - name: commit
+      - name: git add
         run: |
           git add .
-          git commit -m "chore(hotfix): :fire: hotfix release [skip ci]"
 
-      - name: push changes
+      - name: commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(hotfix): :fire: hotfix release [skip ci]"
+          repo: ${{ github.repository }}
+          branch: ${{ inputs.ref }}
+
+      - name: pull commit
         run: |
-          git push origin ${{ inputs.ref }}
+          git stash
+          git pull
 
       - name: fetch develop and main
         if: ${{ github.event.inputs.tag_version == 'latest' }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -47,15 +47,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm changeset version
 
-      - name: commit
+      - name: git add
         run: |
           git add .
-          git commit -m "chore(release): :rocket: prepare release [skip ci]"
 
-      - name: push changes
+      - name: commit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(release): :rocket: prepare release [skip ci]"
+          repo: ${{ github.repository }}
+          branch: ${{ inputs.ref }}
+
+      - name: pull commit
         run: |
-          git push origin ${{ inputs.ref }}
-          git fetch origin
+          git stash
+          git pull origin ${{ inputs.ref }}
 
       - name: fetch develop and main
         run: |

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -52,13 +52,13 @@ jobs:
           git add .
 
       - name: commit
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: planetscale/ghcommit-action@v0.1.6
         with:
           commit_message: "chore(release): :rocket: prepare release [skip ci]"
           repo: ${{ github.repository }}
           branch: ${{ inputs.ref }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: pull commit
         run: |

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -87,30 +87,42 @@ jobs:
         with:
           from_level: major
           to_level: patch
+      - name: Add changed files
+        run: |
+          git add .
       - name: commit (from release branch)
         if: ${{ startsWith(github.ref_name, 'release') }}
         env:
           LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
           LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-        run: |
-          git add . &&
-          git commit -m "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}]" ||
-          echo ""
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
+          repo: ${{ github.repository }}
+          branch: ${{ github.ref_name }}
       - name: commit (from hotfix branch)
         if: ${{ startsWith(github.ref_name, 'hotfix') }}
         env:
           LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
           LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-        run: |
-          git add . &&
-          git commit -m "chore(hotfix): :fire: hotfix prerelease [${{ env.LLD }}, ${{ env.LLM }}]" ||
-          echo ""
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(hotfix): :fire: hotfix prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
+          repo: ${{ github.repository }}
+          branch: ${{ github.ref_name }}
       - name: commit (from ${{ inputs.ref }} branch) workflow dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          git add .
-          git commit -m "chore(prerelease): :rocket: ${{ inputs.ref }} prerelease [LLD(${{ steps.post-desktop-version.outputs.version }}), LLM(${{ steps.post-mobile-version.outputs.version }})]" ||
-          echo ""
+        env:
+          LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
+          LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: planetscale/ghcommit-action@v0.1.6
+        with:
+          commit_message: "chore(prerelease): :rocket: ${{ inputs.ref }} prerelease [LLD(${{ steps.post-desktop-version.outputs.version }}), LLM(${{ steps.post-mobile-version.outputs.version }})]"
+          repo: ${{ github.repository }}
+          branch: ${{ inputs.ref }}
       - name: authenticate with npm
         uses: actions/setup-node@v4
         with:
@@ -119,16 +131,6 @@ jobs:
         run: pnpm changeset publish --no-git-tag
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
-      - name: push changes (push event)
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          git pull --rebase
-          git push origin ${{ github.ref_name }}
-      - name: push changes (other events)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          git pull --rebase
-          git push origin ${{ inputs.ref }}
       - uses: actions/github-script@v7
         name: trigger prerelease build for desktop
         if: ${{ steps.desktop-version.outputs.version != steps.post-desktop-version.outputs.version }}

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -92,37 +92,37 @@ jobs:
           git add .
       - name: commit (from release branch)
         if: ${{ startsWith(github.ref_name, 'release') }}
-        env:
-          LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
-          LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: planetscale/ghcommit-action@v0.1.6
         with:
           commit_message: "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
           repo: ${{ github.repository }}
           branch: ${{ github.ref_name }}
-      - name: commit (from hotfix branch)
-        if: ${{ startsWith(github.ref_name, 'hotfix') }}
         env:
           LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
           LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: commit (from hotfix branch)
+        if: ${{ startsWith(github.ref_name, 'hotfix') }}
         uses: planetscale/ghcommit-action@v0.1.6
         with:
           commit_message: "chore(hotfix): :fire: hotfix prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
           repo: ${{ github.repository }}
           branch: ${{ github.ref_name }}
-      - name: commit (from ${{ inputs.ref }} branch) workflow dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
           LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: commit (from ${{ inputs.ref }} branch) workflow dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: planetscale/ghcommit-action@v0.1.6
         with:
           commit_message: "chore(prerelease): :rocket: ${{ inputs.ref }} prerelease [LLD(${{ steps.post-desktop-version.outputs.version }}), LLM(${{ steps.post-mobile-version.outputs.version }})]"
           repo: ${{ github.repository }}
           branch: ${{ inputs.ref }}
+        env:
+          LLD: LLD(${{ steps.post-desktop-version.outputs.version }})
+          LLM: LLM(${{ steps.post-mobile-version.outputs.version }})
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: authenticate with npm
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Hopefully the final PR for https://ledgerhq.atlassian.net/browse/LIVE-17241

- Reverts LedgerHQ/ledger-live#9389
- Uses the live-github-bot installation token instead of the generic GITHUB_TOKEN to sign commits. This creates commits signed as `live-github-bot`. `live-github-bot` is exempt from the branch protections that blocked commits made from the generic `github-actions[bot]` user.

### Part 1: creating verified commits under `live-github-bot`

Creating (verified) commits as live-github-bot is demonstrated in [this test PR](https://github.com/LedgerHQ/ledger-live/pull/9409), which creates several commits with several different methods in a separate branch. These commits can be viewed here: https://github.com/LedgerHQ/ledger-live/compare/develop...commit-test-branch (see commit 23b253bbbea90f0a604149cdb7933bd710580000, which was generated from the action invocation at [this line](https://github.com/LedgerHQ/ledger-live/pull/9409/files#diff-cf62d1a039bb3d2b8223fffbf7e45e15a86ceb2a3f2929bdf76574b60370a298R60) - this is the pattern that is rolled out in this PR).

### Part 2: verifying that verified commits from `live-github-bot` pass branch protection rules
I was able to recreate the original commit failure due to branch protection rules, then successfully allow commits to be created via exemption targeting `live-github-bot` in this [test PR](https://github.com/LedgerHQ/ledger-live/pull/9417).