### PR TITLE
ci: update github app login, to real value this time

### DIFF
--- a/tools/github-bot/src/features/autoClose/index.ts
+++ b/tools/github-bot/src/features/autoClose/index.ts
@@ -13,7 +13,7 @@ export function autoClose(app: Probot) {
 
     if (
       repository.repo !== "ledger-live" ||
-      login !== "app/smartling-github-connector" ||
+      login !== "smartling-github-connector[bot]" ||
       !/^smartling-(content-updated|translation-completed)-.+/.test(branch)
     ) {
       return;


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LIVE-17102

The [last PR](https://github.com/LedgerHQ/ledger-live/pull/9301) to attempt to auto-close smartling PRs didn't work. I suspected the app's login name wasn't correct, so set up [a proxy using smee](https://smee.io/ITmIQR5eaI2DeydR) and fired some github webhooks at it as I manually closed and reopened a smartling PR. This revealed the real `login` value for the smartling github app, which is updated in this PR.