### PR TITLE
fix: remove sortbymarketcap snapshot update in release workflow

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -49,23 +49,6 @@ jobs:
           branch: ${{ env.RELEASE_BRANCH }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-      - name: update sortByMarketcap snapshot
-        run: pnpm common jest --runTestsByPath src/currencies/sortByMarketcap.test.ts -u
-      - name: Add changed files
-        run: |
-          git stash
-          git fetch origin $RELEASE_BRANCH          # make sure previous commit is included
-          git pull --rebase origin $RELEASE_BRANCH  # make sure previous commit is included
-          git stash pop
-          git add .
-      - name: commit sortByMarketcap.test.ts
-        uses: planetscale/ghcommit-action@v0.1.6
-        with:
-          commit_message: "update sortByMarketcap snapshot"
-          repo: ${{ github.repository }}
-          branch: ${{ env.RELEASE_BRANCH }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Move patch updates to minor
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Remove sortByMarketCap update during the release process as we don't rely on the snapshot anymore.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
