### PR TITLE
ci: exit prerelease on develop

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@ledgerhq/live-cli": "24.12.1",


### PR DESCRIPTION
Exits prerelease mode on `develop`. Follows [this discussion](https://ledger.slack.com/archives/C040D9JMVQ8/p1741163572969049)