### PR TITLE
fix: potential wrong type for the hydrate value [LIVE-17507]

### DIFF
--- a/.changeset/famous-jobs-sort.md
+++ b/.changeset/famous-jobs-sort.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": minor
+---
+
+fix: potential wrong type for the hydrate value

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/preload.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/preload.unit.test.ts
@@ -219,6 +219,14 @@ describe("EVM Family", () => {
         ]);
       });
 
+      it("should register ERC20 tokens from embedded with anything other than an array", async () => {
+        hydrate({}, currency1);
+
+        expect(CALTokensAPI.addTokens).toHaveBeenCalledWith([
+          CALTokensAPI.convertERC20(usdcDefinition),
+        ]);
+      });
+
       it("should register ERC20 tokens", async () => {
         hydrate([usdcDefinition, usdtDefinition], currency1);
 

--- a/libs/coin-modules/coin-evm/src/preload.ts
+++ b/libs/coin-modules/coin-evm/src/preload.ts
@@ -87,7 +87,7 @@ export async function preload(currency: CryptoCurrency): Promise<ERC20Token[] | 
 }
 
 export function hydrate(value: unknown, currency: CryptoCurrency): void {
-  if (!value || !Array.isArray(value)) {
+  if (!Array.isArray(value)) {
     const { chainId } = currency.ethereumLikeInfo || {};
     const tokens = tokensByChainId[chainId as keyof typeof tokensByChainId] || [];
     addTokens(tokens.map(convertERC20));

--- a/libs/coin-modules/coin-evm/src/preload.ts
+++ b/libs/coin-modules/coin-evm/src/preload.ts
@@ -86,8 +86,8 @@ export async function preload(currency: CryptoCurrency): Promise<ERC20Token[] | 
   return erc20;
 }
 
-export function hydrate(value: ERC20Token[] | null | undefined, currency: CryptoCurrency): void {
-  if (!value) {
+export function hydrate(value: unknown, currency: CryptoCurrency): void {
+  if (!value || !Array.isArray(value)) {
     const { chainId } = currency.ethereumLikeInfo || {};
     const tokens = tokensByChainId[chainId as keyof typeof tokensByChainId] || [];
     addTokens(tokens.map(convertERC20));


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Add account token listing

### 📝 Description

Update expected type for the evm hydrate function to check all possible types for value
It also aligns better with the currencyBridge type for hydrate

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-17507]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17507]: https://ledgerhq.atlassian.net/browse/LIVE-17507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ