### PR TITLE
Feat/error drawer swap

### DIFF
--- a/.changeset/hot-penguins-swim.md
+++ b/.changeset/hot-penguins-swim.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat: allow error drawer to be shown when receiving custom.exchange.error when no drawers are opened

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -82,10 +82,10 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
             );
           },
           "custom.exchange.error": ({ error }) => {
-            if (!isDrawerOpen) {
-              dispatch(closePlatformAppDrawer());
-              setDrawer(WebviewErrorDrawer, error);
-            }
+            // if (!isDrawerOpen) {
+            dispatch(closePlatformAppDrawer());
+            setDrawer(WebviewErrorDrawer, error);
+            // }
             return Promise.resolve();
           },
         },

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -82,10 +82,8 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
             );
           },
           "custom.exchange.error": ({ error }) => {
-            // if (!isDrawerOpen) {
             dispatch(closePlatformAppDrawer());
             setDrawer(WebviewErrorDrawer, error);
-            // }
             return Promise.resolve();
           },
         },

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/CustomHandlers.ts
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 import {
   handlers as exchangeHandlers,
@@ -13,13 +13,10 @@ import { closePlatformAppDrawer, openExchangeDrawer } from "~/renderer/actions/U
 import { WebviewProps } from "../Web3AppWebview/types";
 import { context } from "~/renderer/drawers/Provider";
 import WebviewErrorDrawer from "~/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer";
-import { platformAppDrawerStateSelector } from "~/renderer/reducers/UI";
 
 export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], accounts: AccountLike[]) {
   const dispatch = useDispatch();
   const { setDrawer } = React.useContext(context);
-
-  const { isOpen: isDrawerOpen } = useSelector(platformAppDrawerStateSelector);
 
   const tracking = useMemo(
     () =>
@@ -89,5 +86,5 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
         },
       }),
     };
-  }, [accounts, tracking, manifest, dispatch, setDrawer, isDrawerOpen]);
+  }, [accounts, tracking, manifest, dispatch, setDrawer]);
 }

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import { useGetSwapTrackingProperties } from "../../utils/index";
-import { Text } from "@ledgerhq/react-ui";
+import { BoxedIcon, Text } from "@ledgerhq/react-ui";
 import ErrorNoBorder from "~/renderer/icons/ErrorNoBorder";
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import ErrorIcon from "~/renderer/components/ErrorIcon";
@@ -82,7 +82,14 @@ export default function WebviewErrorDrawer(error?: SwapLiveError) {
       <TrackPage category="Swap" name="Webview error drawer" {...swapDefaultTrack} {...error} />
       <Box mt={3} flow={4} mx={5}>
         <Logo>
-          <ErrorIcon size={24} error={error} />
+          <Box alignSelf="center">
+            <BoxedIcon
+              Icon={() => <ErrorIcon error={error} size={24} />}
+              size={64}
+              iconSize={24}
+              iconColor={"neutral.c100"}
+            />
+          </Box>
         </Logo>
         <ErrorTitle>
           <Trans i18nKey={titleKey} />

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
@@ -7,6 +7,7 @@ import { useGetSwapTrackingProperties } from "../../utils/index";
 import { Text } from "@ledgerhq/react-ui";
 import ErrorNoBorder from "~/renderer/icons/ErrorNoBorder";
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
+import ErrorIcon from "~/renderer/components/ErrorIcon";
 
 const ContentBox = styled(Box)`
   display: flex;
@@ -81,7 +82,7 @@ export default function WebviewErrorDrawer(error?: SwapLiveError) {
       <TrackPage category="Swap" name="Webview error drawer" {...swapDefaultTrack} {...error} />
       <Box mt={3} flow={4} mx={5}>
         <Logo>
-          <ErrorNoBorder size={44} />
+          <ErrorIcon size={24} error={error} />
         </Logo>
         <ErrorTitle>
           <Trans i18nKey={titleKey} />

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
@@ -5,7 +5,6 @@ import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import { useGetSwapTrackingProperties } from "../../utils/index";
 import { BoxedIcon, Text } from "@ledgerhq/react-ui";
-import ErrorNoBorder from "~/renderer/icons/ErrorNoBorder";
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import ErrorIcon from "~/renderer/components/ErrorIcon";
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - 

### 📝 Description

Before the change we had an infinite drawer when /swap failed (inbetween state where no drawer where technically opened)
This fix just removes the isSomething open, close it and open the error drawer, to just close everything opened and open the error drawer. 
Could have an impact on other errors, exchange live apps


https://github.com/user-attachments/assets/38f39e26-f845-4bb4-b15e-0343f5aaf259




### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-17483

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
