### PR TITLE
fix: Fix Overflow in Settings for LedgerSync Entry point

### DIFF
--- a/.changeset/tame-fans-perform.md
+++ b/.changeset/tame-fans-perform.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Overflow in Settings for LedgerSync Entry point

--- a/apps/ledger-live-desktop/src/newArch/features/LedgerSyncEntryPoints/components/SettingsEntryPoint/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/LedgerSyncEntryPoints/components/SettingsEntryPoint/index.tsx
@@ -12,37 +12,44 @@ export default function SettingsEntryPoint({ onPress }: { onPress: () => void })
 
   return (
     <SettingsSectionRowContainer tabIndex={-1}>
-      <Flex alignItems="center" justifyContent="center">
-        <Flex position="relative">
-          <Illustration lightSource={LogoLight} darkSource={LogoDark} size={24} />
-          <Flex
-            bg="error.c60"
-            width={4}
-            height={4}
-            position="absolute"
-            right={0}
-            bottom={0}
-            borderRadius="50%"
-          />
-        </Flex>
-        <Flex flexDirection="column" ml={4}>
-          <Box ff="Inter|SemiBold" color="palette.text.shade100" fontSize={14}>
-            {t("walletSync.entryPoints.settings.title")}
-          </Box>
-          <Box
-            ff="Inter"
-            fontSize={3}
-            color="palette.text.shade60"
-            mt={1}
-            mr={1}
-            style={{
-              maxWidth: 520,
-            }}
-          >
-            {t("walletSync.entryPoints.settings.description")}
-          </Box>
-        </Flex>
+      <Flex position="relative">
+        <Illustration lightSource={LogoLight} darkSource={LogoDark} size={24} />
+        <Flex
+          bg="error.c60"
+          width={4}
+          height={4}
+          position="absolute"
+          right={0}
+          bottom={0}
+          borderRadius="50%"
+        />
       </Flex>
+
+      <Box
+        grow
+        shrink
+        ml={4}
+        style={{
+          marginRight: "10%",
+        }}
+      >
+        <Box ff="Inter|SemiBold" color="palette.text.shade100" fontSize={14}>
+          {t("walletSync.entryPoints.settings.title")}
+        </Box>
+        <Box
+          ff="Inter"
+          fontSize={3}
+          color="palette.text.shade60"
+          mt={1}
+          mr={1}
+          style={{
+            maxWidth: 520,
+          }}
+        >
+          {t("walletSync.entryPoints.settings.description")}
+        </Box>
+      </Box>
+
       <Button variant="main" onClick={onPress}>
         <Text color="neutral.c00">{t("walletSync.entryPoints.settings.cta")}</Text>
       </Button>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Overflow in Settings for LedgerSync Entry point when text is too long (German or French Maybe)

Before

<img width="1024" alt="Screenshot 2025-03-07 at 14 03 05" src="https://github.com/user-attachments/assets/278427b8-e5ec-4cbf-a783-19a794d0bd1b" />

After


https://github.com/user-attachments/assets/a5610976-b88c-43ce-a023-96046d2b1184


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17545] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17545]: https://ledgerhq.atlassian.net/browse/LIVE-17545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ