### PR TITLE
fix: elliptic pinned to 6.6.1

### DIFF
--- a/.changeset/mean-numbers-smell.md
+++ b/.changeset/mean-numbers-smell.md
@@ -1,0 +1,27 @@
+---
+"@ledgerhq/live-cli": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/web-tools": minor
+"@ledgerhq/coin-bitcoin": minor
+"@ledgerhq/coin-cardano": minor
+"@ledgerhq/coin-casper": minor
+"@ledgerhq/coin-cosmos": minor
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/coin-filecoin": minor
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/coin-icon": minor
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/coin-ton": minor
+"@ledgerhq/coin-tron": minor
+"@ledgerhq/coin-vechain": minor
+"@ledgerhq/evm-tools": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/hw-app-eth": minor
+"@ledgerhq/hw-app-vet": minor
+"@ledgerhq/live-signer-evm": minor
+"@ledgerhq/live-wallet": minor
+"@ledgerhq/test-utils": minor
+---
+
+Fix elliptic library version used

--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
       "tslib": "2.6.2",
       "@hashgraph/sdk>@hashgraph/cryptography": "1.1.2",
       "@hashgraph/sdk>@grpc/grpc-js": "1.6.7",
-      "@ethersproject/providers>ws": "7.5.10"
+      "@ethersproject/providers>ws": "7.5.10",
+      "elliptic": "6.6.1"
     },
     "patchedDependencies": {
       "react-native-fast-crypto@2.2.0": "patches/react-native-fast-crypto@2.2.0.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   '@hashgraph/sdk>@hashgraph/cryptography': 1.1.2
   '@hashgraph/sdk>@grpc/grpc-js': 1.6.7
   '@ethersproject/providers>ws': 7.5.10
+  elliptic: 6.6.1
 
 packageExtensionsChecksum: 505470d279d34dbf557b1005424e3d1d
 
@@ -20450,11 +20451,8 @@ packages:
     resolution: {integrity: sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==}
     engines: {node: '>=0.10.0'}
 
-  elliptic@6.5.4:
-    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
-
-  elliptic@6.5.5:
-    resolution: {integrity: sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==}
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   embla-carousel-autoplay@8.4.0:
     resolution: {integrity: sha512-AJHXrnaY+Tf4tb/+oItmJSpz4P0WvS62GrW5Z4iFY3zsH0mkKcijzd04LIkj0P4DkTazIBEuXple+nUVmuMsrQ==}
@@ -35394,7 +35392,7 @@ snapshots:
       '@cosmjs/utils': 0.24.1
       bip39: 3.1.0
       bn.js: 4.12.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       js-sha3: 0.8.0
       libsodium-wrappers: 0.7.13
       pbkdf2: 3.1.2
@@ -35409,7 +35407,7 @@ snapshots:
       '@cosmjs/utils': 0.26.8
       '@noble/hashes': 1.7.0
       bn.js: 5.2.1
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       libsodium-wrappers: 0.7.13
 
   '@cosmjs/crypto@0.31.3':
@@ -35419,7 +35417,7 @@ snapshots:
       '@cosmjs/utils': 0.31.3
       '@noble/hashes': 1.7.0
       bn.js: 5.2.1
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       libsodium-wrappers-sumo: 0.7.13
 
   '@cosmjs/encoding@0.24.1':
@@ -36527,7 +36525,7 @@ snapshots:
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       bn.js: 5.2.1
-      elliptic: 6.5.4
+      elliptic: 6.6.1
       hash.js: 1.1.7
 
   '@ethersproject/solidity@5.7.0':
@@ -37772,7 +37770,7 @@ snapshots:
     dependencies:
       bignumber.js: 9.1.2
       crypto-js: 4.2.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       expo-crypto: 10.2.0
       expo-random: 12.3.0
       js-base64: 3.7.7
@@ -37882,7 +37880,7 @@ snapshots:
       '@iov/encoding': 2.1.0
       bip39: 3.1.0
       bn.js: 4.12.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       js-sha3: 0.8.0
       libsodium-wrappers: 0.7.13
       pbkdf2: 3.1.2
@@ -38796,7 +38794,7 @@ snapshots:
       bip39: 3.1.0
       buffer: 6.0.3(patch_hash=2xnca52oxhztvr7iaoovwclcze)
       crypto-js: 4.2.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       sha.js: 2.4.11
 
   '@keplr-wallet/proto-types@0.12.89':
@@ -45345,7 +45343,7 @@ snapshots:
       bn.js: 5.2.1
       buffer: 6.0.3(patch_hash=2xnca52oxhztvr7iaoovwclcze)
       chai: 4.4.1
-      elliptic: 6.5.4
+      elliptic: 6.6.1
       hash.js: 1.1.7
       pbkdf2: 3.1.2
 
@@ -45700,7 +45698,7 @@ snapshots:
       blakejs: 1.2.1
       bs58check: 3.0.1
       buffer: 6.0.3(patch_hash=2xnca52oxhztvr7iaoovwclcze)
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       typedarray-to-buffer: 4.0.0
 
   '@testing-library/dom@9.3.4':
@@ -45862,7 +45860,7 @@ snapshots:
     dependencies:
       asn1.js: 5.4.1
       base64url: 3.0.1
-      elliptic: 6.5.5
+      elliptic: 6.6.1
 
   '@trysound/sax@0.2.0': {}
 
@@ -47042,7 +47040,7 @@ snapshots:
       '@types/node': 10.17.60
       aes-js: 3.0.0
       bn.js: 4.12.0
-      elliptic: 6.5.4
+      elliptic: 6.6.1
       hash.js: 1.1.3
       js-sha3: 0.5.7
       scrypt-js: 2.0.4
@@ -48598,7 +48596,7 @@ snapshots:
 
   babel-plugin-styled-components@2.1.4(@babel/core@7.24.3)(styled-components@5.3.11(@babel/core@7.24.3)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)):
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-module-imports': 7.24.3
       '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.3)
       lodash: 4.17.21
@@ -48609,7 +48607,7 @@ snapshots:
 
   babel-plugin-styled-components@2.1.4(@babel/core@7.24.3)(styled-components@5.3.11(@babel/core@7.24.3)(react-is@18.3.1)(react@18.3.1)):
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-module-imports': 7.24.3
       '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.3)
       lodash: 4.17.21
@@ -49167,7 +49165,7 @@ snapshots:
       browserify-rsa: 4.1.0
       create-hash: 1.2.0
       create-hmac: 1.1.7
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       hash-base: 3.0.4
       inherits: 2.0.4
       parse-asn1: 5.1.7
@@ -50227,7 +50225,7 @@ snapshots:
   create-ecdh@4.0.4:
     dependencies:
       bn.js: 4.12.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
 
   create-hash@1.2.0:
     dependencies:
@@ -51546,17 +51544,7 @@ snapshots:
 
   elegant-spinner@1.0.1: {}
 
-  elliptic@6.5.4:
-    dependencies:
-      bn.js: 4.12.0
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-
-  elliptic@6.5.5:
+  elliptic@6.6.1:
     dependencies:
       bn.js: 4.12.0
       brorand: 1.1.0
@@ -52559,7 +52547,7 @@ snapshots:
   eth-lib@0.1.29:
     dependencies:
       bn.js: 4.12.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       nano-json-stream-parser: 0.1.2
       servify: 0.1.12
       ws: 3.3.3
@@ -52572,7 +52560,7 @@ snapshots:
   eth-lib@0.2.8:
     dependencies:
       bn.js: 4.12.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       xhr-request-promise: 0.1.3
 
   ethereum-bloom-filters@1.0.10:
@@ -57695,7 +57683,7 @@ snapshots:
       '@types/elliptic': 6.4.18
       asn1.js: 5.4.1
       bn.js: 4.12.0
-      elliptic: 6.5.5
+      elliptic: 6.6.1
 
   keygrip@1.1.0:
     dependencies:
@@ -63740,13 +63728,13 @@ snapshots:
 
   secp256k1@4.0.3:
     dependencies:
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       node-addon-api: 2.0.2
       node-gyp-build: 4.8.0
 
   secp256k1@5.0.0:
     dependencies:
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       node-addon-api: 5.1.0
       node-gyp-build: 4.8.0
 
@@ -65279,7 +65267,7 @@ snapshots:
       '@vechain/ethers': 4.0.27-5
       bignumber.js: 7.2.1
       blakejs: 1.2.1
-      elliptic: 6.5.4
+      elliptic: 6.6.1
       fast-json-stable-stringify: 2.1.0
       js-sha3: 0.5.7
       rlp: 2.2.7
@@ -65338,7 +65326,7 @@ snapshots:
       bindings: 1.5.0
       bn.js: 4.12.0
       create-hmac: 1.1.7
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       nan: 2.20.0
 
   tiny-secp256k1@1.1.7:
@@ -65346,7 +65334,7 @@ snapshots:
       bindings: 1.5.0
       bn.js: 4.12.0
       create-hmac: 1.1.7
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       nan: 2.20.0
 
   tiny-typed-emitter@2.1.0: {}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** 

Coin Integration:
- [ ] BTC
- [ ] ETH
- [ ] Vechain
- [ ] Cosmos
- [ ] Hedera
- [ ] Cardano
- [ ] Icon
- [ ] Casper
- [ ] Tron
- [ ] Tezos

And all coin modules using node-libs-react-native

Live Hub:
- [ ] LLD Auto Upgrade
- [x] Ledger Sync

PTX Swap:
- [ ] App exchange


### 📝 Description

Upgrade elliptic dependency.

`pnpm why elliptic -r --parseable`

```
/apps/cli
/libs/coin-modules/coin-bitcoin
/libs/ledgerjs/packages/hw-app-btc
/libs/hw-ledger-key-ring-protocol
/libs/ledger-key-ring-protocol
/node_modules/.pnpm/bip32@2.0.6/node_modules/bip32
/node_modules/.pnpm/bitcoinjs-lib@5.2.0/node_modules/bitcoinjs-lib
/node_modules/.pnpm/elliptic@6.6.1/node_modules/elliptic
/node_modules/.pnpm/secp256k1@4.0.3/node_modules/secp256k1
/node_modules/.pnpm/secp256k1@5.0.0/node_modules/secp256k1
/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1
/node_modules/.pnpm/tiny-secp256k1@1.1.7/node_modules/tiny-secp256k1
/apps/ledger-live-desktop
/node_modules/.pnpm/@blooo+hw-app-acre@1.1.1/node_modules/@blooo/hw-app-acre
/node_modules/.pnpm/@celo+connect@6.0.2/node_modules/@celo/connect
/node_modules/.pnpm/@celo+contractkit@8.3.1/node_modules/@celo/contractkit
/node_modules/.pnpm/@celo+hw-app-eth@1.0.1/node_modules/@celo/hw-app-eth
/node_modules/.pnpm/@celo+utils@7.0.0/node_modules/@celo/utils
/node_modules/.pnpm/@celo+wallet-base@6.0.3/node_modules/@celo/wallet-base
/node_modules/.pnpm/@celo+wallet-ledger@6.0.3/node_modules/@celo/wallet-ledger
/node_modules/.pnpm/@celo+wallet-local@6.0.3/node_modules/@celo/wallet-local
/node_modules/.pnpm/@celo+wallet-remote@6.0.3/node_modules/@celo/wallet-remote
/node_modules/.pnpm/@cosmjs+amino@0.31.3/node_modules/@cosmjs/amino
/node_modules/.pnpm/@cosmjs+amino@0.26.8/node_modules/@cosmjs/amino
/node_modules/.pnpm/@cosmjs+crypto@0.31.3/node_modules/@cosmjs/crypto
/node_modules/.pnpm/@cosmjs+crypto@0.26.8/node_modules/@cosmjs/crypto
/node_modules/.pnpm/@cosmjs+crypto@0.24.1/node_modules/@cosmjs/crypto
/node_modules/.pnpm/@cosmjs+launchpad@0.24.1/node_modules/@cosmjs/launchpad
/node_modules/.pnpm/@cosmjs+proto-signing@0.26.8/node_modules/@cosmjs/proto-signing
/node_modules/.pnpm/@cosmjs+proto-signing@0.24.1/node_modules/@cosmjs/proto-signing
/node_modules/.pnpm/@cosmjs+stargate@0.26.8/node_modules/@cosmjs/stargate
/node_modules/.pnpm/@cosmjs+tendermint-rpc@0.26.8/node_modules/@cosmjs/tendermint-rpc
/node_modules/.pnpm/@ethereumjs+common@2.6.5/node_modules/@ethereumjs/common
/node_modules/.pnpm/@ethereumjs+tx@3.5.2/node_modules/@ethereumjs/tx
/node_modules/.pnpm/@ethersproject+abi@5.7.0/node_modules/@ethersproject/abi
/node_modules/.pnpm/@ethersproject+abstract-provider@5.7.0/node_modules/@ethersproject/abstract-provider
/node_modules/.pnpm/@ethersproject+abstract-signer@5.7.0/node_modules/@ethersproject/abstract-signer
/node_modules/.pnpm/@ethersproject+contracts@5.7.0/node_modules/@ethersproject/contracts
/node_modules/.pnpm/@ethersproject+hash@5.7.0/node_modules/@ethersproject/hash
/node_modules/.pnpm/@ethersproject+hdnode@5.7.0/node_modules/@ethersproject/hdnode
/node_modules/.pnpm/@ethersproject+json-wallets@5.7.0/node_modules/@ethersproject/json-wallets
/node_modules/.pnpm/@ethersproject+providers@5.7.2/node_modules/@ethersproject/providers
/node_modules/.pnpm/@ethersproject+signing-key@5.7.0/node_modules/@ethersproject/signing-key
/node_modules/.pnpm/@ethersproject+transactions@5.7.0/node_modules/@ethersproject/transactions
/node_modules/.pnpm/@ethersproject+wallet@5.7.0/node_modules/@ethersproject/wallet
/node_modules/.pnpm/@ethersproject+wordlists@5.7.0/node_modules/@ethersproject/wordlists
/node_modules/.pnpm/@hashgraph+cryptography@1.1.2/node_modules/@hashgraph/cryptography
/node_modules/.pnpm/@hashgraph+sdk@2.14.2_patch_hash=hno7opkpqo3efbuenv6ysglr4m/node_modules/@hashgraph/sdk
/node_modules/.pnpm/@iov+crypto@2.1.0/node_modules/@iov/crypto
/node_modules/.pnpm/@keplr-wallet+cosmos@0.9.16/node_modules/@keplr-wallet/cosmos
/node_modules/.pnpm/@keplr-wallet+crypto@0.9.10/node_modules/@keplr-wallet/crypto
/node_modules/.pnpm/@keplr-wallet+types@0.9.12/node_modules/@keplr-wallet/types
/node_modules/.pnpm/@keplr-wallet+unit@0.9.12/node_modules/@keplr-wallet/unit
/libs/coin-modules/coin-cardano
/libs/coin-modules/coin-casper
/libs/coin-modules/coin-cosmos
/libs/coin-modules/coin-evm
/libs/coin-modules/coin-filecoin
/libs/coin-modules/coin-hedera
/libs/coin-modules/coin-icon
/libs/coin-modules/coin-tezos
/libs/coin-modules/coin-tron
/libs/coin-modules/coin-vechain
/node_modules/.pnpm/@ledgerhq+evm-tools@1.3.0/node_modules/@ledgerhq/evm-tools
/libs/evm-tools
/libs/ledgerjs/packages/hw-app-eth
/libs/ledgerjs/packages/hw-app-vet
/apps/cli
/libs/ledger-live-common
/libs/live-signer-evm
/libs/live-wallet
/libs/test-utils
/node_modules/.pnpm/@stricahq+bip32ed25519@1.0.4/node_modules/@stricahq/bip32ed25519
/node_modules/.pnpm/@taquito+ledger-signer@20.0.1/node_modules/@taquito/ledger-signer
/node_modules/.pnpm/@taquito+local-forging@20.0.1/node_modules/@taquito/local-forging
/node_modules/.pnpm/@taquito+michelson-encoder@20.0.1/node_modules/@taquito/michelson-encoder
/node_modules/.pnpm/@taquito+rpc@20.0.1/node_modules/@taquito/rpc
/node_modules/.pnpm/@taquito+taquito@20.0.1/node_modules/@taquito/taquito
/node_modules/.pnpm/@taquito+utils@20.0.1/node_modules/@taquito/utils
/node_modules/.pnpm/@vechain+ethers@4.0.27-5/node_modules/@vechain/ethers
/node_modules/.pnpm/@zondax+ledger-cosmos-js@3.0.3_@types+node@22.10.10_eslint@8.57.0_lodash@4.17.21_prettier@3.2_nlkszyn7plnspj2xq4ohjegjga/node_modules/@zondax/ledger-cosmos-js
/node_modules/.pnpm/browserify-sign@4.2.3/node_modules/browserify-sign
/node_modules/.pnpm/casper-js-sdk@2.15.4/node_modules/casper-js-sdk
/node_modules/.pnpm/create-ecdh@4.0.4/node_modules/create-ecdh
/node_modules/.pnpm/crypto-browserify@3.12.0/node_modules/crypto-browserify
/node_modules/.pnpm/eth-lib@0.1.29/node_modules/eth-lib
/node_modules/.pnpm/eth-lib@0.2.8/node_modules/eth-lib
/node_modules/.pnpm/ethereum-cryptography@0.1.3/node_modules/ethereum-cryptography
/node_modules/.pnpm/ethereumjs-util@7.1.5/node_modules/ethereumjs-util
/node_modules/.pnpm/ethers@5.7.2/node_modules/ethers
/node_modules/.pnpm/icon-sdk-js@1.5.2/node_modules/icon-sdk-js
/node_modules/.pnpm/key-encoder@2.0.3/node_modules/key-encoder
/node_modules/.pnpm/secretjs@0.17.8/node_modules/secretjs
/node_modules/.pnpm/swarm-js@0.1.42/node_modules/swarm-js
/node_modules/.pnpm/thor-devkit@2.0.9/node_modules/thor-devkit
/node_modules/.pnpm/tronweb@5.3.2/node_modules/tronweb
/node_modules/.pnpm/web3@1.10.4/node_modules/web3
/node_modules/.pnpm/web3-bzz@1.10.4/node_modules/web3-bzz
/node_modules/.pnpm/web3-core@1.10.4/node_modules/web3-core
/node_modules/.pnpm/web3-core-method@1.10.4/node_modules/web3-core-method
/node_modules/.pnpm/web3-eth@1.10.4/node_modules/web3-eth
/node_modules/.pnpm/web3-eth-abi@1.10.4/node_modules/web3-eth-abi
/node_modules/.pnpm/web3-eth-accounts@1.10.4/node_modules/web3-eth-accounts
/node_modules/.pnpm/web3-eth-contract@1.10.4/node_modules/web3-eth-contract
/node_modules/.pnpm/web3-eth-ens@1.10.4/node_modules/web3-eth-ens
/node_modules/.pnpm/web3-eth-personal@1.10.4/node_modules/web3-eth-personal
/node_modules/.pnpm/web3-net@1.10.4/node_modules/web3-net
/node_modules/.pnpm/web3-shh@1.10.4/node_modules/web3-shh
```

Our packages:
```
/apps/cli
/libs/coin-modules/coin-bitcoin
/libs/ledgerjs/packages/hw-app-btc
/libs/hw-ledger-key-ring-protocol
/libs/ledger-key-ring-protocol
/libs/coin-modules/coin-cardano
/libs/coin-modules/coin-casper
/libs/coin-modules/coin-cosmos
/libs/coin-modules/coin-evm
/libs/coin-modules/coin-filecoin
/libs/coin-modules/coin-hedera
/libs/coin-modules/coin-icon
/libs/coin-modules/coin-tezos
/libs/coin-modules/coin-tron
/libs/coin-modules/coin-vechain
/libs/evm-tools
/libs/ledgerjs/packages/hw-app-eth
/libs/ledgerjs/packages/hw-app-vet
/libs/ledger-live-common
/libs/live-signer-evm
/libs/live-wallet
/libs/test-utils
```

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-17600


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
