### PR TITLE
fix(LIVE-17499) Swap connect device too small

### DIFF
--- a/.changeset/great-mayflies-return.md
+++ b/.changeset/great-mayflies-return.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix large padding on Swap connect device screen

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -44,7 +44,7 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   const requestToSetHeaderOptions = useCallback(() => undefined, []);
   const request = useMemo(() => route.params.request, [route.params.request]);
   return (
-    <SafeAreaView style={styles.root}>
+    <SafeAreaView style={styles.root} edges={["bottom"]}>
       <Flex px={16} py={8} flex={1}>
         <SelectDevice2
           onSelect={setDevice}

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -63,9 +63,4 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   );
 }
 
-const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-    padding: 32,
-  },
-});
+const styles = StyleSheet.create({ root: { flex: 1 } });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Removes large padding around Device Selection page used by Swap.

| Before        | After         |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/298c4665-a8d7-447e-aaf5-3cac4efbec30) | ![image](https://github.com/user-attachments/assets/b710760c-fc37-4007-853c-f0fbb6a631bb) |
| ![image](https://github.com/user-attachments/assets/2056c67d-1f2e-45ce-a269-5f4a19ef5028) | ![image](https://github.com/user-attachments/assets/b02b5adc-9552-4aa5-8a97-c41368a04335) |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17499](https://ledgerhq.atlassian.net/browse/LIVE-17499)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17499]: https://ledgerhq.atlassian.net/browse/LIVE-17499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ