### PR TITLE
ci: temporarily log out PR event attributes for smartling PRs

### DIFF
--- a/.github/workflows/temp-log-pr-event.yml
+++ b/.github/workflows/temp-log-pr-event.yml
@@ -1,0 +1,17 @@
+# Temporary workflow for dissecting the PR event for Smartling PRs as investigation for #LIVE-17102
+# Will be removed by @angusbayley by end of March 2025
+
+name: Debug PR Event
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log PR Info
+        run: |
+          echo "Repository: ${{ github.repository }}"
+          echo "Branch: ${{ github.head_ref }}"
+          echo "User Login: ${{ github.actor }}"


### PR DESCRIPTION
[Ticket](https://ledgerhq.atlassian.net/browse/LIVE-17102)

Adds temporary workflow for dissecting the PR event for Smartling PRs, following on from difficulties getting the [autoClose](https://github.com/LedgerHQ/ledger-live/blob/develop/tools/github-bot/src/features/autoClose/index.ts) feature to target smartling PRs successfully.

Will be removed by me  by end of March 2025
