### PR TITLE
fix(coin:tezos): better test labels

### DIFF
--- a/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/listOperations.test.ts
@@ -96,10 +96,10 @@ describe("listOperations", () => {
   });
 
   it.each([
-    { ...undelegate, storageFee: 1, bakerFee: 2, allocationFee: 3 },
-    { ...delegate, storageFee: 1, bakerFee: 2, allocationFee: 3 },
-    { ...transfer, storageFee: 1, bakerFee: 2, allocationFee: 3 },
-  ])("should compute the fees properly", async operation => {
+    ["undelegate", { ...undelegate, storageFee: 1, bakerFee: 2, allocationFee: 3 }],
+    ["delegate", { ...delegate, storageFee: 1, bakerFee: 2, allocationFee: 3 }],
+    ["transfer", { ...transfer, storageFee: 1, bakerFee: 2, allocationFee: 3 }],
+  ])("should compute the fees properly for %s operation", async (_label, operation) => {
     // Given
     mockNetworkGetTransactions.mockResolvedValue([operation]);
     // When


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. NO, UNNEEDED
- [x] **Covered by automatic tests. 
- [x] **Impact of the changes:** NONE
  - ...

### 📝 Description

just a follow up after comment of previous pr https://github.com/LedgerHQ/ledger-live/pull/9194/files#r1987253571
![image](https://github.com/user-attachments/assets/cab45de7-d7b4-41d7-9e89-acdde428638c)
