### PR TITLE
chore: Set Ruby version to 3.3.0 for Gemfile

### DIFF
--- a/.changeset/plenty-avocados-switch.md
+++ b/.changeset/plenty-avocados-switch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Ruby version fixed to 3.3.0

--- a/apps/ledger-live-mobile/Gemfile
+++ b/apps/ledger-live-mobile/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "3.3.0"
+
 gem "fastlane", '~> 2.223.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem "dotenv"

--- a/apps/ledger-live-mobile/Gemfile.lock
+++ b/apps/ledger-live-mobile/Gemfile.lock
@@ -287,5 +287,8 @@ DEPENDENCIES
   fastlane-plugin-versioning_android
   semver2 (~> 3.4, >= 3.4.2)
 
+RUBY VERSION
+   ruby 3.3.0p0
+
 BUNDLED WITH
    2.5.7


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

### **Pull Request Description**

This PR **locks Ruby to version 3.3.0** to ensure consistency with the [**Ansible script**](https://github.com/LedgerHQ/device-experience-dx/blob/main/ansible_osx.yml#L132) which relies on this specific version.

On **new Mac machines**, the default Ruby version is now **3.4.1**, which causes compatibility issues and prevents certain commands from executing correctly, particularly with **CocoaPods** and **Bundler**. This issue is also relevant for **Linux** environments, where installing Ruby 3.3.0 requires **OpenSSL 3** to compile Ruby correctly.

This update ensures that all developers use **Ruby 3.3.0** and avoid errors related to version 3.4.1. It provides a stable environment for **Mac**, **Linux**, and users of the **rbenv** and **RVM** Ruby version managers.

---

### 📖 **Installation Steps**

[Issue with openssl](https://github.com/rbenv/homebrew-tap/issues/9#issuecomment-1683015411)

#### **For Mac**

1. **Install OpenSSL 3** (necessary for RVM and rbenv to install Ruby):
   ```sh
   brew install openssl@3
   ```

---

#### **RVM (Ruby Version Manager)**


1. **Install Ruby 3.3.0 with OpenSSL 3 using RVM**:
   ```sh
   rvm install 3.3.0 --with-openssl-dir=$(brew --prefix openssl@3)
   ```

2. **Set Ruby 3.3.0 as the default version using RVM**:
   ```sh
   rvm use ruby-3.3.0
   ```

---

#### **rbenv (Ruby Version Manager)**

1. **Install Ruby 3.3.0 with OpenSSL 3 using rbenv**:
   ```sh
   rbenv install 3.3.0 --with-openssl-dir=$(brew --prefix openssl@3)
   ```

2. **Set Ruby 3.3.0 as the global version using rbenv**:
   ```sh
   rbenv global 3.3.0
   ```

---

#### **For Linux**

1. **Install OpenSSL 3**:
   On **Ubuntu/Debian**, use the following commands to install OpenSSL:
   ```sh
   sudo apt update
   sudo apt install -y openssl libssl-dev
   ```

2. **Install Ruby 3.3.0 with OpenSSL 3 using RVM**:
   ```sh
   rvm install 3.3.0 --with-openssl-dir=/usr/include/openssl
   ```

3. **Set Ruby 3.3.0 as the default version using RVM**:
   ```sh
   rvm use ruby-3.3.0 --default
   ```

4. **Install Ruby 3.3.0 with OpenSSL 3 using rbenv**:
   ```sh
   rbenv install 3.3.0 --with-openssl-dir=/usr/include/openssl
   ```

5. **Set Ruby 3.3.0 as the global version using rbenv**:
   ```sh
   rbenv global 3.3.0
   ```

---

### 📌 **Post-Installation Steps**

1. **Clean and reinstall `pnpm` dependencies**:
   ```sh
   pnpm clean && pnpm store prune && pnpm i
   ```

2. **Navigate to the `ios` folder in the mobile app**:
   ```sh
   cd ios
   ```

3. **Install Bundler dependencies again in `ios`**:
   ```sh
   bundle install
   ```

4. **Install CocoaPods dependencies with repo update**:
   ```sh
   bundle exec pod install --repo-update
   ```

5. **Return to the root project directory**:
   ```sh
   cd ledger-live
   ```

6. **Run the mobile-specific pod install**:
   ```sh
   pnpm mobile pod
   ```

---

### 📌 **Xcode Troubleshooting**

1. **Clean the build folder** in Xcode if you're encountering issues.

2. If you see the error:  
   **"unable to initiate PIF transfer session"**  

   - Navigate to `~/Library/Caches`
   - Delete any previous sessions with:
     ```sh
     rm -rf org.swift.swiftpm/*
     ```

3. After cleaning the build folder, try building again.

---

### 📝 **Notes for Linux:**

- On **Linux**, installing **OpenSSL 3** depends on your distribution. Use the appropriate package manager for your system.
- **RVM** and **rbenv** both handle Ruby installation with OpenSSL, as long as the required libraries are installed correctly.

### Demo
<img width="1066" alt="Screenshot 2025-03-11 at 14 20 23" src="https://github.com/user-attachments/assets/06cede8a-e673-42ec-a4e2-ba5053ad5ab1" />
<img width="1058" alt="Screenshot 2025-03-11 at 14 20 00" src="https://github.com/user-attachments/assets/ec09eeab-6ee5-4610-9bd3-516fe86729c6" />



### ❓ Context

- **JIRA or GitHub link**: [LIVE-17613] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17613]: https://ledgerhq.atlassian.net/browse/LIVE-17613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ