### PR TITLE
bugfix: '-' with neutral color displayed for 0% variation in market and asset list

### DIFF
--- a/.changeset/gold-walls-kiss.md
+++ b/.changeset/gold-walls-kiss.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+'-' in neutral color displayed for 0% variation in market and asset list on LLM

--- a/apps/ledger-live-mobile/src/components/Delta.tsx
+++ b/apps/ledger-live-mobile/src/components/Delta.tsx
@@ -34,20 +34,27 @@ function Delta({
   const { t } = useTranslation();
 
   const percentPlaceholder = fallbackToPercentPlaceholder ? (
-    <Text variant={"large"} color="neutral.c60" fontWeight={"semiBold"} {...textProperties}>
-      -
+    // eslint-disable-next-line i18next/no-literal-string
+    <Text variant="large" color="neutral.c60" fontWeight="semiBold" {...textProperties}>
+      &minus;
     </Text>
   ) : null;
 
   const delta =
     percent && valueChange.percentage ? valueChange.percentage * 100 : valueChange.value;
 
+  const roundedDelta = parseFloat(delta.toFixed(0));
+
+  if (roundedDelta === 0) {
+    return percentPlaceholder;
+  }
+
   const [color, ArrowIcon, sign] =
-    delta !== 0
-      ? delta > 0
-        ? ["success.c50", ArrowEvolutionUpMedium, "+"]
-        : ["error.c50", ArrowEvolutionDownMedium, "-"]
-      : ["neutral.c70", () => null, ""];
+    roundedDelta > 0
+      ? ["success.c50", ArrowEvolutionUpMedium, "+"]
+      : roundedDelta < 0
+        ? ["error.c50", ArrowEvolutionDownMedium, "-"]
+        : ["neutral.c70", () => null, "-"];
 
   if (
     percent &&

--- a/apps/ledger-live-mobile/src/newArch/features/Market/components/DeltaVariation/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/components/DeltaVariation/index.tsx
@@ -19,19 +19,19 @@ function DeltaVariation({ value, percent, ...props }: Props) {
 
   if (roundedDelta === 0) {
     return (
-      <Text variant={"large"} color="neutral.c60" fontWeight={"semiBold"}>
-        -
+      // eslint-disable-next-line i18next/no-literal-string
+      <Text variant="large" color="neutral.c60" fontWeight="semiBold">
+        &minus;
       </Text>
     );
   }
 
   const [color, ArrowIcon, sign] =
-    delta !== 0
-      ? delta > 0
-        ? ["success.c50", IconsLegacy.ArrowEvolutionUpMedium, "+"]
-        : ["error.c50", IconsLegacy.ArrowEvolutionDownMedium, "-"]
-      : ["neutral.c100", null, "-"];
-
+    roundedDelta > 0.0
+      ? ["success.c50", IconsLegacy.ArrowEvolutionUpMedium, "+"]
+      : roundedDelta < 0.0
+        ? ["error.c50", IconsLegacy.ArrowEvolutionDownMedium, "-"]
+        : ["neutral.c70", null, "-"];
   return (
     <Flex flexDirection="row" alignItems="center">
       {percent && ArrowIcon ? <ArrowIcon size={20} color={color} /> : null}

--- a/apps/ledger-live-mobile/src/newArch/features/Market/components/DeltaVariation/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/components/DeltaVariation/index.tsx
@@ -15,12 +15,22 @@ function DeltaVariation({ value, percent, ...props }: Props) {
 
   const absDelta = Math.abs(delta);
 
+  const roundedDelta = parseFloat(delta.toFixed(2));
+
+  if (roundedDelta === 0) {
+    return (
+      <Text variant={"large"} color="neutral.c60" fontWeight={"semiBold"}>
+        -
+      </Text>
+    );
+  }
+
   const [color, ArrowIcon, sign] =
     delta !== 0
       ? delta > 0
         ? ["success.c50", IconsLegacy.ArrowEvolutionUpMedium, "+"]
         : ["error.c50", IconsLegacy.ArrowEvolutionDownMedium, "-"]
-      : ["neutral.c100", null, ""];
+      : ["neutral.c100", null, "-"];
 
   return (
     <Flex flexDirection="row" alignItems="center">


### PR DESCRIPTION
…on LLM

'-' in neutral color displayed for 0% variation in market and asset  list on LLM

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

'-' with neutral color displayed for 0% variation in market and asset list

<img width="389" alt="Screenshot 2025-03-11 at 15 15 41" src="https://github.com/user-attachments/assets/4dfe13de-3888-49e1-ab3a-4f7822ef4fac" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15671]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15671]: https://ledgerhq.atlassian.net/browse/LIVE-15671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ