### PR TITLE
fix(wallet-api): signMessage modal continue button not visible with light theme [LIVE-17617]

### DIFF
--- a/.changeset/stupid-fans-push.md
+++ b/.changeset/stupid-fans-push.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(wallet-api): signMessage modal continue button not visible with light theme

--- a/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignMessage/steps/StepSummary.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
+import ButtonV3 from "~/renderer/components/ButtonV3";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import Text from "~/renderer/components/Text";
 import { getLLDCoinFamily } from "~/renderer/families";
@@ -222,15 +223,14 @@ export default function StepSummary({ account, message: messageData }: StepProps
 export function StepSummaryFooter({ transitionTo }: StepProps) {
   return (
     <Box horizontal justifyContent="flex-end">
-      <Button
+      <ButtonV3
         onClick={() => {
           transitionTo("sign");
         }}
-        style={{ borderRadius: 20, backgroundColor: "white" }}
-        color="neutral.c00"
+        variant="main"
       >
         <Trans i18nKey="common.continue" />
-      </Button>
+      </ButtonV3>
     </Box>
   );
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** I don't think we cover this part in any UI test at the moment
- [x] **Impact of the changes:** 
  - wallet-api signMessage modal

### 📝 Description

We introduced an UI regression in https://github.com/LedgerHQ/ledger-live/pull/9158
It didn't use the theme correctly
We now use the proper button from the design system to match the figma instead of editing the styles of the old button

| Light theme       | Dark theme         |
| ------------- | ------------- |
| <img width="525" alt="Screenshot 2025-03-14 at 08 23 55" src="https://github.com/user-attachments/assets/86acef46-9e89-4c00-bc84-dbebb2b0eea4" />  | <img width="520" alt="Screenshot 2025-03-14 at 08 24 19" src="https://github.com/user-attachments/assets/a4c1b4f8-35ba-41e2-b6e6-3126d46d8d70" /> |


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17617]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17617]: https://ledgerhq.atlassian.net/browse/LIVE-17617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ