### PR TITLE
feat: Improve useLocalizedUrl & fix Support/Academy rediction with url localized

### DIFF
--- a/.changeset/ten-cherries-carry.md
+++ b/.changeset/ten-cherries-carry.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+Rework useLocalizedUrl to be used in LLD & LLM, fix some edge cases

--- a/apps/ledger-live-desktop/src/config/urls.ts
+++ b/apps/ledger-live-desktop/src/config/urls.ts
@@ -38,7 +38,7 @@ export const urls = {
   promoNanoX:
     "https://www.ledger.com/pages/ledger-nano-x#utm_source=Ledger%20Live%20Desktop%20App&utm_medium=Ledger%20Live&utm_campaign=Ledger%20Live%20Desktop%20-%20Banner%20LNX",
   // Ledger support
-  faq: "https://support.ledger.com/?redirect=false",
+  faq: "https://support.ledger.com",
   chatbot:
     "https://live-chat-static.sprinklr.com/test-html/index.html?appId=633307d2cd91267be7d0eea7_app_300078095&env=prod3&skin=MODERN&variant=PAGE&scope=CONVERSATION",
   ledgerStatus: "https://status.ledger.com/",

--- a/apps/ledger-live-desktop/src/renderer/hooks/useLocalizedUrls/useLocalizedUrls.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useLocalizedUrls/useLocalizedUrls.test.tsx
@@ -47,6 +47,23 @@ describe("useLocalizedUrl", () => {
 
     setLocaleMockWithURL("zh", urls.ledgerValidator);
     expect(localizedUrl).toEqual("https://www.ledger.com/zh-hans/staking");
+
+    setLocaleMockWithURL("th", urls.ledgerValidator);
+    expect(localizedUrl).toEqual("https://www.ledger.com/staking");
+
+    setLocaleMockWithURL("en", urls.ledgerValidator);
+    expect(localizedUrl).toEqual("https://www.ledger.com/staking");
+  });
+
+  test("LEDGER_BASE", () => {
+    setLocaleMockWithURL("fr", urls.faq);
+    expect(localizedUrl).toEqual("https://support.ledger.com/fr");
+
+    setLocaleMockWithURL("pt", urls.faq);
+    expect(localizedUrl).toEqual("https://support.ledger.com/pt-br");
+
+    setLocaleMockWithURL("zh", urls.faq);
+    expect(localizedUrl).toEqual("https://support.ledger.com/zh-cn");
   });
 
   test("LEDGER_SUPPORT_SALESFORCE", () => {
@@ -58,6 +75,9 @@ describe("useLocalizedUrl", () => {
 
     setLocaleMockWithURL("zh", urls.troubleshootingUSB);
     expect(localizedUrl).toEqual("https://support.ledger.com/zh-cn/article/115005165269-zd");
+
+    setLocaleMockWithURL("th", urls.troubleshootingUSB);
+    expect(localizedUrl).toEqual("https://support.ledger.com/article/115005165269-zd");
   });
 
   test("SHOP", () => {
@@ -74,6 +94,16 @@ describe("useLocalizedUrl", () => {
     setLocaleMockWithURL("pt", urls.banners.blackfriday);
     expect(localizedUrl).toEqual(
       "https://shop.ledger.com/pt-br/pages/black-friday?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+
+    setLocaleMockWithURL("th", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/pages/black-friday?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+
+    setLocaleMockWithURL("en", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/pages/black-friday?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=banner_carousel",
     );
   });
 

--- a/apps/ledger-live-mobile/src/languages.ts
+++ b/apps/ledger-live-mobile/src/languages.ts
@@ -39,6 +39,10 @@ export const supportedLocales: LocaleKeys[] = Config.LEDGER_DEBUG_ALL_LANGS
   ? localeIds
   : ["en", "fr", "es", "ru", "zh", "de", "tr", "ja", "ko", "pt", "th"];
 
+export type LanguageId = (typeof supportedLocales)[number];
+
+export type LanguageMap<T = string> = { [key in LanguageId]: T };
+
 export type Locale = keyof typeof languages;
 
 /**

--- a/apps/ledger-live-mobile/src/newArch/hooks/useLocalizedUrls/index.ts
+++ b/apps/ledger-live-mobile/src/newArch/hooks/useLocalizedUrls/index.ts
@@ -1,6 +1,6 @@
 import { useSelector } from "react-redux";
-import { DEFAULT_LANGUAGE, LanguageMap } from "~/config/languages";
-import { languageSelector } from "~/renderer/reducers/settings";
+import { DEFAULT_LANGUAGE_LOCALE, LanguageMap } from "~/languages";
+import { languageSelector } from "~/reducers/settings";
 import { useLocalizedUrl as useLocalizedUrlHook } from "@ledgerhq/live-common/hooks/useLocalizedUrl";
 
 const languages: LanguageMap = {
@@ -15,6 +15,7 @@ const languages: LanguageMap = {
   ja: "ja",
   ko: "ko",
   th: "",
+  ar: "",
 };
 
 export const useLocalizedUrl = (url: string) => {
@@ -22,7 +23,7 @@ export const useLocalizedUrl = (url: string) => {
 
   return useLocalizedUrlHook(url, {
     languages,
-    defaultLanguage: DEFAULT_LANGUAGE.id,
+    defaultLanguage: DEFAULT_LANGUAGE_LOCALE,
     currentLanguage: language,
   });
 };

--- a/apps/ledger-live-mobile/src/newArch/hooks/useLocalizedUrls/useLocalizedUrls.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/hooks/useLocalizedUrls/useLocalizedUrls.test.tsx
@@ -1,0 +1,120 @@
+import { combineReducers, legacy_createStore as createStore } from "redux";
+import React from "react";
+import * as redux from "react-redux";
+import { Provider } from "react-redux";
+import { useLocalizedUrl } from ".";
+import { renderHook } from "@testing-library/react-native";
+import settings from "~/reducers/settings";
+import { urls } from "~/utils/urls";
+const store = createStore(
+  combineReducers({
+    settings,
+  }),
+);
+
+describe("useLocalizedUrl", () => {
+  // Needed to wrap hook in a Redux Store
+  const HookWrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  // prepare mocking useSelector
+  const spy = jest.spyOn(redux, "useSelector");
+
+  let localizedUrl: ReturnType<typeof useLocalizedUrl>;
+
+  const setLocaleMockWithURL = (locale: string, url: string) => {
+    spy.mockReturnValue(locale);
+    const { result } = renderHook(() => useLocalizedUrl(url), {
+      wrapper: HookWrapper,
+    });
+    localizedUrl = result.current;
+  };
+
+  test("LEDGER", () => {
+    setLocaleMockWithURL("fr", urls.resources.ledgerAcademy);
+    expect(localizedUrl).toEqual(
+      "https://www.ledger.com/fr/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+    );
+
+    setLocaleMockWithURL("ja", urls.resources.ledgerAcademy);
+    expect(localizedUrl).toEqual(
+      "https://www.ledger.com/ja/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+    );
+
+    setLocaleMockWithURL("pt", urls.resources.ledgerAcademy);
+    expect(localizedUrl).toEqual(
+      "https://www.ledger.com/pt-br/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+    );
+
+    setLocaleMockWithURL("zh", urls.resources.ledgerAcademy);
+    expect(localizedUrl).toEqual(
+      "https://www.ledger.com/zh-hans/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+    );
+
+    setLocaleMockWithURL("en", urls.resources.ledgerAcademy);
+    expect(localizedUrl).toEqual(
+      "https://www.ledger.com/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+    );
+
+    setLocaleMockWithURL("th", urls.resources.ledgerAcademy);
+    expect(localizedUrl).toEqual(
+      "https://www.ledger.com/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+    );
+  });
+
+  test("LEDGER_SUPPORT_SALESFORCE", () => {
+    setLocaleMockWithURL("fr", urls.pairingIssues);
+    expect(localizedUrl).toEqual("https://support.ledger.com/fr/article/360025864773-zd");
+
+    setLocaleMockWithURL("en", urls.pairingIssues);
+    expect(localizedUrl).toEqual("https://support.ledger.com/article/360025864773-zd");
+
+    setLocaleMockWithURL("zh", urls.pairingIssues);
+    expect(localizedUrl).toEqual("https://support.ledger.com/zh-cn/article/360025864773-zd");
+
+    setLocaleMockWithURL("th", urls.pairingIssues);
+    expect(localizedUrl).toEqual("https://support.ledger.com/article/360025864773-zd");
+
+    setLocaleMockWithURL("en", urls.pairingIssues);
+    expect(localizedUrl).toEqual("https://support.ledger.com/article/360025864773-zd");
+  });
+
+  test("SHOP", () => {
+    setLocaleMockWithURL("fr", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/fr/pages/black-friday?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+
+    setLocaleMockWithURL("es", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/es/pages/black-friday?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+
+    setLocaleMockWithURL("pt", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/pt-br/pages/black-friday?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+
+    setLocaleMockWithURL("th", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/pages/black-friday?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+
+    setLocaleMockWithURL("en", urls.banners.blackfriday);
+    expect(localizedUrl).toEqual(
+      "https://shop.ledger.com/pages/black-friday?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=banner_carousel",
+    );
+  });
+
+  test("other url", () => {
+    setLocaleMockWithURL("fr", urls.ledgerStatus);
+    expect(localizedUrl).toEqual(urls.ledgerStatus);
+
+    setLocaleMockWithURL("es", urls.ledgerStatus);
+    expect(localizedUrl).toEqual(urls.ledgerStatus);
+
+    setLocaleMockWithURL("pt", urls.ledgerStatus);
+    expect(localizedUrl).toEqual(urls.ledgerStatus);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Resources.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Resources.tsx
@@ -14,10 +14,15 @@ import SettingsNavigationScrollView from "./SettingsNavigationScrollView";
 import SettingsCard from "~/components/SettingsCard";
 import { urls } from "~/utils/urls";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 
 const Resources = () => {
   const { t } = useTranslation();
   const chatbotSupportFeature = useFeature("llmChatbotSupport");
+
+  const gettingStartedUrl = useLocalizedUrl(urls.resources.gettingStarted);
+  const helpCenterUrl = useLocalizedUrl(urls.resources.helpCenter);
+  const ledgerAcademyUrl = useLocalizedUrl(urls.resources.ledgerAcademy);
 
   return (
     <SettingsNavigationScrollView>
@@ -25,7 +30,7 @@ const Resources = () => {
         title={t("help.gettingStarted.title")}
         desc={t("help.gettingStarted.desc")}
         Icon={NanoSFoldedMedium}
-        onClick={() => Linking.openURL(urls.resources.gettingStarted)}
+        onClick={() => Linking.openURL(gettingStartedUrl)}
       />
       {chatbotSupportFeature?.enabled ? (
         <SettingsCard
@@ -39,14 +44,14 @@ const Resources = () => {
           title={t("help.helpCenter.title")}
           desc={t("help.helpCenter.desc")}
           Icon={LifeRingMedium}
-          onClick={() => Linking.openURL(urls.resources.helpCenter)}
+          onClick={() => Linking.openURL(helpCenterUrl)}
         />
       )}
       <SettingsCard
         title={t("help.ledgerAcademy.title")}
         desc={t("help.ledgerAcademy.desc")}
         Icon={NewsMedium}
-        onClick={() => Linking.openURL(urls.resources.ledgerAcademy)}
+        onClick={() => Linking.openURL(ledgerAcademyUrl)}
       />
       <SettingsCard
         title={t("help.facebook.title")}

--- a/apps/ledger-live-mobile/src/utils/urls.tsx
+++ b/apps/ledger-live-mobile/src/utils/urls.tsx
@@ -174,7 +174,7 @@ export const urls = {
   resources: {
     gettingStarted:
       "https://www.ledger.com/start?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
-    helpCenter: "https://support.ledger.com/?redirect=false",
+    helpCenter: "https://support.ledger.com",
     ledgerAcademy:
       "https://www.ledger.com/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
     facebook: "https://facebook.com/Ledger",

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -159,6 +159,7 @@
     "src/hooks/useDebounce.ts",
     "src/hooks/useTimer.ts",
     "src/hooks/useInternalAppIds.ts",
+    "src/hooks/useLocalizedUrl.ts",
     "src/hw/actions/app.ts",
     "src/hw/actions/completeExchange.ts",
     "src/hw/actions/initSwap.ts",

--- a/libs/ledger-live-common/src/hooks/useLocalizedUrl.test.ts
+++ b/libs/ledger-live-common/src/hooks/useLocalizedUrl.test.ts
@@ -1,0 +1,100 @@
+import { getLocalizedUrl, useLocalizedUrl } from "./useLocalizedUrl";
+
+const languages: Record<string, string> = {
+  en: "",
+  fr: "fr",
+  es: "es",
+  de: "de",
+  ru: "ru",
+  zh: "zh-hans",
+  tr: "tr",
+  pt: "pt-br",
+  ja: "ja",
+  ko: "ko",
+  th: "",
+};
+
+const defaultLanguage = "en";
+
+describe("getLocalizedUrl", () => {
+  test('returns correct URL without language part for default language ("en")', () => {
+    const url = getLocalizedUrl("https://www.ledger.com", languages, "en", defaultLanguage);
+    expect(url).toBe("https://www.ledger.com");
+  });
+
+  test('returns correct URL with language part for non-default language ("fr")', () => {
+    const url = getLocalizedUrl("https://www.ledger.com", languages, "fr", defaultLanguage);
+    expect(url).toBe("https://www.ledger.com/fr");
+  });
+
+  test("handles suffix properly", () => {
+    const url = getLocalizedUrl(
+      "https://www.ledger.com",
+      languages,
+      "fr",
+      defaultLanguage,
+      "article/123",
+    );
+    expect(url).toBe("https://www.ledger.com/fr/article/123");
+  });
+
+  test("defaults to empty language part if language not in map", () => {
+    const url = getLocalizedUrl("https://www.ledger.com", languages, "it", defaultLanguage);
+    expect(url).toBe("https://www.ledger.com");
+  });
+
+  test('returns URL without language part for "th"', () => {
+    const url = getLocalizedUrl("https://www.ledger.com", languages, "th", defaultLanguage);
+    expect(url).toBe("https://www.ledger.com");
+  });
+});
+
+describe("useLocalizedUrl", () => {
+  const config = {
+    currentLanguage: "fr",
+    defaultLanguage: "en",
+    languages: languages,
+  };
+
+  test('transforms URL for LEDGER with language part ("fr")', () => {
+    const url = "https://www.ledger.com";
+    const transformedUrl = useLocalizedUrl(url, config);
+    expect(transformedUrl).toBe("https://www.ledger.com/fr");
+  });
+
+  test('transforms URL for SHOP with language part ("fr")', () => {
+    const url = "https://shop.ledger.com";
+    const transformedUrl = useLocalizedUrl(url, config);
+    expect(transformedUrl).toBe("https://shop.ledger.com/fr");
+  });
+
+  test('transforms URL for BASE_LEDGER_SUPPORT with language part ("fr")', () => {
+    const url = "https://support.ledger.com";
+    const transformedUrl = useLocalizedUrl(url, config);
+    expect(transformedUrl).toBe("https://support.ledger.com/fr");
+  });
+
+  test('transforms URL for SALESFORCE_SUPPORT with language part ("fr")', () => {
+    const url = "https://support.ledger.com/article/123";
+    const transformedUrl = useLocalizedUrl(url, config);
+    expect(transformedUrl).toBe("https://support.ledger.com/fr/article/123");
+  });
+
+  test("does not transform URL if no matching pattern", () => {
+    const url = "https://status.ledger.com";
+    const transformedUrl = useLocalizedUrl(url, config);
+    expect(transformedUrl).toBe(url);
+  });
+
+  test('returns correct URL with suffix when language is "fr"', () => {
+    const url = "https://support.ledger.com/article/115005165269-zd";
+    const transformedUrl = useLocalizedUrl(url, config);
+    expect(transformedUrl).toBe("https://support.ledger.com/fr/article/115005165269-zd");
+  });
+
+  test('returns URL without language part for "th"', () => {
+    const url = "https://www.ledger.com";
+    const transformedUrl = useLocalizedUrl(url, { ...config, currentLanguage: "th" });
+    expect(transformedUrl).toBe("https://www.ledger.com");
+  });
+});

--- a/libs/ledger-live-common/src/hooks/useLocalizedUrl.ts
+++ b/libs/ledger-live-common/src/hooks/useLocalizedUrl.ts
@@ -1,0 +1,83 @@
+type Config = {
+  currentLanguage: string;
+  defaultLanguage: string;
+  languages: Record<string, string>;
+};
+
+export const BASE_LEDGER_SUPPORT = "https://support.ledger.com";
+export const LEDGER = "https://www.ledger.com";
+export const SHOP = "https://shop.ledger.com";
+export const SALESFORCE_SUPPORT = `${BASE_LEDGER_SUPPORT}/article`;
+
+/**
+ * Constructs a localized URL based on the provided base URL, language, default language, and optional suffix.
+ * If the language is the default language, the language part is omitted from the URL.
+ *
+ * @param {string} baseUrl - The base URL (e.g., "https://www.ledger.com").
+ * @param {LanguageMap} langMap - A mapping of language codes to their respective language identifiers (e.g., { en: "en", fr: "fr", ... }).
+ * @param {keyof LanguageMap} lang - The selected language code (e.g., "en", "fr").
+ * @param {string} DEFAULT_LANGUAGE - The default language configuration(e.g., "en").
+ * @param {string} [suffix=""] - An optional suffix to append to the URL (e.g., "article/123").
+ *
+ * @returns {string} - The localized URL, including the language part (if applicable) and any suffix.
+ */
+export const getLocalizedUrl = (
+  baseUrl: string,
+  langMap: Record<string, string>,
+  lang: string,
+  defaultLanguage: string,
+  suffix = "",
+) => {
+  // Determine the language part based on the selected language. If the language is the default,
+  // we don't include it in the URL. If the language isn't in the langMap, fallback to an empty string.
+  const languagePart = lang === defaultLanguage ? "" : langMap[lang] || "";
+
+  // If a suffix is provided, prepend it with a "/" for proper URL formatting.
+  const suffixPart = suffix ? `/${suffix}` : "";
+
+  // Return the final URL by concatenating the base URL, language part (if any), and the suffix (if any).
+  return `${baseUrl}${languagePart && `/${languagePart}`}${suffixPart}`;
+};
+
+export const useLocalizedUrl = (
+  url: string,
+  { languages, defaultLanguage, currentLanguage }: Config,
+) => {
+  const LEDGER_LANG = { ...languages };
+  const SHOP_LANG = { ...languages };
+  const SALESFORCE_LANG = {
+    ...languages,
+    zh: "zh-cn",
+  };
+
+  // Define the language patterns in the URL, using the helper function
+  const languagePatterns: Record<string, string> = {
+    [LEDGER]: getLocalizedUrl(LEDGER, LEDGER_LANG, currentLanguage, defaultLanguage),
+    [SHOP]: getLocalizedUrl(SHOP, SHOP_LANG, currentLanguage, defaultLanguage),
+    [BASE_LEDGER_SUPPORT]: getLocalizedUrl(
+      BASE_LEDGER_SUPPORT,
+      SALESFORCE_LANG,
+      currentLanguage,
+      defaultLanguage,
+    ),
+    [SALESFORCE_SUPPORT]: getLocalizedUrl(
+      BASE_LEDGER_SUPPORT,
+      SALESFORCE_LANG,
+      currentLanguage,
+      defaultLanguage,
+      "article",
+    ),
+  };
+
+  const matchingPattern = Object.keys(languagePatterns).find(pattern => url.startsWith(pattern));
+
+  // If no matching pattern, return the original URL
+  if (!matchingPattern) {
+    return url;
+  }
+
+  // Replace the matching part with the corresponding localized URL
+  const transformedUrl = url.replace(matchingPattern, languagePatterns[matchingPattern]);
+
+  return transformedUrl;
+};


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Rework useLocalizedUrl hook to be centralised in live-common
- fix some edge case ("thai" was not handled correclty)
- some url were broken
- Fix LedgerAcademy and support url localisation

https://github.com/user-attachments/assets/443ca9c6-e41f-417e-9bae-db37a15b82a4

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17680]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->




---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17680]: https://ledgerhq.atlassian.net/browse/LIVE-17680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ