### PR TITLE
fix: wallet-api transition animation between live-apps [LIVE-17717]

### DIFF
--- a/.changeset/weak-frogs-taste.md
+++ b/.changeset/weak-frogs-taste.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: wallet-api transition animation between live-apps

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/index.tsx
@@ -26,6 +26,7 @@ export const Web3AppWebview = forwardRef<WebviewAPI, WebviewProps>(
     if (semver.satisfies(WALLET_API_VERSION, manifest.apiVersion)) {
       return (
         <WalletAPIWebview
+          key={manifest.id}
           manifest={manifest}
           currentAccountHistDb={currentAccountHistDb}
           inputs={inputs}
@@ -40,6 +41,7 @@ export const Web3AppWebview = forwardRef<WebviewAPI, WebviewProps>(
 
     return (
       <PlatformAPIWebview
+        key={manifest.id}
         manifest={manifest}
         currentAccountHistDb={currentAccountHistDb}
         inputs={inputs}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** 
- [x] **Impact of the changes:**
  - live-apps

### 📝 Description

Setting a key to reset the states of the component when we change manifest to get the transition animation to work on page load

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17717]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17717]: https://ledgerhq.atlassian.net/browse/LIVE-17717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ