### PR TITLE
:lipstick: (lld) drawer animation nft gallery

### DIFF
--- a/.changeset/nine-tables-smile.md
+++ b/.changeset/nine-tables-smile.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix drawer animation on newArch nft gallery

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Nfts/components/DetailDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Nfts/components/DetailDrawer/index.tsx
@@ -21,7 +21,6 @@ const NftDetailDrawer = ({ account, tokenId, isOpened, setIsOpened }: NftsDetail
     originalUri,
     useFallback,
     mediaType,
-    doNotOpenDrawer,
     setUseFallback,
     onNFTSend,
   } = useNftDetailDrawer(account, tokenId);
@@ -30,8 +29,6 @@ const NftDetailDrawer = ({ account, tokenId, isOpened, setIsOpened }: NftsDetail
     useCollectibles();
 
   const handleRequestClose = useCallback(() => setIsOpened(false), [setIsOpened]);
-
-  if (doNotOpenDrawer) return null;
 
   return (
     <DetailDrawer

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Nfts/components/TokensList/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Nfts/components/TokensList/index.tsx
@@ -17,7 +17,7 @@ function View({
   return (
     <>
       <TokensList account={account} collectibles={formattedNfts} onItemClick={onItemClick} />
-      {isDrawerOpen && (
+      {nftIdToOpen && (
         <NftDetailDrawer
           isOpened={isDrawerOpen}
           setIsOpened={setIsDrawerOpen}

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/Nfts/components/TokensList/useTokensListModel.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/Nfts/components/TokensList/useTokensListModel.tsx
@@ -42,7 +42,8 @@ export const useTokensListModel = ({ nfts, account }: BaseNftsProps): TokensList
   }, [metadata, nftsList]);
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [nftIdToOpen, setNftIdToOpen] = useState<string>("");
+  const [nftIdToOpen, setNftIdToOpen] = useState(formattedNfts[0]?.collectibleId);
+
   const onItemClick = (id: string) => {
     setNftIdToOpen(id);
     setIsDrawerOpen(true);

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/components/DetailDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/components/DetailDrawer/index.tsx
@@ -120,7 +120,7 @@ const DetailDrawerComponent: React.FC<DetailDrawerProps> & {
     <SideDrawer
       withPaddingTop
       isOpen={isOpened}
-      direction={"left"}
+      direction="left"
       onRequestClose={handleRequestClose}
       forceDisableFocusTrap
     >

--- a/apps/ledger-live-desktop/src/newArch/features/Collectibles/types/TokensList.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/Collectibles/types/TokensList.ts
@@ -16,7 +16,7 @@ export type TokensListProps = {
     mediaType: string;
   }[];
   isDrawerOpen: boolean;
-  nftIdToOpen: string;
+  nftIdToOpen: string | null;
   setIsDrawerOpen: (isDrawerOpen: boolean) => void;
   onItemClick: (id: string) => void;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - detail drawer

### 📝 Description

Small animation fix. Animation wasn't triggered because te parent component of the side drawer was unmounted. This was done like this to avoid ts issue. Instead we should define a tokenId by default (the first of the list) so we ensure tokenId is never undefined. This way the sidedrawer always exists and appears with all the animations

| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/433b2042-3f71-4c07-a06f-f69a40b97323|https://github.com/user-attachments/assets/de886ec6-90de-4e59-8681-6a53539a3407|


### ❓ Context

- **JIRA or GitHub link**: NO NEED <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
