### PR TITLE
:bug: (llm) network banner animation receive flow

### DIFF
--- a/.changeset/sharp-snails-fetch.md
+++ b/.changeset/sharp-snails-fetch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix network banner animation on select network during receive flow


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - receive flow select network

### 📝 Description

Adjust the animation of the network banner on receive flow (select network).

I've imported the animation used in newArch to have the same one. Since this screen will me be migrated a day to the new one (the one inside new arch) it's not necessary to move the hook and the networkBanner.



| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/28e39f8b-7272-410a-96a9-a0269cbd2652|https://github.com/user-attachments/assets/ca0f4b41-b1d6-47e1-a738-48ddbb4c43c3| 

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17759](https://ledgerhq.atlassian.net/browse/LIVE-17759)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17759]: https://ledgerhq.atlassian.net/browse/LIVE-17759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ