### PR TITLE
LIVE-17649: Fix dapp opening from staking modal(drawer in LLM)

### DIFF
--- a/.changeset/heavy-stingrays-ring.md
+++ b/.changeset/heavy-stingrays-ring.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Pass LL account to dapps and WAPI account to dapp browser v2

--- a/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/AccountHeaderManageActions.ts
@@ -1,13 +1,11 @@
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import { useCallback } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import IconCoins from "~/renderer/icons/Coins";
 import { openModal } from "~/renderer/actions/modals";
 import { isAccountEmpty } from "@ledgerhq/live-common/account/index";
 import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
 import { useHistory } from "react-router";
-import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
-import { walletSelector } from "~/renderer/reducers/wallet";
 
 type Props = {
   account: AccountLike;
@@ -18,7 +16,6 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const dispatch = useDispatch();
   const history = useHistory();
   const label = useGetStakeLabelLocaleBased();
-  const walletState = useSelector(walletSelector);
 
   const isEthereumAccount = account.type === "Account" && account.currency.id === "ethereum";
   const isBscAccount = account.type === "Account" && account.currency.id === "bsc";
@@ -52,14 +49,13 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
         }),
       );
     } else if (account.type === "Account") {
-      const walletApiAccount = accountToWalletAPIAccount(walletState, account, parentAccount);
       dispatch(
         openModal("MODAL_EVM_STAKE", {
-          account: walletApiAccount,
+          account,
         }),
       );
     }
-  }, [account, dispatch, parentAccount, walletState]);
+  }, [account, dispatch, parentAccount]);
 
   const getStakeAction = useCallback(() => {
     if (isEthereumAccount) {

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/EthStakingModalBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/EthStakingModalBody.tsx
@@ -1,16 +1,16 @@
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { appendQueryParamsToDappURL } from "@ledgerhq/live-common/platform/utils/appendQueryParamsToDappURL";
 import { Flex } from "@ledgerhq/react-ui";
-import { EthStakingProvider } from "@ledgerhq/types-live";
+import { AccountLike, EthStakingProvider } from "@ledgerhq/types-live";
 import React, { useCallback } from "react";
 import { useHistory } from "react-router-dom";
 import { track } from "~/renderer/analytics/segment";
 import { ProviderItem } from "./component/ProviderItem";
 import { getTrackProperties } from "./utils/getTrackProperties";
-import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
+import { getWalletApiIdFromAccountId } from "@ledgerhq/live-common/wallet-api/converters";
 
 type Props = {
-  account: WalletAPIAccount;
+  account: AccountLike;
   onClose?: () => void;
   source?: string;
   providers: EthStakingProvider[];
@@ -39,7 +39,10 @@ export function EthStakingModalBody({ source, onClose, account, providers }: Pro
         pathname: value,
         ...(customDappUrl ? { customDappUrl } : {}),
         state: {
-          accountId: account.id,
+          accountId:
+            manifest?.params && "dappUrl" in manifest.params
+              ? getWalletApiIdFromAccountId(account.id)
+              : account.id,
         },
       });
       onClose?.();

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/EthStakingModalBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/EthStakingModalBody.tsx
@@ -40,9 +40,9 @@ export function EthStakingModalBody({ source, onClose, account, providers }: Pro
         ...(customDappUrl ? { customDappUrl } : {}),
         state: {
           accountId:
-            manifest?.params && "dappUrl" in manifest.params
-              ? getWalletApiIdFromAccountId(account.id)
-              : account.id,
+            manifest?.dapp
+              ? account.id
+              : getWalletApiIdFromAccountId(account.id),
         },
       });
       onClose?.();

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/EthStakingModalBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/EthStakingModalBody.tsx
@@ -39,10 +39,7 @@ export function EthStakingModalBody({ source, onClose, account, providers }: Pro
         pathname: value,
         ...(customDappUrl ? { customDappUrl } : {}),
         state: {
-          accountId:
-            manifest?.dapp
-              ? account.id
-              : getWalletApiIdFromAccountId(account.id),
+          accountId: manifest?.dapp ? account.id : getWalletApiIdFromAccountId(account.id),
         },
       });
       onClose?.();

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal/index.tsx
@@ -1,7 +1,7 @@
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { Box, Button, Flex, Icons, Text } from "@ledgerhq/react-ui";
-import { EthStakingProvider, EthStakingProviderCategory } from "@ledgerhq/types-live";
+import { AccountLike, EthStakingProvider, EthStakingProviderCategory } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -14,7 +14,6 @@ import EthStakeIllustration from "~/renderer/icons/EthStakeIllustration";
 import { openURL } from "~/renderer/linking";
 import { EthStakingModalBody } from "./EthStakingModalBody";
 import { Footer, Header, IconButton, ScrollableContainer, SHADOW_HEIGHT } from "./styles";
-import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
 
 const ethMagnitude = getCryptoCurrencyById("ethereum").units[0].magnitude;
 
@@ -30,7 +29,7 @@ type Option = EthStakingProviderCategory | "all";
 const OPTION_VALUES: Option[] = ["all", "liquid", "protocol", "pooling", "restaking"] as const;
 
 export interface Props {
-  account: WalletAPIAccount;
+  account: AccountLike;
   /** Analytics source */
   source?: string;
   hasCheckbox?: boolean;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal_deprecated/EthStakingModalBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal_deprecated/EthStakingModalBody.tsx
@@ -17,7 +17,7 @@ import { ListProvider, ListProviders } from "./types";
 import { getTrackProperties } from "./utils/getTrackProperties";
 
 import ProviderItem from "./component/ProviderItem";
-import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
+import { AccountLike } from "@ledgerhq/types-live";
 
 const ethMagnitude = getCryptoCurrencyById("ethereum").units[0].magnitude;
 
@@ -33,7 +33,7 @@ export type StakeOnClickProps = {
 };
 
 interface Props {
-  account: WalletAPIAccount;
+  account: AccountLike;
   singleProviderRedirectMode?: boolean;
   onClose?: () => void;
   hasCheckbox?: boolean;
@@ -87,13 +87,13 @@ export function EthStakingModalBody({
 
   const checkBoxOnChange = useCallback(() => {
     const value = !doNotShowAgain;
-    global.localStorage.setItem(`${LOCAL_STORAGE_KEY_PREFIX}${account?.currency}`, `${value}`);
+    global.localStorage.setItem(`${LOCAL_STORAGE_KEY_PREFIX}${account?.id}`, `${value}`);
     setDoNotShowAgain(value);
     track("button_clicked2", {
       button: "not_show",
       ...getTrackProperties({ value, modal: source }),
     });
-  }, [doNotShowAgain, account?.currency, source]);
+  }, [doNotShowAgain, account?.id, source]);
 
   const hasMinValidatorEth = account.spendableBalance.isGreaterThan(ETH_LIMIT);
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal_deprecated/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/StakeFlowModal_deprecated/index.tsx
@@ -4,10 +4,10 @@ import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { Flex } from "@ledgerhq/react-ui";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { EthStakingModalBody } from "./EthStakingModalBody";
-import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
+import { AccountLike } from "@ledgerhq/types-live";
 
 type Props = {
-  account: WalletAPIAccount;
+  account: AccountLike;
   singleProviderRedirectMode?: boolean;
   /** Analytics source */
   source?: string;

--- a/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/modals.ts
@@ -1,11 +1,11 @@
 import { MakeModalsType } from "~/renderer/modals/types";
 import { EditTransactionModal, EditTransactionModalProps } from "./EditTransaction/Modal";
 import MODAL_EVM_STAKE from "./StakeModalVersionWrapper";
-import { WalletAPIAccount } from "@ledgerhq/live-common/wallet-api/types";
+import { AccountLike } from "@ledgerhq/types-live";
 
 export type ModalsData = {
   MODAL_EVM_STAKE: {
-    account: WalletAPIAccount;
+    account: AccountLike;
     hasCheckbox?: boolean;
     singleProviderRedirectMode?: boolean;
     source?: string;

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -31,19 +31,18 @@ import { getEnv } from "@ledgerhq/live-env";
 import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
 import { FeatureToggle, useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { LOCAL_STORAGE_KEY_PREFIX } from "./StepReceiveStakingFlow";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { openModal } from "~/renderer/actions/modals";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getLLDCoinFamily } from "~/renderer/families";
 import { firstValueFrom } from "rxjs";
 import { useCompleteActionCallback } from "~/renderer/components/PostOnboardingHub/logic/useCompleteAction";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
-import { useMaybeAccountName, walletSelector } from "~/renderer/reducers/wallet";
+import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 import { UTXOAddressAlert } from "~/renderer/components/UTXOAddressAlert";
 import { isUTXOCompliant } from "@ledgerhq/live-common/currencies/helpers";
 import MemoTagInfo from "~/newArch/features/MemoTag/components/MemoTagInfo";
 import { MEMO_TAG_COINS } from "~/newArch/features/MemoTag/constants";
-import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
 
 const Separator = styled.div`
   border-top: 1px solid #99999933;
@@ -183,7 +182,6 @@ const StepReceiveFunds = (props: StepProps) => {
   } = props;
   const dispatch = useDispatch();
   const completeAction = useCompleteActionCallback();
-  const walletState = useSelector(walletSelector);
 
   const receiveStakingFlowConfig = useFeature("receiveStakingFlowConfigDesktop");
   const receivedCurrencyId: string | undefined =
@@ -266,11 +264,9 @@ const StepReceiveFunds = (props: StepProps) => {
       });
       // Only open EVM staking modal if the user received ETH or an EVM currency supported by the providers
       if (isDirectStakingEnabledForAccount) {
-        const walletApiAccount = accountToWalletAPIAccount(walletState, mainAccount);
-
         dispatch(
           openModal("MODAL_EVM_STAKE", {
-            account: walletApiAccount,
+            account: mainAccount,
             hasCheckbox: true,
             singleProviderRedirectMode: false,
             source: "receive",
@@ -297,7 +293,6 @@ const StepReceiveFunds = (props: StepProps) => {
     onClose,
     transitionTo,
     completeAction,
-    walletState,
     isSPLToken,
   ]);
 

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
@@ -36,9 +36,9 @@ export function EvmStakingDrawerBody({ providers, accountId, onClose }: Props) {
             platform: manifest.id,
             name: manifest.name,
             accountId:
-              manifest?.params && "dappUrl" in manifest.params
-                ? getWalletApiIdFromAccountId(accountId)
-                : accountId,
+              manifest?.dapp
+                ? accountId
+                : getWalletApiIdFromAccountId(accountId),
             ...(customDappURL ? { customDappURL } : {}),
           });
         });

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
@@ -35,10 +35,7 @@ export function EvmStakingDrawerBody({ providers, accountId, onClose }: Props) {
           navigation.navigate(ScreenName.PlatformApp, {
             platform: manifest.id,
             name: manifest.name,
-            accountId:
-              manifest?.dapp
-                ? accountId
-                : getWalletApiIdFromAccountId(accountId),
+            accountId: manifest?.dapp ? accountId : getWalletApiIdFromAccountId(accountId),
             ...(customDappURL ? { customDappURL } : {}),
           });
         });

--- a/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/StakingDrawer/EvmStakingDrawerBody.tsx
@@ -8,6 +8,7 @@ import { useAnalytics } from "~/analytics";
 import { NavigatorName, ScreenName } from "~/const";
 import { EvmStakingDrawerProvider } from "./EvmStakingDrawerProvider";
 import { ListProvider } from "./types";
+import { getWalletApiIdFromAccountId } from "@ledgerhq/live-common/wallet-api/converters";
 
 interface Props {
   providers: ListProvider[];
@@ -34,7 +35,10 @@ export function EvmStakingDrawerBody({ providers, accountId, onClose }: Props) {
           navigation.navigate(ScreenName.PlatformApp, {
             platform: manifest.id,
             name: manifest.name,
-            accountId,
+            accountId:
+              manifest?.params && "dappUrl" in manifest.params
+                ? getWalletApiIdFromAccountId(accountId)
+                : accountId,
             ...(customDappURL ? { customDappURL } : {}),
           });
         });

--- a/apps/ledger-live-mobile/src/families/evm/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/accountActions.tsx
@@ -9,7 +9,6 @@ import { NavigatorName, ScreenName } from "~/const";
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
-import { accountToWalletAPIAccount } from "@ledgerhq/live-common/wallet-api/converters";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 
 const ethMagnitude = getCryptoCurrencyById("ethereum").units[0].magnitude ?? 18;
@@ -44,12 +43,7 @@ const getAccountType = (account: AccountLike): AccountTypeGetterProps => {
   return { isEthAccount, isPOLAccount, isBscAccount, isAvaxAccount, isStakekit };
 };
 
-function getNavigatorParams({
-  parentRoute,
-  account,
-  parentAccount,
-  walletState,
-}: Props): NavigationParamsType {
+function getNavigatorParams({ parentRoute, account, parentAccount }: Props): NavigationParamsType {
   const { isPOLAccount, isBscAccount, isAvaxAccount, isStakekit } = getAccountType(account);
 
   if (isAccountEmpty(account)) {
@@ -91,21 +85,19 @@ function getNavigatorParams({
     ];
   }
 
-  const walletApiAccount = accountToWalletAPIAccount(walletState, account, parentAccount);
-
   const params = {
     screen: parentRoute.name,
     drawer: {
       id: "EvmStakingDrawer",
       props: {
         singleProviderRedirectMode: true,
-        accountId: walletApiAccount.id,
+        accountId: account.id,
         has32Eth: account.spendableBalance.gt(ETH_LIMIT),
       },
     },
     params: {
       ...(parentRoute.params ?? {}),
-      account: walletApiAccount,
+      account,
       parentAccount,
     },
   };


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Account passed to dapps VS account passed to dapp browser v2

### 📝 Description

This PR fixes a bug where when opening a dapp from eth staking modal (drawer in LLM) the wrong account was selected. It now passes a LL account id to a dapp and a wallet api account id to dapp browser v2 as it uses the wallet api.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17649](https://ledgerhq.atlassian.net/browse/LIVE-17649)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17649]: https://ledgerhq.atlassian.net/browse/LIVE-17649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ