### PR TITLE
fix: 🎯 target LNS opt out users with many swaps with the upsell campaign

### DIFF
--- a/.changeset/slimy-elephants-itch.md
+++ b/.changeset/slimy-elephants-itch.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Target LNS opt out users with many swaps with the upsell campaign

--- a/apps/ledger-live-desktop/src/newArch/features/LNSUpsell/__tests__/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/LNSUpsell/__tests__/LNSUpsellBanner.test.tsx
@@ -48,7 +48,7 @@ describe("LNSUpsellBanner ", () => {
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
 
-    it("should not render if the user swapped currencies at least twice", () => {
+    it("should not render if the (opted in) user swapped currencies at least twice", () => {
       renderBanner({ swapHistory: [{}, {}] });
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
@@ -73,7 +73,26 @@ describe("LNSUpsellBanner ", () => {
 
       expect(openURL).toHaveBeenCalledTimes(1);
       expect(openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
-      // NOTE track will be called but this function has it's own logic not to track opt out users
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Level up wallet",
+        link: "https://example.com/optOutCta",
+        page,
+      });
+    });
+
+    it("should render for opted out with 2 or more swaps", () => {
+      renderBanner({ isOptIn: false, swapHistory: [{}, {}] });
+      fireEvent.click(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
+
+      expect(openURL).toHaveBeenCalledTimes(1);
+      expect(openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Level up wallet",
+        link: "https://example.com/optOutCta",
+        page,
+      });
     });
 
     function renderBanner({

--- a/apps/ledger-live-desktop/src/newArch/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
@@ -20,9 +20,10 @@ export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSBannerS
 
   const accounts = useSelector(accountsSelector);
   const swapCount = accounts.reduce((count, account) => count + account.swapHistory.length, 0);
+  const isExcluded = isOptIn && swapCount >= 2;
 
-  const enabled = ff?.enabled && params?.[location as keyof LNSBannerState["params"]];
-  const isShown = Boolean(enabled && hasOnlySeenLNS && swapCount < 2);
+  const isEnabled = Boolean(ff?.enabled && params?.[location as keyof LNSBannerState["params"]]);
+  const isShown = isEnabled && hasOnlySeenLNS && !isExcluded;
 
   return { isShown, params, tracking };
 }

--- a/apps/ledger-live-mobile/src/newArch/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -40,7 +40,7 @@ describe("LNSUpsellBanner ", () => {
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
 
-    it("should not render if the user swapped currencies at least twice", () => {
+    it("should not render if the (opted in) user swapped currencies at least twice", () => {
       renderBanner({ swapHistory: [{}, {}] });
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
@@ -65,7 +65,26 @@ describe("LNSUpsellBanner ", () => {
 
       expect(Linking.openURL).toHaveBeenCalledTimes(1);
       expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
-      // NOTE track will be called but this function has it's own logic not to track opt out users
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Level up wallet",
+        link: "https://example.com/optOutCta",
+        page,
+      });
+    });
+
+    it("should render for opted out with 2 or more swaps", () => {
+      renderBanner({ isOptIn: false, swapHistory: [{}, {}] });
+      fireEvent.press(screen.getByText(t(`lnsUpsell.opted_out.cta`)));
+
+      expect(Linking.openURL).toHaveBeenCalledTimes(1);
+      expect(Linking.openURL).toHaveBeenCalledWith("https://example.com/optOutCta");
+      expect(track).toHaveBeenCalledTimes(1);
+      expect(track).toHaveBeenCalledWith("button_clicked", {
+        button: "Level up wallet",
+        link: "https://example.com/optOutCta",
+        page,
+      });
     });
 
     function renderBanner({

--- a/apps/ledger-live-mobile/src/newArch/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
@@ -26,9 +26,10 @@ export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSUpsellB
 
   const accounts = useSelector(accountsSelector);
   const swapCount = accounts.reduce((count, account) => count + account.swapHistory.length, 0);
+  const isExcluded = isOptIn && swapCount >= 2;
 
-  const isEnabled = ff?.enabled && params?.[location];
-  const isShown = Boolean(isEnabled && hasOnlySeenLNS && swapCount < 2);
+  const isEnabled = Boolean(ff?.enabled && params?.[location]);
+  const isShown = isEnabled && hasOnlySeenLNS && !isExcluded;
 
   return { isShown, params, tracking };
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The LNS upsell banner should still be displayed for opt out users with 2 or more swaps on LLD and LLM.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-15816] and [LIVE-15849]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-15816]: https://ledgerhq.atlassian.net/browse/LIVE-15816
[LIVE-15849]: https://ledgerhq.atlassian.net/browse/LIVE-15849