### PR TITLE
ci: check versions regardless of workflow run reason

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -77,12 +77,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
       - name: check if desktop versions are different
-        if: ${{ inputs.caller == 'release-prepare' || inputs.caller == 'release-prepare-hotfix' }}
         id: desktop-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-desktop/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT
       - name: check if mobile versions are different
-        if: ${{ inputs.caller == 'release-prepare' || inputs.caller == 'release-prepare-hotfix' }}
         id: mobile-changed
         run: |
           echo "status=$(git diff HEAD HEAD~1 ./apps/ledger-live-mobile/package.json | grep '"version": "' | wc -l)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -7,10 +7,6 @@ on:
         description: "the ref (branch) to release from"
         required: false
         default: main
-      caller:
-        type: string
-        description: "the workflow that called this one"
-        required: true
   workflow_dispatch:
     inputs:
       app:

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -139,5 +139,4 @@ jobs:
       # For more info about why we do this, see this doc:
       # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
       ref: ${{ github.event.inputs.tag_version == 'latest' && 'main' || 'hotfix' }}
-      caller: release-prepare-hotfix
     secrets: inherit

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -90,5 +90,4 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
       ref: main
-      caller: release-prepare
     secrets: inherit


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LIVE-17626

Removes the `if` condition which causes differences in mobile/desktop versions to be recorded only if the workflow is called from `release-prepare`.

This means we always do the version check regardless of workflow caller

Test PR: https://github.com/LedgerHQ/ledger-live/pull/9593 (tests underway ⏳)