### PR TITLE
fix: sol staking delegate from-address

### DIFF
--- a/.changeset/gold-cars-knock.md
+++ b/.changeset/gold-cars-knock.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+fix: sol staking delegate from-address

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -441,7 +441,7 @@ async function deriveStakeCreateAccountCommandDescriptor(
   const warnings: Record<string, Error> = {};
 
   const commandDescriptor = tx.model.commandDescriptor;
-  if (isValidCommandDescriptor(commandDescriptor)) return commandDescriptor!;
+  if (isValidStakeCreateAccountCommandDescriptor(commandDescriptor)) return commandDescriptor!;
 
   const { fee, spendable } = await estimateFeeAndSpendable(api, mainAccount, tx);
   const txAmount = tx.useAllAmount ? spendable : tx.amount;
@@ -841,9 +841,12 @@ function validateRecipientRequiredMemo(
   }
 }
 
-function isValidCommandDescriptor(commandDescriptor: CommandDescriptor | undefined) {
+function isValidStakeCreateAccountCommandDescriptor(
+  commandDescriptor: CommandDescriptor | undefined,
+) {
   const txCommand = commandDescriptor?.command as StakeCreateAccountCommand | undefined;
 
+  // Ensures commandDescriptor has all required data, avoiding regeneration
   if (
     commandDescriptor &&
     txCommand?.amount &&

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -441,7 +441,7 @@ async function deriveStakeCreateAccountCommandDescriptor(
   const warnings: Record<string, Error> = {};
 
   const commandDescriptor = tx.model.commandDescriptor;
-  if (isValidStakeCreateAccountCommandDescriptor(commandDescriptor)) return commandDescriptor!;
+  if (isValidStakeCreateAccountCommandDescriptor(commandDescriptor)) return commandDescriptor;
 
   const { fee, spendable } = await estimateFeeAndSpendable(api, mainAccount, tx);
   const txAmount = tx.useAllAmount ? spendable : tx.amount;
@@ -843,7 +843,7 @@ function validateRecipientRequiredMemo(
 
 function isValidStakeCreateAccountCommandDescriptor(
   commandDescriptor: CommandDescriptor | undefined,
-) {
+): commandDescriptor is CommandDescriptor {
   const txCommand = commandDescriptor?.command as StakeCreateAccountCommand | undefined;
 
   // Ensures commandDescriptor has all required data, avoiding regeneration

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -56,6 +56,7 @@ import type {
   SolanaStake,
   SolanaTokenAccount,
   SolanaTokenProgram,
+  StakeCreateAccountCommand,
   StakeCreateAccountTransaction,
   StakeDelegateTransaction,
   StakeSplitTransaction,
@@ -438,6 +439,9 @@ async function deriveStakeCreateAccountCommandDescriptor(
 ): Promise<CommandDescriptor> {
   const errors: Record<string, Error> = {};
   const warnings: Record<string, Error> = {};
+
+  const commandDescriptor = tx.model.commandDescriptor;
+  if (isValidCommandDescriptor(commandDescriptor)) return commandDescriptor!;
 
   const { fee, spendable } = await estimateFeeAndSpendable(api, mainAccount, tx);
   const txAmount = tx.useAllAmount ? spendable : tx.amount;
@@ -835,6 +839,25 @@ function validateRecipientRequiredMemo(
     // LLM expects <transaction> as error key to disable continue button
     errors.transaction = errors.memo;
   }
+}
+
+function isValidCommandDescriptor(commandDescriptor: CommandDescriptor | undefined) {
+  const txCommand = commandDescriptor?.command as StakeCreateAccountCommand | undefined;
+
+  if (
+    commandDescriptor &&
+    txCommand?.amount &&
+    txCommand.stakeAccRentExemptAmount &&
+    txCommand.fromAccAddress &&
+    txCommand.stakeAccAddress &&
+    txCommand.delegate &&
+    txCommand.seed &&
+    commandDescriptor.fee
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 export { prepareTransaction };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

#### Problem

When staking Solana on LLM, the Nano X may disconnect at step 2 of 3 while confirming the transaction. After reconnecting, the **"Delegate From"** address shown on LLM changes, while the address on the Nano X remains the same, causing a mismatch.

#### Solution

Avoid updating the transaction when one is already prepared for the `stake.createAccount` SOL action.


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-13341


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
