### PR TITLE
Delete trustchain before starting synchronisation

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
@@ -3,7 +3,7 @@ import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "../../utils/customJsonReporter";
 import { CLI } from "tests/utils/cliUtils";
-import { expect, TestInfo } from "@playwright/test";
+import { expect } from "@playwright/test";
 import { LedgerSyncCliHelper } from "../../utils/ledgerSyncCliUtils";
 import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
 

--- a/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
@@ -11,30 +11,41 @@ const app: AppInfos = AppInfos.LS;
 const accountId = accounts[0].id;
 const accountName = accountNames[accountId];
 
+function setupSeed() {
+  test.beforeAll(async () => {
+    process.env.SEED = "X";
+  });
+  test.afterAll(async () => {
+    process.env.SEED = "X";
+  });
+}
+
+function initializeThenDeleteTrustchain() {
+  return [
+    LedgerSyncCliHelper.initializeLedgerKeyRingProtocol,
+    LedgerSyncCliHelper.initializeLedgerSync,
+    async () => LedgerSyncCliHelper.deleteLedgerSyncData(),
+  ];
+}
+
+function initializeTrustchain() {
+  return [
+    LedgerSyncCliHelper.initializeLedgerKeyRingProtocol,
+    LedgerSyncCliHelper.initializeLedgerSync,
+    async () =>
+      CLI.ledgerSync({
+        ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
+        ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
+      }),
+  ];
+}
+
 test.describe(`[${app.name}] Sync Accounts`, () => {
+  setupSeed();
   test.use({
     userdata: "skip-onboarding",
     speculosApp: app,
-    cliCommands: [
-      async () => {
-        return LedgerSyncCliHelper.initializeLedgerKeyRingProtocol();
-      },
-      async () => {
-        return LedgerSyncCliHelper.deleteLedgerSyncData();
-      },
-      async () => {
-        return LedgerSyncCliHelper.initializeLedgerKeyRingProtocol();
-      },
-      async () => {
-        return LedgerSyncCliHelper.initializeLedgerSync();
-      },
-      async () => {
-        return CLI.ledgerSync({
-          ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
-          ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
-        });
-      },
-    ],
+    cliCommands: [...initializeThenDeleteTrustchain(), ...initializeTrustchain()],
   });
 
   test(

--- a/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
@@ -6,17 +6,19 @@ import { CLI } from "tests/utils/cliUtils";
 import { expect } from "@playwright/test";
 import { LedgerSyncCliHelper } from "../../utils/ledgerSyncCliUtils";
 import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
+import { getEnv, setEnv } from "@ledgerhq/live-env";
 
 const app: AppInfos = AppInfos.LS;
 const accountId = accounts[0].id;
 const accountName = accountNames[accountId];
 
 function setupSeed() {
+  const prevSeed = getEnv("SEED");
   test.beforeAll(async () => {
-    process.env.SEED = "X";
+    process.env.SEED = "Temporary_SEED";
   });
   test.afterAll(async () => {
-    process.env.SEED = "X";
+    setEnv("SEED", prevSeed);
   });
 }
 

--- a/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/ledgerSync.spec.ts
@@ -20,6 +20,12 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
         return LedgerSyncCliHelper.initializeLedgerKeyRingProtocol();
       },
       async () => {
+        return LedgerSyncCliHelper.deleteLedgerSyncData();
+      },
+      async () => {
+        return LedgerSyncCliHelper.initializeLedgerKeyRingProtocol();
+      },
+      async () => {
         return LedgerSyncCliHelper.initializeLedgerSync();
       },
       async () => {
@@ -29,10 +35,6 @@ test.describe(`[${app.name}] Sync Accounts`, () => {
         });
       },
     ],
-  });
-
-  test.afterAll(async ({}, testInfo: TestInfo) => {
-    await LedgerSyncCliHelper.deleteLedgerSyncData(testInfo);
   });
 
   test(

--- a/apps/ledger-live-desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/apps/ledger-live-desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -157,7 +157,7 @@ export class LedgerSyncCliHelper {
     return output;
   }
 
-  static async deleteLedgerSyncData(testInfo: TestInfo) {
+  static async deleteLedgerSyncData() {
     await CLI.ledgerSync({
       deleteData: true,
       ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,

--- a/apps/ledger-live-desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/apps/ledger-live-desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -1,7 +1,7 @@
 import { CLI } from "tests/utils/cliUtils";
 import { activateLedgerSync } from "@ledgerhq/live-common/e2e/speculos";
 import { accountNames, accounts } from "tests/testdata/ledgerSyncTestData";
-import { Page, TestInfo } from "@playwright/test";
+import { Page } from "@playwright/test";
 import { Application } from "tests/page";
 import { DistantState as LiveData } from "@ledgerhq/live-wallet/walletsync/index";
 import { getEnv } from "@ledgerhq/live-env";

--- a/apps/ledger-live-desktop/tests/utils/ledgerSyncCliUtils.ts
+++ b/apps/ledger-live-desktop/tests/utils/ledgerSyncCliUtils.ts
@@ -158,27 +158,17 @@ export class LedgerSyncCliHelper {
   }
 
   static async deleteLedgerSyncData(testInfo: TestInfo) {
-    try {
-      await CLI.ledgerSync({
-        deleteData: true,
-        ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
-        ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
-      });
+    await CLI.ledgerSync({
+      deleteData: true,
+      ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
+      ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
+    });
 
-      await CLI.ledgerKeyRingProtocol({
-        destroyKeyRingTree: true,
-        ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
-        ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
-      });
-    } catch (error) {
-      if (
-        (error as Error).message?.includes("Not a member of trustchain") &&
-        testInfo.status == testInfo.expectedStatus
-      )
-        return; // Not logging error as trustchain was deleted within the test
-
-      console.error("AfterAll Hook: Error deleting trustchain\n", error);
-    }
+    await CLI.ledgerKeyRingProtocol({
+      destroyKeyRingTree: true,
+      ...LedgerSyncCliHelper.ledgerKeyRingProtocolArgs,
+      ...LedgerSyncCliHelper.ledgerSyncPushDataArgs,
+    });
   }
 
   static checkSynchronizationSuccess(page: Page, app: Application) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

To avoid failures during execution due to a trust chain that was not properly destroyed when a test fails, the trust chain should be created and then destroyed at the beginning of the script to ensure a fresh new trust chain.

<!--
Before  :                                                                                          | After         |
| we initialized the trust chain and then started the sync tests.  |   we initialize and destroy the trust chain before initializing it again, just before starting the sync tests |
|  we used the same seed for all our test cases            |    we use a specific, hardcoded seed dedicated to ledger sync tests           |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- https://ledgerhq.atlassian.net/browse/QAA-178 -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
