### PR TITLE
feat: Display Collections for Solana in Account Page under FF 🔧

### DIFF
--- a/.changeset/chilly-cups-perform.md
+++ b/.changeset/chilly-cups-perform.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Display Collections for Solana in Account Page under FF

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/nftHelper.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/nftHelper.test.ts
@@ -1,0 +1,96 @@
+import { Account, AccountLike } from "@ledgerhq/types-live";
+import { isNFTCollectionsDisplayable } from "../nftHelper";
+
+import { getEnv } from "@ledgerhq/live-env";
+import { isNFTActive } from "@ledgerhq/coin-framework/nft/support";
+
+jest.mock("@ledgerhq/live-env", () => ({
+  getEnv: jest.fn() as jest.Mock,
+}));
+
+jest.mock("@ledgerhq/coin-framework/nft/support", () => ({
+  isNFTActive: jest.fn() as jest.Mock,
+}));
+
+describe("nftHelper", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("isNFTCollectionsDisplayable", () => {
+    it("returns false if account is empty", () => {
+      const account = {
+        type: "Account",
+        currency: {
+          id: "ethereum",
+        },
+      } as Account;
+      const isAccountEmpty = true;
+      const llmSolanaNftsEnabled = false;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      expect(result).toBe(false);
+    });
+
+    it("returns false if account is not an Account", () => {
+      const account = {
+        type: "TokenAccount",
+        currency: {
+          id: "ethereum",
+        },
+      } as unknown as AccountLike;
+      const isAccountEmpty = false;
+      const llmSolanaNftsEnabled = false;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      expect(result).toBe(false);
+    });
+
+    it("returns false if account === solana and llmSolanaNftsEnabled === false", () => {
+      (getEnv as jest.Mock).mockReturnValue(["solana"]);
+      const account = {
+        type: "Account",
+        currency: {
+          id: "solana",
+        },
+      } as Account;
+      const nftCurrencies = getEnv("NFT_CURRENCIES");
+
+      (isNFTActive as jest.Mock).mockReturnValue(nftCurrencies.includes(account.currency.id));
+
+      const isAccountEmpty = false;
+      const llmSolanaNftsEnabled = false;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      expect(result).toBe(false);
+    });
+
+    it("returns true if account === solana and llmSolanaNftsEnabled === true", () => {
+      (getEnv as jest.Mock).mockReturnValue(["solana"]);
+      const account = {
+        type: "Account",
+        currency: {
+          id: "solana",
+        },
+      } as Account;
+      const nftCurrencies = getEnv("NFT_CURRENCIES");
+
+      (isNFTActive as jest.Mock).mockReturnValue(nftCurrencies.includes(account.currency.id));
+
+      const isAccountEmpty = false;
+      const llmSolanaNftsEnabled = true;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      expect(result).toBe(true);
+    });
+
+    it("returns true if account !== solana and llmSolanaNftsEnabled === false", () => {
+      const account = {
+        type: "Account",
+        currency: {
+          id: "ethereum",
+        },
+      } as Account;
+      const isAccountEmpty = false;
+      const llmSolanaNftsEnabled = false;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Account/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/index.tsx
@@ -26,7 +26,7 @@ import accountSyncRefreshControl from "~/components/accountSyncRefreshControl";
 import { NavigatorName, ScreenName } from "~/const";
 import CurrencyBackgroundGradient from "~/components/CurrencyBackgroundGradient";
 import AccountHeader from "./AccountHeader";
-import { getListHeaderComponents } from "./ListHeaderComponent";
+import { useListHeaderComponents } from "./ListHeaderComponent";
 import { withDiscreetMode } from "~/context/DiscreetModeContext";
 import SectionContainer from "../WalletCentricSections/SectionContainer";
 import SectionTitle from "../WalletCentricSections/SectionTitle";
@@ -140,7 +140,7 @@ const AccountScreenInner = ({
     console.warn(err);
   }
 
-  const { listHeaderComponents } = getListHeaderComponents({
+  const { listHeaderComponents } = useListHeaderComponents({
     account,
     parentAccount,
     currency,

--- a/apps/ledger-live-mobile/src/screens/Account/nftHelper.ts
+++ b/apps/ledger-live-mobile/src/screens/Account/nftHelper.ts
@@ -1,0 +1,19 @@
+import { AccountLike } from "@ledgerhq/types-live";
+import { isNFTActive } from "@ledgerhq/coin-framework/nft/support";
+
+type SolanaProps = {
+  llmSolanaNftsEnabled?: boolean;
+};
+
+export function isNFTCollectionsDisplayable(
+  account: AccountLike,
+  isAccountEmpty: boolean,
+  { llmSolanaNftsEnabled = false }: SolanaProps,
+): boolean {
+  return (
+    !isAccountEmpty &&
+    account.type === "Account" &&
+    isNFTActive(account.currency) &&
+    (account.currency.id !== "solana" || llmSolanaNftsEnabled)
+  );
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Display Solana Collections when FF is ON, hidden when FF OFF 
- The wording will be automatically replace the placeholder with Solana instead of Eth when collections are empty

https://github.com/user-attachments/assets/eb2ca7c3-fbff-4024-987a-62d62e2c8b85



### ❓ Context

- **JIRA or GitHub link**: [LIVE-17561] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17561]: https://ledgerhq.atlassian.net/browse/LIVE-17561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ