### PR TITLE
Remove ticker from ADA validator names

### DIFF
--- a/.changeset/wise-cups-warn.md
+++ b/.changeset/wise-cups-warn.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Remove ticker from ADA validator names

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorRow.tsx
@@ -40,7 +40,7 @@ function CardanoPoolRow({ pool, active, onClick, unit, currency }: Props) {
         address: pool.poolId,
       }}
       icon={<LedgerPoolIcon validator={pool} />}
-      title={`${pool.ticker} - ${pool.name}` || pool.poolId}
+      title={pool.name || pool.poolId}
       onExternalLink={onExternalLink}
       unit={unit}
       sideInfo={


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

### Problem  
Displaying validator names, particularly on Ledger Live Desktop, in the format **"validatorTicker" - "validatorName"** prevents proper filtering on the backend, which is done by **validatorName**.  

### Solution  
Remove the ticker from the displayed name — this has been validated with the product team, specifically with Livio.

| Before            |        After       |
| ------------- | ------------- |
|   <img width="533" alt="image" src="https://github.com/user-attachments/assets/05d93571-0a17-45a2-a94e-1751274b37f7" />     |     <img width="534" alt="image" src="https://github.com/user-attachments/assets/30f53f74-36ac-48f5-842c-6015fcc1eb6a" /> |


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
