### PR TITLE
feat: Hide send button in NFT gallery Account for Solana

### DIFF
--- a/.changeset/fast-balloons-type.md
+++ b/.changeset/fast-balloons-type.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Hide send button in NFT gallery Account for Solana

--- a/apps/ledger-live-mobile/src/screens/Nft/NftGallery/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Nft/NftGallery/index.tsx
@@ -33,6 +33,7 @@ type NavigationProps = BaseComposite<
 
 const NftGallery = () => {
   const nftsFromSimplehashFeature = useFeature("nftsFromSimplehash");
+  const llmSolanaNftsEnabled = useFeature("llmSolanaNfts")?.enabled || false;
   const threshold = nftsFromSimplehashFeature?.params?.threshold;
   const nftsFromSimplehashEnabled = nftsFromSimplehashFeature?.enabled;
   const navigation = useNavigation<NavigationProps["navigation"]>();
@@ -108,6 +109,7 @@ const NftGallery = () => {
   );
 
   const isNFTDisabled = useFeature("disableNftSend")?.enabled && Platform.OS === "ios";
+  const displaySendBtn = account.currency.id !== "solana" || llmSolanaNftsEnabled;
 
   return (
     <SafeAreaView isFlex edges={["bottom"]}>
@@ -125,15 +127,17 @@ const NftGallery = () => {
         initialNumToRender={1}
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={
-          <View style={styles.sendButtonContainer}>
-            <Button
-              type="primary"
-              IconLeft={SendIcon}
-              containerStyle={styles.sendButton}
-              title={t("account.send")}
-              onPress={isNFTDisabled ? onOpenModal : goToCollectionSelection}
-            />
-          </View>
+          displaySendBtn ? (
+            <View style={styles.sendButtonContainer}>
+              <Button
+                type="primary"
+                IconLeft={SendIcon}
+                containerStyle={styles.sendButton}
+                title={t("account.send")}
+                onPress={isNFTDisabled ? onOpenModal : goToCollectionSelection}
+              />
+            </View>
+          ) : null
         }
         ListFooterComponent={() =>
           collections.length > collectionsCount ? <LoadingFooter /> : null


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Conditional expression that evaluates whether the "Send" button should be displayed, based on two conditions:

`account.currency.id !== "solana"`: The button is shown if the account's currency is not Solana (i.e., the currency is something other than Solana).
`llmSolanaNftsEnabled`: If Solana NFTs are enabled, this part of the expression is true, and the button will be shown regardless of the currency.


https://github.com/user-attachments/assets/b327a27d-371f-4555-98ca-efd2bfe9a559



### ❓ Context

- **JIRA or GitHub link**: [LIVE-17570] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17570]: https://ledgerhq.atlassian.net/browse/LIVE-17570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ