### PR TITLE
feat: update currencies list with Blockscout explorer links

### DIFF
--- a/.changeset/pink-icons-talk.md
+++ b/.changeset/pink-icons-talk.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+change explorer URLs to Blockscout for a variety of EVM coins

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -21,7 +21,25 @@
  * if bitcoin family, supportsSegwit defines if it supports segwit.
  */
 
-import { CoinType, CryptoCurrency, CryptoCurrencyId, Unit } from "@ledgerhq/types-cryptoassets";
+import {
+  CoinType,
+  CryptoCurrency,
+  CryptoCurrencyId,
+  ExplorerView,
+  Unit,
+} from "@ledgerhq/types-cryptoassets";
+
+/**
+ * Make an ExplorerView for a Blockscout based explorer
+ * @param baseURL The explorer base URL. It MUST be properly formatted with no trailing slash. No checks are performed.
+ */
+function blockscoutExplorerView(baseURL: string) {
+  return {
+    tx: `${baseURL}/tx/$hash`,
+    address: `${baseURL}/address/$address`,
+    token: `${baseURL}/address/$address?tab=token_transfer&token=$contractAddress`,
+  } satisfies ExplorerView;
+}
 
 const makeTestnetUnit = u => ({ ...u, code: `𝚝${u.code}` });
 
@@ -3595,13 +3613,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 42161,
     },
-    explorerViews: [
-      {
-        tx: "https://arbiscan.io/tx/$hash",
-        address: "https://arbiscan.io/address/$address",
-        token: "https://arbiscan.io/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://arbitrum.blockscout.com")],
   },
   arbitrum_sepolia: {
     type: "CryptoCurrency",
@@ -3620,13 +3632,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 421614,
     },
-    explorerViews: [
-      {
-        tx: "https://sepolia.arbiscan.io/tx/$hash",
-        address: "https://sepolia.arbiscan.io/address/$address",
-        token: "https://sepolia.arbiscan.io/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://arbitrum-sepolia.blockscout.com")],
   },
   // Cronos EVM blockchain
   cronos: {
@@ -3649,13 +3655,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
         magnitude: 18,
       },
     ],
-    explorerViews: [
-      {
-        tx: "https://cronoscan.com/tx/$hash",
-        address: "https://cronoscan.com/address/$address",
-        token: "https://cronoscan.com/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://crypto.org/explorer")],
   },
   fantom: {
     type: "CryptoCurrency",
@@ -3693,12 +3693,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
       chainId: 14,
     },
     units: ethereumUnits("FLR", "FLR"),
-    explorerViews: [
-      {
-        tx: "https://flare-explorer.flare.network/tx/$hash/internal-transactions",
-        address: "https://flare-explorer.flare.network/address/$address/transactions",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://flare-explorer.flare.network")],
   },
   songbird: {
     type: "CryptoCurrency",
@@ -3714,12 +3709,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
       chainId: 19,
     },
     units: ethereumUnits("SGB", "SGB"),
-    explorerViews: [
-      {
-        tx: "https://songbird-explorer.flare.network/tx/$hash/internal-transactions",
-        address: "https://songbird-explorer.flare.network/address/$address/transactions",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://songbird-explorer.flare.network")],
   },
   moonbeam: {
     type: "CryptoCurrency",
@@ -3763,13 +3753,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 30,
     },
-    explorerViews: [
-      {
-        tx: "https://explorer.rootstock.io/tx/$hash",
-        address: "https://explorer.rootstock.io/address/$address",
-        token: "https://explorer.rootstock.io/address/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://rootstock.blockscout.com")],
   },
   bittorrent: {
     type: "CryptoCurrency",
@@ -3807,13 +3791,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 10,
     },
-    explorerViews: [
-      {
-        tx: "https://optimistic.etherscan.io/tx/$hash",
-        address: "https://optimistic.etherscan.io/address/$address",
-        token: "https://optimistic.etherscan.io/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://optimism.blockscout.com")],
     keywords: ["optimism"],
   },
   optimism_sepolia: {
@@ -3831,13 +3809,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 11155420,
     },
-    explorerViews: [
-      {
-        tx: "https://sepolia-optimism.etherscan.io/tx/$hash",
-        address: "https://sepolia-optimism.etherscan.io/address/$address",
-        token: "https://sepolia-optimism.etherscan.io/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://optimism-sepolia.blockscout.com")],
   },
   energy_web: {
     type: "CryptoCurrency",
@@ -3853,13 +3825,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 246,
     },
-    explorerViews: [
-      {
-        tx: "https://explorer.energyweb.org/tx/$hash",
-        address: "https://explorer.energyweb.org/address/$address",
-        token: "https://explorer.energyweb.org/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://explorer.energyweb.org")],
   },
   astar: {
     type: "CryptoCurrency",
@@ -3875,13 +3841,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 592,
     },
-    explorerViews: [
-      {
-        tx: "https://blockscout.com/astar/tx/$hash",
-        address: "https://blockscout.com/astar/address/$address",
-        token: "https://blockscout.com/astar/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://astar.blockscout.com")],
   },
   metis: {
     type: "CryptoCurrency",
@@ -3897,13 +3857,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 1088,
     },
-    explorerViews: [
-      {
-        tx: "https://andromeda-explorer.metis.io/tx/$hash",
-        address: "https://andromeda-explorer.metis.io/address/$address",
-        token: "https://andromeda-explorer.metis.io/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://andromeda-explorer.metis.io")],
   },
   boba: {
     type: "CryptoCurrency",
@@ -3963,13 +3917,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 106,
     },
-    explorerViews: [
-      {
-        tx: "https://evmexplorer.velas.com/tx/$hash",
-        address: "https://evmexplorer.velas.com/address/$address",
-        token: "https://evmexplorer.velas.com/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://evmexplorer.velas.com")],
   },
   syscoin: {
     type: "CryptoCurrency",
@@ -3985,13 +3933,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 57,
     },
-    explorerViews: [
-      {
-        tx: "https://explorer.syscoin.org/tx/$hash",
-        address: "https://explorer.syscoin.org/address/$address",
-        token: "https://explorer.syscoin.org/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://explorer.syscoin.org")],
   },
   telos_evm: {
     type: "CryptoCurrency",
@@ -4029,13 +3971,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 1101,
     },
-    explorerViews: [
-      {
-        tx: "https://zkevm.polygonscan.com/tx/$hash",
-        address: "https://zkevm.polygonscan.com/address/$address",
-        token: "https://zkevm.polygonscan.com/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://zkevm.blockscout.com")],
   },
   polygon_zk_evm_testnet: {
     type: "CryptoCurrency",
@@ -4054,13 +3990,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 1442,
     },
-    explorerViews: [
-      {
-        tx: "https://testnet-zkevm.polygonscan.com/tx/$hash",
-        address: "https://testnet-zkevm.polygonscan.com/address/$address",
-        token: "https://testnet-zkevm.polygonscan.com/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://explorer-ui.cardona.zkevm-rpc.com")],
   },
   base: {
     type: "CryptoCurrency",
@@ -4076,13 +4006,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 8453,
     },
-    explorerViews: [
-      {
-        tx: "https://basescan.org/tx/$hash",
-        address: "https://basescan.org/address/$address",
-        token: "https://basescan.org/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://base.blockscout.com")],
   },
   base_sepolia: {
     type: "CryptoCurrency",
@@ -4101,13 +4025,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 84532,
     },
-    explorerViews: [
-      {
-        tx: "https://sepolia.basescan.org/tx/$hash",
-        address: "https://sepolia.basescan.org/address/$address",
-        token: "https://sepolia.basescan.org/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://base-sepolia.blockscout.com")],
   },
   klaytn: {
     type: "CryptoCurrency",
@@ -4145,13 +4063,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 245022934,
     },
-    explorerViews: [
-      {
-        tx: "https://neonscan.org/tx/$hash",
-        address: "https://neonscan.org/address/$address",
-        token: "https://neonscan.org/token/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://neon.blockscout.com")],
   },
   lukso: {
     type: "CryptoCurrency",
@@ -4168,13 +4080,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 42,
     },
-    explorerViews: [
-      {
-        tx: "https://explorer.execution.mainnet.lukso.network/tx/$hash",
-        address: "https://explorer.execution.mainnet.lukso.network/address/$address",
-        token: "https://explorer.execution.mainnet.lukso.network/token/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://explorer.execution.mainnet.lukso.network")],
   },
   linea: {
     type: "CryptoCurrency",
@@ -4238,13 +4144,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 81457,
     },
-    explorerViews: [
-      {
-        tx: "https://blastscan.io/tx/$hash",
-        address: "https://blastscan.io/address/$address",
-        token: "https://blastscan.io/token/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://blast.blockscout.com")],
   },
   blast_sepolia: {
     type: "CryptoCurrency",
@@ -4262,13 +4162,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 168587773,
     },
-    explorerViews: [
-      {
-        tx: "https://testnet.blastscan.io/tx/$hash",
-        address: "https://testnet.blastscan.io/address/$address",
-        token: "https://testnet.blastscan.io/token/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://blast-testnet.blockscout.com")],
   },
   scroll: {
     type: "CryptoCurrency",
@@ -4285,13 +4179,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 534352,
     },
-    explorerViews: [
-      {
-        tx: "https://scrollscan.com/tx/$hash",
-        address: "https://scrollscan.com/address/$address",
-        token: "https://scrollscan.com/token/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://scroll.blockscout.com")],
   },
   scroll_sepolia: {
     type: "CryptoCurrency",
@@ -4309,13 +4197,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 534351,
     },
-    explorerViews: [
-      {
-        tx: "https://sepolia.scrollscan.dev/tx/$hash",
-        address: "https://sepolia.scrollscan.dev/address/$address",
-        token: "https://sepolia.scrollscan.dev/token/$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://scroll-sepolia.blockscout.com")],
   },
   etherlink: {
     type: "CryptoCurrency",
@@ -4331,13 +4213,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 42793,
     },
-    explorerViews: [
-      {
-        tx: "https://explorer.etherlink.com/tx/$hash",
-        address: "https://explorer.etherlink.com/address/$address",
-        token: "https://explorer.etherlink.com/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://explorer.etherlink.com")],
   },
   zksync: {
     type: "CryptoCurrency",
@@ -4353,13 +4229,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 324,
     },
-    explorerViews: [
-      {
-        tx: "https://explorer.zksync.io/tx/$hash",
-        address: "https://explorer.zksync.io/address/$address",
-        token: "https://explorer.zksync.io/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://zksync.blockscout.com")],
   },
   zksync_sepolia: {
     type: "CryptoCurrency",
@@ -4375,13 +4245,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     ethereumLikeInfo: {
       chainId: 300,
     },
-    explorerViews: [
-      {
-        tx: "https://sepolia-era.zksync.network/tx/$hash",
-        address: "https://sepolia-era.zksync.network/address/$address",
-        token: "https://sepolia-era.zksync.network/token/$contractAddress?a=$address",
-      },
-    ],
+    explorerViews: [blockscoutExplorerView("https://zksync-sepolia.blockscout.com")],
   },
   // Keep it at the bottom
   // Tickers dup

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -3656,7 +3656,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
         magnitude: 18,
       },
     ],
-    explorerViews: [blockscoutExplorerView("https://cronos.org/explorer/")],
+    explorerViews: [blockscoutExplorerView("https://cronos.org/explorer")],
   },
   fantom: {
     type: "CryptoCurrency",

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -3656,7 +3656,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
         magnitude: 18,
       },
     ],
-    explorerViews: [blockscoutExplorerView("https://crypto.org/explorer")],
+    explorerViews: [blockscoutExplorerView("https://cronos.org/explorer/")],
   },
   fantom: {
     type: "CryptoCurrency",

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -31,6 +31,7 @@ import {
 
 /**
  * Make an ExplorerView for a Blockscout based explorer
+ * @private
  * @param baseURL The explorer base URL. It MUST be properly formatted with no trailing slash. No checks are performed.
  */
 function blockscoutExplorerView(baseURL: string) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

EVM chains using Blockscout as source will also use Blockscout to construct explorer URLs. Chains impacted:

- arbitrum
- cronos
- flare
- songbird
- rsk
- optimism
- optimism sepolia
- energy web
- astar
- metis
- velas
- syscoin
- polygon zk evm
- base
- base sepolia
- neon
- lukso
- blast
- blast sepolia
- scroll
- scroll sepolia
- etherlink
- zk sync
- zk sync sepolia


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17751](https://ledgerhq.atlassian.net/browse/LIVE-17751)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17751]: https://ledgerhq.atlassian.net/browse/LIVE-17751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ