### PR TITLE
Revert "feat(LIVE-17514): remove unused Swap feature flags"

### DIFF
--- a/.changeset/grumpy-cherries-know.md
+++ b/.changeset/grumpy-cherries-know.md
@@ -1,6 +1,0 @@
----
-"@ledgerhq/types-live": minor
-"@ledgerhq/live-common": minor
----
-
-Remove unused feature flags

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
@@ -8,6 +8,7 @@ export const useFilteredProviders = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<unknown>(null);
   const ptxSwapMoonpayProviderFlag = useFeature("ptxSwapMoonpayProvider");
+  const ptxSwapExodusProviderFlag = useFeature("ptxSwapExodusProvider");
   const fetchProviders = useCallback(async () => {
     try {
       const ledgerSignatureEnv = getEnv("MOCK_EXCHANGE_TEST_CONFIG") ? "test" : "prod";
@@ -18,6 +19,9 @@ export const useFilteredProviders = () => {
       if (!ptxSwapMoonpayProviderFlag?.enabled) {
         filteredProviders = filteredProviders.filter(provider => provider !== "moonpay");
       }
+      if (!ptxSwapExodusProviderFlag?.enabled) {
+        filteredProviders = filteredProviders.filter(provider => provider !== "exodus");
+      }
 
       setProviders(filteredProviders);
     } catch (error) {
@@ -25,7 +29,7 @@ export const useFilteredProviders = () => {
     } finally {
       setLoading(false);
     }
-  }, [ptxSwapMoonpayProviderFlag]);
+  }, [ptxSwapMoonpayProviderFlag, ptxSwapExodusProviderFlag]);
 
   useEffect(() => {
     fetchProviders();

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -437,6 +437,7 @@ export const DEFAULT_FEATURES: Features = {
   },
 
   ptxSwapMoonpayProvider: DEFAULT_FEATURE,
+  ptxSwapExodusProvider: DEFAULT_FEATURE,
 
   myLedgerDisplayAppDeveloperName: DEFAULT_FEATURE,
   nftsFromSimplehash: {

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -181,6 +181,7 @@ export type Features = CurrencyFeatures & {
   flexibleContentCards: Feature_FlexibleContentCards;
   llmAnalyticsOptInPrompt: Feature_LlmAnalyticsOptInPrompt;
   ptxSwapMoonpayProvider: Feature_PtxSwapMoonpayProvider;
+  ptxSwapExodusProvider: Feature_PtxSwapExodusProvider;
   lldAnalyticsOptInPrompt: Feature_LldAnalyticsOptInPrompt;
   lldChatbotSupport: Feature_LldChatbotSupport;
   llmChatbotSupport: Feature_LlmChatbotSupport;
@@ -606,6 +607,7 @@ export type Feature_lldnewArchOrdinals = DefaultFeature;
 export type Feature_SpamFilteringTx = DefaultFeature;
 export type Feature_MemoTag = DefaultFeature;
 export type Feature_PtxSwapMoonpayProvider = DefaultFeature;
+export type Feature_PtxSwapExodusProvider = DefaultFeature;
 
 export type Feature_LlmRebornLP = Feature<{
   variant: ABTestingVariants;


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#9482

Exodus should not appear, even after removing this flag. Currently it does.
