### PR TITLE
[QAA Updating delegate and swap e2e tests

### DIFF
--- a/apps/ledger-live-desktop/tests/page/swap.page.ts
+++ b/apps/ledger-live-desktop/tests/page/swap.page.ts
@@ -268,6 +268,7 @@ export class SwapPage extends AppPage {
   @step("Click Exchange button")
   async clickExchangeButton(electronApp: ElectronApplication, provider: string) {
     const [, webview] = electronApp.windows();
+    await expect(webview.getByRole("button", { name: `Swap with ${provider}` })).toBeEnabled();
     await webview.getByRole("button", { name: `Swap with ${provider}` }).click();
   }
 
@@ -276,6 +277,7 @@ export class SwapPage extends AppPage {
     const [, webview] = electronApp.windows();
     const continueButton = webview.getByRole("button", { name: `Continue with ${provider}` });
     await expect(continueButton).toBeVisible();
+    await expect(continueButton).toBeEnabled();
     await continueButton.click();
   }
 

--- a/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/delegate.spec.ts
@@ -46,7 +46,7 @@ const e2eDelegationAccounts = [
 
 const e2eDelegationAccountsWithoutBroadcast = [
   {
-    delegate: new Delegate(Account.ADA_1, "0.01", "LBF3 - Ledger by Figment 3"),
+    delegate: new Delegate(Account.ADA_1, "0.01", "Ledger by Figment 3"),
     xrayTicket: "B2CQA-3023",
   },
   {
@@ -69,7 +69,7 @@ const validators = [
     xrayTicket: "B2CQA-2732, B2CQA-2765",
   },
   {
-    delegate: new Delegate(Account.ADA_2, "0.01", "LBF2 - Ledger by Figment 2"),
+    delegate: new Delegate(Account.ADA_2, "0.01", "Ledger by Figment 2"),
     xrayTicket: "B2CQA-2766",
   },
   {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
