### PR TITLE
Feature/live 17711 loader transaction check

### DIFF
--- a/.changeset/little-ladybugs-build.md
+++ b/.changeset/little-ladybugs-build.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-dmk": minor
+---
+
+Bump up dmk version and disable dmk refresher

--- a/.changeset/swift-eels-repair.md
+++ b/.changeset/swift-eels-repair.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-signer-evm": minor
+---
+
+Use observable instead of promise for signing

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/blast.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/blast.ts
@@ -72,6 +72,7 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
     ]);
 
     const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    // @ts-expect-error - TODO: fix this
     const signerContext: Parameters<typeof resolver>[0] = (deviceId, fn) => fn(new Eth(transport));
 
     const lastBlockNumber = await provider.getBlockNumber();

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/ethereum.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/ethereum.ts
@@ -136,6 +136,7 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
       spawnAnvil("https://rpc.ankr.com/eth"),
     ]);
 
+    // @ts-expect-error - TODO: fix this
     const signerContext: Parameters<typeof resolver>[0] = (deviceId, fn) => fn(new Eth(transport));
 
     setCoinConfig(() => ({

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/polygon.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/polygon.ts
@@ -128,6 +128,7 @@ export const scenarioPolygon: Scenario<EvmTransaction, Account> = {
     ]);
 
     const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    // @ts-expect-error - TODO: fix this
     const signerContext: Parameters<typeof resolver>[0] = (deviceId, fn) => fn(new Eth(transport));
 
     const lastBlockNumber = await provider.getBlockNumber();

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/scroll.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/scroll.ts
@@ -76,6 +76,7 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
     ]);
 
     const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    // @ts-expect-error - TODO: fix this
     const signerContext: Parameters<typeof resolver>[0] = (deviceId, fn) => fn(new Eth(transport));
 
     const lastBlockNumber = await provider.getBlockNumber();

--- a/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/sonic.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/coin-tester/scenarii/sonic.ts
@@ -71,6 +71,7 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
       spawnAnvil("https://rpc.ankr.com/sonic_mainnet"),
     ]);
 
+    // @ts-expect-error - TODO: fix this
     const signerContext: Parameters<typeof resolver>[0] = (_, fn) => fn(new Eth(transport));
 
     setCoinConfig(() => ({

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/signOperation.unit.test.ts
@@ -3,6 +3,7 @@ import { Account } from "@ledgerhq/types-live";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { SignerContext } from "@ledgerhq/coin-framework/signer";
+import { concat, of } from "rxjs";
 import { Transaction as EvmTransaction } from "../../types";
 import { makeAccount } from "../fixtures/common.fixtures";
 import { buildSignOperation } from "../../signOperation";
@@ -52,11 +53,10 @@ const mockSignerContext: SignerContext<EvmSigner> = <T>(
     setLoadConfig: jest.fn(),
     getAddress: jest.fn(),
     clearSignTransaction: () =>
-      Promise.resolve({
-        r: "123",
-        s: "abc",
-        v: "27",
-      }),
+      concat(
+        of({ type: "signer.evm.signing" }),
+        of({ type: "signer.evm.signed", value: { r: "123", s: "abc", v: "27" } }),
+      ),
     signEIP712HashedMessage: jest.fn(),
     signEIP712Message: jest.fn(),
     signPersonalMessage: jest.fn(),

--- a/libs/coin-modules/coin-evm/src/signOperation.ts
+++ b/libs/coin-modules/coin-evm/src/signOperation.ts
@@ -1,11 +1,11 @@
-import { Observable } from "rxjs";
+import { from, Observable, switchMap, tap, finalize } from "rxjs";
 import { getEnv } from "@ledgerhq/live-env";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { SignerContext } from "@ledgerhq/coin-framework/signer";
 import { isNFTActive } from "@ledgerhq/coin-framework/nft/support";
 import type { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";
-import { EvmSignature, EvmSigner } from "./types/signer";
+import type { EvmSigner } from "./types/signer";
 import { prepareForSignOperation } from "./prepareTransaction";
 import { getSerializedTransaction } from "./transaction";
 import { Transaction } from "./types";
@@ -17,67 +17,80 @@ export const buildSignOperation =
   (signerContext: SignerContext<EvmSigner>): AccountBridge<Transaction>["signOperation"] =>
   ({ account, deviceId, transaction }) =>
     new Observable(o => {
-      async function main(): Promise<void> {
-        const preparedTransaction = await prepareForSignOperation({
-          account,
-          transaction,
-        });
-        const serializedTxHexString = getSerializedTransaction(preparedTransaction).slice(2); // Remove 0x prefix
+      from(prepareForSignOperation({ account, transaction }))
+        .pipe(
+          switchMap(preparedTransaction => {
+            const serializedTxHexString = getSerializedTransaction(preparedTransaction).slice(2); // Remove 0x prefix
 
-        // Configure type of resolutions necessary for the clear signing
-        const resolutionConfig: ResolutionConfig = {
-          externalPlugins: true,
-          erc20: true,
-          nft: isNFTActive(account.currency),
-          domains: transaction.recipientDomain ? [transaction.recipientDomain] : [],
-          uniswapV3: true,
-        };
-        const loadConfig: LoadConfig = {
-          cryptoassetsBaseURL: getEnv("DYNAMIC_CAL_BASE_URL"),
-          nftExplorerBaseURL: getEnv("NFT_METADATA_SERVICE") + "/v1/ethereum",
-        };
+            // Configure type of resolutions necessary for the clear signing
+            const resolutionConfig: ResolutionConfig = {
+              externalPlugins: true,
+              erc20: true,
+              nft: isNFTActive(account.currency),
+              domains: transaction.recipientDomain ? [transaction.recipientDomain] : [],
+              uniswapV3: true,
+            };
+            const loadConfig: LoadConfig = {
+              cryptoassetsBaseURL: getEnv("DYNAMIC_CAL_BASE_URL"),
+              nftExplorerBaseURL: getEnv("NFT_METADATA_SERVICE") + "/v1/ethereum",
+            };
 
-        o.next({
-          type: "device-signature-requested",
-        });
+            return signerContext(deviceId, async signer => {
+              signer.setLoadConfig(loadConfig);
 
-        const sig = (await signerContext(deviceId, signer => {
-          signer.setLoadConfig(loadConfig);
-          // Request signature on the nano
-          return signer.clearSignTransaction(
-            account.freshAddressPath,
-            serializedTxHexString,
-            resolutionConfig,
-            true,
-          );
-        })) as EvmSignature;
+              return new Promise<void>((resolve, reject) => {
+                signer
+                  .clearSignTransaction(
+                    account.freshAddressPath,
+                    serializedTxHexString,
+                    resolutionConfig,
+                    true,
+                  )
+                  .pipe(
+                    tap(event => {
+                      if (event.type === "signer.evm.signing") {
+                        o.next({ type: "device-signature-requested" });
+                      }
+                      if (event.type === "signer.evm.signed") {
+                        o.next({ type: "device-signature-granted" });
 
-        o.next({ type: "device-signature-granted" }); // Signature is done
+                        const sig = event.value;
+                        const signature = getSerializedTransaction(preparedTransaction, {
+                          r: "0x" + sig.r,
+                          s: "0x" + sig.s,
+                          v: typeof sig.v === "number" ? sig.v : parseInt(sig.v, 16),
+                        });
 
-        // Create a new serialized tx with the signature now
-        const signature = await getSerializedTransaction(preparedTransaction, {
-          r: "0x" + sig.r,
-          s: "0x" + sig.s,
-          v: typeof sig.v === "number" ? sig.v : parseInt(sig.v, 16),
-        });
+                        const operation = buildOptimisticOperation(account, {
+                          ...transaction,
+                          nonce: preparedTransaction.nonce,
+                        });
 
-        const operation = buildOptimisticOperation(account, {
-          ...transaction,
-          nonce: preparedTransaction.nonce,
-        });
+                        o.next({
+                          type: "signed",
+                          signedOperation: {
+                            operation,
+                            signature,
+                          },
+                        });
 
-        o.next({
-          type: "signed",
-          signedOperation: {
-            operation,
-            signature,
+                        o.complete();
+                      }
+                    }),
+                    finalize(() => resolve()),
+                  )
+                  .subscribe({
+                    error: error => {
+                      reject(error);
+                    },
+                  });
+              });
+            });
+          }),
+        )
+        .subscribe({
+          error: error => {
+            o.error(error);
           },
         });
-      }
-
-      main().then(
-        () => o.complete(),
-        /* istanbul ignore next: don't test throwing an error */
-        e => o.error(e),
-      );
     });

--- a/libs/coin-modules/coin-evm/src/types/signer.ts
+++ b/libs/coin-modules/coin-evm/src/types/signer.ts
@@ -1,5 +1,6 @@
 import { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
 import { EIP712Message } from "@ledgerhq/types-live";
+import { Observable } from "rxjs";
 
 export type EvmAddress = {
   publicKey: string;
@@ -13,6 +14,20 @@ export type EvmSignature = {
   r: string;
 };
 
+export type EvmSignerEventType =
+  | "signer.evm.loading-context"
+  | "signer.evm.signing"
+  | "signer.evm.signed";
+
+export type EvmSignerEvent =
+  | {
+      type: Exclude<EvmSignerEventType, "signer.evm.signed">;
+    }
+  | {
+      type: "signer.evm.signed";
+      value: EvmSignature;
+    };
+
 export interface EvmSigner {
   getAddress: (
     path: string,
@@ -20,23 +35,23 @@ export interface EvmSigner {
     boolChaincode?: boolean,
     chainId?: string,
   ) => Promise<EvmAddress>;
-  signTransaction: (path: string, rawTxHex: string, resolution?: any) => Promise<EvmSignature>;
-  signPersonalMessage: (path: string, messageHex: string) => Promise<EvmSignature>;
+  signTransaction: (path: string, rawTxHex: string, resolution?: any) => Observable<EvmSignerEvent>;
+  signPersonalMessage: (path: string, messageHex: string) => Observable<EvmSignerEvent>;
   signEIP712Message(
     path: string,
     jsonMessage: EIP712Message,
     fullImplem?: boolean,
-  ): Promise<EvmSignature>;
+  ): Observable<EvmSignerEvent>;
   setLoadConfig: (config: LoadConfig) => void;
   clearSignTransaction: (
     path: string,
     rawTxHex: string,
     resolutionConfig: ResolutionConfig,
     throwOnError: boolean,
-  ) => Promise<EvmSignature>;
+  ) => Observable<EvmSignerEvent>;
   signEIP712HashedMessage: (
     path: string,
     domainSeparatorHex: string,
     hashStructMessageHex: string,
-  ) => Promise<EvmSignature>;
+  ) => Observable<EvmSignerEvent>;
 }

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -157,7 +157,7 @@
     "@ledgerhq/crypto-icons-ui": "workspace:^",
     "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-core": "workspace:^",
-    "@ledgerhq/device-management-kit": "0.6.4",
+    "@ledgerhq/device-management-kit": "0.6.5",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-algorand": "workspace:^",

--- a/libs/live-dmk/package.json
+++ b/libs/live-dmk/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@ledgerhq/device-management-kit": "0.6.4",
+    "@ledgerhq/device-management-kit": "0.6.5",
     "@ledgerhq/device-transport-kit-web-hid": "1.1.0",
     "@ledgerhq/hw-transport": "workspace:^",
     "@ledgerhq/logs": "^6.12.0",

--- a/libs/live-dmk/src/transport/DeviceManagementKitTransport.ts
+++ b/libs/live-dmk/src/transport/DeviceManagementKitTransport.ts
@@ -72,7 +72,12 @@ export class DeviceManagementKitTransport extends Transport {
     const [discoveredDevice] = await firstValueFrom(
       deviceManagementKit.listenToAvailableDevices({}),
     );
-    const connectedSessionId = await deviceManagementKit.connect({ device: discoveredDevice });
+    const connectedSessionId = await deviceManagementKit.connect({
+      device: discoveredDevice,
+      sessionRefresherOptions: {
+        isRefresherDisabled: true,
+      },
+    });
 
     tracer.trace("[open] Connected");
     const transport = new DeviceManagementKitTransport(deviceManagementKit, connectedSessionId);
@@ -146,7 +151,12 @@ export class DeviceManagementKitTransport extends Transport {
       const [discoveredDevice] = await firstValueFrom(
         deviceManagementKit.listenToAvailableDevices({}),
       );
-      const connectedSessionId = await deviceManagementKit.connect({ device: discoveredDevice });
+      const connectedSessionId = await deviceManagementKit.connect({
+        device: discoveredDevice,
+        sessionRefresherOptions: {
+          isRefresherDisabled: true,
+        },
+      });
       this.sessionId = connectedSessionId;
     }
 

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -28,9 +28,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/coin-evm": "workspace:^",
-    "@ledgerhq/context-module": "1.3.0",
-    "@ledgerhq/device-management-kit": "0.6.4",
-    "@ledgerhq/device-signer-kit-ethereum": "1.3.1",
+    "@ledgerhq/context-module": "1.3.1",
+    "@ledgerhq/device-management-kit": "0.6.5",
+    "@ledgerhq/device-signer-kit-ethereum": "1.3.3",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-eth": "workspace:^",
     "rxjs": "7.8.1"

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -1,4 +1,4 @@
-import { lastValueFrom } from "rxjs";
+import { lastValueFrom, Observable } from "rxjs";
 import {
   GetAddressDAError,
   SignerEth,
@@ -6,6 +6,9 @@ import {
   SignPersonalMessageDAError,
   SignTransactionDAError,
   SignTypedDataDAError,
+  SignTransactionDAStep,
+  SignTypedDataDAStateStep,
+  Signature,
 } from "@ledgerhq/device-signer-kit-ethereum";
 import {
   DeviceActionState,
@@ -15,8 +18,8 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { EIP712Message } from "@ledgerhq/types-live";
 import { EthAppPleaseEnableContractData, UserRefusedOnDevice } from "@ledgerhq/errors";
-import { EvmAddress, EvmSignature, EvmSigner } from "@ledgerhq/coin-evm/types/signer";
-import { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
+import { EvmAddress, EvmSigner, EvmSignerEvent } from "@ledgerhq/coin-evm/types/signer";
+import type { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
 
 export type DAError =
   | GetAddressDAError
@@ -70,22 +73,38 @@ export class DmkSignerEth implements EvmSigner {
     }
   }
 
-  async signPersonalMessage(path: string, messageHex: string): Promise<EvmSignature> {
+  private _formatSignature(signature: Signature) {
+    return {
+      r: signature.r.slice(2),
+      s: signature.s.slice(2),
+      v: signature.v,
+    };
+  }
+
+  signPersonalMessage(path: string, messageHex: string): Observable<EvmSignerEvent> {
     const buffer = hexaStringToBuffer(messageHex);
 
     if (!buffer) {
       throw new Error("Invalid message");
     }
 
-    const result = this._mapResult(
-      await lastValueFrom(this.signer.signMessage(path, buffer).observable),
-    );
-
-    return {
-      r: result.r.slice(2),
-      s: result.s.slice(2),
-      v: result.v,
-    };
+    return new Observable(observer => {
+      observer.next({ type: "signer.evm.signing" });
+      this.signer.signMessage(path, buffer).observable.subscribe({
+        next: result => {
+          if (result.status === DeviceActionStatus.Error) {
+            observer.error(this._mapError<SignPersonalMessageDAError>(result.error));
+          } else if (result.status === DeviceActionStatus.Completed) {
+            observer.next({
+              type: "signer.evm.signed",
+              value: this._formatSignature(result.output),
+            });
+          }
+        },
+        error: error => observer.error(error),
+        complete: () => observer.complete(),
+      });
+    });
   }
 
   async getAddress(
@@ -109,42 +128,75 @@ export class DmkSignerEth implements EvmSigner {
       chainCode: result.chainCode,
     };
   }
-  async signTransaction(path: string, rawTxHex: string, _resolution?: any): Promise<EvmSignature> {
+  signTransaction(path: string, rawTxHex: string, _resolution?: any): Observable<EvmSignerEvent> {
     const buffer = hexaStringToBuffer(rawTxHex);
 
     if (!buffer) {
       throw new Error("Invalid transaction");
     }
 
-    const result = this._mapResult(
-      await lastValueFrom(this.signer.signTransaction(path, buffer).observable),
-    );
-
-    return {
-      r: result.r.slice(2),
-      s: result.s.slice(2),
-      v: result.v,
-    };
+    return new Observable(observer => {
+      this.signer.signTransaction(path, buffer).observable.subscribe({
+        next: result => {
+          if (result.status === DeviceActionStatus.Error) {
+            observer.error(this._mapError<SignTransactionDAError>(result.error));
+          }
+          if (result.status === DeviceActionStatus.Pending) {
+            if (result.intermediateValue.step === SignTransactionDAStep.SIGN_TRANSACTION) {
+              observer.next({ type: "signer.evm.signing" });
+            }
+            if (result.intermediateValue.step === SignTransactionDAStep.BUILD_CONTEXT) {
+              observer.next({ type: "signer.evm.loading-context" });
+            }
+          } else if (result.status === DeviceActionStatus.Completed) {
+            observer.next({
+              type: "signer.evm.signed",
+              value: this._formatSignature(result.output),
+            });
+          }
+        },
+        error: error => observer.error(error),
+        complete: () => observer.complete(),
+      });
+    });
   }
 
-  async signEIP712Message(
+  signEIP712Message(
     path: string,
     jsonMessage: EIP712Message,
     _fullImplem?: boolean,
-  ): Promise<EvmSignature> {
-    const result = this._mapResult(
-      await lastValueFrom(this.signer.signTypedData(path, jsonMessage).observable),
-    );
-
-    return {
-      r: result.r.slice(2),
-      s: result.s.slice(2),
-      v: result.v,
-    };
+  ): Observable<EvmSignerEvent> {
+    return new Observable(observer => {
+      this.signer.signTypedData(path, jsonMessage).observable.subscribe({
+        next: result => {
+          if (result.status === DeviceActionStatus.Error) {
+            observer.error(this._mapError<SignTypedDataDAError>(result.error));
+          }
+          if (result.status === DeviceActionStatus.Pending) {
+            if (
+              result.intermediateValue.step === SignTypedDataDAStateStep.SIGN_TYPED_DATA ||
+              result.intermediateValue.step === SignTypedDataDAStateStep.SIGN_TYPED_DATA_LEGACY
+            ) {
+              observer.next({ type: "signer.evm.signing" });
+            }
+            if (result.intermediateValue.step === SignTypedDataDAStateStep.BUILD_CONTEXT) {
+              observer.next({ type: "signer.evm.loading-context" });
+            }
+          } else if (result.status === DeviceActionStatus.Completed) {
+            observer.next({
+              type: "signer.evm.signed",
+              value: this._formatSignature(result.output),
+            });
+          }
+        },
+        error: error => observer.error(error),
+        complete: () => observer.complete(),
+      });
+    });
   }
 
   setLoadConfig(_config: LoadConfig) {
-    console.log("not implemented");
+    // not implemented
   }
 
   clearSignTransaction(
@@ -152,7 +204,7 @@ export class DmkSignerEth implements EvmSigner {
     rawTxHex: string,
     _resolutionConfig: ResolutionConfig,
     _throwOnError: boolean,
-  ): Promise<EvmSignature> {
+  ) {
     return this.signTransaction(path, rawTxHex);
   }
 
@@ -160,7 +212,7 @@ export class DmkSignerEth implements EvmSigner {
     _path: string,
     _domainSeparatorHex: string,
     _hashStructMessageHex: string,
-  ): Promise<EvmSignature> {
+  ): Observable<EvmSignerEvent> {
     throw new Error("Method not implemented.");
   }
 }

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -1,9 +1,7 @@
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import { EIP712Message } from "@ledgerhq/types-live";
-import { of } from "rxjs";
+import { lastValueFrom, of } from "rxjs";
 import { DmkSignerEth } from "../src/DmkSignerEth";
-
-console.log = jest.fn();
 
 describe("DmkSignerEth", () => {
   const dmkMock = {
@@ -163,7 +161,7 @@ describe("DmkSignerEth", () => {
       });
 
       // WHEN
-      const result = await signer.signPersonalMessage(path, messageHex);
+      const result = await lastValueFrom(signer.signPersonalMessage(path, messageHex));
 
       // THEN
       expect(dmkMock.executeDeviceAction).toHaveBeenCalledWith(
@@ -179,9 +177,12 @@ describe("DmkSignerEth", () => {
         }),
       );
       expect(result).toEqual({
-        r: "01",
-        s: "02",
-        v: 3,
+        type: "signer.evm.signed",
+        value: {
+          r: "01",
+          s: "02",
+          v: 3,
+        },
       });
     });
 
@@ -192,7 +193,7 @@ describe("DmkSignerEth", () => {
 
       // WHEN
       try {
-        await signer.signPersonalMessage(path, messageHex);
+        await lastValueFrom(signer.signPersonalMessage(path, messageHex));
         fail("should throw an error");
       } catch (error) {
         // THEN
@@ -213,35 +214,11 @@ describe("DmkSignerEth", () => {
 
       // WHEN
       try {
-        await signer.signPersonalMessage(path, messageHex);
+        await lastValueFrom(signer.signPersonalMessage(path, messageHex));
         fail("should throw an error");
       } catch (error) {
         // THEN
         expect(error).toEqual(new Error());
-      }
-    });
-
-    it.each([
-      DeviceActionStatus.NotStarted,
-      DeviceActionStatus.Pending,
-      DeviceActionStatus.Stopped,
-    ])(`should throw an error if the device action status is %s`, async status => {
-      // GIVEN
-      const path = "path";
-      const messageHex = "0x010203040506";
-      dmkMock.executeDeviceAction.mockReturnValue({
-        observable: of({
-          status,
-        }),
-      });
-
-      // WHEN
-      try {
-        await signer.signPersonalMessage(path, messageHex);
-        fail("should throw an error");
-      } catch (error) {
-        // THEN
-        expect(error).toEqual(new Error("Unknown device action status"));
       }
     });
   });
@@ -263,7 +240,7 @@ describe("DmkSignerEth", () => {
       });
 
       // WHEN
-      const result = await signer.signTransaction(path, rawTxHex);
+      const result = await lastValueFrom(signer.signTransaction(path, rawTxHex));
 
       // THEN
       expect(dmkMock.executeDeviceAction).toHaveBeenCalledWith(
@@ -278,9 +255,12 @@ describe("DmkSignerEth", () => {
         }),
       );
       expect(result).toEqual({
-        r: "01",
-        s: "02",
-        v: 3,
+        type: "signer.evm.signed",
+        value: {
+          r: "01",
+          s: "02",
+          v: 3,
+        },
       });
     });
 
@@ -317,7 +297,7 @@ describe("DmkSignerEth", () => {
       });
 
       // WHEN
-      const result = await signer.clearSignTransaction(path, rawTxHex, {}, false);
+      const result = await lastValueFrom(signer.clearSignTransaction(path, rawTxHex, {}, false));
 
       // THEN
       expect(dmkMock.executeDeviceAction).toHaveBeenCalledWith(
@@ -332,9 +312,12 @@ describe("DmkSignerEth", () => {
         }),
       );
       expect(result).toEqual({
-        r: "01",
-        s: "02",
-        v: 3,
+        type: "signer.evm.signed",
+        value: {
+          r: "01",
+          s: "02",
+          v: 3,
+        },
       });
     });
   });
@@ -356,7 +339,7 @@ describe("DmkSignerEth", () => {
       });
 
       // WHEN
-      const result = await signer.signEIP712Message(path, message);
+      const result = await lastValueFrom(signer.signEIP712Message(path, message));
 
       // THEN
       expect(dmkMock.executeDeviceAction).toHaveBeenCalledWith(
@@ -371,9 +354,12 @@ describe("DmkSignerEth", () => {
         }),
       );
       expect(result).toEqual({
-        r: "01",
-        s: "02",
-        v: 3,
+        type: "signer.evm.signed",
+        value: {
+          r: "01",
+          s: "02",
+          v: 3,
+        },
       });
     });
 
@@ -390,7 +376,7 @@ describe("DmkSignerEth", () => {
 
       // WHEN
       try {
-        await signer.signEIP712Message(path, message);
+        await lastValueFrom(signer.signEIP712Message(path, message));
         fail("should throw an error");
       } catch (error) {
         // THEN
@@ -418,7 +404,9 @@ describe("DmkSignerEth", () => {
 
       // WHEN
       try {
-        await signer.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex);
+        await lastValueFrom(
+          signer.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex),
+        );
         fail("should throw an error");
       } catch (error) {
         // THEN

--- a/libs/live-signer-evm/tests/LegacySignerEth.test.ts
+++ b/libs/live-signer-evm/tests/LegacySignerEth.test.ts
@@ -1,0 +1,296 @@
+import Eth from "@ledgerhq/hw-app-eth";
+import { EIP712Message } from "@ledgerhq/types-live";
+import { lastValueFrom } from "rxjs";
+import { LegacySignerEth } from "../src/LegacySignerEth";
+import { ResolutionConfig, LoadConfig } from "@ledgerhq/hw-app-eth/lib/services/types";
+
+jest.mock("@ledgerhq/hw-app-eth");
+
+describe("LegacySignerEth", () => {
+  const ethMock = {
+    getAddress: jest.fn(),
+    signTransaction: jest.fn(),
+    signPersonalMessage: jest.fn(),
+    signEIP712Message: jest.fn(),
+    signEIP712HashedMessage: jest.fn(),
+    clearSignTransaction: jest.fn(),
+    setLoadConfig: jest.fn(),
+  };
+
+  let signer: LegacySignerEth;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Eth as jest.Mock).mockImplementation(() => ethMock);
+    signer = new LegacySignerEth({} as any);
+  });
+
+  describe("getAddress", () => {
+    it("should get the address without boolDisplay and boolChainCode", async () => {
+      // GIVEN
+      const path = "path";
+      ethMock.getAddress.mockResolvedValue({
+        address: "address",
+        publicKey: "publicKey",
+        chainCode: undefined,
+      });
+
+      // WHEN
+      const result = await signer.getAddress(path);
+
+      // THEN
+      expect(ethMock.getAddress).toHaveBeenCalledWith(path, undefined, undefined, undefined);
+      expect(result).toEqual({
+        address: "address",
+        publicKey: "publicKey",
+        chainCode: undefined,
+      });
+    });
+
+    it("should get the address with boolDisplay and boolChainCode", async () => {
+      // GIVEN
+      const path = "path";
+      ethMock.getAddress.mockResolvedValue({
+        address: "address",
+        publicKey: "publicKey",
+        chainCode: "chainCode",
+      });
+
+      // WHEN
+      const result = await signer.getAddress(path, true, true);
+
+      // THEN
+      expect(ethMock.getAddress).toHaveBeenCalledWith(path, true, true, undefined);
+      expect(result).toEqual({
+        address: "address",
+        publicKey: "publicKey",
+        chainCode: "chainCode",
+      });
+    });
+
+    it("should get the address with chainId", async () => {
+      // GIVEN
+      const path = "path";
+      const chainId = "1";
+      ethMock.getAddress.mockResolvedValue({
+        address: "address",
+        publicKey: "publicKey",
+        chainCode: "chainCode",
+      });
+
+      // WHEN
+      const result = await signer.getAddress(path, true, true, chainId);
+
+      // THEN
+      expect(ethMock.getAddress).toHaveBeenCalledWith(path, true, true, chainId);
+      expect(result).toEqual({
+        address: "address",
+        publicKey: "publicKey",
+        chainCode: "chainCode",
+      });
+    });
+  });
+
+  describe("signPersonalMessage", () => {
+    it("should sign the personal message", async () => {
+      // GIVEN
+      const path = "path";
+      const messageHex = "0x010203040506";
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.signPersonalMessage.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(signer.signPersonalMessage(path, messageHex));
+
+      // THEN
+      expect(ethMock.signPersonalMessage).toHaveBeenCalledWith(path, messageHex);
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+  });
+
+  describe("signTransaction", () => {
+    it("should sign the transaction", async () => {
+      // GIVEN
+      const path = "path";
+      const rawTxHex = "0x010203040506";
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.signTransaction.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(signer.signTransaction(path, rawTxHex));
+
+      // THEN
+      expect(ethMock.signTransaction).toHaveBeenCalledWith(path, rawTxHex, undefined);
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+
+    it("should sign the transaction with resolution", async () => {
+      // GIVEN
+      const path = "path";
+      const rawTxHex = "0x010203040506";
+      const resolution = { some: "resolution" };
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.signTransaction.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(signer.signTransaction(path, rawTxHex, resolution));
+
+      // THEN
+      expect(ethMock.signTransaction).toHaveBeenCalledWith(path, rawTxHex, resolution);
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+  });
+
+  describe("signEIP712Message", () => {
+    it("should sign the EIP712 message", async () => {
+      // GIVEN
+      const path = "path";
+      const message = { message: "message" } as unknown as EIP712Message;
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.signEIP712Message.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(signer.signEIP712Message(path, message));
+
+      // THEN
+      expect(ethMock.signEIP712Message).toHaveBeenCalledWith(path, message, undefined);
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+
+    it("should sign the EIP712 message with fullImplem", async () => {
+      // GIVEN
+      const path = "path";
+      const message = { message: "message" } as unknown as EIP712Message;
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.signEIP712Message.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(signer.signEIP712Message(path, message, true));
+
+      // THEN
+      expect(ethMock.signEIP712Message).toHaveBeenCalledWith(path, message, true);
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+  });
+
+  describe("signEIP712HashedMessage", () => {
+    it("should sign the EIP712 hashed message", async () => {
+      // GIVEN
+      const path = "path";
+      const domainSeparatorHex = "domainSeparatorHex";
+      const hashStructMessageHex = "hashStructMessageHex";
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.signEIP712HashedMessage.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(
+        signer.signEIP712HashedMessage(path, domainSeparatorHex, hashStructMessageHex),
+      );
+
+      // THEN
+      expect(ethMock.signEIP712HashedMessage).toHaveBeenCalledWith(
+        path,
+        domainSeparatorHex,
+        hashStructMessageHex,
+      );
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+  });
+
+  describe("clearSignTransaction", () => {
+    it("should sign the transaction", async () => {
+      // GIVEN
+      const path = "path";
+      const rawTxHex = "0x010203040506";
+      const resolutionConfig: ResolutionConfig = {
+        erc20: true,
+        externalPlugins: true,
+        nft: true,
+      };
+      const signature = {
+        r: "01",
+        s: "02",
+        v: 3,
+      };
+      ethMock.clearSignTransaction.mockResolvedValue(signature);
+
+      // WHEN
+      const result = await lastValueFrom(
+        signer.clearSignTransaction(path, rawTxHex, resolutionConfig, true),
+      );
+
+      // THEN
+      expect(ethMock.clearSignTransaction).toHaveBeenCalledWith(
+        path,
+        rawTxHex,
+        resolutionConfig,
+        true,
+      );
+      expect(result).toEqual({
+        type: "signer.evm.signed",
+        value: signature,
+      });
+    });
+  });
+
+  describe("setLoadConfig", () => {
+    it("should set the load config", () => {
+      // GIVEN
+      const config: LoadConfig = {
+        nftExplorerBaseURL: "https://nft-explorer.example.com",
+        pluginBaseURL: "https://plugins.example.com",
+        extraPlugins: null,
+        cryptoassetsBaseURL: "https://cryptoassets.example.com",
+        calServiceURL: "https://cal.example.com",
+      };
+
+      // WHEN
+      signer.setLoadConfig(config);
+
+      // THEN
+      expect(ethMock.setLoadConfig).toHaveBeenCalledWith(config);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3211,12 +3211,12 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0
-      msw:
-        specifier: 2.7.3
-        version: 2.7.3(typescript@5.4.3)
       jest-sonar:
         specifier: 0.2.16
         version: 0.2.16
+      msw:
+        specifier: 2.7.3
+        version: 2.7.3(typescript@5.4.3)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.5(jest@29.7.0)(typescript@5.4.3)
@@ -3381,12 +3381,12 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.10.10)
-      msw:
-        specifier: ^2.7.3
-        version: 2.7.3(@types/node@22.10.10)(typescript@5.4.3)
       jest-sonar:
         specifier: 0.2.16
         version: 0.2.16
+      msw:
+        specifier: ^2.7.3
+        version: 2.7.3(@types/node@22.10.10)(typescript@5.4.3)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.5(jest@29.7.0(@types/node@22.10.10))(typescript@5.4.3)
@@ -7051,11 +7051,11 @@ importers:
   libs/live-dmk:
     dependencies:
       '@ledgerhq/device-management-kit':
-        specifier: 0.6.4
-        version: 0.6.4(rxjs@7.8.1)
+        specifier: 0.6.5
+        version: 0.6.5(rxjs@7.8.1)
       '@ledgerhq/device-transport-kit-web-hid':
         specifier: 1.1.0
-        version: 1.1.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))(rxjs@7.8.1)
+        version: 1.1.0(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))(rxjs@7.8.1)
       '@ledgerhq/hw-transport':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-transport
@@ -12486,6 +12486,11 @@ packages:
 
   '@ledgerhq/device-management-kit@0.6.4':
     resolution: {integrity: sha512-gcaEBZvqLH/4GtzzVfHvwtUgjSjgfvyCBCuVMUJZUXbGckqwION7dsjgILIZjouMFDtEciKC4pg+PJ5oeNWY5Q==}
+    peerDependencies:
+      rxjs: ^7.8.2
+
+  '@ledgerhq/device-management-kit@0.6.5':
+    resolution: {integrity: sha512-kyUKA/UW0Mh2ygm27SD2ZxmDny6RDmvZTTMwERqQzvsm+jpG+/VZ6wWOb81NRxkgFa7RJ3r6oDNGJYxFBwDiuQ==}
     peerDependencies:
       rxjs: ^7.8.2
 
@@ -39511,6 +39516,25 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1)':
+    dependencies:
+      '@sentry/minimal': 6.19.7
+      axios: 1.8.3
+      inversify: 6.2.2(reflect-metadata@0.2.2)
+      inversify-logger-middleware: 3.1.0
+      isomorphic-ws: 5.0.0(ws@8.18.0)
+      purify-ts: 2.1.0
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.1
+      semver: 7.6.3
+      url: 0.11.4
+      uuid: 11.1.0
+      ws: 8.18.0
+      xstate: 5.19.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@ledgerhq/device-signer-kit-ethereum@1.3.1(@ledgerhq/context-module@1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))':
     dependencies:
       '@ledgerhq/context-module': 1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))
@@ -39527,9 +39551,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-transport-kit-web-hid@1.1.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))(rxjs@7.8.1)':
+  '@ledgerhq/device-transport-kit-web-hid@1.1.0(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))(rxjs@7.8.1)':
     dependencies:
-      '@ledgerhq/device-management-kit': 0.6.4(rxjs@7.8.1)
+      '@ledgerhq/device-management-kit': 0.6.5(rxjs@7.8.1)
       '@sentry/minimal': 6.19.7
       purify-ts: 2.1.0
       rxjs: 7.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4358,8 +4358,8 @@ importers:
         specifier: workspace:^
         version: link:../device-core
       '@ledgerhq/device-management-kit':
-        specifier: 0.6.4
-        version: 0.6.4(rxjs@7.8.1)
+        specifier: 0.6.5
+        version: 0.6.5(rxjs@7.8.1)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -7256,14 +7256,14 @@ importers:
         specifier: workspace:^
         version: link:../coin-modules/coin-evm
       '@ledgerhq/context-module':
-        specifier: 1.3.0
-        version: 1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))
-      '@ledgerhq/device-management-kit':
-        specifier: 0.6.4
-        version: 0.6.4(rxjs@7.8.1)
-      '@ledgerhq/device-signer-kit-ethereum':
         specifier: 1.3.1
-        version: 1.3.1(@ledgerhq/context-module@1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))
+        version: 1.3.1(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))
+      '@ledgerhq/device-management-kit':
+        specifier: 0.6.5
+        version: 0.6.5(rxjs@7.8.1)
+      '@ledgerhq/device-signer-kit-ethereum':
+        specifier: 1.3.3
+        version: 1.3.3(@ledgerhq/context-module@1.3.1(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -12461,10 +12461,10 @@ packages:
     version: 1.3.1
     hasBin: true
 
-  '@ledgerhq/context-module@1.3.0':
-    resolution: {integrity: sha512-VgidnK8CQT8E4DXZPnMawJhPwgTG94aa0b+mPiR2JLxzyXNqjwNEHrhhptTfELir4ctrz5W9aj9a948fpAHu9g==}
+  '@ledgerhq/context-module@1.3.1':
+    resolution: {integrity: sha512-hXoYe21bF+LNuuRpEDFRs2LpI4eK/BlAEa9o+Ncmz7/mTZ2xs2klo5q2exbQZJ8rBXYVu/NMtgDIfGLFe889vw==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': 0.6.2
+      '@ledgerhq/device-management-kit': 0.6.5
 
   '@ledgerhq/crypto-icons-ui@file:libs/ui/packages/crypto-icons':
     resolution: {directory: libs/ui/packages/crypto-icons, type: directory}
@@ -12484,21 +12484,16 @@ packages:
   '@ledgerhq/cryptoassets@6.37.0':
     resolution: {integrity: sha512-xwrDKTS9koQBNNzc7CqgV6zfGHvNFWJjlIL0Kc4O4DVWYR2vUdztUHcvwHD1KPjxNYhVnsgIopmtq47fHt3nMg==}
 
-  '@ledgerhq/device-management-kit@0.6.4':
-    resolution: {integrity: sha512-gcaEBZvqLH/4GtzzVfHvwtUgjSjgfvyCBCuVMUJZUXbGckqwION7dsjgILIZjouMFDtEciKC4pg+PJ5oeNWY5Q==}
-    peerDependencies:
-      rxjs: ^7.8.2
-
   '@ledgerhq/device-management-kit@0.6.5':
     resolution: {integrity: sha512-kyUKA/UW0Mh2ygm27SD2ZxmDny6RDmvZTTMwERqQzvsm+jpG+/VZ6wWOb81NRxkgFa7RJ3r6oDNGJYxFBwDiuQ==}
     peerDependencies:
       rxjs: ^7.8.2
 
-  '@ledgerhq/device-signer-kit-ethereum@1.3.1':
-    resolution: {integrity: sha512-a5SObmpOnls3ejKKqiZXhRFFxWJx7srcxC9jN8xIT6OJKMFcdOOcbn3pmNv0adO4bP9sOZJDfnB9m60mR+ttGw==}
+  '@ledgerhq/device-signer-kit-ethereum@1.3.3':
+    resolution: {integrity: sha512-f3LtWaalXdb3p8G+9frb3s78xz1096CkXALlBsIlgZ6qmUuY3ALooFtwkZBC/mIglfoMX8mPEcby+NwNkQQUJA==}
     peerDependencies:
-      '@ledgerhq/context-module': ^1.3.0
-      '@ledgerhq/device-management-kit': 0.6.4
+      '@ledgerhq/context-module': ^1.3.1
+      '@ledgerhq/device-management-kit': ^0.6.5
 
   '@ledgerhq/device-transport-kit-web-hid@1.1.0':
     resolution: {integrity: sha512-fDXsaeccDZQlAzzXjMtnl/jh3CUANoZj+qbzQjRSOp0aojOjIU+uh4WajLLQ0Ov46wxkS6Yd8xXw8F3p822ohg==}
@@ -39467,10 +39462,10 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
-  '@ledgerhq/context-module@1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))':
+  '@ledgerhq/context-module@1.3.1(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))':
     dependencies:
-      '@ledgerhq/device-management-kit': 0.6.4(rxjs@7.8.1)
-      axios: 1.7.9
+      '@ledgerhq/device-management-kit': 0.6.5(rxjs@7.8.1)
+      axios: 1.8.3
       crypto-js: 4.2.0
       ethers: 6.13.4
       inversify: 6.2.2(reflect-metadata@0.2.2)
@@ -39497,25 +39492,6 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  '@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1)':
-    dependencies:
-      '@sentry/minimal': 6.19.7
-      axios: 1.8.3
-      inversify: 6.2.2(reflect-metadata@0.2.2)
-      inversify-logger-middleware: 3.1.0
-      isomorphic-ws: 5.0.0(ws@8.18.0)
-      purify-ts: 2.1.0
-      reflect-metadata: 0.2.2
-      rxjs: 7.8.1
-      semver: 7.6.3
-      url: 0.11.4
-      uuid: 11.1.0
-      ws: 8.18.0
-      xstate: 5.19.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1)':
     dependencies:
       '@sentry/minimal': 6.19.7
@@ -39535,11 +39511,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-ethereum@1.3.1(@ledgerhq/context-module@1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))':
+  '@ledgerhq/device-signer-kit-ethereum@1.3.3(@ledgerhq/context-module@1.3.1(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))':
     dependencies:
-      '@ledgerhq/context-module': 1.3.0(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))
-      '@ledgerhq/device-management-kit': 0.6.4(rxjs@7.8.1)
-      '@ledgerhq/signer-utils': 1.0.4(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))
+      '@ledgerhq/context-module': 1.3.1(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))
+      '@ledgerhq/device-management-kit': 0.6.5(rxjs@7.8.1)
+      '@ledgerhq/signer-utils': 1.0.4(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))
       ethers: 6.13.4
       inversify: 6.2.2(reflect-metadata@0.2.2)
       inversify-logger-middleware: 3.1.0
@@ -39668,9 +39644,9 @@ snapshots:
 
   '@ledgerhq/logs@6.12.0': {}
 
-  '@ledgerhq/signer-utils@1.0.4(@ledgerhq/device-management-kit@0.6.4(rxjs@7.8.1))':
+  '@ledgerhq/signer-utils@1.0.4(@ledgerhq/device-management-kit@0.6.5(rxjs@7.8.1))':
     dependencies:
-      '@ledgerhq/device-management-kit': 0.6.4(rxjs@7.8.1)
+      '@ledgerhq/device-management-kit': 0.6.5(rxjs@7.8.1)
 
   '@ledgerhq/types-live@6.53.1':
     dependencies:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

#### Intro

The DMK (Device Management Kit) provides precise tracking of the current step in the process. This PR aims to optimize the timing of the `device-signature-requested` event.

Instead of emitting this event immediately before calling the `sign` function, we now wait until the DMK reaches the `BUILD_CONTEXT` step. This adjustment ensures that the default `Loading...` screen remains visible while metadata is being fetched from the backend, improving the user experience by providing more accurate feedback during the process.

#### Changes

The `EvmSigner` `sign` functions now return observables instead of promises. This change allows for the tracking of intermediate steps within the DMK. By using observables, we can monitor progress and handle events.

#### Demo


https://github.com/user-attachments/assets/a3cee52f-26b9-44a2-830e-aeaec503ccfa


#### Notes

The `coin-tester` EVM integration is currently non-functional because it relies on the outdated `hw-app-eth` instead of a `EvmSigner` implementation. directly. Additionally, using the correct `EvmSigner` implementation (`LegacySignerEth`) is not feasible due to recursive dependencies between the `coin-evm` and `live-signer-evm` packages. This issue needs to be addressed to ensure proper functionality and avoid circular dependency problems.

I have a WIP branch to move the 'coin-tester' part in a separate module [here](https://github.com/LedgerHQ/ledger-live/tree/feature/extract-coin-tester-evm)


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17711]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17711]: https://ledgerhq.atlassian.net/browse/LIVE-17711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ