### PR TITLE
fix: disable ky default timeout with solana coin [LIVE-17918]

### DIFF
--- a/.changeset/afraid-wasps-sing.md
+++ b/.changeset/afraid-wasps-sing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+fix: disable ky default timeout with solana coin

--- a/libs/coin-modules/coin-solana/src/api/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/api/chain/index.ts
@@ -129,6 +129,8 @@ const remapErrorsWithRetry = <P extends Promise<T>, T>(callback: () => P, times 
   };
 };
 
+const kyNoTimeout = ky.create({ timeout: false });
+
 export function getChainAPI(
   config: Config,
   logger?: (url: string, options: any) => void,
@@ -146,7 +148,7 @@ export function getChainAPI(
     if (!_connection) {
       _connection = new Connection(config.endpoint, {
         ...(fetchMiddleware ? { fetchMiddleware } : {}),
-        fetch: ky as typeof fetch, // Type cast for jest test having an issue with the type
+        fetch: kyNoTimeout as typeof fetch, // Type cast for jest test having an issue with the type
         commitment: "confirmed",
         confirmTransactionInitialTimeout: getEnv("SOLANA_TX_CONFIRMATION_TIMEOUT") || 0,
       });


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Solana add account, send/receive and sync

### 📝 Description

[ky default timeout of 10s](https://github.com/sindresorhus/ky#timeout) was creating errors on our automated tests and could create issues if the node has a lot of latency

We disable it for now but we should probably default to some timeout at some point

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17918]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17918]: https://ledgerhq.atlassian.net/browse/LIVE-17918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ