### PR TITLE
:bug: (ios) reintegrate splashscreen

### DIFF
--- a/.changeset/pink-lamps-warn.md
+++ b/.changeset/pink-lamps-warn.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Re integrate ios static splashscreen

--- a/apps/ledger-live-mobile/e2e/helpers.ts
+++ b/apps/ledger-live-mobile/e2e/helpers.ts
@@ -214,6 +214,7 @@ export async function launchApp() {
         '\\(".*sdk.*.braze.*",".*.googleapis.com/.*",".*clients3.google.com.*",".*tron.coin.ledger.com/wallet/getBrokerage.*"\\)',
       mock: getEnv("MOCK") ? getEnv("MOCK") : "0",
       disable_broadcast: getEnv("DISABLE_TRANSACTION_BROADCAST") ? 1 : 0,
+      IS_TEST: true,
     },
     languageAndLocale: {
       language: "en-US",

--- a/apps/ledger-live-mobile/ios/ledgerlivemobile/AppDelegate.mm
+++ b/apps/ledger-live-mobile/ios/ledgerlivemobile/AppDelegate.mm
@@ -7,6 +7,7 @@
 #import "BrazeReactUtils.h"
 #import "BrazeReactBridge.h"
 #import <Firebase.h>
+#import "RNSplashScreen.h"
 
 
 @implementation AppDelegate
@@ -72,10 +73,16 @@ static NSString *const iOSPushAutoEnabledKey = @"iOSPushAutoEnabled";
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"ledgerlivemobile" initialProperties:nil];
 
+  BOOL isRunningDetox = [[[NSProcessInfo processInfo] arguments] containsObject:@"-IS_TEST"];
+
+  if(isRunningDetox) return YES;
+
   [self.window makeKeyAndVisible];
   UIStoryboard *sb = [UIStoryboard storyboardWithName:@"LaunchScreen" bundle:nil];
   UIViewController *vc = [sb instantiateInitialViewController];
   rootView.loadingView = vc.view;
+
+  [RNSplashScreen show];
 
   return YES;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ✨ IOS Launchscreen ✨ 

### 📝 Description

Non animated splashscreen until the swift module is ready. (https://github.com/LedgerHQ/ledger-live/pull/9592)
ByPass the splashscreen during e2e tests so it doesn't duplicate WS. 


https://github.com/user-attachments/assets/53d5105e-3c7a-4f13-af38-efa8602b788a



Detox test

https://github.com/user-attachments/assets/224097be-34c0-4673-835e-0058b96ff3be




<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:[LIVE-17159](https://ledgerhq.atlassian.net/browse/LIVE-17159) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17159]: https://ledgerhq.atlassian.net/browse/LIVE-17159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ