### PR TITLE
fix (llm): patch hermes typed arrays

### DIFF
--- a/.changeset/breezy-birds-cheat.md
+++ b/.changeset/breezy-birds-cheat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix (llm): patch hermes typed arrays

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "1.0.2",
     "@braze/react-native-sdk": "10.0.0",
+    "@exodus/patch-broken-hermes-typed-arrays": "1.0.0-alpha.1",
     "@formatjs/intl-locale": "3.4.5",
     "@formatjs/intl-pluralrules": "5.2.12",
     "@formatjs/intl-relativetimeformat": "11.2.12",

--- a/apps/ledger-live-mobile/src/polyfill.ts
+++ b/apps/ledger-live-mobile/src/polyfill.ts
@@ -29,6 +29,9 @@ import "@formatjs/intl-relativetimeformat/locale-data/ko";
 // Fix error when adding Solana account
 import "@azure/core-asynciterator-polyfill";
 
+// Fix error when sending a token transaction in Stellar
+import "@exodus/patch-broken-hermes-typed-arrays";
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 global.Buffer = require("buffer").Buffer;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
       '@braze/react-native-sdk':
         specifier: 10.0.0
         version: 10.0.0
+      '@exodus/patch-broken-hermes-typed-arrays':
+        specifier: 1.0.0-alpha.1
+        version: 1.0.0-alpha.1
       '@formatjs/intl-locale':
         specifier: 3.4.5
         version: 3.4.5
@@ -3211,12 +3214,12 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0
-      msw:
-        specifier: 2.7.3
-        version: 2.7.3(typescript@5.4.3)
       jest-sonar:
         specifier: 0.2.16
         version: 0.2.16
+      msw:
+        specifier: 2.7.3
+        version: 2.7.3(typescript@5.4.3)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.5(jest@29.7.0)(typescript@5.4.3)
@@ -3381,12 +3384,12 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.10.10)
-      msw:
-        specifier: ^2.7.3
-        version: 2.7.3(@types/node@22.10.10)(typescript@5.4.3)
       jest-sonar:
         specifier: 0.2.16
         version: 0.2.16
+      msw:
+        specifier: ^2.7.3
+        version: 2.7.3(@types/node@22.10.10)(typescript@5.4.3)
       ts-jest:
         specifier: ^29.1.1
         version: 29.1.5(jest@29.7.0(@types/node@22.10.10))(typescript@5.4.3)
@@ -11636,6 +11639,9 @@ packages:
 
   '@ethersproject/wordlists@5.7.0':
     resolution: {integrity: sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==}
+
+  '@exodus/patch-broken-hermes-typed-arrays@1.0.0-alpha.1':
+    resolution: {integrity: sha512-oYv+2IJxaNVTnF7lJqS+wrW0JisE9kcKlgQnkrdhtlsfRmFlcYPdPSO8eaIXKHKkzKndy3I+ZzTELg+BVi3vSg==}
 
   '@expo/bunyan@4.0.0':
     resolution: {integrity: sha512-Ydf4LidRB/EBI+YrB+cVLqIseiRfjUI/AeHBgjGMtq3GroraDu81OV7zqophRgupngoL3iS3JUMDMnxO7g39qA==}
@@ -37133,6 +37139,8 @@ snapshots:
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/strings': 5.7.0
+
+  '@exodus/patch-broken-hermes-typed-arrays@1.0.0-alpha.1': {}
 
   '@expo/bunyan@4.0.0':
     dependencies:


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Broadcasting a token transaction in Stellar is simply failing in LLM. This is because the Stellar SDK makes some buffer deserializations of the transaction signature, which don't work well in React Native.

As an example, sending `"USDC"` is perceived as sending `"85,83,68,67"` (stringified version of its `Uint8Array`) and fails when entering https://github.com/stellar/js-stellar-base/blob/68b8bae058b2d62b4b65fbee66b2e3945b836111/src/asset.js#L20-L24

We add (another 😞) polyfill to patch this.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
