### PR TITLE
fix(lld): 🐛 prevent long technical errors from breaking the node error layout

### DIFF
--- a/.changeset/hungry-balloons-grin.md
+++ b/.changeset/hungry-balloons-grin.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Prevent long technical errors from breaking the node error layout

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/Confirmation/NodeError/TechnicalErrorSection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/Confirmation/NodeError/TechnicalErrorSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Flex, Text, Icons } from "@ledgerhq/react-ui";
+import { Box, Flex, Text, Icons } from "@ledgerhq/react-ui";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { useCopyToClipboard } from "~/newArch/hooks/useCopyToClipboard";
@@ -41,6 +41,7 @@ const StyledText = styled(Text)`
   overflow: hidden;
   text-overflow: ellipsis;
   padding-right: 6px;
+  word-break: break-word;
 `;
 
 const TechnicalErrorSection = ({ error, onSaveLogs }: Props) => {
@@ -68,14 +69,14 @@ const TechnicalErrorSection = ({ error, onSaveLogs }: Props) => {
       flex={1}
       width="100%"
     >
-      <Flex flexShrink={1}>
+      <Box flexShrink={1}>
         <StyledText variant="bodyLineHeight" fontSize={13} flex={1} color="neutral.c70">
           <Text color="neutral.c100">
             {t("errors.TransactionBroadcastError.technicalErrorTitle")}
           </Text>
           <Text color="neutral.c70">{error.message}</Text>
         </StyledText>
-      </Flex>
+      </Box>
       <Flex columnGap={2} alignSelf="start">
         <InteractFlex onClick={onSaveLogs} flexShrink={1}>
           <Icons.Download color="neutral.c100" size="S" />

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/Confirmation/NodeError/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/Confirmation/NodeError/index.tsx
@@ -72,7 +72,7 @@ const NodeError: React.FC<Props> = ({ error }) => {
           }
         />
       </Flex>
-      <Flex flexDirection="column" rowGap={16} flex={1} alignItems="flex-start">
+      <Flex flexDirection="column" rowGap={16} flex={1} alignItems="flex-start" maxWidth="100%">
         <InteractFlex alignItems="center" onClick={onShowMore}>
           <Text variant="bodyLineHeight" fontSize={13}>
             {t("errors.TransactionBroadcastError.needHelp")}
@@ -85,7 +85,7 @@ const NodeError: React.FC<Props> = ({ error }) => {
           )}
         </InteractFlex>
         {isShowMore && (
-          <Flex flexDirection="column" flex={1}>
+          <Flex flexDirection="column" flex={2} maxWidth="100%">
             <HelpSection onGetHelp={onGetHelp} />
             <TechnicalErrorSection error={error} onSaveLogs={onSaveLogs} />
           </Flex>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix the error layout.

| Before        | After         |
| ------------- | ------------- |
|  <img width="539" alt="Screenshot 2025-03-26 at 18 22 38" src="https://github.com/user-attachments/assets/0923d6de-2699-4269-8ba3-b2211a7dcf46" />      |   <img width="539" alt="Screenshot 2025-03-26 at 19 11 22" src="https://github.com/user-attachments/assets/ffe80d04-af1b-40b6-a027-4d22085f029d" />         |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17745]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17745]: https://ledgerhq.atlassian.net/browse/LIVE-17745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ