### PR TITLE
fix: 🐛 trend on range pre-dating owning an asset

### DIFF
--- a/.changeset/tall-crabs-jump.md
+++ b/.changeset/tall-crabs-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-countervalues": minor
+---
+
+Fix trend on range predating owning an asset

--- a/libs/live-countervalues/src/__snapshots__/portfolio.test.ts.snap
+++ b/libs/live-countervalues/src/__snapshots__/portfolio.test.ts.snap
@@ -6554,8 +6554,8 @@ exports[`Portfolio getPortfolio snapshot 1`] = `
     },
   ],
   "countervalueChange": {
-    "percentage": undefined,
-    "value": 16232,
+    "percentage": 323.64,
+    "value": 16182,
   },
   "countervalueReceiveSum": 0,
   "countervalueSendSum": 0,

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -12,7 +12,6 @@ import type {
   BalanceHistory,
   PortfolioRange,
   PortfolioRangeConfig,
-  BalanceHistoryWithCountervalue,
   AccountPortfolio,
   Portfolio,
   CurrencyPortfolio,
@@ -151,12 +150,19 @@ export function getBalanceHistory(
 }
 
 export function getBalanceHistoryWithCountervalue(
+  ...args: Parameters<typeof getBalanceHistoryWithChanges>
+): AccountPortfolio {
+  const { history, countervalueAvailable, changes } = getBalanceHistoryWithChanges(...args);
+  return { history, countervalueAvailable, ...changes() };
+}
+
+function getBalanceHistoryWithChanges(
   account: AccountLike,
   range: PortfolioRange,
   count: number,
   cvState: CounterValuesState,
   cvCurrency: Currency,
-): AccountPortfolio {
+) {
   const balanceHistory = getBalanceHistory(account, range, count);
   const currency = getAccountCurrency(account);
   const counterValues = calculateMany(cvState, balanceHistory, {
@@ -183,9 +189,9 @@ export function getBalanceHistoryWithCountervalue(
     });
   }
 
-  function calcChanges(h: BalanceHistoryWithCountervalue) {
-    const from = h[0];
-    const to = h[h.length - 1];
+  function calcChanges(start = 0) {
+    const from = history.at(start) ?? { value: 0, countervalue: 0 };
+    const to = history.at(-1) ?? { value: 0, countervalue: 0 };
     return {
       countervalueReceiveSum: 0,
       // not available here
@@ -207,7 +213,7 @@ export function getBalanceHistoryWithCountervalue(
   return {
     history,
     countervalueAvailable,
-    ...calcChanges(history),
+    changes: calcChanges,
   };
 }
 
@@ -257,15 +263,9 @@ export function getPortfolio(
   const unavailableAccounts = [];
 
   for (const account of accounts) {
-    const p = getBalanceHistoryWithCountervalue(account, range, count, cvState, cvCurrency);
+    const p = getBalanceHistoryWithChanges(account, range, count, cvState, cvCurrency);
     if (p.countervalueAvailable) {
-      availables.push({
-        account,
-        history: p.history,
-        change: p.countervalueChange,
-        countervalueReceiveSum: p.countervalueReceiveSum,
-        countervalueSendSum: p.countervalueSendSum,
-      });
+      availables.push({ account, history: p.history, changes: p.changes });
     } else {
       unavailableAccounts.push(account);
     }
@@ -276,21 +276,32 @@ export function getPortfolio(
     date,
     value: histories.reduce((sum, h) => sum + (h[i]?.countervalue ?? 0), 0),
   }));
+
+  const firstSignificantHistoryIndex = balanceHistory.findIndex(balance => balance.value !== 0);
+  const firstSignificantHistoryValue = balanceHistory.at(firstSignificantHistoryIndex)?.value ?? 0;
+
   const [countervalueChangeValue, countervalueReceiveSum, countervalueSendSum] = availables.reduce(
-    (prev, a) => [
-      prev[0] + a.change.value, // TODO Portfolio: it'll always be 0, no? 🤔
-      prev[1] + a.countervalueReceiveSum,
-      prev[2] + a.countervalueSendSum,
-    ],
+    (sums, { changes }) => {
+      const { countervalueChange, countervalueReceiveSum, countervalueSendSum } = changes(
+        firstSignificantHistoryIndex,
+      );
+      return [
+        sums[0] + countervalueChange.value,
+        sums[1] + countervalueReceiveSum,
+        sums[2] + countervalueSendSum,
+      ];
+    },
     [0, 0, 0],
   );
+
   // in case there were no receive, we just track the market change
   // weighted by the current balances
   const balanceDivider = getEnv("EXPERIMENTAL_ROI_CALCULATION")
     ? countervalueReceiveSum === 0
-      ? balanceHistory[0].value + countervalueSendSum
+      ? firstSignificantHistoryValue + countervalueSendSum
       : countervalueReceiveSum
-    : balanceHistory[0].value;
+    : firstSignificantHistoryValue;
+
   return {
     balanceHistory,
     balanceAvailable: accounts.length === 0 || availables.length > 0,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "watch:es:ljs": "pnpm turbo run watch:es --filter=\"./libs/ledgerjs/**\" --concurrency 44",
     "watch:common": "pnpm turbo run watch --filter=./libs/ledger-live-common",
     "watch:es:common": "pnpm turbo run watch:es --filter=./libs/ledger-live-common",
+    "watch:countervalues": "pnpm turbo run watch --filter=./libs/live-countervalues",
     "dev:cli": "pnpm turbo run watch --filter=@ledgerhq/live-cli",
     "dev:lld": "pnpm turbo start --filter=ledger-live-desktop",
     "dev:lld:debug": "DEV_TOOLS=1 LEDGER_INTERNAL_ARGS=--inspect ELECTRON_ARGS=--remote-debugging-port=8315 pnpm turbo start --filter=ledger-live-desktop",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

#### Context

Given a range sufficiently large the user would have not owned any tokens. So the "ALL" range will always start with the user owning 0 of a given token. When the user owns some of it the trend would be infinite (nothing to something). Up to know this was addressed by not displaying the trend in this case.

#### New Solution

Now the trend will be calculated starting from the first tokens received/purchased by the user:

| Before        | After         |
| ------------- | ------------- |
|     <video src="https://github.com/user-attachments/assets/4e366682-cea6-4316-b6c0-e38209f57c31" />          |    <video src="https://github.com/user-attachments/assets/e006273c-ccfd-4c0a-96eb-b30dc9556564" />           |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-16965]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16965]: https://ledgerhq.atlassian.net/browse/LIVE-16965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ