### PR TITLE
feat(LIVE-17796): Swap LLM should only reference accounts on initial load

### DIFF
--- a/.changeset/tiny-spies-march.md
+++ b/.changeset/tiny-spies-march.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Swap WebView should generate swap params based on accounts available on initial load

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
@@ -2,7 +2,7 @@ import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { currentAccountAtom } from "@ledgerhq/live-common/wallet-api/useDappLogic";
 import { Flex } from "@ledgerhq/native-ui";
-import React from "react";
+import React, { useRef } from "react";
 import { Platform } from "react-native";
 import { useSelector } from "react-redux";
 import { useTheme } from "styled-components/native";
@@ -20,6 +20,7 @@ import {
 import { useSwapLiveAppCustomHandlers } from "./hooks/useSwapLiveAppCustomHandlers";
 import { DefaultAccountSwapParamList } from "../types";
 import { useTranslateToSwapAccount } from "./hooks/useTranslateToSwapAccount";
+import { flattenAccountsSelector } from "~/reducers/accounts";
 
 type Props = {
   manifest: LiveAppManifest;
@@ -39,7 +40,10 @@ export function WebView({ manifest, params, setWebviewState }: Props) {
   const exportSettings = useSelector(exportSettingsSelector);
   const devMode = exportSettings.developerModeEnabled.toString();
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
-  const swapParams = useTranslateToSwapAccount(params);
+
+  const currentAccounts = useSelector(flattenAccountsSelector);
+  const stableCurrentAccounts = useRef(currentAccounts).current; // only consider accounts available upon initial WebView load
+  const swapParams = useTranslateToSwapAccount(params, stableCurrentAccounts);
 
   // ScopeProvider required to prevent conflicts between Swap's Webview instance and deeplink instances
   return (

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useTranslateToSwapAccount.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useTranslateToSwapAccount.ts
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 
 import * as walletApi from "@ledgerhq/live-common/wallet-api/converters";
 import { walletSelector } from "~/reducers/wallet";
-import { flattenAccountsSelector } from "~/reducers/accounts";
 
 import { DefaultAccountSwapParamList } from "../../types";
 import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
@@ -28,9 +27,9 @@ const getHighestBalanceAccount = (accounts: AccountLike[]): AccountLike => {
 
 export const useTranslateToSwapAccount = (
   params: DefaultAccountSwapParamList | null,
+  currentAccounts: AccountLike[],
 ): SwapLiveUrlParams => {
   const walletState = useSelector(walletSelector);
-  const currentAccounts: AccountLike[] = useSelector(flattenAccountsSelector);
 
   return useMemo(() => {
     const newParams: SwapLiveUrlParams = {};


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When the mobile Swap view loads, the accounts available at the time should be used to deduce an available default account.  Further updates to the available accounts should not be used to prevent changing the Swap URL params while it's open.

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17796](https://ledgerhq.atlassian.net/browse/LIVE-17796)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17796]: https://ledgerhq.atlassian.net/browse/LIVE-17796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ