### PR TITLE
chore: set Jest default reporter in Coin Integration configs

### DIFF
--- a/libs/coin-framework/jest.config.js
+++ b/libs/coin-framework/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
     "text",
   ],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "framework-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-algorand/jest.config.js
+++ b/libs/coin-modules/coin-algorand/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "algorand-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-aptos/jest.config.js
+++ b/libs/coin-modules/coin-aptos/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "aptos-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-bitcoin/jest.config.js
+++ b/libs/coin-modules/coin-bitcoin/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   modulePathIgnorePatterns: ["__tests__/fixtures"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "bitcoin-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-cardano/jest.config.js
+++ b/libs/coin-modules/coin-cardano/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "cardano-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-casper/jest.config.js
+++ b/libs/coin-modules/coin-casper/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "casper-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-cosmos/jest.config.js
+++ b/libs/coin-modules/coin-cosmos/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   modulePathIgnorePatterns: ["__tests__/fixtures"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "cosmos-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-evm/jest.config.js
+++ b/libs/coin-modules/coin-evm/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: ["jest-expect-message", "dotenv/config"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "evm-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-filecoin/jest.config.js
+++ b/libs/coin-modules/coin-filecoin/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "filecoin-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-hedera/jest.config.js
+++ b/libs/coin-modules/coin-hedera/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   modulePathIgnorePatterns: ["__tests__/fixtures"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "hedera-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-icon/jest.config.js
+++ b/libs/coin-modules/coin-icon/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   ],
   coverageReporters: ["json", ["lcov", { file: "icon-lcov.info", projectRoot: "../" }], "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "icon-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-internet_computer/jest.config.js
+++ b/libs/coin-modules/coin-internet_computer/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "icp-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-module-boilerplate/jest.config.js
+++ b/libs/coin-modules/coin-module-boilerplate/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.integ\\.test\\.[tj]s"],
   workerThreads: true,
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/coin-modules/coin-multiversx/jest.config.js
+++ b/libs/coin-modules/coin-multiversx/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "multiversx-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-near/jest.config.js
+++ b/libs/coin-modules/coin-near/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "near-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-polkadot/jest.config.js
+++ b/libs/coin-modules/coin-polkadot/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   modulePathIgnorePatterns: ["src/test/coin-tester"],
   setupFilesAfterEnv: ["jest-expect-message", "dotenv/config"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "polkadot-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-solana/jest.config.js
+++ b/libs/coin-modules/coin-solana/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
   transformIgnorePatterns: [`node_modules/.pnpm/(?!(${transformIncludePatterns.join("|")}))`],
   modulePathIgnorePatterns: ["__tests__/fixtures"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "solana-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-stacks/jest.config.js
+++ b/libs/coin-modules/coin-stacks/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "stacks-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-stellar/jest.config.js
+++ b/libs/coin-modules/coin-stellar/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.integ\\.test\\.[tj]s"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "stellar-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-tezos/jest.config.js
+++ b/libs/coin-modules/coin-tezos/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   ],
   coverageReporters: ["json", ["lcov", { file: "tezos-lcov.info", projectRoot: "../" }], "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "tezos-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-ton/jest.config.js
+++ b/libs/coin-modules/coin-ton/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
     "__tests__/integration/bridge.integration.test.ts", // this file is tested at the live-common level
   ],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "ton-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-tron/jest.config.js
+++ b/libs/coin-modules/coin-tron/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.(integ|integration)\\.test\\.[tj]s"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "tron-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-vechain/jest.config.js
+++ b/libs/coin-modules/coin-vechain/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   testEnvironment: "node",
   testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "vechain-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/coin-modules/coin-xrp/jest.config.js
+++ b/libs/coin-modules/coin-xrp/jest.config.js
@@ -14,6 +14,7 @@ module.exports = {
   coverageReporters: ["json", ["lcov", { file: "xrp-lcov.info", projectRoot: "../" }], "text"],
   workerThreads: true,
   reporters: [
+    "default",
     [
       "jest-sonar",
       { outputName: "xrp-sonar-executionTests-report.xml", reportedFilePath: "absolute" },

--- a/libs/ledgerjs/packages/hw-app-algorand/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-algorand/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-aptos/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-aptos/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-btc/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-cosmos/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-cosmos/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-eth/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-exchange/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/jest.config.ts
@@ -13,6 +13,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-hedera/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-hedera/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-helium/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-helium/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-icon/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-icon/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-multiversx/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-multiversx/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-near/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-near/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-polkadot/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-polkadot/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-solana/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-solana/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-str/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-str/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-tezos/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-tezos/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-trx/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-trx/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-vet/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-vet/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {

--- a/libs/ledgerjs/packages/hw-app-xrp/jest.config.ts
+++ b/libs/ledgerjs/packages/hw-app-xrp/jest.config.ts
@@ -12,6 +12,7 @@ export default {
   ],
   coverageReporters: ["json", ["lcov", { projectRoot: "../" }], "json-summary", "text"],
   reporters: [
+    "default",
     [
       "jest-sonar",
       {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This [PR](https://github.com/LedgerHQ/ledger-live/pull/9298) that added SonarQube integration breaks Jest reporting on CI and in the terminal—we no longer see how many tests ran or which one failed. 
It's annoying on CI to understand what's going on, but also locally.  
The issue comes from replacing the default reporter with `jest-sonar`.  
We want to keep it on CI, but maybe we should also keep the default reporter, especially locally, since we don't care about Sonar in that case.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
