### PR TITLE
[LIVE-17848] fix(onboarding): redirection at the end (for Flex)

### DIFF
--- a/.changeset/little-emus-act.md
+++ b/.changeset/little-emus-act.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Feature flag: default value of deviceInitialApps aligned with prod

--- a/.changeset/wicked-otters-smile.md
+++ b/.changeset/wicked-otters-smile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix redirection at the end of the sync onboarding

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
@@ -17,12 +17,14 @@ import {
   setOnboardingHasDevice,
 } from "~/actions/settings";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
+import { useIsFocused, useNavigation } from "@react-navigation/core";
 
 type Props = BaseComposite<
   StackScreenProps<SyncOnboardingStackParamList, ScreenName.SyncOnboardingCompletion>
 >;
 
-const CompletionScreen = ({ navigation, route }: Props) => {
+const CompletionScreen = ({ route }: Props) => {
+  const navigation = useNavigation<RootNavigation>();
   const { device } = route.params;
   const dispatch = useDispatch();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
@@ -36,12 +38,11 @@ const CompletionScreen = ({ navigation, route }: Props) => {
     dispatch(setHasBeenRedirectedToPostOnboarding(false));
   }, [dispatch, hasCompletedOnboarding]);
 
-  const hasRedirected = React.useRef(false);
+  const isFocused = useIsFocused();
 
   const redirectToMainScreen = useCallback(() => {
-    if (hasRedirected.current) return;
-    hasRedirected.current = true;
-    (navigation as unknown as RootNavigation).reset({
+    if (!isFocused) return;
+    navigation.reset({
       index: 0,
       routes: [
         {
@@ -56,7 +57,7 @@ const CompletionScreen = ({ navigation, route }: Props) => {
         },
       ],
     });
-  }, [navigation]);
+  }, [isFocused, navigation]);
 
   return (
     <TouchableWithoutFeedback onPress={redirectToMainScreen}>

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/EuropaCompletionView.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/EuropaCompletionView.tsx
@@ -1,5 +1,5 @@
 import Animation from "~/components/Animation";
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Dimensions, Image } from "react-native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Flex } from "@ledgerhq/native-ui";
@@ -10,14 +10,28 @@ type Props = {
   onAnimationFinish: () => void;
 };
 
+const redirectDelay = 2500;
+
 const EuropaCompletionView: React.FC<Props> = ({ onAnimationFinish }) => {
   const { height: screenHeight, width: screenWidth } = Dimensions.get("screen");
+
+  const delayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    delayRef.current = setTimeout(onAnimationFinish, redirectDelay);
+
+    return () => {
+      if (delayRef.current) {
+        clearTimeout(delayRef.current);
+        delayRef.current = null;
+      }
+    };
+  }, [onAnimationFinish]);
 
   return (
     <Flex height="100%" width="100%">
       <Animation
         source={OnboardingSuccessAnimation}
-        onAnimationFinish={onAnimationFinish}
         loop={false}
         style={{
           position: "absolute",

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
@@ -120,7 +120,6 @@ enum CompanionStepKey {
   EarlySecurityCheckCompleted = 0,
   Pin,
   Seed,
-  Backup,
   Apps,
   Ready,
   Exit,
@@ -385,7 +384,9 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
         deviceOnboardingState.currentOnboardingStep,
       )
     ) {
-      setCompanionStepKey(CompanionStepKey.Apps);
+      setCompanionStepKey(
+        deviceInitialApps?.enabled ? CompanionStepKey.Apps : CompanionStepKey.Ready,
+      );
       seededDeviceHandled.current = true;
       return;
     }
@@ -438,7 +439,12 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
       default:
         break;
     }
-  }, [deviceOnboardingState, notifyEarlySecurityCheckShouldReset, shouldRestoreApps]);
+  }, [
+    deviceInitialApps?.enabled,
+    deviceOnboardingState,
+    notifyEarlySecurityCheckShouldReset,
+    shouldRestoreApps,
+  ]);
 
   // When the user gets close to the seed generation step, sets the lost synchronization delay
   // and timers to a higher value. It avoids having a warning message while the connection is lost
@@ -466,7 +472,7 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
 
   const addedToKnownDevices = useRef(false);
   useEffect(() => {
-    if (companionStepKey >= CompanionStepKey.Backup) {
+    if (companionStepKey >= CompanionStepKey.Apps) {
       // Stops the polling once the device is seeded
       setIsPollingOn(false);
       // At this step, device has been successfully setup so it can be saved in

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -124,7 +124,7 @@ export const DEFAULT_FEATURES: Features = {
   },
 
   deviceInitialApps: {
-    enabled: false,
+    enabled: true,
     params: { apps: ["Bitcoin", "Ethereum"] },
   },
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Sync onboarding redirection.

### 📝 Description

The issue seems to be that `onAnimationFinished` captures the first function passed to it, and in that case it was capturing an early `navigation` object which was probably invalid.

PS: also noticed that there was an issue regarding the `deviceInitialApps`: its default value was `enabled: false` and the behavior of the SyncOnboarding was not taking that value into account.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17848] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17848]: https://ledgerhq.atlassian.net/browse/LIVE-17848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ