### PR TITLE
fix(LIVE-17937): add margin to top of StartExchange screen

### DIFF
--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -45,7 +45,7 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   const request = useMemo(() => route.params.request, [route.params.request]);
   return (
     <SafeAreaView style={styles.root} edges={["bottom"]}>
-      <Flex px={16} py={8} flex={1}>
+      <Flex px={16} py={8} flex={1} mt={8}>
         <SelectDevice2
           onSelect={setDevice}
           stopBleScanning={!!device || !isFocused}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add a top margin on the StartExchange screen in order to not have multiple lines stuck together and improve readability.


| Before        | After         |
| ------------- | ------------- |
| ![Screenshot 2025-03-28 at 07 46 07](https://github.com/user-attachments/assets/ce79f644-d031-4002-bfa4-556fd949818d) | ![Screenshot 2025-03-28 at 07 45 39](https://github.com/user-attachments/assets/96bb1baa-5c62-4789-802e-0febb2742004) |


### ❓ Context

[- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
](https://ledgerhq.atlassian.net/browse/LIVE-17937)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
