### PR TITLE
fix (coin-stellar): operation identifiers are wrong

### DIFF
--- a/.changeset/twelve-jokes-admire.md
+++ b/.changeset/twelve-jokes-admire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": patch
+---
+
+fix (coin-stellar): operation identifiers are wrong

--- a/libs/coin-modules/coin-stellar/src/network/serialization.ts
+++ b/libs/coin-modules/coin-stellar/src/network/serialization.ts
@@ -90,7 +90,7 @@ async function formatOperation(
     : null;
 
   const operation: StellarOperation = {
-    id: encodeOperationId(accountId, rawOperation.id, type), // rawOperation.id is unique, but not the hash
+    id: encodeOperationId(accountId, rawOperation.transaction_hash, type),
     accountId,
     fee: new BigNumber(transaction.fee_charged),
     value: rawOperation?.asset_code ? new BigNumber(transaction.fee_charged) : value,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This partially reverts https://github.com/LedgerHQ/ledger-live/pull/9584.

The way operation identifiers are built has changed (using Stellar transaction `id`), whereas new operations continue to use the old way (using Stellar transaction `hash`).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
