### PR TITLE
feat(LIVE-17932): softExit WebPTX parameter

### DIFF
--- a/.changeset/twenty-camels-hammer.md
+++ b/.changeset/twenty-camels-hammer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+WebPTXPlayer should accept softExit param so Buy navigates back to Swap

--- a/apps/ledger-live-mobile/src/screens/PTX/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/index.tsx
@@ -106,6 +106,7 @@ export function PtxScreen({ route, config }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
+  const { softExit, ...searchInput } = Object.fromEntries(searchParams.entries());
 
   return manifest ? (
     <>
@@ -126,9 +127,10 @@ export function PtxScreen({ route, config }: Props) {
             providerTestId: localManifest?.providerTestId,
           }),
           ...customParams,
-          ...Object.fromEntries(searchParams.entries()),
+          ...searchInput,
         }}
         config={config}
+        softExit={softExit === "true"}
       />
     </>
   ) : (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adds the query param 'softExit' WebPTXPlayer so that deeplinks opening WebPTXPlayers (eg Swap opening Buy) can specify the close should navigate back to Swap. 


| Without softExit param        | With softExit param         |
| ------------- | ------------- |
| ![Kapture 2025-03-28 at 11 14 59](https://github.com/user-attachments/assets/a6aa1aa6-791c-4550-bbee-672681f16ca6)  close navigates back to home |  ![Kapture 2025-03-28 at 11 13 05](https://github.com/user-attachments/assets/d26bc50e-3d67-4dff-8250-301496fd444a) close navigates back to previous screen |


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17932](https://ledgerhq.atlassian.net/browse/LIVE-17932)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17932]: https://ledgerhq.atlassian.net/browse/LIVE-17932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ