### PR TITLE
:bug: (llm) tx history preview

### DIFF
--- a/.changeset/empty-gifts-care.md
+++ b/.changeset/empty-gifts-care.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix transaction history when there is subaccount + change weird navigation effect

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -352,6 +352,7 @@ export default function BaseNavigator() {
                 ),
                 headerLeft: () => <NavigationHeaderBackButton />,
                 headerRight: () => <NavigationHeaderCloseButton />,
+                cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
               };
             }
 
@@ -369,6 +370,7 @@ export default function BaseNavigator() {
               ),
               headerLeft: () => <NavigationHeaderBackButton />,
               headerRight: () => null,
+              cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
             };
           }}
         />
@@ -426,7 +428,6 @@ export default function BaseNavigator() {
           options={{
             title: t("analytics.operations.title"),
             headerRight: () => null,
-            cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
           }}
         />
         <Stack.Screen

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/OperationsList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { SectionList, SectionListData, SectionListRenderItem } from "react-native";
 import { Flex } from "@ledgerhq/native-ui";
 import { Account, AccountLike, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
-import { isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
+import { flattenAccounts, isAccountEmpty } from "@ledgerhq/live-common/account/helpers";
 
 import { Trans } from "react-i18next";
 
@@ -46,7 +46,8 @@ export function OperationsList({
     index,
     section,
   }) => {
-    const account = allAccounts.find(a => a.id === item.accountId);
+    const flattenedAccounts = flattenAccounts(accountsFiltered);
+    const account = flattenedAccounts.find(a => a.id === item.accountId);
     const parentAccount =
       account && account.type !== "Account"
         ? (allAccounts.find(a => a.id === account.parentId) as Account)
@@ -59,7 +60,7 @@ export function OperationsList({
         operation={item}
         parentAccount={parentAccount}
         account={account}
-        multipleAccounts={accountsFiltered.length > 1}
+        multipleAccounts={flattenedAccounts.length > 1}
         isLast={section.data.length - 1 === index}
       />
     );

--- a/apps/ledger-live-mobile/src/screens/WalletCentricSections/OperationsHistory/OperationRowContainer.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricSections/OperationsHistory/OperationRowContainer.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { AccountLike, Operation } from "@ledgerhq/types-live";
+import OperationRow from "~/components/OperationRow";
+import { parentAccountSelector } from "~/reducers/accounts";
+import { State } from "~/reducers/types";
+
+type OperationRowContainerProps = {
+  operation: Operation;
+  account: AccountLike;
+  multipleAccounts: boolean;
+  isLast: boolean;
+};
+
+export function OperationRowContainer({
+  operation,
+  account,
+  multipleAccounts,
+  isLast,
+}: Readonly<OperationRowContainerProps>) {
+  const parentAccount = useSelector((state: State) => parentAccountSelector(state, { account }));
+
+  return (
+    <OperationRow
+      operation={operation}
+      parentAccount={parentAccount}
+      account={account}
+      multipleAccounts={multipleAccounts}
+      isLast={isLast}
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/WalletCentricSections/OperationsHistory/OperationsHistoryList.tsx
+++ b/apps/ledger-live-mobile/src/screens/WalletCentricSections/OperationsHistory/OperationsHistoryList.tsx
@@ -1,15 +1,12 @@
 import React, { useCallback } from "react";
-import { Operation, DailyOperationsSection, SubAccount } from "@ledgerhq/types-live";
+import { Operation, DailyOperationsSection } from "@ledgerhq/types-live";
 import { Button } from "@ledgerhq/native-ui";
 import { SectionListRenderItemInfo, SectionList } from "react-native";
-
-import { useSelector } from "react-redux";
-import OperationRow from "~/components/OperationRow";
-import { parentAccountSelector } from "~/reducers/accounts";
 import SectionHeader from "~/components/SectionHeader";
-import { State } from "~/reducers/types";
 import { ViewProps } from "./types";
 import { useTranslation } from "react-i18next";
+import { flattenAccounts } from "@ledgerhq/coin-framework/lib/account/helpers";
+import { OperationRowContainer } from "./OperationRowContainer";
 
 const keyExtractor = (operation: Operation) => operation.id;
 
@@ -28,20 +25,16 @@ export function OperationsHistoryList({
 
   const renderItem = useCallback(
     ({ item, index, section }: SectionListRenderItemInfo<Operation, DailyOperationsSection>) => {
-      const account = accounts.find(a => a.id === item.accountId) as SubAccount;
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const parentAccount = useSelector((state: State) =>
-        parentAccountSelector(state, { account }),
-      );
+      const flattenedAccounts = flattenAccounts(accounts);
+      const account = flattenedAccounts.find(a => a.id === item.accountId);
 
       if (!account) return null;
 
       return (
-        <OperationRow
+        <OperationRowContainer
           operation={item}
-          parentAccount={parentAccount}
           account={account}
-          multipleAccounts={accounts.length > 1}
+          multipleAccounts={flattenedAccounts.length > 1}
           isLast={section.data.length - 1 === index}
         />
       );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - tx history
  - operation navigation

### 📝 Description

We had an issue regarding tx history because we didn't check the subaccounts of an account. That's why we have the issue on Eth, Sol and evms etc ... 
Also we were displaying "received" or "send" if there was only one parent account. But this can be confusing if there is subAccount.

+ Change weird navigation

+ Fix non respected eslint rule

https://github.com/user-attachments/assets/145f6469-c205-4a3a-81ba-128ec92b21e5


<!--
| Before        | After         |
| ------------- | ------------- |
|               |             |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17251](https://ledgerhq.atlassian.net/browse/LIVE-17251)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17251]: https://ledgerhq.atlassian.net/browse/LIVE-17251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ