### PR TITLE
fix(lld): unwanted rendering when clicking the 'close' button from the recover screen just after onboarding

### DIFF
--- a/.changeset/wild-books-act.md
+++ b/.changeset/wild-books-act.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix unwanted rendering when clicking the 'close' button from the recover screen just after onboarding

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/index.ts
@@ -9,6 +9,9 @@ import { useHistory } from "react-router";
 /**
  * Navigates to the post onboarding or to the Ledger Recover upsell if needed
  * */
+// TODO: Rename and refactor this function and use algebraic data types like Result
+// to avoid the need of a fallback redirection and to make the function more readable
+// and maintainable. (see neverthrow library for example)
 export function useRedirectToPostOnboardingCallback() {
   const history = useHistory();
   const lastOnboardedDevice = useSelector(lastOnboardedDeviceSelector);

--- a/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useAutoRedirectToPostOnboarding/index.ts
@@ -29,10 +29,14 @@ export function useRedirectToPostOnboardingCallback() {
       if (shouldRedirectToRecoverUpsell) {
         openRecoverUpsell({ fallbackRedirection });
         onDone();
-      } else if (shouldRedirectToPostOnboarding && lastOnboardedDevice) {
+        return true;
+      }
+      if (shouldRedirectToPostOnboarding && lastOnboardedDevice) {
         openPostOnboarding({ deviceModelId: lastOnboardedDevice.modelId, fallbackRedirection });
         onDone();
+        return true;
       }
+      return false;
     },
     [
       fallbackRedirection,

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -364,7 +364,6 @@ export function useDeepLinkHandler() {
           dispatch(setLedgerSyncDrawerVisibility(true));
           break;
         }
-        case "portfolio":
         default:
           if (!tryRedirectToPostOnboardingOrRecover()) {
             navigate("/");

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -15,6 +15,7 @@ import { setDrawerVisibility as setLedgerSyncDrawerVisibility } from "~/renderer
 import { CARD_APP_ID, WC_ID } from "@ledgerhq/live-common/wallet-api/constants";
 import { getAccountsOrSubAccountsByCurrency, trackDeeplinkingEvent } from "./utils";
 import { Currency } from "@ledgerhq/types-cryptoassets";
+import { useRedirectToPostOnboardingCallback } from "../useAutoRedirectToPostOnboarding";
 
 export function useDeepLinkHandler() {
   const dispatch = useDispatch();
@@ -22,12 +23,13 @@ export function useDeepLinkHandler() {
   const location = useLocation();
   const history = useHistory();
   const { setUrl } = useStorylyContext();
-  const navigateToHome = () => history.push("/");
+  const navigateToHome = useCallback(() => history.push("/"), [history]);
   const navigateToPostOnboardingHub = useNavigateToPostOnboardingHubCallback();
   const postOnboardingDeeplinkHandler = usePostOnboardingDeeplinkHandler(
     navigateToHome,
     navigateToPostOnboardingHub,
   );
+  const tryRedirectToPostOnboardingOrRecover = useRedirectToPostOnboardingCallback();
 
   const navigate = useCallback(
     (
@@ -364,11 +366,21 @@ export function useDeepLinkHandler() {
         }
         case "portfolio":
         default:
-          navigate("/");
+          if (!tryRedirectToPostOnboardingOrRecover()) {
+            navigate("/");
+          }
           break;
       }
     },
-    [accounts, dispatch, location.pathname, navigate, postOnboardingDeeplinkHandler, setUrl],
+    [
+      accounts,
+      dispatch,
+      location.pathname,
+      navigate,
+      postOnboardingDeeplinkHandler,
+      setUrl,
+      tryRedirectToPostOnboardingOrRecover,
+    ],
   );
 
   return {

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/index.tsx
@@ -36,7 +36,6 @@ import { useDisplayOnPortfolioAnalytics } from "LLD/features/AnalyticsOptInPromp
 import PortfolioContentCards from "LLD/features/DynamicContent/components/PortfolioContentCards";
 import { LNSUpsellBanner, useLNSUpsellBannerState } from "LLD/features/LNSUpsell";
 import useActionCards from "~/renderer/hooks/useActionCards";
-import { useAutoRedirectToPostOnboarding } from "~/renderer/hooks/useAutoRedirectToPostOnboarding";
 import { useNftCollectionsStatus } from "~/renderer/hooks/nfts/useNftCollectionsStatus";
 
 // This forces only one visible top banner at a time
@@ -64,9 +63,6 @@ export default function DashboardPage() {
     [accounts],
   );
   const isPostOnboardingBannerVisible = usePostOnboardingEntryPointVisibleOnWallet();
-
-  useAutoRedirectToPostOnboarding();
-
   const [shouldFilterTokenOpsZeroAmount] = useFilterTokenOperationsZeroAmount();
   const { hiddenNftCollections } = useNftCollectionsStatus(true);
   const filterOperations = useCallback(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**  I modified the routing that was happening inside the Dashboard component instead of being dispatched like other routes. Maybe it was done for a good reason, as a workaround for example, but I don't envision why atm so don't hesitate to enlighten me ;). Also, for this same reason I encourage the QA to ensure the routing experience doesn't provide any regression 🙏. 

### 📝 Description

After the onboarding, when clicking the `close` button, it was displaying the Portfolio before the PostOnboarding. It was caused by a re-routing called during the `Dashboard` rendering. So, it was logically processing, first the `Dashboard` rendering and then the one from the component provided by the re-routing. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-17336


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
