### PR TITLE
fix: error thrown in the wrong case [LIVE-18005]

### DIFF
--- a/.changeset/dry-buses-switch.md
+++ b/.changeset/dry-buses-switch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix: error thrown in the wrong case

--- a/apps/ledger-live-desktop/src/renderer/families/evm/nft.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/nft.ts
@@ -14,17 +14,30 @@ export const injectNftIntoTransaction = (
   nftProperties: Partial<NftProperties>,
   standard?: NFTStandard,
 ): EvmTransaction => {
-  if (transaction.mode === "send") {
-    throw new Error("Expected an NFT transaction but received a Send mode transactions");
+  if (!standard) {
+    if (transaction.mode === "send") {
+      throw new Error("Expected an NFT transaction but received a Send mode transactions");
+    }
+
+    return {
+      ...transaction,
+      mode: transaction.mode,
+      nft: {
+        collectionName: transaction.nft?.collectionName ?? "",
+        contract: nftProperties?.contract ?? transaction.nft?.contract ?? "",
+        tokenId: nftProperties?.tokenId ?? transaction.nft?.tokenId ?? "",
+        quantity: nftProperties?.quantity ?? transaction.nft?.quantity ?? new BigNumber(NaN),
+      },
+    };
   }
 
-  if (standard && standard === "SPL") {
+  if (standard === "SPL") {
     throw new Error("Expected an ERC721 or ERC1155 standard but received an SPL standard");
   }
 
   return {
     ...transaction,
-    mode: standard ? <Lowercase<typeof standard>>standard.toLowerCase() : transaction.mode,
+    mode: <Lowercase<typeof standard>>standard.toLowerCase(),
     nft: {
       collectionName: transaction.nft?.collectionName ?? "",
       contract: nftProperties?.contract ?? transaction.nft?.contract ?? "",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - EVM nft send

### 📝 Description

We should only check for `transaction.mode === "send"` when we don't have an `NFTStandard` passed in

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18005]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18005]: https://ledgerhq.atlassian.net/browse/LIVE-18005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ