### PR TITLE
fix(live-17987): convert bignumber to big int

### DIFF
--- a/.changeset/afraid-avocados-kneel.md
+++ b/.changeset/afraid-avocados-kneel.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-framework": patch
+---
+
+fix conversion of bignumber to bigint

--- a/libs/coin-framework/src/utils.test.ts
+++ b/libs/coin-framework/src/utils.test.ts
@@ -14,4 +14,10 @@ describe("bigNumberToBigInt", () => {
     const result = fromBigNumberToBigInt(value, defaultValue);
     expect(result).toEqual(defaultValue);
   });
+  it("should convert to BigInt for very large numbers", () => {
+    const valueStr = "1234567890123456789012345678901234567890";
+    const valBignumber = new BigNumber(valueStr);
+    const valBigint = fromBigNumberToBigInt(valBignumber);
+    expect(valBigint).toEqual(BigInt(valueStr));
+  });
 });

--- a/libs/coin-framework/src/utils.ts
+++ b/libs/coin-framework/src/utils.ts
@@ -5,7 +5,7 @@ export function fromBigNumberToBigInt<T>(
   defaultValue?: T,
 ): bigint | T {
   if (bigNumber != null) {
-    return BigInt(bigNumber.toString());
+    return BigInt(bigNumber.toFixed());
   }
   return defaultValue as T;
 }


### PR DESCRIPTION



### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** 
  - ...

### 📝 Description

For very big numbers, .toString returned scientific notation. Conversion to bigint failed in that situation

### ❓ Context

[LIVE-17987]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17987]: https://ledgerhq.atlassian.net/browse/LIVE-17987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ