### PR TITLE
bugfix: layout issue when no send button in NFTViewer

### DIFF
--- a/.changeset/lemon-geese-admire.md
+++ b/.changeset/lemon-geese-admire.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix layout Issue when no send button

--- a/apps/ledger-live-mobile/src/components/Nft/NftViewer.tsx
+++ b/apps/ledger-live-mobile/src/components/Nft/NftViewer.tsx
@@ -401,8 +401,8 @@ const NftViewer = ({ route }: Props) => {
           </Box>
 
           <Box mb={8} flexWrap={"nowrap"} flexDirection={"row"} justifyContent={"center"}>
-            {displaySendBtn && (
-              <Box flexGrow={1} flexShrink={1} mr={6} style={styles.sendButtonContainer}>
+            <Box flexGrow={1} flexShrink={1} mr={6} style={styles.sendButtonContainer}>
+              {displaySendBtn && (
                 <Button
                   type="main"
                   Icon={IconsLegacy.ArrowFromBottomMedium}
@@ -411,8 +411,9 @@ const NftViewer = ({ route }: Props) => {
                 >
                   <Trans i18nKey="account.send" />
                 </Button>
-              </Box>
-            )}
+              )}
+            </Box>
+
             {nftMetadata?.links && (
               <Box style={styles.ellipsisButtonContainer} flexShrink={0} width={"48px"}>
                 <Button


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

layout issue when no send button in NFTViewer

Before
<img width="354" alt="Screenshot 2025-03-31 at 15 46 15" src="https://github.com/user-attachments/assets/64cac752-d070-471b-82a9-9138cde7ced6" />


After

<img width="357" alt="Screenshot 2025-03-31 at 15 43 49" src="https://github.com/user-attachments/assets/219973cb-76e4-4bb3-a2f0-e109c417cdcf" />

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
