### PR TITLE
:pencil2: (lld) add fallback to sync error message

### DIFF
--- a/.changeset/chilly-hairs-cough.md
+++ b/.changeset/chilly-hairs-cough.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Sync error add a fallback message to avoid non ux error message

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountSyncStatusIndicator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountSyncStatusIndicator.tsx
@@ -85,7 +85,10 @@ class StatusError extends PureComponent<{
               maxWidth: 250,
             }}
           >
-            <TranslatedError error={error} />
+            <TranslatedError
+              fallback={<Trans i18nKey="errors.AccountNeedResync.title" />}
+              error={error}
+            />
           </Box>
         }
       >


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - account row sync indicator

### 📝 Description

I've not been able to reproduce the issue since it's more like an infra error. But from my understanding we can add this fallback this way we won't display the message if there is no corresponding translation but "please, try again" instead. What's better than [Object Object] or "no network" I guess

![image](https://github.com/user-attachments/assets/e223d456-1f06-42ab-b54d-93a9775fbd22)



### ❓ Context

- **JIRA or GitHub link**: [LIVE-16756](https://ledgerhq.atlassian.net/browse/LIVE-16756)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-16756]: https://ledgerhq.atlassian.net/browse/LIVE-16756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ