### PR TITLE
fix(LIVE-18007): fix stellar coin-module ignoring `memo` craft parameter

### DIFF
--- a/.changeset/loud-apples-own.md
+++ b/.changeset/loud-apples-own.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-stellar": patch
+---
+
+fix stellar coin-module ignoring `memo` craft parameter

--- a/.changeset/loud-apples-own.md
+++ b/.changeset/loud-apples-own.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-stellar": patch
+"@ledgerhq/coin-stellar": minor
 ---
 
 fix stellar coin-module ignoring `memo` craft parameter

--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -93,6 +93,11 @@ describe.skip("Stellar Api", () => {
       return transactionEnvelope.value().tx().fee();
     }
 
+    function readMemo(transactionXdr: string) {
+      const transactionEnvelope = xdr.TransactionEnvelope.fromXDR(transactionXdr, "base64");
+      return (transactionEnvelope.value().tx() as xdr.TransactionV0).memo();
+    }
+
     it("returns a raw transaction", async () => {
       const result = await module.craftTransaction({
         type: TYPE,
@@ -130,6 +135,28 @@ describe.skip("Stellar Api", () => {
 
       const fees = readFees(transactionXdr);
       expect(fees).toEqual(Number(customFees));
+    });
+
+    it("should have no memo when not provided by user", async () => {
+      const transactionXdr = await module.craftTransaction({
+        type: TYPE,
+        sender: ADDRESS,
+        recipient: RECIPIENT,
+        amount: AMOUNT,
+      });
+      expect(readMemo(transactionXdr)).toEqual(xdr.Memo.memoNone());
+    });
+
+    it("should have a memo when provided by user", async () => {
+      const transactionXdr = await module.craftTransaction({
+        type: TYPE,
+        sender: ADDRESS,
+        recipient: RECIPIENT,
+        amount: AMOUNT,
+        memoType: "MEMO_TEXT",
+        memoValue: "test",
+      });
+      expect(readMemo(transactionXdr)).toEqual(xdr.Memo.memoText(Buffer.from("test", "ascii")));
     });
   });
 });

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -31,17 +31,17 @@ export function createApi(config: StellarConfig): Api<StellarToken> {
   };
 }
 
+type TransactionIntentExtra = {
+  memoType?: string | null | undefined;
+  memoValue?: string | null | undefined;
+};
+
 async function craft(
   transactionIntent: TransactionIntent<StellarToken>,
   customFees?: bigint,
 ): Promise<string> {
   const fees = customFees !== undefined ? customFees : await estimateFees();
-  const supplement = transactionIntent.asset
-    ? {
-        assetCode: transactionIntent.asset.assetCode,
-        assetIssuer: transactionIntent.asset.assetIssuer,
-      }
-    : {};
+  const extra = transactionIntent as TransactionIntentExtra;
   const tx = await craftTransaction(
     { address: transactionIntent.sender },
     {
@@ -49,8 +49,10 @@ async function craft(
       recipient: transactionIntent.recipient,
       amount: transactionIntent.amount,
       fee: fees,
-      assetCode: supplement?.assetCode,
-      assetIssuer: supplement?.assetIssuer,
+      assetCode: transactionIntent.asset?.assetCode,
+      assetIssuer: transactionIntent.asset?.assetIssuer,
+      memoType: extra.memoType,
+      memoValue: extra.memoValue,
     },
   );
   return tx.xdr;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This is a regression from LedgerHQ/ledger-live#9466, `memo` is ignored when crafting stellar transactions through coin modules API.

Note: stellar tests are skipped, I ran them manually

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-18007


---
### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
