### PR TITLE
[QAA] Fix e2e apps for release testing 

### DIFF
--- a/apps/ledger-live-desktop/tests/page/swap.page.ts
+++ b/apps/ledger-live-desktop/tests/page/swap.page.ts
@@ -290,10 +290,10 @@ export class SwapPage extends AppPage {
   @step("Click Exchange button")
   async clickExchangeButton(electronApp: ElectronApplication, provider: string) {
     const [, webview] = electronApp.windows();
-    const SwapButton = webview.getByRole("button", { name: `Swap with ${provider}` });
-    await expect(SwapButton).toBeVisible();
-    await expect(SwapButton).toBeEnabled();
-    await SwapButton.click();
+    const swapButton = webview.getByRole("button", { name: `Swap with ${provider}` });
+    await expect(swapButton).toBeVisible();
+    await expect(swapButton).toBeEnabled();
+    await swapButton.click();
   }
 
   @step("Go to provider live app")

--- a/apps/ledger-live-desktop/tests/page/swap.page.ts
+++ b/apps/ledger-live-desktop/tests/page/swap.page.ts
@@ -290,8 +290,10 @@ export class SwapPage extends AppPage {
   @step("Click Exchange button")
   async clickExchangeButton(electronApp: ElectronApplication, provider: string) {
     const [, webview] = electronApp.windows();
-    await expect(webview.getByRole("button", { name: `Swap with ${provider}` })).toBeEnabled();
-    await webview.getByRole("button", { name: `Swap with ${provider}` }).click();
+    const SwapButton = webview.getByRole("button", { name: `Swap with ${provider}` });
+    await expect(SwapButton).toBeVisible();
+    await expect(SwapButton).toBeEnabled();
+    await SwapButton.click();
   }
 
   @step("Go to provider live app")

--- a/apps/ledger-live-desktop/tests/specs/speculos/swap.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/speculos/swap.spec.ts
@@ -439,7 +439,7 @@ const tooLowAmountForQuoteSwaps = [
     quotesVisible: true,
   },
   {
-    swap: new Swap(Account.ETH_USDT_2, Account.BTC_NATIVE_SEGWIT_1, "10", Fee.MEDIUM),
+    swap: new Swap(Account.ETH_USDT_2, Account.BTC_NATIVE_SEGWIT_1, "20", Fee.MEDIUM),
     xrayTicket: "B2CQA-3241",
     errorMessage: new RegExp(`\\d+(\\.\\d{1,10})? ETH needed for network fees\\.\\s*$`),
     ctaBanner: true,

--- a/apps/ledger-live-desktop/tests/userdata/speculos-tests-app.json
+++ b/apps/ledger-live-desktop/tests/userdata/speculos-tests-app.json
@@ -11777,8 +11777,8 @@
               "id": "js:2:ethereum:0x43047a5023D55a8658Fcb1c1Cea468311AdAA3Ad:+ethereum%2Ferc20%2Fusd~!underscore!~tether~!underscore!~~!underscore!~erc20~!underscore!~",
               "parentId": "js:2:ethereum:0x43047a5023D55a8658Fcb1c1Cea468311AdAA3Ad:",
               "tokenId": "ethereum/erc20/usd_tether__erc20_",
-              "balance": "11006649",
-              "spendableBalance": "11006649",
+              "balance": "24237000",
+              "spendableBalance": "24237000",
               "balanceHistoryCache": {
                 "HOUR": {
                   "balances": [

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -231,18 +231,18 @@ export const specs: Specs = {
     dependency: "",
   },
   Polygon: {
-    currency: getCryptoCurrencyById("polygon"),
+    currency: getCryptoCurrencyById("ethereum"),
     appQuery: {
       model: DeviceModelId.nanoSP,
-      appName: "Polygon",
+      appName: "Ethereum",
     },
     dependency: "",
   },
   Binance_Smart_Chain: {
-    currency: getCryptoCurrencyById("bsc"),
+    currency: getCryptoCurrencyById("ethereum"),
     appQuery: {
       model: DeviceModelId.nanoSP,
-      appName: "Binance Smart Chain",
+      appName: "Ethereum",
     },
     dependency: "",
   },

--- a/libs/ledger-live-common/src/e2e/speculos.ts
+++ b/libs/ledger-live-common/src/e2e/speculos.ts
@@ -231,7 +231,7 @@ export const specs: Specs = {
     dependency: "",
   },
   Polygon: {
-    currency: getCryptoCurrencyById("ethereum"),
+    currency: getCryptoCurrencyById("polygon"),
     appQuery: {
       model: DeviceModelId.nanoSP,
       appName: "Ethereum",
@@ -239,7 +239,7 @@ export const specs: Specs = {
     dependency: "",
   },
   Binance_Smart_Chain: {
-    currency: getCryptoCurrencyById("ethereum"),
+    currency: getCryptoCurrencyById("bsc"),
     appQuery: {
       model: DeviceModelId.nanoSP,
       appName: "Ethereum",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Following the activation of the feature flag `config_nanoapp_ethereum`, we needed to update the nano app used for our Binance Smart Chain and Polygon tests.

- Updated the minimum amount for USDT => BTC swap.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [QAA-529](https://ledgerhq.atlassian.net/browse/QAA-529)

### ✅ CI

- **CI**: [RUN](https://github.com/LedgerHQ/ledger-live/actions/runs/14222684993)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-529]: https://ledgerhq.atlassian.net/browse/QAA-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ