### PR TITLE
fix: missing LedgerLive userAgent on LLM webview [LIVE-18142]

### DIFF
--- a/.changeset/cyan-chairs-rest.md
+++ b/.changeset/cyan-chairs-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: missing LedgerLive userAgent on LLM webview

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useMemo, forwardRef } from "react";
 import { useSelector } from "react-redux";
-import { ActivityIndicator, Linking, StyleSheet, View } from "react-native";
+import VersionNumber from "react-native-version-number";
+import { ActivityIndicator, Linking, Platform, StyleSheet, View } from "react-native";
 import { WebView as RNWebView, WebViewMessageEvent } from "react-native-webview";
 import { useNavigation } from "@react-navigation/native";
 import { JSONRPCRequest } from "json-rpc-2.0";
@@ -49,6 +50,8 @@ import { useWebviewState } from "./helpers";
 import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { walletSelector } from "~/reducers/wallet";
 import { WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
+
+const APPLICATION_NAME = `ledgerlivemobile/${VersionNumber.appVersion} llm-${Platform.OS}/${VersionNumber.appVersion}`;
 
 function renderLoading() {
   return (
@@ -536,6 +539,7 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         style={styles.webview}
         javaScriptCanOpenWindowsAutomatically={javaScriptCanOpenWindowsAutomatically}
         webviewDebuggingEnabled={__DEV__}
+        applicationNameForUserAgent={APPLICATION_NAME}
         {...webviewProps}
       />
     );

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useState } from "react";
-import { ActivityIndicator, StyleSheet, View } from "react-native";
+import VersionNumber from "react-native-version-number";
+import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 import { WebView as RNWebView } from "react-native-webview";
 import Config from "react-native-config";
 import { WebviewAPI, WebviewProps } from "./types";
@@ -9,6 +10,8 @@ import { INTERNAL_APP_IDS, WC_ID } from "@ledgerhq/live-common/wallet-api/consta
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { INJECTED_JAVASCRIPT } from "./dappInject";
 import { NoAccountScreen } from "./NoAccountScreen";
+
+const APPLICATION_NAME = `ledgerlivemobile/${VersionNumber.appVersion} llm-${Platform.OS}/${VersionNumber.appVersion}`;
 
 export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
   (
@@ -83,6 +86,7 @@ export const WalletAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
         style={[styles.webview, { display: error ? "none" : "flex" }]}
         renderError={() => <NetworkError handleTryAgain={reloadWebView} />}
         testID="wallet-api-webview"
+        applicationNameForUserAgent={APPLICATION_NAME}
         webviewDebuggingEnabled={__DEV__}
         allowsUnsecureHttps={__DEV__ && !!Config.IGNORE_CERTIFICATE_ERRORS}
         javaScriptCanOpenWindowsAutomatically={javaScriptCanOpenWindowsAutomatically}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually
- [x] **Impact of the changes:**
  - almost all webviews on mobile, so discover, earn, buy, swap and others

### 📝 Description

LLM was not setting a userAgent like LLD is doing automatically for the webviews so we're adding it here for mobile

<img width="1028" alt="Screenshot 2025-04-03 at 18 22 34" src="https://github.com/user-attachments/assets/ddac5867-cebb-4497-9a7f-61a9bfd405fa" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18142]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18142]: https://ledgerhq.atlassian.net/browse/LIVE-18142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ