### PR TITLE
ci: target new labels for mac runners

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -71,7 +71,7 @@ env:
 jobs:
   detox-tests-ios:
     name: "LLM - iOS Detox Tests"
-    runs-on: [m1, ARM64]
+    runs-on: [general-pool, macOS, ARM64]
     if: ${{ !inputs.speculos_tests && github.event_name != 'schedule' }}
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"


### PR DESCRIPTION
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-17774

LL equivalent of LLB's https://github.com/LedgerHQ/ledger-live-build/pull/124

Use new Mac labels to target mac runners