### PR TITLE
feat: Add the LLM resolution tool in Electron within the PTX WebView

### DIFF
--- a/.changeset/light-planets-brake.md
+++ b/.changeset/light-planets-brake.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add the LLD resolution tool in Electron within the PTX WebView

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/TopBar.tsx
@@ -18,6 +18,9 @@ import { track } from "~/renderer/analytics/segment";
 import { INTERNAL_APP_IDS } from "@ledgerhq/live-common/wallet-api/constants";
 import { useInternalAppIds } from "@ledgerhq/live-common/hooks/useInternalAppIds";
 import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
+import Switch from "../Switch";
+import { Icons } from "@ledgerhq/react-ui/index";
+import Input from "~/renderer/components/Input";
 
 const Container = styled(Box).attrs(() => ({
   horizontal: true,
@@ -93,14 +96,27 @@ const RightContainer = styled(Box).attrs(() => ({
   ml: "auto",
 }))``;
 
+export interface MobileView {
+  display: boolean;
+  width: number;
+}
+
 export type Props = {
   icon?: boolean;
   manifest: LiveAppManifest;
   webviewAPIRef: RefObject<WebviewAPI>;
   webviewState: WebviewState;
+  mobileView: MobileView;
+  setMobileView?: React.Dispatch<React.SetStateAction<MobileView>>;
 };
 
-export const TopBar = ({ manifest, webviewAPIRef, webviewState }: Props) => {
+export const TopBar = ({
+  manifest,
+  webviewAPIRef,
+  webviewState,
+  mobileView,
+  setMobileView,
+}: Props) => {
   const { t } = useTranslation();
   const lastMatchingURL = useRef<string | null>(null);
   const history = useHistory();
@@ -189,6 +205,17 @@ export const TopBar = ({ manifest, webviewAPIRef, webviewState }: Props) => {
     webview.reload();
   }, [webviewAPIRef]);
 
+  const toggleMobileView = useCallback(async () => {
+    setMobileView?.(prev => ({ ...prev, display: !prev.display }));
+  }, [setMobileView]);
+
+  const updateMobileWidth = useCallback(
+    async (width: number) => {
+      setMobileView?.(prev => ({ ...prev, width: width > 0 ? width : 355 }));
+    },
+    [setMobileView],
+  );
+
   useEffect(() => {
     if (isInternalApp) {
       const url = safeUrl(webviewState.url);
@@ -240,6 +267,33 @@ export const TopBar = ({ manifest, webviewAPIRef, webviewState }: Props) => {
               <Trans i18nKey="common.sync.devTools" />
             </ItemContent>
           </ItemContainer>
+          <Separator />
+          <ItemContainer isInteractive onClick={toggleMobileView} style={{ marginRight: 0 }}>
+            <Icons.Desktop size="S" />
+            <ItemContent>
+              <Switch isChecked={mobileView.display}></Switch>
+            </ItemContent>
+            <Icons.Mobile size="S" />
+          </ItemContainer>
+          {mobileView.display && (
+            <Box style={{ marginRight: 16 }}>
+              <Input
+                small
+                value={`${mobileView.width}` || ""}
+                onChange={(e: string) => {
+                  const value = parseInt(e, 10) || 0;
+                  updateMobileWidth?.(value);
+                }}
+                onBlur={() => {
+                  if (!mobileView.width) {
+                    updateMobileWidth?.(355);
+                  }
+                }}
+                style={{ width: 30, textAlign: "center" }}
+                maxLength={4}
+              />
+            </Box>
+          )}
         </>
       ) : null}
       <RightContainer>

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/index.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { flattenAccountsSelector } from "~/renderer/reducers/accounts";
 import { Web3AppWebview } from "../Web3AppWebview";
-import { TopBar } from "./TopBar";
+import { TopBar, MobileView } from "./TopBar";
 import Box from "../Box";
 import { WebviewAPI, WebviewProps, WebviewState } from "../Web3AppWebview/types";
 import { initialWebviewState } from "../Web3AppWebview/helpers";
@@ -22,9 +22,25 @@ export const Wrapper = styled(Box).attrs(() => ({
   position: relative;
 `;
 
+const initialMobileView: MobileView = {
+  display: false,
+  width: 355,
+};
+interface WebViewWrapperProps {
+  mobileView: MobileView;
+}
+
+export const WebViewWrapper = styled.div<WebViewWrapperProps>`
+  flex: 1;
+  height: 100%;
+  ${({ mobileView }) =>
+    mobileView.display ? `width: ${mobileView.width ?? 355}px;` : "width: 100%;"}
+`;
+
 export default function WebPTXPlayer({ manifest, inputs }: WebviewProps) {
   const webviewAPIRef = useRef<WebviewAPI>(null);
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
+  const [mobileView, setMobileView] = useState<MobileView>(initialMobileView);
 
   const accounts = useSelector(flattenAccountsSelector);
   const customHandlers = usePTXCustomHandlers(manifest, accounts);
@@ -32,14 +48,22 @@ export default function WebPTXPlayer({ manifest, inputs }: WebviewProps) {
   return (
     <Container>
       <Wrapper>
-        <TopBar manifest={manifest} webviewAPIRef={webviewAPIRef} webviewState={webviewState} />
-        <Web3AppWebview
+        <TopBar
           manifest={manifest}
-          inputs={inputs}
-          onStateChange={setWebviewState}
-          ref={webviewAPIRef}
-          customHandlers={customHandlers}
+          webviewAPIRef={webviewAPIRef}
+          webviewState={webviewState}
+          mobileView={mobileView}
+          setMobileView={setMobileView}
         />
+        <WebViewWrapper mobileView={mobileView}>
+          <Web3AppWebview
+            manifest={manifest}
+            inputs={inputs}
+            onStateChange={setWebviewState}
+            ref={webviewAPIRef}
+            customHandlers={customHandlers}
+          />
+        </WebViewWrapper>
       </Wrapper>
     </Container>
   );

--- a/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPTXPlayer/index.tsx
@@ -33,6 +33,7 @@ interface WebViewWrapperProps {
 export const WebViewWrapper = styled.div<WebViewWrapperProps>`
   flex: 1;
   height: 100%;
+  display: flex;
   ${({ mobileView }) =>
     mobileView.display ? `width: ${mobileView.width ?? 355}px;` : "width: 100%;"}
 `;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Added device toggle to the TopBar allowing user to switch resolution between mobile and desktop
- functionality hidden behind **Enable dev tool** developer setting
- functionality has only been applied to PTX WebView, but can be applied to other webviews across LL if required


### ❓ Context

- **JIRA or GitHub link**: [LIVE-17090] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


![image](https://github.com/user-attachments/assets/b20cee66-365a-4d12-82c1-abfab3e0483f)


[LIVE-17090]: https://ledgerhq.atlassian.net/browse/LIVE-17090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ