### PR TITLE
[DO NOT MERGE] chore: set provider in dmk

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -57,6 +57,7 @@ import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/po
 import { setShareAnalytics, setSharePersonalizedRecommendations } from "./actions/settings";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useEnforceSupportedLanguage } from "./hooks/useEnforceSupportedLanguage";
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
 
 const PlatformCatalog = lazy(() => import("~/renderer/screens/platform"));
 const Dashboard = lazy(() => import("~/renderer/screens/dashboard"));
@@ -193,6 +194,9 @@ export default function Default() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const accounts = useSelector(accountsSelector);
   const analyticsConsoleActive = useEnv("ANALYTICS_CONSOLE");
+  const providerNumber = useEnv("FORCE_PROVIDER");
+  const ldmkFeatureFlag = useFeature("ldmkTransport");
+  const dmk = useDeviceManagementKit();
 
   useAccountsWithFundsListener(accounts, updateIdentify);
   useListenToHidDevices();
@@ -210,6 +214,14 @@ export default function Default() {
   const isLocked = useSelector(isLockedSelector);
   const dispatch = useDispatch();
   const isNftReworkedEnabled = nftReworked?.enabled;
+
+  useEffect(() => {
+    if (providerNumber && ldmkFeatureFlag?.enabled) {
+      dmk?.setProvider(providerNumber);
+    }
+    // setting provider only at initialisation
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ldmkFeatureFlag, dmk]);
 
   useEffect(() => {
     if (

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -90,6 +90,7 @@ import { trustchainStoreSelector } from "@ledgerhq/ledger-key-ring-protocol/stor
 import { walletSelector } from "~/reducers/wallet";
 import { exportWalletState, walletStateExportShouldDiffer } from "@ledgerhq/live-wallet/store";
 import { registerTransports } from "~/services/registerTransports";
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-mobile";
 
 if (Config.DISABLE_YELLOW_BOX) {
   LogBox.ignoreAllLogs();
@@ -120,9 +121,19 @@ function App() {
   const accounts = useSelector(accountsSelector);
   const analyticsFF = useFeature("llmAnalyticsOptInPrompt");
   const isLDMKEnabled = Boolean(useFeature("ldmkTransport")?.enabled);
+  const providerNumber = useEnv("FORCE_PROVIDER");
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const dmk = useDeviceManagementKit();
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (providerNumber && isLDMKEnabled) {
+      dmk?.setProvider(providerNumber);
+    }
+    // setting provider only at initialisation
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLDMKEnabled, dmk]);
 
   useEffect(() => registerTransports(isLDMKEnabled), [isLDMKEnabled]);
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureRow.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { setEnvUnsafe, isEnvDefault, getEnv } from "@ledgerhq/live-env";
-
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-mobile";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { FeatureId } from "@ledgerhq/types-live";
 import { Feature, isReadOnly } from "../../../experimental";
@@ -32,10 +32,21 @@ const FeatureRowWithFeatureFlag = ({
   return !featureFlag?.enabled ? <FeatureRow feature={feature} /> : null;
 };
 
-const FeatureRow = ({ feature }: Props) => {
+const FeatureRow = ({
+  feature,
+  onChangeOverride,
+}: Props & { onChangeOverride?: (name: string, value: unknown) => void }) => {
   const { type, ...rest } = feature;
   const Children = experimentalTypesMap[type];
   const { t } = useTranslation();
+  const handleChange = (name: string, value: unknown): boolean => {
+    if (onChangeOverride) {
+      onChangeOverride(name, value);
+      return true;
+    }
+    setEnvUnsafe(name, value);
+    return true;
+  };
   // we only display a feature as experimental if it is not enabled already via feature flag
   return (
     <SettingsRow
@@ -46,7 +57,7 @@ const FeatureRow = ({ feature }: Props) => {
       <Children
         checked={!isEnvDefault(feature.name)}
         readOnly={isReadOnly(feature.name)}
-        onChange={setEnvUnsafe}
+        onChange={handleChange}
         isDefault={isEnvDefault(feature.name) || getEnv(feature.name) === undefined}
         {...rest}
         value={getEnv(feature.name) as number}
@@ -55,11 +66,34 @@ const FeatureRow = ({ feature }: Props) => {
   );
 };
 
+const ForceProviderFeatureRow = ({ feature }: Props) => {
+  const dmk = useDeviceManagementKit();
+  const ldmkFeatureFlag = useFeature("ldmkTransport");
+
+  const onChangeOverride = (name: string, value: unknown) => {
+    if (dmk && ldmkFeatureFlag?.enabled) {
+      dmk.setProvider(value);
+    }
+    setEnvUnsafe(name, value);
+  };
+
+  return <FeatureRow feature={feature} onChangeOverride={onChangeOverride} />;
+};
+
+const PluckProviderFeatureRow = (feature: Feature) => {
+  switch (feature.name) {
+    case "FORCE_PROVIDER":
+      return <ForceProviderFeatureRow key={feature.name} feature={feature} />;
+    default:
+      return <FeatureRow key={feature.name} feature={feature} />;
+  }
+};
+
 const FeatureRowCommon = ({ feature }: Props) =>
   feature.rolloutFeatureFlag ? (
     <FeatureRowWithFeatureFlag feature={feature} featureFlagId={feature.rolloutFeatureFlag} />
   ) : (
-    <FeatureRow feature={feature} />
+    PluckProviderFeatureRow(feature)
   );
 
 export default FeatureRowCommon;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
