### PR TITLE
🐛  bugfix(lld): change ledger sync default device model from nanos…

### DIFF
--- a/.changeset/pretty-moons-rescue.md
+++ b/.changeset/pretty-moons-rescue.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LLD - Ledger Sync Default Device Model animation changed from NanoS to Stax

--- a/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/DeviceActions/openOrInstall.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/WalletSync/screens/DeviceActions/openOrInstall.tsx
@@ -7,6 +7,7 @@ import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { createAction } from "@ledgerhq/live-common/hw/actions/app";
 import { TRUSTCHAIN_APP_NAME } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
+import { DeviceModelId } from "@ledgerhq/devices";
 
 const action = createAction(getEnv("MOCK") ? mockedEventEmitter : connectApp);
 
@@ -22,6 +23,7 @@ export default function OpenOrInstallTrustChainApp({ goNext }: Props) {
       action={action}
       request={request}
       onResult={({ device }) => goNext(device)}
+      overridesPreferredDeviceModel={DeviceModelId.stax}
     />
   );
 }


### PR DESCRIPTION
… to stax

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Stax Device animation displayed instead of the NanoS one

### 📝 Description


| Before        | After         |
| ------------- | ------------- |
|![Screenshot 2025-04-08 at 09 58 37](https://github.com/user-attachments/assets/e25d2c7c-c4b2-4c15-902d-8bfdf08042c9)|![Screenshot 2025-04-08 at 09 46 23](https://github.com/user-attachments/assets/5a0fd0a6-a32e-4b18-a722-a2945b1c25e1)|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18262]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18262]: https://ledgerhq.atlassian.net/browse/LIVE-18262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ