### PR TITLE
fix(wallet-api): account.receive doesn't resolve when dismissing the modal [LIVE-18234]

### DIFF
--- a/.changeset/thin-garlics-fail.md
+++ b/.changeset/thin-garlics-fail.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(wallet-api): account.receive doesn't resolve when dismissing the modal

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -116,6 +116,10 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
                     tracking.platformReceiveFail(manifest);
                     reject(error);
                   },
+                  onClose: () => {
+                    tracking.platformReceiveFail(manifest);
+                    reject(new UserRefusedOnDevice());
+                  },
                   verifyAddress: true,
                 }),
               ),

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -74,7 +74,14 @@ function useUiHook(manifest: AppManifest, tracking: Record<string, TrackFunction
           },
         );
       },
-      "account.receive": ({ account, parentAccount, accountAddress, onSuccess, onError }) => {
+      "account.receive": ({
+        account,
+        parentAccount,
+        accountAddress,
+        onSuccess,
+        onError,
+        onCancel,
+      }) => {
         ipcRenderer.send("show-app", {});
         dispatch(
           openModal("MODAL_EXCHANGE_CRYPTO_DEVICE", {
@@ -84,6 +91,7 @@ function useUiHook(manifest: AppManifest, tracking: Record<string, TrackFunction
               onSuccess(accountAddress);
             },
             onCancel: onError,
+            onClose: onCancel,
             verifyAddress: true,
           }),
         );

--- a/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/ExchangeDeviceConfirm/index.tsx
@@ -154,6 +154,7 @@ export type DataProp = {
   onResult: (c: AccountLike, b: Account | undefined | null, a: AppResult | boolean) => void;
   verifyAddress?: boolean;
   onCancel?: (error: Error) => void;
+  onClose?: () => void;
   flow?: string;
 };
 type Props = {
@@ -298,13 +299,13 @@ const BuyCryptoModal = ({
     />
   );
 };
-const BuyCrypto = ({ flow }: { flow?: string }) => {
+const BuyCrypto = ({ flow, onClose }: { flow?: string; onClose?: () => void }) => {
   const render = useCallback(
     ({ data, onClose }: { data: DataProp; onClose: () => void }) => (
       <BuyCryptoModal data={data} onClose={onClose} flow={flow} />
     ),
     [flow],
   );
-  return <Modal name="MODAL_EXCHANGE_CRYPTO_DEVICE" centered render={render} />;
+  return <Modal name="MODAL_EXCHANGE_CRYPTO_DEVICE" centered render={render} onClose={onClose} />;
 };
 export default BuyCrypto;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually at the moment
- [x] **Impact of the changes:**
  - not much live-app that use the `account.receive`

### 📝 Description

`account.receive` doesn't resolve when dismissing the modal on desktop


https://github.com/user-attachments/assets/b1322933-8644-4c36-87cc-d0f779a798ed

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18234]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18234]: https://ledgerhq.atlassian.net/browse/LIVE-18234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ