### PR TITLE
fix(LIVE-18325): add test case reproducing tezos fee estimation bug

### DIFF
--- a/libs/coin-modules/coin-tezos/src/logic/estimateFees.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/estimateFees.integ.test.ts
@@ -20,6 +20,12 @@ describe("estimateFees", () => {
       balance: BigInt("2000000"),
       revealed: false,
     },
+    {
+      // No xpub provided
+      address: "tz2BLK1LbU1bUEj6v7L97U7ZXM5tZWr6vZEr",
+      balance: BigInt("2000000"),
+      revealed: false,
+    },
   ];
 
   it.each(accounts)("returns correct value", async account => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Tezos coin module uses `getAccountInfo` to get the account pub key, and configure the signer to perform the fee estimation. But sometimes the pub key is not returned (seems when account is unrevealed), and we end formatting a bogus key. This works with some accounts but not all, see integration tests.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-18325


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
