### PR TITLE
Fix/zcash txversion all backward compatible

### DIFF
--- a/.changeset/fresh-fans-fetch.md
+++ b/.changeset/fresh-fans-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-btc": patch
+---
+
+fix: zcash, fix consensus branch id computation

--- a/.changeset/rare-apes-appear.md
+++ b/.changeset/rare-apes-appear.md
@@ -1,6 +1,5 @@
 ---
 "@ledgerhq/hw-app-btc": patch
-"@ledgerhq/live-common": patch
 ---
 
 fix: zcash, fix consensus branch id computation

--- a/.changeset/rare-apes-appear.md
+++ b/.changeset/rare-apes-appear.md
@@ -1,5 +1,6 @@
 ---
 "@ledgerhq/hw-app-btc": patch
+"@ledgerhq/live-common": patch
 ---
 
 fix: zcash, fix consensus branch id computation

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -53,7 +53,7 @@ const appConfig: Record<string, ConfigInfo> = {
   config_nanoapp_zcash: {
     type: "object",
     default: {
-      minVersion: "2.3.2",
+      minVersion: "2.3.1",
     },
   },
   config_nanoapp_near: {

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -53,7 +53,7 @@ const appConfig: Record<string, ConfigInfo> = {
   config_nanoapp_zcash: {
     type: "object",
     default: {
-      minVersion: "2.3.1",
+      minVersion: "2.3.2",
     },
   },
   config_nanoapp_near: {

--- a/libs/ledgerjs/packages/hw-app-btc/src/constants.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/constants.ts
@@ -17,5 +17,19 @@ export const OP_EQUALVERIFY = 0x88;
 export const OP_CHECKSIG = 0xac;
 export const OP_RETURN = 0x6a;
 
-// https://zips.z.cash/zip-0253
-export const ZCASH_NU6_ACTIVATION_HEIGHT = 2726400;
+export const ZCASH_ACTIVATION_HEIGHTS = {
+  // https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html
+  // https://zips.z.cash/zip-0253
+  NU6: 2726400,
+  // https://zips.z.cash/zip-0252
+  NU5: 1687104,
+  // https://zips.z.cash/zip-0251
+  CANOPY: 1046400,
+  // https://zips.z.cash/zip-0250
+  HEARTWOOD: 903000,
+  // https://z.cash/upgrade/blossom/
+  // https://zips.z.cash/zip-0206
+  BLOSSOM: 653600,
+  // https://zips.z.cash/zip-0205
+  SAPLING: 419200,
+};

--- a/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
@@ -73,13 +73,17 @@ export async function getTrustedInput(
 
   const processWholeScriptBlock = block => getTrustedInputRaw(transport, block);
 
+  const isZcash = additionals.includes("zcash");
+  // NOTE: this isn't necessary as consensusBranchId is only set when the transaction is a zcash tx
+  // but better safe than sorry
+  const zCashConsensusBranchId = transaction.consensusBranchId || Buffer.alloc(0);
   await getTrustedInputRaw(
     transport,
     Buffer.concat([
       transaction.version,
       transaction.timestamp || Buffer.alloc(0),
       transaction.nVersionGroupId || Buffer.alloc(0),
-      transaction.consensusBranchId || Buffer.alloc(0),
+      isZcash ? zCashConsensusBranchId : Buffer.alloc(0),
       createVarint(inputs.length),
     ]),
     indexLookup,

--- a/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
@@ -79,6 +79,7 @@ export async function getTrustedInput(
       transaction.version,
       transaction.timestamp || Buffer.alloc(0),
       transaction.nVersionGroupId || Buffer.alloc(0),
+      transaction.consensusBranchId || Buffer.alloc(0),
       createVarint(inputs.length),
     ]),
     indexLookup,

--- a/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
@@ -35,7 +35,6 @@ export async function getTrustedInput(
 ): Promise<string> {
   const { inputs, outputs, locktime, nExpiryHeight, extraData } = transaction;
 
-
   if (!outputs || !locktime) {
     throw new Error("getTrustedInput: locktime & outputs is expected");
   }
@@ -92,7 +91,7 @@ export async function getTrustedInput(
       transaction.version,
       transaction.timestamp || Buffer.alloc(0),
       transaction.nVersionGroupId || Buffer.alloc(0),
-      (isZcash && !useOlderZcash) ? zCashConsensusBranchId : Buffer.alloc(0),
+      isZcash && !useOlderZcash ? zCashConsensusBranchId : Buffer.alloc(0),
       createVarint(inputs.length),
     ]),
     indexLookup,

--- a/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInput.ts
@@ -3,7 +3,6 @@ import type Transport from "@ledgerhq/hw-transport";
 import type { Transaction } from "./types";
 import { MAX_SCRIPT_BLOCK } from "./constants";
 import { createVarint } from "./varint";
-import { getAppAndVersion } from "./getAppAndVersion";
 import { shouldUseOlderZcash } from "./utils";
 
 export async function getTrustedInputRaw(

--- a/libs/ledgerjs/packages/hw-app-btc/src/serializeTransaction.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/serializeTransaction.ts
@@ -67,7 +67,7 @@ export function serializeTransaction(
     return Buffer.concat([
       transaction.version,
       transaction.nVersionGroupId || Buffer.alloc(0),
-      Buffer.from([0x55, 0x10, 0xe7, 0xc8]), // Zcash Consensus Branch ID: 0xC8E71055 refer to https://zips.z.cash/zip-0253
+      transaction.consensusBranchId || Buffer.from([0x00, 0x00, 0x00, 0x00]),
       transaction.locktime || Buffer.from([0x00, 0x00, 0x00, 0x00]),
       transaction.nExpiryHeight || Buffer.from([0x00, 0x00, 0x00, 0x00]),
       useWitness ? Buffer.from("0001", "hex") : Buffer.alloc(0),

--- a/libs/ledgerjs/packages/hw-app-btc/src/splitTransaction.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/splitTransaction.ts
@@ -2,6 +2,7 @@ import { log } from "@ledgerhq/logs";
 import type { Transaction, TransactionInput, TransactionOutput } from "./types";
 import { getVarint } from "./varint";
 import { formatTransactionDebug } from "./debug";
+
 export function splitTransaction(
   transactionHex: string,
   isSegwitSupported: boolean | null | undefined = false,

--- a/libs/ledgerjs/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
@@ -45,6 +45,7 @@ export async function startUntrustedHashTransactionInput(
     transaction.version,
     transaction.timestamp || Buffer.alloc(0),
     transaction.nVersionGroupId || Buffer.alloc(0),
+    transaction.consensusBranchId || Buffer.alloc(0),
     createVarint(transaction.inputs.length),
   ]);
   await startUntrustedHashTransactionInputRaw(

--- a/libs/ledgerjs/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
@@ -3,6 +3,7 @@ import type { Transaction } from "./types";
 import { createVarint } from "./varint";
 import { MAX_SCRIPT_BLOCK } from "./constants";
 import { shouldUseOlderZcash } from "./utils";
+
 export function startUntrustedHashTransactionInputRaw(
   transport: Transport,
   newTransaction: boolean,

--- a/libs/ledgerjs/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/startUntrustedHashTransactionInput.ts
@@ -41,11 +41,13 @@ export async function startUntrustedHashTransactionInput(
   additionals: Array<string> = [],
   useTrustedInputForSegwit = false,
 ): Promise<any> {
+  const isZcash = additionals.includes("zcash");
+  const zCashConsensusBranchId = transaction.consensusBranchId || Buffer.alloc(0);
   let data = Buffer.concat([
     transaction.version,
     transaction.timestamp || Buffer.alloc(0),
     transaction.nVersionGroupId || Buffer.alloc(0),
-    transaction.consensusBranchId || Buffer.alloc(0),
+    isZcash ? zCashConsensusBranchId : Buffer.alloc(0),
     createVarint(transaction.inputs.length),
   ]);
   await startUntrustedHashTransactionInputRaw(

--- a/libs/ledgerjs/packages/hw-app-btc/src/types.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/types.ts
@@ -38,6 +38,8 @@ export interface Transaction {
   nExpiryHeight?: Buffer;
   // extraData is used only for Zcash and ZenCash and komodo
   extraData?: Buffer;
+  // zCash specific
+  consensusBranchId?: Buffer;
 }
 
 export interface TrustedInput {

--- a/libs/ledgerjs/packages/hw-app-btc/src/utils.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/utils.ts
@@ -2,22 +2,20 @@ import semver from "semver";
 import type Transport from "@ledgerhq/hw-transport";
 import { getAppAndVersion } from "./getAppAndVersion";
 
-
+/*
+FIXME: this temporary, remove once both LLM7 & LLDR8 are out
+*/
 export async function shouldUseOlderZcash(transport: Transport): Promise<boolean> {
   let useOlderZcash = false;
   try {
     const { name, version } = await getAppAndVersion(transport);
-    console.log({ name, version });
 
     if (name != "Zcash") return false;
     const coercedVersion = semver.coerce(version);
-    console.log({ name, version, coercedVersion });
     if (semver.lt(coercedVersion, "2.3.2")) {
-      console.log("Zcash version is older than 2.3.2");
       useOlderZcash = true;
     }
   } catch (e: any) {
-    console.log("Error getting app version", e);
     if (e.statusCode === 0x6d00) {
       useOlderZcash = false;
     } else {

--- a/libs/ledgerjs/packages/hw-app-btc/src/utils.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/utils.ts
@@ -1,0 +1,28 @@
+import semver from "semver";
+import type Transport from "@ledgerhq/hw-transport";
+import { getAppAndVersion } from "./getAppAndVersion";
+
+
+export async function shouldUseOlderZcash(transport: Transport): Promise<boolean> {
+  let useOlderZcash = false;
+  try {
+    const { name, version } = await getAppAndVersion(transport);
+    console.log({ name, version });
+
+    if (name != "Zcash") return false;
+    const coercedVersion = semver.coerce(version);
+    console.log({ name, version, coercedVersion });
+    if (semver.lt(coercedVersion, "2.3.2")) {
+      console.log("Zcash version is older than 2.3.2");
+      useOlderZcash = true;
+    }
+  } catch (e: any) {
+    console.log("Error getting app version", e);
+    if (e.statusCode === 0x6d00) {
+      useOlderZcash = false;
+    } else {
+      throw e;
+    }
+  }
+  return useOlderZcash;
+}

--- a/libs/ledgerjs/packages/hw-app-btc/tests/createTransaction.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/createTransaction.test.ts
@@ -1,11 +1,13 @@
 import { ZCASH_ACTIVATION_HEIGHTS } from "../src/constants";
 import { getDefaultVersions } from "../src/createTransaction";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
+import * as hwUtils from "../src/utils";
 import Btc from "../src/Btc";
 
 describe("createTransaction", () => {
   describe("createTransaction", () => {
     test("zcash", async () => {
+      jest.spyOn(hwUtils, "shouldUseOlderZcash").mockResolvedValue(false);
       const transport = await openTransportReplayer(
         RecordStore.fromString(`
         => b001000000

--- a/libs/ledgerjs/packages/hw-app-btc/tests/createTransaction.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/createTransaction.test.ts
@@ -1,4 +1,4 @@
-import { ZCASH_NU6_ACTIVATION_HEIGHT } from "../src/constants";
+import { ZCASH_ACTIVATION_HEIGHTS } from "../src/constants";
 import { getDefaultVersions } from "../src/createTransaction";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 import Btc from "../src/Btc";
@@ -10,7 +10,7 @@ describe("createTransaction", () => {
         RecordStore.fromString(`
         => b001000000
         <= 01055a6361736805322e332e3101029000
-        => e04200000d00000000050000800a27a72601
+        => e04200001100000000050000800a27a726b4d0d6c201
         <= 9000
         => e0428000251d73f1a467297aab205ee7a4ed506f28ea558056401b4f6d308016c1b58d27f4010000006a
         <= 9000
@@ -28,7 +28,7 @@ describe("createTransaction", () => {
         <= 9000
         => e042800009000000000400000000
         <= 3200ed40989caa0731d6526fe4e03d49c54720be148f911924129e15d7ecf6e190829edb0000000050c3000000000000d53c396d2f5c98619000
-        => e04200000d00000000060000800a27a72601
+        => e04200001100000000050000800a27a7265510e7c801
         <= 9000
         => e0428000258c63f70704d9987dafffc5481b171dee900e9b6d71261fee880543bc96c41d11000000006b
         <= 9000
@@ -51,7 +51,7 @@ describe("createTransaction", () => {
         <= 9000
         => e04000000100
         <= 9000
-        => e0440000050100000002
+        => e044000009010000005510e7c802
         <= 9000
 
         => e04480003b01383200ed40989caa0731d6526fe4e03d49c54720be148f911924129e15d7ecf6e190829edb0000000050c3000000000000d53c396d2f5c986119
@@ -74,7 +74,7 @@ describe("createTransaction", () => {
         <= 00009000
 
 
-        => e0440080050100000002
+        => e044008009010000005510e7c802
         <= 9000
 
         => e04480803b01383200ed40989caa0731d6526fe4e03d49c54720be148f911924129e15d7ecf6e190829edb0000000050c3000000000000d53c396d2f5c986100
@@ -154,10 +154,8 @@ output 1: amount 0e532a0000000000 script 76a9144cd6509f71020b6a9e890bef43c4d5e61
         sapling: false,
         isDecred: false,
         expiryHeight: undefined,
-        blockHeight: undefined,
       });
       expect(result.defaultVersion.readUInt32LE(0)).toBe(1);
-      expect(result.defaultVersionNu5Only.readUInt32LE(0)).toBe(1);
     });
 
     it("should return Zcash versions with expiryHeight and blockHeight below activation height", () => {
@@ -166,24 +164,20 @@ output 1: amount 0e532a0000000000 script 76a9144cd6509f71020b6a9e890bef43c4d5e61
         sapling: false,
         isDecred: false,
         expiryHeight: Buffer.alloc(4),
-        blockHeight: 1000,
       });
       expect(result.defaultVersion.readUInt32LE(0)).toBe(0x80000005);
-      expect(result.defaultVersionNu5Only.readUInt32LE(0)).toBe(0x80000005);
     });
 
     it("should return Zcash versions with expiryHeight and blockHeight above activation height", () => {
       const blockHeight = 3_000_000;
-      expect(blockHeight > ZCASH_NU6_ACTIVATION_HEIGHT).toBe(true);
+      expect(blockHeight > ZCASH_ACTIVATION_HEIGHTS.NU6).toBe(true);
       const result = getDefaultVersions({
         isZcash: true,
         sapling: false,
         isDecred: false,
         expiryHeight: Buffer.alloc(4),
-        blockHeight: blockHeight,
       });
-      expect(result.defaultVersion.readUInt32LE(0)).toBe(0x80000006);
-      expect(result.defaultVersionNu5Only.readUInt32LE(0)).toBe(0x80000005);
+      expect(result.defaultVersion.readUInt32LE(0)).toBe(0x80000005);
     });
 
     it("should return Sapling versions with expiryHeight", () => {
@@ -192,10 +186,8 @@ output 1: amount 0e532a0000000000 script 76a9144cd6509f71020b6a9e890bef43c4d5e61
         sapling: true,
         isDecred: false,
         expiryHeight: Buffer.alloc(4),
-        blockHeight: undefined,
       });
       expect(result.defaultVersion.readUInt32LE(0)).toBe(0x80000004);
-      expect(result.defaultVersionNu5Only.readUInt32LE(0)).toBe(0x80000004);
     });
 
     it("should return non-Sapling versions with expiryHeight", () => {
@@ -204,10 +196,8 @@ output 1: amount 0e532a0000000000 script 76a9144cd6509f71020b6a9e890bef43c4d5e61
         sapling: false,
         isDecred: false,
         expiryHeight: Buffer.alloc(4),
-        blockHeight: undefined,
       });
       expect(result.defaultVersion.readUInt32LE(0)).toBe(0x80000003);
-      expect(result.defaultVersionNu5Only.readUInt32LE(0)).toBe(0x80000003);
     });
 
     it("should return default versions for Decred with expiryHeight", () => {
@@ -216,10 +206,8 @@ output 1: amount 0e532a0000000000 script 76a9144cd6509f71020b6a9e890bef43c4d5e61
         sapling: false,
         isDecred: true,
         expiryHeight: Buffer.alloc(4),
-        blockHeight: undefined,
       });
       expect(result.defaultVersion.readUInt32LE(0)).toBe(1);
-      expect(result.defaultVersionNu5Only.readUInt32LE(0)).toBe(1);
     });
   });
 });

--- a/libs/ledgerjs/packages/hw-app-btc/tests/splitTransaction.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/splitTransaction.test.ts
@@ -1,0 +1,85 @@
+import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
+import Btc from "../src/Btc";
+
+describe("splitTransaction", () => {
+  test("zcash", async () => {
+    const transport = await openTransportReplayer(RecordStore.fromString(""));
+    const btc = new Btc({ transport, currency: "zcash" });
+    /*
+
+splitTransaction 050000800a27a726b4d0d6c20000000000000000011d73f1a467297aab205ee7a4ed506f28ea558056401b4f6d308016c1b58d27f4010000006a4730440220337050efe67689fdbdccd2058f6f7b7fe3b13070d91cd0d7ecb1f84e622a220b02201356d33259d64db1095879cfce666b016771cf4e239376497b7f82efedd9c54a01210396fcfd94e1bfb2949e0acbab934583c11ad29d14105d25528aff75673c50650c000000000250c30000000000001976a914de3542c396924ada3c5850225770f6dd3e2249b988ac3df2c202000000001976a914fc0da061ca85923e01d97ac276aa8dc890a28efa88ac000000:
+TX version 05000080 locktime 00000000 timestamp  nVersionGroupId 0a27a726 nExpiryHeight 00000000 extraData 
+input 0: prevout 1d73f1a467297aab205ee7a4ed506f28ea558056401b4f6d308016c1b58d27f401000000 script 4730440220337050efe67689fdbdccd2058f6f7b7fe3b13070d91cd0d7ecb1f84e622a220b02201356d33259d64db1095879cfce666b016771cf4e239376497b7f82efedd9c54a01210396fcfd94e1bfb2949e0acbab934583c11ad29d14105d25528aff75673c50650c sequence 00000000
+output 0: amount 50c3000000000000 script 76a914de3542c396924ada3c5850225770f6dd3e2249b988ac
+output 1: amount 3df2c20200000000 script 76a914fc0da061ca85923e01d97ac276aa8dc890a28efa88ac
+      */
+    const tx1 = btc.splitTransaction(
+      "050000800a27a726b4d0d6c20000000000000000011d73f1a467297aab205ee7a4ed506f28ea558056401b4f6d308016c1b58d27f4010000006a4730440220337050efe67689fdbdccd2058f6f7b7fe3b13070d91cd0d7ecb1f84e622a220b02201356d33259d64db1095879cfce666b016771cf4e239376497b7f82efedd9c54a01210396fcfd94e1bfb2949e0acbab934583c11ad29d14105d25528aff75673c50650c000000000250c30000000000001976a914de3542c396924ada3c5850225770f6dd3e2249b988ac3df2c202000000001976a914fc0da061ca85923e01d97ac276aa8dc890a28efa88ac000000",
+      true,
+      true,
+      ["zcash", "sapling"],
+    );
+    /*
+       splitTransaction 050000800a27a7265510e7c80000000000000000018c63f70704d9987dafffc5481b171dee900e9b6d71261fee880543bc96c41d11000000006b48304502210098a92ce696ff51d46233885e5ea7d0bc0bcd04621c6d79e4230e579f9b13f1480220772d04b65133859ef7fb146a41080b1187335fed9daf62a237b6bd54657f555d0121039402a22682e936ab3c1e2f649859ba13b39a59bd74212ac903a42b5aea5032790000000002404b4c00000000001976a914c59ace9b52af703379f3f89ebbc8ec1813ca50ec88ac0e532a00000000001976a9144cd6509f71020b6a9e890bef43c4d5e61f9c0dad88ac000000:
+TX version 05000080 locktime 00000000 timestamp  nVersionGroupId 0a27a726 nExpiryHeight 00000000 extraData 
+input 0: prevout 8c63f70704d9987dafffc5481b171dee900e9b6d71261fee880543bc96c41d1100000000 script 48304502210098a92ce696ff51d46233885e5ea7d0bc0bcd04621c6d79e4230e579f9b13f1480220772d04b65133859ef7fb146a41080b1187335fed9daf62a237b6bd54657f555d0121039402a22682e936ab3c1e2f649859ba13b39a59bd74212ac903a42b5aea503279 sequence 00000000
+output 0: amount 404b4c0000000000 script 76a914c59ace9b52af703379f3f89ebbc8ec1813ca50ec88ac
+output 1: amount 0e532a0000000000 script 76a9144cd6509f71020b6a9e890bef43c4d5e61f9c0dad88ac
+      */
+    const tx2 = btc.splitTransaction(
+      "050000800a27a7265510e7c80000000000000000018c63f70704d9987dafffc5481b171dee900e9b6d71261fee880543bc96c41d11000000006b48304502210098a92ce696ff51d46233885e5ea7d0bc0bcd04621c6d79e4230e579f9b13f1480220772d04b65133859ef7fb146a41080b1187335fed9daf62a237b6bd54657f555d0121039402a22682e936ab3c1e2f649859ba13b39a59bd74212ac903a42b5aea5032790000000002404b4c00000000001976a914c59ace9b52af703379f3f89ebbc8ec1813ca50ec88ac0e532a00000000001976a9144cd6509f71020b6a9e890bef43c4d5e61f9c0dad88ac000000",
+      true,
+      true,
+      ["zcash", "sapling"],
+    );
+  });
+  test("Zcash Sapling transaction (v4)", async () => {
+    const transport = await openTransportReplayer(RecordStore.fromString(""));
+    const btc = new Btc({ transport, currency: "zcash" });
+
+    const hex =
+      "0400008085202f890177507ef339c27d8d453723c568361fb93671f521f1ba2c42a0f136650939aaa5010000006b48304502210099a9fa0817083a1ce6f96404ed7366d9200f5533a9ccfcd4eddb50be4646c8a102205a6cccc8965f1ea45d6f32d96dda89a3cbb0422fad2a0e05b40fa51c0e51322a0121029f7331870af5630f14fe86e10b6ef696ee152bffb34e71396a4ce82ef64aa23effffffff0240781501000000001976a9144cf48844c49a77ba86e48b070f06151b712c862988ace39e0f02000000001976a91445110888402e6fd0c86329d9eda36c7a3fa354a588ac00000000000000000000000000000000000000";
+
+    const tx = btc.splitTransaction(hex, true, true, ["zcash", "sapling"]);
+
+    expect(tx?.version.toString("hex")).toBe("04000080");
+    // expect(tx.nVersionGroupId).toBeDefined();
+    expect(tx.nVersionGroupId?.toString("hex")).toBe("85202f89");
+    expect(tx.locktime?.toString("hex")).toBe("00000000");
+    expect(tx.nExpiryHeight?.toString("hex")).toBe("00000000");
+
+    expect(tx.inputs.length).toBe(1);
+    expect(tx.outputs?.length).toBe(2);
+
+    expect(tx.outputs![0].amount.toString("hex")).toBe("4078150100000000")
+    expect(tx.outputs![0].script.toString("hex")).toBe("76a9144cf48844c49a77ba86e48b070f06151b712c862988ac");
+    
+    expect(tx.extraData).toBeDefined();
+    expect(tx.extraData?.length).toBe(11); // valueBalance (8) + shieldedSpend (1) + shieldedOutput (1) + joinSplit (1)
+    expect(tx.extraData!.toString("hex")).toBe("0000000000000000" + "00" +  "00" + "00"); // empty shielded stuff
+  });
+
+  test.only("Zcash NU5 transaction (v5)", async () => {
+    const transport = await openTransportReplayer(RecordStore.fromString(""));
+    const btc = new Btc({ transport, currency: "zcash" });
+
+    const hex =
+      "050000800a27a7265510e7c8000000000000000001b5c51aa7f90bd40671eb4887f0022613f5c773f8a30e0c38ff9fc933b754a218000000006b483045022100b4b7b664f7ac6e78026f81f04f9c6fbd7ccbee532ba53e4150ccb6a7c0bd21510220277b4cfdf44683e77a4211e88a3052be00d1c678c36f357db935450c13f2f33701210223b8ffaccab6cc90d2164bfc4361bb058b030217e7cccf677347f075beeef3bb0000000001c0a79500000000001976a914168bb00f59a2d1a059d7e60fcc709cd5a979992988ac000000";
+
+    const tx = btc.splitTransaction(hex, true, true, ["zcash", "sapling"]);
+
+    expect(tx.version.toString("hex")).toBe("05000080");
+    expect(tx.nVersionGroupId?.toString("hex")).toBe("0a27a726");
+    expect(tx.locktime?.toString("hex")).toBe("00000000");
+    expect(tx.nExpiryHeight?.toString("hex")).toBe("00000000");
+
+    expect(tx.inputs.length).toBe(1);
+    expect(tx.outputs?.length).toBe(1);
+
+    expect(tx.outputs![0].amount.toString("hex")).toBe("c0a7950000000000");
+    expect(tx.outputs![0].script.toString("hex")).toBe("76a914168bb00f59a2d1a059d7e60fcc709cd5a979992988ac");
+    expect(tx.extraData).toBeDefined();
+    // Overwinter : use nJoinSplit (1)
+    expect(tx.extraData!.length).toBe(0); // no extraData for pure NU5 transparent tx
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Goal:
Refactor and fix Zcash consensus branch ID computation in LedgerJS Bitcoin app, to properly handle multiple Zcash network upgrades (NU6, NU5, etc.), and improve transaction versioning & serialization for Zcash.

Goes hand in hand with: https://github.com/LedgerHQ/app-zcash/compare/develop...LedgerHQ:app-zcash:fix/apa/anotherone

#### Code Improvements

- Branch IDs by Height
Old: single constant ZCASH_NU6_ACTIVATION_HEIGHT.

New: new object ZCASH_ACTIVATION_HEIGHTS with all major Zcash network upgrade heights (Sapling, Blossom, Heartwood, Canopy, NU5, NU6).

- New `getZcashBranchId()` function
Determines correct consensusBranchId based on block height.

Maps block height to correct consensus branch ID per Zcash specs.

- Simplified `getDefaultVersions()`
Removed outdated logic about defaultVersionNu5Only.

Keeps only defaultVersion (cleaner logic).

- Transaction creation flow:
Injects the correct consensusBranchId into:

Inputs processing, Final transaction, Serialization, Trusted Input generation and Signature hashing flow

- Type update
Transaction type now includes optional `consensusBranchId`.

#### Serialization improvements

Replaces hardcoded consensus branch ID in serializeTransaction.ts with dynamic value:

```diff
- Buffer.from([0x55, 0x10, 0xe7, 0xc8])
+ transaction.consensusBranchId || Buffer.from([0x00, 0x00, 0x00, 0x00])
```

#### Tests

- Updated existing tests in createTransaction.test.ts to remove defaultVersionNu5Only assertions.

- Added new test suite splitTransaction.test.ts:

Tests Zcash NU5, Sapling, and multi-version transactions.

Ensures splitTransaction properly reads versions, group IDs, expiry height, inputs, outputs, and extra data.

Covers: Sapling transactions (v4) and NU5 transactions (v5)

Summary outcome:

✅ More future-proof Zcash support (handles past & future upgrades cleanly).
✅ Critical bugfix: consensus branch ID is now computed dynamically, removing hardcoded assumptions.

### ❓ Context

- **JIRA or GitHub link**: LIVE-17666

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)