### PR TITLE
📈 (dmk): Add analytics for opt-in for transaction checks

### DIFF
--- a/.changeset/weak-pumpkins-retire.md
+++ b/.changeset/weak-pumpkins-retire.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-evm": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-signer-evm": minor
+---
+
+Add tracking during opt-in transaction checks

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.test.ts
@@ -1,0 +1,191 @@
+import { renderHook } from "tests/testUtils";
+import {
+  useTrackTransactionChecksFlow,
+  UseTrackTransactionChecksFlow,
+} from "./useTrackTransactionChecksFlow";
+import { track } from "../segment";
+import { CONNECTION_TYPES } from "./variables";
+import { DeviceInfo } from "@ledgerhq/types-live";
+import { AppAndVersion } from "@ledgerhq/live-common/hw/connectApp";
+
+jest.mock("../segment", () => ({
+  track: jest.fn(),
+  setAnalyticsFeatureFlagMethod: jest.fn(),
+}));
+
+describe("useTrackTransactionChecksFlow", () => {
+  const deviceMock = {
+    modelId: "Europa",
+    wired: true,
+  };
+
+  const deviceInfoMock: DeviceInfo = {
+    version: "2.0.0",
+    hardwareVersion: 1,
+    mcuVersion: "1.1.0",
+    bootloaderVersion: "1.2.0",
+    providerName: "Ledger",
+    languageId: 1,
+    majMin: "2.0",
+    targetId: "0.0",
+    isBootloader: false,
+    isOSU: false,
+    managerAllowed: false,
+    pinValidated: false,
+  };
+
+  const appAndVersionMock: AppAndVersion = {
+    name: "Bitcoin",
+    version: "1.0.0",
+    flags: 0x1234,
+  };
+
+  const defaultArgs: UseTrackTransactionChecksFlow = {
+    location: "Transaction",
+    device: deviceMock,
+    deviceInfo: deviceInfoMock,
+    appAndVersion: appAndVersionMock,
+    transactionChecksOptInTriggered: false,
+    isTrackingEnabled: true,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should track 'Transaction Check Opt-in Triggered' when transactionChecksOptInTriggered changes from false to true", () => {
+    const { rerender } = renderHook(
+      (props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props),
+      {
+        initialProps: { ...defaultArgs, transactionChecksOptInTriggered: false },
+      },
+    );
+
+    rerender({ ...defaultArgs, transactionChecksOptInTriggered: true });
+
+    expect(track).toHaveBeenCalledWith(
+      "Transaction Check Opt-in Triggered",
+      expect.objectContaining({
+        deviceType: "Europa",
+        connectionType: CONNECTION_TYPES.USB,
+        platform: "LLD",
+        page: "Transaction",
+        appName: "Bitcoin",
+        appVersion: "1.0.0",
+        appFlags: "4660",
+        deviceInfoHardwareVersion: 1,
+        deviceInfoMcuVersion: "1.1.0",
+        deviceInfoBootloaderVersion: "1.2.0",
+        deviceInfoProviderName: "Ledger",
+        deviceInfoLanguageId: 1,
+      }),
+      true,
+    );
+  });
+
+  it("should not track events if transactionChecksOptInTriggered is false", () => {
+    renderHook((props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props), {
+      initialProps: { ...defaultArgs, transactionChecksOptInTriggered: false },
+    });
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("should not track events if transactionChecksOptInTriggered is null", () => {
+    renderHook((props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props), {
+      initialProps: { ...defaultArgs, transactionChecksOptInTriggered: null },
+    });
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("should not track events if transactionChecksOptInTriggered is undefined", () => {
+    renderHook((props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props), {
+      initialProps: { ...defaultArgs, transactionChecksOptInTriggered: undefined },
+    });
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("should use 'unknown' as page when location is undefined", () => {
+    renderHook((props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props), {
+      initialProps: { ...defaultArgs, location: undefined, transactionChecksOptInTriggered: true },
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "Transaction Check Opt-in Triggered",
+      expect.objectContaining({
+        page: "unknown",
+      }),
+      true,
+    );
+  });
+
+  it("should include correct connection type based on device.wired", () => {
+    const bleDeviceMock = { ...deviceMock, wired: false };
+
+    renderHook((props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props), {
+      initialProps: {
+        ...defaultArgs,
+        device: bleDeviceMock,
+        transactionChecksOptInTriggered: true,
+      },
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "Transaction Check Opt-in Triggered",
+      expect.objectContaining({
+        connectionType: CONNECTION_TYPES.BLE,
+      }),
+      true,
+    );
+  });
+
+  it("should only track once even if transactionChecksOptInTriggered remains true on rerender", () => {
+    const { rerender } = renderHook(
+      (props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props),
+      {
+        initialProps: { ...defaultArgs, transactionChecksOptInTriggered: true },
+      },
+    );
+
+    // First render should trigger tracking
+    expect(track).toHaveBeenCalledTimes(1);
+
+    // Rerender with the same props
+    rerender({ ...defaultArgs, transactionChecksOptInTriggered: true });
+
+    // Should still only be called once
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle null deviceInfo and appAndVersion", () => {
+    renderHook((props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props), {
+      initialProps: {
+        ...defaultArgs,
+        deviceInfo: null,
+        appAndVersion: null,
+        transactionChecksOptInTriggered: true,
+      },
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "Transaction Check Opt-in Triggered",
+      expect.objectContaining({
+        deviceType: "Europa",
+        connectionType: CONNECTION_TYPES.USB,
+        platform: "LLD",
+        page: "Transaction",
+        appName: undefined,
+        appVersion: undefined,
+        appFlags: undefined,
+        deviceInfoHardwareVersion: undefined,
+        deviceInfoMcuVersion: undefined,
+        deviceInfoBootloaderVersion: undefined,
+        deviceInfoProviderName: undefined,
+        deviceInfoLanguageId: undefined,
+      }),
+      true,
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.ts
@@ -1,0 +1,47 @@
+import { Device } from "@ledgerhq/types-devices";
+import { track } from "../segment";
+import { CONNECTION_TYPES } from "./variables";
+import { useRef } from "react";
+import { DeviceInfo } from "@ledgerhq/types-live";
+import { AppAndVersion } from "@ledgerhq/live-common/hw/connectApp";
+
+export type UseTrackTransactionChecksFlow = {
+  location: string | undefined;
+  device: Device;
+  deviceInfo: DeviceInfo | undefined | null;
+  appAndVersion: AppAndVersion | undefined | null;
+  transactionChecksOptInTriggered: boolean | undefined | null;
+  isTrackingEnabled: boolean;
+};
+
+export const useTrackTransactionChecksFlow = ({
+  location,
+  device,
+  deviceInfo,
+  appAndVersion,
+  transactionChecksOptInTriggered,
+  isTrackingEnabled,
+}: UseTrackTransactionChecksFlow) => {
+  const triggered = useRef(false);
+
+  if (transactionChecksOptInTriggered && !triggered.current) {
+    triggered.current = true;
+
+    const defaultPayload = {
+      page: location ?? "unknown",
+      deviceType: device?.modelId,
+      connectionType: device?.wired ? CONNECTION_TYPES.USB : CONNECTION_TYPES.BLE,
+      platform: "LLD",
+      appName: appAndVersion?.name,
+      appVersion: appAndVersion?.version,
+      appFlags: appAndVersion?.flags.toString(),
+      deviceInfoHardwareVersion: deviceInfo?.hardwareVersion,
+      deviceInfoMcuVersion: deviceInfo?.mcuVersion,
+      deviceInfoBootloaderVersion: deviceInfo?.bootloaderVersion,
+      deviceInfoProviderName: deviceInfo?.providerName,
+      deviceInfoLanguageId: deviceInfo?.languageId,
+    };
+
+    track("Transaction Check Opt-in Triggered", defaultPayload, isTrackingEnabled);
+  }
+};

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -88,6 +88,7 @@ import { useTrackSendFlow } from "~/renderer/analytics/hooks/useTrackSendFlow";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import { useTrackSyncFlow } from "~/renderer/analytics/hooks/useTrackSyncFlow";
 import { useTrackGenericDAppTransactionSend } from "~/renderer/analytics/hooks/useTrackGenericDAppTransactionSend";
+import { useTrackTransactionChecksFlow } from "~/renderer/analytics/hooks/useTrackTransactionChecksFlow";
 
 export type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
 
@@ -153,6 +154,7 @@ type States = PartialNullable<{
   imageCommitRequested: boolean;
   manifestName: string;
   manifestId: string;
+  transactionChecksOptInTriggered: boolean;
 }>;
 
 type InnerProps<P> = {
@@ -226,6 +228,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     onRepairModal,
     deviceSignatureRequested,
     deviceStreamingProgress,
+    transactionChecksOptInTriggered,
     displayUpgradeWarning,
     passWarning,
     initSwapRequested,
@@ -315,6 +318,15 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     openedAppName: appAndVersion?.name,
     isLocked,
     inWrongDeviceForAccount,
+    isTrackingEnabled: useSelector(trackingEnabledSelector),
+  });
+
+  useTrackTransactionChecksFlow({
+    location,
+    device,
+    deviceInfo,
+    appAndVersion,
+    transactionChecksOptInTriggered,
     isTrackingEnabled: useSelector(trackingEnabledSelector),
   });
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -248,6 +248,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   const swapDefaultTrack = useGetSwapTrackingProperties();
   const stateSettings = useSelector(settingsSelector);
   const walletState = useSelector(walletSelector);
+  const isTrackingEnabled = useSelector(trackingEnabledSelector);
 
   useTrackManagerSectionEvents({
     location: location === HOOKS_TRACKING_LOCATIONS.managerDashboard ? location : undefined,
@@ -255,7 +256,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     allowManagerRequested: hookState.allowManagerRequested,
     clsImageRemoved: hookState.imageRemoved,
     error,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
   });
 
   useTrackReceiveFlow({
@@ -264,14 +265,14 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     error,
     inWrongDeviceForAccount,
     isLocked,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
   });
 
   useTrackAddAccountModal({
     location: location === HOOKS_TRACKING_LOCATIONS.addAccountModal ? location : undefined,
     device,
     error,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
     requestOpenApp,
     userMustConnectDevice: !isLoading && !device,
     isLocked,
@@ -281,7 +282,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     location: location === HOOKS_TRACKING_LOCATIONS.exchange ? location : undefined,
     device,
     error,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
     isLocked,
     inWrongDeviceForAccount,
     isRequestOpenAppExchange: requestOpenApp === "Exchange",
@@ -295,7 +296,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     requestOpenApp,
     isLedgerSyncAppOpen: appAndVersion?.name === "Ledger Sync",
     isLocked,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
     inWrongDeviceForAccount,
   });
 
@@ -305,7 +306,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     error,
     inWrongDeviceForAccount,
     isLocked,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
   });
 
   useTrackGenericDAppTransactionSend({
@@ -318,7 +319,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     openedAppName: appAndVersion?.name,
     isLocked,
     inWrongDeviceForAccount,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
   });
 
   useTrackTransactionChecksFlow({
@@ -327,7 +328,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     deviceInfo,
     appAndVersion,
     transactionChecksOptInTriggered,
-    isTrackingEnabled: useSelector(trackingEnabledSelector),
+    isTrackingEnabled,
   });
 
   const type = useTheme().colors.palette.type;

--- a/libs/coin-modules/coin-evm/src/signOperation.ts
+++ b/libs/coin-modules/coin-evm/src/signOperation.ts
@@ -48,6 +48,9 @@ export const buildSignOperation =
                   )
                   .pipe(
                     tap(event => {
+                      if (event.type === "signer.evm.transaction-checks-opt-in-triggered") {
+                        o.next({ type: "transaction-checks-opt-in-triggered" });
+                      }
                       if (event.type === "signer.evm.signing") {
                         o.next({ type: "device-signature-requested" });
                       }

--- a/libs/coin-modules/coin-evm/src/types/signer.ts
+++ b/libs/coin-modules/coin-evm/src/types/signer.ts
@@ -17,7 +17,8 @@ export type EvmSignature = {
 export type EvmSignerEventType =
   | "signer.evm.loading-context"
   | "signer.evm.signing"
-  | "signer.evm.signed";
+  | "signer.evm.signed"
+  | "signer.evm.transaction-checks-opt-in-triggered";
 
 export type EvmSignerEvent =
   | {

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -26,6 +26,7 @@ type State = {
   deviceSignatureRequested: boolean;
   deviceStreamingProgress: number | null | undefined;
   transactionSignError: Error | null | undefined;
+  transactionChecksOptInTriggered: boolean;
   manifestId?: string;
   manifestName?: string;
 };
@@ -81,6 +82,7 @@ const initialState = {
   deviceSignatureRequested: false,
   deviceStreamingProgress: null,
   transactionSignError: null,
+  transactionChecksOptInTriggered: false,
 };
 
 const reducer = (state: State, e: Event): State => {
@@ -105,6 +107,9 @@ const reducer = (state: State, e: Event): State => {
 
     case "device-streaming":
       return { ...state, deviceStreamingProgress: e.progress };
+
+    case "transaction-checks-opt-in-triggered":
+      return { ...state, transactionChecksOptInTriggered: true };
 
     default:
       return state;

--- a/libs/ledgerjs/packages/types-live/src/transaction.ts
+++ b/libs/ledgerjs/packages/types-live/src/transaction.ts
@@ -50,6 +50,9 @@ export type SignOperationEvent = // Used when lot of exchange is needed with the
   | {
       type: "signed";
       signedOperation: SignedOperation;
+    }
+  | {
+      type: "transaction-checks-opt-in-triggered";
     };
 
 /**
@@ -71,6 +74,9 @@ export type SignOperationEventRaw =
   | {
       type: "signed";
       signedOperation: SignedOperationRaw;
+    }
+  | {
+      type: "transaction-checks-opt-in-triggered";
     };
 /**
  * Transaction is a generic object that holds all state for all transactions

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -148,6 +148,9 @@ export class DmkSignerEth implements EvmSigner {
             if (result.intermediateValue.step === SignTransactionDAStep.BUILD_CONTEXT) {
               observer.next({ type: "signer.evm.loading-context" });
             }
+            if (result.intermediateValue.step === SignTransactionDAStep.WEB3_CHECKS_OPT_IN) {
+              observer.next({ type: "signer.evm.transaction-checks-opt-in-triggered" });
+            }
           } else if (result.status === DeviceActionStatus.Completed) {
             observer.next({
               type: "signer.evm.signed",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add analytics on LLD when the opt-in transaction checks screen appear on the device

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17708]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17708]: https://ledgerhq.atlassian.net/browse/LIVE-17708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ