### PR TITLE
ci: Skip CI at various points to prevent re-running of release-prerel…

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -44,7 +44,7 @@ jobs:
       - name: commit new tokens
         uses: planetscale/ghcommit-action@v0.2.9
         with:
-          commit_message: "chore(prerelease) update cryptoassets"
+          commit_message: "chore(prerelease) update cryptoassets [skip ci]"
           repo: ${{ github.repository }}
           branch: ${{ env.RELEASE_BRANCH }}
         env:

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -94,7 +94,7 @@ jobs:
         if: ${{ startsWith(github.ref_name, 'release') }}
         uses: planetscale/ghcommit-action@v0.2.9
         with:
-          commit_message: "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}]"
+          commit_message: "chore(prerelease): :rocket: release prerelease [${{ env.LLD }}, ${{ env.LLM }}] [skip ci]"
           repo: ${{ github.repository }}
           branch: ${{ github.ref_name }}
         env:


### PR DESCRIPTION
When running the release flows pre-release is triggered multiple times due to multiple commits. This PR aims to trigger the pre-release flow only on the commit created by "entering prerelease mode"

https://github.com/LedgerHQ/ledger-live/actions/workflows/release-prerelease.yml

Skip these runs 
https://github.com/LedgerHQ/ledger-live/actions/runs/14466745791
https://github.com/LedgerHQ/ledger-live/actions/runs/14466920674

Keep this run
https://github.com/LedgerHQ/ledger-live/actions/runs/14466747362