### PR TITLE
[LIVE-18386][DMK/LLD] Open app state during update firmware flow is not handle correctly

### DIFF
--- a/.changeset/quiet-deers-decide.md
+++ b/.changeset/quiet-deers-decide.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix wrong warning message when updating firmware

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -14,6 +14,7 @@ import { DisconnectedDevice, DisconnectedDeviceDuringOperation } from "@ledgerhq
 import SideDrawerHeader from "~/renderer/components/SideDrawerHeader";
 import { createFirmwareUpdateSteps } from "./helpers/createFirmwareUpdateSteps";
 import { StepId, STEPS } from "./types";
+import { isWebHidSendReportError } from "@ledgerhq/live-dmk-desktop";
 
 type MaybeError = Error | undefined | null;
 
@@ -61,7 +62,9 @@ const UpdateModal = ({
   const isDisconnectedDeviceError = err instanceof DisconnectedDevice;
   const isDisconnectedDeviceDuringOperationError = err instanceof DisconnectedDeviceDuringOperation;
   const isDeviceDisconnected =
-    isDisconnectedDeviceError || isDisconnectedDeviceDuringOperationError;
+    isDisconnectedDeviceError ||
+    isDisconnectedDeviceDuringOperationError ||
+    isWebHidSendReportError(err);
 
   const onRequestCancel = useCallback(() => {
     (showDisclaimer && !isDeviceDisconnected) || stateStepId === STEPS.FINISH || cancel


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- Fix wrong warning message when updating firmware.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18386](https://ledgerhq.atlassian.net/browse/LIVE-18386)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18386]: https://ledgerhq.atlassian.net/browse/LIVE-18386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ