### PR TITLE
ci: Pre-release version downgrading fix

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -39,30 +39,8 @@ jobs:
         id: setup-caches
         with:
           install-proto: true
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: desktop-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-desktop
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: mobile-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-mobile
       - name: install dependencies
         run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
-      - name: build libs
-        run: pnpm run build:libs
-      - name: versioning
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm changeset version
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: post-desktop-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-desktop
-      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
-        id: post-mobile-version
-        with:
-          path: ${{ github.workspace }}/apps/ledger-live-mobile
       - name: Move patch updates to minor for release branch
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases
@@ -87,6 +65,28 @@ jobs:
         with:
           from_level: major
           to_level: patch
+      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+        id: desktop-version
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-desktop
+      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+        id: mobile-version
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-mobile
+      - name: build libs
+        run: pnpm run build:libs
+      - name: versioning
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm changeset version
+      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+        id: post-desktop-version
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-desktop
+      - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
+        id: post-mobile-version
+        with:
+          path: ${{ github.workspace }}/apps/ledger-live-mobile
       - name: Add changed files
         run: |
           git add .


### PR DESCRIPTION
The below is for a fake "hotfix"

**Example of existing run result:**

Changesets have not been changed to patch - minor bumps on the package.json
Version bumps on LLD for example, are minor bumps
Changeset files however, have been changed to patch

Run: https://github.com/LedgerHQ/ledger-live/actions/runs/14492829164/job/40653082356
Resultant commit: https://github.com/LedgerHQ/ledger-live/commit/a72faf418187d0ebee4ba08ab5e363c4ebb4607c#diff-238841de2c515a7e5d07e9971f56a338005955814621075667f1312278cd8cc0
Branch: https://github.com/LedgerHQ/ledger-live/tree/support/versioningtest-fail

**Changed run result:**

Changesets have been patched and reflect in the package.json
Commit message reflects patch version
Changeset files have also been changed to patch

Run: https://github.com/LedgerHQ/ledger-live/actions/runs/14493106729/job/40653962294
Resultant commit: https://github.com/LedgerHQ/ledger-live/commit/d04fdf303a72a07cb038d4fa5df4baf8ec47f460
Branch: https://github.com/LedgerHQ/ledger-live/tree/support/versioningtest-pass

**Follow up pre-release - minor bump to desktop:**

Changeset file changed to patch
Commit message reflects prerelease patch +1 version
Package.json shows a patch
No bump to mobile

Run: https://github.com/LedgerHQ/ledger-live/actions/runs/14493423859/job/40655003373
Resultant commit: https://github.com/LedgerHQ/ledger-live/commit/f5ba3edce480263e790228b22c2b618d6ef113fd

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-18425
