### PR TITLE
feat(LIVE-18439): add swap live app feature flag to llm analytics

### DIFF
--- a/.changeset/nasty-bats-clap.md
+++ b/.changeset/nasty-bats-clap.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add ptx swap live app feature flag to LLM analytics

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -80,6 +80,8 @@ const getFeatureFlagProperties = () => {
     const stakingProviders = analyticsFeatureFlagMethod("ethStakingProviders");
     const stakePrograms = analyticsFeatureFlagMethod("stakePrograms");
 
+    const ptxSwapLiveAppMobileFlag = analyticsFeatureFlagMethod("ptxSwapLiveAppMobile");
+
     const isBatch1Enabled =
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 1;
     const isBatch2Enabled =
@@ -88,6 +90,8 @@ const getFeatureFlagProperties = () => {
       !!fetchAdditionalCoins?.enabled && fetchAdditionalCoins?.params?.batch === 3;
     const stakingProvidersEnabled =
       stakingProviders?.enabled && stakingProviders?.params?.listProvider.length;
+
+    const ptxSwapLiveAppMobileEnabled = Boolean(ptxSwapLiveAppMobileFlag?.enabled);
 
     const stakingCurrenciesEnabled =
       stakePrograms?.enabled && stakePrograms?.params?.list?.length
@@ -105,6 +109,7 @@ const getFeatureFlagProperties = () => {
       stakingProvidersEnabled,
       stakingCurrenciesEnabled,
       partnerStakingCurrenciesEnabled,
+      ptxSwapLiveAppMobileEnabled,
     });
   })();
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - It simply adds an additional entry to the Segment analytics user object on LLM. This should give us data to track whether users are shown the new Swap Live App or the legacy one.

### 📝 Description

Checking if the feature flag for "ptxSwapLiveAppMobile" is set and pass that information to the Segment analytics setup as additional properties.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: LIVE-18439


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
