### PR TITLE
feat(BACK-8727): stellar coin module: make craft return signature payload instead of transaction envelope

### DIFF
--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -1,6 +1,6 @@
 import type { Api, Operation } from "@ledgerhq/coin-framework/api/index";
 import { xdr } from "@stellar/stellar-sdk";
-import { createApi } from ".";
+import { createApi, envelopeFromAnyXDR } from ".";
 import { StellarAsset } from "../types";
 
 /**
@@ -90,12 +90,12 @@ describe.skip("Stellar Api", () => {
     const AMOUNT = BigInt(1_000_000);
 
     function readFees(transactionXdr: string) {
-      const transactionEnvelope = xdr.TransactionEnvelope.fromXDR(transactionXdr, "base64");
+      const transactionEnvelope = envelopeFromAnyXDR(transactionXdr, "base64");
       return transactionEnvelope.value().tx().fee();
     }
 
     function readMemo(transactionXdr: string) {
-      const transactionEnvelope = xdr.TransactionEnvelope.fromXDR(transactionXdr, "base64");
+      const transactionEnvelope = envelopeFromAnyXDR(transactionXdr, "base64");
       return (transactionEnvelope.value().tx() as xdr.TransactionV0).memo();
     }
 
@@ -108,7 +108,9 @@ describe.skip("Stellar Api", () => {
         amount: AMOUNT,
       });
 
-      expect(result.length).toEqual(188);
+      const envelope = envelopeFromAnyXDR(result, "base64");
+
+      expect(envelope.toXDR("base64").length).toEqual(188);
     });
 
     it("should use estimated fees when user does not provide them for crafting a transaction", async () => {

--- a/libs/coin-modules/coin-stellar/src/logic/combine.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/combine.ts
@@ -1,6 +1,10 @@
-import { Networks, Transaction as StellarSdkTransaction } from "@stellar/stellar-sdk";
+import { Networks, Transaction as StellarSdkTransaction, xdr } from "@stellar/stellar-sdk";
 
-export function combine(transaction: string, signature: string, publicKey: string): string {
+export function combine(
+  transaction: string | xdr.TransactionEnvelope,
+  signature: string,
+  publicKey: string,
+): string {
   const unsignedTx = new StellarSdkTransaction(transaction, Networks.PUBLIC);
   unsignedTx.addSignature(publicKey, signature);
   return unsignedTx.toXDR();

--- a/libs/coin-modules/coin-stellar/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/craftTransaction.ts
@@ -28,7 +28,7 @@ export async function craftTransaction(
     memoType?: string | null | undefined;
     memoValue?: string | null | undefined;
   },
-): Promise<{ transaction: StellarSdkTransaction; xdr: string }> {
+): Promise<{ transaction: StellarSdkTransaction; xdr: string; signatureBase: string }> {
   const { amount, recipient, fee, memoType, memoValue, type, assetCode, assetIssuer } = transaction;
   const source = await loadAccount(account.address);
 
@@ -78,6 +78,7 @@ export async function craftTransaction(
   return {
     transaction: craftedTransaction,
     xdr: craftedTransaction.toXDR(),
+    signatureBase: craftedTransaction.signatureBase().toString("base64"),
   };
 }
 


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Ledger Vault specific issue:
- coin module encodes transactions using XDR type `TransactionEnvelope`:
- Vault HSM only supports transactions encoded using XDR type `TransactionSignaturePayload`

This pull request implements, as a workaround:
 - `craft` returns `TransactionSignaturePayload` instead of `TransactionEnvelope`
 - `combine` accepts both `TransactionEnvelope` or `TransactionSignaturePayload` as input. If a `TransactionSignaturePayload` is provided, a `TransactionEnvelope` is manually reconstructed from it

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-8727
- https://ledger.slack.com/archives/C07RB4NNN3H/p1744799137180009

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
