### PR TITLE
feat: add more data on events for the dapp browser v3 [LIVE-18407]

### DIFF
--- a/.changeset/lemon-boxes-try.md
+++ b/.changeset/lemon-boxes-try.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat: add more data on events for the dapp browser v3

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/WalletAPIWebview.tsx
@@ -2,7 +2,6 @@
 
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
-import { TrackFunction } from "@ledgerhq/live-common/platform/tracking";
 import {
   ExchangeType,
   UiHook,
@@ -48,7 +47,7 @@ import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 const wallet = { name: "ledger-live-desktop", version: __APP_VERSION__ };
 
-function useUiHook(manifest: AppManifest, tracking: Record<string, TrackFunction>): UiHook {
+function useUiHook(manifest: AppManifest, tracking: TrackingAPI): UiHook {
   const { pushToast } = useToasts();
   const { t } = useTranslation();
   const dispatch = useDispatch();

--- a/libs/ledger-live-common/src/platform/logic.test.ts
+++ b/libs/ledger-live-common/src/platform/logic.test.ts
@@ -26,6 +26,7 @@ import { RawPlatformTransaction } from "./rawTypes";
 import * as serializers from "./serializers";
 import { LiveAppManifest } from "./types";
 import { initialState } from "@ledgerhq/live-wallet/store";
+import { TrackingAPI } from "./tracking";
 
 describe("receiveOnAccountLogic", () => {
   const walletState = initialState;
@@ -621,13 +622,13 @@ function createAppManifest(id = "1"): LiveAppManifest {
 }
 
 function createContextContainingAccountId(
-  tracking: Record<string, jest.Mock>,
+  tracking: Partial<TrackingAPI>,
   ...accountIds: string[]
 ): WebPlatformContext {
   return {
     manifest: createAppManifest(),
     accounts: [...accountIds.map(val => createFixtureAccount(val)), createFixtureAccount()],
-    tracking,
+    tracking: tracking as TrackingAPI,
   };
 }
 

--- a/libs/ledger-live-common/src/platform/logic.ts
+++ b/libs/ledger-live-common/src/platform/logic.ts
@@ -12,7 +12,7 @@ import {
   deserializePlatformTransaction,
   deserializePlatformSignedTransaction,
 } from "./serializers";
-import type { TrackFunction } from "./tracking";
+import type { TrackingAPI } from "./tracking";
 import { LiveAppManifest, TranslatableString } from "./types";
 import { isTokenAccount, getMainAccount, isAccount } from "../account/index";
 import { getAccountBridge } from "../bridge/index";
@@ -29,7 +29,7 @@ export function translateContent(content: string | TranslatableString, locale = 
 export type WebPlatformContext = {
   manifest: LiveAppManifest;
   accounts: AccountLike[];
-  tracking: Record<string, TrackFunction>;
+  tracking: TrackingAPI;
 };
 
 function getParentAccount(account: AccountLike, fromAccounts: AccountLike[]): Account | undefined {

--- a/libs/ledger-live-common/src/platform/tracking.ts
+++ b/libs/ledger-live-common/src/platform/tracking.ts
@@ -11,8 +11,6 @@ type TrackPlatform = (
   mandatory: boolean | null,
 ) => void;
 
-export type TrackFunction = (manifest: LiveAppManifest) => void;
-
 /**
  * Obtain Event data from Platform App manifest
  *
@@ -28,7 +26,7 @@ function getEventData(manifest: LiveAppManifest) {
  * @param trackCall
  * @returns a dictionary of event to trigger.
  */
-export default function trackingWrapper(trackCall: TrackPlatform): Record<string, TrackFunction> {
+export default function trackingWrapper(trackCall: TrackPlatform) {
   const track = (event: string, properties: Record<string, any> | null) =>
     trackCall(event, properties, null);
 
@@ -158,5 +156,7 @@ export default function trackingWrapper(trackCall: TrackPlatform): Record<string
     platformSignMessageUserRefused: (manifest: LiveAppManifest) => {
       track("Platform sign message user refused", getEventData(manifest));
     },
-  };
+  } as const;
 }
+
+export type TrackingAPI = ReturnType<typeof trackingWrapper>;

--- a/libs/ledger-live-common/src/wallet-api/tracking.ts
+++ b/libs/ledger-live-common/src/wallet-api/tracking.ts
@@ -1,4 +1,4 @@
-import type { AppManifest } from "./types";
+import type { AppManifest, DAppTrackingData } from "./types";
 
 /**
  * This signature is to be compatible with track method of `segment.js` file in LLM and LLD
@@ -226,14 +226,14 @@ export default function trackingWrapper(trackCall: TrackWalletAPI) {
       track("WalletAPI bitcoin family account xpub success", getEventData(manifest));
     },
 
-    dappSendTransactionRequested: (manifest: AppManifest) => {
-      track("dApp SendTransaction requested", getEventData(manifest));
+    dappSendTransactionRequested: (manifest: AppManifest, trackingData: DAppTrackingData) => {
+      track("dApp SendTransaction requested", { ...getEventData(manifest), ...trackingData });
     },
-    dappSendTransactionSuccess: (manifest: AppManifest) => {
-      track("dApp SendTransaction success", getEventData(manifest));
+    dappSendTransactionSuccess: (manifest: AppManifest, trackingData: DAppTrackingData) => {
+      track("dApp SendTransaction success", { ...getEventData(manifest), ...trackingData });
     },
-    dappSendTransactionFail: (manifest: AppManifest) => {
-      track("dApp SendTransaction fail", getEventData(manifest));
+    dappSendTransactionFail: (manifest: AppManifest, trackingData?: DAppTrackingData) => {
+      track("dApp SendTransaction fail", { ...getEventData(manifest), ...(trackingData || {}) });
     },
     dappPersonalSignRequested: (manifest: AppManifest) => {
       track("dApp PersonalSign requested", getEventData(manifest));

--- a/libs/ledger-live-common/src/wallet-api/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/types.ts
@@ -77,3 +77,9 @@ export type RecentlyUsedIdDb = {
 };
 
 export type CurrentAccountHistIDb = Record<string, string>;
+
+export type DAppTrackingData = {
+  type: "approve" | "transfer";
+  currency: string;
+  network: CryptoCurrency["id"];
+};

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -8,7 +8,7 @@ import { getAccountBridge } from "../bridge";
 import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network/network";
 import { getWalletAPITransactionSignFlowInfos } from "./converters";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { findTokenByAddress, getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { prepareMessageToSign } from "../hw/signMessage/index";
 import { CurrentAccountHistDB, UiHook, usePermission } from "./react";
 import BigNumber from "bignumber.js";
@@ -505,16 +505,22 @@ export function useDappLogic({
 
               const transactionType = getTransactionType(fields);
 
+              const token = findTokenByAddress(tx.recipient);
+
+              const accountCurrencyName =
+                currentAccount.type === "TokenAccount"
+                  ? currentAccount.token.name
+                  : currentAccount.currency.name;
+
+              const accountNetwork =
+                currentAccount.type === "TokenAccount"
+                  ? currentAccount.token.parentCurrency.id
+                  : currentAccount.currency.id;
+
               trackingData = {
                 type: transactionType === "Approve" ? "approve" : "transfer",
-                currency:
-                  currentAccount.type === "TokenAccount"
-                    ? currentAccount.token.name
-                    : currentAccount.currency.name,
-                network:
-                  currentAccount.type === "TokenAccount"
-                    ? currentAccount.token.parentCurrency.id
-                    : currentAccount.currency.id,
+                currency: token ? token.name : accountCurrencyName,
+                network: token ? token.parentCurrency.id : accountNetwork,
               };
 
               const options = nanoApp

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useRef, useCallback, useState } from "react";
 import { Account, AccountLike, Operation, SignedOperation } from "@ledgerhq/types-live";
 import { atom, useAtom } from "jotai";
-import { AppManifest, WalletAPITransaction } from "./types";
+import { AppManifest, DAppTrackingData, WalletAPITransaction } from "./types";
 import { getMainAccount, getParentAccount } from "../account";
 import { TrackingAPI } from "./tracking";
 import { getAccountBridge } from "../bridge";
@@ -15,6 +15,8 @@ import BigNumber from "bignumber.js";
 import { safeEncodeEIP55 } from "@ledgerhq/coin-evm/logic";
 import { SmartWebsocket } from "./SmartWebsocket";
 import { stripHexPrefix } from "./helpers";
+import { DeviceTransactionField, getDeviceTransactionConfig } from "../transaction";
+import type { Transaction } from "../generated/types";
 
 type MessageId = number | string | null;
 
@@ -201,6 +203,16 @@ function isParentAccountPresent(
   }
 
   return true;
+}
+
+function getTransactionType(fields: Array<DeviceTransactionField>): string {
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i];
+    if (field.type === "text" && field.label === "Type") {
+      return field.value;
+    }
+  }
+  return "";
 }
 
 export function useDappLogic({
@@ -471,16 +483,44 @@ export function useDappLogic({
               : currentParentAccount.freshAddress;
 
           if (address.toLowerCase() === ethTX.from.toLowerCase()) {
+            let trackingData: DAppTrackingData | undefined;
             try {
-              const options = nanoApp
-                ? { hwAppId: nanoApp, dependencies: dependencies }
-                : undefined;
-              tracking.dappSendTransactionRequested(manifest);
-
               const signFlowInfos = getWalletAPITransactionSignFlowInfos({
                 walletApiTransaction: tx,
                 account: currentAccount,
               });
+
+              const fields = getDeviceTransactionConfig({
+                account: currentAccount,
+                parentAccount: currentParentAccount,
+                transaction: signFlowInfos.liveTx as Transaction,
+                status: {
+                  errors: {},
+                  warnings: {},
+                  estimatedFees: new BigNumber(0),
+                  amount: new BigNumber(0),
+                  totalSpent: new BigNumber(0),
+                },
+              });
+
+              const transactionType = getTransactionType(fields);
+
+              trackingData = {
+                type: transactionType === "Approve" ? "approve" : "transfer",
+                currency:
+                  currentAccount.type === "TokenAccount"
+                    ? currentAccount.token.name
+                    : currentAccount.currency.name,
+                network:
+                  currentAccount.type === "TokenAccount"
+                    ? currentAccount.token.parentCurrency.id
+                    : currentAccount.currency.id,
+              };
+
+              const options = nanoApp
+                ? { hwAppId: nanoApp, dependencies: dependencies }
+                : undefined;
+              tracking.dappSendTransactionRequested(manifest, trackingData);
 
               const signedTransaction = await new Promise<SignedOperation>((resolve, reject) =>
                 uiHook["transaction.sign"]({
@@ -517,7 +557,7 @@ export function useDappLogic({
                 optimisticOperation,
               );
 
-              tracking.dappSendTransactionSuccess(manifest);
+              tracking.dappSendTransactionSuccess(manifest, trackingData);
 
               postMessage(
                 JSON.stringify({
@@ -527,7 +567,7 @@ export function useDappLogic({
                 }),
               );
             } catch (error) {
-              tracking.dappSendTransactionFail(manifest);
+              tracking.dappSendTransactionFail(manifest, trackingData);
               postMessage(
                 JSON.stringify({
                   id: data.id,


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Tested manually
- [x] **Impact of the changes:**
  - dApp browser v3 send transaction only

### 📝 Description

Add more data on send transaction events for the dApp browser v3

<img width="1741" alt="Screenshot 2025-04-17 at 09 33 38" src="https://github.com/user-attachments/assets/5eb08802-af0b-413c-86d9-ff2b83eedcbd" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18407]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18407]: https://ledgerhq.atlassian.net/browse/LIVE-18407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ