### PR TITLE
ci: Add concurrency statement to pre-release

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -10,6 +10,10 @@ on:
         description: the branch to prerelease from
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   prerelease:
     name: Prerelease


### PR DESCRIPTION
Currently when pre-release is kicked off a number of jobs get spawned over the various commits. This should prevent the pile-up of running jobs by cancelling the previous job. Only the most recent job should run.

This will also prevent the issue shown here (branch in the repo gets updated while job is in flight): https://github.com/LedgerHQ/ledger-live/actions/runs/14514102960/job/40719873518

https://github.com/LedgerHQ/ledger-live/actions/workflows/release-prerelease.yml

Run 1: Cancelled by second run and noted in annotations https://github.com/LedgerHQ/ledger-live/actions/runs/14533099245
Run 2: Succeeded (though manually cancelled to avoid triggering builds) https://github.com/LedgerHQ/ledger-live/actions/runs/14533101538 