### PR TITLE
bugfix: LIVE-14178 - Fix Cannot use 'in' operator to search for 'links' in Invalid extension provided

### DIFF
--- a/.changeset/nasty-cows-retire.md
+++ b/.changeset/nasty-cows-retire.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Cannot use 'in' operator to search for 'links' in Invalid extension provided error fixed

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.test.tsx
@@ -1,0 +1,74 @@
+import { useErrorLinks } from "./useErrorLinks";
+import { renderHook } from "tests/testSetup";
+
+const renderUseErrorLinks = (error?: Error | null) => {
+  return renderHook(() => useErrorLinks(error));
+};
+
+describe("useErrorLinks", () => {
+  it("returns empty object when no error is provided", () => {
+    const { result } = renderUseErrorLinks();
+    expect(result.current).toEqual({});
+  });
+
+  it("returns empty object when error has no links", () => {
+    const error = new Error("Test error");
+    const { result } = renderUseErrorLinks(error);
+    expect(result.current).toEqual({});
+  });
+
+  it("creates links for absolute URLs", () => {
+    const error = {
+      links: ["https://example.com", "http://test.com"],
+    } as unknown as Error;
+    const { result } = renderUseErrorLinks(error);
+
+    expect(Object.keys(result.current)).toHaveLength(2);
+  });
+
+  it("creates buttons for relative URLs", () => {
+    const error = {
+      links: ["/relative/path?param=value"],
+    } as unknown as Error;
+    const { result } = renderUseErrorLinks(error);
+    const currentResult = result.current;
+    expect(currentResult).toBeInstanceOf(Object);
+    expect(Object.keys(currentResult)).toHaveLength(1);
+
+    expect(currentResult["link0"].props["data-testid"]).toBe("translated-error-link-0");
+  });
+
+  it("filters out invalid links", () => {
+    const error = {
+      links: ["https://example.com", 123, null, undefined, "/relative/path"],
+    } as unknown as Error;
+    const { result } = renderUseErrorLinks(error);
+    const currentResult = result.current;
+
+    expect(Object.keys(currentResult)).toHaveLength(2);
+
+    expect(currentResult["link0"].props["data-testid"]).toBe("translated-error-link-0");
+    expect(currentResult["link1"].props["data-testid"]).toBe("translated-error-link-1");
+  });
+
+  it("handles the condition getSafeStringLinks correctly", () => {
+    const validError = { links: ["https://example.com"] } as unknown as Error;
+    const invalidError1 = { links: "not-an-array" } as unknown as Error;
+    const invalidError2 = { noLinks: [] } as unknown as Error;
+
+    //https://ledgerhq.atlassian.net/browse/LIVE-14178
+    const errorInOperator = "Invalid extension provided" as unknown as Error;
+
+    const { result: resultValid } = renderUseErrorLinks(validError);
+    expect(Object.keys(resultValid.current)).toHaveLength(1);
+
+    const { result: resultInvalid1 } = renderUseErrorLinks(invalidError1);
+    expect(resultInvalid1.current).toEqual({});
+
+    const { result: resultInvalid2 } = renderUseErrorLinks(invalidError2);
+    expect(resultInvalid2.current).toEqual({});
+
+    const { result: resultErrorInOperator } = renderUseErrorLinks(errorInOperator);
+    expect(resultErrorInOperator.current).toEqual({});
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/hooks/useErrorLinks.tsx
@@ -1,24 +1,15 @@
-import React, { useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { useHistory } from "react-router";
 import * as S from "../styles";
 import { openURL } from "~/renderer/linking";
+import { getSafeStringLinks, isAbsoluteUrl } from "../utils";
 
-function isAbsoluteUrl(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
+export function useErrorLinks(error?: Error | null): Record<string, ReactElement> {
+  const safeStringLinks = getSafeStringLinks(error);
 
-export function useErrorLinks(error?: Error | null) {
-  const errorLinks = error && "links" in error && Array.isArray(error.links) && error?.links;
   const history = useHistory();
   return useMemo(() => {
-    if (errorLinks) {
-      const safeStringLinks = errorLinks.filter((link): link is string => typeof link === "string");
-
+    if (safeStringLinks.length > 0) {
       return safeStringLinks.reduce((prev, curr, index) => {
         if (isAbsoluteUrl(curr)) {
           return {
@@ -52,5 +43,5 @@ export function useErrorLinks(error?: Error | null) {
 
     return {};
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errorLinks]);
+  }, [safeStringLinks]);
 }

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/utils/index.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/utils/index.test.ts
@@ -1,0 +1,70 @@
+import { getSafeStringLinks, isAbsoluteUrl } from "./index";
+
+describe("getSafeStringLinks", () => {
+  describe("returns an empty array", () => {
+    it("when error is undefined", () => {
+      expect(getSafeStringLinks(undefined)).toEqual([]);
+    });
+
+    it("when error is null", () => {
+      expect(getSafeStringLinks(null)).toEqual([]);
+    });
+
+    it("when error has no links", () => {
+      const error = new Error("Test error");
+      expect(getSafeStringLinks(error)).toEqual([]);
+    });
+
+    it("when error is not an object", () => {
+      expect(getSafeStringLinks("not-an-object" as unknown as Error)).toEqual([]);
+    });
+
+    it("when error does not have 'links' property", () => {
+      const error = { message: "Test error" } as unknown as Error;
+      expect(getSafeStringLinks(error)).toEqual([]);
+    });
+
+    it("when 'links' is not an array", () => {
+      const error = { links: "not-an-array" } as unknown as Error;
+      expect(getSafeStringLinks(error)).toEqual([]);
+    });
+  });
+
+  describe("filters and returns valid links", () => {
+    it("filters out non-string links", () => {
+      const error = {
+        links: ["https://example.com", 123, null, undefined, "/relative/path"],
+      } as unknown as Error;
+      expect(getSafeStringLinks(error)).toEqual(["https://example.com", "/relative/path"]);
+    });
+
+    it("returns all string links", () => {
+      const error = {
+        links: ["https://example.com", "/relative/path"],
+      } as unknown as Error;
+      expect(getSafeStringLinks(error)).toEqual(["https://example.com", "/relative/path"]);
+    });
+
+    it("returns filtered string links when 'links' is a valid array", () => {
+      const error = { links: ["https://example.com", 123, null] } as unknown as Error;
+      expect(getSafeStringLinks(error)).toEqual(["https://example.com"]);
+    });
+  });
+});
+
+describe("isAbsoluteUrl", () => {
+  it("returns true for absolute URLs", () => {
+    expect(isAbsoluteUrl("https://example.com")).toBe(true);
+    expect(isAbsoluteUrl("http://example.com")).toBe(true);
+  });
+
+  it("returns false for relative URLs", () => {
+    expect(isAbsoluteUrl("/relative/path")).toBe(false);
+    expect(isAbsoluteUrl("relative/path")).toBe(false);
+  });
+
+  it("returns false for invalid URLs", () => {
+    expect(isAbsoluteUrl("invalid-url")).toBe(false);
+    expect(isAbsoluteUrl("")).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/TranslatedError/utils/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/TranslatedError/utils/index.ts
@@ -1,0 +1,16 @@
+function getSafeStringLinks(error?: Error | null): string[] {
+  return error && typeof error === "object" && "links" in error && Array.isArray(error.links)
+    ? error.links.filter((link): link is string => typeof link === "string")
+    : [];
+}
+
+function isAbsoluteUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export { getSafeStringLinks, isAbsoluteUrl };


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The error Cannot use 'in' operator to search for 'links' in Invalid extension provided could occur if the links property is a string instead of an object.

<img width="414" alt="Screenshot 2025-04-17 at 16 18 38" src="https://github.com/user-attachments/assets/36639e2c-7988-4f35-b57f-79165fb70fe9" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-14178] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-14178]: https://ledgerhq.atlassian.net/browse/LIVE-14178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ