### PR TITLE
[DSDK-710] Use ConnectApp Device Action in Ledger Live

### DIFF
--- a/.changeset/proud-books-sneeze.md
+++ b/.changeset/proud-books-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Use ConnectApp Device Action inside Ledger Live

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -182,6 +182,7 @@
     "@ledgerhq/live-app-sdk": "^0.8.1",
     "@ledgerhq/live-config": "workspace:^",
     "@ledgerhq/live-countervalues": "workspace:^",
+    "@ledgerhq/live-dmk-shared": "workspace:^",
     "@ledgerhq/live-countervalues-react": "workspace:^",
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-hooks": "workspace:*",

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -41,3 +41,14 @@ export function mustUpgrade(appName: string, appVersion: string): boolean {
   }
   return false;
 }
+
+export function getMinVersion(appName: string): string | undefined {
+  if (getEnv("DISABLE_APP_VERSION_REQUIREMENTS")) {
+    return undefined;
+  }
+  // we should convert the app name to camel case and replace spaces with underscores to match the config convention in firebase
+  const minVersion = LiveConfig.getValueByKey(
+    `config_nanoapp_${appName.toLowerCase().replace(/ /g, "_")}`,
+  )?.minVersion;
+  return minVersion ? semver.coerce(minVersion)?.version : undefined;
+}

--- a/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
@@ -1,0 +1,354 @@
+import { Observable, Subject, of, share, takeUntil } from "rxjs";
+import { catchError, tap, withLatestFrom } from "rxjs/operators";
+import type {
+  DeviceManagementKit,
+  DeviceActionState,
+  InstallPlan,
+  ExecuteDeviceActionReturnType,
+  DeviceSessionState,
+  GetOsVersionResponse,
+  FirmwareUpdateContext as DmkFirmwareUpdateContext,
+} from "@ledgerhq/device-management-kit";
+import {
+  DeviceActionStatus,
+  DeviceLockedError,
+  DeviceSessionStateType,
+  DeviceStatus,
+  UserInteractionRequired,
+  OutOfMemoryDAError,
+  SecureChannelError,
+  UnsupportedFirmwareDAError,
+} from "@ledgerhq/device-management-kit";
+import type {
+  ConnectAppDAOutput,
+  ConnectAppDAError,
+  ConnectAppDAIntermediateValue,
+} from "@ledgerhq/live-dmk-shared";
+import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import {
+  UserRefusedAllowManager,
+  UserRefusedOnDevice,
+  LatestFirmwareVersionRequired,
+} from "@ledgerhq/errors";
+
+import type { SkippedAppOp } from "../apps/types";
+import { SkipReason } from "../apps/types";
+import { parseDeviceInfo } from "../deviceSDK/tasks/getDeviceInfo";
+import { ConnectAppEvent } from "./connectApp";
+
+export class ConnectAppEventMapper {
+  private permissionRequested: boolean = false;
+  private lastSeenDeviceSent: boolean = false;
+  private installPlan: InstallPlan | null = null;
+  private eventSubject = new Subject<ConnectAppEvent>();
+
+  constructor(
+    private dmk: DeviceManagementKit,
+    private sessionId: string,
+    private appName: string,
+    private events: ExecuteDeviceActionReturnType<
+      ConnectAppDAOutput,
+      ConnectAppDAError,
+      ConnectAppDAIntermediateValue
+    >,
+  ) {}
+
+  map(): Observable<ConnectAppEvent> {
+    const cancelAction = this.events.cancel;
+    const unsubscribe = new Subject<void>();
+
+    // Create a shared observable for device session state
+    const deviceSessionState = this.dmk
+      .getDeviceSessionState({ sessionId: this.sessionId })
+      .pipe(share());
+
+    // Subscribe to device action events
+    this.events.observable
+      .pipe(
+        withLatestFrom(deviceSessionState),
+        tap(([event, deviceState]) => this.handleEvent(event, deviceState)),
+        takeUntil(unsubscribe),
+        catchError(error => this.handleError(error)),
+      )
+      .subscribe();
+
+    // Subscribe to device session state events
+    deviceSessionState
+      .pipe(
+        tap(deviceState => this.handleDeviceState(deviceState)),
+        takeUntil(unsubscribe),
+      )
+      .subscribe();
+
+    return new Observable<ConnectAppEvent>(observer => {
+      const sub = this.eventSubject.subscribe(observer);
+      return () => {
+        sub.unsubscribe();
+        cancelAction();
+        unsubscribe.next();
+      };
+    });
+  }
+
+  private handleDeviceState(deviceState: DeviceSessionState): void {
+    if (deviceState.sessionStateType === DeviceSessionStateType.Connected) {
+      return;
+    }
+
+    if (deviceState.deviceStatus === DeviceStatus.NOT_CONNECTED) {
+      this.eventSubject.next({ type: "disconnected", expected: false });
+    } else if (
+      deviceState.firmwareVersion?.metadata &&
+      deviceState.firmwareUpdateContext &&
+      !this.lastSeenDeviceSent
+    ) {
+      this.lastSeenDeviceSent = true;
+      this.eventSubject.next({
+        type: "device-update-last-seen",
+        deviceInfo: this.mapDeviceInfo(deviceState.firmwareVersion.metadata),
+        latestFirmware: this.mapLatestFirmware(deviceState.firmwareUpdateContext),
+      });
+    }
+  }
+
+  private handleEvent(
+    event: DeviceActionState<ConnectAppDAOutput, ConnectAppDAError, ConnectAppDAIntermediateValue>,
+    deviceState: DeviceSessionState,
+  ): void {
+    switch (event.status) {
+      case DeviceActionStatus.Pending:
+        this.handlePendingEvent(event.intermediateValue);
+        break;
+      case DeviceActionStatus.Completed:
+        this.handleCompletedEvent(event.output, deviceState);
+        break;
+      case DeviceActionStatus.Error:
+        this.handleErrorEvent(event.error, deviceState);
+        break;
+      case DeviceActionStatus.NotStarted:
+      case DeviceActionStatus.Stopped:
+        this.eventSubject.error(new Error("Unexpected device action status"));
+        break;
+    }
+  }
+
+  private handlePendingEvent(intermediateValue: ConnectAppDAIntermediateValue): void {
+    switch (intermediateValue.requiredUserInteraction) {
+      case UserInteractionRequired.ConfirmOpenApp:
+        this.eventSubject.next({ type: "ask-open-app", appName: this.appName });
+        break;
+      case UserInteractionRequired.AllowSecureConnection:
+        if (!this.permissionRequested) {
+          this.permissionRequested = true;
+          this.eventSubject.next({ type: "device-permission-requested" });
+        }
+        break;
+      case UserInteractionRequired.UnlockDevice:
+        this.eventSubject.next({ type: "lockedDevice" });
+        break;
+      case UserInteractionRequired.None:
+        if (this.permissionRequested) {
+          this.permissionRequested = false;
+          this.eventSubject.next({ type: "device-permission-granted" });
+
+          // Simulate apps listing (not systematic step in LDMK)
+          this.eventSubject.next({ type: "listing-apps" });
+        }
+        if (intermediateValue.installPlan !== null) {
+          this.handleInstallPlan(intermediateValue.installPlan);
+        }
+        break;
+    }
+  }
+
+  private handleInstallPlan(installPlan: InstallPlan): void {
+    // Handle install plan resolved events
+    if (this.installPlan === null) {
+      // Skipped applications
+      const alreadyInstalled = this.mapSkippedApps(
+        installPlan.alreadyInstalled,
+        SkipReason.AppAlreadyInstalled,
+      );
+      const missing = this.mapSkippedApps(
+        installPlan.missingApplications,
+        SkipReason.NoSuchAppOnProvider,
+      );
+      const skippedAppOps = [...alreadyInstalled, ...missing];
+      if (skippedAppOps.length > 0) {
+        this.eventSubject.next({
+          type: "some-apps-skipped",
+          skippedAppOps,
+        });
+      }
+
+      // Install queue content
+      this.eventSubject.next({
+        type: "listed-apps",
+        installQueue: installPlan.installPlan.map(app => app.versionName),
+      });
+    }
+
+    // Handle ongoing install events
+    this.eventSubject.next({
+      type: "inline-install",
+      progress: installPlan.currentProgress,
+      itemProgress: installPlan.currentIndex,
+      currentAppOp: {
+        type: "install",
+        name: installPlan.installPlan[installPlan.currentIndex]!.versionName,
+      },
+      installQueue: installPlan.installPlan.map(app => app.versionName),
+    });
+    this.installPlan = installPlan;
+  }
+
+  private handleCompletedEvent(output: ConnectAppDAOutput, deviceState: DeviceSessionState): void {
+    if (deviceState.sessionStateType !== DeviceSessionStateType.Connected) {
+      // Handle opened app
+      const currentApp = deviceState.currentApp;
+      let flags: number | Buffer = 0;
+      if (typeof currentApp.flags === "number") {
+        flags = currentApp.flags;
+      } else if (currentApp.flags !== undefined) {
+        flags = Buffer.from(currentApp.flags);
+      }
+      this.eventSubject.next({
+        type: "opened",
+        app: {
+          name: currentApp.name,
+          version: currentApp.version,
+          flags,
+        },
+        derivation: output.derivation ? { address: output.derivation } : undefined,
+      });
+    }
+    this.eventSubject.complete();
+  }
+
+  private handleErrorEvent(error: ConnectAppDAError, deviceState: DeviceSessionState): void {
+    if (error instanceof OutOfMemoryDAError && this.installPlan !== null) {
+      const appNames = this.installPlan.installPlan.map(app => app.versionName);
+      this.eventSubject.next({
+        type: "app-not-installed",
+        appNames,
+        appName: appNames[0]!,
+      });
+      this.eventSubject.complete();
+    } else if (
+      error instanceof UnsupportedFirmwareDAError &&
+      deviceState.sessionStateType !== DeviceSessionStateType.Connected
+    ) {
+      this.eventSubject.error(
+        new LatestFirmwareVersionRequired("LatestFirmwareVersionRequired", {
+          current: deviceState.firmwareUpdateContext!.currentFirmware.version,
+          latest: deviceState.firmwareUpdateContext!.availableUpdate!.finalFirmware.version,
+        }),
+      );
+    } else if (error instanceof DeviceLockedError) {
+      this.eventSubject.next({ type: "lockedDevice" });
+      this.eventSubject.complete();
+    } else if (error instanceof SecureChannelError) {
+      this.eventSubject.error(new UserRefusedAllowManager());
+    } else if ("_tag" in error && error._tag === "WebHidSendReportError") {
+      this.eventSubject.next({ type: "disconnected", expected: false });
+      this.eventSubject.complete();
+    } else if ("errorCode" in error && typeof error.errorCode === "string" && "_tag" in error) {
+      this.eventSubject.error(this.mapDeviceError(error.errorCode, error._tag));
+    } else {
+      this.eventSubject.error(error);
+    }
+  }
+
+  private handleError(error: Error): Observable<never> {
+    this.eventSubject.error(error);
+    return of();
+  }
+
+  private mapDeviceError(errorCode: string, defaultMessage: string): Error {
+    switch (errorCode) {
+      case "5501":
+        return new UserRefusedOnDevice();
+      default:
+        return new Error(defaultMessage);
+    }
+  }
+
+  private mapSkippedApps(appNames: string[], reason: SkipReason): SkippedAppOp[] {
+    return appNames.map(name => ({
+      reason,
+      appOp: {
+        type: "install",
+        name,
+      },
+    }));
+  }
+
+  private mapDeviceInfo(osVersion: GetOsVersionResponse): DeviceInfo {
+    return parseDeviceInfo({
+      isBootloader: osVersion.isBootloader,
+      rawVersion: osVersion.seVersion, // Always the SE version since at this step we cannot be in bootloader mode
+      targetId: osVersion.targetId,
+      seVersion: osVersion.seVersion,
+      seTargetId: osVersion.seTargetId,
+      mcuBlVersion: undefined, // We cannot be in bootloader mode at this step
+      mcuVersion: osVersion.mcuSephVersion,
+      mcuTargetId: osVersion.mcuTargetId,
+      flags: Buffer.from(osVersion.seFlags),
+      bootloaderVersion: osVersion.mcuBootloaderVersion,
+      hardwareVersion: parseInt(osVersion.hwVersion, 16),
+      languageId: osVersion.langId,
+    });
+  }
+
+  private mapLatestFirmware(updateContext: DmkFirmwareUpdateContext): FirmwareUpdateContext | null {
+    if (!updateContext.availableUpdate) {
+      return null;
+    }
+    const availableUpdate = updateContext.availableUpdate;
+    const osu = availableUpdate.osuFirmware;
+    const final = availableUpdate.finalFirmware;
+    return {
+      osu: {
+        id: osu.id,
+        perso: osu.perso,
+        firmware: osu.firmware,
+        firmware_key: osu.firmwareKey,
+        hash: osu.hash || "",
+        next_se_firmware_final_version: osu.nextFinalFirmware,
+        // Following fields are inherited from dto, but unused
+        description: undefined,
+        display_name: undefined,
+        notes: undefined,
+        name: "",
+        date_creation: "",
+        date_last_modified: "",
+        device_versions: [],
+        providers: [],
+        previous_se_firmware_final_version: [],
+      },
+      final: {
+        id: final.id,
+        name: final.version,
+        version: final.version,
+        perso: final.perso,
+        firmware: final.firmware || "",
+        firmware_key: final.firmwareKey || "",
+        hash: final.hash || "",
+        bytes: final.bytes || 0,
+        mcu_versions: final.mcuVersions,
+        // Following fields are inherited from dto, but unused
+        description: undefined,
+        display_name: undefined,
+        notes: undefined,
+        se_firmware: 0,
+        date_creation: "",
+        date_last_modified: "",
+        device_versions: [],
+        application_versions: [],
+        osu_versions: [],
+        providers: [],
+      },
+      shouldFlashMCU: availableUpdate.mcuUpdateRequired,
+    };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5096,6 +5096,9 @@ importers:
       '@ledgerhq/live-countervalues-react':
         specifier: workspace:^
         version: link:../live-countervalues-react
+      '@ledgerhq/live-dmk-shared':
+        specifier: workspace:^
+        version: link:../live-dmk-shared
       '@ledgerhq/live-env':
         specifier: workspace:^
         version: link:../env


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
