### PR TITLE
fix(BACK-8730): [coin-modules][tron] get balance fails on inactive account

### DIFF
--- a/.changeset/hot-crabs-arrive.md
+++ b/.changeset/hot-crabs-arrive.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+When account is not yet activated, RPC returns an empty account list => return an empty balance instead of crashing

--- a/libs/coin-modules/coin-tron/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getBalance.test.ts
@@ -256,6 +256,19 @@ describe("getBalance", () => {
       },
     ]);
   });
+
+  it("returns empty balance if account is inactive", async () => {
+    mockServer.listen({ onUnhandledRequest: "error" });
+    mockServer.use(
+      http.get(
+        "http://tron.explorer.com/v1/accounts/41ae18eb0a9e067f8884058470ed187f44135d816d",
+        () => HttpResponse.json({ data: [] }),
+      ),
+    );
+    const balance = await getBalance("41ae18eb0a9e067f8884058470ed187f44135d816d");
+    expect(balance).toEqual([]);
+  });
+
   mockServer.close();
 });
 

--- a/libs/coin-modules/coin-tron/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getBalance.ts
@@ -10,6 +10,10 @@ const bigIntOrZero = (val: number | BigNumber | undefined | null): bigint =>
 
 export async function getBalance(address: string): Promise<Balance<TronAsset>[]> {
   const accounts = await fetchTronAccount(address);
+
+  // if account is not activated, an empty array is returned
+  if (accounts.length === 0) return [];
+
   const account = accounts[0];
 
   const nativeBalance: Balance<TronAsset> = computeBalance(account);


### PR DESCRIPTION

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

When account is not yet activated, RPC returns an empty account list => return an empty balance instead of crashing

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-8730


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
