### PR TITLE
fix(LIVE-17938): reset swap navigation stack after success

### DIFF
--- a/.changeset/rich-mice-mate.md
+++ b/.changeset/rich-mice-mate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Reset Swap Navigation stack after successful swap transaction when navigating to transaction history screen

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
@@ -40,7 +40,17 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
   }, []);
 
   const onComplete = useCallback(() => {
-    navigation.navigate(ScreenName.SwapHistory);
+    navigation.reset({
+      index: 1,
+      routes: [
+        {
+          name: ScreenName.SwapTab,
+        },
+        {
+          name: ScreenName.SwapHistory,
+        },
+      ],
+    });
   }, [navigation]);
 
   return (


### PR DESCRIPTION
Reset Swap Navigation stack after successful swap transaction when navigating to transaction history screen

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** After successful swap transactions the navigation stack for swap gets reset when the user navigates to history screen.
  - ...

### 📝 Description

After a successful swap transactions the navigation stack for swap gets reset when the user navigates to history screen from the success screen. This allows the back button on the history screen to go back to the default swap tab screen instead of toggling between success screen and history screen.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-17938


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
