### PR TITLE
bugfix: Renaming accounts in Account Settings

### DIFF
--- a/.changeset/real-snakes-arrive.md
+++ b/.changeset/real-snakes-arrive.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Renaming accounts in EditAccountSettings

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -164,6 +164,7 @@ const customRender = (
   };
 
   return {
+    store,
     user: userEvent.setup(userEventOptions),
     ...rntlRender(ui, { wrapper: ProvidersWrapper, ...renderOptions }),
   };

--- a/apps/ledger-live-mobile/src/screens/AccountSettings/__tests__/EditAccountName.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/AccountSettings/__tests__/EditAccountName.test.tsx
@@ -1,0 +1,123 @@
+import { render } from "@tests/test-renderer";
+import React from "react";
+import EditAccountName from "../EditAccountName";
+import { ScreenName } from "~/const";
+import { AccountSettingsNavigatorParamList } from "~/components/RootNavigator/types/AccountSettingsNavigator";
+import { RouteProp } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { genAccount } from "@ledgerhq/live-common/mock/account";
+
+const onAccountNameChange = jest.fn();
+
+const mockedNavigation = {
+  replace: jest.fn(),
+  push: jest.fn(),
+  pop: jest.fn(),
+  popToTop: jest.fn(),
+  goBack: jest.fn(),
+  navigate: jest.fn(),
+  reset: jest.fn(),
+  setParams: jest.fn(),
+  dispatch: jest.fn(),
+  isFocused: jest.fn(),
+  canGoBack: jest.fn(),
+  getId: jest.fn(),
+  getParent: jest.fn(),
+  getState: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+  setOptions: jest.fn(),
+};
+
+const genAcc = {
+  ...genAccount("Acc1", { currency: getCryptoCurrencyById("bitcoin") }),
+  index: 0,
+};
+
+const mockedRoute: RouteProp<AccountSettingsNavigatorParamList, ScreenName.EditAccountName> = {
+  key: "EditAccountName",
+  name: ScreenName.EditAccountName,
+  params: { accountId: genAcc.id },
+};
+
+const Stack = createStackNavigator<
+  BaseNavigatorStackParamList & AccountSettingsNavigatorParamList
+>();
+
+function EditAccountNameNavigator({ useAccount = false }: { useAccount?: boolean }) {
+  const routeParams = useAccount
+    ? { accountId: undefined, account: genAcc, onAccountNameChange }
+    : { accountId: genAcc.id };
+
+  return (
+    <Stack.Navigator initialRouteName={ScreenName.EditAccountName}>
+      <Stack.Screen name={ScreenName.EditAccountName}>
+        {() => (
+          <EditAccountName
+            navigation={mockedNavigation}
+            route={{ ...mockedRoute, params: routeParams }}
+          />
+        )}
+      </Stack.Screen>
+    </Stack.Navigator>
+  );
+}
+
+const renderWithState = (useAccount = false) =>
+  render(<EditAccountNameNavigator useAccount={useAccount} />, {
+    overrideInitialState: state => ({
+      ...state,
+      accounts: { active: [genAcc] },
+      wallet: { ...state.wallet, accountNames: new Map<string, string>() },
+    }),
+  });
+
+describe("EditAccountName", () => {
+  test("renders correctly with initial state", () => {
+    const { getByTestId } = renderWithState();
+    expect(getByTestId("account-rename-text-input").props.value).toBe("Bitcoin 1");
+    expect(getByTestId("account-rename-apply")).toBeDefined();
+  });
+
+  test("updates account name on text input change", async () => {
+    const newName = "New Account Name";
+    const { getByTestId, user } = renderWithState();
+    const input = getByTestId("account-rename-text-input");
+    await user.clear(input);
+    await user.type(input, newName);
+    expect(input.props.value).toBe(newName);
+  });
+
+  test("dispatches actions and navigates back on valid name submission from AccountPage", async () => {
+    const updatedName = "Updated Account Name";
+    const { getByTestId, user, store } = renderWithState();
+    await user.clear(getByTestId("account-rename-text-input"));
+    await user.type(getByTestId("account-rename-text-input"), updatedName);
+    await user.press(getByTestId("account-rename-apply"));
+
+    expect(store.getState().wallet.accountNames.get(genAcc.id)).toEqual(updatedName);
+
+    expect(mockedNavigation.goBack).toHaveBeenCalled();
+  });
+
+  test("calls onAccountNameChange and navigates back on submission from AddAccount", async () => {
+    const updatedName = "Updated Account Name Bis";
+    const { getByTestId, user } = renderWithState(true);
+    await user.clear(getByTestId("account-rename-text-input"));
+    await user.type(getByTestId("account-rename-text-input"), updatedName);
+    await user.press(getByTestId("account-rename-apply"));
+
+    expect(onAccountNameChange).toHaveBeenCalledWith(updatedName, genAcc);
+    expect(mockedNavigation.goBack).toHaveBeenCalled();
+  });
+
+  test("disables apply button when input is empty", async () => {
+    const { getByTestId, user } = renderWithState();
+    const input = getByTestId("account-rename-text-input");
+    await user.clear(input);
+    await user.type(input, " ");
+    expect(getByTestId("account-rename-apply").props.accessibilityState.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

- EditAccount component from Class to functionnal component
- Tests on EditAccount

Edit Account

https://github.com/user-attachments/assets/41f09081-37f0-4c35-bf5a-637077e845e7


ADD Account (with ledgerSync activated)
 
https://github.com/user-attachments/assets/d68591ea-f0e0-4bf7-98ca-5a460e1d9b93




### ❓ Context

- **JIRA or GitHub link**:  [LIVE-17458] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17458]: https://ledgerhq.atlassian.net/browse/LIVE-17458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ