### PR TITLE
fix: Reorder HW operations during SUI TX signing

### DIFF
--- a/.changeset/green-garlics-enjoy.md
+++ b/.changeset/green-garlics-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+Fix HW operations order during TX signing

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
@@ -39,18 +39,16 @@ export const buildSignOperation =
           }),
         };
 
-        const { unsigned } = await buildTransaction(account, transactionToSign);
-
-        const signData = messageWithIntent("TransactionData", unsigned);
-
-        const { signature } = await signerContext(deviceId, signer =>
-          signer.signTransaction(account.freshAddressPath, signData),
-        );
-
         const publicKeyResult = await signerContext(deviceId, signer =>
           signer.getPublicKey(account.freshAddressPath),
         );
         const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
+
+        const { unsigned } = await buildTransaction(account, transactionToSign);
+        const signData = messageWithIntent("TransactionData", unsigned);
+        const { signature } = await signerContext(deviceId, signer =>
+          signer.signTransaction(account.freshAddressPath, signData),
+        );
 
         const serializedSignature = toSerializedSignature({
           signature,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - SWAP works as expected.

### 📝 Description

Since it is not possible to derive SUI public key from it's address, during the TX signing public key is requested from device. In the SWAP context it is crucial to perform all HW operations before TX SIGN. Otherwise, exchange app can't handle it since lib mode is closed already.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
