### PR TITLE
chore: bring back zx v7 verbosity

### DIFF
--- a/apps/cli/scripts/build.mjs
+++ b/apps/cli/scripts/build.mjs
@@ -4,6 +4,8 @@ import fs from "node:fs";
 import { createExportableManifest } from "@pnpm/exportable-manifest";
 import { readProjectManifestOnly } from "@pnpm/read-project-manifest";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }
@@ -13,16 +15,16 @@ echo(chalk.green("Building bundled javascript"));
 await $`tsup src/cli.ts`;
 
 echo(chalk.green("Copy the built folder to the publication folder"));
-fs.cpSync('lib', 'dist/lib', {
+fs.cpSync("lib", "dist/lib", {
   force: true,
-  recursive: true
+  recursive: true,
 });
 
 echo(chalk.green("Creating package.json with ledger dependencies removed"));
 
 const manifest = await readProjectManifestOnly("./");
 Object.entries(manifest.dependencies).forEach(([packageName]) => {
-  if (packageName.startsWith('@ledgerhq')) {
+  if (packageName.startsWith("@ledgerhq")) {
     delete manifest.dependencies[packageName];
   }
 });
@@ -31,13 +33,13 @@ const exportable = await createExportableManifest("./", manifest, { catalogs: []
 fs.writeFileSync("dist/package.json", JSON.stringify(exportable));
 
 echo(chalk.green("Copy the .md's to the publication folder"));
-fs.copyFileSync('README.md', 'dist/README.md');
-fs.copyFileSync('CHANGELOG.md', 'dist/CHANGELOG.md');
+fs.copyFileSync("README.md", "dist/README.md");
+fs.copyFileSync("CHANGELOG.md", "dist/CHANGELOG.md");
 
 echo(chalk.green("Copy the bin folder to finish the publication folder"));
-fs.cpSync('bin', 'dist/bin', {
+fs.cpSync("bin", "dist/bin", {
   force: true,
-  recursive: true
+  recursive: true,
 });
 
 echo(chalk.green("Bundling complete"));

--- a/apps/cli/scripts/gen.mjs
+++ b/apps/cli/scripts/gen.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env zx
 import "zx/globals";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/apps/cli/scripts/test.mjs
+++ b/apps/cli/scripts/test.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env zx
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }
@@ -18,5 +20,4 @@ if (errors.length > 0) {
     "/!\\ NOGO. Some warnings are logged by the CLI. Please fix them, this is a blocker to not ship more warnings than we already have. It costs time for all devs when we do.",
     errors,
   );
-
 }

--- a/apps/ledger-live-desktop/scripts/ci-lint.mjs
+++ b/apps/ledger-live-desktop/scripts/ci-lint.mjs
@@ -2,6 +2,8 @@
 import { basename } from "path";
 import stylish from "../../../node_modules/eslint/lib/cli-engine/formatters/stylish.js";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/apps/ledger-live-desktop/scripts/replace-assets.mjs
+++ b/apps/ledger-live-desktop/scripts/replace-assets.mjs
@@ -3,16 +3,24 @@ import "zx/globals";
 import fs from "fs";
 import path from "path";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }
 
 const basePath = path.join(__dirname, "..", "..", "..");
 const srcPath = path.join(__dirname, "..", "src");
-const replaceAssetsPath = path.join(basePath, "ledger-live-internal-assets", "apps", "ledger-live-desktop", "src");
+const replaceAssetsPath = path.join(
+  basePath,
+  "ledger-live-internal-assets",
+  "apps",
+  "ledger-live-desktop",
+  "src",
+);
 
-async function replaceAssets(){
-  await fs.promises.cp(replaceAssetsPath, srcPath, { recursive: true, force: true});
+async function replaceAssets() {
+  await fs.promises.cp(replaceAssetsPath, srcPath, { recursive: true, force: true });
 }
 
 await replaceAssets();

--- a/apps/ledger-live-desktop/scripts/sync-families-dispatch.mjs
+++ b/apps/ledger-live-desktop/scripts/sync-families-dispatch.mjs
@@ -3,6 +3,8 @@ import "zx/globals";
 import fs from "fs";
 import path from "path";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/apps/ledger-live-mobile/scripts/download-hermes-profile.mjs
+++ b/apps/ledger-live-mobile/scripts/download-hermes-profile.mjs
@@ -4,6 +4,8 @@
 import fs from "fs";
 import path from "path";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/apps/ledger-live-mobile/scripts/e2e-ci.mjs
+++ b/apps/ledger-live-mobile/scripts/e2e-ci.mjs
@@ -8,6 +8,8 @@ let shard = "";
 let target = "release";
 let filter = "";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/apps/ledger-live-mobile/scripts/gen-metafile.mjs
+++ b/apps/ledger-live-mobile/scripts/gen-metafile.mjs
@@ -4,6 +4,8 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/apps/ledger-live-mobile/scripts/post.mjs
+++ b/apps/ledger-live-mobile/scripts/post.mjs
@@ -83,6 +83,8 @@ function runHashChecks(writeCache = false) {
   return compareHashes(cache, result);
 }
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }
@@ -174,10 +176,10 @@ BRAZE_CUSTOM_ENDPOINT="sdk.fra-02.braze.eu"`;
       echo(chalk.red(str));
 
       if (process.env.CI) {
-        const output = process.env['GITHUB_OUTPUT']
-        const data = `error<<GHA_OUTPUT_DELIMITER\n${str}\nGHA_OUTPUT_DELIMITER\n`
+        const output = process.env["GITHUB_OUTPUT"];
+        const data = `error<<GHA_OUTPUT_DELIMITER\n${str}\nGHA_OUTPUT_DELIMITER\n`;
         writeFileSync(output, data);
-        echo(chalk.red('Error available in step output.error'));
+        echo(chalk.red("Error available in step output.error"));
       }
 
       await $`exit 1`;

--- a/apps/ledger-live-mobile/scripts/replace-assets.mjs
+++ b/apps/ledger-live-mobile/scripts/replace-assets.mjs
@@ -3,16 +3,23 @@ import "zx/globals";
 import fs from "fs";
 import path from "path";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }
 
 const rootPath = path.join(__dirname, "..", "..", "..");
 const basePath = path.join(__dirname, "..");
-const replaceAssetsPath = path.join(rootPath, "ledger-live-internal-assets", "apps", "ledger-live-mobile");
+const replaceAssetsPath = path.join(
+  rootPath,
+  "ledger-live-internal-assets",
+  "apps",
+  "ledger-live-mobile",
+);
 
-async function replaceAssets(){
-  await fs.promises.cp(replaceAssetsPath, basePath, { recursive: true, force: true});
+async function replaceAssets() {
+  await fs.promises.cp(replaceAssetsPath, basePath, { recursive: true, force: true });
 }
 
 await replaceAssets();

--- a/apps/ledger-live-mobile/scripts/sync-families-dispatch.mjs
+++ b/apps/ledger-live-mobile/scripts/sync-families-dispatch.mjs
@@ -2,6 +2,8 @@
 import "zx/globals";
 import rimraf from "rimraf";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/libs/ledger-live-common/scripts/build-ts.mjs
+++ b/libs/ledger-live-common/scripts/build-ts.mjs
@@ -2,6 +2,8 @@
 import "zx/globals";
 import rimraf from "rimraf";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/libs/ledger-live-common/scripts/sync-families-dispatch.mjs
+++ b/libs/ledger-live-common/scripts/sync-families-dispatch.mjs
@@ -2,6 +2,8 @@
 import rimraf from "rimraf";
 import "zx/globals";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }
@@ -18,7 +20,7 @@ const targets = [
   "mock.ts",
   "account.ts",
   "platformAdapter.ts",
-  "walletApiAdapter.ts"
+  "walletApiAdapter.ts",
 ];
 
 // Coins using coin-framework

--- a/libs/ledger-live-common/scripts/watch-ts-es.mjs
+++ b/libs/ledger-live-common/scripts/watch-ts-es.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env zx
 import "zx/globals";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }

--- a/libs/ledger-live-common/scripts/watch-ts.mjs
+++ b/libs/ledger-live-common/scripts/watch-ts.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env zx
 import "zx/globals";
 
+$.verbose = true; // everything works like in v7
+
 if (os.platform() === "win32") {
   usePowerShell();
 }


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.**
- [ ] **Impact of the changes:**

### 📝 Description

After updating to v8 we missed that the default verbosity level changed, this PR brings it back to v7 defaults

https://github.com/google/zx/releases/tag/8.0.0
![image](https://github.com/user-attachments/assets/5dd3efdb-884b-4bf0-9c7d-ce1cc853acac)

It should help get proper details instead of this
<img width="983" alt="Screenshot 2025-04-22 at 17 39 53" src="https://github.com/user-attachments/assets/df7b79d5-4d12-46eb-838f-d2a0ebb83a03" />

### ❓ Context

- **JIRA or GitHub link**: 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
