### PR TITLE
LIVE-18338: implement protocol info modal for api deposit flow

### DIFF
--- a/.changeset/quiet-pets-fail.md
+++ b/.changeset/quiet-pets-fail.md
@@ -1,0 +1,8 @@
+---
+"live-mobile": minor
+"@ledgerhq/icons-ui": minor
+"@ledgerhq/live-common": patch
+---
+
+Adds a new `ProtocolInfoModal` for the Defi yield flow.
+Fixes typo in one of the tests for `live-common`

--- a/apps/ledger-live-mobile/src/actions/earn.ts
+++ b/apps/ledger-live-mobile/src/actions/earn.ts
@@ -1,6 +1,10 @@
 import { createAction } from "redux-actions";
 import { EarnActionTypes } from "./types";
-import type { EarnSetInfoModalPayload, EarnSetMenuModalPayload } from "./types";
+import type {
+  EarnSetInfoModalPayload,
+  EarnSetMenuModalPayload,
+  EarnSetProtocolInfoModalPayload,
+} from "./types";
 
 export const makeSetEarnInfoModalAction = createAction<EarnSetInfoModalPayload>(
   EarnActionTypes.EARN_INFO_MODAL,
@@ -8,4 +12,8 @@ export const makeSetEarnInfoModalAction = createAction<EarnSetInfoModalPayload>(
 
 export const makeSetEarnMenuModalAction = createAction<EarnSetMenuModalPayload>(
   EarnActionTypes.EARN_MENU_MODAL,
+);
+
+export const makeSetEarnProtocolInfoModalAction = createAction<EarnSetProtocolInfoModalPayload>(
+  EarnActionTypes.EARN_PROTOCOL_INFO_MODAL,
 );

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -498,13 +498,19 @@ export type SwapPayload = UpdateProvidersPayload | UpdateTransactionPayload | Up
 export enum EarnActionTypes {
   EARN_INFO_MODAL = "EARN_INFO_MODAL",
   EARN_MENU_MODAL = "EARN_MENU_MODAL",
+  EARN_PROTOCOL_INFO_MODAL = "EARN_PROTOCOL_INFO_MODAL",
 }
 
 export type EarnSetInfoModalPayload = EarnState["infoModal"] | undefined;
 
 export type EarnSetMenuModalPayload = EarnState["menuModal"] | undefined;
 
-export type EarnPayload = EarnSetInfoModalPayload | EarnSetMenuModalPayload;
+export type EarnSetProtocolInfoModalPayload = EarnState["protocolInfoModal"] | undefined;
+
+export type EarnPayload =
+  | EarnSetInfoModalPayload
+  | EarnSetMenuModalPayload
+  | EarnSetProtocolInfoModalPayload;
 
 // === PROTECT ACTIONS ===
 export enum ProtectActionTypes {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -1,21 +1,20 @@
-import React, { useEffect, useMemo } from "react";
-import { createStackNavigator } from "@react-navigation/stack";
-
-import { useTheme } from "styled-components/native";
-import { useRoute } from "@react-navigation/native";
-import { useDispatch, useSelector } from "react-redux";
+import { getParentAccount, isTokenAccount } from "@ledgerhq/coin-framework/lib/account/helpers";
 import { getAccountIdFromWalletAccountId } from "@ledgerhq/live-common/wallet-api/converters";
-
-import { ScreenName, NavigatorName } from "~/const";
+import { useRoute } from "@react-navigation/native";
+import { createStackNavigator } from "@react-navigation/stack";
+import React, { useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useTheme } from "styled-components/native";
+import { NavigatorName, ScreenName } from "~/const";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
+import { flattenAccountsSelector } from "~/reducers/accounts";
+import { EarnScreen } from "~/screens/PTX/Earn";
+import { EarnInfoDrawer } from "~/screens/PTX/Earn/EarnInfoDrawer";
+import { EarnMenuDrawer } from "~/screens/PTX/Earn/EarnMenuDrawer";
+import { EarnProtocolInfoDrawer } from "~/screens/PTX/Earn/EarnProtocolInfoDrawer";
+import { useStakingDrawer } from "../Stake/useStakingDrawer";
 import type { EarnLiveAppNavigatorParamList } from "./types/EarnLiveAppNavigator";
 import type { BaseComposite, StackNavigatorProps } from "./types/helpers";
-import { EarnScreen } from "~/screens/PTX/Earn";
-import { flattenAccountsSelector } from "~/reducers/accounts";
-import { EarnInfoDrawer } from "~/screens/PTX/Earn/EarnInfoDrawer";
-import { useStakingDrawer } from "../Stake/useStakingDrawer";
-import { EarnMenuDrawer } from "~/screens/PTX/Earn/EarnMenuDrawer";
-import { getParentAccount, isTokenAccount } from "@ledgerhq/coin-framework/lib/account/helpers";
 
 const Stack = createStackNavigator<EarnLiveAppNavigatorParamList>();
 
@@ -123,6 +122,7 @@ const Earn = (props: NavigationProps) => {
           },
         }}
       />
+      <EarnProtocolInfoDrawer />
       <EarnInfoDrawer />
       <EarnMenuDrawer />
     </>

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1103,6 +1103,32 @@
     "tryEnablingAgain": "Try enabling location again",
     "noInfos": "Ledger does not access your location information."
   },
+  "earn": {
+    "deposit": {
+      "protocolInfoModal": {
+        "title": "To choose a protocol, here’s a few things to bear in mind:",
+        "items": {
+          "protocol": {
+            "highlighted": "A protocol",
+            "description": " is a platform that lets you get rewards by using your deposited crypto for lending, liquidity, or staking."
+          },
+          "apy": {
+            "highlighted": "APY (Annual Percentage Yield)",
+            "description": " is how much interest you can earn over a year. Higher APY means higher earnings."
+          },
+          "tvl": {
+            "highlighted": "TVL (Total value locked)",
+            "description": " is the total money deposited on the protocol by other users. Higher TVL means the protocol is trusted by more people."
+          },
+          "strategy": {
+            "highlighted": "Strategy",
+            "description0": " is the method a protocol uses to generate rewards for you.",
+            "description1": "For example, if a protocol uses lending as its strategy, it lends out your deposited stablecoin to borrowers. You then earn interest which varies based on demand."
+          }
+        }
+      }
+    }
+  },
   "permissions": {
     "open": "Open app permissions",
     "authorize": "Authorize",

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -23,7 +23,11 @@ import { useGeneralTermsAccepted } from "~/logic/terms";
 import { Writeable } from "~/types/helpers";
 import { lightTheme, darkTheme, Theme } from "../colors";
 import { track } from "~/analytics";
-import { makeSetEarnInfoModalAction, makeSetEarnMenuModalAction } from "~/actions/earn";
+import {
+  makeSetEarnInfoModalAction,
+  makeSetEarnMenuModalAction,
+  makeSetEarnProtocolInfoModalAction,
+} from "~/actions/earn";
 import { blockPasswordLock } from "../actions/appstate";
 import { useStorylyContext } from "~/components/StorylyStories/StorylyProvider";
 import { navigationIntegration } from "../sentry";
@@ -592,34 +596,38 @@ export const DeeplinksProvider = ({
           }
 
           if (hostname === "earn") {
-            if (searchParams.get("action") === "info-modal") {
-              const message = searchParams.get("message") ?? "";
-              const messageTitle = searchParams.get("messageTitle") ?? "";
-              const learnMoreLink = searchParams.get("learnMoreLink") ?? "";
-
-              dispatch(
-                makeSetEarnInfoModalAction({
-                  message,
-                  messageTitle,
-                  learnMoreLink,
-                }),
-              );
-              return;
-            }
-            if (searchParams.get("action") === "menu-modal") {
-              const title = searchParams.get("title") ?? "";
-              const options = searchParams.get("options") ?? "";
-
-              dispatch(
-                makeSetEarnMenuModalAction({
-                  title,
-                  options: JSON.parse(options) as {
-                    label: string;
-                    metadata: OptionMetadata;
-                  }[],
-                }),
-              );
-              return;
+            switch (searchParams.get("action")) {
+              case "info-modal": {
+                const message = searchParams.get("message") ?? "";
+                const messageTitle = searchParams.get("messageTitle") ?? "";
+                const learnMoreLink = searchParams.get("learnMoreLink") ?? "";
+                dispatch(
+                  makeSetEarnInfoModalAction({
+                    message,
+                    messageTitle,
+                    learnMoreLink,
+                  }),
+                );
+                return;
+              }
+              case "menu-modal": {
+                const title = searchParams.get("title") ?? "";
+                const options = searchParams.get("options") ?? "";
+                dispatch(
+                  makeSetEarnMenuModalAction({
+                    title,
+                    options: JSON.parse(options) as {
+                      label: string;
+                      metadata: OptionMetadata;
+                    }[],
+                  }),
+                );
+                return;
+              }
+              case "protocol-info-modal": {
+                dispatch(makeSetEarnProtocolInfoModalAction(true));
+                return;
+              }
             }
           }
           if ((hostname === "discover" || hostname === "recover") && platform) {

--- a/apps/ledger-live-mobile/src/reducers/earn.ts
+++ b/apps/ledger-live-mobile/src/reducers/earn.ts
@@ -6,12 +6,14 @@ import {
   EarnPayload,
   EarnSetInfoModalPayload,
   EarnSetMenuModalPayload,
+  EarnSetProtocolInfoModalPayload,
 } from "../actions/types";
 import type { EarnState, State } from "./types";
 
 export const INITIAL_STATE: EarnState = {
   infoModal: {},
   menuModal: undefined,
+  protocolInfoModal: undefined,
 };
 
 const handlers: ReducerMap<EarnState, EarnPayload> = {
@@ -23,13 +25,15 @@ const handlers: ReducerMap<EarnState, EarnPayload> = {
     ...state,
     menuModal: (action as Action<EarnSetMenuModalPayload>).payload,
   }),
+  [EarnActionTypes.EARN_PROTOCOL_INFO_MODAL]: (state, action): EarnState => ({
+    ...state,
+    protocolInfoModal: (action as Action<EarnSetProtocolInfoModalPayload>).payload,
+  }),
 };
 
 const storeSelector = (state: State): EarnState => state.earn;
 
 export const exportSelector = storeSelector;
-
-export default handleActions<EarnState, EarnPayload>(handlers, INITIAL_STATE);
 
 export const earnInfoModalSelector = createSelector(
   storeSelector,
@@ -40,3 +44,10 @@ export const earnMenuModalSelector = createSelector(
   storeSelector,
   (state: EarnState) => state.menuModal,
 );
+
+export const earnProtocolInfoModalSelector = createSelector(
+  storeSelector,
+  (state: EarnState) => state.protocolInfoModal,
+);
+
+export default handleActions<EarnState, EarnPayload>(handlers, INITIAL_STATE);

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -319,6 +319,7 @@ export type EarnState = {
     title?: string;
     options: { label: string; metadata: OptionMetadata }[];
   };
+  protocolInfoModal?: true;
 };
 
 // === PROTECT STATE ===

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnProtocolInfoDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnProtocolInfoDrawer.tsx
@@ -1,0 +1,114 @@
+import { Flex, Icons, Text } from "@ledgerhq/native-ui";
+import React, { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { makeSetEarnProtocolInfoModalAction } from "~/actions/earn";
+import { Track } from "~/analytics";
+import { rgba } from "~/colors";
+import Circle from "~/components/Circle";
+import QueuedDrawer from "~/components/QueuedDrawer";
+import { earnProtocolInfoModalSelector } from "~/reducers/earn";
+
+const ICON_CIRCLE_SIZE = 32;
+const ICON_SIZE = "XS";
+const ICON_SPACING = 16;
+const DESCRIPTION_PADDING = 8;
+
+const ICON_PROTOCOL_COLOR = "#97A5EE";
+const ICON_APY_COLOR = "#8BBA74";
+const ICON_TVL_COLOR = "#F1C247";
+const ICON_STRATEGY_COLOR = "#BBB0FF";
+
+export function EarnProtocolInfoDrawer() {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const [modalOpened, setModalOpened] = useState(false);
+
+  const openModal = useCallback(() => setModalOpened(true), []);
+
+  const closeModal = useCallback(async () => {
+    await dispatch(makeSetEarnProtocolInfoModalAction(undefined));
+    await setModalOpened(false);
+  }, [dispatch]);
+  const state = useSelector(earnProtocolInfoModalSelector);
+
+  useEffect(() => {
+    if (!modalOpened && state) {
+      openModal();
+    }
+  }, [openModal, modalOpened, state]);
+
+  return (
+    <QueuedDrawer isRequestingToBeOpened={modalOpened} onClose={closeModal}>
+      <Flex rowGap={32}>
+        <Track onMount event="Earn Protocol Info Modal" />
+        <Flex rowGap={32} alignItems="center">
+          <Text variant="h4" fontFamily="Inter" textAlign="center">
+            {t("earn.deposit.protocolInfoModal.title")}
+          </Text>
+
+          <Flex alignItems="left" rowGap={24}>
+            <Flex flexDirection="row" columnGap={ICON_SPACING} px={DESCRIPTION_PADDING}>
+              <Circle size={ICON_CIRCLE_SIZE} bg={rgba(ICON_PROTOCOL_COLOR, 0.1)}>
+                <Icons.Protocol size={ICON_SIZE} color={ICON_PROTOCOL_COLOR} />
+              </Circle>
+              <Flex>
+                <Text variant="paragraph" color="neutral.c70">
+                  <Text variant="paragraph" fontWeight="semiBold">
+                    {t("earn.deposit.protocolInfoModal.items.protocol.highlighted")}
+                  </Text>
+                  {t("earn.deposit.protocolInfoModal.items.protocol.description")}
+                </Text>
+              </Flex>
+            </Flex>
+
+            <Flex flexDirection="row" columnGap={ICON_SPACING} px={DESCRIPTION_PADDING}>
+              <Circle size={ICON_CIRCLE_SIZE} bg={rgba(ICON_APY_COLOR, 0.1)}>
+                <Icons.ProtocolApy size={ICON_SIZE} color={ICON_APY_COLOR} />
+              </Circle>
+              <Flex>
+                <Text variant="paragraph" color="neutral.c70">
+                  <Text variant="paragraph">
+                    {t("earn.deposit.protocolInfoModal.items.apy.highlighted")}
+                  </Text>
+                  {t("earn.deposit.protocolInfoModal.items.apy.description")}
+                </Text>
+              </Flex>
+            </Flex>
+
+            <Flex flexDirection="row" columnGap={ICON_SPACING} px={DESCRIPTION_PADDING}>
+              <Circle size={ICON_CIRCLE_SIZE} bg={rgba(ICON_TVL_COLOR, 0.1)}>
+                <Icons.ProtocolTvl size={ICON_SIZE} color={ICON_TVL_COLOR} />
+              </Circle>
+              <Flex>
+                <Text variant="paragraph" color="neutral.c70">
+                  <Text variant="paragraph">
+                    {t("earn.deposit.protocolInfoModal.items.tvl.highlighted")}
+                  </Text>
+                  {t("earn.deposit.protocolInfoModal.items.tvl.description")}
+                </Text>
+              </Flex>
+            </Flex>
+
+            <Flex flexDirection="row" columnGap={ICON_SPACING} px={DESCRIPTION_PADDING}>
+              <Circle size={ICON_CIRCLE_SIZE} bg={rgba(ICON_STRATEGY_COLOR, 0.1)}>
+                <Icons.ProtocolStrategy size={ICON_SIZE} color={ICON_STRATEGY_COLOR} />
+              </Circle>
+              <Flex rowGap={8}>
+                <Text variant="paragraph" color="neutral.c70">
+                  <Text variant="paragraph">
+                    {t("earn.deposit.protocolInfoModal.items.strategy.highlighted")}
+                  </Text>
+                  {t("earn.deposit.protocolInfoModal.items.strategy.description0")}
+                </Text>
+                <Text variant="paragraph" color="neutral.c70">
+                  {t("earn.deposit.protocolInfoModal.items.strategy.description1")}
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </QueuedDrawer>
+  );
+}

--- a/libs/ledger-live-common/src/featureFlags/stakePrograms/index.test.ts
+++ b/libs/ledger-live-common/src/featureFlags/stakePrograms/index.test.ts
@@ -33,7 +33,7 @@ const feature_stake_programs_json: Feature_StakePrograms = {
   },
 };
 
-describe("stakeProgramToEarnParam", () => {
+describe("stakeProgramsToEarnParam", () => {
   it("should return `undefined` when there are no redirects", () => {
     const result = stakeProgramsToEarnParam(feature_stake_programs_empty_json);
     expect(result).toEqual(undefined);

--- a/libs/ui/packages/icons/src/svg/protocol-apy.svg
+++ b/libs/ui/packages/icons/src/svg/protocol-apy.svg
@@ -1,0 +1,13 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <path d="M7.8623 6.13743L10.1384 3.86133" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7.71693 3.7698C7.71704 3.73945 7.7417 3.71492 7.77205 3.71497C7.8024 3.71503 7.82697 3.73965 7.82697 3.77C7.82697 3.80034 7.8024 3.82496 7.77205 3.82502C7.7417 3.82507 7.71704 3.80054 7.71693 3.7702V3.7698" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M5.33301 4.66578V3.53197C5.33301 2.31644 6.31839 1.33105 7.53392 1.33105H10.4685C11.684 1.33105 12.6694 2.31644 12.6694 3.53197V6.46653C12.6694 7.68206 11.684 8.66744 10.4685 8.66744H10.0016" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10.285 6.2282C10.2849 6.25855 10.2602 6.28308 10.2299 6.28303C10.1995 6.28297 10.1749 6.25835 10.1749 6.228C10.1749 6.19765 10.1995 6.17304 10.2299 6.17298C10.2602 6.17293 10.2849 6.19745 10.285 6.2278V6.2282" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M12.6694 10.668V14.0027" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M11.335 12.0019L12.6688 10.668" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M14.0028 12.0019L12.6689 10.668" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M1.99805 8.40039V12.9356C1.99881 13.5248 3.19245 14.0027 4.66582 14.0027C6.1392 14.0027 7.33284 13.5248 7.3336 12.9356V8.40039" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7.33284 8.40012C7.33284 8.98932 6.13844 9.46723 4.66506 9.46723C3.19169 9.46723 1.99805 8.98932 1.99805 8.40012C1.99805 7.81016 3.19321 7.33301 4.66582 7.33301C6.13844 7.33301 7.33284 7.81092 7.3336 8.40012" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M1.99805 10.668C1.99805 11.2572 3.19169 11.7351 4.66506 11.7351C6.13844 11.7351 7.33284 11.2572 7.33284 10.668" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/libs/ui/packages/icons/src/svg/protocol-strategy.svg
+++ b/libs/ui/packages/icons/src/svg/protocol-strategy.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <path d="M12.6663 8.66622V5.83594" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <rect x="11.333" y="8.66699" width="2.66667" height="6" rx="1.33333" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.0273 2.18419L11.2375 3.76273C11.109 4.01942 11.1593 4.3295 11.3623 4.53245L12.6662 5.83639L13.9717 4.53089C14.1747 4.32793 14.2249 4.01785 14.0965 3.76116L13.3075 2.18419C13.251 2.0713 13.1356 2 13.0094 2H12.3254C12.1992 2 12.0838 2.0713 12.0273 2.18419V2.18419Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M3.33301 2L1.33301 4V5.33333H7.99968C8.36787 5.33333 8.66634 5.03486 8.66634 4.66667V2.66667C8.66634 2.29848 8.36787 2 7.99968 2H3.33301Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M4 5.33301H6.66667V13.333C6.66667 14.0694 6.06971 14.6663 5.33333 14.6663V14.6663C4.59695 14.6663 4 14.0694 4 13.333V5.33301Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/libs/ui/packages/icons/src/svg/protocol-tvl.svg
+++ b/libs/ui/packages/icons/src/svg/protocol-tvl.svg
@@ -1,0 +1,11 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 8.34033L5.33333 8.32633" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M4 9.65983L5.33333 8.3265L4 6.99316" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M8.95367 13.968L12.9537 13.0846C13.565 12.95 13.9997 12.4086 13.9997 11.7826V4.21731C13.9997 3.59198 13.565 3.04998 12.9537 2.91531L8.95367 2.03198C8.12167 1.84798 7.33301 2.48131 7.33301 3.33398V12.666C7.33301 13.5186 8.12167 14.152 8.95367 13.968Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M10.4777 9.31765L11.1443 9.17031C11.4497 9.10298 11.667 8.83231 11.667 8.51965V7.48098C11.667 7.16831 11.4497 6.89765 11.1443 6.83031L10.4777 6.68298C10.061 6.59098 9.66699 6.90765 9.66699 7.33365V8.66698C9.66699 9.09298 10.061 9.40965 10.4777 9.31765V9.31765Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M4.00033 13.333V13.9997" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M12.6663 13.1465V13.9998" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7.51467 13.3337H3.33333C2.59667 13.3337 2 12.737 2 12.0003V10.667" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7.33333 3.33398H3.33333C2.59667 3.33398 2 3.93065 2 4.66732V5.99998" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/libs/ui/packages/icons/src/svg/protocol.svg
+++ b/libs/ui/packages/icons/src/svg/protocol.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 3.99935H10.6667" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12.6663 6.66634H8.66634C7.92967 6.66634 7.33301 6.06967 7.33301 5.33301V2.66634C7.33301 1.92967 7.92967 1.33301 8.66634 1.33301H12.6663C13.403 1.33301 13.9997 1.92967 13.9997 2.66634V5.33301C13.9997 6.06967 13.403 6.66634 12.6663 6.66634Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M13.9997 11.9993H5.33301" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M12.667 13.3327L14.0003 11.9993L12.667 10.666" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M3.33333 9.33301H7.33333C8.07 9.33301 8.66667 9.92967 8.66667 10.6663V13.333C8.66667 14.0697 8.07 14.6663 7.33333 14.6663H3.33333C2.59667 14.6663 2 14.0697 2 13.333V10.6663C2 9.92967 2.59667 9.33301 3.33333 9.33301Z" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M3.33333 2.66602L2 3.99935L3.33333 5.33268" stroke="white" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Adds a new deeplink modal under the Earn umbrella

### 📝 Description

Implements a native mobile version of the Protocol Info Modal required for the step of choosing a DeFi protocol for Stablecoin Yield.

![image](https://github.com/user-attachments/assets/2f6a2224-3fc3-403d-8aac-1b11b87de703)

### ❓ Context

- **JIRA**: [LIVE-18338](https://ledgerhq.atlassian.net/browse/LIVE-18338)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18338]: https://ledgerhq.atlassian.net/browse/LIVE-18338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ