### PR TITLE
feat: remove NFT support in LLM

### DIFF
--- a/.changeset/cold-tomatoes-greet.md
+++ b/.changeset/cold-tomatoes-greet.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+NFT Support in LLM

--- a/apps/ledger-live-mobile/e2e/specs/deeplinks.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/deeplinks.spec.ts
@@ -57,7 +57,7 @@ describe("DeepLinks Tests", () => {
     await app.discover.expectApp(randomLiveApp);
   });
 
-  it("should open NFT Gallery", async () => {
+  it.skip("should open NFT Gallery", async () => {
     await app.nftGallery.openViaDeeplink();
     await app.nftGallery.expectGalleryVisible();
   });

--- a/apps/ledger-live-mobile/e2e/specs/speculos/deeplinks.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/deeplinks.spec.ts
@@ -65,7 +65,7 @@ describe("DeepLinks Tests", () => {
     await app.discover.expectApp(randomLiveApp);
   });
 
-  it("should open NFT Gallery", async () => {
+  it.skip("should open NFT Gallery", async () => {
     await app.nftGallery.openViaDeeplink();
     await app.nftGallery.expectGalleryVisible();
   });

--- a/apps/ledger-live-mobile/e2e/specs/speculos/nftGallery.spec.ts
+++ b/apps/ledger-live-mobile/e2e/specs/speculos/nftGallery.spec.ts
@@ -1,4 +1,4 @@
-describe("NFT Gallery screen", () => {
+describe.skip("NFT Gallery screen", () => {
   const nanoApp = AppInfos.ETHEREUM;
   const accountCurrency = Currency.ETH.id;
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
@@ -22,6 +22,7 @@ import WalletTabHeader from "../WalletTab/WalletTabHeader";
 import { WalletTabNavigatorStackParamList } from "./types/WalletTabNavigator";
 import { ScreenName, NavigatorName } from "~/const/navigation";
 import MarketWalletTabNavigator from "LLM/features/Market/WalletTabNavigator";
+import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 
 const WalletTab = createMaterialTopTabNavigator<WalletTabNavigatorStackParamList>();
 
@@ -34,6 +35,8 @@ export default function WalletTabNavigator() {
   const lastVisitedTab = useSelector(walletTabNavigatorLastVisitedTabSelector);
   const { t } = useTranslation();
   const [currentRouteName, setCurrentRouteName] = useState<string | undefined>();
+
+  const llmNftSupport = useFeature("llNftSupport");
 
   return (
     <WalletTabNavigatorScrollManager currentRouteName={currentRouteName}>
@@ -71,13 +74,15 @@ export default function WalletTabNavigator() {
             }}
           />
 
-          <WalletTab.Screen
-            name={ScreenName.WalletNftGallery}
-            component={WalletNftGallery}
-            options={{
-              title: t("wallet.tabs.nft"),
-            }}
-          />
+          {llmNftSupport?.enabled && (
+            <WalletTab.Screen
+              name={ScreenName.WalletNftGallery}
+              component={WalletNftGallery}
+              options={{
+                title: t("wallet.tabs.nft"),
+              }}
+            />
+          )}
 
           <WalletTab.Screen
             name={NavigatorName.Market}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/WalletTabNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   createMaterialTopTabNavigator,
@@ -38,11 +38,19 @@ export default function WalletTabNavigator() {
 
   const llmNftSupport = useFeature("llNftSupport");
 
+  const initialRouteName = useMemo(
+    () =>
+      lastVisitedTab === ScreenName.WalletNftGallery && !llmNftSupport?.enabled
+        ? ScreenName.Portfolio
+        : lastVisitedTab,
+    [lastVisitedTab, llmNftSupport?.enabled],
+  );
+
   return (
     <WalletTabNavigatorScrollManager currentRouteName={currentRouteName}>
       <Box flexGrow={1} bg={"background.main"}>
         <WalletTab.Navigator
-          initialRouteName={lastVisitedTab}
+          initialRouteName={initialRouteName}
           tabBar={tabBarOptions}
           style={{ backgroundColor: "transparent" }}
           sceneContainerStyle={{ backgroundColor: "transparent" }}

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -89,6 +89,7 @@ export function useListHeaderComponents({
   listHeaderComponents: ReactNode[];
   stickyHeaderIndices?: number[];
 } {
+  const llmNftSupport = useFeature("llNftSupport");
   const llmSolanaNfts = useFeature("llmSolanaNfts");
   if (!account) return { listHeaderComponents: [], stickyHeaderIndices: undefined };
 
@@ -135,7 +136,8 @@ export function useListHeaderComponents({
     isStuckOperation({ family: mainAccount.currency.family, operation: oldestEditableOperation });
 
   const displayNftCollections = isNFTCollectionsDisplayable(account, empty, {
-    llmSolanaNftsEnabled: llmSolanaNfts?.enabled,
+    llmNftSupportEnabled: !!llmNftSupport?.enabled,
+    llmSolanaNftsEnabled: !!llmSolanaNfts?.enabled,
   });
 
   const coinConfig = getCurrencyConfiguration(currency);

--- a/apps/ledger-live-mobile/src/screens/Account/__tests__/nftHelper.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Account/__tests__/nftHelper.test.ts
@@ -44,7 +44,7 @@ describe("nftHelper", () => {
       expect(result).toBe(false);
     });
 
-    it("returns false if account === solana and llmSolanaNftsEnabled === false", () => {
+    it("returns false if account === solana, llmNftSupportEnabled === false, and llmSolanaNftsEnabled === false", () => {
       (getEnv as jest.Mock).mockReturnValue(["solana"]);
       const account = {
         type: "Account",
@@ -57,12 +57,16 @@ describe("nftHelper", () => {
       (isNFTActive as jest.Mock).mockReturnValue(nftCurrencies.includes(account.currency.id));
 
       const isAccountEmpty = false;
+      const llmNftSupportEnabled = false;
       const llmSolanaNftsEnabled = false;
-      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, {
+        llmNftSupportEnabled,
+        llmSolanaNftsEnabled,
+      });
       expect(result).toBe(false);
     });
 
-    it("returns true if account === solana and llmSolanaNftsEnabled === true", () => {
+    it("returns true if account === solana, llmNftSupportEnabled === true, and llmSolanaNftsEnabled === true", () => {
       (getEnv as jest.Mock).mockReturnValue(["solana"]);
       const account = {
         type: "Account",
@@ -75,12 +79,38 @@ describe("nftHelper", () => {
       (isNFTActive as jest.Mock).mockReturnValue(nftCurrencies.includes(account.currency.id));
 
       const isAccountEmpty = false;
+      const llmNftSupportEnabled = true;
       const llmSolanaNftsEnabled = true;
-      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, {
+        llmNftSupportEnabled,
+        llmSolanaNftsEnabled,
+      });
       expect(result).toBe(true);
     });
 
-    it("returns true if account !== solana and llmSolanaNftsEnabled === false", () => {
+    it("returns false if account === solana, llmNftSupportEnabled === true, and llmSolanaNftsEnabled === false", () => {
+      (getEnv as jest.Mock).mockReturnValue(["solana"]);
+      const account = {
+        type: "Account",
+        currency: {
+          id: "solana",
+        },
+      } as Account;
+      const nftCurrencies = getEnv("NFT_CURRENCIES");
+
+      (isNFTActive as jest.Mock).mockReturnValue(nftCurrencies.includes(account.currency.id));
+
+      const isAccountEmpty = false;
+      const llmNftSupportEnabled = true;
+      const llmSolanaNftsEnabled = false;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, {
+        llmNftSupportEnabled,
+        llmSolanaNftsEnabled,
+      });
+      expect(result).toBe(false);
+    });
+
+    it("returns true if account !== solana, llmNftSupportEnabled === true, and llmSolanaNftsEnabled === false", () => {
       const account = {
         type: "Account",
         currency: {
@@ -88,8 +118,38 @@ describe("nftHelper", () => {
         },
       } as Account;
       const isAccountEmpty = false;
+      const llmNftSupportEnabled = true;
       const llmSolanaNftsEnabled = false;
-      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmSolanaNftsEnabled });
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, {
+        llmNftSupportEnabled,
+        llmSolanaNftsEnabled,
+      });
+      expect(result).toBe(true);
+    });
+
+    it("returns false if llmNftSupportEnabled === false", () => {
+      const account = {
+        type: "Account",
+        currency: {
+          id: "ethereum",
+        },
+      } as Account;
+      const isAccountEmpty = false;
+      const llmNftSupportEnabled = false;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmNftSupportEnabled });
+      expect(result).toBe(false);
+    });
+
+    it("returns true if llmNftSupportEnabled === true", () => {
+      const account = {
+        type: "Account",
+        currency: {
+          id: "ethereum",
+        },
+      } as Account;
+      const isAccountEmpty = false;
+      const llmNftSupportEnabled = true;
+      const result = isNFTCollectionsDisplayable(account, isAccountEmpty, { llmNftSupportEnabled });
       expect(result).toBe(true);
     });
   });

--- a/apps/ledger-live-mobile/src/screens/Account/nftHelper.ts
+++ b/apps/ledger-live-mobile/src/screens/Account/nftHelper.ts
@@ -1,16 +1,18 @@
 import { AccountLike } from "@ledgerhq/types-live";
 import { isNFTActive } from "@ledgerhq/coin-framework/nft/support";
 
-type SolanaProps = {
+type FeatureProps = {
+  llmNftSupportEnabled?: boolean;
   llmSolanaNftsEnabled?: boolean;
 };
 
 export function isNFTCollectionsDisplayable(
   account: AccountLike,
   isAccountEmpty: boolean,
-  { llmSolanaNftsEnabled = false }: SolanaProps,
+  { llmSolanaNftsEnabled = false, llmNftSupportEnabled = false }: FeatureProps,
 ): boolean {
   return (
+    llmNftSupportEnabled &&
     !isAccountEmpty &&
     account.type === "Account" &&
     isNFTActive(account.currency) &&

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Generators/index.tsx
@@ -16,6 +16,7 @@ import { useReboot } from "~/context/Reboot";
 import { INITIAL_STATE as INITIAL_SETTINGS_STATE } from "~/reducers/settings";
 import { INITIAL_STATE as INITIAL_ACCOUNTS_STATE } from "~/reducers/accounts";
 import { INITIAL_STATE as INITIAL_BLE_STATE } from "~/reducers/ble";
+import FeatureToggle from "@ledgerhq/live-common/featureFlags/FeatureToggle";
 
 export default function Generators() {
   const dispatch = useDispatch();
@@ -92,12 +93,15 @@ export default function Generators() {
         desc="Replace existing accounts with 10 mock accounts from random currencies."
         count={10}
       />
-      <GenerateMockAccount
-        title="Accounts with NFTs"
-        desc="Select for which currencies you want to generate accounts and NFTs"
-        iconLeft={<Icons.Nft size="M" color="black" />}
-        withNft
-      />
+      <FeatureToggle featureId="llNftSupport">
+        <GenerateMockAccount
+          title="Accounts with NFTs"
+          desc="Select for which currencies you want to generate accounts and NFTs"
+          iconLeft={<Icons.Nft size="M" color="black" />}
+          withNft
+        />
+      </FeatureToggle>
+
       {getEnv("MOCK") ? <ToggleServiceStatusIncident /> : null}
       <ImportBridgeStreamData
         title="Import .env BRIDGESTREAM_DATA"
@@ -134,12 +138,14 @@ export default function Generators() {
         iconLeft={<IconsLegacy.NanoMedium size={24} color="black" />}
         onPress={onWipeBLE}
       />
-      <SettingsRow
-        title="Reset HiddenCollections NFTs"
-        desc="Remove all NFTs from the HiddenCollection list"
-        iconLeft={<Icons.Nft size="M" color="black" />}
-        onPress={onWipeAntiSpam}
-      />
+      <FeatureToggle featureId="llNftSupport">
+        <SettingsRow
+          title="Reset HiddenCollections NFTs"
+          desc="Remove all NFTs from the HiddenCollection list"
+          iconLeft={<Icons.Nft size="M" color="black" />}
+          onPress={onWipeAntiSpam}
+        />
+      </FeatureToggle>
     </SettingsNavigationScrollView>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Hiding NFTs in LLM 
- Gallery
- Collections
- Tools

WalletTab when FF OFF


https://github.com/user-attachments/assets/f5b9bf68-bc75-44b3-8906-3f4cacb33c96


### ❓ Context

- **JIRA or GitHub link**: [LIVE-18378] [LIVE-18408] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18378]: https://ledgerhq.atlassian.net/browse/LIVE-18378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-18408]: https://ledgerhq.atlassian.net/browse/LIVE-18408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ