### PR TITLE
:bug: (llm) fix ratingsDataOfUserSelector type

### DIFF
--- a/.changeset/strange-suits-fix.md
+++ b/.changeset/strange-suits-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix type of appFirstStartDate

--- a/apps/ledger-live-mobile/src/reducers/ratings.ts
+++ b/apps/ledger-live-mobile/src/reducers/ratings.ts
@@ -56,7 +56,13 @@ export const ratingsModalOpenSelector = (s: State) => s.ratings.isRatingsModalOp
 export const ratingsModalLockedSelector = (s: State) => s.ratings.isRatingsModalLocked;
 export const ratingsCurrentRouteNameSelector = (s: State) => s.ratings.currentRouteName;
 export const ratingsHappyMomentSelector = (s: State) => s.ratings.happyMoment;
-export const ratingsDataOfUserSelector = (s: State) => s.ratings.dataOfUser;
+export const ratingsDataOfUserSelector = (s: State) => {
+  const dataOfUser = { ...s.ratings.dataOfUser };
+  if (typeof s.ratings.dataOfUser?.appFirstStartDate === "string") {
+    dataOfUser.appFirstStartDate = new Date(s.ratings.dataOfUser.appFirstStartDate);
+  }
+  return dataOfUser;
+};
 export const satisfactionSelector = (s: State) => s.ratings.dataOfUser?.satisfaction;
 
 export default handleActions<RatingsState, RatingsPayload>(handlers, INITIAL_STATE);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

ratingsDataOfUserSelector returned appFirstStartDate as a string instead of a date causing a warning in dev. It's fixed

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
