### PR TITLE
fix: wrong transaction kind for solana SPL [LIVE-18586]

### DIFF
--- a/.changeset/khaki-brooms-sort.md
+++ b/.changeset/khaki-brooms-sort.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": minor
+---
+
+fix: wrong transaction kind for solana SPL

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -827,6 +827,18 @@ async function deriveStakeSplitCommandDescriptor(
 
 // if subaccountid present - it's a token transfer
 function updateModelIfSubAccountIdPresent(tx: Transaction): Transaction {
+  if (tx.subAccountId && tx.model.kind === "transfer") {
+    return {
+      ...tx,
+      model: {
+        kind: "token.transfer",
+        uiState: {
+          ...tx.model.uiState,
+          subAccountId: tx.subAccountId,
+        },
+      },
+    };
+  }
   if (
     tx.subAccountId &&
     // Using this instead of includes to get proper type narrowing


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** It should be but we'll take a look later
- [x] **Impact of the changes:**
  - SPL send

### 📝 Description

Fixing a change where we forgot to also set transaction to `token.transfer` if initiated as `transfer` with a `subAccountId`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18586] [LIVE-18585] [LIVE-18603]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18586]: https://ledgerhq.atlassian.net/browse/LIVE-18586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-18585]: https://ledgerhq.atlassian.net/browse/LIVE-18585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-18603]: https://ledgerhq.atlassian.net/browse/LIVE-18603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ