### PR TITLE
bugfixe: wrong size for retry button in device action

### DIFF
--- a/.changeset/light-mice-boil.md
+++ b/.changeset/light-mice-boil.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+bugfixe: wrong size for retry button in device action

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -206,8 +206,8 @@ const ButtonContainer = styled(Box).attrs(({ theme }) => ({
   alignItems: "center",
   justifyContent: "center",
   gap: `${theme.space[4]}px`,
-}))`
-  align-self: stretch;
+}))<{ stretch?: boolean }>`
+  ${({ stretch }) => stretch && "align-self: stretch;"}
 `;
 
 const ButtonGroup = styled(Box).attrs(({ theme }) => ({
@@ -784,6 +784,7 @@ export const renderError = ({
   learnMoreLink,
   learnMoreTextKey,
   Icon,
+  stretch,
 }: {
   error: Error | ErrorConstructor;
   t: TFunction;
@@ -803,6 +804,7 @@ export const renderError = ({
   device?: Device | null;
   inlineRetry?: boolean;
   withDescription?: boolean;
+  stretch?: boolean;
   Icon?: (props: { color?: string | undefined; size?: number | undefined }) => JSX.Element;
 }) => {
   let tmpError = error;
@@ -864,7 +866,7 @@ export const renderError = ({
           ) : undefined
         }
       />
-      <ButtonContainer>
+      <ButtonContainer stretch={stretch}>
         {managerAppName || requireFirmwareUpdate ? (
           <OpenManagerButton
             appName={managerAppName}
@@ -919,6 +921,7 @@ export const renderInWrongAppForAccount = ({
     error: new WrongDeviceForAccount(""),
     withExportLogs: true,
     onRetry,
+    stretch: true,
   });
 
 export const renderConnectYourDevice = ({


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
bugfixe: wrong size for retry button in device action

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18570]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

<img width="1022" alt="Screenshot 2025-04-28 at 09 56 58" src="https://github.com/user-attachments/assets/6646a6b3-0dcf-41fb-8d0b-90c357eba010" />

<img width="509" alt="Screenshot 2025-04-25 at 15 53 07" src="https://github.com/user-attachments/assets/912c9a04-d793-4ecb-8d70-76084e1efb41" />

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18570]: https://ledgerhq.atlassian.net/browse/LIVE-18570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ