### PR TITLE
Support/ci codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 # fdp-ci team
 .github                                                 @ledgerhq/fdp-ci
 .github/workflows/test-ui-e2e-only-desktop.yml          @ledgerhq/fdp-ci  @ledgerhq/qaa
+.github/workflows/test-mobile-e2e-reusable.yml          @ledgerhq/fdp-ci  @ledgerhq/qaa
 .github/workflows/test-design-system-reusable.yml       @ledgerhq/fdp-ci  @ledgerhq/live-hub
 
 # Hub team


### PR DESCRIPTION
Making .github codeowned by fdp-ci with a shared ownership exception list. Anything that touches the PR flows should have fdp-ci as owner in addition to any teams that may be the actual maintainers.

Can be checked by hovering over the icon within the branch as per below:
<img width="307" alt="Screenshot 2025-04-28 at 09 33 58" src="https://github.com/user-attachments/assets/a8cb9d81-63e5-45d7-ab60-8dcc0c79a4c2" />

**Examples**

Standard CI file ownership:
https://github.com/LedgerHQ/ledger-live/blob/support/ci-codeowners/.github/workflows/test-desktop-reusable.yml

Override 1:
https://github.com/LedgerHQ/ledger-live/blob/support/ci-codeowners/.github/workflows/bot-testing-nitrogen.yml

Override 2:
https://github.com/LedgerHQ/ledger-live/blob/support/ci-codeowners/.github/workflows/test-ui-e2e-only-desktop.yml

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-18519
