### PR TITLE
bugfixe: Discreet mode wallet selection

### DIFF
--- a/.changeset/smooth-birds-chew.md
+++ b/.changeset/smooth-birds-chew.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+bugfixe: Discreet mode wallet selection

--- a/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/RequestAccount/02-SelectAccount.tsx
@@ -25,6 +25,7 @@ import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/Ba
 import { Flex } from "@ledgerhq/native-ui";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { AddAccountContexts } from "LLM/features/Accounts/screens/AddAccount/enums";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
 
 const SEARCH_KEYS = [
   "name",
@@ -272,4 +273,4 @@ const styles = StyleSheet.create({
     flexDirection: "row",
   },
 });
-export default SelectAccount;
+export default withDiscreetMode(SelectAccount);

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -13,10 +13,11 @@ import { SendFundsNavigatorStackParamList } from "~/components/RootNavigator/typ
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import SafeAreaView from "~/components/SafeAreaView";
 import { AccountLike } from "@ledgerhq/types-live";
+import { withDiscreetMode } from "~/context/DiscreetModeContext";
 
 type Props = StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendCoin>;
 
-export default function ReceiveFunds({ navigation, route }: Props) {
+function ReceiveFunds({ navigation, route }: Props) {
   const {
     selectedCurrency,
     currency: initialCurrencySelected,
@@ -95,3 +96,5 @@ export default function ReceiveFunds({ navigation, route }: Props) {
     </SafeAreaView>
   );
 }
+
+export default withDiscreetMode(ReceiveFunds);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

bugfixe: Discreet mode wallet selection

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18578]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

<img width="362" alt="Screenshot 2025-04-28 at 11 57 24" src="https://github.com/user-attachments/assets/4c7636d9-e7ab-4c42-a7a6-f54096da41fe" />
<img width="362" alt="Screenshot 2025-04-28 at 13 48 35" src="https://github.com/user-attachments/assets/69136e56-8cb9-4f79-b781-21a1c1f1b0d5" />

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18578]: https://ledgerhq.atlassian.net/browse/LIVE-18578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ