### PR TITLE
fix: localize stellar polyfill and revert it once used

### DIFF
--- a/.changeset/gorgeous-weeks-protect.md
+++ b/.changeset/gorgeous-weeks-protect.md
@@ -1,6 +1,6 @@
 ---
-"@ledgerhq/coin-stellar": patch
-"live-mobile": patch
+"@ledgerhq/coin-stellar": minor
+"live-mobile": minor
 ---
 
 fix: isolate stellar polyfill and revert it once used

--- a/.changeset/gorgeous-weeks-protect.md
+++ b/.changeset/gorgeous-weeks-protect.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-stellar": patch
+"live-mobile": patch
+---
+
+fix: isolate stellar polyfill and revert it once used

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -74,7 +74,6 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "1.0.2",
     "@braze/react-native-sdk": "10.0.0",
-    "@exodus/patch-broken-hermes-typed-arrays": "1.0.0-alpha.1",
     "@formatjs/intl-locale": "3.4.5",
     "@formatjs/intl-pluralrules": "5.2.12",
     "@formatjs/intl-relativetimeformat": "11.2.12",

--- a/apps/ledger-live-mobile/src/polyfill.ts
+++ b/apps/ledger-live-mobile/src/polyfill.ts
@@ -29,9 +29,6 @@ import "@formatjs/intl-relativetimeformat/locale-data/ko";
 // Fix error when adding Solana account
 import "@azure/core-asynciterator-polyfill";
 
-// Fix error when sending a token transaction in Stellar
-import "@exodus/patch-broken-hermes-typed-arrays";
-
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 global.Buffer = require("buffer").Buffer;
 

--- a/libs/coin-modules/coin-stellar/.unimportedrc.json
+++ b/libs/coin-modules/coin-stellar/.unimportedrc.json
@@ -15,5 +15,9 @@
   ],
   "ignoreUnused": [
     "rxjs"
+  ],
+  "ignoreUnresolved": [],
+  "ignoreUnimported": [
+    "src/globals.d.ts"
   ]
 }

--- a/libs/coin-modules/coin-stellar/package.json
+++ b/libs/coin-modules/coin-stellar/package.json
@@ -132,7 +132,8 @@
     "bignumber.js": "^9.1.2",
     "expect": "^27.4.6",
     "invariant": "^2.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@exodus/patch-broken-hermes-typed-arrays": "1.0.0-alpha.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/libs/coin-modules/coin-stellar/src/globals.d.ts
+++ b/libs/coin-modules/coin-stellar/src/globals.d.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-var */
+
+export {};
+
+declare global {
+  var HermesInternal: any | undefined;
+}

--- a/libs/coin-modules/coin-stellar/src/network/horizon.ts
+++ b/libs/coin-modules/coin-stellar/src/network/horizon.ts
@@ -32,6 +32,7 @@ import {
   getReservedBalance,
   rawOperationsToOperations,
 } from "./serialization";
+import { patchHermesTypedArraysIfNeeded, unpatchHermesTypedArrays } from "../polyfill";
 
 const FALLBACK_BASE_FEE = 100;
 const TRESHOLD_LOW = 0.5;
@@ -385,7 +386,10 @@ export async function fetchSigners(account: Account): Promise<Signer[]> {
 }
 
 export async function broadcastTransaction(signedTransaction: string): Promise<string> {
+  patchHermesTypedArraysIfNeeded();
   const transaction = new StellarSdkTransaction(signedTransaction, Networks.PUBLIC);
+  // Immediately restore
+  unpatchHermesTypedArrays();
   const res = await getServer().submitTransaction(transaction, {
     skipMemoRequiredCheck: true,
   });

--- a/libs/coin-modules/coin-stellar/src/polyfill.ts
+++ b/libs/coin-modules/coin-stellar/src/polyfill.ts
@@ -20,13 +20,12 @@ let hermesTypedArrayPatched = false;
 
 export function patchHermesTypedArraysIfNeeded() {
   if (global.HermesInternal && !hermesTypedArrayPatched) {
-      try {
-        log("coin:stellar", "🔵 Patching TypedArray because of Hermes bug");
-        require("@exodus/patch-broken-hermes-typed-arrays");
-        hermesTypedArrayPatched = true;
-      } catch (e) {
-        log("coin:stellar", "Failed to patch typed arrays");
-      }
+    try {
+      log("coin:stellar", "🔵 Patching TypedArray because of Hermes bug");
+      require("@exodus/patch-broken-hermes-typed-arrays");
+      hermesTypedArrayPatched = true;
+    } catch (e) {
+      log("coin:stellar", "Failed to patch typed arrays");
     }
   }
 }

--- a/libs/coin-modules/coin-stellar/src/polyfill.ts
+++ b/libs/coin-modules/coin-stellar/src/polyfill.ts
@@ -19,8 +19,7 @@ const OriginalTypedArrayMethods = {
 let hermesTypedArrayPatched = false;
 
 export function patchHermesTypedArraysIfNeeded() {
-  if (global.HermesInternal) {
-    if (!hermesTypedArrayPatched) {
+  if (global.HermesInternal && !hermesTypedArrayPatched) {
       try {
         log("coin:stellar", "🔵 Patching TypedArray because of Hermes bug");
         require("@exodus/patch-broken-hermes-typed-arrays");

--- a/libs/coin-modules/coin-stellar/src/polyfill.ts
+++ b/libs/coin-modules/coin-stellar/src/polyfill.ts
@@ -1,0 +1,47 @@
+import { log } from "@ledgerhq/logs";
+
+/*
+ * This whole patch thing is messy:
+ * It's goal is to: Fix error when sending a token transaction in Stellar
+ * It originally was in ledger-mobile polyfill.ts (https://github.com/LedgerHQ/ledger-live/pull/9687)
+ * But globally patching is not a good idea, and broke the polkadot sdk
+ */
+
+// Save original methods once at app startup
+const OriginalTypedArrayMethods = {
+  subarray: Uint8Array.prototype.subarray,
+  slice: Uint8Array.prototype.slice,
+  map: Uint8Array.prototype.map,
+  filter: Uint8Array.prototype.filter,
+};
+
+// Track whether we actually patched
+let hermesTypedArrayPatched = false;
+
+export function patchHermesTypedArraysIfNeeded() {
+  if (global.HermesInternal) {
+    if (!hermesTypedArrayPatched) {
+      try {
+        log("coin:stellar", "🔵 Patching TypedArray because of Hermes bug");
+        require("@exodus/patch-broken-hermes-typed-arrays");
+        hermesTypedArrayPatched = true;
+      } catch (e) {
+        log("coin:stellar", "Failed to patch typed arrays");
+      }
+    }
+  }
+}
+
+export function unpatchHermesTypedArrays() {
+  if (hermesTypedArrayPatched) {
+    const TypedArray = Object.getPrototypeOf(Uint8Array);
+
+    TypedArray.prototype.subarray = OriginalTypedArrayMethods.subarray;
+    TypedArray.prototype.slice = OriginalTypedArrayMethods.slice;
+    TypedArray.prototype.map = OriginalTypedArrayMethods.map;
+    TypedArray.prototype.filter = OriginalTypedArrayMethods.filter;
+
+    log("coin:stellar", "🟢 Reverted TypedArray methods to originals");
+    hermesTypedArrayPatched = false; // reset
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,9 +874,6 @@ importers:
       '@braze/react-native-sdk':
         specifier: 10.0.0
         version: 10.0.0
-      '@exodus/patch-broken-hermes-typed-arrays':
-        specifier: 1.0.0-alpha.1
-        version: 1.0.0-alpha.1
       '@formatjs/intl-locale':
         specifier: 3.4.5
         version: 3.4.5
@@ -3691,6 +3688,9 @@ importers:
 
   libs/coin-modules/coin-stellar:
     dependencies:
+      '@exodus/patch-broken-hermes-typed-arrays':
+        specifier: 1.0.0-alpha.1
+        version: 1.0.0-alpha.1
       '@ledgerhq/coin-framework':
         specifier: workspace:^
         version: link:../../coin-framework


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### Description:


#### Before:

- The @exodus/patch-broken-hermes-typed-arrays polyfill was globally applied in ledger-live-mobile's main polyfill (apps/ledger-live-mobile/src/polyfill.ts).

- This global patching caused regressions for other coins, notably breaking Polkadot (which heavily depends on Uint8Array internals).

- All modules, even those not needing the fix (like Polkadot), were impacted.

#### After:

- Removed the global import of @exodus/patch-broken-hermes-typed-arrays from mobile polyfill.

- Moved the patching logic inside coin-stellar only, where the problem with Stellar transactions actually occurs.

- Introduced `patchHermesTypedArraysIfNeeded` and `unpatchHermesTypedArrays` utilities inside libs/coin-modules/coin-stellar.

- At transaction broadcast time (broadcastTransaction), the patch is applied temporarily just for the Stellar transaction creation, then immediately reverted.

As a result, other coins like Polkadot remain unaffected and continue working as before.

Also made the patch idempotent and safe: won't patch twice, and won't unpatch unnecessarily.


### ❓ Context

- **JIRA or GitHub link**: LIVE-18541


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
