### PR TITLE
bugfixe: Wrong size for ledger nano X Image on ledger sync

### DIFF
--- a/.changeset/famous-nails-give.md
+++ b/.changeset/famous-nails-give.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+bugfixe: Wrong size for ledger nano X Image on ledger sync

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/FollowInstructions/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/FollowInstructions/index.tsx
@@ -34,7 +34,7 @@ const FollowInstructions: React.FC<Props> = ({ device }) => {
             key: "openApp",
             theme,
           })}
-          style={animationStyles(device.modelId)}
+          style={{ ...animationStyles(device.modelId), width: "60%" }}
         />
       </AnimationContainer>
       <Flex justifyContent="center" alignItems="center" flexDirection="column" rowGap={16}>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

bugfixe: Wrong size for ledger nano X Image on ledger sync

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18727]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


![img_7602_720](https://github.com/user-attachments/assets/8810c792-100b-4c88-90d3-90e8ec07872a)

<img width="362" alt="Screenshot 2025-04-28 at 16 08 06" src="https://github.com/user-attachments/assets/d14e524a-b109-4034-b212-180a305dfb7d" />

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18727]: https://ledgerhq.atlassian.net/browse/LIVE-18727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ