### PR TITLE
ci: Allowing disabling of turbo caching on called LLM E2E flow

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -3,6 +3,7 @@ name: "Test Mobile E2E"
 on:
   schedule:
     - cron: "0 3 * * 1-5"
+
   workflow_call:
     inputs:
       macos-specificity-runner-label:
@@ -10,6 +11,16 @@ on:
         required: false
         type: string
         default: "general-pool"
+      disable-turbo-cache:
+        description: Disable turbo caching
+        required: false
+        type: boolean
+        default: false
+      ref:
+        description: Ref to checkout
+        required: true
+        type: string
+        default: "refs/heads/develop"
   workflow_dispatch:
     inputs:
       ref:
@@ -84,16 +95,21 @@ jobs:
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
+      SEED: ${{ vars.SEED_QAA_B2C }}
+      INPUT_SPECULOS: ${{ inputs.speculos_tests || github.event_name == 'schedule' }}
+      INPUTS_TEST_FILTER: ${{ inputs.test_filter }}
     outputs:
       status: ${{ steps.detox.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
     steps:
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
+          repository: LedgerHQ/ledger-live
 
       - name: setup caches
-        id: caches
+        id: setup-caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         with:
           skip-pod-cache: "true"
@@ -145,22 +161,32 @@ jobs:
           bucket: ll-gha-s3-cache
           region: ${{ secrets.AWS_CACHE_REGION }}
           use-fallback: false
+
       - name: Build dependencies
-        run: |
-          pnpm build:llm:deps --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        with:
+          command: pnpm build:llm:deps
+          turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          turbo_port: ${{ steps.setup-caches.outputs.port }}
+          disable_cache: ${{ inputs.disable-turbo-cache || false }}
+
       - name: Build Dummy Live SDK and Dummy Wallet API apps for testing
         run: |
           pnpm build:dummy-apps
         shell: bash
+
       - name: Create iOS simulator
         id: simulator
         run: xcrun simctl create "iOS Simulator" "iPhone 15"
+
       - name: Build iOS app for Detox test run
         if: steps.detox-build.outputs.cache-hit != 'true'
         run: pnpm mobile e2e:ci -p ios -b
+
       - name: Build JS Bundle app for Detox test run
         if: steps.detox-build.outputs.cache-hit == 'true'
         run: pnpm mobile e2e:ci -p ios --bundle
+
       - name: Setup Speculos image and Coin Apps
         if: ${{ env.SPECULOS_RUN == 'true' }}
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
@@ -169,18 +195,22 @@ jobs:
           speculos_tag: ${{ env.SPECULOS_IMAGE_TAG }}
           bot_id: ${{ secrets.GH_BOT_APP_ID }}
           bot_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+
       - name: Test iOS app
         id: detox
         timeout-minutes: 75
-        run: pnpm test:llm:ios:e2e --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" -- -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos') ${INPUTS_TEST_FILTER:+--filter} "${{ inputs.test_filter }}"
-        env:
-          SEED: ${{ secrets.SEED_QAA_B2C }}
-          INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}
-          INPUTS_TEST_FILTER: ${{ inputs.test_filter }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        with:
+          command: pnpm test:llm:ios:e2e -- -p ios -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos') ${INPUTS_TEST_FILTER:+--filter} "${{ inputs.test_filter }}"
+          turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          turbo_port: ${{ steps.setup-caches.outputs.port }}
+          disable_cache: ${{ inputs.disable-turbo-cache || false }}
+
       - name: Delete iOS simulator
         if: ${{ always() }}
         run: |
           xcrun simctl list devices | grep 'iOS Simulator' | awk -F '[()]' '{print $2}' | xargs -I {} sh -c 'echo "Deleting simulator: {}"; xcrun simctl delete {} || echo "Failed to delete: {}"'
+
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() || steps.detox.outcome == 'cancelled' }}
@@ -258,6 +288,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
+          repository: LedgerHQ/ledger-live
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -292,13 +323,23 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="live-cli*..." --filter="@ledgerhq/dummy-*-app..." --no-frozen-lockfile --unsafe-perm
+
       - name: Build dependencies
-        run: |
-          pnpm build:llm:deps --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        with:
+          command: pnpm build:llm:deps
+          turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          turbo_port: ${{ steps.setup-caches.outputs.port }}
+          disable_cache: ${{ inputs.disable-turbo-cache || false }}
+
       - name: Build Dummy Live SDK and Dummy Wallet API apps for testing
-        run: |
-          pnpm build:dummy-apps --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
-        shell: bash
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        with:
+          command: pnpm build:dummy-apps
+          turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          turbo_port: ${{ steps.setup-caches.outputs.port }}
+          disable_cache: ${{ inputs.disable-turbo-cache || false }}
+
       - name: Build Android app for Detox test run
         run: |
           pnpm mobile e2e:ci -p android -b $([[ "$PRODUCTION" == "true" ]] && printf %s '--production')
@@ -338,6 +379,7 @@ jobs:
           disable-linux-hw-accel: false
           emulator-options: ${{ env.AVD_OPTIONS }}
           script: ./tools/scripts/wait_emulator_idle.sh
+
       - name: Setup Speculos image and Coin Apps
         if: ${{ env.SPECULOS_RUN == 'true' }}
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-speculos_image@develop
@@ -346,14 +388,22 @@ jobs:
           speculos_tag: ${{ env.SPECULOS_IMAGE_TAG }}
           bot_id: ${{ secrets.GH_BOT_APP_ID }}
           bot_key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+
       - name: Build CLI
         if: ${{ env.SPECULOS_RUN == 'true' }}
-        run: pnpm build:cli --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
+        uses: LedgerHQ/ledger-live/tools/actions/composites/turbo-step@develop
+        with:
+          command: pnpm build:cli
+          turbo_server_token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+          turbo_port: ${{ steps.setup-caches.outputs.port }}
+          disable_cache: ${{ inputs.disable-turbo-cache || false }}
+
       - name: Set DISABLE_TRANSACTION_BROADCAST
         if: ${{ env.SPECULOS_RUN == 'true' }}
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
         with:
           enable_broadcast: ${{ inputs.enable_broadcast }}
+
       - name: Run Android Tests
         id: detox
         run: pnpm mobile e2e:ci -p android -t $([[ "$INPUT_SPECULOS" == "true" ]] && printf %s '--speculos') $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') --shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }} ${INPUTS_TEST_FILTER:+--filter} "${{ inputs.test_filter }}"
@@ -364,6 +414,7 @@ jobs:
           INPUT_SPECULOS: ${{ env.SPECULOS_RUN }}
           PRODUCTION: ${{ inputs.production_firebase }}
           INPUTS_TEST_FILTER: ${{ inputs.test_filter }}
+
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() || steps.detox.outcome == 'cancelled' }}
@@ -371,6 +422,7 @@ jobs:
         with:
           name: "android-test-artifacts-${{ matrix.shardIndex }}"
           path: apps/ledger-live-mobile/artifacts/
+
       - name: Set job output based on detox result
         id: set-output
         if: ${{ !cancelled() }}
@@ -446,6 +498,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
+          repository: LedgerHQ/ledger-live
 
       - name: Download Allure Results
         uses: actions/download-artifact@v4

--- a/tools/actions/composites/turbo-step/action.yml
+++ b/tools/actions/composites/turbo-step/action.yml
@@ -1,0 +1,34 @@
+name: turbo-step
+description: Configures turborepo credentials
+inputs:
+  command:
+    description: "Command to run"
+  turbo_server_token:
+    type: string
+    description: "The turborepo server token"
+  turbo_port:
+    description: "Turbo Server Port Number"
+    type: string
+    required: true
+  disable_cache:
+    description: "Disable turbo caching"
+    type: boolean
+    required: false
+    default: false
+runs:
+  using: composite
+  steps:
+
+    - name: "Uncached turbo run"
+      if: ${{ inputs.disable_cache == 'true' }}
+      run: ${{ inputs.command }}
+      shell: bash
+
+    - name: "Cached turbo run"
+      if: ${{ inputs.disable_cache != 'true' }}
+      shell: bash
+      run: ${{ inputs.command }}
+      env:
+        TURBO_TOKEN: ${{ inputs.turbo_server_token }}
+        TURBO_TEAM: "foo"
+        TURBO_API: http://127.0.0.1:${{ inputs.turbo_port }}


### PR DESCRIPTION
This PR refactors how we pass commands into turbo to improve readability. It also provides the ability to turn of caching when calling a workflow to enable macOS image tests

Run with cache enabled: https://github.com/LedgerHQ/ledger-live/actions/runs/14859050799/job/41719117354
Run with cache skipped: https://github.com/LedgerHQ/ledger-live/actions/runs/14857984926/job/41715736865

PR 2 of 2 for https://ledgerhq.atlassian.net/browse/LIVE-18505