### PR TITLE
conf(live-common): add default value to polygon explorer batch size

### DIFF
--- a/.changeset/curvy-needles-mate.md
+++ b/.changeset/curvy-needles-mate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+conf(live-common): add polygon explorer batch size default value

--- a/libs/ledger-live-common/src/families/evm/config.ts
+++ b/libs/ledger-live-common/src/families/evm/config.ts
@@ -240,6 +240,7 @@ const evmConfig: CurrencyLiveConfigDefinition = {
       explorer: {
         type: "ledger",
         explorerId: "matic",
+        batchSize: 10,
       },
       gasTracker: {
         type: "ledger",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Default Polygon batch size to 10, as suggested by the backend team (cf https://ledger.slack.com/archives/C02JFKVJHA6/p1744873319520749?thread_ts=1744725154.424639&cid=C02JFKVJHA6)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
