### PR TITLE
fix: return hash instead id in exchange complete methods in LLM

### DIFF
--- a/.changeset/soft-meals-cover.md
+++ b/.changeset/soft-meals-cover.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Return hash instead id in exchange complete methods

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -515,7 +515,7 @@ function useUiHook(): UiHook {
                 onCancel(result.error);
               }
               if (result.operation) {
-                onSuccess(result.operation.id);
+                onSuccess(result.operation.hash);
               }
               setDevice(undefined);
               const n =

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -96,7 +96,7 @@ export function usePTXCustomHandlers(manifest: WebviewProps["manifest"], account
                     });
                   }
                   if (result.operation) {
-                    onSuccess(result.operation.id);
+                    onSuccess(result.operation.hash);
                   }
                   setDevice(undefined);
                   !result.error && navigation.pop();


### PR DESCRIPTION
It started behaving incorrectly on February 10th. It looks like someone fixed a bug, but the change had an unintended side effect — even though the fix itself seems logically sound.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18746


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
