### PR TITLE
ci: Reduce likelihood of commit collisions on release-create

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -26,7 +26,6 @@ jobs:
       - name: create release branch
         run: |
           git checkout -b $RELEASE_BRANCH
-          git push -u origin $RELEASE_BRANCH
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -38,6 +37,8 @@ jobs:
         run: pnpm build:libs
       - name: import CAL tokens
         run: pnpm import:cal-tokens
+      - name: Push branch
+        run: git push -u origin $RELEASE_BRANCH
       - name: Add changed files
         run: |
           git add .


### PR DESCRIPTION
Currently prerelease is triggered at the moment the new release branch is created. This change brings the branch creation time later on in the script so that prerelease is not triggered until after the heavy actions are done.

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-18770
Green Run: https://github.com/LedgerHQ/ledger-live/actions/runs/14757191674/job/41428390527
Branch with commits: https://github.com/LedgerHQ/ledger-live/compare/develop...release-test