### PR TITLE
✨ (dmk): Add tracking for transaction checks opt in result

### DIFF
--- a/.changeset/empty-ants-hug.md
+++ b/.changeset/empty-ants-hug.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-evm": minor
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-signer-evm": minor
+---
+
+Add tracking for transaction checks opt in result

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.test.ts
@@ -46,6 +46,7 @@ describe("useTrackTransactionChecksFlow", () => {
     deviceInfo: deviceInfoMock,
     appAndVersion: appAndVersionMock,
     transactionChecksOptInTriggered: false,
+    transactionChecksOptIn: null,
     isTrackingEnabled: true,
   };
 
@@ -187,5 +188,47 @@ describe("useTrackTransactionChecksFlow", () => {
       }),
       true,
     );
+  });
+
+  it("should track 'Transaction Check Opt-in' when transactionChecksOptIn changes from null to true", () => {
+    const { rerender } = renderHook(
+      (props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props),
+      {
+        initialProps: {
+          ...defaultArgs,
+          transactionChecksOptIn: null,
+          transactionChecksOptInTriggered: true,
+        } as UseTrackTransactionChecksFlow,
+      },
+    );
+
+    rerender({
+      ...defaultArgs,
+      transactionChecksOptIn: true,
+      transactionChecksOptInTriggered: true,
+    });
+
+    expect(track).toHaveBeenCalledWith("Transaction Check Opt-in", expect.any(Object), true);
+  });
+
+  it("should track 'Transaction Check Opt-out' when transactionChecksOptIn changes from null to false", () => {
+    const { rerender } = renderHook(
+      (props: UseTrackTransactionChecksFlow) => useTrackTransactionChecksFlow(props),
+      {
+        initialProps: {
+          ...defaultArgs,
+          transactionChecksOptIn: null,
+          transactionChecksOptInTriggered: true,
+        } as UseTrackTransactionChecksFlow,
+      },
+    );
+
+    rerender({
+      ...defaultArgs,
+      transactionChecksOptIn: false,
+      transactionChecksOptInTriggered: true,
+    });
+
+    expect(track).toHaveBeenCalledWith("Transaction Check Opt-out", expect.any(Object), true);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackTransactionChecksFlow.ts
@@ -11,8 +11,34 @@ export type UseTrackTransactionChecksFlow = {
   deviceInfo: DeviceInfo | undefined | null;
   appAndVersion: AppAndVersion | undefined | null;
   transactionChecksOptInTriggered: boolean | undefined | null;
+  transactionChecksOptIn: boolean | undefined | null;
   isTrackingEnabled: boolean;
 };
+
+const getDefaultPayload = ({
+  location,
+  device,
+  deviceInfo,
+  appAndVersion,
+}: {
+  location: string | undefined;
+  device: Device;
+  deviceInfo: DeviceInfo | undefined | null;
+  appAndVersion: AppAndVersion | undefined | null;
+}) => ({
+  page: location ?? "unknown",
+  deviceType: device?.modelId,
+  connectionType: device?.wired ? CONNECTION_TYPES.USB : CONNECTION_TYPES.BLE,
+  platform: "LLD",
+  appName: appAndVersion?.name,
+  appVersion: appAndVersion?.version,
+  appFlags: appAndVersion?.flags.toString(),
+  deviceInfoHardwareVersion: deviceInfo?.hardwareVersion,
+  deviceInfoMcuVersion: deviceInfo?.mcuVersion,
+  deviceInfoBootloaderVersion: deviceInfo?.bootloaderVersion,
+  deviceInfoProviderName: deviceInfo?.providerName,
+  deviceInfoLanguageId: deviceInfo?.languageId,
+});
 
 export const useTrackTransactionChecksFlow = ({
   location,
@@ -20,28 +46,33 @@ export const useTrackTransactionChecksFlow = ({
   deviceInfo,
   appAndVersion,
   transactionChecksOptInTriggered,
+  transactionChecksOptIn,
   isTrackingEnabled,
 }: UseTrackTransactionChecksFlow) => {
-  const triggered = useRef(false);
+  const optInTriggered = useRef(false);
+  const optInResult = useRef(false);
 
-  if (transactionChecksOptInTriggered && !triggered.current) {
-    triggered.current = true;
+  if (transactionChecksOptInTriggered && !optInTriggered.current) {
+    optInTriggered.current = true;
 
-    const defaultPayload = {
-      page: location ?? "unknown",
-      deviceType: device?.modelId,
-      connectionType: device?.wired ? CONNECTION_TYPES.USB : CONNECTION_TYPES.BLE,
-      platform: "LLD",
-      appName: appAndVersion?.name,
-      appVersion: appAndVersion?.version,
-      appFlags: appAndVersion?.flags.toString(),
-      deviceInfoHardwareVersion: deviceInfo?.hardwareVersion,
-      deviceInfoMcuVersion: deviceInfo?.mcuVersion,
-      deviceInfoBootloaderVersion: deviceInfo?.bootloaderVersion,
-      deviceInfoProviderName: deviceInfo?.providerName,
-      deviceInfoLanguageId: deviceInfo?.languageId,
-    };
+    track(
+      "Transaction Check Opt-in Triggered",
+      getDefaultPayload({ location, device, deviceInfo, appAndVersion }),
+      isTrackingEnabled,
+    );
+  }
 
-    track("Transaction Check Opt-in Triggered", defaultPayload, isTrackingEnabled);
+  if (
+    transactionChecksOptIn !== null &&
+    transactionChecksOptIn !== undefined &&
+    !optInResult.current
+  ) {
+    optInResult.current = true;
+
+    track(
+      transactionChecksOptIn ? "Transaction Check Opt-in" : "Transaction Check Opt-out",
+      getDefaultPayload({ location, device, deviceInfo, appAndVersion }),
+      isTrackingEnabled,
+    );
   }
 };

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -155,6 +155,7 @@ type States = PartialNullable<{
   manifestName: string;
   manifestId: string;
   transactionChecksOptInTriggered: boolean;
+  transactionChecksOptIn: boolean;
 }>;
 
 type InnerProps<P> = {
@@ -229,6 +230,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     deviceSignatureRequested,
     deviceStreamingProgress,
     transactionChecksOptInTriggered,
+    transactionChecksOptIn,
     displayUpgradeWarning,
     passWarning,
     initSwapRequested,
@@ -328,6 +330,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     deviceInfo,
     appAndVersion,
     transactionChecksOptInTriggered,
+    transactionChecksOptIn,
     isTrackingEnabled,
   });
 

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/signOperation.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/signOperation.unit.test.ts
@@ -201,6 +201,70 @@ describe("EVM Family", () => {
           },
         });
       });
+
+      it("should emit transaction-checks-opt-out event", done => {
+        // GIVEN
+        const signOpObservable = buildSignOperation(mockSignerContext)({
+          account,
+          transaction: transactionEIP1559,
+          deviceId: "",
+        });
+        clearSignTransactionMock.mockImplementation(() =>
+          concat(
+            of({ type: "signer.evm.transaction-checks-opt-out" }),
+            of({ type: "signer.evm.signing" }),
+            of({ type: "signer.evm.signed", value: { r: "123", s: "abc", v: "27" } }),
+          ),
+        );
+
+        // WHEN
+        const subscription = signOpObservable.subscribe({
+          next: event => {
+            if (event.type === "transaction-checks-opt-out") {
+              subscription.unsubscribe();
+              done();
+            }
+          },
+          error: err => {
+            throw err;
+          },
+          complete: () => {
+            throw new Error("no transaction-checks-opt-out event");
+          },
+        });
+      });
+
+      it("should emit transaction-checks-opt-in event", done => {
+        // GIVEN
+        const signOpObservable = buildSignOperation(mockSignerContext)({
+          account,
+          transaction: transactionEIP1559,
+          deviceId: "",
+        });
+        clearSignTransactionMock.mockImplementation(() =>
+          concat(
+            of({ type: "signer.evm.transaction-checks-opt-in" }),
+            of({ type: "signer.evm.signing" }),
+            of({ type: "signer.evm.signed", value: { r: "123", s: "abc", v: "27" } }),
+          ),
+        );
+
+        // WHEN
+        const subscription = signOpObservable.subscribe({
+          next: event => {
+            if (event.type === "transaction-checks-opt-in") {
+              subscription.unsubscribe();
+              done();
+            }
+          },
+          error: err => {
+            throw err;
+          },
+          complete: () => {
+            throw new Error("no transaction-checks-opt-in-failed event");
+          },
+        });
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-evm/src/signOperation.ts
+++ b/libs/coin-modules/coin-evm/src/signOperation.ts
@@ -51,6 +51,12 @@ export const buildSignOperation =
                       if (event.type === "signer.evm.transaction-checks-opt-in-triggered") {
                         o.next({ type: "transaction-checks-opt-in-triggered" });
                       }
+                      if (event.type === "signer.evm.transaction-checks-opt-in") {
+                        o.next({ type: "transaction-checks-opt-in" });
+                      }
+                      if (event.type === "signer.evm.transaction-checks-opt-out") {
+                        o.next({ type: "transaction-checks-opt-out" });
+                      }
                       if (event.type === "signer.evm.signing") {
                         o.next({ type: "device-signature-requested" });
                       }

--- a/libs/coin-modules/coin-evm/src/types/signer.ts
+++ b/libs/coin-modules/coin-evm/src/types/signer.ts
@@ -18,7 +18,9 @@ export type EvmSignerEventType =
   | "signer.evm.loading-context"
   | "signer.evm.signing"
   | "signer.evm.signed"
-  | "signer.evm.transaction-checks-opt-in-triggered";
+  | "signer.evm.transaction-checks-opt-in-triggered"
+  | "signer.evm.transaction-checks-opt-in"
+  | "signer.evm.transaction-checks-opt-out";
 
 export type EvmSignerEvent =
   | {

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -27,6 +27,7 @@ type State = {
   deviceStreamingProgress: number | null | undefined;
   transactionSignError: Error | null | undefined;
   transactionChecksOptInTriggered: boolean;
+  transactionChecksOptIn: boolean | null;
   manifestId?: string;
   manifestName?: string;
 };
@@ -83,6 +84,7 @@ const initialState = {
   deviceStreamingProgress: null,
   transactionSignError: null,
   transactionChecksOptInTriggered: false,
+  transactionChecksOptIn: null,
 };
 
 const reducer = (state: State, e: Event): State => {
@@ -110,6 +112,12 @@ const reducer = (state: State, e: Event): State => {
 
     case "transaction-checks-opt-in-triggered":
       return { ...state, transactionChecksOptInTriggered: true };
+
+    case "transaction-checks-opt-in":
+      return { ...state, transactionChecksOptIn: true };
+
+    case "transaction-checks-opt-out":
+      return { ...state, transactionChecksOptIn: false };
 
     default:
       return state;

--- a/libs/ledgerjs/packages/types-live/src/transaction.ts
+++ b/libs/ledgerjs/packages/types-live/src/transaction.ts
@@ -53,6 +53,12 @@ export type SignOperationEvent = // Used when lot of exchange is needed with the
     }
   | {
       type: "transaction-checks-opt-in-triggered";
+    }
+  | {
+      type: "transaction-checks-opt-in";
+    }
+  | {
+      type: "transaction-checks-opt-out";
     };
 
 /**
@@ -77,6 +83,12 @@ export type SignOperationEventRaw =
     }
   | {
       type: "transaction-checks-opt-in-triggered";
+    }
+  | {
+      type: "transaction-checks-opt-in";
+    }
+  | {
+      type: "transaction-checks-opt-out";
     };
 /**
  * Transaction is a generic object that holds all state for all transactions

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -30,7 +30,7 @@
     "@ledgerhq/coin-evm": "workspace:^",
     "@ledgerhq/context-module": "0.0.0-fix-rn-ble-20250425173318",
     "@ledgerhq/device-management-kit": "0.0.0-fix-rn-ble-20250425173318",
-    "@ledgerhq/device-signer-kit-ethereum": "0.0.0-fix-rn-ble-20250425173318",
+    "@ledgerhq/device-signer-kit-ethereum": "0.0.0-opt-in-result-20250429135049",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-eth": "workspace:^",
     "rxjs": "7.8.1"

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -152,6 +152,18 @@ export class DmkSignerEth implements EvmSigner {
             if (result.intermediateValue.step === SignTransactionDAStep.WEB3_CHECKS_OPT_IN) {
               observer.next({ type: "signer.evm.transaction-checks-opt-in-triggered" });
             }
+            if (
+              result.intermediateValue.step === SignTransactionDAStep.WEB3_CHECKS_OPT_IN_RESULT &&
+              result.intermediateValue.result === true
+            ) {
+              observer.next({ type: "signer.evm.transaction-checks-opt-in" });
+            }
+            if (
+              result.intermediateValue.step === SignTransactionDAStep.WEB3_CHECKS_OPT_IN_RESULT &&
+              result.intermediateValue.result === false
+            ) {
+              observer.next({ type: "signer.evm.transaction-checks-opt-out" });
+            }
           } else if (result.status === DeviceActionStatus.Completed) {
             observer.next({
               type: "signer.evm.signed",

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -2,6 +2,7 @@ import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-manage
 import { EIP712Message } from "@ledgerhq/types-live";
 import { lastValueFrom, of } from "rxjs";
 import { DmkSignerEth } from "../src/DmkSignerEth";
+import { SignTransactionDAStep } from "@ledgerhq/device-signer-kit-ethereum";
 
 describe("DmkSignerEth", () => {
   const dmkMock = {
@@ -324,6 +325,52 @@ describe("DmkSignerEth", () => {
           s: "02",
           v: 3,
         },
+      });
+    });
+
+    it("should emit transaction-checks-opt-in event", async () => {
+      // GIVEN
+      const path = "path";
+      const rawTxHex = "0x010203040506";
+      dmkMock.executeDeviceAction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            step: SignTransactionDAStep.WEB3_CHECKS_OPT_IN_RESULT,
+            result: true,
+          },
+        }),
+      });
+
+      // WHEN
+      const result = await lastValueFrom(signer.signTransaction(path, rawTxHex));
+
+      // THEN
+      expect(result).toEqual({
+        type: "signer.evm.transaction-checks-opt-in",
+      });
+    });
+
+    it("should emit transaction-checks-opt-out event", async () => {
+      // GIVEN
+      const path = "path";
+      const rawTxHex = "0x010203040506";
+      dmkMock.executeDeviceAction.mockReturnValue({
+        observable: of({
+          status: DeviceActionStatus.Pending,
+          intermediateValue: {
+            step: SignTransactionDAStep.WEB3_CHECKS_OPT_IN_RESULT,
+            result: false,
+          },
+        }),
+      });
+
+      // WHEN
+      const result = await lastValueFrom(signer.signTransaction(path, rawTxHex));
+
+      // THEN
+      expect(result).toEqual({
+        type: "signer.evm.transaction-checks-opt-out",
       });
     });
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7909,8 +7909,8 @@ importers:
         specifier: 0.0.0-fix-rn-ble-20250425173318
         version: 0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)
       '@ledgerhq/device-signer-kit-ethereum':
-        specifier: 0.0.0-fix-rn-ble-20250425173318
-        version: 0.0.0-fix-rn-ble-20250425173318(@ledgerhq/context-module@0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))
+        specifier: 0.0.0-opt-in-result-20250429135049
+        version: 0.0.0-opt-in-result-20250429135049(@ledgerhq/context-module@0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
@@ -13271,11 +13271,11 @@ packages:
     peerDependencies:
       rxjs: ^7.8.2
 
-  '@ledgerhq/device-signer-kit-ethereum@0.0.0-fix-rn-ble-20250425173318':
-    resolution: {integrity: sha512-OXTp1Za3hIZe/Gc8yX76MVrxwh0/jpH6ANqySvpa+DlYLp+wjkvVCnpFDppTGTi1LmUumgAPVJnLFuXKCNoMVQ==}
+  '@ledgerhq/device-signer-kit-ethereum@0.0.0-opt-in-result-20250429135049':
+    resolution: {integrity: sha512-X+GMWd/wF+T+bsXKBFzJAPxtR3m1lNa/Cot3ZtCVVppsmiLak46WZqk545SXCaf3xLPFmRYZ8bR7QO6ajXvT8Q==}
     peerDependencies:
-      '@ledgerhq/context-module': 0.0.0-fix-rn-ble-20250425173318
-      '@ledgerhq/device-management-kit': 0.0.0-fix-rn-ble-20250425173318
+      '@ledgerhq/context-module': 0.0.0-opt-in-result-20250429135049
+      '@ledgerhq/device-management-kit': 0.0.0-opt-in-result-20250429135049
 
   '@ledgerhq/device-transport-kit-react-native-ble@0.0.0-fix-rn-ble-20250425173318':
     resolution: {integrity: sha512-qjzrVbxqaGIpksrNFqBT1t2v3q5Ch7O0cMErk6YSCo8XFdzaiLh1ghX5gkC6KhpSWQNStpBAXyNXqV93WCKWGw==}
@@ -13355,10 +13355,10 @@ packages:
   '@ledgerhq/logs@6.12.0':
     resolution: {integrity: sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==}
 
-  '@ledgerhq/signer-utils@0.0.0-fix-rn-ble-20250425173318':
-    resolution: {integrity: sha512-4kNUXFBjv0H96vOTNCo6vcsZEXg7WV6ULzLmHDekJBZAVgjhn/DO2HF2XLm+LMp3r2dpP/32APpmF242eaEsYg==}
+  '@ledgerhq/signer-utils@0.0.0-opt-in-result-20250429135049':
+    resolution: {integrity: sha512-XCL3C8ZdD6nK7gg2rupSpGj4CB6NxUd+R757J/Gq7NLXET5rmzX1z9EDOnC1vA/1jbj9uRb75Xz4afT+GD+ysg==}
     peerDependencies:
-      '@ledgerhq/device-management-kit': 0.0.0-fix-rn-ble-20250425173318
+      '@ledgerhq/device-management-kit': 0.0.0-opt-in-result-20250429135049
 
   '@ledgerhq/types-live@6.53.1':
     resolution: {integrity: sha512-ukaDDyxg7quBQ0vdoQQjj3ICqiG13gO/rGIO0Jm2nRh/icbLWgxfsI2wX0u0ugJQJ+q/muiX+wJrMJn9EKhEaQ==}
@@ -40882,17 +40882,17 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-ethereum@0.0.0-fix-rn-ble-20250425173318(@ledgerhq/context-module@0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))':
+  '@ledgerhq/device-signer-kit-ethereum@0.0.0-opt-in-result-20250429135049(@ledgerhq/context-module@0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)))(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))':
     dependencies:
       '@ledgerhq/context-module': 0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))
       '@ledgerhq/device-management-kit': 0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)
-      '@ledgerhq/signer-utils': 0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))
+      '@ledgerhq/signer-utils': 0.0.0-opt-in-result-20250429135049(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))
       ethers: 6.13.4
       inversify: 6.2.2(reflect-metadata@0.2.2)
       inversify-logger-middleware: 3.1.0
       purify-ts: 2.1.0
       reflect-metadata: 0.2.2
-      semver: 7.6.3
+      semver: 7.7.1
       xstate: 5.19.2
     transitivePeerDependencies:
       - bufferutil
@@ -41026,7 +41026,7 @@ snapshots:
 
   '@ledgerhq/logs@6.12.0': {}
 
-  '@ledgerhq/signer-utils@0.0.0-fix-rn-ble-20250425173318(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))':
+  '@ledgerhq/signer-utils@0.0.0-opt-in-result-20250429135049(@ledgerhq/device-management-kit@0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1))':
     dependencies:
       '@ledgerhq/device-management-kit': 0.0.0-fix-rn-ble-20250425173318(rxjs@7.8.1)
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** Should track opt in result
  - ...

### 📝 Description

Add tracking for transaction checks opt in result. When the user will select to opt-in or not, the dmk will notify the result to LL that will be able to track it using specific hook.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-17946]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17946]: https://ledgerhq.atlassian.net/browse/LIVE-17946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ