### PR TITLE
feat(live-18576): tron listOperations uses minHeight filter

### DIFF
--- a/.changeset/tender-feet-knock.md
+++ b/.changeset/tender-feet-knock.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": major
+---
+
+Implement filter by min height on tron listOperations

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -68,7 +68,7 @@ describe("createApi", () => {
     await api.estimateFees(intent);
     await api.getBalance("address");
     await api.lastBlock();
-    await api.listOperations("address", {} as Pagination);
+    await api.listOperations("address", { minHeight: 14 } as Pagination);
 
     // Test that each of the methods was called with correct arguments
     expect(broadcast).toHaveBeenCalledWith("transaction");
@@ -77,6 +77,6 @@ describe("createApi", () => {
     expect(craftTransaction).toHaveBeenCalledWith(intent);
     expect(getBalance).toHaveBeenCalledWith("address");
     expect(lastBlock).toHaveBeenCalled();
-    expect(listOperations).toHaveBeenCalledWith("address", {});
+    expect(listOperations).toHaveBeenCalledWith("address", 14);
   });
 });

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -1,4 +1,10 @@
-import type { Api, FeeEstimation, TransactionIntent } from "@ledgerhq/coin-framework/api/index";
+import type {
+  Api,
+  FeeEstimation,
+  Operation,
+  Pagination,
+  TransactionIntent,
+} from "@ledgerhq/coin-framework/api/index";
 import coinConfig, { type TronConfig } from "../config";
 import {
   broadcast,
@@ -6,7 +12,7 @@ import {
   craftTransaction,
   estimateFees,
   getBalance,
-  listOperations,
+  listOperations as logicListOperations,
   lastBlock,
 } from "../logic";
 import type { TronAsset } from "../types";
@@ -28,4 +34,12 @@ export function createApi(config: TronConfig): Api<TronAsset> {
 async function estimate(transactionIntent: TransactionIntent<TronAsset>): Promise<FeeEstimation> {
   const fees = await estimateFees(transactionIntent);
   return { value: fees };
+}
+
+async function listOperations(
+  address: string,
+  pagination: Pagination,
+): Promise<[Operation<TronAsset>[], string]> {
+  const { minHeight } = pagination;
+  return logicListOperations(address, minHeight);
 }

--- a/libs/coin-modules/coin-tron/src/bridge/synchronization.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/synchronization.ts
@@ -12,7 +12,7 @@ import compact from "lodash/compact";
 import get from "lodash/get";
 import { computeBalanceBridge, lastBlock } from "../logic";
 import { getOperationsPageSize } from "../logic/pagination";
-import { fetchTronAccountTxs } from "../network";
+import { defaultFetchParams, fetchTronAccountTxs } from "../network";
 import { TronAccount, TrongridExtraTxInfo, TronOperation } from "../types";
 import {
   defaultTronResources,
@@ -73,6 +73,7 @@ export const getAccountShape: GetAccountShape<TronAccount> = async (
     address,
     txs => txs.length < operationsPageSize,
     cacheTransactionInfoById,
+    defaultFetchParams,
   );
 
   const tronResources = await getTronResources(acc, txs, cacheTransactionInfoById);

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
@@ -15,6 +15,32 @@ describe("listOperations", () => {
     }));
   });
 
+  describe("Account TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9 with minHeight", () => {
+    // https://tronscan.org/#/address/TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9
+
+    let operations: Operation<TronAsset>[];
+
+    const testingAccount = "TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9";
+
+    // there are 2 operations with height >= 40832955
+    const minHeight = 40832955;
+    const historySize = 2;
+    const txHashAtMinHeight = "242591f43c74e45bf4c5c423be2f600c9a53237bde4c793faff5f3120f8745d7";
+
+    beforeAll(async () => {
+      [operations] = await listOperations(testingAccount, minHeight);
+    });
+
+    describe("List", () => {
+      it("should fetch operations successfully", async () => {
+        expect(Array.isArray(operations)).toBeDefined();
+        expect(operations.length).toBeGreaterThanOrEqual(historySize);
+        expect(operations.filter(op => op.tx.block.height < minHeight).length).toEqual(0);
+        expect(operations.find(op => op.tx.hash === txHashAtMinHeight)).toBeDefined();
+      });
+    });
+  });
+
   // We could create a loop on array of account addresses and use standard test cases, but this way it's more readable / flexible
   describe("Account TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9", () => {
     // https://tronscan.org/#/address/TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9
@@ -29,7 +55,7 @@ describe("listOperations", () => {
     const magnitudeMultiplier = 1000000;
 
     beforeAll(async () => {
-      [operations] = await listOperations(testingAccount);
+      [operations] = await listOperations(testingAccount, 0);
     });
 
     describe("List", () => {
@@ -98,7 +124,6 @@ describe("listOperations", () => {
             recipients: [testingAccount],
             senders: ["THAe4BNVxp293qgyQEqXEkHMpPcqtG73bi"],
             asset: { type: "native" },
-            operationIndex: 0,
           });
         });
 
@@ -113,7 +138,6 @@ describe("listOperations", () => {
             senders: [testingAccount],
             recipients: ["TASbVCzbnwu8swZEGFBAH88Z4AwTTBt1PW"],
             asset: { type: "native" },
-            operationIndex: 0,
           });
         });
       });
@@ -134,7 +158,6 @@ describe("listOperations", () => {
               standard: "trc10",
               tokenId: "1004031",
             },
-            operationIndex: 0,
           });
         });
 
@@ -152,7 +175,6 @@ describe("listOperations", () => {
               standard: "trc10",
               tokenId: "1002000",
             },
-            operationIndex: 0,
           });
         });
       });
@@ -173,7 +195,6 @@ describe("listOperations", () => {
               standard: "trc20",
               contractAddress: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
             },
-            operationIndex: 0,
           });
         });
 
@@ -192,7 +213,6 @@ describe("listOperations", () => {
               standard: "trc20",
               contractAddress: "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
             },
-            operationIndex: 0,
           });
         });
       });

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.unit.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { fetchTronAccountTxs } from "../network";
+import { defaultFetchParams, fetchTronAccountTxs, getBlock } from "../network";
 import { fromTrongridTxInfoToOperation } from "../network/trongrid/trongrid-adapters";
 import { TrongridTxInfo, TronAsset } from "../types";
 import { listOperations } from "./listOperations";
@@ -8,6 +8,7 @@ import type { Operation } from "@ledgerhq/coin-framework/api/index";
 // Mock the fetchTronAccountTxs and fromTrongridTxInfoToOperation functions
 jest.mock("../network", () => ({
   fetchTronAccountTxs: jest.fn(),
+  getBlock: jest.fn(),
 }));
 
 jest.mock("../network/trongrid/trongrid-adapters", () => ({
@@ -17,13 +18,27 @@ jest.mock("../network/trongrid/trongrid-adapters", () => ({
 describe("listOperations", () => {
   const mockAddress = "tronExampleAddress";
 
+  const mockBlockTime = new Date("2023-01-01T00:00:00Z");
+  const mockBlockTimestamp = mockBlockTime.getTime();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getBlock as jest.Mock).mockResolvedValue({
+      time: mockBlockTime,
+    });
+  });
+
+  const expectedFetchParams = {
+    ...defaultFetchParams,
+    minTimestamp: mockBlockTimestamp,
+  };
+
   it("should fetch transactions and return operations", async () => {
     const mockTxs: Partial<TrongridTxInfo>[] = [
       { txID: "tx1", value: new BigNumber(0) },
       { txID: "tx2", value: new BigNumber(42) },
     ];
 
-    const mockOperations: Partial<Operation<TronAsset>>[] = [
+    const expectedOperations: Partial<Operation<TronAsset>>[] = [
       { tx: { hash: "tx1" } as Partial<Operation<TronAsset>>["tx"], value: BigInt(0) },
       { tx: { hash: "tx2" } as Partial<Operation<TronAsset>>["tx"], value: BigInt(42) },
     ];
@@ -36,25 +51,35 @@ describe("listOperations", () => {
       };
     });
 
-    const [operations, token] = await listOperations(mockAddress);
+    const [operations, token] = await listOperations(mockAddress, 0);
 
-    expect(fetchTronAccountTxs).toHaveBeenCalledWith(mockAddress, expect.any(Function), {});
+    expect(fetchTronAccountTxs).toHaveBeenCalledWith(
+      mockAddress,
+      expect.any(Function),
+      {},
+      expectedFetchParams,
+    );
     expect(fromTrongridTxInfoToOperation).toHaveBeenCalledTimes(mockTxs.length);
-    expect(operations).toEqual(mockOperations);
+    expect(operations).toEqual(expectedOperations);
     expect(token).toBe("");
   });
 
   it("should handle empty transactions", async () => {
     const mockTxs: Partial<TrongridTxInfo>[] = [];
-    const mockOperations: Partial<Operation<TronAsset>>[] = [];
+    const expectedOperations: Partial<Operation<TronAsset>>[] = [];
 
     (fetchTronAccountTxs as jest.Mock).mockResolvedValue(mockTxs);
     (fromTrongridTxInfoToOperation as jest.Mock).mockImplementation(() => null);
 
-    const [operations, token] = await listOperations(mockAddress);
+    const [operations, token] = await listOperations(mockAddress, 0);
 
-    expect(fetchTronAccountTxs).toHaveBeenCalledWith(mockAddress, expect.any(Function), {});
-    expect(operations).toEqual(mockOperations);
+    expect(fetchTronAccountTxs).toHaveBeenCalledWith(
+      mockAddress,
+      expect.any(Function),
+      {},
+      expectedFetchParams,
+    );
+    expect(operations).toEqual(expectedOperations);
     expect(token).toBe("");
   });
 
@@ -62,6 +87,6 @@ describe("listOperations", () => {
     const exampleError = new Error("Network error!");
     (fetchTronAccountTxs as jest.Mock).mockRejectedValue(exampleError);
 
-    await expect(listOperations(mockAddress)).rejects.toThrow(new Error(exampleError.message));
+    await expect(listOperations(mockAddress, 0)).rejects.toThrow(new Error(exampleError.message));
   });
 });

--- a/libs/coin-modules/coin-tron/src/network/index.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.integ.test.ts
@@ -1,4 +1,10 @@
-import { fetchTronAccount, fetchTronAccountTxs, fetchTronTxDetail, getTronAccountNetwork } from ".";
+import {
+  defaultFetchParams,
+  fetchTronAccount,
+  fetchTronAccountTxs,
+  fetchTronTxDetail,
+  getTronAccountNetwork,
+} from ".";
 import coinConfig from "../config";
 import fetchTronTxs from "./fixtures/fetchTronAccountTxs.fixture.json";
 
@@ -24,7 +30,12 @@ describe("TronGrid", () => {
       "maps all fields correctly",
       async () => {
         // WHEN
-        const results = await fetchTronAccountTxs(address, txs => txs.length < 100, {});
+        const results = await fetchTronAccountTxs(
+          address,
+          txs => txs.length < 100,
+          {},
+          defaultFetchParams,
+        );
 
         // THEN
         expect(results).not.toHaveLength(0);

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -2,7 +2,7 @@ import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { TRANSACTION_DETAIL_FIXTURE, TRANSACTION_FIXTURE, TRC20_FIXTURE } from "./types.fixture";
 import coinConfig from "../config";
-import { fetchTronAccountTxs } from ".";
+import { defaultFetchParams, fetchTronAccountTxs } from ".";
 
 const TRON_BASE_URL_TEST = "https://httpbin.org";
 
@@ -50,7 +50,12 @@ describe("fetchTronAccountTxs", () => {
 
   it("convert correctly operations from the blockchain", async () => {
     // WHEN
-    const results = await fetchTronAccountTxs("ADDRESS", txs => txs.length < 100, {});
+    const results = await fetchTronAccountTxs(
+      "ADDRESS",
+      txs => txs.length < 100,
+      {},
+      defaultFetchParams,
+    );
 
     // THEN
     const tx = results.find(tx => tx.blockHeight === 62258698);

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./format";
 import {
   AccountTronAPI,
+  Block,
   isMalformedTransactionTronAPI,
   isTransactionTronAPI,
   MalformedTransactionTronAPI,
@@ -365,17 +366,31 @@ export async function fetchTronAccount(addr: string): Promise<AccountTronAPI[]> 
   }
 }
 
-export async function getLastBlock(): Promise<{
-  height: number;
-  hash: string;
-  time: Date;
-}> {
+export async function getLastBlock(): Promise<Block> {
   const data = await fetch(`/wallet/getnowblock`);
-  return {
+  return toBlock(data);
+}
+
+export async function getBlock(blockNumber: number): Promise<Block> {
+  const data = await fetch(`/wallet/getblock?id_or_num=${encodeURIComponent(blockNumber)}`);
+  const ret = toBlock(data);
+  if (!ret.height) {
+    ret.height = blockNumber;
+  }
+  return ret;
+}
+
+function toBlock(data: any): Block {
+  // some old blocks doesn't have a timestamp
+  const timestamp = data.block_header.raw_data.timestamp;
+  const ret: Block = {
     height: data.block_header.raw_data.number,
     hash: data.blockID,
-    time: new Date(data.block_header.raw_data.timestamp),
   };
+  if (timestamp) {
+    ret.time = new Date(timestamp);
+  }
+  return ret;
 }
 
 // For the moment, fetching transaction info is the only way to get fees from a transaction
@@ -463,23 +478,37 @@ const getTrc20 = async (
   };
 };
 
+export type FetchTxsStopPredicate = (
+  txs: Array<TransactionTronAPI | Trc20API | MalformedTransactionTronAPI>,
+) => boolean;
+
+export type FetchParams = {
+  limit: number;
+  minTimestamp: number;
+};
+
+export const defaultFetchParams: FetchParams = {
+  limit: 100,
+  minTimestamp: 0,
+} as const;
+
 export async function fetchTronAccountTxs(
   addr: string,
-  shouldFetchMoreTxs: (
-    txs: Array<TransactionTronAPI | Trc20API | MalformedTransactionTronAPI>,
-  ) => boolean,
+  shouldFetchMoreTxs: FetchTxsStopPredicate,
   cacheTransactionInfoById: Record<string, TronTransactionInfo>,
+  params: FetchParams,
 ): Promise<TrongridTxInfo[]> {
-  const entireTxs = (
+  const queryParamsNativeTxs = `limit=${params.limit}&min_timestamp=${params.minTimestamp}`;
+  const nativeTxs = (
     await getAllTransactions<
       (TransactionTronAPI & { detail?: TronTransactionInfo }) | MalformedTransactionTronAPI
     >(
-      `${getBaseApiUrl()}/v1/accounts/${addr}/transactions?limit=100`,
+      `${getBaseApiUrl()}/v1/accounts/${addr}/transactions?${queryParamsNativeTxs}`,
       shouldFetchMoreTxs,
       getTransactions(cacheTransactionInfoById),
     )
   )
-    .filter((tx): tx is TransactionTronAPI => isTransactionTronAPI(tx))
+    .filter(isTransactionTronAPI)
     .filter(tx => {
       // custom smart contract tx has internal txs
       const hasInternalTxs =
@@ -496,17 +525,19 @@ export async function fetchTronAccountTxs(
       return !isDuplicated && !hasInternalTxs && type !== "TriggerSmartContract";
     })
     .map(tx => formatTrongridTxResponse(tx));
-  // we need to fetch and filter trc20 transactions from another endpoint
 
-  const entireTrc20Txs = (
+  // we need to fetch and filter trc20 transactions from another endpoint
+  // doc https://developers.tron.network/reference/get-trc20-transaction-info-by-account-address
+  const queryParamsTrc20Txs = `limit=${params.limit}&min_timestamp=${params.minTimestamp}`;
+  const trc20Txs = (
     await getAllTransactions<Trc20API>(
-      `${getBaseApiUrl()}/v1/accounts/${addr}/transactions/trc20?get_detail=true`,
+      `${getBaseApiUrl()}/v1/accounts/${addr}/transactions/trc20?${queryParamsTrc20Txs}&get_detail=true`,
       shouldFetchMoreTxs,
       getTrc20,
     )
   ).map(tx => formatTrongridTrc20TxResponse(tx));
 
-  const txInfos: TrongridTxInfo[] = compact(entireTxs.concat(entireTrc20Txs)).sort(
+  const txInfos: TrongridTxInfo[] = compact(nativeTxs.concat(trc20Txs)).sort(
     (a, b) => b.date.getTime() - a.date.getTime(),
   );
   return txInfos;

--- a/libs/coin-modules/coin-tron/src/network/types.ts
+++ b/libs/coin-modules/coin-tron/src/network/types.ts
@@ -65,8 +65,8 @@ export type TransactionTronAPI<T = TransactionContract> = {
   raw_data_hex: string;
   net_fee: number;
   energy_usage: number;
-  blockNumber?: number;
   block_timestamp: number;
+  blockNumber?: number;
   energy_fee: number;
   energy_usage_total: number;
   unfreeze_amount?: number;
@@ -178,6 +178,12 @@ export type MalformedTransactionTronAPI = {
   to_address: string;
   tx_id: string;
   from_address: string;
+};
+
+export type Block = {
+  height: number;
+  hash: string;
+  time?: Date;
 };
 
 export function isMalformedTransactionTronAPI(


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Tron accounts may have a number of txs > 1000
  - Very big accounts may be problematic with initial sync if they use api or logic layer.
  - bridge is not impacted because it uses network layer with same behavior as before

### 📝 Description

Lama adapter needs to have the unlimited set of txs regarding LES needs. The 1000 limit wasn't acceptable. So we implemented the minHeight filter, like we did on other coins.

The limitation of this implementation is that it will be difficult to do initial sync of accounts with a lot of txs.

### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-18576 
- https://ledger.slack.com/archives/C08CS1LMBCY/p1745916858272569


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
