### PR TITLE
fix: change amount in command if it is not the same in the transaction

### DIFF
--- a/.changeset/funny-brooms-tell.md
+++ b/.changeset/funny-brooms-tell.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Update commande if transaction is updated

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -591,7 +591,8 @@ async function deriveStakeCreateAccountCommandDescriptor(
   const warnings: Record<string, Error> = {};
 
   const commandDescriptor = tx.model.commandDescriptor;
-  if (isValidStakeCreateAccountCommandDescriptor(commandDescriptor)) return commandDescriptor;
+  if (isValidStakeCreateAccountCommandDescriptor(commandDescriptor, tx.amount.toNumber()))
+    return commandDescriptor;
 
   const { fee, spendable } = await estimateFeeAndSpendable(api, mainAccount, tx);
   const txAmount = tx.useAllAmount ? spendable : tx.amount;
@@ -1011,6 +1012,7 @@ function validateRecipientRequiredMemo(
 
 function isValidStakeCreateAccountCommandDescriptor(
   commandDescriptor: CommandDescriptor | undefined,
+  amount: number,
 ): commandDescriptor is CommandDescriptor {
   const txCommand = commandDescriptor?.command as StakeCreateAccountCommand | undefined;
 
@@ -1018,6 +1020,7 @@ function isValidStakeCreateAccountCommandDescriptor(
   if (
     commandDescriptor &&
     txCommand?.amount &&
+    txCommand.amount == amount &&
     txCommand.stakeAccRentExemptAmount &&
     txCommand.fromAccAddress &&
     txCommand.stakeAccAddress &&


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The fiat value does not update when the SOL amount is changed after an initial value has been entered. It remains stuck on the previous fiat value.


https://github.com/user-attachments/assets/bd5bfa0d-52d9-4491-b50e-2ef98d432fb7



### ❓ Context

- **JIRA or GitHub link**: [LIVE-18742](https://ledgerhq.atlassian.net/browse/LIVE-18742)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18742]: https://ledgerhq.atlassian.net/browse/LIVE-18742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ