### PR TITLE
feat(LIVE-18797): add header for exchange start device select screen

### DIFF
--- a/.changeset/gold-turtles-fly.md
+++ b/.changeset/gold-turtles-fly.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add header with title and back button to exchange start device select screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/PlatformExchangeNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/PlatformExchangeNavigator.tsx
@@ -20,8 +20,9 @@ export default function PlatformExchangeNavigator() {
         name={ScreenName.PlatformStartExchange}
         component={PlatformStartExchange}
         options={{
-          headerStyle: styles.headerNoShadow,
-          title: t("transfer.swap.landing.header"),
+          title: t("deviceConnect.title"),
+          headerShown: true,
+          headerRight: undefined,
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -46,7 +46,7 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   const request = useMemo(() => route.params.request, [route.params.request]);
   return (
     <SafeAreaView style={styles.root} edges={["bottom"]}>
-      <Flex px={16} py={8} flex={1} mt={8}>
+      <Flex px={16} flex={1} mt={8}>
         <SelectDevice2
           onSelect={setDevice}
           stopBleScanning={!!device || !isFocused}


### PR DESCRIPTION
add header with title and back button to exchange start device select screen

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Does add a header with back button to the Exchange Start Screen (device selection - see screenshots)

### 📝 Description

After selecting a provider during the swap flow the user will be guided to the "device selection" screen, which currently doesn't have a title or on screen back navigation, which could potentially cause users (that don't know about swipe back navigation, or with Android back button) cancel the transaction.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->
<img width="300" src="https://github.com/user-attachments/assets/756508d6-bb61-4b45-b4be-814241b51d37"/>
<img width="300" src="https://github.com/user-attachments/assets/48f02399-2f88-4575-bbfb-edaaa6d4f226"/>

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18797


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
