### PR TITLE
ci: Auto close smartling PR and skip workflow

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip == 'true' || steps.smartling_check.outputs.should_skip == 'true' }}
     env:
-      IS_SMARTLING: ${{ startsWith(github.event.pull_request.head.ref, 'smartling-content-updated') || startsWith(github.event.pull_request.head.ref, 'smartling-translation-completed') }}
+      IS_SMARTLING: ${{ startsWith(github.event.pull_request.head.ref, 'smartling-content-updated') == 'true' || startsWith(github.event.pull_request.head.ref, 'smartling-translation-completed') == 'true' }}
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v5


### PR DESCRIPTION
This PR is designed to skip Smartling workflows to preserve runner resources. It also closes the auto-created PR

Auto closing PR demonstrated here: https://github.com/LedgerHQ/ledger-live/actions/runs/14859710735/job/41721284973
This PR's workflow run shows a non auto-closed PR.

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-18162