### PR TITLE
fix: use base58 encoding for Solana signMessage signature

### DIFF
--- a/.changeset/fresh-fishes-change.md
+++ b/.changeset/fresh-fishes-change.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/live-common": minor
+---
+
+fix: use base58 encoding for Solana signMessage signature

--- a/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
@@ -17,8 +17,8 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
     const SIGNATURE =
       "4gVuB1KsM58fb3vRpnDucwW4Vi6fVGA51QDQd9ARvx4GH5yYVDPzDnvzUbSJf3YLWWdsX7zCMSN9N1GMnTYwWiJf";
 
-    const HEXADECIMAL_SIGNATURE =
-      "3467567542314b734d35386662337652706e4475637757345669366656474135315144516439415276783447483579595644507a446e767a5562534a6633594c5757647358377a434d534e394e31474d6e54597757694a66";
+    const BASE58_SIGNATURE =
+      "RTCCo3j8Nx4FocNfEjPqTFgsDjxge5YR3tapEpbWVRgzbPcnTAYD54KiodwhVETwHYLLb5gVACSmrH8RN5ZMEhq7iH88mVb1peF3pDKRgJGZ3opDhonkc5Tj";
 
     const getAppConfigurationMock = jest.fn(() => {
       return Promise.resolve({
@@ -50,7 +50,7 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
       { message: messageHex },
     );
 
-    expect(result.signature).toEqual("0x" + HEXADECIMAL_SIGNATURE);
+    expect(result.signature).toEqual(BASE58_SIGNATURE);
     expect(signMessageMock).toHaveBeenCalledTimes(1);
     expect(signMessageMock).toHaveBeenCalledWith(accountFreshAddressPath, offchainMessage);
   });
@@ -60,8 +60,8 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
     const SIGNATURE =
       "4gVuB1KsM58fb3vRpnDucwW4Vi6fVGA51QDQd9ARvx4GH5yYVDPzDnvzUbSJf3YLWWdsX7zCMSN9N1GMnTYwWiJf";
 
-    const HEXADECIMAL_SIGNATURE =
-      "3467567542314b734d35386662337652706e4475637757345669366656474135315144516439415276783447483579595644507a446e767a5562534a6633594c5757647358377a434d534e394e31474d6e54597757694a66";
+    const BASE58_SIGNATURE =
+      "RTCCo3j8Nx4FocNfEjPqTFgsDjxge5YR3tapEpbWVRgzbPcnTAYD54KiodwhVETwHYLLb5gVACSmrH8RN5ZMEhq7iH88mVb1peF3pDKRgJGZ3opDhonkc5Tj";
 
     const getAppConfigurationMock = jest.fn(() => {
       return Promise.resolve({
@@ -93,7 +93,7 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
       { message: messageHex },
     );
 
-    expect(result.signature).toEqual("0x" + HEXADECIMAL_SIGNATURE);
+    expect(result.signature).toEqual(BASE58_SIGNATURE);
     expect(signMessageMock).toHaveBeenCalledTimes(1);
     expect(signMessageMock).toHaveBeenCalledWith(accountFreshAddressPath, offchainMessage);
   });

--- a/libs/coin-modules/coin-solana/src/hw-signMessage.ts
+++ b/libs/coin-modules/coin-solana/src/hw-signMessage.ts
@@ -4,6 +4,7 @@ import { Account, AnyMessage, DeviceId } from "@ledgerhq/types-live";
 import { SolanaSigner } from "./signer";
 import { toOffChainMessage } from "./offchainMessage/format";
 import coinConfig from "./config";
+import bs58 from "bs58";
 
 export const signMessage =
   (signerContext: SignerContext<SolanaSigner>) =>
@@ -31,5 +32,5 @@ export const signMessage =
       );
     });
 
-    return { signature: "0x" + result.signature.toString("hex") };
+    return { signature: bs58.encode(result.signature) };
   };

--- a/libs/ledger-live-common/src/families/solana/setup.test.ts
+++ b/libs/ledger-live-common/src/families/solana/setup.test.ts
@@ -8,6 +8,8 @@ import { solanaConfig } from "./config";
 
 const SIGNATURE =
   "97fb71bae8971e272b17a464dc2f76995de2da9fc5d40e369edc43b0c3f7c601c4e5a60bb7c6ac69671120c381ce5cab7a06f53eb802e3ac555066455f2cbd05";
+const BASE58_SIGNATURE =
+  "43EtUq3x4vxxSZ2UyNxJXopCmF78UJFPySv5kRjQRX2PVuMBLQCPTRjJgPWKgN7fJXVoKZRAvU6W3T6ajJu3sce8";
 
 const APP_VERSION = "1.8.2";
 const getAppConfigurationMock = jest.fn(() => {
@@ -20,7 +22,7 @@ const getAppConfigurationMock = jest.fn(() => {
 
 const signOffchainMessageMock = jest.fn(() =>
   Promise.resolve({
-    signature: SIGNATURE,
+    signature: Buffer.from(SIGNATURE, "hex"),
   }),
 );
 
@@ -57,7 +59,7 @@ describe("Testing setup on Solana", () => {
         "ff736f6c616e61206f6666636861696e00000000000000000000000000000000000000000000000000000000000000000000016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be0323538003463366636653637323034663636363632643433363836313639366532303534363537333734323034643635373337333631363736353265",
       );
 
-      expect(result.signature).toEqual("0x" + SIGNATURE);
+      expect(result.signature).toEqual(BASE58_SIGNATURE);
       expect(result.rsv).toBeUndefined();
     });
   });

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -446,7 +446,11 @@ export function useWalletAPIServer({
                 if (done) return;
                 done = true;
                 tracking.signMessageSuccess(manifest);
-                resolve(Buffer.from(signature.replace("0x", ""), "hex"));
+                resolve(
+                  signature.startsWith("0x")
+                    ? Buffer.from(signature.replace("0x", ""), "hex")
+                    : Buffer.from(signature),
+                );
               },
               onCancel: () => {
                 if (done) return;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - solana sign message

### 📝 Description

The signature returned by signMessage for the Solana was not in base58 as expected by a lot of apps

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
