### PR TITLE
fix(live-18576,coin-tron): retrieve limited number of oldest operations first

### DIFF
--- a/.changeset/angry-scissors-argue.md
+++ b/.changeset/angry-scissors-argue.md
@@ -2,4 +2,4 @@
 "@ledgerhq/coin-tron": minor
 ---
 
-On tron, API has a hard limit on the number of transaction to retrieve. The API returns the oldest set of transactions it can find according to the minHeight parameter.
+On tron, API has a hard limit on the number of operations to retrieve. The API returns the oldest set of operations it can find according to the minHeight parameter.

--- a/.changeset/angry-scissors-argue.md
+++ b/.changeset/angry-scissors-argue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+On tron, API has a hard limit on the number of transaction to retrieve. The API returns the oldest set of transactions it can find according to the minHeight parameter.

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -68,7 +68,8 @@ describe("createApi", () => {
     await api.estimateFees(intent);
     await api.getBalance("address");
     await api.lastBlock();
-    await api.listOperations("address", { minHeight: 14 } as Pagination);
+    const minHeight = 14;
+    await api.listOperations("address", { minHeight: minHeight } as Pagination);
 
     // Test that each of the methods was called with correct arguments
     expect(broadcast).toHaveBeenCalledWith("transaction");
@@ -77,6 +78,10 @@ describe("createApi", () => {
     expect(craftTransaction).toHaveBeenCalledWith(intent);
     expect(getBalance).toHaveBeenCalledWith("address");
     expect(lastBlock).toHaveBeenCalled();
-    expect(listOperations).toHaveBeenCalledWith("address", 14);
+    expect(listOperations).toHaveBeenCalledWith("address", {
+      minHeight: minHeight,
+      order: "asc",
+      softLimit: 200,
+    });
   });
 });

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -43,7 +43,7 @@ async function listOperations(
 ): Promise<[Operation<TronAsset>[], string]> {
   const { minHeight } = pagination;
   const options: Options = {
-    softLimit: 1000,
+    softLimit: 200,
     minHeight: minHeight,
     order: "asc",
   } as const;

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -14,6 +14,7 @@ import {
   getBalance,
   listOperations as logicListOperations,
   lastBlock,
+  Options,
 } from "../logic";
 import type { TronAsset } from "../types";
 
@@ -41,5 +42,10 @@ async function listOperations(
   pagination: Pagination,
 ): Promise<[Operation<TronAsset>[], string]> {
   const { minHeight } = pagination;
-  return logicListOperations(address, minHeight);
+  const options: Options = {
+    softLimit: 1000,
+    minHeight: minHeight,
+    order: "asc",
+  } as const;
+  return logicListOperations(address, options);
 }

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
@@ -1,4 +1,4 @@
-import { listOperations } from "./listOperations";
+import { defaultOptions, listOperations, Options } from "./listOperations";
 import coinConfig from "../config";
 import { Operation } from "@ledgerhq/coin-framework/api/types";
 import { TronAsset } from "../types";
@@ -23,20 +23,93 @@ describe("listOperations", () => {
     const testingAccount = "TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9";
 
     // there are 2 operations with height >= 40832955
-    const minHeight = 40832955;
+    const options = { ...defaultOptions, minHeight: 40832955 };
     const historySize = 2;
     const txHashAtMinHeight = "242591f43c74e45bf4c5c423be2f600c9a53237bde4c793faff5f3120f8745d7";
 
     beforeAll(async () => {
-      [operations] = await listOperations(testingAccount, minHeight);
+      [operations] = await listOperations(testingAccount, options);
     });
 
     describe("List", () => {
       it("should fetch operations successfully", async () => {
         expect(Array.isArray(operations)).toBeDefined();
         expect(operations.length).toBeGreaterThanOrEqual(historySize);
-        expect(operations.filter(op => op.tx.block.height < minHeight).length).toEqual(0);
+        expect(operations.filter(op => op.tx.block.height < options.minHeight).length).toEqual(0);
         expect(operations.find(op => op.tx.hash === txHashAtMinHeight)).toBeDefined();
+      });
+    });
+  });
+
+  describe("Account TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L withe more than 15k+ txs, with minHeight 0 / order asc / softLimit 2", () => {
+    // https://tronscan.org/#/address/TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L
+
+    let operations: Operation<TronAsset>[];
+
+    const testingAccount = "TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L";
+
+    const options: Options = { minHeight: 0, order: "asc", softLimit: 2 };
+    const oldestNativeTxHash = "ebd45e2bd6a83949971554ff84fd6253bc7c77f7ef38cc9ca98c070feeac30d0";
+    const oldestTrc20TxHash = "d9e56dbac3b7bcab20ae72beaaae9634155bbc0855d230fb8fdb9139b3696796";
+
+    beforeAll(async () => {
+      [operations] = await listOperations(testingAccount, options);
+    });
+
+    describe("List", () => {
+      it("should fetch operations successfully", async () => {
+        expect(Array.isArray(operations)).toBeDefined();
+        expect(operations.length).toBeLessThanOrEqual(options.softLimit * 2);
+        expect(operations.filter(op => op.tx.block.height < options.minHeight).length).toEqual(0);
+        // FIXME
+        operations.forEach(op => console.log(op.tx.hash));
+        expect(operations.find(op => op.tx.hash === oldestNativeTxHash)).toBeDefined();
+        expect(operations.find(op => op.tx.hash === oldestTrc20TxHash)).toBeDefined();
+        for (let i = 0; i < operations.length - 2; i++) {
+          // transactions are sorted by descencing order (newest first)
+          // even if we query oldest tx ("asc" order)
+          expect(operations[i].tx.block.height).toBeGreaterThanOrEqual(
+            operations[i + 1].tx.block.height,
+          );
+        }
+      });
+    });
+  });
+
+  describe("Account TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L withe more than 15k+ txs, with minHeight / order asc / softLimit 2", () => {
+    // https://tronscan.org/#/address/TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L
+
+    let operations: Operation<TronAsset>[];
+
+    const testingAccount = "TRRYfGVrzuUvJYRe9UaA8KqxjgVSwU9m6L";
+
+    const options: Options = { minHeight: 52848767, order: "asc", softLimit: 2 };
+
+    // at height 52848767 there is a trc20 tx with hash:
+    const oldestTrc20TxHash = "ab4dba763e4f320f4631268c413926e680c58a3d5228b504d79e9d974dcf9c4b";
+    // the counterpart native tx height is at 53204348 with tx hash:
+    const oldestNativeTxHash = "9d51fb7877a7193af05917dee3aaa5e1e22fcbce36ad0d4593eaca4b8d5d1002";
+
+    beforeAll(async () => {
+      [operations] = await listOperations(testingAccount, options);
+    });
+
+    describe("List", () => {
+      it("should fetch operations successfully", async () => {
+        expect(Array.isArray(operations)).toBeDefined();
+        expect(operations.length).toBeLessThanOrEqual(options.softLimit * 2);
+        expect(operations.filter(op => op.tx.block.height < options.minHeight).length).toEqual(0);
+        // FIXME
+        operations.forEach(op => console.log(op.tx.hash));
+        expect(operations.find(op => op.tx.hash === oldestNativeTxHash)).toBeDefined();
+        expect(operations.find(op => op.tx.hash === oldestTrc20TxHash)).toBeDefined();
+        for (let i = 0; i < operations.length - 2; i++) {
+          // transactions are sorted by descencing order (newest first)
+          // even if we query oldest tx ("asc" order)
+          expect(operations[i].tx.block.height).toBeGreaterThanOrEqual(
+            operations[i + 1].tx.block.height,
+          );
+        }
       });
     });
   });
@@ -55,7 +128,7 @@ describe("listOperations", () => {
     const magnitudeMultiplier = 1000000;
 
     beforeAll(async () => {
-      [operations] = await listOperations(testingAccount, 0);
+      [operations] = await listOperations(testingAccount, defaultOptions);
     });
 
     describe("List", () => {

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.integ.test.ts
@@ -61,8 +61,6 @@ describe("listOperations", () => {
         expect(Array.isArray(operations)).toBeDefined();
         expect(operations.length).toBeLessThanOrEqual(options.softLimit * 2);
         expect(operations.filter(op => op.tx.block.height < options.minHeight).length).toEqual(0);
-        // FIXME
-        operations.forEach(op => console.log(op.tx.hash));
         expect(operations.find(op => op.tx.hash === oldestNativeTxHash)).toBeDefined();
         expect(operations.find(op => op.tx.hash === oldestTrc20TxHash)).toBeDefined();
         for (let i = 0; i < operations.length - 2; i++) {
@@ -99,8 +97,6 @@ describe("listOperations", () => {
         expect(Array.isArray(operations)).toBeDefined();
         expect(operations.length).toBeLessThanOrEqual(options.softLimit * 2);
         expect(operations.filter(op => op.tx.block.height < options.minHeight).length).toEqual(0);
-        // FIXME
-        operations.forEach(op => console.log(op.tx.hash));
         expect(operations.find(op => op.tx.hash === oldestNativeTxHash)).toBeDefined();
         expect(operations.find(op => op.tx.hash === oldestTrc20TxHash)).toBeDefined();
         for (let i = 0; i < operations.length - 2; i++) {

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.ts
@@ -8,18 +8,42 @@ import {
 import { fromTrongridTxInfoToOperation } from "../network/trongrid/trongrid-adapters";
 import { TronAsset } from "../types";
 
-const neverStop: FetchTxsContinuePredicate = () => true;
+export type Options = {
+  // the soft limit is an indicative number of transactions to fetch
+  // it is "soft" because it is not guaranteed that the number of transactions
+  // returned will be less than this number, but it is guaranteed to be:
+  //  <= 2 * softLimit (2 times that number)
+  softLimit: number;
+  minHeight: number;
+  order: "asc" | "desc";
+};
+
+export const defaultOptions: Options = {
+  softLimit: 1000,
+  minHeight: 0,
+  order: "desc",
+} as const;
 
 export async function listOperations(
   address: string,
-  minHeight: number,
+  options: Options,
 ): Promise<[Operation<TronAsset>[], string]> {
   // there is a possible optimisation here: when height is 0, set the minTimestamp to 0
-  const block = await getBlock(minHeight);
-  const fetchParams = block.time
-    ? { ...defaultFetchParams, minTimestamp: block.time?.getTime() }
-    : defaultFetchParams;
-  const txs = await fetchTronAccountTxs(address, neverStop, {}, fetchParams);
+  const block = await getBlock(options.minHeight);
+  const minTimestamp = block.time?.getTime() ?? defaultFetchParams.minTimestamp;
+  const fetchParams = {
+    ...defaultFetchParams,
+    minTimestamp: minTimestamp,
+    order: options.order,
+    hintGlobalLimit: options.softLimit,
+  };
+
+  // under the hood, the netwark fetches native transactions and trc20 transactions separately
+  // that same predicate is used to stop fetching both calls
+  // that's why we have a "soft" limit, with the guarantee of total number of transactions to be less than 2 * softLimit
+  const untilLimitReached: FetchTxsContinuePredicate = ops => ops.length < options.softLimit;
+
+  const txs = await fetchTronAccountTxs(address, untilLimitReached, {}, fetchParams);
   return [
     txs
       // TODO: adapt directly in network calls

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.ts
@@ -38,7 +38,7 @@ export async function listOperations(
     hintGlobalLimit: options.softLimit,
   };
 
-  // under the hood, the netwark fetches native transactions and trc20 transactions separately
+  // under the hood, the network fetches native transactions and trc20 transactions separately
   // that same predicate is used to stop fetching both calls
   // that's why we have a "soft" limit, with the guarantee of total number of transactions to be less than 2 * softLimit
   const untilLimitReached: FetchTxsContinuePredicate = ops => ops.length < options.softLimit;

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.unit.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { defaultFetchParams, fetchTronAccountTxs, getBlock } from "../network";
 import { fromTrongridTxInfoToOperation } from "../network/trongrid/trongrid-adapters";
 import { TrongridTxInfo, TronAsset } from "../types";
-import { listOperations } from "./listOperations";
+import { defaultOptions, listOperations } from "./listOperations";
 import type { Operation } from "@ledgerhq/coin-framework/api/index";
 
 // Mock the fetchTronAccountTxs and fromTrongridTxInfoToOperation functions
@@ -51,7 +51,7 @@ describe("listOperations", () => {
       };
     });
 
-    const [operations, token] = await listOperations(mockAddress, 0);
+    const [operations, token] = await listOperations(mockAddress, defaultOptions);
 
     expect(fetchTronAccountTxs).toHaveBeenCalledWith(
       mockAddress,
@@ -71,7 +71,7 @@ describe("listOperations", () => {
     (fetchTronAccountTxs as jest.Mock).mockResolvedValue(mockTxs);
     (fromTrongridTxInfoToOperation as jest.Mock).mockImplementation(() => null);
 
-    const [operations, token] = await listOperations(mockAddress, 0);
+    const [operations, token] = await listOperations(mockAddress, defaultOptions);
 
     expect(fetchTronAccountTxs).toHaveBeenCalledWith(
       mockAddress,
@@ -87,6 +87,8 @@ describe("listOperations", () => {
     const exampleError = new Error("Network error!");
     (fetchTronAccountTxs as jest.Mock).mockRejectedValue(exampleError);
 
-    await expect(listOperations(mockAddress, 0)).rejects.toThrow(new Error(exampleError.message));
+    await expect(listOperations(mockAddress, defaultOptions)).rejects.toThrow(
+      new Error(exampleError.message),
+    );
   });
 });

--- a/libs/coin-modules/coin-tron/src/logic/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/listOperations.unit.test.ts
@@ -30,6 +30,8 @@ describe("listOperations", () => {
   const expectedFetchParams = {
     ...defaultFetchParams,
     minTimestamp: mockBlockTimestamp,
+    hintGlobalLimit: 1000,
+    order: "desc",
   };
 
   it("should fetch transactions and return operations", async () => {

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -492,7 +492,7 @@ export type FetchParams = {
 };
 
 export const defaultFetchParams: FetchParams = {
-  limitPerCall: 200,
+  limitPerCall: 100,
   minTimestamp: 0,
   order: "desc",
 } as const;
@@ -506,7 +506,6 @@ export async function fetchTronAccountTxs(
   const adjustedLimitPerCall = params.hintGlobalLimit
     ? Math.min(params.limitPerCall, params.hintGlobalLimit)
     : params.limitPerCall;
-  console.log("🦄🦄 adjustedLimitPerCall", adjustedLimitPerCall);
   const queryParams = `limit=${adjustedLimitPerCall}&min_timestamp=${params.minTimestamp}&order_by=block_timestamp,${params.order}`;
   const nativeTxs = (
     await getAllTransactions<


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - the network and logic layers has changed signatures. The new signature introduce parameters used to better control the underlying call to tronscan.
  - the default parameters are same as before
  - no impact on bridge with default parameters 
  - the api changes behavior: now it returns a limited number of 400 operations. Oldest operations are guaranteed to be returned first. 

### 📝 Description

- lama-adapter needs to fetch 15k+ operations on some accounts
- this is about ~7k calls made on trongrid where none of them should fail
- looks like we missed a lot of operations trying to fetch all in one gulp
- this commit let the possibility to fetch deepest operations first and still fixing a limit on the total number of operations
- lama-adapter will be able to sync the whole set of operations by fetching bit by bit


### ❓ Context

- https://ledgerhq.atlassian.net/browse/LIVE-18576


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
