### PR TITLE
fix: add spacing above recover banner

### DIFF
--- a/.changeset/chatty-clocks-pull.md
+++ b/.changeset/chatty-clocks-pull.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+add spacing above recover banner to avoid overlapping other components

--- a/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
+++ b/apps/ledger-live-mobile/src/components/RecoverBanner/index.tsx
@@ -99,7 +99,7 @@ function RecoverBanner() {
   const isWarning = stepNumber > 2;
 
   return (
-    <Flex justifyContent="center" position="relative">
+    <Flex justifyContent="center" position="relative" mt={3}>
       <Flex
         position="relative"
         columnGap={12}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Visual overlap between recover banner and components above it. Added a small margin to produce gap between the components.

<img width="331" alt="Screenshot 2025-05-08 at 14 57 41" src="https://github.com/user-attachments/assets/49ec109c-0eee-4a58-8927-397db1d59a41" />
(Black bar is a test component in place of a braze card)

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18798


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
