### PR TITLE
fix(LIVE-18832): remove discreetmode param from both llm and lld swap…

### DIFF
--- a/.changeset/wise-jokes-dream.md
+++ b/.changeset/wise-jokes-dream.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Remove passing of discreetmode parameter to swap live app to prevent page refreh on LLD when the mode is toggled and for consistency on LLM

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -52,7 +52,6 @@ import {
 } from "../utils/index";
 import FeesDrawerLiveApp from "./FeesDrawerLiveApp";
 import WebviewErrorDrawer from "./WebviewErrorDrawer/index";
-import { useDiscreetMode } from "~/renderer/components/Discreet";
 
 export class UnableToLoadSwapLiveError extends Error {
   constructor(message: string) {
@@ -128,7 +127,6 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
   const currentVersion = __APP_VERSION__;
   const enablePlatformDevTools = useSelector(enablePlatformDevToolsSelector);
   const devMode = useSelector(developerModeSelector);
-  const discreet = useDiscreetMode();
   const accounts = useSelector(flattenAccountsSelector);
   const { t } = useTranslation();
   const swapDefaultTrack = useGetSwapTrackingProperties();
@@ -490,7 +488,6 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
             swapApiBase: SWAP_API_BASE,
             swapUserIp: SWAP_USER_IP,
             devMode,
-            discreetMode: discreet,
             lastSeenDevice: lastSeenDevice?.modelId,
             currentVersion,
             platform: "LLD",

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/WebView.tsx
@@ -13,7 +13,6 @@ import { getCountryLocale } from "~/helpers/getStakeLabelLocaleBased";
 import { useSettings } from "~/hooks";
 import {
   counterValueCurrencySelector,
-  discreetModeSelector,
   exportSettingsSelector,
   lastSeenDeviceSelector,
 } from "~/reducers/settings";
@@ -33,7 +32,6 @@ export function WebView({ manifest, params, setWebviewState }: Props) {
   const { theme } = useTheme();
   const { language } = useSettings();
   const { ticker: currencyTicker } = useSelector(counterValueCurrencySelector);
-  const discreet = useSelector(discreetModeSelector);
   const countryLocale = getCountryLocale();
   const SWAP_API_BASE = useEnv("SWAP_API_BASE");
   const SWAP_USER_IP = useEnv("SWAP_USER_IP");
@@ -63,7 +61,6 @@ export function WebView({ manifest, params, setWebviewState }: Props) {
             countryLocale,
             currencyTicker,
             lastSeenDevice: lastSeenDevice?.modelId,
-            discreetMode: discreet ? "true" : "false",
             OS: Platform.OS,
             platform: "LLM", // need consistent format with LLD, Platform doesn't work
             ...swapParams,


### PR DESCRIPTION
… app

remove discreetmode param from both llm and lld swap app

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18832


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
