### PR TITLE
fix: add polyfill for ky retry on LLM Android

### DIFF
--- a/.changeset/new-flies-smell.md
+++ b/.changeset/new-flies-smell.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add polyfill for ky retry on LLM Android

--- a/apps/ledger-live-mobile/src/polyfill.ts
+++ b/apps/ledger-live-mobile/src/polyfill.ts
@@ -28,6 +28,7 @@ import "@formatjs/intl-relativetimeformat/locale-data/ko";
 
 // Fix error when adding Solana account
 import "@azure/core-asynciterator-polyfill";
+import { Platform } from "react-native";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 global.Buffer = require("buffer").Buffer;
@@ -55,6 +56,16 @@ Promise.allSettled =
     ));
 
 process.browser = true; // for readable-stream/lib/_stream_writable.js
+
+// // Polyfill for AbortSignal.throwIfAborted on Android
+const isAndroid = Platform.OS === "android";
+if (isAndroid && typeof AbortSignal !== "undefined" && !AbortSignal.prototype.throwIfAborted) {
+  AbortSignal.prototype.throwIfAborted = function () {
+    if (this.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+  };
+}
 
 // FIXME shim want to set it to false tho...
 if (__DEV__ && process.env.NODE_ENV !== "test") {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add polyfill to handle the error `undefined is not a function` when ky retry and call `signal.throwIfAborted();`

https://github.com/sindresorhus/ky/issues/588#issuecomment-2256808504

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-18520](https://ledgerhq.atlassian.net/browse/LIVE-18520)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18520]: https://ledgerhq.atlassian.net/browse/LIVE-18520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ