### PR TITLE
Feat/live 17027 Have ability in Firebase to get a firmware minapp version different according to device type (NanoS, NanoX, Stax, etc.)

### DIFF
--- a/.changeset/shy-eels-reflect.md
+++ b/.changeset/shy-eels-reflect.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/devices": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: device specific config for min app version

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -36,12 +36,9 @@ const appConfig: Record<string, ConfigInfo> = {
     type: "object",
     default: {
       minVersion: "1.2.0",
-      // nanoS: {
-      //   minVersion: "1.8.0",
-      // },
-      //  nanoSP: {
-      //    minVersion: "1.7.0",
-      //  },
+      nanoSP: {
+        minVersion: "1.8.0",
+      },
     },
   },
   config_nanoapp_celo: {

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -36,9 +36,6 @@ const appConfig: Record<string, ConfigInfo> = {
     type: "object",
     default: {
       minVersion: "1.2.0",
-      nanoSP: {
-        minVersion: "1.8.0",
-      },
     },
   },
   config_nanoapp_celo: {

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -36,6 +36,12 @@ const appConfig: Record<string, ConfigInfo> = {
     type: "object",
     default: {
       minVersion: "1.2.0",
+      // nanoS: {
+      //   minVersion: "1.8.0",
+      // },
+      // nanoSP: {
+      //   minVersion: "1.8.0",
+      // },
     },
   },
   config_nanoapp_celo: {

--- a/libs/ledger-live-common/src/apps/config.ts
+++ b/libs/ledger-live-common/src/apps/config.ts
@@ -39,9 +39,9 @@ const appConfig: Record<string, ConfigInfo> = {
       // nanoS: {
       //   minVersion: "1.8.0",
       // },
-      // nanoSP: {
-      //   minVersion: "1.8.0",
-      // },
+      //  nanoSP: {
+      //    minVersion: "1.7.0",
+      //  },
     },
   },
   config_nanoapp_celo: {

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -3,6 +3,8 @@ import { shouldUseTrustedInputForSegwit } from "@ledgerhq/hw-app-btc/shouldUseTr
 import { getDependencies } from "./polyfill";
 import { getEnv } from "@ledgerhq/live-env";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { DeviceModelId, deviceIdsList } from "@ledgerhq/devices";
+import { includes } from "../helpers";
 
 export function shouldUpgrade(appName: string, appVersion: string): boolean {
   if (getEnv("DISABLE_APP_VERSION_REQUIREMENTS")) return false;
@@ -26,12 +28,30 @@ export function shouldUpgrade(appName: string, appVersion: string): boolean {
   return false;
 }
 
-export function mustUpgrade(appName: string, appVersion: string): boolean {
+export function hasDeviceConfigForApp(appName: string): boolean {
   if (getEnv("DISABLE_APP_VERSION_REQUIREMENTS")) return false;
   // we should convert the app name to camel case and replace spaces with underscores to match the config convention in firebase
-  const minVersion = LiveConfig.getValueByKey(
+  const config = LiveConfig.getValueByKey(
     `config_nanoapp_${appName.toLowerCase().replace(/ /g, "_")}`,
-  )?.minVersion;
+  );
+
+  if (!config) return false;
+
+  return Object.keys(config).some(key => includes(deviceIdsList, key));
+}
+
+export function mustUpgrade(
+  appName: string,
+  appVersion: string,
+  deviceModelId?: DeviceModelId,
+): boolean {
+  if (getEnv("DISABLE_APP_VERSION_REQUIREMENTS")) return false;
+  // we should convert the app name to camel case and replace spaces with underscores to match the config convention in firebase
+  const config = LiveConfig.getValueByKey(
+    `config_nanoapp_${appName.toLowerCase().replace(/ /g, "_")}`,
+  );
+  const deviceConfig = deviceModelId ? config?.[deviceModelId] : undefined;
+  const minVersion = deviceConfig?.minVersion || config?.minVersion;
   if (minVersion) {
     // necessary when using test versions on other providers that often end up on -dev
     const appVersionCoerced = semver.coerce(appVersion);

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -457,6 +457,7 @@ export const createAction = (
     const firmwareResolvedRef = useRef(false);
     const outdatedAppRef = useRef<AppAndVersion>();
     const deviceModelIdRef = useRef<DeviceModelId>();
+    const mightHaveOutdatedAppRef = useRef(false);
 
     const request = useMemo(
       () => inferCommandParams(appRequest), // for now i don't have better
@@ -482,6 +483,7 @@ export const createAction = (
             requireLatestFirmware: firmwareResolvedRef.current ? undefined : requireLatestFirmware,
             outdatedApp: outdatedAppRef.current,
             deviceModelId: deviceModelIdRef.current,
+            mightHaveOutdatedApp: mightHaveOutdatedAppRef.current,
           },
         }).pipe(
           tap(e => {
@@ -492,6 +494,8 @@ export const createAction = (
               firmwareResolvedRef.current = true;
             } else if (e.type === "has-outdated-app") {
               outdatedAppRef.current = e.outdatedApp as AppAndVersion;
+            } else if (e.type === "might-have-outdated-app") {
+              mightHaveOutdatedAppRef.current = true;
             } else if (e.type === "set-device-model-id") {
               deviceModelIdRef.current = e.deviceModelId;
             }

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -23,6 +23,7 @@ import type { Account, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getImplementation, ImplementationType } from "./implementations";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 
 export type State = {
   isLoading: boolean;
@@ -455,6 +456,8 @@ export const createAction = (
     const dependenciesResolvedRef = useRef(false);
     const firmwareResolvedRef = useRef(false);
     const outdatedAppRef = useRef<AppAndVersion>();
+    const deviceModelIdRef = useRef<DeviceModelId>();
+    const mightHaveOutdatedAppRef = useRef(false);
 
     const request = useMemo(
       () => inferCommandParams(appRequest), // for now i don't have better
@@ -479,6 +482,8 @@ export const createAction = (
             dependencies: dependenciesResolvedRef.current ? undefined : dependencies,
             requireLatestFirmware: firmwareResolvedRef.current ? undefined : requireLatestFirmware,
             outdatedApp: outdatedAppRef.current,
+            deviceModelId: deviceModelIdRef.current,
+            mightHaveOutdatedApp: mightHaveOutdatedAppRef.current,
           },
         }).pipe(
           tap(e => {
@@ -489,6 +494,10 @@ export const createAction = (
               firmwareResolvedRef.current = true;
             } else if (e.type === "has-outdated-app") {
               outdatedAppRef.current = e.outdatedApp as AppAndVersion;
+            } else if (e.type === "might-have-outdated-app") {
+              mightHaveOutdatedAppRef.current = true;
+            } else if (e.type === "set-device-model-id") {
+              deviceModelIdRef.current = e.deviceModelId;
             }
           }),
         );

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -87,6 +87,7 @@ export type AppRequest = {
   withInlineInstallProgress?: boolean;
   requireLatestFirmware?: boolean;
   allowPartialDependencies?: boolean;
+  mightHaveOutdatedApp?: boolean;
 };
 
 export type AppResult = {
@@ -381,6 +382,7 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
     requireLatestFirmware,
     allowPartialDependencies = false,
     dependencies: appDependencies,
+    mightHaveOutdatedApp,
   } = appRequest;
   let { appName, currency } = appRequest;
 
@@ -405,6 +407,7 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
       dependencies,
       requireLatestFirmware,
       allowPartialDependencies,
+      mightHaveOutdatedApp: mightHaveOutdatedApp ?? false,
     };
   }
 
@@ -441,6 +444,7 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
       ...extra,
     },
     allowPartialDependencies,
+    mightHaveOutdatedApp: mightHaveOutdatedApp ?? false,
   };
 }
 

--- a/libs/ledger-live-common/src/hw/actions/app.ts
+++ b/libs/ledger-live-common/src/hw/actions/app.ts
@@ -87,7 +87,6 @@ export type AppRequest = {
   withInlineInstallProgress?: boolean;
   requireLatestFirmware?: boolean;
   allowPartialDependencies?: boolean;
-  mightHaveOutdatedApp?: boolean;
 };
 
 export type AppResult = {
@@ -382,7 +381,6 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
     requireLatestFirmware,
     allowPartialDependencies = false,
     dependencies: appDependencies,
-    mightHaveOutdatedApp,
   } = appRequest;
   let { appName, currency } = appRequest;
 
@@ -407,7 +405,6 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
       dependencies,
       requireLatestFirmware,
       allowPartialDependencies,
-      mightHaveOutdatedApp: mightHaveOutdatedApp ?? false,
     };
   }
 
@@ -444,7 +441,6 @@ function inferCommandParams(appRequest: AppRequest): ConnectAppRequest {
       ...extra,
     },
     allowPartialDependencies,
-    mightHaveOutdatedApp: mightHaveOutdatedApp ?? false,
   };
 }
 
@@ -461,7 +457,6 @@ export const createAction = (
     const firmwareResolvedRef = useRef(false);
     const outdatedAppRef = useRef<AppAndVersion>();
     const deviceModelIdRef = useRef<DeviceModelId>();
-    const mightHaveOutdatedAppRef = useRef(false);
 
     const request = useMemo(
       () => inferCommandParams(appRequest), // for now i don't have better
@@ -487,7 +482,6 @@ export const createAction = (
             requireLatestFirmware: firmwareResolvedRef.current ? undefined : requireLatestFirmware,
             outdatedApp: outdatedAppRef.current,
             deviceModelId: deviceModelIdRef.current,
-            mightHaveOutdatedApp: mightHaveOutdatedAppRef.current,
           },
         }).pipe(
           tap(e => {
@@ -498,8 +492,6 @@ export const createAction = (
               firmwareResolvedRef.current = true;
             } else if (e.type === "has-outdated-app") {
               outdatedAppRef.current = e.outdatedApp as AppAndVersion;
-            } else if (e.type === "might-have-outdated-app") {
-              mightHaveOutdatedAppRef.current = true;
             } else if (e.type === "set-device-model-id") {
               deviceModelIdRef.current = e.deviceModelId;
             }

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -26,7 +26,6 @@ import getDeviceInfo from "./getDeviceInfo";
 import getAddress from "./getAddress";
 import openApp from "./openApp";
 import quitApp from "./quitApp";
-import { LatestFirmwareVersionRequired } from "../errors";
 import { hasDeviceConfigForApp, mustUpgrade } from "../apps";
 import isUpdateAvailable from "./isUpdateAvailable";
 import { LockedDeviceEvent } from "./actions/types";

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
@@ -12,6 +12,7 @@ import semver from "semver";
 import { AppAndVersion } from "./connectApp";
 import { mustUpgrade } from "../apps";
 import { getAppsCatalogForDevice } from "../device/use-cases/getAppsCatalogForDevice";
+import { identifyTargetId } from "@ledgerhq/devices/lib/index";
 
 const isUpdateAvailable = async (
   deviceInfo: DeviceInfo,
@@ -32,7 +33,11 @@ const isUpdateAvailable = async (
 
   return (
     !!appAvailableInProvider &&
-    !mustUpgrade(appAvailableInProvider.versionName, appAvailableInProvider.version)
+    !mustUpgrade(
+      appAvailableInProvider.versionName,
+      appAvailableInProvider.version,
+      identifyTargetId(Number(deviceInfo.targetId))?.id,
+    )
   );
 };
 

--- a/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
+++ b/libs/ledger-live-common/src/hw/isUpdateAvailable.ts
@@ -12,7 +12,7 @@ import semver from "semver";
 import { AppAndVersion } from "./connectApp";
 import { mustUpgrade } from "../apps";
 import { getAppsCatalogForDevice } from "../device/use-cases/getAppsCatalogForDevice";
-import { identifyTargetId } from "@ledgerhq/devices/lib/index";
+import { identifyTargetId } from "@ledgerhq/devices";
 
 const isUpdateAvailable = async (
   deviceInfo: DeviceInfo,

--- a/libs/ledger-live-common/src/load/speculos.ts
+++ b/libs/ledger-live-common/src/load/speculos.ts
@@ -79,7 +79,7 @@ export async function listAppCandidates(cwd: string): Promise<AppCandidate[]> {
             if (
               semver.valid(appVersion) &&
               !shouldUpgrade(appName, appVersion) &&
-              !mustUpgrade(appName, appVersion)
+              !mustUpgrade(appName, appVersion, model)
             ) {
               c.push({
                 path: p4,

--- a/libs/ledgerjs/packages/devices/src/index.ts
+++ b/libs/ledgerjs/packages/devices/src/index.ts
@@ -135,6 +135,8 @@ const productMap = {
 
 const devicesList: DeviceModel[] = Object.values(devices);
 
+export const deviceIdsList = Object.values(productMap);
+
 /**
  *
  */


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [X] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Behavior have changed on device action modal, we need to come back to the dashboard when an app is opened to get the device model (technical need)

### 📝 Description

Have ability in Firebase to get a firmware minapp version different according to device type (NanoS, NanoX, Stax, etc.)
We can now have a min version for a specific device model on LLD 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> [LIVE-17027](https://ledgerhq.atlassian.net/browse/LIVE-17027?atlOrigin=eyJpIjoiZGViMDNhODA0YmE2NDMxYWIxNWFlNDhhMzAyOTg0ZTEiLCJwIjoiaiJ9)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
