### PR TITLE
feat: solana off-chain message signing returns the envelope with the signedMessage [LIVE-19009]

### DIFF
--- a/.changeset/flat-trees-pay.md
+++ b/.changeset/flat-trees-pay.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: solana off-chain message signing returns the envelope with the signedMessage

--- a/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
@@ -3,6 +3,7 @@ import { Account, AnyMessage, TypedEvmMessage } from "@ledgerhq/types-live";
 import { signMessage } from "../../hw-signMessage";
 import { PubKeyDisplayMode, SolanaSigner } from "../../signer";
 import coinConfig from "../../config";
+import bs58 from "bs58";
 
 coinConfig.setCoinConfig(() => ({
   legacyOCMSMaxVersion: "1.8.2",
@@ -18,7 +19,9 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
       "4gVuB1KsM58fb3vRpnDucwW4Vi6fVGA51QDQd9ARvx4GH5yYVDPzDnvzUbSJf3YLWWdsX7zCMSN9N1GMnTYwWiJf";
 
     const BASE58_SIGNATURE =
-      "RTCCo3j8Nx4FocNfEjPqTFgsDjxge5YR3tapEpbWVRgzbPcnTAYD54KiodwhVETwHYLLb5gVACSmrH8RN5ZMEhq7iH88mVb1peF3pDKRgJGZ3opDhonkc5Tj";
+      "23mXB2pc8EQzc2mT3VJR4KkBFZaUVL9Pn7LUn8NMKeHKbS1hMj1QqGsUHHD3JMGhAWtFfcmnPhFSpPttChTNzsB9";
+    const BASE58_ENVELOPE =
+      "LwsiJTXpooGk31Y4CaV1Qs12wTabaF83J9Tg32kPb7kk9BXc8ncpoDBzV1NPSumKckhx7dVwFH729vdvB71f8KGpp18g29N2XAD3MUiNz9tPJu36GGN4pkL7vXurXUeQqMTXdJMdH2tzaXkT3vQ9hSLDfBPhQ7Vx9Echz5CYu5u4hZapaytx177WNke8oWDTqABnqQZ3YDGt7vYDoJ2LkiGHqcqXfeVmmsAtuALSxqo75zrWi7EXadQ9CZWWX7tFnXHLY6kEksqVj2ERM9RZEyNQ3tt";
 
     const getAppConfigurationMock = jest.fn(() => {
       return Promise.resolve({
@@ -50,7 +53,8 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
       { message: messageHex },
     );
 
-    expect(result.signature).toEqual(BASE58_SIGNATURE);
+    expect(result.signature).toEqual(BASE58_ENVELOPE);
+    expect(bs58.encode(bs58.decode(result.signature).subarray(1, 65))).toEqual(BASE58_SIGNATURE);
     expect(signMessageMock).toHaveBeenCalledTimes(1);
     expect(signMessageMock).toHaveBeenCalledWith(accountFreshAddressPath, offchainMessage);
   });
@@ -61,7 +65,9 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
       "4gVuB1KsM58fb3vRpnDucwW4Vi6fVGA51QDQd9ARvx4GH5yYVDPzDnvzUbSJf3YLWWdsX7zCMSN9N1GMnTYwWiJf";
 
     const BASE58_SIGNATURE =
-      "RTCCo3j8Nx4FocNfEjPqTFgsDjxge5YR3tapEpbWVRgzbPcnTAYD54KiodwhVETwHYLLb5gVACSmrH8RN5ZMEhq7iH88mVb1peF3pDKRgJGZ3opDhonkc5Tj";
+      "23mXB2pc8EQzc2mT3VJR4KkBFZaUVL9Pn7LUn8NMKeHKbS1hMj1QqGsUHHD3JMGhAWtFfcmnPhFSpPttChTNzsB9";
+    const BASE58_ENVELOPE =
+      "tDAHsdMRLpSiAFbdWRS6d7TyG64QSwJFuRSHNH6UyjE8wQwDgawYRsUsau2n9s5drPkmDLTJdTrkA5uRYsHmmfzuMsBQvo6e72LwNjfNhmVko8ffmfM1ZNKZmyiurvDb2nfoFsLXmYTainNmRKwS6iGSBvWBYHRDMwUiX2z15gBokN2iMhuCvDsFHHVn7H4vQG";
 
     const getAppConfigurationMock = jest.fn(() => {
       return Promise.resolve({
@@ -93,7 +99,8 @@ describe("Testing call to hardware off-chain sign message on Solana", () => {
       { message: messageHex },
     );
 
-    expect(result.signature).toEqual(BASE58_SIGNATURE);
+    expect(result.signature).toEqual(BASE58_ENVELOPE);
+    expect(bs58.encode(bs58.decode(result.signature).subarray(1, 65))).toEqual(BASE58_SIGNATURE);
     expect(signMessageMock).toHaveBeenCalledTimes(1);
     expect(signMessageMock).toHaveBeenCalledWith(accountFreshAddressPath, offchainMessage);
   });

--- a/libs/ledger-live-common/src/families/solana/setup.test.ts
+++ b/libs/ledger-live-common/src/families/solana/setup.test.ts
@@ -5,11 +5,14 @@ import { PubKeyDisplayMode } from "@ledgerhq/coin-solana/signer";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { messageSigner } from "./setup";
 import { solanaConfig } from "./config";
+import bs58 from "bs58";
 
 const SIGNATURE =
   "97fb71bae8971e272b17a464dc2f76995de2da9fc5d40e369edc43b0c3f7c601c4e5a60bb7c6ac69671120c381ce5cab7a06f53eb802e3ac555066455f2cbd05";
 const BASE58_SIGNATURE =
   "43EtUq3x4vxxSZ2UyNxJXopCmF78UJFPySv5kRjQRX2PVuMBLQCPTRjJgPWKgN7fJXVoKZRAvU6W3T6ajJu3sce8";
+const BASE58_ENVELOPE =
+  "2MZJAqnJPmTqcnhFkR34XCbfRaZTT5dqAyQmFc37dS22cYn4HS81nBgYQDa199idtBWvvwCVa8yvn6rqkjtMS3WDWods2HabwZnv1TUABUbvVkjwh2T9vD1KYzBe3mim9Dk2jCHPuG1mKN8pdV2Sh8A8vjXaxwUNg714SMK4x2wg5Ww3Fb72MDXi9jgvXmt6FpehJZVfgFLFnUtr5YBW5xiBPQYFN6aHjzHwHcecmXCGLavvK4DVoUjufLinrXiMYUdEGqnSjzwTHRF6mjUVcP3nC";
 
 const APP_VERSION = "1.8.2";
 const getAppConfigurationMock = jest.fn(() => {
@@ -59,7 +62,8 @@ describe("Testing setup on Solana", () => {
         "ff736f6c616e61206f6666636861696e00000000000000000000000000000000000000000000000000000000000000000000016b4a46c53959cac0eff146ab323053cfc503321adfd453a7c67c91a24be0323538003463366636653637323034663636363632643433363836313639366532303534363537333734323034643635373337333631363736353265",
       );
 
-      expect(result.signature).toEqual(BASE58_SIGNATURE);
+      expect(result.signature).toEqual(BASE58_ENVELOPE);
+      expect(bs58.encode(bs58.decode(result.signature).subarray(1, 65))).toEqual(BASE58_SIGNATURE);
       expect(result.rsv).toBeUndefined();
     });
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Solana sign message with the wallet-api

### 📝 Description

We now return [an envelope](https://docs.anza.xyz/proposals/off-chain-message-signing#envelope) containing both the signature and the signedMessage
It allows live-apps and dApps to verify the signature against the message constructed by LL with the header

You can use the following manifest to test the feature with this small live-app: https://codesandbox.io/p/sandbox/5gz86q

<details>
  <summary>Manifest</summary>
    
```md
{
  "id": "sol-test-sign",
  "author": "",
  "private": false,
  "name": "Sol test sign",
  "url": "https://5gz86q.csb.app/",
  "homepageUrl": "https://5gz86q.csb.app/",
  "icon": "",
  "platforms": ["ios", "android", "desktop"],
  "apiVersion": "^2.0.0",
  "manifestVersion": "2",
  "branch": "stable",
  "categories": ["DeFi"],
  "currencies": ["solana"],
  "highlight": false,
  "content": {
    "description": {
      "en": "description"
    },
    "shortDescription": {
      "en": "shortDescription"
    }
  },
  "domains": ["https://"],
  "visibility": "complete",
  "permissions": ["account.request", "message.sign"]
}
```
  
</details>


https://github.com/user-attachments/assets/9ff11ad6-aa9f-4b1f-bc3d-36c50232dcd5

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19009]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19009]: https://ledgerhq.atlassian.net/browse/LIVE-19009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ