### PR TITLE
fix: optimize the "Add account" flow in Hedera

### DIFF
--- a/.changeset/late-sheep-argue.md
+++ b/.changeset/late-sheep-argue.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": patch
+---
+
+fix slow "add account" flow with Hedera

--- a/libs/coin-modules/coin-hedera/src/api/mirror.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.test.ts
@@ -1,0 +1,76 @@
+import network from "@ledgerhq/live-network/network";
+import { getAccountTransactions } from "./mirror";
+
+jest.mock("@ledgerhq/live-network/network");
+const mockedNetwork = jest.mocked(network);
+
+const makeMockResponse = (data: any): Awaited<ReturnType<typeof network>> => ({
+  data,
+  status: 200,
+  statusText: "OK",
+  headers: {},
+  config: {
+    headers: {} as any,
+  },
+});
+
+describe("getAccountTransactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should include 'account.id', 'limit=100' and 'order=desc' query params", async () => {
+    mockedNetwork.mockResolvedValueOnce(
+      makeMockResponse({ transactions: [], links: { next: null } }),
+    );
+
+    await getAccountTransactions("0.0.1234", null);
+
+    const calledUrl = mockedNetwork.mock.calls[0][0].url;
+    expect(calledUrl).toContain("account.id=0.0.1234");
+    expect(calledUrl).toContain("limit=100");
+    expect(calledUrl).toContain("order=desc");
+  });
+
+  it("should break early if no transactions are returned", async () => {
+    mockedNetwork.mockResolvedValueOnce(
+      makeMockResponse({
+        transactions: [],
+        links: { next: "/next-1" },
+      }),
+    );
+
+    const result = await getAccountTransactions("0.0.1234", null);
+
+    expect(mockedNetwork).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it("should keep fetching if links.next is present and new transactions are returned", async () => {
+    mockedNetwork
+      .mockResolvedValueOnce(
+        makeMockResponse({
+          transactions: [{ consensus_timestamp: "1" }],
+          links: { next: "/next-1" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeMockResponse({
+          transactions: [{ consensus_timestamp: "2" }],
+          links: { next: "/next-2" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeMockResponse({
+          transactions: [],
+          links: { next: "/next-3" },
+        }),
+      );
+
+    const result = await getAccountTransactions("0.0.1234", null);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(tx => tx.consensus_timestamp)).toEqual(["1", "2"]);
+    expect(mockedNetwork).toHaveBeenCalledTimes(3);
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/api/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.ts
@@ -56,7 +56,7 @@ interface HederaMirrorTransaction {
   consensus_timestamp: string;
 }
 
-async function getAccountTransactions(
+export async function getAccountTransactions(
   address: string,
   since: string | null,
 ): Promise<HederaMirrorTransaction[]> {

--- a/libs/coin-modules/coin-hedera/src/api/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.ts
@@ -16,12 +16,12 @@ const fetch = (path: string) => {
   });
 };
 
-export interface Account {
+interface HederaMirrorAccount {
   accountId: AccountId;
   balance: BigNumber;
 }
 
-export async function getAccountsForPublicKey(publicKey: string): Promise<Account[]> {
+export async function getAccountsForPublicKey(publicKey: string): Promise<HederaMirrorAccount[]> {
   let r;
   try {
     r = await fetch(`/api/v1/accounts?account.publicKey=${publicKey}&balance=false`);
@@ -30,7 +30,7 @@ export async function getAccountsForPublicKey(publicKey: string): Promise<Accoun
     throw e;
   }
   const rawAccounts = r.data.accounts;
-  const accounts: Account[] = [];
+  const accounts: HederaMirrorAccount[] = [];
 
   for (const raw of rawAccounts) {
     const accountBalance = await getAccountBalance(raw.account);
@@ -44,6 +44,11 @@ export async function getAccountsForPublicKey(publicKey: string): Promise<Accoun
   return accounts;
 }
 
+interface HederaMirrorTransfer {
+  account: string;
+  amount: number;
+}
+
 interface HederaMirrorTransaction {
   transfers: HederaMirrorTransfer[];
   charged_tx_fee: string;
@@ -51,27 +56,39 @@ interface HederaMirrorTransaction {
   consensus_timestamp: string;
 }
 
-interface HederaMirrorTransfer {
-  account: string;
-  amount: number;
+async function getAccountTransactions(
+  address: string,
+  since: string | null,
+): Promise<HederaMirrorTransaction[]> {
+  const transactions: HederaMirrorTransaction[] = [];
+  const params = new URLSearchParams({
+    "account.id": address,
+  });
+
+  if (since) {
+    params.append("timestamp", `gt:${since}`);
+  }
+
+  let nextUrl = `/api/v1/transactions?${params.toString()}`;
+
+  while (nextUrl) {
+    const res = await fetch(nextUrl);
+    const newTransactions = res.data.transactions as HederaMirrorTransaction[];
+    if (newTransactions.length === 0) break;
+    transactions.push(...newTransactions);
+    nextUrl = res.data.links.next;
+  }
+
+  return transactions;
 }
 
 export async function getOperationsForAccount(
   ledgerAccountId: string,
   address: string,
-  latestOperationTimestamp: string,
+  latestOperationTimestamp: string | null,
 ): Promise<Operation[]> {
+  const rawOperations = await getAccountTransactions(address, latestOperationTimestamp);
   const operations: Operation[] = [];
-  let r = await fetch(
-    `/api/v1/transactions?account.id=${address}&timestamp=gt:${latestOperationTimestamp}`,
-  );
-  const rawOperations = r.data.transactions as HederaMirrorTransaction[];
-
-  while (r.data.links.next) {
-    r = await fetch(r.data.links.next);
-    const newOperations = r.data.transactions as HederaMirrorTransaction[];
-    rawOperations.push(...newOperations);
-  }
 
   for (const raw of rawOperations) {
     const { consensus_timestamp } = raw;

--- a/libs/coin-modules/coin-hedera/src/api/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.ts
@@ -63,6 +63,8 @@ async function getAccountTransactions(
   const transactions: HederaMirrorTransaction[] = [];
   const params = new URLSearchParams({
     "account.id": address,
+    order: "desc",
+    limit: "100",
   });
 
   if (since) {

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -36,16 +36,14 @@ export const getAccountShape: GetAccountShape<Account> = async (
   // grab latest operation's consensus timestamp for incremental sync
   const oldOperations = initialAccount?.operations ?? [];
   const latestOperationTimestamp = oldOperations[0]
-    ? Math.floor(oldOperations[0].date.getTime() / 1000)
+    ? new BigNumber(Math.floor(oldOperations[0].date.getTime() / 1000))
     : null;
 
   // merge new operations w/ previously synced ones
   const newOperations = await getOperationsForAccount(
     liveAccountId,
     address,
-    typeof latestOperationTimestamp === "number"
-      ? new BigNumber(latestOperationTimestamp).toString()
-      : null,
+    latestOperationTimestamp ? latestOperationTimestamp.toString() : null,
   );
   const operations = mergeOps(oldOperations, newOperations);
 

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -37,13 +37,15 @@ export const getAccountShape: GetAccountShape<Account> = async (
   const oldOperations = initialAccount?.operations ?? [];
   const latestOperationTimestamp = oldOperations[0]
     ? Math.floor(oldOperations[0].date.getTime() / 1000)
-    : 0;
+    : null;
 
   // merge new operations w/ previously synced ones
   const newOperations = await getOperationsForAccount(
     liveAccountId,
     address,
-    new BigNumber(latestOperationTimestamp).toString(),
+    typeof latestOperationTimestamp === "number"
+      ? new BigNumber(latestOperationTimestamp).toString()
+      : null,
   );
   const operations = mergeOps(oldOperations, newOperations);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Hedera account scanning is much faster

### 📝 Description

This pull request fixes slow account scanning when adding a new Hedera account. 

Here is a demo of how it works now:
https://drive.google.com/file/d/1xOLbOj8AEUaMnO_UsjWl23hD9nreaCdZ/view. 

You can notice that it takes more than 300 requests per account to get the list of transactions from the Mirror Node API. This can be easily reproduced by going to: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?account.id=0.0.8835924&timestamp=gt:0 and trying to fetch the transactions until `links.next = null`. 

The proposed fix is to simply break the loop when the transactions array is empty, avoiding unnecessary pagination when we know no more data can be returned.

Here is a demo of how it works after the change is made: https://drive.google.com/file/d/1M4Fyq2ebZJixOpv3NtrpD9ggvE9B4DQs/view

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)