### PR TITLE
[LIVE-18379][LIVE-18826] Feature flag to control NFT usage for custom lock screen

### DIFF
--- a/.changeset/moody-timers-compare.md
+++ b/.changeset/moody-timers-compare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add FF to control NFT as custom lock screen

--- a/.changeset/thin-mice-study.md
+++ b/.changeset/thin-mice-study.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add FF to control NFT as custom lock screen

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
@@ -19,6 +19,7 @@ import useIsMounted from "@ledgerhq/live-common/hooks/useIsMounted";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { analyticsPageNames, analyticsFlowName } from "./shared";
 import { useTrack } from "~/renderer/analytics/segment";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 type Props = StepProps & {
   onResult: (res: ImageBase64Data) => void;
@@ -58,6 +59,7 @@ const StepChooseImage: React.FC<Props> = props => {
   const isMounted = useIsMounted();
   const { t } = useTranslation();
   const track = useTrack();
+  const llNftSupportEnabled = useFeature("llNftSupport")?.enabled ?? false;
 
   const [selectedNftId, setSelectedNftId] = useState<string>();
   const [selectedNftBase64Data, setSelectedNftBase64] = useState<ImageBase64Data | null>(null);
@@ -150,14 +152,16 @@ const StepChooseImage: React.FC<Props> = props => {
               })
             }
           />
-          <ImportNFTButton
-            onClick={() => {
-              setIsShowingNftGallery(true);
-              track("button_clicked2", {
-                button: "Choose from NFT gallery",
-              });
-            }}
-          />
+          {llNftSupportEnabled ? (
+            <ImportNFTButton
+              onClick={() => {
+                setIsShowingNftGallery(true);
+                track("button_clicked2", {
+                  button: "Choose from NFT gallery",
+                });
+              }}
+            />
+          ) : null}
           {hasCustomLockScreen ? (
             <Link
               size="medium"

--- a/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomImage/CustomImageBottomModal.tsx
@@ -16,6 +16,7 @@ import DeviceAction from "../DeviceAction";
 import { useStaxRemoveImageDeviceAction } from "~/hooks/deviceActions";
 import { type CLSSupportedDeviceModelId } from "@ledgerhq/live-common/device/use-cases/isCustomLockScreenSupported";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 const analyticsDrawerName = "Choose an image to set as your device lockscreen";
 
@@ -53,6 +54,7 @@ const CustomImageBottomModal: React.FC<Props> = props => {
   } = props;
   const { t } = useTranslation();
   const { pushToast } = useToasts();
+  const llNftSupportEnabled = useFeature("llNftSupport")?.enabled ?? false;
 
   const navigation = useNavigation<StackNavigatorNavigation<BaseNavigatorStackParamList>>();
 
@@ -169,13 +171,15 @@ const CustomImageBottomModal: React.FC<Props> = props => {
             eventProperties={analyticsButtonChoosePhoneGalleryEventProps}
           />
           <Flex mt={6} />
-          <ModalChoice
-            onPress={handleSelectFromNFTGallery}
-            title={t("customImage.drawer.options.selectFromNFTGallery")}
-            iconName={"Ticket"}
-            event="button_clicked"
-            eventProperties={analyticsButtonChooseNFTGalleryEventProps}
-          />
+          {llNftSupportEnabled ? (
+            <ModalChoice
+              onPress={handleSelectFromNFTGallery}
+              title={t("customImage.drawer.options.selectFromNFTGallery")}
+              iconName={"Ticket"}
+              event="button_clicked"
+              eventProperties={analyticsButtonChooseNFTGalleryEventProps}
+            />
+          ) : null}
           {deviceHasImage ? (
             <Button
               mt={6}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Now the usage of NFT as custom lock screen is controlled by feature flag `llNftSupport`.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18379][LIVE-18826]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18379]: https://ledgerhq.atlassian.net/browse/LIVE-18379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ