### PR TITLE
fix(LIVE-18412): add check for existing provider urls in swap history

### DIFF
--- a/.changeset/fuzzy-plums-care.md
+++ b/.changeset/fuzzy-plums-care.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+add check for existing provider url config to prevent app from crashing on navigation

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/OperationDetails.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/OperationDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import { Icon, Text } from "@ledgerhq/native-ui";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -55,9 +55,8 @@ export function OperationDetails({ route }: OperationDetailsParamList) {
     fromCurrency?.type === "CryptoCurrency" &&
     getTransactionExplorer(getDefaultExplorerView(fromCurrency), operation.hash);
 
-  const openProvider = useCallback(() => {
-    Linking.openURL(urls.swap.providers[provider as keyof typeof urls.swap.providers].main);
-  }, [provider]);
+  const providerUrl =
+    urls.swap.providers[provider as keyof typeof urls.swap.providers]?.main || undefined;
 
   const fromAccountName = useMaybeAccountName(fromAccount);
   const toAccountName = useMaybeAccountName(toAccount);
@@ -106,12 +105,21 @@ export function OperationDetails({ route }: OperationDetailsParamList) {
           <LText style={styles.label} color="grey">
             <Trans i18nKey={"transfer.swap.operationDetails.provider"} />
           </LText>
-          <TouchableOpacity style={styles.providerLinkContainer} onPress={openProvider}>
-            <Text paddingRight={2} color="primary.c100">
+          {providerUrl ? (
+            <TouchableOpacity
+              style={styles.providerLinkContainer}
+              onPress={() => Linking.openURL(providerUrl)}
+            >
+              <Text paddingRight={2} color="primary.c100">
+                {getProviderName(provider)}
+              </Text>
+              <ExternalLink size={11} color={colors.live} />
+            </TouchableOpacity>
+          ) : (
+            <Text marginBottom={8} color="primary.c100">
               {getProviderName(provider)}
             </Text>
-            <ExternalLink size={11} color={colors.live} />
-          </TouchableOpacity>
+          )}
           <LText style={styles.label} color="grey">
             <Trans i18nKey={"transfer.swap.operationDetails.date"} />
           </LText>


### PR DESCRIPTION
add check for existing provider urls in swap history

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** Saves the app from crashing when users click a provider link with no defined url
  - ...

### 📝 Description
On Swap History -> Operation Details screen the app is crashing when we don't have a url for the provider defined.
Changes: Adding a check for provider urls to make sure we have a valid link. If the url is missing we only show the provider name and don't add a link.
Images with Link and without Link

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->
<img src="https://github.com/user-attachments/assets/784a6411-29f8-4744-b2be-759135372fb0" width=350 />
<img src="https://github.com/user-attachments/assets/92093535-1100-4ca3-af6d-7a3bf72d2be7" width=350 />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18412


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
