### PR TITLE
chore: set provider in dmk

### DIFF
--- a/.changeset/great-laws-obey.md
+++ b/.changeset/great-laws-obey.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Implement DMK setProvider

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -57,6 +57,7 @@ import { useAutoDismissPostOnboardingEntryPoint } from "@ledgerhq/live-common/po
 import { setShareAnalytics, setSharePersonalizedRecommendations } from "./actions/settings";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useEnforceSupportedLanguage } from "./hooks/useEnforceSupportedLanguage";
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
 
 const PlatformCatalog = lazy(() => import("~/renderer/screens/platform"));
 const Dashboard = lazy(() => import("~/renderer/screens/dashboard"));
@@ -193,6 +194,9 @@ export default function Default() {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const accounts = useSelector(accountsSelector);
   const analyticsConsoleActive = useEnv("ANALYTICS_CONSOLE");
+  const providerNumber = useEnv("FORCE_PROVIDER");
+  const ldmkFeatureFlag = useFeature("ldmkTransport");
+  const dmk = useDeviceManagementKit();
 
   useAccountsWithFundsListener(accounts, updateIdentify);
   useListenToHidDevices();
@@ -210,6 +214,14 @@ export default function Default() {
   const isLocked = useSelector(isLockedSelector);
   const dispatch = useDispatch();
   const isNftReworkedEnabled = nftReworked?.enabled;
+
+  useEffect(() => {
+    if (providerNumber && ldmkFeatureFlag?.enabled) {
+      dmk?.setProvider(providerNumber);
+    }
+    // setting provider only at initialisation
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ldmkFeatureFlag, dmk]);
 
   useEffect(() => {
     if (

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
@@ -19,32 +19,27 @@ import LottieTester from "./LottieTester";
 import StorylyTester from "./StorylyTester";
 import PostOnboardingHubTester from "./PostOnboardingHubTester";
 import VaultSigner from "./VaultSigner";
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-desktop";
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
 const experimentalTypesMap = {
   toggle: ExperimentalSwitch,
   integer: ExperimentalInteger,
   float: ExperimentalFloat,
 };
-const ExperimentalFeatureRow = ({
+
+const BaseExperimentalFeatureRow = ({
   feature,
-  onDirtyChange,
+  onChange,
 }: {
   feature: Feature;
-  onDirtyChange: () => void;
+  onChange: (name: EnvName, value: unknown) => void;
 }) => {
   const { dirty, ...rest } = feature;
   const Children = experimentalTypesMap[feature.type];
   const envValue = useEnv(feature.name);
   const isDefault = isEnvDefault(feature.name);
-  const onChange = useCallback(
-    (name: EnvName, value: unknown) => {
-      if (dirty) {
-        onDirtyChange();
-      }
-      setEnvOnAllThreads(name, value);
-    },
-    [dirty, onDirtyChange],
-  );
+
   return Children ? (
     <Row title={feature.title} desc={feature.description}>
       <Children
@@ -57,6 +52,55 @@ const ExperimentalFeatureRow = ({
     </Row>
   ) : null;
 };
+
+const ExperimentalFeatureRow = ({
+  feature,
+  onDirtyChange,
+}: {
+  feature: Feature;
+  onDirtyChange: () => void;
+}) => {
+  const { dirty } = feature;
+  const onChange = useCallback(
+    (name: EnvName, value: unknown) => {
+      if (dirty) {
+        onDirtyChange();
+      }
+      setEnvOnAllThreads(name, value);
+    },
+    [dirty, onDirtyChange],
+  );
+
+  return <BaseExperimentalFeatureRow feature={feature} onChange={onChange} />;
+};
+
+const ForceProviderFeatureRow = ({
+  feature,
+  onDirtyChange,
+}: {
+  feature: Feature;
+  onDirtyChange: () => void;
+}) => {
+  const { dirty } = feature;
+  const dmk = useDeviceManagementKit();
+  const ldmkFeatureFlag = useFeature("ldmkTransport");
+
+  const onChange = useCallback(
+    (name: EnvName, value: unknown) => {
+      if (dirty) {
+        onDirtyChange();
+      }
+      if (dmk && ldmkFeatureFlag?.enabled && typeof value === "number") {
+        dmk.setProvider(value);
+      }
+      setEnvOnAllThreads(name, value);
+    },
+    [dirty, onDirtyChange, dmk, ldmkFeatureFlag],
+  );
+
+  return <BaseExperimentalFeatureRow feature={feature} onChange={onChange} />;
+};
+
 const EthereumBridgeRow = () => {
   const dispatch = useDispatch();
   return (
@@ -75,10 +119,33 @@ const EthereumBridgeRow = () => {
     </Row>
   );
 };
+
+const PluckProviderFeatureRow = (feature: Feature, onDirtyChange: () => void) => {
+  switch (feature.name) {
+    case "FORCE_PROVIDER":
+      return (
+        <ForceProviderFeatureRow
+          key={feature.name}
+          feature={feature}
+          onDirtyChange={onDirtyChange}
+        />
+      );
+    default:
+      return (
+        <ExperimentalFeatureRow
+          key={feature.name}
+          feature={feature}
+          onDirtyChange={onDirtyChange}
+        />
+      );
+  }
+};
+
 const SectionExperimental = () => {
   const [needsCleanCache, setNeedsCleanCache] = useState(false);
   const dispatch = useDispatch();
   const onDirtyChange = useCallback(() => setNeedsCleanCache(true), []);
+
   useEffect(() => {
     return () => {
       if (needsCleanCache) {
@@ -86,6 +153,7 @@ const SectionExperimental = () => {
       }
     };
   }, [dispatch, needsCleanCache]);
+
   return (
     <div data-e2e="experimental_section_title">
       <TrackPage category="Settings" name="Experimental" />
@@ -94,13 +162,9 @@ const SectionExperimental = () => {
           <Trans i18nKey="settings.experimental.disclaimer"></Trans>
         </Alert>
         {experimentalFeatures.map(feature =>
-          !feature.shadow || (feature.shadow && !isEnvDefault(feature.name)) ? (
-            <ExperimentalFeatureRow
-              key={feature.name}
-              feature={feature}
-              onDirtyChange={onDirtyChange}
-            />
-          ) : null,
+          !feature.shadow || (feature.shadow && !isEnvDefault(feature.name))
+            ? PluckProviderFeatureRow(feature, onDirtyChange)
+            : null,
         )}
         {process.env.SHOW_ETHEREUM_BRIDGE ? <EthereumBridgeRow /> : null}
         {process.env.DEBUG_LOTTIE ? <LottieTester /> : null}
@@ -112,4 +176,5 @@ const SectionExperimental = () => {
     </div>
   );
 };
+
 export default SectionExperimental;

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -92,6 +92,7 @@ import { exportWalletState, walletStateExportShouldDiffer } from "@ledgerhq/live
 import { registerTransports } from "~/services/registerTransports";
 import { useDeviceManagementKitEnabled } from "@ledgerhq/live-dmk-mobile";
 import { StoragePerformanceOverlay } from "./newArch/storage/screens/PerformanceMonitor";
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-mobile";
 
 if (Config.DISABLE_YELLOW_BOX) {
   LogBox.ignoreAllLogs();
@@ -122,9 +123,19 @@ function App() {
   const accounts = useSelector(accountsSelector);
   const analyticsFF = useFeature("llmAnalyticsOptInPrompt");
   const isLDMKEnabled = useDeviceManagementKitEnabled();
+  const providerNumber = useEnv("FORCE_PROVIDER");
   const hasSeenAnalyticsOptInPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const dmk = useDeviceManagementKit();
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (providerNumber && isLDMKEnabled) {
+      dmk?.setProvider(providerNumber);
+    }
+    // setting provider only at initialisation
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLDMKEnabled, dmk]);
 
   useEffect(() => registerTransports(isLDMKEnabled), [isLDMKEnabled]);
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Experimental/FeatureRow.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { setEnvUnsafe, isEnvDefault, getEnv } from "@ledgerhq/live-env";
-
+import { useDeviceManagementKit } from "@ledgerhq/live-dmk-mobile";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { FeatureId } from "@ledgerhq/types-live";
 import { Feature, isReadOnly } from "../../../experimental";
@@ -32,10 +32,21 @@ const FeatureRowWithFeatureFlag = ({
   return !featureFlag?.enabled ? <FeatureRow feature={feature} /> : null;
 };
 
-const FeatureRow = ({ feature }: Props) => {
+const FeatureRow = ({
+  feature,
+  onChangeOverride,
+}: Props & { onChangeOverride?: (name: string, value: unknown) => void }) => {
   const { type, ...rest } = feature;
   const Children = experimentalTypesMap[type];
   const { t } = useTranslation();
+  const handleChange = (name: string, value: unknown): boolean => {
+    if (onChangeOverride) {
+      onChangeOverride(name, value);
+      return true;
+    }
+    setEnvUnsafe(name, value);
+    return true;
+  };
   // we only display a feature as experimental if it is not enabled already via feature flag
   return (
     <SettingsRow
@@ -46,7 +57,7 @@ const FeatureRow = ({ feature }: Props) => {
       <Children
         checked={!isEnvDefault(feature.name)}
         readOnly={isReadOnly(feature.name)}
-        onChange={setEnvUnsafe}
+        onChange={handleChange}
         isDefault={isEnvDefault(feature.name) || getEnv(feature.name) === undefined}
         {...rest}
         value={getEnv(feature.name) as number}
@@ -55,11 +66,34 @@ const FeatureRow = ({ feature }: Props) => {
   );
 };
 
+const ForceProviderFeatureRow = ({ feature }: Props) => {
+  const dmk = useDeviceManagementKit();
+  const ldmkFeatureFlag = useFeature("ldmkTransport");
+
+  const onChangeOverride = (name: string, value: unknown) => {
+    if (dmk && ldmkFeatureFlag?.enabled && typeof value === "number") {
+      dmk.setProvider(value);
+    }
+    setEnvUnsafe(name, value);
+  };
+
+  return <FeatureRow feature={feature} onChangeOverride={onChangeOverride} />;
+};
+
+const PluckProviderFeatureRow = (feature: Feature) => {
+  switch (feature.name) {
+    case "FORCE_PROVIDER":
+      return <ForceProviderFeatureRow key={feature.name} feature={feature} />;
+    default:
+      return <FeatureRow key={feature.name} feature={feature} />;
+  }
+};
+
 const FeatureRowCommon = ({ feature }: Props) =>
   feature.rolloutFeatureFlag ? (
     <FeatureRowWithFeatureFlag feature={feature} featureFlagId={feature.rolloutFeatureFlag} />
   ) : (
-    <FeatureRow feature={feature} />
+    PluckProviderFeatureRow(feature)
   );
 
 export default FeatureRowCommon;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR introduces the new `setProvider` feature from the Device Management Kit and integrates it into both LLM and LLD. 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: 
- [DSDK-712](https://ledgerhq.atlassian.net/browse/DSDK-712)
- [DSDK-719](https://ledgerhq.atlassian.net/browse/DSDK-719)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[DSDK-712]: https://ledgerhq.atlassian.net/browse/DSDK-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSDK-719]: https://ledgerhq.atlassian.net/browse/DSDK-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ