### PR TITLE
fix: show ton tokens in swap history

### DIFF
--- a/.changeset/plenty-files-talk.md
+++ b/.changeset/plenty-files-talk.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-ton": minor
+---
+
+feat: show ton tokens in swap history

--- a/.changeset/shiny-swans-roll.md
+++ b/.changeset/shiny-swans-roll.md
@@ -1,5 +1,6 @@
 ---
 "@ledgerhq/coin-ton": minor
+"@ledgerhq/live-common": minor
 ---
 
 feat: show ton tokens in swap history

--- a/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/api.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/api.ts
@@ -137,3 +137,11 @@ export async function estimateFee(
 export async function broadcastTx(bocBase64: string): Promise<string> {
   return (await send<TonResponseMessage>("/message", { boc: bocBase64 })).message_hash;
 }
+
+export async function fetchAdjacentTransactions(
+  txHash: string,
+  dir: "in" | "out" = "in",
+): Promise<TonTransactionsList> {
+  const url = `/adjacentTransactions?hash=${encodeURIComponent(txHash)}&direction=${dir}`;
+  return await fetch<TonTransactionsList>(url);
+}

--- a/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
@@ -169,7 +169,7 @@ export function mapTxToOps(
     if (isSending) {
       ops.push({
         id: encodeOperationId(accountId, hash, "OUT"),
-        hash,
+        hash: tx.out_msgs[0].hash,
         type: "OUT",
         value: BigNumber(tx.out_msgs[0].value ?? 0),
         fee: BigNumber(tx.total_fees),
@@ -202,6 +202,7 @@ export function mapJettonTxToOps(
   accountId: string,
   addr: string,
   addressBook: TonAddressBook,
+  jettonTxMessageHashesMap?: Map<string, string>,
 ): (tx: TonJettonTransfer) => TonOperation[] {
   return (tx: TonJettonTransfer): TonOperation[] => {
     const accountAddr = Address.parse(addr).toString({ urlSafe: true, bounceable: false });
@@ -258,8 +259,12 @@ export function mapJettonTxToOps(
     }
 
     if (isSending) {
+      const hash_message = jettonTxMessageHashesMap
+        ? jettonTxMessageHashesMap.get(hash) ?? hash
+        : hash;
+
       ops.push({
-        id: encodeOperationId(tokenAccountId, hash, "OUT"),
+        id: encodeOperationId(tokenAccountId, hash_message, "OUT"),
         hash,
         type: "OUT",
         value: BigNumber(tx.amount),

--- a/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
@@ -169,7 +169,7 @@ export function mapTxToOps(
     if (isSending) {
       ops.push({
         id: encodeOperationId(accountId, hash, "OUT"),
-        hash: tx.out_msgs[0].hash, // this hash matches with in_msg.hash of IN transaction
+        hash,
         type: "OUT",
         value: BigNumber(tx.out_msgs[0].value ?? 0),
         fee: BigNumber(tx.total_fees),
@@ -258,6 +258,8 @@ export function mapJettonTxToOps(
     }
 
     if (isSending) {
+      console.log("token sending tx.transaction_hash");
+      console.log(tx.transaction_hash);
       ops.push({
         id: encodeOperationId(tokenAccountId, hash, "OUT"),
         hash,

--- a/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
@@ -258,8 +258,6 @@ export function mapJettonTxToOps(
     }
 
     if (isSending) {
-      console.log("token sending tx.transaction_hash");
-      console.log(tx.transaction_hash);
       ops.push({
         id: encodeOperationId(tokenAccountId, hash, "OUT"),
         hash,

--- a/libs/coin-modules/coin-ton/src/synchronisation.ts
+++ b/libs/coin-modules/coin-ton/src/synchronisation.ts
@@ -144,7 +144,7 @@ const getSubAccountShape = async (
     pendingOperations: maybeExistingSubAccount ? maybeExistingSubAccount.pendingOperations : [],
     creationDate: operations.length > 0 ? operations[operations.length - 1].date : new Date(),
     balanceHistoryCache: emptyHistoryCache, // calculated in the jsHelpers
-    swapHistory: [],
+    swapHistory: maybeExistingSubAccount ? maybeExistingSubAccount.swapHistory : [],
     jettonWallet, // Address of the jetton wallet contract that holds the token balance and handles transfers
   };
 };

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
@@ -17,7 +17,9 @@ const getSwapOperationMap =
       tokenId,
     } = swapOperation;
     // Find operation by matching its hash which is embedded in the operationId
-    const operation = account.operations.find(o => operationId.includes(o.hash));
+    const operation = account.operations.find(
+      o => operationId.includes(o.hash) || o.id === operationId,
+    );
     const optimisticOperation = !operation
       ? account.pendingOperations.find(o => o.id === operationId)
       : null;

--- a/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getCompleteSwapHistory.ts
@@ -21,7 +21,7 @@ const getSwapOperationMap =
       o => operationId.includes(o.hash) || o.id === operationId,
     );
     const optimisticOperation = !operation
-      ? account.pendingOperations.find(o => o.id === operationId)
+      ? account.pendingOperations.find(o => operationId.includes(o.hash) || o.id === operationId)
       : null;
     const op = operation || optimisticOperation;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We want to be able to show users TON and Token swaps in the history.
For the others chains, it all good.

What is the problem ?
Actually, int the swap logic, to retrieve the operation behind a swap, they compare ids. 
So the Swap Operation Id (operationId) need to match with the hash of the operation.
But in the context of TON, it is not the case.

What is the Solution ?
Put as hash the same as the one used when crafting a SwapOperation.

##### SWAP TON TOKEN (USDT) —>  TON COIN

https://github.com/user-attachments/assets/9e3509f0-6a83-402f-83de-ed1cd0687b2b


##### SWAP TON COIN —> TON TOKEN (USDT) 

https://github.com/user-attachments/assets/1e7eeb87-7ba3-46d5-ba84-bb08cb8879e1


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-18917


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
