### PR TITLE
chore: update default legacyOCMSMaxVersion

### DIFF
--- a/.changeset/lazy-chairs-film.md
+++ b/.changeset/lazy-chairs-film.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+chore: update default legacyOCMSMaxVersion

--- a/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/__tests__/unit/hw-signMessage.unit.test.ts
@@ -6,7 +6,7 @@ import coinConfig from "../../config";
 import bs58 from "bs58";
 
 coinConfig.setCoinConfig(() => ({
-  legacyOCMSMaxVersion: "1.8.2",
+  legacyOCMSMaxVersion: "1.8.0",
   queuedInterval: 1,
   token2022Enabled: false,
   status: { type: "active" },

--- a/libs/ledger-live-common/src/families/solana/config.ts
+++ b/libs/ledger-live-common/src/families/solana/config.ts
@@ -10,7 +10,7 @@ export const solanaConfig: CurrencyLiveConfigDefinition = {
       },
       token2022Enabled: false,
       queuedInterval: 100,
-      legacyOCMSMaxVersion: "1.8.2",
+      legacyOCMSMaxVersion: "1.8.0",
     } satisfies SolanaCoinConfig,
   },
 };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Sign Message Solana default config

### 📝 Description

Updates the default config version to toggle between legacy OCMS header or newer one now that we know the expected prod version of 1.8.0

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
