### PR TITLE
fix(BACK-8848): [coin-modules][stellar] push down filtering predicate

### DIFF
--- a/.changeset/tidy-cheetahs-exercise.md
+++ b/.changeset/tidy-cheetahs-exercise.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-stellar": minor
+---
+
+fix(BACK-8848): [coin-modules][stellar] push down filtering predicate
+
+* `listOperations` uses N+1 RPC requests instead of just 1, because it fetches block metadata for each transaction
+* `minHeight` is only applied after doing all this, so when requesting operations on an up to date address we do the
+  N+1 requests for the whole first page (200 txs), then throw out everything
+* => push down predicate to the inner level so that we do only 1 RPC request

--- a/libs/coin-modules/coin-stellar/src/api/index.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.test.ts
@@ -79,16 +79,6 @@ describe("operations", () => {
     expect(mockGetOperations).toHaveBeenCalledTimes(1);
   });
 
-  it("should return 0 operations if start is greater than the last operation", async () => {
-    mockGetOperations.mockResolvedValue([[mockOperation], ""]);
-
-    // When
-    const operations = await api.listOperations("addr", { minHeight: 100 });
-
-    // Then
-    expect(operations).toEqual([[], ""]);
-  });
-
   it("should call multiple times listOperations", async () => {
     mockGetOperations
       .mockResolvedValueOnce([[mockOperation], "10"])

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -109,17 +109,15 @@ async function operationsFromHeight(
   // so the only strategy to get ALL operations is to iterate over all of them in descending order
   // until we reach the desired minHeight
   while (state.continueIterations) {
-    const options: ListOperationsOptions = { limit: state.pageSize, order: "desc" };
+    const options: ListOperationsOptions = { limit: state.pageSize, order: "desc", minHeight };
     if (state.apiNextCursor) {
       options.cursor = state.apiNextCursor;
     }
     try {
       const [operations, nextCursor] = await listOperations(address, options);
-      const filteredOperations = operations.filter(op => op.tx.block.height >= state.heightLimit);
-      state.accumulator.push(...filteredOperations);
+      state.accumulator.push(...operations);
       state.apiNextCursor = nextCursor;
-      state.continueIterations =
-        operations.length === filteredOperations.length && nextCursor !== "";
+      state.continueIterations = nextCursor !== "";
     } catch (e: unknown) {
       if (e instanceof LedgerAPI4xx && (e as unknown as { status: number }).status === 429) {
         log("coin:stellar", "(api/operations): TooManyRequests, retrying in 4s");

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.ts
@@ -7,17 +7,19 @@ export type ListOperationsOptions = {
   limit?: number;
   cursor?: string;
   order: "asc" | "desc";
+  minHeight: number;
 };
 
 export async function listOperations(
   address: string,
-  { limit, cursor, order }: ListOperationsOptions,
+  { limit, cursor, order, minHeight }: ListOperationsOptions,
 ): Promise<[Operation<StellarAsset>[], string]> {
   // Fake accountId
   const accountId = "";
   const [operations, nextCursor] = await fetchOperations({
     accountId,
     addr: address,
+    minHeight,
     order: order,
     limit,
     cursor: cursor,

--- a/libs/coin-modules/coin-stellar/src/logic/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-stellar/src/logic/listOperations.unit.test.ts
@@ -8,6 +8,7 @@ describe("listOperations", () => {
     status: { type: "active" },
     explorer: { url: "https://stellar.coin.ledger.com" },
   }));
+
   it("lists operations associated with an address", async () => {
     jest.spyOn(OperationCallBuilder.prototype, "call").mockResolvedValue({
       records: [
@@ -74,7 +75,7 @@ describe("listOperations", () => {
       ],
     } as any);
 
-    expect(await listOperations("address", { order: "asc" })).toEqual([
+    expect(await listOperations("address", { order: "asc", minHeight: 0 })).toEqual([
       [
         {
           id: "transaction_hash1-operation_id1",
@@ -120,6 +121,107 @@ describe("listOperations", () => {
         },
       ],
       "token3",
+    ]);
+  });
+
+  it("stops at minHeight", async () => {
+    jest.spyOn(OperationCallBuilder.prototype, "call").mockResolvedValue({
+      records: [
+        {
+          id: "operation_id1",
+          transaction_hash: "transaction_hash1",
+          paging_token: "token1",
+          source_account: "address",
+          from: "address",
+          to: "receiver1",
+          amount: "46.0600000",
+          type: HorizonApi.OperationResponseType.payment,
+          transaction_successful: true,
+          created_at: "2025-01-01",
+          transaction: () => ({
+            fee_charged: "111900",
+            ledger_attr: 42,
+            ledger: () => ({
+              hash: "block_hash1",
+              closed_at: "2025-01-01",
+            }),
+          }),
+        },
+        {
+          id: "operation_id2",
+          transaction_hash: "transaction_hash1",
+          paging_token: "token2",
+          source_account: "address",
+          from: "address",
+          to: "receiver2",
+          amount: "666.0000000",
+          type: HorizonApi.OperationResponseType.payment,
+          transaction_successful: false,
+          created_at: "2025-01-01",
+          transaction: () => ({
+            fee_charged: "11100",
+            ledger_attr: 41,
+            ledger: () => ({
+              hash: "block_hash1",
+              closed_at: "2025-01-01",
+            }),
+          }),
+        },
+        {
+          id: "operation_id3",
+          transaction_hash: "transaction_hash2",
+          paging_token: "token3",
+          source_account: "sender",
+          from: "sender",
+          to: "address",
+          amount: "50.5000000",
+          type: HorizonApi.OperationResponseType.payment,
+          transaction_successful: true,
+          created_at: "2025-01-01",
+          transaction: () => ({
+            fee_charged: "111",
+            ledger_attr: 40,
+            ledger: () => ({
+              hash: "block_hash1",
+              closed_at: "2025-01-01",
+            }),
+          }),
+        },
+      ],
+    } as any);
+
+    expect(await listOperations("address", { order: "asc", minHeight: 41 })).toEqual([
+      [
+        {
+          id: "transaction_hash1-operation_id1",
+          asset: { type: "native" },
+          senders: ["address"],
+          recipients: ["receiver1"],
+          tx: {
+            block: { hash: "block_hash1", height: 42, time: new Date("2025-01-01") },
+            date: new Date("2025-01-01"),
+            fees: 111900n,
+            hash: "transaction_hash1",
+          },
+          type: "OUT",
+          value: 460600000n,
+        },
+        {
+          id: "transaction_hash1-operation_id2",
+          asset: { type: "native" },
+          senders: ["address"],
+          recipients: ["receiver2"],
+          tx: {
+            block: { hash: "block_hash1", height: 41, time: new Date("2025-01-01") },
+            date: new Date("2025-01-01"),
+            fees: 11100n,
+            hash: "transaction_hash1",
+          },
+          type: "OUT",
+          value: 11100n,
+        },
+      ],
+      "",
     ]);
   });
 });

--- a/libs/coin-modules/coin-stellar/src/network/serialization.ts
+++ b/libs/coin-modules/coin-stellar/src/network/serialization.ts
@@ -43,10 +43,11 @@ export function getReservedBalance(account: Horizon.ServerApi.AccountRecord): Bi
     .plus(amountInOffers);
 }
 
-export function rawOperationsToOperations(
+export async function rawOperationsToOperations(
   operations: RawOperation[],
   addr: string,
   accountId: string,
+  minHeight: number,
 ): Promise<StellarOperation[]> {
   const supportedOperationTypes = [
     "create_account",
@@ -56,7 +57,7 @@ export function rawOperationsToOperations(
     "change_trust",
   ];
 
-  return Promise.all(
+  const ops = await Promise.all(
     operations
       .filter(operation => {
         return (
@@ -69,16 +70,22 @@ export function rawOperationsToOperations(
         );
       })
       .filter(operation => supportedOperationTypes.includes(operation.type))
-      .map(operation => formatOperation(operation, accountId, addr)),
+      .map(operation => formatOperation(operation, accountId, addr, minHeight)),
   );
+
+  return ops.filter(op => op !== undefined) as StellarOperation[];
 }
 
 async function formatOperation(
   rawOperation: RawOperation,
   accountId: string,
   addr: string,
-): Promise<StellarOperation> {
+  minHeight: number,
+): Promise<StellarOperation | undefined> {
   const transaction = await rawOperation.transaction();
+
+  if (transaction.ledger_attr < minHeight) return undefined;
+
   const { hash: blockHash, closed_at: blockTime } = await transaction.ledger();
   const type = getOperationType(rawOperation, addr);
   const value = getValue(rawOperation, transaction, type);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

* `listOperations` uses N+1 RPC requests instead of just 1, because it fetches block metadata for each transaction
* `minHeight` is only applied after doing all this, so when requesting operations on an up to date address we do the N+1 requests for the whole first page (200 txs), then throw out everything
* => push down predicate to the inner level so that we do only 1 RPC request

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-8848

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
