### PR TITLE
LIVE-17878: track of Manage/Earn more position before opening link

### DIFF
--- a/.changeset/slow-bottles-think.md
+++ b/.changeset/slow-bottles-think.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix tracking of Manage/Earn more on LLM

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -40,10 +40,10 @@ export function EarnMenuDrawer() {
             link ? (
               <OptionButton
                 key={label}
-                onPress={() => {
-                  Linking.openURL(link);
-                  track(button, tracked);
+                onPress={async () => {
+                  await track(button, tracked);
                   closeDrawer();
+                  await Linking.openURL(link);
                 }}
               >
                 {label}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - fix tracking on MenuDrawr

### 📝 Description

Fix the tracking of Manage/Earn more position before opening links to the different dapps.

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-17878](https://ledgerhq.atlassian.net/browse/LIVE-17878)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17878]: https://ledgerhq.atlassian.net/browse/LIVE-17878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ