### PR TITLE
chore/LIVE-19248 App crash when opening account in E2E tests

### DIFF
--- a/.changeset/gentle-geckos-melt.md
+++ b/.changeset/gentle-geckos-melt.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix E2E tests, remove test code

--- a/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ListHeaderComponent.tsx
@@ -37,7 +37,6 @@ import ErrorWarning from "./ErrorWarning";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 import { isNFTCollectionsDisplayable } from "./nftHelper";
 import NftEntryPoint from "LLM/features/NftEntryPoint";
-import { log } from "console";
 
 type Props = {
   account?: AccountLike;
@@ -146,7 +145,6 @@ export function useListHeaderComponents({
     "disableDelegation" in currencyConfig &&
     currencyConfig.disableDelegation === true;
 
-  log("disableDelegation:", disableDelegation);
   return {
     listHeaderComponents: [
       <Box mt={6} onLayout={onAccountCardLayout} key="AccountGraphCard">
@@ -191,7 +189,6 @@ export function useListHeaderComponents({
       (AccountHeaderRendered || AccountBalanceSummaryFooterRendered || secondaryActions.length > 0)
         ? [
             <SectionContainer key="AccountHeader">
-              <p>{disableDelegation}</p>
               <SectionTitle title={t("account.earn")} containerProps={{ mx: 6, mb: 6 }} />
               <Box>
                 {AccountHeaderRendered && (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impacts

### 📝 Description

App crash when opening account in E2E tests
Remove test code

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19248](https://ledgerhq.atlassian.net/browse/LIVE-19248?atlOrigin=eyJpIjoiZTgwMzViOTUwNjRkNGU1MzgxYTQwOWZmOWQyMWJiYjIiLCJwIjoiaiJ9) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19248]: https://ledgerhq.atlassian.net/browse/LIVE-19248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ