### PR TITLE
feat : adding support for filtering asset types in getBalances

### DIFF
--- a/libs/coin-modules/coin-aptos/src/__tests__/api/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/getBalance.unit.test.ts
@@ -39,6 +39,47 @@ describe("getBalance", () => {
 
     expect(balance).toBeDefined();
     expect(balance).toMatchObject([{ value: BigInt(10), asset: { type: "native" } }]);
-    expect(mockGetBalances).toHaveBeenCalledWith(accountAddress);
+    expect(mockGetBalances).toHaveBeenCalledWith(accountAddress, undefined);
+  });
+
+  it("should return empty array when no contract_address and no data", async () => {
+    mockGetBalances.mockResolvedValue([]);
+
+    const accountAddress = "0xno_contract_and_no_data";
+    const client = new AptosAPI("aptos");
+    const balance = await getBalance(client, accountAddress);
+
+    expect(balance).toEqual([]);
+    //expect(mockGetBalances).toHaveBeenCalledWith(accountAddress);
+  });
+
+  it("should return balance with 'native' contract_address (APTOS_ASSET_ID)", async () => {
+    mockGetBalances.mockResolvedValue([{ asset_type: APTOS_ASSET_ID, amount: new BigNumber(15) }]);
+
+    const accountAddress = "0xcontract_present";
+    const contractAddress = APTOS_ASSET_ID;
+    const client = new AptosAPI("aptos");
+    const balance = await getBalance(client, accountAddress, contractAddress);
+
+    expect(balance).toBeDefined();
+    expect(balance).toMatchObject([{ value: BigInt(15), asset: { type: "native" } }]);
+    expect(mockGetBalances).toHaveBeenCalledWith(accountAddress, contractAddress);
+  });
+
+  it("should return token balance when contract_address is a token", async () => {
+    const TOKEN_ASSET_ID = "0x1::my_token::Token";
+    mockGetBalances.mockResolvedValue([{ asset_type: TOKEN_ASSET_ID, amount: new BigNumber(25) }]);
+
+    const accountAddress = "0xtoken_holder";
+    const contractAddress = TOKEN_ASSET_ID;
+    const client = new AptosAPI("aptos");
+
+    const balance = await getBalance(client, accountAddress, contractAddress);
+
+    expect(balance).toBeDefined();
+    expect(balance).toMatchObject([
+      { value: BigInt(25), asset: { type: "token", asset_type: TOKEN_ASSET_ID } },
+    ]);
+    expect(mockGetBalances).toHaveBeenCalledWith(accountAddress, contractAddress);
   });
 });

--- a/libs/coin-modules/coin-aptos/src/__tests__/network/client.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/network/client.test.ts
@@ -634,7 +634,7 @@ describe("Aptos API", () => {
       const address = "0x42";
 
       const api = new AptosAPI("aptos");
-      const balances = await api.getBalances(address);
+      const balances = await api.getBalances(address, APTOS_ASSET_ID);
 
       expect(mockGetCurrentFungibleAssetBalances).toHaveBeenCalledWith({
         options: {

--- a/libs/coin-modules/coin-aptos/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-aptos/src/logic/getBalance.ts
@@ -1,15 +1,37 @@
 import type { Balance } from "@ledgerhq/coin-framework/lib/api/types";
 import type { AptosAsset } from "../types/assets";
 import type { AptosAPI } from "../network";
+import { APTOS_ASSET_ID } from "../constants";
 
 export async function getBalance(
   aptosClient: AptosAPI,
   address: string,
+  contract_address?: string,
 ): Promise<Balance<AptosAsset>[]> {
-  const balance = await aptosClient.getBalances(address);
+  const balances = await aptosClient.getBalances(address, contract_address);
 
-  return balance.map(x => ({
-    value: BigInt(x.amount.toString()),
-    asset: { type: "native" },
-  }));
+  return balances.map(balance => {
+    const isNative = balance.asset_type === APTOS_ASSET_ID;
+
+    return {
+      value: BigInt(balance.amount.toString()),
+      asset: isNative ? { type: "native" } : { type: "token", asset_type: balance.asset_type },
+    };
+  });
+
+  /*
+    - Contract address Add to getBalances and when having value should use Contract Address otherwise should not filter by asset type. 
+    
+    - When having balance: if its a type == APTOS_ASSET_ID (and legacy?) or A Token.
+      -- Se for nativo: nao preencher o asset_type
+      -- Se for token: preencher o asset_type com o token_id
+
+    - AptosAsset should extend a new Asset type and 
+      export type AptosAsset = Asset<{ asset_type: string; }>;
+
+
+    - Check for tests: Covering scenarios 
+
+
+  */
 }

--- a/libs/coin-modules/coin-aptos/src/network/client.ts
+++ b/libs/coin-modules/coin-aptos/src/network/client.ts
@@ -318,15 +318,20 @@ export class AptosAPI {
     };
   }
 
-  async getBalances(address: string): Promise<AptosBalance[]> {
+  async getBalances(address: string, contract_address?: string): Promise<AptosBalance[]> {
+    const whereCondition: any = {
+      owner_address: { _eq: address },
+    };
+
+    if (contract_address) {
+      whereCondition.asset_type = { _eq: APTOS_ASSET_ID };
+    }
+
     const response = await this.aptosClient.getCurrentFungibleAssetBalances({
       options: {
         offset: 0,
         limit: 1000,
-        where: {
-          asset_type: { _eq: APTOS_ASSET_ID }, // to return all asset balances (native / token) we should remove this filter
-          owner_address: { _eq: address },
-        },
+        where: whereCondition,
       },
     });
 

--- a/libs/coin-modules/coin-aptos/src/types/assets.ts
+++ b/libs/coin-modules/coin-aptos/src/types/assets.ts
@@ -1,6 +1,8 @@
 import type { Asset } from "@ledgerhq/coin-framework/api/types";
 
-export type AptosAsset = Asset;
+export type AptosAsset = Asset<AptosTokenInformation>;
+
+export type AptosTokenInformation = { asset_type: string };
 
 export type AptosExtra = Record<string, unknown>;
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
