### PR TITLE
fix(live-19133): handle offline state in swap webview

### DIFF
--- a/.changeset/hip-apples-report.md
+++ b/.changeset/hip-apples-report.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix(swap): handle offline state in swap webview and error cases

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -491,13 +491,16 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
     [isOffline],
   );
 
-  const manifestUrl = useMemo(() => `${manifest.url}#${hashString}`, [manifest.url, hashString]);
+  const manifestWithHash = useMemo(
+    () => ({ ...manifest, url: `${manifest.url}#${hashString}` }),
+    [manifest, hashString],
+  );
 
   return (
     <>
       {enablePlatformDevTools && (
         <TopBar
-          manifest={{ ...manifest, url: manifestUrl }}
+          manifest={manifestWithHash}
           webviewAPIRef={webviewAPIRef}
           webviewState={webviewState}
         />
@@ -505,7 +508,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
 
       <SwapWebAppWrapper>
         <Web3AppWebview
-          manifest={{ ...manifest, url: `${manifest.url}#${hashString}` }}
+          manifest={manifestWithHash}
           inputs={{
             theme: themeType,
             lang: locale,

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -468,7 +468,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
   const onStateChange: WebviewProps["onStateChange"] = state => {
     setWebviewState(state);
 
-    if (!state?.loading && state?.isAppUnavailable) {
+    if (!state?.loading && state?.isAppUnavailable && !isOffline) {
       liveAppUnavailable();
       captureException(
         new UnableToLoadSwapLiveError(
@@ -486,11 +486,18 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [webviewState?.url]);
 
+  const customWebviewStyle = useMemo(
+    () => (isOffline ? { display: "none" } : undefined),
+    [isOffline],
+  );
+
+  const manifestUrl = useMemo(() => `${manifest.url}#${hashString}`, [manifest.url, hashString]);
+
   return (
     <>
       {enablePlatformDevTools && (
         <TopBar
-          manifest={{ ...manifest, url: `${manifest.url}#${hashString}` }}
+          manifest={{ ...manifest, url: manifestUrl }}
           webviewAPIRef={webviewAPIRef}
           webviewState={webviewState}
         />
@@ -513,6 +520,7 @@ const SwapWebView = ({ manifest, liveAppUnavailable }: SwapWebProps) => {
           onStateChange={onStateChange}
           ref={webviewAPIRef}
           customHandlers={customHandlers as never}
+          webviewStyle={customWebviewStyle}
         />
       </SwapWebAppWrapper>
     </>

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import { DEFAULT_FEATURES } from "@ledgerhq/live-common/featureFlags/defaultFeatures";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
@@ -18,6 +18,7 @@ import { DefaultAccountSwapParamList, DetailsSwapParamList } from "../types";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { SwapNavigatorParamList } from "~/components/RootNavigator/types/SwapNavigator";
 import { ScreenName } from "~/const";
+import { useNetInfo } from "@react-native-community/netinfo";
 
 // set the default manifest ID for the production swap live app
 // in case the FF is failing to load the manifest ID
@@ -39,8 +40,8 @@ export function SwapLiveApp({
   const { t } = useTranslation();
   const ptxSwapLiveAppMobile = useFeature("ptxSwapLiveAppMobile");
 
-  const APP_MANIFEST_NOT_FOUND_ERROR = new Error(t("errors.AppManifestNotFoundError.title"));
-  const APP_MANIFEST_UNKNOWN_ERROR = new Error(t("errors.AppManifestUnknownError.title"));
+  const APP_FAILED_TO_LOAD = new Error(t("errors.AppManifestNotFoundError.title"));
+  const APP_MANIFEST_NOT_FOUND_ERROR = new Error(t("errors.AppManifestUnknownError.title"));
 
   const swapLiveAppManifestID =
     (ptxSwapLiveAppMobile?.params?.manifest_id as string) || DEFAULT_MANIFEST_ID;
@@ -55,19 +56,24 @@ export function SwapLiveApp({
 
   const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
   const isWebviewError = webviewState?.url.includes("/unknown-error");
+  const { isConnected } = useNetInfo();
 
-  const manifest: LiveAppManifest | undefined = !localManifest ? remoteManifest : localManifest;
-  const defaultParams = isDefaultAccountSwapParamsList(params) ? params : null;
+  const manifest = useMemo<LiveAppManifest | undefined>(
+    () => (!localManifest ? remoteManifest : localManifest),
+    [localManifest, remoteManifest],
+  );
+  const defaultParams = useMemo(
+    () => (isDefaultAccountSwapParamsList(params) ? params : null),
+    [params],
+  );
 
-  if (!manifest || isWebviewError) {
+  if (!manifest || isWebviewError || !isConnected) {
     return (
       <Flex flex={1} justifyContent="center" alignItems="center">
         {remoteLiveAppState.isLoading ? (
           <InfiniteLoader />
         ) : (
-          <GenericErrorView
-            error={isWebviewError ? APP_MANIFEST_UNKNOWN_ERROR : APP_MANIFEST_NOT_FOUND_ERROR}
-          />
+          <GenericErrorView error={!manifest ? APP_MANIFEST_NOT_FOUND_ERROR : APP_FAILED_TO_LOAD} />
         )}
       </Flex>
     );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


fix(swap): handle offline state in swap webview and error cases

- Add offline state check before showing unavailable app error
- Hide webview when offline to prevent blank screen
- Simplify error handling logic in mobile swap screen
- Memoize manifest URL and params for better performance

https://github.com/user-attachments/assets/3bfc1890-2798-4413-b843-5c2c68c31890



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->
https://ledgerhq.atlassian.net/browse/LIVE-18314 
https://ledgerhq.atlassian.net/browse/LIVE-19133 
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
