### PR TITLE
Disable aptos token integration test

### DIFF
--- a/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
@@ -142,7 +142,8 @@ describe("createApi", () => {
     });
   });
 
-  describe("listOperationsTokens", () => {
+  // TODO: enable when aptos token will be enabled
+  describe.skip("listOperationsTokens", () => {
     it("returns operations from account", async () => {
       const block = await api.lastBlock();
 
@@ -207,8 +208,8 @@ describe("createApi", () => {
         senders: ["0x24dbf71ba20209753035505c51d4607ed67aa0c81b930d9ef4483ec84b349fcb"],
         asset: {
           type: "token",
-          asset_type: "coin",
-          address:
+          standard: "coin",
+          contractAddress:
             "0xd11107bdf0d6d7040c6c0bfbdecb6545191fdf13e8d8d259952f53e1713f61b5::staked_coin::StakedAptos",
         },
         tx: {
@@ -226,8 +227,8 @@ describe("createApi", () => {
         senders: [tokenAccount.freshAddress],
         asset: {
           type: "token",
-          asset_type: "coin",
-          address:
+          standard: "coin",
+          contractAddress:
             "0xd11107bdf0d6d7040c6c0bfbdecb6545191fdf13e8d8d259952f53e1713f61b5::staked_coin::StakedAptos",
         },
         tx: {
@@ -250,8 +251,8 @@ describe("createApi", () => {
         senders: ["0x24dbf71ba20209753035505c51d4607ed67aa0c81b930d9ef4483ec84b349fcb"],
         asset: {
           type: "token",
-          asset_type: "fungible_asset",
-          address: "0x2ebb2ccac5e027a87fa0e2e5f656a3a4238d6a48d93ec9b610d570fc0aa0df12",
+          standard: "fungible_asset",
+          contractAddress: "0x2ebb2ccac5e027a87fa0e2e5f656a3a4238d6a48d93ec9b610d570fc0aa0df12",
         },
         tx: {
           hash: "0x88856968603dee4f08579036bc30322b9a5f329561656888e3467ce27cc11ea7",
@@ -268,8 +269,8 @@ describe("createApi", () => {
         senders: [tokenAccount.freshAddress],
         asset: {
           type: "token",
-          asset_type: "fungible_asset",
-          address: "0x2ebb2ccac5e027a87fa0e2e5f656a3a4238d6a48d93ec9b610d570fc0aa0df12",
+          standard: "fungible_asset",
+          contractAddress: "0x2ebb2ccac5e027a87fa0e2e5f656a3a4238d6a48d93ec9b610d570fc0aa0df12",
         },
         tx: {
           hash: "0x8aa9e980760fe8aeb6804f387350b3019a2471aa61a5506a260c32cd5d6db32c",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** disable tests that is dependent on the env variable
  - ...

### 📝 Description

The integration test for list aptos tokens operations fails because of tokens are disabled in develop. We need to disable this test until aptos tokens will be available.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19040](https://ledgerhq.atlassian.net/browse/LIVE-19040)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
