### PR TITLE
🐛  Fix LLD Rename Account

### DIFF
--- a/.changeset/friendly-books-sing.md
+++ b/.changeset/friendly-books-sing.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-wallet": patch
+"ledger-live-desktop-e2e-tests": patch
+---
+
+LLD - Fix rename account

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -112,6 +112,9 @@ async function init() {
   const store = createStore({
     dbMiddleware,
   });
+  if (getEnv("PLAYWRIGHT_RUN")) {
+    (window as Window & { __STORE__?: ReturnType<typeof createStore> }).__STORE__ = store;
+  }
   sentry(() => sentryLogsSelector(store.getState()));
   let notifiedSentryLogs = false;
   store.subscribe(() => {

--- a/apps/ledger-live-desktop/src/renderer/reducers/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/index.ts
@@ -15,6 +15,7 @@ import { WalletState } from "@ledgerhq/live-wallet/store";
 import walletSync, { WalletSyncState } from "./walletSync";
 import trustchain from "./trustchain";
 import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
+import { getEnv } from "@ledgerhq/live-env";
 
 export type State = {
   accounts: AccountsState;
@@ -46,4 +47,5 @@ export default combineReducers({
   wallet,
   walletSync,
   trustchain,
+  ...(getEnv("PLAYWRIGHT_RUN") && { lastAction: (_, action) => action }),
 });

--- a/e2e/desktop/tests/page/index.ts
+++ b/e2e/desktop/tests/page/index.ts
@@ -28,6 +28,7 @@ import { OperationDrawer } from "./drawer/operation.drawer";
 import { LiveApp } from "./liveApp.page";
 import { OnboardingPage } from "./onboarding.page";
 import { BuyAndSellPage } from "./buyAndSell.page";
+import { Redux } from "tests/utils/redux";
 
 export class Application extends PageHolder {
   public account = new AccountPage(this.page);
@@ -59,4 +60,5 @@ export class Application extends PageHolder {
   public operationDrawer = new OperationDrawer(this.page);
   public liveApp = new LiveApp(this.page);
   public buyAndSell = new BuyAndSellPage(this.page, this.electronApp);
+  public redux = new Redux(this.page);
 }

--- a/e2e/desktop/tests/specs/rename.account.spec.ts
+++ b/e2e/desktop/tests/specs/rename.account.spec.ts
@@ -1,0 +1,54 @@
+import { test } from "../fixtures/common";
+import { expect } from "@playwright/test";
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { addTmsLink } from "../utils/allureUtils";
+import { getDescription } from "../utils/customJsonReporter";
+import { CLI } from "../utils/cliUtils";
+import { getUserdata } from "../utils/userdata";
+
+const accounts = [{ account: Account.ATOM_1, xrayTicket: "B2CQA-2996" }];
+
+for (const account of accounts) {
+  test.describe("Rename Account", () => {
+    test.use({
+      userdata: "skip-onboarding",
+      cliCommands: [
+        (appjsonPath: string) => {
+          return CLI.liveData({
+            currency: account.account.currency.id,
+            index: account.account.index,
+            add: true,
+            appjson: appjsonPath,
+          });
+        },
+      ],
+      speculosApp: account.account.currency.speculosApp,
+    });
+
+    test(
+      `[${account.account.currency.name}] Rename Account`,
+      {
+        annotation: {
+          type: "TMS",
+          description: account.xrayTicket,
+        },
+      },
+      async ({ app, userdataFile, electronApp }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+        await app.redux.listenToReduxActions();
+
+        await app.layout.goToAccounts();
+        await app.accounts.navigateToAccountByName(account.account.accountName);
+        await app.account.expectAccountVisibility(account.account.accountName);
+
+        const newName = "New account name";
+        await app.account.renameAccount(newName);
+        await app.account.expectAccountVisibility(newName);
+        await app.redux.waitForReduxAction("UPDATE_ACCOUNT");
+        await electronApp.close();
+        const userData = await getUserdata(userdataFile);
+        expect(userData.data.wallet.accountsData.accountNames[0][1]).toBe(newName);
+      },
+    );
+  });
+}

--- a/e2e/desktop/tests/utils/redux.ts
+++ b/e2e/desktop/tests/utils/redux.ts
@@ -1,0 +1,51 @@
+import { Page } from "@playwright/test";
+
+declare global {
+  interface Window {
+    recordAction?: (action: any) => void;
+    __STORE__?: any;
+  }
+}
+
+export type Action = {
+  type: string;
+  payload: any;
+};
+
+export class Redux {
+  constructor(protected page: Page) {}
+
+  public actions: Action[] = [];
+
+  public listenToReduxActions = async () => {
+    await this.page.exposeFunction("recordAction", (action: Action) => {
+      this.actions.push(action);
+    });
+
+    await this.page.evaluate(() => {
+      const store = window.__STORE__;
+      store.subscribe(() => {
+        const lastAction = store.getState().lastAction;
+        if (lastAction && window.recordAction) {
+          window.recordAction(lastAction);
+        }
+      });
+    });
+  };
+
+  public async waitForReduxAction(actionType: string, timeout: number = 5000) {
+    this.actions = [];
+    return new Promise((resolve, reject) => {
+      const checkAction = () => {
+        const action = this.actions.find(action => action.type === actionType);
+        if (action) {
+          resolve(action);
+        } else {
+          setTimeout(checkAction, 100);
+        }
+      };
+      setTimeout(() => reject(new Error(`Timeout waiting for action: ${actionType}`)), timeout);
+      checkAction();
+    });
+  }
+}

--- a/e2e/desktop/tests/utils/userdata.ts
+++ b/e2e/desktop/tests/utils/userdata.ts
@@ -1,0 +1,6 @@
+import fsPromises from "fs/promises";
+
+export const getUserdata = async (userdataFile: string) => {
+  const jsonFile = await fsPromises.readFile(userdataFile, "utf-8");
+  return JSON.parse(jsonFile);
+};

--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -225,6 +225,10 @@ describe("Wallet store", () => {
   const exportedState = {
     walletSyncState: { data: {}, version: 42 },
     nonImportedAccountInfos: [],
+    accountsData: {
+      accountNames: [],
+      starredAccountIds: [],
+    },
   };
 
   it("allows partial wallet state", () => {
@@ -242,9 +246,47 @@ describe("Wallet store", () => {
     expect(walletSyncStateSelector(result)).toEqual({ data: {}, version: 42 });
   });
 
+  it("can import the wallet state with renamed accounts and starred accounts", () => {
+    const result = handlers.IMPORT_WALLET_SYNC(
+      initialState,
+      importWalletState({
+        ...exportedState,
+        accountsData: {
+          accountNames: [[ETHEREUM_ACCOUNT, "New name"]],
+          starredAccountIds: [ETHEREUM_ACCOUNT],
+        },
+      }),
+    );
+    expect(walletSyncStateSelector(result)).toEqual({ data: {}, version: 42 });
+    expect(accountNameSelector(result, { accountId: ETHEREUM_ACCOUNT })).toBe("New name");
+    expect(isStarredAccountSelector(result, { accountId: ETHEREUM_ACCOUNT })).toBe(true);
+  });
+
   it("can export the wallet state", () => {
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(exportWalletState(result)).toEqual(exportedState);
+  });
+
+  it("can export the wallet state with updated values", () => {
+    const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
+    // Check that the exported state includes rename of accounts.
+    const resultRename = handlers.SET_ACCOUNT_NAME(
+      result,
+      setAccountName(ETHEREUM_ACCOUNT, "New name"),
+    );
+    // Check that the exported state includes starred  accounts.
+    const resultStarred = handlers.SET_ACCOUNT_STARRED(
+      resultRename,
+      setAccountStarred(POLKADOT_ACCOUNT, true),
+    );
+
+    expect(exportWalletState(resultStarred)).toEqual({
+      ...exportedState,
+      accountsData: {
+        accountNames: [[ETHEREUM_ACCOUNT, "New name"]],
+        starredAccountIds: [POLKADOT_ACCOUNT],
+      },
+    });
   });
 
   it("walletStateExportShouldDiffer", () => {

--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -262,6 +262,22 @@ describe("Wallet store", () => {
     expect(isStarredAccountSelector(result, { accountId: ETHEREUM_ACCOUNT })).toBe(true);
   });
 
+  it("can import the wallet state with renamed accounts and starred accounts", () => {
+    const result = handlers.IMPORT_WALLET_SYNC(
+      initialState,
+      importWalletState({
+        ...exportedState,
+        accountsData: {
+          accountNames: [[ETHEREUM_ACCOUNT, "New name"]],
+          starredAccountIds: [ETHEREUM_ACCOUNT],
+        },
+      }),
+    );
+    expect(walletSyncStateSelector(result)).toEqual({ data: {}, version: 42 });
+    expect(accountNameSelector(result, { accountId: ETHEREUM_ACCOUNT })).toBe("New name");
+    expect(isStarredAccountSelector(result, { accountId: ETHEREUM_ACCOUNT })).toBe(true);
+  });
+
   it("can export the wallet state", () => {
     const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
     expect(exportWalletState(result)).toEqual(exportedState);
@@ -348,7 +364,6 @@ describe("Wallet store", () => {
         nonImportedAccountInfos: exportedState.nonImportedAccountInfos,
       }),
     );
-    // console.log(stateImport1);
     expect(exportWalletState(stateImport1)).toEqual({
       walletSyncState: exportedState.walletSyncState,
       nonImportedAccountInfos: exportedState.nonImportedAccountInfos,
@@ -376,6 +391,28 @@ describe("Wallet store", () => {
       accountsData: {
         accountNames: [["mock:1:ethereum:eth:", "New name"]],
         starredAccountIds: ["mock:1:ethereum:eth:", "mock:1:ethereum:eth:|0"],
+      },
+    });
+  });
+
+  it("can export the wallet state with updated values", () => {
+    const result = handlers.IMPORT_WALLET_SYNC(initialState, importWalletState(exportedState));
+    // Check that the exported state includes rename of accounts.
+    const resultRename = handlers.SET_ACCOUNT_NAME(
+      result,
+      setAccountName(ETHEREUM_ACCOUNT, "New name"),
+    );
+    // Check that the exported state includes starred  accounts.
+    const resultStarred = handlers.SET_ACCOUNT_STARRED(
+      resultRename,
+      setAccountStarred(POLKADOT_ACCOUNT, true),
+    );
+
+    expect(exportWalletState(resultStarred)).toEqual({
+      ...exportedState,
+      accountsData: {
+        accountNames: [[ETHEREUM_ACCOUNT, "New name"]],
+        starredAccountIds: [POLKADOT_ACCOUNT],
       },
     });
   });

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -175,8 +175,12 @@ export const importWalletState = (payload: Partial<ExportedWalletState>) => ({
   type: "IMPORT_WALLET_SYNC",
   payload: {
     ...payload,
-    accountNames: new Map(payload?.accountsData?.accountNames ?? []),
-    starredAccountIds: new Set(payload?.accountsData?.starredAccountIds ?? []),
+    ...(payload?.accountsData?.accountNames
+      ? { accountNames: new Map(payload.accountsData.accountNames) }
+      : {}),
+    ...(payload?.accountsData?.starredAccountIds
+      ? { starredAccountIds: new Set(payload.accountsData.starredAccountIds) }
+      : {}),
   },
 });
 

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -31,6 +31,10 @@ export type WalletState = {
 export type ExportedWalletState = {
   walletSyncState: WSState;
   nonImportedAccountInfos: NonImportedAccountInfo[];
+  accountsData: {
+    accountNames: Array<[string, string]>;
+    starredAccountIds: string[];
+  };
 };
 
 export const initialState: WalletState = {
@@ -169,7 +173,11 @@ export const initAccounts = (accounts: Account[], accountsUserData: AccountUserD
  */
 export const importWalletState = (payload: Partial<ExportedWalletState>) => ({
   type: "IMPORT_WALLET_SYNC",
-  payload,
+  payload: {
+    ...payload,
+    accountNames: new Map(payload?.accountsData?.accountNames ?? []),
+    starredAccountIds: new Set(payload?.accountsData?.starredAccountIds ?? []),
+  },
 });
 
 export const walletSyncUpdate = (data: DistantState | null, version: number) => ({
@@ -246,6 +254,10 @@ export const accountRawToAccountUserData = (raw: AccountRaw): AccountUserData =>
 export const exportWalletState = (state: WalletState): ExportedWalletState => ({
   walletSyncState: state.walletSyncState,
   nonImportedAccountInfos: state.nonImportedAccountInfos,
+  accountsData: {
+    accountNames: Array.from(state.accountNames),
+    starredAccountIds: Array.from(state.starredAccountIds),
+  },
 });
 
 export const walletStateExportShouldDiffer = (a: WalletState, b: WalletState): boolean => {

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -267,7 +267,9 @@ export const exportWalletState = (state: WalletState): ExportedWalletState => ({
 export const walletStateExportShouldDiffer = (a: WalletState, b: WalletState): boolean => {
   return (
     a.walletSyncState !== b.walletSyncState ||
-    a.nonImportedAccountInfos !== b.nonImportedAccountInfos
+    a.nonImportedAccountInfos !== b.nonImportedAccountInfos ||
+    a.accountNames !== b.accountNames ||
+    a.starredAccountIds !== b.starredAccountIds
   );
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Added tests to cover the regression issue that previously forced us to revert this PR
This was due to a change in the ExportedWalletState data returned by the wallet-store.
It caused the `accountNameWithDefaultSelector` and the `isStarredAccountSelector` selectors to make the app crash after rolling back to a previous version not containing the rename account fix.
To prevent this, we nest the `accountNames` and `starredAccountIds` in an `accountsData` property.

Also added a test to validate that the account renamed and accounts starred in a previous app version will be kept with this fix
The Ledger Sync tests confirms that this fix does not impact the Ledger Sync feature.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-18928]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-18928]: https://ledgerhq.atlassian.net/browse/LIVE-18928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ