### PR TITLE
fix: estimation fee with no bandwidth

### DIFF
--- a/.changeset/thick-donuts-attack.md
+++ b/.changeset/thick-donuts-attack.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+fix: Tron new feeEstimation if no Bandwidth

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import getEstimatedFees from "./getEstimateFees";
 import { extractBandwidthInfo } from "./utils";
 import { estimateFees, getAccount } from "../logic";
-import { ACTIVATION_FEES, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { Transaction } from "../types";
 
@@ -65,7 +65,7 @@ describe("getEstimatedFees", () => {
       });
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
-      expect(result).toEqual(BigNumber(200).multipliedBy(1000));
+      expect(result).toEqual(STANDARD_FEES_NATIVE);
     });
 
     it("should return 0 if bandwidth is sufficient", async () => {

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import getEstimatedFees from "./getEstimateFees";
 import { extractBandwidthInfo } from "./utils";
 import { estimateFees, getAccount } from "../logic";
-import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { ACTIVATION_FEES, STANDARD_FEES_TRC_20 } from "../logic/constants";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import { Transaction } from "../types";
 
@@ -65,7 +65,7 @@ describe("getEstimatedFees", () => {
       });
 
       const result = await getEstimatedFees(mockAccount, mockTransaction);
-      expect(result).toEqual(STANDARD_FEES_NATIVE);
+      expect(result).toEqual(BigNumber(200).multipliedBy(1000));
     });
 
     it("should return 0 if bandwidth is sufficient", async () => {

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -1,6 +1,6 @@
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { ACTIVATION_FEES, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
 import type { AccountTronAPI } from "../network/types";
 import type { Transaction, TronAsset } from "../types";
 import { extractBandwidthInfo, getEstimatedBlockSize } from "./utils";
@@ -10,7 +10,7 @@ import type { TransactionIntent } from "@ledgerhq/coin-framework/api/index";
 // see : https://developers.tron.network/docs/bandwith#section-bandwidth-points-consumption
 // 1. cost around 200 Bandwidth, if not enough check Free Bandwidth
 // 2. If not enough, will cost some TRX
-// 3. normal transfert cost around 0.002 TRX
+// 3. normal transfert cost around 0.270 TRX
 const getFeesFromBandwidth = (account: Account, transaction: Transaction): BigNumber => {
   const { freeUsed, freeLimit, gainedUsed, gainedLimit } = extractBandwidthInfo(
     transaction.networkInfo,
@@ -19,8 +19,7 @@ const getFeesFromBandwidth = (account: Account, transaction: Transaction): BigNu
   const estimatedBandwidthCost = getEstimatedBlockSize(account, transaction);
 
   if (available.lt(estimatedBandwidthCost)) {
-    const estimatedFees = estimatedBandwidthCost.multipliedBy(1000); // 1 Bandwidth point cost 0.001 TRX
-    return estimatedFees;
+    return STANDARD_FEES_NATIVE; // cost is around 0.270 TRX
   }
 
   return new BigNumber(0); // no fee

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -1,6 +1,6 @@
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
-import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { ACTIVATION_FEES, STANDARD_FEES_TRC_20 } from "../logic/constants";
 import type { AccountTronAPI } from "../network/types";
 import type { Transaction, TronAsset } from "../types";
 import { extractBandwidthInfo, getEstimatedBlockSize } from "./utils";
@@ -19,7 +19,8 @@ const getFeesFromBandwidth = (account: Account, transaction: Transaction): BigNu
   const estimatedBandwidthCost = getEstimatedBlockSize(account, transaction);
 
   if (available.lt(estimatedBandwidthCost)) {
-    return STANDARD_FEES_NATIVE; // cost is around 0.002 TRX
+    const estimatedFees = estimatedBandwidthCost.multipliedBy(1000); // 1 Bandwidth point cost 0.001 TRX
+    return estimatedFees;
   }
 
   return new BigNumber(0); // no fee

--- a/libs/coin-modules/coin-tron/src/logic/constants.ts
+++ b/libs/coin-modules/coin-tron/src/logic/constants.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "bignumber.js";
 
 export const ONE_TRX = new BigNumber(1000000);
-export const STANDARD_FEES_NATIVE = new BigNumber(2000);
+export const STANDARD_FEES_NATIVE = new BigNumber(270000);
 export const ACTIVATION_FEES = ONE_TRX.multipliedBy(1.1); // ONE TRX fee + 0.1 TRX activation cost
 export const ACTIVATION_FEES_TRC_20 = ONE_TRX.multipliedBy(27.6009);
 export const STANDARD_FEES_TRC_20 = ONE_TRX.multipliedBy(13.7409);


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We use to have a default value for transaction using no bandwidth  (0.002 TRX).
But the correct value is (0.001 TRX per bandwidth point needed to complete the transaction.)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19388](https://ledgerhq.atlassian.net/browse/LIVE-19388)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19388]: https://ledgerhq.atlassian.net/browse/LIVE-19388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ