### PR TITLE
🐛  LLM - Claim atom header size now scaling depending on screen

### DIFF
--- a/.changeset/slimy-pens-exist.md
+++ b/.changeset/slimy-pens-exist.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+LLM - Fix Header text too long on atom claim page

--- a/apps/ledger-live-mobile/src/components/StepHeader.tsx
+++ b/apps/ledger-live-mobile/src/components/StepHeader.tsx
@@ -7,9 +7,10 @@ type Props = {
   title: React.ReactNode;
   subtitle?: React.ReactNode;
   testID?: string;
+  adjustFontSize?: boolean;
 };
 
-export default function StepHeader({ title, subtitle, testID }: Props) {
+export default function StepHeader({ title, subtitle, testID, adjustFontSize }: Props) {
   return (
     <TouchableWithoutFeedback onPress={scrollToTop}>
       <Flex flexDirection={"column"} justifyContent={"center"} flex={1} py={3}>
@@ -31,6 +32,7 @@ export default function StepHeader({ title, subtitle, testID }: Props) {
           textAlign={"center"}
           color={"neutral.c100"}
           testID={testID}
+          adjustsFontSizeToFit={adjustFontSize}
         >
           {title}
         </Text>

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/index.tsx
@@ -13,6 +13,7 @@ import ClaimRewardsConnectDevice from "~/screens/ConnectDevice";
 import ClaimRewardsValidationError from "./04-ValidationError";
 import ClaimRewardsValidationSuccess from "./04-ValidationSuccess";
 import type { CosmosClaimRewardsFlowParamList } from "./types";
+import { Flex } from "@ledgerhq/native-ui";
 
 const totalSteps = "3";
 
@@ -32,13 +33,16 @@ function ClaimRewardsFlow() {
         component={ClaimRewardsSelectValidator}
         options={{
           headerTitle: () => (
-            <StepHeader
-              title={t("cosmos.claimRewards.stepperHeader.validator")}
-              subtitle={t("cosmos.claimRewards.stepperHeader.stepRange", {
-                currentStep: "1",
-                totalSteps,
-              })}
-            />
+            <Flex flex={1} width="90%" alignSelf="center">
+              <StepHeader
+                title={t("cosmos.claimRewards.stepperHeader.validator")}
+                subtitle={t("cosmos.claimRewards.stepperHeader.stepRange", {
+                  currentStep: "1",
+                  totalSteps,
+                })}
+                adjustFontSize
+              />
+            </Flex>
           ),
           headerLeft: () => null,
           headerStyle: {


### PR DESCRIPTION
…n size

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Claim atom header title scale to fit the size of the screen without overlapping on the close button

| Before        | After         |
| ------------- | ------------- |
|<img width="409" alt="Screenshot 2025-06-02 at 18 23 04" src="https://github.com/user-attachments/assets/421136fb-9403-4b15-96d7-38a0503fbca6" />|<img width="409" alt="Screenshot 2025-06-02 at 18 21 43" src="https://github.com/user-attachments/assets/dc4808da-0b4e-464d-b420-29434a6871ad" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-15454]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-15454]: https://ledgerhq.atlassian.net/browse/LIVE-15454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ