### PR TITLE
fix: amend the name and attributes of the EarnMenuDrawer events

### DIFF
--- a/.changeset/dirty-flies-eat.md
+++ b/.changeset/dirty-flies-eat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixes the name of the event and the button attribute for drawer events

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnMenuDrawer.tsx
@@ -9,6 +9,9 @@ import { track } from "~/analytics";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import { earnMenuModalSelector } from "~/reducers/earn";
 
+/** TODO Should be a shared constant throughout the app for all events */
+const BUTTON_CLICKED_TRACK_EVENT = "button_clicked";
+
 export function EarnMenuDrawer() {
   const dispatch = useDispatch();
   const [modalOpened, setModalOpened] = useState(false);
@@ -36,12 +39,12 @@ export function EarnMenuDrawer() {
           </Text>
         ) : null}
         <Flex rowGap={16}>
-          {modal?.options.map(({ label, metadata: { link, button, ...tracked } }) =>
+          {modal?.options.map(({ label, metadata: { link, ...tracked } }) =>
             link ? (
               <OptionButton
                 key={label}
                 onPress={async () => {
-                  await track(button, tracked);
+                  await track(BUTTON_CLICKED_TRACK_EVENT, tracked);
                   closeDrawer();
                   await Linking.openURL(link);
                 }}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Small fix to the attribute names

### 📝 Description

Amend the name and attributes of the EarnMenuDrawer events

### ❓ Context

- **JIRA**: (LIVE-17878)[https://ledgerhq.atlassian.net/browse/LIVE-17878]

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
