### PR TITLE
fix(BACK-9017): [coin-modules][tezos] ALPACA tezos craft is missing leading `0x03` byte in raw transaction

### DIFF
--- a/.changeset/silver-dolphins-melt.md
+++ b/.changeset/silver-dolphins-melt.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tezos": minor
+---
+
+[coin-modules][tezos] ALPACA tezos craft is missing leading `0x03` byte in raw transaction

--- a/libs/coin-modules/coin-tezos/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-tezos/src/bridge/signOperation.ts
@@ -89,12 +89,7 @@ export const buildSignOperation =
 
           const forgedBytes = await rawEncode(contents);
 
-          // 0x03 is a conventional prefix (aka a watermark) for tezos transactions
-          const signature = await ledgerSigner.sign(
-            Buffer.concat([Buffer.from("03", "hex"), Buffer.from(forgedBytes, "hex")]).toString(
-              "hex",
-            ),
-          );
+          const signature = await ledgerSigner.sign(forgedBytes);
 
           return {
             type,

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.test.ts
@@ -1,4 +1,4 @@
-import { craftTransaction } from "./craftTransaction";
+import { craftTransaction, rawEncode } from "./craftTransaction";
 import { getTezosToolkit } from "./tezosToolkit";
 import coinConfig from "../config";
 import { OpKind } from "@taquito/rpc";
@@ -158,5 +158,15 @@ describe("craftTransaction", () => {
     };
 
     await expect(craftTransaction(account, transaction)).rejects.toThrow("unsupported mode");
+  });
+
+  it("should include leading watermark byte when using rawEncode", async () => {
+    mockTezosToolkit.rpc.getBlock.mockResolvedValue({ hash: "aaaa" });
+    mockTezosToolkit.rpc.forgeOperations.mockResolvedValue("deadcafe");
+
+    const rawTx = await rawEncode([]);
+
+    // 0x03 is a conventional prefix (aka a watermark) for tezos transactions
+    expect(rawTx).toEqual("03deadcafe");
   });
 });

--- a/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/craftTransaction.ts
@@ -1,4 +1,4 @@
-import { OpKind, type OperationContents } from "@taquito/rpc";
+import { type OperationContents, OpKind } from "@taquito/rpc";
 import { DEFAULT_FEE } from "@taquito/taquito";
 import coinConfig from "../config";
 import { UnsupportedTransactionMode } from "../types/errors";
@@ -115,5 +115,6 @@ export async function rawEncode(contents: OperationContents[]): Promise<string> 
     contents,
   });
 
-  return forgedBytes;
+  // 0x03 is a conventional prefix (aka a watermark) for tezos transactions
+  return Buffer.concat([Buffer.from("03", "hex"), Buffer.from(forgedBytes, "hex")]).toString("hex");
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add the leading `0x03` byte in `rawEncode` instead of only bridge, so that ALPACA gets the same crafted transactions for signing.
Note: I checked `rawEncode` is only used here

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-9017
- https://ledger.slack.com/archives/C07RB4NNN3H/p1748944367222189


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
