### PR TITLE
fix(LLM): memoTagInput retain input focus on modal close

### DIFF
--- a/.changeset/tame-wolves-compare.md
+++ b/.changeset/tame-wolves-compare.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+retain memo tag input focus on drawer dismiss

--- a/apps/ledger-live-mobile/src/families/algorand/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/MemoTagInput.tsx
@@ -5,10 +5,16 @@ import type { Transaction as AlgorandTransaction } from "@ledgerhq/live-common/f
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<AlgorandTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<AlgorandTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     maxLength={ALGORAND_MAX_MEMO_SIZE}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    ref={ref}
   />
-);
+));
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/cardano/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/MemoTagInput.tsx
@@ -5,15 +5,21 @@ import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 import { truncateUtf8 } from "LLM/utils/truncateUtf8";
 
-export default (props: MemoTagInputProps<CardanoTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<CardanoTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    ref={ref}
   />
-);
+));
 
 // From the Cardano metadata documentation:
 // > Strings must be at most 64 bytes when UTF-8 encoded.
 // https://developers.cardano.org/docs/get-started/cardano-serialization-lib/transaction-metadata/#metadata-limitations
 const MAX_MEMO_LENGTH = 64;
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/casper/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/MemoTagInput.tsx
@@ -5,7 +5,10 @@ import type { Transaction as CasperTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<CasperTransaction>) => {
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<CasperTransaction>
+>((props, ref) => {
   const { t } = useTranslation();
   return (
     <GenericMemoTagInput
@@ -13,6 +16,9 @@ export default (props: MemoTagInputProps<CasperTransaction>) => {
       textToValue={text => text.replace(/\D/g, "")}
       valueToTxPatch={value => tx => ({ ...tx, transferId: value || undefined })}
       placeholder={t("send.summary.transferId")}
+      ref={ref}
     />
   );
-};
+});
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/cosmos/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/MemoTagInput.tsx
@@ -4,9 +4,15 @@ import type { Transaction as CosmosTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<CosmosTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<CosmosTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    ref={ref}
   />
-);
+));
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/hedera/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/MemoTagInput.tsx
@@ -4,9 +4,15 @@ import type { Transaction as HederaTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<HederaTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<HederaTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    ref={ref}
   />
-);
+));
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/internet_computer/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/MemoTagInput.tsx
@@ -5,7 +5,10 @@ import type { Transaction as ICPTransaction } from "@ledgerhq/live-common/famili
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<ICPTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<ICPTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     textToValue={text => {
@@ -13,5 +16,8 @@ export default (props: MemoTagInputProps<ICPTransaction>) => (
       return value ? String(value) : "";
     }}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    ref={ref}
   />
-);
+));
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/MemoTagInput.tsx
@@ -7,12 +7,18 @@ import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 import { truncateUtf8 } from "LLM/utils/truncateUtf8";
 
-export default (props: MemoTagInputProps<SolanaTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<SolanaTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     textToValue={text => truncateUtf8(text, MAX_MEMO_LENGTH)}
     valueToTxPatch={value => tx =>
       merge({}, tx, { model: { uiState: { memo: value || undefined } } })
     }
+    ref={ref}
   />
-);
+));
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/stacks/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/stacks/MemoTagInput.tsx
@@ -12,10 +12,16 @@ import { truncateUtf8 } from "LLM/utils/truncateUtf8";
 //  While this string is in fact encoded in 68B in UTF8 which is well above STX limit.
 // `truncateUtf8` will truncate the string correctly, which is 8👍 with 2 characters to spare.
 
-export default (props: MemoTagInputProps<StacksTransaction>) => (
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<StacksTransaction>
+>((props, ref) => (
   <GenericMemoTagInput
     {...props}
     textToValue={text => truncateUtf8(text, STACKS_MAX_MEMO_SIZE)}
     valueToTxPatch={value => tx => ({ ...tx, memo: value || undefined })}
+    ref={ref}
   />
-);
+));
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/MemoTagInput.tsx
@@ -10,7 +10,10 @@ import { AnimatedInputSelect } from "@ledgerhq/native-ui";
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { MemoTypeDrawer, MEMO_TYPES } from "./MemoTypeDrawer";
 
-export default ({ onChange, ...inputProps }: MemoTagInputProps<StellarTransaction>) => {
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof AnimatedInputSelect>,
+  MemoTagInputProps<StellarTransaction>
+>(({ onChange, ...inputProps }, ref) => {
   const { t } = useTranslation();
 
   const [memoType, setMemoType] = useState<MemoType>("NO_MEMO");
@@ -52,6 +55,7 @@ export default ({ onChange, ...inputProps }: MemoTagInputProps<StellarTransactio
           text: t(MEMO_TYPES.get(memoType) ?? "send.summary.memo.type"),
           onPressSelect: () => setIsOpen(true),
         }}
+        ref={ref}
       />
 
       <MemoTypeDrawer
@@ -62,6 +66,8 @@ export default ({ onChange, ...inputProps }: MemoTagInputProps<StellarTransactio
       />
     </>
   );
-};
+});
 
 type MemoType = Parameters<(typeof MEMO_TYPES)["get"]>[0];
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/ton/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/ton/MemoTagInput.tsx
@@ -5,13 +5,19 @@ import type { Transaction as TonTransaction } from "@ledgerhq/live-common/famili
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<TonTransaction>) => {
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<TonTransaction>
+>((props, ref) => {
   const { t } = useTranslation();
   return (
     <GenericMemoTagInput
       {...props}
       valueToTxPatch={value => tx => ({ ...tx, comment: { isEncrypted: false, text: value } })}
       placeholder={t("send.summary.comment")}
+      ref={ref}
     />
   );
-};
+});
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/families/xrp/MemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/families/xrp/MemoTagInput.tsx
@@ -5,14 +5,20 @@ import type { Transaction as RippleTransaction } from "@ledgerhq/live-common/fam
 import type { MemoTagInputProps } from "LLM/features/MemoTag/types";
 import { GenericMemoTagInput } from "LLM/features/MemoTag/components/GenericMemoTagInput";
 
-export default (props: MemoTagInputProps<RippleTransaction>) => {
+const MemoTagInput = React.forwardRef<
+  React.ComponentRef<typeof GenericMemoTagInput>,
+  MemoTagInputProps<RippleTransaction>
+>((props, ref) => {
   const { t } = useTranslation();
   return (
     <GenericMemoTagInput
       {...props}
+      ref={ref}
       textToValue={text => text.replace(/\D/g, "")}
       valueToTxPatch={value => tx => ({ ...tx, tag: value ? Number(value) : undefined })}
       placeholder={t("send.summary.tag")}
     />
   );
-};
+});
+
+export default MemoTagInput;

--- a/apps/ledger-live-mobile/src/newArch/features/MemoTag/components/GenericMemoTagInput.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/MemoTag/components/GenericMemoTagInput.tsx
@@ -9,27 +9,28 @@ type Props<T extends Transaction = Transaction> = MemoTagInputProps<T> & {
   valueToTxPatch: (text: string) => TxPatch<T>;
 };
 
-export function GenericMemoTagInput<T extends Transaction>({
-  onChange,
-  valueToTxPatch,
-  textToValue,
-  ...inputProps
-}: Props<T>) {
-  const [value, setValue] = React.useState("");
+type AnimatedInputRef = React.ComponentRef<typeof AnimatedInput>;
 
-  const handleChange = (text: string) => {
-    const value = textToValue?.(text) ?? text;
-    const patch = valueToTxPatch(value);
-    setValue(value);
-    onChange({ value, patch });
-  };
+export const GenericMemoTagInput = React.forwardRef<AnimatedInputRef, Props>(
+  <T extends Transaction>(props: Props<T>, ref: React.ForwardedRef<AnimatedInputRef>) => {
+    const { onChange, valueToTxPatch, textToValue, ...inputProps } = props;
+    const [value, setValue] = React.useState("");
 
-  return (
-    <AnimatedInput
-      {...inputProps}
-      value={value}
-      onChangeText={handleChange}
-      testID="memo-tag-input"
-    />
-  );
-}
+    const handleChange = (text: string) => {
+      const value = textToValue?.(text) ?? text;
+      const patch = valueToTxPatch(value);
+      setValue(value);
+      onChange({ value, patch });
+    };
+
+    return (
+      <AnimatedInput
+        {...inputProps}
+        value={value}
+        onChangeText={handleChange}
+        testID="memo-tag-input"
+        ref={ref}
+      />
+    );
+  },
+);

--- a/apps/ledger-live-mobile/src/newArch/features/MemoTag/types.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/MemoTag/types.ts
@@ -6,4 +6,7 @@ export type TxPatch<T extends Transaction> = (tx: T) => T;
 export type MemoTagInputProps<T extends Transaction = Transaction> = Omit<
   AnimatedInputProps,
   "value" | "onChangeText" | "onChange"
-> & { onChange: (update: { patch: TxPatch<T>; value: string; error?: Error }) => void };
+> & {
+  onChange: (update: { patch: TxPatch<T>; value: string; error?: Error }) => void;
+  ref?: React.ForwardedRef<AnimatedInputProps>;
+};

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -47,6 +47,7 @@ import {
   hasProblematicExtension,
 } from "@ledgerhq/live-common/families/solana/token";
 import { urls } from "~/utils/urls";
+import { GenericMemoTagInput } from "~/newArch/features/MemoTag/components/GenericMemoTagInput";
 
 const withoutHiddenError = (error: Error): Error | null =>
   error instanceof RecipientRequired ? null : error;
@@ -64,6 +65,8 @@ export default function SendSelectRecipient({ route }: Props) {
   const { t } = useTranslation();
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   invariant(account, "account is missing");
+
+  const memoTagRef = useRef<React.ComponentRef<typeof GenericMemoTagInput>>(null);
 
   const mainAccount = getMainAccount(account, parentAccount);
   const currencySettings = useSelector((s: State) =>
@@ -174,10 +177,10 @@ export default function SendSelectRecipient({ route }: Props) {
     MemoTagDrawerState.INITIAL,
   );
 
-  const handleMemoTagDrawerClose = useCallback(
-    () => setMemoTagDrawerState(MemoTagDrawerState.SHOWN),
-    [],
-  );
+  const handleMemoTagDrawerClose = useCallback(() => {
+    setMemoTagDrawerState(MemoTagDrawerState.SHOWN);
+    setTimeout(() => memoTagRef.current?.focus?.(), 500); // Workaround to focus the memo tag input after the drawer is closed.
+  }, []);
 
   const onPressContinue = useCallback(() => {
     if (
@@ -343,7 +346,7 @@ export default function SendSelectRecipient({ route }: Props) {
                 <memoTag.Input
                   testID="memo-tag-input"
                   placeholder={t("send.summary.memo.title")}
-                  autoFocus={memoTagDrawerState === MemoTagDrawerState.SHOWN}
+                  ref={memoTagRef}
                   onChange={memoTag.handleChange}
                 />
                 <Text mt={4} pl={2} color="alert">


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Ensures the memo tag input is focused once the modal is dismissed


### ❓ Context

- **JIRA or GitHub link**: [LIVE-19476](https://ledgerhq.atlassian.net/browse/LIVE-19476)

https://github.com/user-attachments/assets/8a690572-5d6c-425c-a4f8-ebddac50cf91


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19476]: https://ledgerhq.atlassian.net/browse/LIVE-19476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ