### PR TITLE
fix(LLM): memoTagInput retain input focus on modal close

### DIFF
--- a/.changeset/perfect-crews-repeat.md
+++ b/.changeset/perfect-crews-repeat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+retain memo tag input focus on drawer dismiss

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -343,7 +343,10 @@ export default function SendSelectRecipient({ route }: Props) {
                 <memoTag.Input
                   testID="memo-tag-input"
                   placeholder={t("send.summary.memo.title")}
-                  autoFocus={memoTagDrawerState === MemoTagDrawerState.SHOWN}
+                  autoFocus={[MemoTagDrawerState.SHOWING, MemoTagDrawerState.SHOWN].includes(
+                    // Ensure the input is focused when the drawer is shown
+                    memoTagDrawerState,
+                  )}
                   onChange={memoTag.handleChange}
                 />
                 <Text mt={4} pl={2} color="alert">


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Ensures the memo tag input is focused once the modal is dismissed

https://github.com/user-attachments/assets/496a6c48-38b0-455d-bfb2-eb0c18d9a3a6


### ❓ Context

- **JIRA or GitHub link**: [LIVE-19476](https://ledgerhq.atlassian.net/browse/LIVE-19476)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19476]: https://ledgerhq.atlassian.net/browse/LIVE-19476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ