### PR TITLE
CI: Stop publishing prerelease packages

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           install-proto: true
       - name: install dependencies
-        run: pnpm i -D
+        run: pnpm i -D -F "ledger-live" --ignore-scripts
       - name: Move patch updates to minor for release branch
         # For more info about why we do this, see this doc:
         # https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4710989838/LL+Incident+Recovery+-+Hotfix+in+all+cases


### PR DESCRIPTION
Removes the following steps:

- Build libs - no longer required when not publishing
- Publish

Restricts pnpm install to develop scripts only (so that changesets are bought in). Ignores post install scripts as these are not required

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-19049
Green Run: https://github.com/LedgerHQ/ledger-live/actions/runs/15635338226