### PR TITLE
bugfix: display of Learn More on Ledger Sync

### DIFF
--- a/.changeset/tough-deers-trade.md
+++ b/.changeset/tough-deers-trade.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix display of Learn More on Ledger Sync

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/walletSyncActivation.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/__integrations__/walletSyncActivation.integration.test.tsx
@@ -100,6 +100,6 @@ describe("WalletSyncActivation", () => {
     });
 
     expect(await screen.findByText(/Turn on Ledger Sync for this phone/i)).toBeVisible();
-    expect(screen.queryByText(/How does Ledger Sync work?/i)).toBeUndefined;
+    expect(screen.queryByText(/How does Ledger Sync work?/i)).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/index.tsx
@@ -51,7 +51,7 @@ const Activation: React.FC<Props> = ({ onSyncMethodPress, navigateToChooseSyncMe
       <Actions
         onPressHasAlreadyCreatedAKey={navigateToChooseSyncMethod}
         onPressSyncAccounts={onSyncMethodPress}
-        onPressLearnMore={onPressLearnMore}
+        onPressLearnMore={learnMoreLink ? onPressLearnMore : undefined}
       />
     </Flex>
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add a guard to prevent display when the link is not provided in the feature flag

The issue was that on staging and dev environments, the learnMoreLink key was missing in the feature flag, while it was present in production. This guard ensures the component does not attempt to render the link if it's undefined.



https://github.com/user-attachments/assets/fa3ba3cd-e645-4b80-b542-5a5a6714b5ba




<img width="340" alt="Screenshot 2025-06-18 at 17 47 54" src="https://github.com/user-attachments/assets/4907dc5f-27e6-47d6-b81f-4f8a91f1a786" />

![Screenshot 2025-06-18 at 17 48 23](https://github.com/user-attachments/assets/100e4292-41e4-4c4a-a145-30f33b1d1cb1)

![Screenshot 2025-06-18 at 17 48 34](https://github.com/user-attachments/assets/356a8608-caba-4cbb-8741-64dc54717a69)



### ❓ Context

- **JIRA or GitHub link**: [LIVE-19709]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19709]: https://ledgerhq.atlassian.net/browse/LIVE-19709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ