### PR TITLE
:sparkles: (lld) [LIVE-19704]: Don't remove devices while a connection is active

### DIFF
--- a/.changeset/forty-pumas-impress.md
+++ b/.changeset/forty-pumas-impress.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-dmk-desktop": minor
+---
+
+Don't remove devices while a connection is active

--- a/apps/ledger-live-desktop/src/renderer/hooks/useListenToHidDevices.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useListenToHidDevices.ts
@@ -10,6 +10,7 @@ import { addDevice, removeDevice, resetDevices } from "~/renderer/actions/device
 export const useListenToHidDevices = () => {
   const dispatch = useDispatch();
   const ldmkFeatureFlag = useFeature("ldmkTransport");
+  const isLdmkConnectAppEnabled = useFeature("ldmkConnectApp")?.enabled ?? false;
 
   const deviceManagementKit = useDeviceManagementKit();
 
@@ -45,8 +46,12 @@ export const useListenToHidDevices = () => {
       });
     }
 
+    const dmkListen = isLdmkConnectAppEnabled
+      ? DeviceManagementKitTransport.listen
+      : DeviceManagementKitTransport.listenLegacyConnectApp;
+
     function syncDevicesWithDmk() {
-      sub = new Observable(DeviceManagementKitTransport.listen).subscribe({
+      sub = new Observable(dmkListen).subscribe({
         next: ({ descriptor, device, deviceModel, type }) => {
           if (device) {
             const deviceId = descriptor || "";
@@ -84,7 +89,7 @@ export const useListenToHidDevices = () => {
       clearTimeout?.(timeoutSyncDevices);
       sub?.unsubscribe?.();
     };
-  }, [dispatch, deviceManagementKit, ldmkFeatureFlag?.enabled]);
+  }, [dispatch, deviceManagementKit, ldmkFeatureFlag?.enabled, isLdmkConnectAppEnabled]);
 
   return null;
 };

--- a/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
+++ b/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
@@ -1,4 +1,5 @@
 import {
+  type DeviceId,
   DeviceManagementKit,
   DeviceStatus,
   type DeviceSessionState,
@@ -8,7 +9,7 @@ import Transport from "@ledgerhq/hw-transport";
 import { dmkToLedgerDeviceIdMap, activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer } from "@ledgerhq/logs";
 import { DescriptorEvent } from "@ledgerhq/types-devices";
-import { firstValueFrom, Observer, startWith, pairwise, map } from "rxjs";
+import { firstValueFrom, Observer, startWith, pairwise, map, Subscription } from "rxjs";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
 
 const tracer = new LocalTracer("live-dmk-tracer", { function: "DeviceManagementKitTransport" });
@@ -87,7 +88,8 @@ export class DeviceManagementKitTransport extends Transport {
     return transport;
   }
 
-  static listen = (observer: Observer<DescriptorEvent<string>>) => {
+  // TODO remove after full ConnectApp migraton: useFeature("ldmkConnectApp")
+  static listenLegacyConnectApp = (observer: Observer<DescriptorEvent<string>>) => {
     const subscription = getDeviceManagementKit()
       .listenToAvailableDevices({})
       .pipe(
@@ -101,7 +103,6 @@ export class DeviceManagementKitTransport extends Transport {
       )
       .subscribe({
         next: ({ added, removed }) => {
-          console.log({ added, removed });
           for (const device of added) {
             const id = dmkToLedgerDeviceIdMap[device.deviceModel.model];
 
@@ -138,6 +139,116 @@ export class DeviceManagementKitTransport extends Transport {
 
     return {
       unsubscribe: () => subscription.unsubscribe(),
+    };
+  };
+
+  // Compose availableDevices and connectedDevices to avoid unwanted disconnection events
+  static listen = (observer: Observer<DescriptorEvent<string>>) => {
+    const dmk = getDeviceManagementKit();
+    const connectedDevices = new Set<DeviceId>();
+    const pendingRemovals = new Map<DeviceId, DiscoveredDevice>();
+    const sessionSubscriptions = new Map<DeviceId, Subscription>();
+
+    const notifyDeviceAdded = (device: DiscoveredDevice) => {
+      const id = dmkToLedgerDeviceIdMap[device.deviceModel.model];
+      tracer.trace(`[listen] device added ${id}`);
+      observer.next({
+        type: "add",
+        descriptor: "",
+        device: device,
+        // @ts-expect-error types are not matching
+        deviceModel: {
+          id,
+        },
+      });
+    };
+
+    const notifyDeviceRemoved = (device: DiscoveredDevice) => {
+      const id = dmkToLedgerDeviceIdMap[device.deviceModel.model];
+      tracer.trace(`[listen] device removed ${id}`);
+      observer.next({
+        type: "remove",
+        descriptor: "",
+        device: device,
+        // @ts-expect-error types are not matching
+        deviceModel: {
+          id,
+        },
+      });
+    };
+
+    const connectedSubscription = dmk.listenToConnectedDevice().subscribe({
+      next: device => {
+        connectedDevices.add(device.id);
+        // Subscribe to session state to detect disconnection
+        const sessionSubscription = dmk
+          .getDeviceSessionState({ sessionId: device.sessionId })
+          .subscribe({
+            next: state => {
+              if (state.deviceStatus === DeviceStatus.NOT_CONNECTED) {
+                connectedDevices.delete(device.id);
+                if (sessionSubscriptions.has(device.id)) {
+                  sessionSubscriptions.get(device.id)!.unsubscribe();
+                  sessionSubscriptions.delete(device.id);
+                }
+                if (pendingRemovals.has(device.id)) {
+                  notifyDeviceRemoved(pendingRemovals.get(device.id)!);
+                  pendingRemovals.delete(device.id);
+                }
+              }
+            },
+            complete: () => {
+              connectedDevices.delete(device.id);
+              sessionSubscriptions.delete(device.id);
+            },
+            error: () => {
+              connectedDevices.delete(device.id);
+              sessionSubscriptions.delete(device.id);
+            },
+          });
+        sessionSubscriptions.set(device.id, sessionSubscription);
+      },
+      error: observer.error,
+      complete: observer.complete,
+    });
+
+    const availableSubscription = dmk
+      .listenToAvailableDevices({})
+      .pipe(
+        startWith<DiscoveredDevice[]>([]),
+        pairwise(),
+        map(([prev, curr]) => {
+          const added = curr.filter(item => !prev.some(prevItem => prevItem.id === item.id));
+          const removed = prev.filter(item => !curr.some(currItem => currItem.id === item.id));
+          return { added, removed };
+        }),
+      )
+      .subscribe({
+        next: ({ added, removed }) => {
+          for (const device of added) {
+            pendingRemovals.delete(device.id);
+            notifyDeviceAdded(device);
+          }
+
+          for (const device of removed) {
+            if (!connectedDevices.has(device.id)) {
+              notifyDeviceRemoved(device);
+            } else {
+              pendingRemovals.set(device.id, device);
+            }
+          }
+        },
+        error: observer.error,
+        complete: observer.complete,
+      });
+
+    return {
+      unsubscribe: () => {
+        availableSubscription.unsubscribe();
+        connectedSubscription.unsubscribe();
+        sessionSubscriptions.forEach(sub => sub.unsubscribe());
+        sessionSubscriptions.clear();
+      },
     };
   };
 


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Fix for: https://ledgerhq.atlassian.net/browse/LIVE-19704

Each time the device is disconnected or reconnected, the connectApp device action is launched again... We should not re-launch it during a flow for a connected device session

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
