### PR TITLE
fix: Add time delay for ios in CI

### DIFF
--- a/e2e/mobile/helpers/commonHelpers.ts
+++ b/e2e/mobile/helpers/commonHelpers.ts
@@ -44,6 +44,14 @@ export function isSpeculosRemote() {
   return process.env.REMOTE_SPECULOS === "true";
 }
 
+export async function addDelayBeforeInteractingWithDevice(
+  // TODO: QAA-683
+  delayIos: number = 10_000,
+  ms: number = 0,
+) {
+  await delay(isSpeculosRemote() && isIos() ? delayIos : ms);
+}
+
 export async function launchApp() {
   const port = await findFreePort();
   closeBridge();

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -2,6 +2,7 @@ import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { allure } from "jest-allure2-reporter/api";
 import { getMinimumSwapAmount } from "@ledgerhq/live-common/e2e/swap";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
+import { addDelayBeforeInteractingWithDevice } from "../../helpers/commonHelpers";
 
 export default class SwapLiveAppPage {
   fromSelector = "from-account-coin-selector";
@@ -107,6 +108,7 @@ export default class SwapLiveAppPage {
 
   @Step("Check error message: $0")
   async checkErrorMessage(errorMessage: string) {
+    await addDelayBeforeInteractingWithDevice();
     const error = await getTextOfElement(this.deviceActionErrorDescriptionId);
     jestExpect(error).toContain(errorMessage);
   }

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -1,4 +1,4 @@
-import { delay, isIos, isSpeculosRemote, openDeeplink } from "../../helpers/commonHelpers";
+import { addDelayBeforeInteractingWithDevice, openDeeplink } from "../../helpers/commonHelpers";
 import { SwapType } from "@ledgerhq/live-common/e2e/models/Swap";
 
 export default class SwapPage {
@@ -30,7 +30,7 @@ export default class SwapPage {
   async verifyAmountsAndAcceptSwap(swap: SwapType, amount: string) {
     await waitForElementById(this.confirmSwapOnDeviceDrawerId);
     await app.speculos.verifyAmountsAndAcceptSwap(swap, amount);
-    await this.delayDeviceActionLoadingCheck();
+    await addDelayBeforeInteractingWithDevice();
     await waitForElementNotVisible(this.deviceActionLoading);
   }
 
@@ -38,7 +38,7 @@ export default class SwapPage {
   async verifyAmountsAndRejectSwap(swap: SwapType, amount: string) {
     await waitForElementById(this.confirmSwapOnDeviceDrawerId);
     await app.speculos.verifyAmountsAndRejectSwap(swap, amount);
-    await this.delayDeviceActionLoadingCheck();
+    await addDelayBeforeInteractingWithDevice();
     await waitForElementNotVisible(this.deviceActionLoading);
   }
 
@@ -46,10 +46,6 @@ export default class SwapPage {
   async waitForSuccessAndContinue() {
     await waitForElementById(this.swapSuccessTitleId);
     await tapById(app.common.proceedButtonId);
-  }
-  async delayDeviceActionLoadingCheck() {
-    //ISSUE: LIVE-19300
-    await delay(isSpeculosRemote() && isIos() ? 45_000 : 20_000);
   }
 
   @Step("Get amount to receive")


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
