### PR TITLE
Feat/live 19506 earn deposit entrypoints mobile

### DIFF
--- a/.changeset/four-colts-bake.md
+++ b/.changeset/four-colts-bake.md
@@ -1,0 +1,7 @@
+---
+"live-mobile": minor
+---
+
+Earn live app now includes multi-screen flows. Handle back navigation within live app via webview back press, revert to the native navigation back press when on the initial screen - when view query param is set to 'amount'.
+
+Extract the Earn live app from the WebPTXPlayer and into an independent, minimal Web3AppWebview wrapper that includes only earn-specific handlers.

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -75,7 +75,7 @@ import NoFundsFlowNavigator from "./NoFundsFlowNavigator";
 import StakeFlowNavigator from "./StakeFlowNavigator";
 import { RecoverPlayer } from "~/screens/Protect/Player";
 import { RedirectToOnboardingRecoverFlowScreen } from "~/screens/Protect/RedirectToOnboardingRecoverFlow";
-import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
+import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 import {
   NavigationHeaderCloseButton,
   NavigationHeaderCloseButtonAdvanced,
@@ -96,6 +96,7 @@ import DeviceSelectionNavigator from "LLM/features/DeviceSelection/Navigator";
 import AssetSelectionNavigator from "LLM/features/AssetSelection/Navigator";
 import AssetsListNavigator from "LLM/features/Assets/Navigator";
 import FeesNavigator from "./FeesNavigator";
+import { getStakeLabelLocaleBased } from "~/helpers/getStakeLabelLocaleBased";
 
 const Stack = createStackNavigator<BaseNavigatorStackParamList>();
 
@@ -537,7 +538,19 @@ export default function BaseNavigator() {
         <Stack.Screen
           name={NavigatorName.Earn}
           component={EarnLiveAppNavigator}
-          options={{ headerShown: false }}
+          options={props => {
+            const stakeLabel = getStakeLabelLocaleBased();
+            const intent = props.route?.params?.params?.intent;
+
+            return intent === "deposit" || intent === "withdraw"
+              ? {
+                  headerShown: true,
+                  closable: false,
+                  headerTitle: t(stakeLabel),
+                  headerRight: () => null,
+                }
+              : { headerShown: false };
+          }}
         />
         <Stack.Screen
           name={NavigatorName.NoFundsFlow}

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -99,9 +99,22 @@ const Earn = (props: NavigationProps) => {
           }
           break;
         }
+        case "go-back": {
+          if (navigation.canGoBack()) {
+            navigation.goBack();
+          } else if (navigation.getParent()?.canGoBack()) {
+            navigation.getParent()?.goBack();
+          } else {
+            // Fallback to main earn screen
+            navigation.navigate(NavigatorName.Earn, {
+              screen: ScreenName.Earn,
+              params: props.route.params,
+            });
+          }
+          break;
+        }
         default: {
-          // eslint-disable-next-line no-console
-          console.log(`EarnLiveAppNavigator: No route for action "${paramAction}"`);
+          console.warn(`EarnLiveAppNavigator: No route for action "${paramAction}"`);
         }
       }
     }
@@ -119,6 +132,7 @@ const Earn = (props: NavigationProps) => {
           ...props.route,
           params: {
             platform: "earn",
+            ...props.route.params,
           },
         }}
       />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/EarnLiveAppNavigator.tsx
@@ -126,6 +126,7 @@ const Earn = (props: NavigationProps) => {
 
   return (
     <>
+      {/* EarnScreen contains the EarnWebview */}
       <EarnScreen
         navigation={props.navigation}
         route={{

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/EarnLiveAppNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/EarnLiveAppNavigator.ts
@@ -1,13 +1,16 @@
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { ScreenName } from "~/const";
 
 export type EarnLiveAppNavigatorParamList = {
   [ScreenName.Earn]: {
     accountId?: string;
-    action?: "get-funds" | "stake" | "stake-account" | "info-modal" | "menu-modal";
+    action?: "get-funds" | "stake" | "stake-account" | "info-modal" | "menu-modal" | "go-back";
     currencyId?: string;
     learnMore?: string;
     message?: string;
     messageTitle?: string;
     platform?: string;
+    intent?: "deposit" | "withdraw";
+    cryptoAssetId?: TokenCurrency["id"]; // Only for deposit/withdraw flows
   };
 };

--- a/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.tsx
+++ b/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useContext, useMemo } from "react";
-import { ParamListBase, RouteProp } from "@react-navigation/native";
 import useFeature from "@ledgerhq/live-common/featureFlags/useFeature";
 import { liveAppContext as remoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
 import { LiveAppRegistry } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/types";
@@ -171,7 +170,7 @@ export function useStake() {
         accountId: accountIdForManifestVersion,
       })?.toString();
 
-      if (manifest.id === "earn") {
+      if (manifest.id === "earn" || manifest.id === "earn-stg") {
         // Earn live app uses a different navigator
         return {
           screen: NavigatorName.Earn,

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnWebview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnWebview/index.tsx
@@ -1,0 +1,114 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { StyleSheet, SafeAreaView, BackHandler, Platform } from "react-native";
+import { useSelector } from "react-redux";
+
+import { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { safeGetRefValue } from "@ledgerhq/live-common/wallet-api/react";
+import { safeUrl } from "@ledgerhq/live-common/wallet-api/helpers";
+
+import { useNavigation } from "@react-navigation/native";
+
+import { flattenAccountsSelector } from "~/reducers/accounts";
+
+import { useEarnCustomHandlers } from "./useEarnWebviewCustomHandlers";
+import { initialWebviewState } from "~/components/Web3AppWebview/helpers";
+import { WebviewAPI, WebviewState } from "~/components/Web3AppWebview/types";
+import { Web3AppWebview } from "~/components/Web3AppWebview";
+import { Loading } from "~/components/Loading";
+import {
+  RootNavigationComposite,
+  StackNavigatorNavigation,
+} from "~/components/RootNavigator/types/helpers";
+import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+
+type Props = {
+  manifest: LiveAppManifest;
+  inputs?: Record<string, string | undefined>;
+  disableHeader?: boolean;
+  softExit?: boolean;
+};
+/** Subset of WebPTXPlayer functionality required for Earn live app. */
+export const EarnWebview = ({ manifest, inputs }: Props) => {
+  const webviewAPIRef = useRef<WebviewAPI>(null);
+  const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
+
+  const navigation =
+    useNavigation<RootNavigationComposite<StackNavigatorNavigation<BaseNavigatorStackParamList>>>();
+
+  const handleHardwareBackPress = useCallback(() => {
+    const webview = safeGetRefValue(webviewAPIRef);
+
+    if (webviewState.canGoBack) {
+      webview.goBack();
+      return true; // prevent default behavior (native navigation)
+    }
+
+    return false;
+  }, [webviewState.canGoBack, webviewAPIRef]);
+
+  useEffect(() => {
+    if (Platform.OS === "android") {
+      const subscription = BackHandler.addEventListener(
+        "hardwareBackPress",
+        handleHardwareBackPress,
+      );
+
+      return () => {
+        subscription.remove();
+      };
+    }
+  }, [handleHardwareBackPress]);
+
+  useEffect(() => {
+    const backHandler = (e: { preventDefault: () => void }) => {
+      const webviewAPI = safeGetRefValue(webviewAPIRef);
+      if (webviewState.canGoBack) {
+        webviewAPI.goBack();
+        e.preventDefault();
+      }
+    };
+
+    const url = safeUrl(webviewState.url);
+    const isInitialWebviewStep = url?.searchParams.get("view") === "amount";
+
+    if (isInitialWebviewStep) {
+      navigation.removeListener("beforeRemove", backHandler);
+    } else {
+      navigation.addListener("beforeRemove", backHandler);
+    }
+    return () => {
+      navigation.removeListener("beforeRemove", backHandler);
+    };
+  }, [webviewState.canGoBack, navigation, webviewState.url]);
+
+  const accounts = useSelector(flattenAccountsSelector);
+  const customHandlers = useEarnCustomHandlers(manifest, accounts);
+
+  return (
+    <SafeAreaView style={[styles.root]}>
+      <Web3AppWebview
+        ref={webviewAPIRef}
+        manifest={manifest}
+        inputs={inputs}
+        onStateChange={setWebviewState}
+        customHandlers={customHandlers}
+      />
+      {webviewState.loading ? <Loading /> : null}
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  headerLeft: {
+    display: "flex",
+    flexDirection: "row",
+    paddingRight: 8,
+  },
+  buttons: {
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+  },
+});

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnWebview/useEarnWebviewCustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnWebview/useEarnWebviewCustomHandlers.ts
@@ -1,0 +1,45 @@
+import { handlers as exchangeHandlers } from "@ledgerhq/live-common/wallet-api/Exchange/server";
+import trackingWrapper from "@ledgerhq/live-common/wallet-api/Exchange/tracking";
+import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
+import type { AccountLike } from "@ledgerhq/types-live";
+import { useMemo } from "react";
+import { track } from "~/analytics";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
+import { WebviewProps } from "~/components/Web3AppWebview/types";
+
+import { sendEarnLiveAppReady } from "../../../../../e2e/bridge/client";
+
+export function useEarnCustomHandlers(manifest: WebviewProps["manifest"], accounts: AccountLike[]) {
+  const tracking = useMemo(
+    () =>
+      trackingWrapper((eventName: string, properties?: Record<string, unknown> | null) =>
+        track(eventName, {
+          ...properties,
+          flowInitiatedFrom:
+            currentRouteNameRef.current === "Platform Catalog"
+              ? "Discover"
+              : currentRouteNameRef.current,
+        }),
+      ),
+    [],
+  );
+
+  return useMemo<WalletAPICustomHandlers>(() => {
+    return {
+      ...exchangeHandlers({
+        accounts,
+        tracking,
+        manifest,
+        uiHooks: {
+          // TODO: decouple isReady handler from the Exchange handlers for Swap/Sell. Only isReady is needed for Earn live app.
+          "custom.exchange.start": () => {},
+          "custom.exchange.complete": () => {},
+          "custom.exchange.error": () => {},
+          "custom.isReady": async () => {
+            sendEarnLiveAppReady();
+          },
+        },
+      })["custom.isReady"],
+    };
+  }, [accounts, manifest, tracking]);
+}

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -74,7 +74,6 @@ function Earn({ route }: Props) {
       <TrackScreen category="EarnDashboard" name="Earn" />
       <EarnWebview
         manifest={manifest}
-        disableHeader
         inputs={{
           theme,
           lang: language,

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -57,7 +57,7 @@ function Earn({ route }: Props) {
   const countryLocale = getCountryLocale();
 
   const stakePrograms = useFeature("stakePrograms");
-  const { stakeProgramsParam } = useMemo(
+  const { stakeProgramsParam, stakeCurrenciesParam } = useMemo(
     () => stakeProgramsToEarnParam(stakePrograms),
     [stakePrograms],
   );
@@ -83,6 +83,9 @@ function Earn({ route }: Props) {
           currencyTicker,
           discreetMode: discreet ? "true" : "false",
           stakeProgramsParam: stakeProgramsParam ? JSON.stringify(stakeProgramsParam) : undefined,
+          stakeCurrenciesParam: stakeCurrenciesParam
+            ? JSON.stringify(stakeCurrenciesParam)
+            : undefined,
           OS: Platform.OS,
           ...params,
           ...Object.fromEntries(searchParams.entries()),

--- a/libs/ledger-live-common/src/featureFlags/stakePrograms/index.ts
+++ b/libs/ledger-live-common/src/featureFlags/stakePrograms/index.ts
@@ -1,12 +1,12 @@
 import type { Feature_StakePrograms } from "@ledgerhq/types-live";
 
 export const stakeProgramsToEarnParam = (stakePrograms: Feature_StakePrograms | null) => {
-  const list = stakePrograms?.params?.list ?? [];
+  const list = stakePrograms?.params?.list ?? undefined;
   const redirects = stakePrograms?.params?.redirects ?? {};
   const result: Record<string, string> = {};
   const keys = Object.keys(redirects);
   if (keys.length === 0) {
-    return { stakeProgramsParam: undefined, stakeCurrenciesParam: [] };
+    return { stakeProgramsParam: undefined, stakeCurrenciesParam: list };
   }
   keys.forEach(key => {
     result[key] = redirects[key].platform;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Entrypoints for depositing USDT, USDC, USDS & Dai stablecoins to earn yield via the earn live app. (Behind feature flag)

### 📝 Description

Allow user to open the earn dashboard without the bottom nav when entering via the "deposit" / "withdraw" stablecoin yield entry points
Closing the earn dashboard from any entry point redirects to where the user originated


### ❓ Context

- **JIRA or GitHub link**: 
- [LIVE-19179](https://ledgerhq.atlassian.net/browse/LIVE-19179)
- [LIVE-19506](https://ledgerhq.atlassian.net/browse/LIVE-19506)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
