### PR TITLE
feat: Display APY for Solana validators

### DIFF
--- a/.changeset/few-turkeys-breathe.md
+++ b/.changeset/few-turkeys-breathe.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-solana": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Display APY for Solana validators

--- a/apps/ledger-live-desktop/src/renderer/families/solana/shared/components/ValidatorRow.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/shared/components/ValidatorRow.tsx
@@ -53,15 +53,27 @@ function SolanaValidatorRow({ validator, active, onClick, unit, currency, disabl
       onExternalLink={onExternalLink}
       unit={unit}
       subtitle={
-        <>
-          <Trans i18nKey="solana.delegation.commission" />
-          <Text
-            style={{
-              marginLeft: 5,
-              fontSize: 11,
-            }}
-          >{`${validator.commission} %`}</Text>
-        </>
+        validator.apy ? (
+          <>
+            <Trans i18nKey="solana.delegation.netApy" />
+            <Text
+              style={{
+                marginLeft: 5,
+                fontSize: 11,
+              }}
+            >{`${(validator.apy * 100).toFixed(2)} %`}</Text>
+          </>
+        ) : (
+          <>
+            <Trans i18nKey="solana.delegation.commission" />
+            <Text
+              style={{
+                marginLeft: 5,
+                fontSize: 11,
+              }}
+            >{`${validator.commission} %`}</Text>
+          </>
+        )
       }
       sideInfo={
         <Box

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -3694,6 +3694,7 @@
     "delegation": {
       "totalStake": "Total stake",
       "commission": "Commission",
+      "netApy": "Net APY",
       "delegate": "Add",
       "listHeader": "Delegations",
       "availableBalance": "Withdrawable",

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectValidator.tsx
@@ -202,7 +202,15 @@ const ValidatorRow = ({
             {validator.name || validator.voteAccount}
           </Text>
           <Text fontWeight="semiBold" numberOfLines={1} style={styles.overdelegated}>
-            <Trans i18nKey="solana.delegation.commission" /> {validator.commission} %
+            {validator.apy ? (
+              <>
+                <Trans i18nKey="solana.delegation.netApy" /> {(validator.apy * 100).toFixed(2)} %
+              </>
+            ) : (
+              <>
+                <Trans i18nKey="solana.delegation.commission" /> {validator.commission} %{" "}
+              </>
+            )}
           </Text>
         </View>
         <Text fontWeight="semiBold" numberOfLines={1} style={[styles.validatorYield]} color="smoke">

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -6099,6 +6099,7 @@
       "iWithdraw": "I withdraw",
       "totalStake": "Total stake",
       "commission": "Commission",
+      "netApy": "Net APY",
       "stakeActivationState": "State",
       "stakeActivePercent": "Active",
       "stakeAvailableBalance": "Available balance",

--- a/libs/coin-modules/coin-solana/src/network/validator-app/index.ts
+++ b/libs/coin-modules/coin-solana/src/network/validator-app/index.ts
@@ -24,6 +24,13 @@ export type ValidatorsAppValidator = {
   name?: string | undefined;
   avatarUrl?: string | undefined;
   wwwUrl?: string | undefined;
+  apy?: number | undefined;
+};
+
+type ValidatorApyRaw = {
+  address: string;
+  delegator_apy: number;
+  name: string;
 };
 
 const URLS = {
@@ -36,18 +43,43 @@ const URLS = {
     const baseUrl = getEnv("SOLANA_VALIDATORS_APP_BASE_URL");
     return baseUrl;
   },
+  validatorApylist: "https://api.figment.io/solana/validators_summary", // TODO: use env variable here (earn reverse proxy endpoint)
 };
+
+async function fetchFigmentApy(
+  cluster: Extract<Cluster, "mainnet-beta" | "testnet">,
+): Promise<Record<string, number>> {
+  if (cluster !== "mainnet-beta") return {};
+  try {
+    const response = await network({ method: "GET", url: URLS.validatorApylist });
+
+    if (response.status === 200 && Array.isArray(response.data)) {
+      return response.data.reduce((acc: Record<string, number>, item: ValidatorApyRaw) => {
+        if (typeof item.address === "string" && typeof item.delegator_apy === "number") {
+          acc[item.address] = item.delegator_apy;
+        }
+        return acc;
+      }, {});
+    }
+  } catch (error) {
+    console.warn("Failed to fetch Figment APY", error);
+  }
+
+  return {};
+}
 
 export async function getValidators(
   cluster: Extract<Cluster, "mainnet-beta" | "testnet">,
 ): Promise<ValidatorsAppValidator[]> {
-  const response = await network({
-    method: "GET",
-    url: URLS.validatorList(cluster),
-  });
+  const [validatorsResponse, apyMap] = await Promise.all([
+    network({ method: "GET", url: URLS.validatorList(cluster) }),
+    fetchFigmentApy(cluster),
+  ]);
 
   const allRawValidators =
-    response.status === 200 ? (response.data as ValidatorsAppValidatorRaw[]) : [];
+    validatorsResponse.status === 200
+      ? (validatorsResponse.data as ValidatorsAppValidatorRaw[])
+      : [];
 
   // validators app data is not clean: random properties can randomly contain
   // data, null, undefined
@@ -69,6 +101,7 @@ export async function getValidators(
         name: validator.name ?? undefined,
         avatarUrl: validator.avatar_url ?? undefined,
         wwwUrl: validator.www_url ?? undefined,
+        apy: apyMap[validator.vote_account],
       };
     }
 

--- a/libs/coin-modules/coin-solana/src/utils.ts
+++ b/libs/coin-modules/coin-solana/src/utils.ts
@@ -19,9 +19,10 @@ export const LEDGER_VALIDATOR_BY_FIGMENT: ValidatorsAppValidator = {
   avatarUrl:
     "https://s3.amazonaws.com/keybase_processed_uploads/3c47b62f3d28ecfd821536f69be82905_360_360.jpg",
   wwwUrl: "https://www.ledger.com/staking",
-  activeStake: 9079057178046828,
+  activeStake: 8860644178046828,
   commission: 7,
   totalScore: 6,
+  apy: 0.078107,
 };
 
 export const LEDGER_VALIDATOR_BY_CHORUS_ONE: ValidatorsAppValidator = {
@@ -30,9 +31,10 @@ export const LEDGER_VALIDATOR_BY_CHORUS_ONE: ValidatorsAppValidator = {
   avatarUrl:
     "https://s3.amazonaws.com/keybase_processed_uploads/3c47b62f3d28ecfd821536f69be82905_360_360.jpg",
   wwwUrl: "https://www.ledger.com/staking",
-  activeStake: 10001001000098,
+  activeStake: 110738001000098,
   commission: 7,
   totalScore: 7,
+  apy: 0.07228,
 };
 
 export const LEDGER_VALIDATOR_DEFAULT = LEDGER_VALIDATOR_BY_FIGMENT;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR implements support for displaying `Net APY` in the Solana staking flow, based on the available validator data from Figment API.  When browsing the list of validators, we should see the `Net APY` if available, if not the `commission rate`.

<div>
  <img src="https://github.com/user-attachments/assets/401ffa57-2c85-4c2d-9c4e-efa26aaaa7c7" width="540" style="display: inline-block;" />
  <img src="https://github.com/user-attachments/assets/4e093d8d-ed9a-42e2-a19e-94718db3d234" width="234" style="display: inline-block;" />
</div>



### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-18999

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
