### PR TITLE
CI: Android native builds to be on-demand

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -62,20 +62,11 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
     secrets: inherit
 
-  # LLM
   test-mobile:
     name: "Test Mobile"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
-    secrets: inherit
-
-  # LLM
-  build-mobile:
-    name: "Build Mobile (Native)"
-    needs: determine-affected
-    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/build-mobile-reusable.yml@develop
     secrets: inherit
 
   test-mobile-e2e:
@@ -135,7 +126,6 @@ jobs:
     needs:
       - build-desktop
       - test-desktop
-      - build-mobile
       - test-mobile
       - test-mobile-e2e
       - test-libraries


### PR DESCRIPTION
The staging android native build is only required in very specific circumstances. This is being moved to a manual trigger as it's not required for repo health due to other checks.

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-19786
