### PR TITLE
converting bigint ot bignumber

### DIFF
--- a/.changeset/seven-dryers-agree.md
+++ b/.changeset/seven-dryers-agree.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aptos": minor
+---
+
+fixing value parser

--- a/libs/coin-modules/coin-aptos/src/network/client.ts
+++ b/libs/coin-modules/coin-aptos/src/network/client.ts
@@ -92,7 +92,7 @@ export class AptosAPI {
       this.getHeight(),
     ]);
     return {
-      balance: balance[0].amount ?? BigNumber(0),
+      balance: balance[0]?.amount ?? BigNumber(0),
       transactions,
       blockHeight,
     };

--- a/libs/coin-modules/coin-aptos/src/network/client.ts
+++ b/libs/coin-modules/coin-aptos/src/network/client.ts
@@ -92,7 +92,7 @@ export class AptosAPI {
       this.getHeight(),
     ]);
     return {
-      balance: balance[0].amount ?? BigInt(0),
+      balance: balance[0].amount ?? BigNumber(0),
       transactions,
       blockHeight,
     };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 
- [x] **Impact of the changes:** Bug fix to getBalances when returning account without amount, was setting the amount using BigInt(0), it was causing errors on LLD, changed it to use the BigNumber(0) would fix it as the expected value is a bigNumber. 
  - ...

### 📝 Description
When executing getAccountInfo we call getBalances in order to return all Aptos accounts in blockchain; When a *account* does not have *amount* we were creating a zero-d amount value with BigInt(0) instead of BigNumber(0).
The change would fix the amount as it sets to correct type.  And checking if the balance object has value, otherwise return BigNumber(0).


| Before        | After         |
| ------------- | ------------- |
|      balance: balance[0]?.amount ?? BigInt(0),         |          balance: balance[0].amount ?? BigNumber(0),     |


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-19542


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
