### PR TITLE
Bugfix/local hedera account transactions fetching

### DIFF
--- a/.changeset/chilly-olives-give.md
+++ b/.changeset/chilly-olives-give.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+prevent breaking loop when mirror node returns empty transactions with links.next

--- a/libs/coin-modules/coin-hedera/src/api/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.ts
@@ -75,10 +75,12 @@ export async function getAccountTransactions(
 
   let nextUrl = `/api/v1/transactions?${params.toString()}`;
 
+  // WARNING: don't break the loop when `transactions` array is empty but `links.next` is present
+  // the mirror node API enforces a 60-day max time range per query, even if `timestamp` param is set
+  // see: https://hedera.com/blog/changes-to-the-hedera-operated-mirror-node
   while (nextUrl) {
     const res = await fetch(nextUrl);
     const newTransactions = res.data.transactions as HederaMirrorTransaction[];
-    if (newTransactions.length === 0) break;
     transactions.push(...newTransactions);
     nextUrl = res.data.links.next;
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Prevents incorrect termination of transaction pagination when using the Hedera mirror node API

### 📝 Description

Issue: [LIVE-19817](https://ledgerhq.atlassian.net/browse/LIVE-19817)

This change fixes a bug in the transaction pagination logic where the loop was prematurely exited when `res.data.transactions` was empty. That condition was originally added as an optimization, based on the assumption that an empty transactions array with a links.next field indicated a mirror node pagination bug.

However, this assumption was incorrect. The API documentation does not mention that the mirror node enforces a 60-day implicit limit on result ranges - even when a custom timestamp parameter is provided.

Due to this behavior, responses may contain an empty transactions array while still including a valid `links.next`, which can cause the loop to exit too early and miss data. Here is an example of account.id that won't see any operations in LL: https://mainnet-public.mirrornode.hedera.com/api/v1/transactions?account.id=0.0.751515&order=desc&limit=100

This behavior is undocumented in the API itself. I found it in the following Hedera blog post:
https://hedera.com/blog/changes-to-the-hedera-operated-mirror-node

The fix removes the early break and adds an explanatory comment to prevent future confusion.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19817]: https://ledgerhq.atlassian.net/browse/LIVE-19817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ