### PR TITLE
bugfix: banner translation

### DIFF
--- a/.changeset/healthy-mangos-run.md
+++ b/.changeset/healthy-mangos-run.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix banner not displaying correct language when switching from one to another

--- a/apps/ledger-live-desktop/src/renderer/components/Updater/Banner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Updater/Banner.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from "react";
-import { Trans } from "react-i18next";
+import React, { useContext, useMemo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
 import IconUpdate from "~/renderer/icons/Update";
@@ -9,6 +9,7 @@ import Spinner from "~/renderer/components/Spinner";
 import TopBanner, { FakeLink, Content } from "~/renderer/components/TopBanner";
 import { UpdaterContext } from "./UpdaterContext";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { TFunction } from "i18next";
 
 export const VISIBLE_STATUS = [
   "download-progress",
@@ -18,88 +19,66 @@ export const VISIBLE_STATUS = [
   "update-available",
   "downloading-update",
 ];
-const CONTENT_BY_STATUS = (
+
+const getContentByStatus = (
   quitAndInstall: () => void,
   reDownload: () => void,
   progress: number,
   version: string,
-): {
-  [x: string]: Content;
-} => ({
+  t: TFunction,
+): Record<string, Content> => ({
   "download-progress": {
     Icon: Spinner,
-    message: <Trans i18nKey="update.downloadInProgress" />,
-    right: (
-      <Trans
-        i18nKey="update.downloadProgress"
-        values={{
-          progress,
-        }}
-      />
-    ),
+    message: t("update.downloadInProgress"),
+    right: t("update.downloadProgress", { progress }),
   },
   checking: {
     Icon: IconDonjon,
-    message: <Trans i18nKey="update.checking" />,
+    message: t("update.checking"),
   },
   "check-success": {
     Icon: IconUpdate,
-    message: <Trans i18nKey="update.checkSuccess" />,
-    right: (
-      <FakeLink onClick={quitAndInstall}>
-        <Trans i18nKey="update.quitAndInstall" />
-      </FakeLink>
-    ),
+    message: t("update.checkSuccess"),
+    right: <FakeLink onClick={quitAndInstall}>{t("update.quitAndInstall")}</FakeLink>,
   },
   "downloading-update": {
     Icon: IconUpdate,
-    message: <Trans i18nKey="update.downloadInProgress" />,
+    message: t("update.downloadInProgress"),
   },
   "update-available": {
     Icon: IconUpdate,
-    message: (
-      <Trans
-        i18nKey="update.updateAvailable"
-        values={{
-          version,
-        }}
-      />
-    ),
+    message: t("update.updateAvailable", { version }),
   },
   error: {
     Icon: IconWarning,
-    message: <Trans i18nKey="update.error" />,
-    right: (
-      <FakeLink onClick={reDownload}>
-        <Trans i18nKey="update.reDownload" />
-      </FakeLink>
-    ),
+    message: t("update.error"),
+    right: <FakeLink onClick={reDownload}>{t("update.reDownload")}</FakeLink>,
   },
 });
-const UpdaterTopBanner = () => {
+
+const UpdaterTopBanner: React.FC = () => {
   const context = useContext(UpdaterContext);
   const urlLive = useLocalizedUrl(urls.liveHome);
-  const reDownload = () => {
+  const { t } = useTranslation();
+
+  const reDownload = useCallback(() => {
     openURL(urlLive);
-  };
-  if (context && context.version) {
+  }, [urlLive]);
+
+  const content = useMemo(() => {
+    if (!context?.version || !VISIBLE_STATUS.includes(context.status)) return null;
     const { status, quitAndInstall, downloadProgress, version } = context;
-    if (!VISIBLE_STATUS.includes(status)) return null;
-    const content: Content | undefined | null = CONTENT_BY_STATUS(
-      quitAndInstall,
-      reDownload,
-      downloadProgress,
-      version,
-    )[status];
-    if (!content) return null;
-    return (
-      <TopBanner
-        testId="layout-app-update-banner"
-        content={content}
-        status={status === "error" ? "alertRed" : "warning"}
-      />
-    );
-  }
-  return null;
+    return getContentByStatus(quitAndInstall, reDownload, downloadProgress, version, t)[status];
+  }, [context, reDownload, t]);
+
+  if (!content) return null;
+
+  return (
+    <TopBanner
+      testId="layout-app-update-banner"
+      content={content}
+      status={context?.status === "error" ? "alertRed" : "warning"}
+    />
+  );
 };
 export default UpdaterTopBanner;

--- a/apps/ledger-live-desktop/src/renderer/components/Updater/UpdaterTopBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Updater/UpdaterTopBanner.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { MaybeUpdateContextType, UpdaterContext } from "./UpdaterContext";
+import UpdaterTopBanner, { VISIBLE_STATUS } from "./Banner";
+import { act, render, screen } from "tests/testSetup";
+
+const defaultContext = {
+  version: "1.0.0",
+  quitAndInstall: jest.fn(),
+  downloadProgress: 42,
+  setStatus: jest.fn(),
+  error: null,
+};
+
+describe("UpdaterTopBanner", () => {
+  it.each(VISIBLE_STATUS)("should render TopBanner for status '%s'", status => {
+    const context: MaybeUpdateContextType = {
+      ...defaultContext,
+      status: status as UpdateStatus,
+    };
+    render(
+      <UpdaterContext.Provider value={context}>
+        <UpdaterTopBanner />
+      </UpdaterContext.Provider>,
+    );
+    expect(screen.queryByTestId("layout-app-update-banner")).toBeInTheDocument();
+  });
+
+  it("should not render TopBanner for unknown status", () => {
+    const context: MaybeUpdateContextType = {
+      ...defaultContext,
+      status: "unknown-status" as UpdateStatus,
+    };
+    render(
+      <UpdaterContext.Provider value={context}>
+        <UpdaterTopBanner />
+      </UpdaterContext.Provider>,
+    );
+    expect(screen.queryByTestId("layout-app-update-banner")).not.toBeInTheDocument();
+  });
+
+  it("should not render TopBanner if context is missing version", () => {
+    const context: MaybeUpdateContextType = {
+      ...defaultContext,
+      status: "download-progress",
+      quitAndInstall: jest.fn(),
+      downloadProgress: 42,
+      version: undefined,
+    };
+    render(
+      <UpdaterContext.Provider value={context}>
+        <UpdaterTopBanner />
+      </UpdaterContext.Provider>,
+    );
+    expect(screen.queryByTestId("layout-app-update-banner")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["check-success", "update.quitAndInstall"],
+    ["error", "update.reDownload"],
+  ])("should render a clickable element in right for status '%s'", (status, matcherOrKey) => {
+    const context: MaybeUpdateContextType = {
+      ...defaultContext,
+      status: status as UpdateStatus,
+    };
+    const { i18n } = render(
+      <UpdaterContext.Provider value={context}>
+        <UpdaterTopBanner />
+      </UpdaterContext.Provider>,
+    );
+
+    expect(screen.getByText(i18n.t(matcherOrKey))).toBeInTheDocument();
+  });
+
+  it("should render the right progress text for status 'download-progress'", () => {
+    const context: MaybeUpdateContextType = {
+      ...defaultContext,
+      status: "download-progress",
+      downloadProgress: 42,
+    };
+    render(
+      <UpdaterContext.Provider value={context}>
+        <UpdaterTopBanner />
+      </UpdaterContext.Provider>,
+    );
+    expect(screen.getByText(/42% completed/)).toBeInTheDocument();
+  });
+
+  it("should update the banner text when language changes", async () => {
+    const context: MaybeUpdateContextType = {
+      ...defaultContext,
+      status: "update-available",
+    };
+    const { i18n } = render(
+      <UpdaterContext.Provider value={context}>
+        <UpdaterTopBanner />
+      </UpdaterContext.Provider>,
+    );
+
+    expect(
+      screen.getByText(`Update to Ledger Live version ${context.version} is available`),
+    ).toBeInTheDocument();
+    await act(async () => {
+      await i18n.changeLanguage("fr");
+    });
+
+    expect(
+      screen.getByText(`Mise à jour disponible vers la version Ledger Live ${context.version}`),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/components/debug/DebugUpdater.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/debug/DebugUpdater.tsx
@@ -12,6 +12,7 @@ const statusToDebug: UpdateStatus[] = [
   "check-success",
   "update-available",
   "download-progress",
+  "downloading-update",
   "error",
 ];
 const ExposeUpdaterWhenInMock = () => {

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -41,6 +41,7 @@ interface RenderReturn {
   store: ReturnType<typeof createStore>;
   user: ReturnType<typeof userEvent.setup>;
   container: HTMLElement;
+  i18n: typeof i18n;
 }
 type DeepPartial<T> = T extends Function
   ? T
@@ -130,6 +131,7 @@ function renderWithMockedCounterValuesProvider(
 
   return {
     store,
+    i18n,
     user: userEvent.setup(userEventOptions),
     ...rtlRender(ui, {
       wrapper: ({ children }) => (
@@ -162,6 +164,7 @@ function render(ui: JSX.Element, options: ExtraOptions = {}): RenderReturn {
 
   return {
     store,
+    i18n,
     user: userEvent.setup(userEventOptions),
     ...rtlRender(ui, {
       wrapper: ({ children }) => <Providers store={store}>{children}</Providers>,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


**UpdaterTopBanner (Desktop)**

* **Refactored** `Banner.tsx`: simplified logic, improved type safety, optimized use of React hooks (`useMemo`, `useCallback`), and enhanced overall readability.
* **Fixed** multilingual support: the banner now correctly reflects language changes dynamically.
* **Added and improved** unit tests: full coverage of all status variants, the `right` field, progress indicator, and responsiveness to language changes (`i18n`).


https://github.com/user-attachments/assets/6fa500ed-ec72-41b2-8388-c59a09afad99




### ❓ Context

- **JIRA or GitHub link**: [LIVE-17282] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-17282]: https://ledgerhq.atlassian.net/browse/LIVE-17282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ