### PR TITLE
ci: Move push to use dedicated mock flow and remove native builds

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -69,8 +69,8 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
     secrets: inherit
 
-  test-mobile-e2e:
-    name: "Build & Test Mobile (Mocked)"
+  build-test-mobile:
+    name: "Build & Test Mobile"
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-mock-reusable.yml@develop
@@ -127,7 +127,7 @@ jobs:
       - build-desktop
       - test-desktop
       - test-mobile
-      - test-mobile-e2e
+      - build-test-mobile
       - test-libraries
       - test-design-system
       - build-web-tools

--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -24,21 +24,19 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
     secrets: inherit
 
-  # LLM
-  build-mobile:
-    name: "Build Mobile"
-    uses: LedgerHQ/ledger-live/.github/workflows/build-mobile-reusable.yml@develop
-    secrets: inherit
-
   test-mobile:
     name: "Test Mobile"
     uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-reusable.yml@develop
     secrets: inherit
 
-  test-mobile-e2e:
-    name: "Test Mobile E2E"
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-reusable.yml@develop
+  build-test-mobile:
+    name: "Build & Test Mobile"
+    needs: determine-affected
+    if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-mobile') && !github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-mock-reusable.yml@develop
     secrets: inherit
+    with:
+      macos-specificity-runner-label: "performance-pool"
 
   # Tests
   test-libraries:
@@ -69,7 +67,7 @@ jobs:
       - test-desktop
       - build-mobile
       - test-mobile
-      - test-mobile-e2e
+      - build-test-mobile
       - test-libraries
       - test-design-system
       - build-web-tools


### PR DESCRIPTION
Cleanup tasks following https://github.com/LedgerHQ/ledger-live/pull/10430

This PR completes the process of separating E2E flows from PR lifecycle runs