### PR TITLE
feat: send/receive HTS tokens - small coin-hedera refactor and basic logic (part 2)

### DIFF
--- a/libs/coin-modules/coin-hedera/package.json
+++ b/libs/coin-modules/coin-hedera/package.json
@@ -86,6 +86,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",
     "expect": "^27.4.6",
+    "imurmurhash": "^0.1.4",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
     "rxjs": "^7.8.1"
@@ -93,6 +94,7 @@
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",
     "@ledgerhq/types-cryptoassets": "workspace:^",
+    "@types/imurmurhash": "^0.1.4",
     "@types/invariant": "^2.2.2",
     "@types/jest": "^29.5.10",
     "@types/lodash": "^4.14.191",

--- a/libs/coin-modules/coin-hedera/src/api/mirror.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.ts
@@ -1,12 +1,8 @@
-import { AccountId } from "@hashgraph/sdk";
 import network from "@ledgerhq/live-network/network";
-import { Operation, OperationType } from "@ledgerhq/types-live";
-import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
-import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
-import { getAccountBalance } from "./network";
-import { base64ToUrlSafeBase64 } from "../bridge/utils";
-import { HederaOperationExtra } from "../types";
+import type { HederaMirrorAccount, HederaMirrorToken, HederaMirrorTransaction } from "./types";
+import { HederaAddAccountError } from "../errors";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
 
 const getMirrorApiUrl = (): string => getEnv("API_HEDERA_MIRROR");
 
@@ -17,45 +13,33 @@ const fetch = (path: string) => {
   });
 };
 
-interface HederaMirrorAccount {
-  accountId: AccountId;
-  balance: BigNumber;
-}
-
 export async function getAccountsForPublicKey(publicKey: string): Promise<HederaMirrorAccount[]> {
   let r;
   try {
-    r = await fetch(`/api/v1/accounts?account.publicKey=${publicKey}&balance=false`);
+    r = await fetch(`/api/v1/accounts?account.publicKey=${publicKey}&balance=true&limit=100`);
   } catch (e: any) {
     if (e.name === "LedgerAPI4xx") return [];
     throw e;
   }
-  const rawAccounts = r.data.accounts;
-  const accounts: HederaMirrorAccount[] = [];
 
-  for (const raw of rawAccounts) {
-    const accountBalance = await getAccountBalance(raw.account);
-
-    accounts.push({
-      accountId: AccountId.fromString(raw.account),
-      balance: accountBalance.balance,
-    });
-  }
+  const accounts = r.data.accounts as HederaMirrorAccount[];
 
   return accounts;
 }
 
-interface HederaMirrorTransfer {
-  account: string;
-  amount: number;
-}
+export async function getAccount(address: string): Promise<HederaMirrorAccount> {
+  try {
+    const res = await fetch(`/api/v1/accounts/${address}`);
+    const account = res.data as HederaMirrorAccount;
 
-interface HederaMirrorTransaction {
-  transfers: HederaMirrorTransfer[];
-  charged_tx_fee: string;
-  transaction_hash: string;
-  consensus_timestamp: string;
-  transaction_id: string;
+    return account;
+  } catch (error) {
+    if (error instanceof LedgerAPI4xx && "status" in error && error.status === 404) {
+      throw new HederaAddAccountError();
+    }
+
+    throw error;
+  }
 }
 
 export async function getAccountTransactions(
@@ -88,85 +72,20 @@ export async function getAccountTransactions(
   return transactions;
 }
 
-export async function getOperationsForAccount(
-  ledgerAccountId: string,
-  address: string,
-  latestOperationTimestamp: string | null,
-): Promise<Operation[]> {
-  const rawOperations = await getAccountTransactions(address, latestOperationTimestamp);
-  const operations: Operation[] = [];
+export async function getAccountTokens(address: string): Promise<HederaMirrorToken[]> {
+  const tokens: HederaMirrorToken[] = [];
+  const params = new URLSearchParams({
+    limit: "100",
+  });
 
-  for (const raw of rawOperations) {
-    const { consensus_timestamp, transaction_id } = raw;
-    const timestamp = new Date(parseInt(consensus_timestamp.split(".")[0], 10) * 1000);
-    const senders: string[] = [];
-    const recipients: string[] = [];
-    const fee = new BigNumber(raw.charged_tx_fee);
-    let value = new BigNumber(0);
-    let type: OperationType = "NONE";
+  let nextUrl = `/api/v1/accounts/${address}/tokens?${params.toString()}`;
 
-    for (let i = raw.transfers.length - 1; i >= 0; i--) {
-      const transfer = raw.transfers[i];
-      const amount = new BigNumber(transfer.amount);
-      const account = AccountId.fromString(transfer.account);
-
-      if (transfer.account === address) {
-        if (amount.isNegative()) {
-          value = amount.abs();
-          type = "OUT";
-        } else {
-          value = amount;
-          type = "IN";
-        }
-      }
-
-      if (amount.isNegative()) {
-        senders.push(transfer.account);
-      } else {
-        if (account.shard.eq(0) && account.realm.eq(0)) {
-          if (account.num.lt(100)) {
-            // account is a node, only add to list if we have none
-            if (recipients.length === 0) {
-              recipients.push(transfer.account);
-            }
-          } else if (account.num.lt(1000)) {
-            // account is a system account that is not a node
-            // do NOT add
-          } else {
-            recipients.push(transfer.account);
-          }
-        } else {
-          recipients.push(transfer.account);
-        }
-      }
-    }
-
-    // NOTE: earlier addresses are the "fee" addresses
-    recipients.reverse();
-    senders.reverse();
-
-    const hash = base64ToUrlSafeBase64(raw.transaction_hash);
-
-    operations.push({
-      value,
-      date: timestamp,
-      // NOTE: there are no "blocks" in hedera
-      // Set a value just so that it's considered confirmed according to isConfirmedOperation
-      blockHeight: 5,
-      blockHash: null,
-      extra: {
-        consensusTimestamp: consensus_timestamp,
-        transactionId: transaction_id,
-      } satisfies HederaOperationExtra,
-      fee,
-      hash,
-      recipients,
-      senders,
-      accountId: ledgerAccountId,
-      id: encodeOperationId(ledgerAccountId, hash, type),
-      type,
-    });
+  while (nextUrl) {
+    const res = await fetch(nextUrl);
+    const newTokens = res.data.tokens as HederaMirrorToken[];
+    tokens.push(...newTokens);
+    nextUrl = res.data.links.next;
   }
 
-  return operations;
+  return tokens;
 }

--- a/libs/coin-modules/coin-hedera/src/api/types.ts
+++ b/libs/coin-modules/coin-hedera/src/api/types.ts
@@ -1,0 +1,48 @@
+type FreezeStatus = "NOT_APPLICABLE" | "FROZEN" | "UNFROZEN";
+
+type KycStatus = "NOT_APPLICABLE" | "GRANTED" | "REVOKED";
+
+export interface HederaMirrorCoinTransfer {
+  account: string;
+  amount: number;
+}
+
+export interface HederaMirrorTokenTransfer {
+  token_id: string;
+  account: string;
+  amount: number;
+  is_approval?: boolean;
+}
+
+export interface HederaMirrorTransaction {
+  transfers: HederaMirrorCoinTransfer[];
+  token_transfers: HederaMirrorTokenTransfer[];
+  charged_tx_fee: string;
+  transaction_hash: string;
+  consensus_timestamp: string;
+  result: string;
+  name: string;
+}
+
+export interface HederaMirrorToken {
+  automatic_association: boolean;
+  balance: number;
+  created_timestamp: string;
+  decimals: number;
+  token_id: string;
+  freeze_status: FreezeStatus;
+  kyc_status: KycStatus;
+}
+
+export interface HederaMirrorAccount {
+  account: string;
+  max_automatic_token_associations: number;
+  balance: {
+    balance: number;
+    timestamp: string;
+    tokens: {
+      token_id: string;
+      balance: number;
+    }[];
+  };
+}

--- a/libs/coin-modules/coin-hedera/src/api/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/api/utils.ts
@@ -1,0 +1,130 @@
+import BigNumber from "bignumber.js";
+import { AccountId } from "@hashgraph/sdk";
+import type { Operation, OperationType } from "@ledgerhq/types-live";
+import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
+import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account";
+import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
+import type { HederaMirrorTokenTransfer, HederaMirrorCoinTransfer } from "./types";
+import { getAccountTransactions } from "./mirror";
+import { base64ToUrlSafeBase64 } from "../bridge/utils";
+
+function isValidRecipient(accountId: AccountId, recipients: string[]): boolean {
+  if (accountId.shard.eq(0) && accountId.realm.eq(0)) {
+    // account is a node, only add to list if we have none
+    if (accountId.num.lt(100)) {
+      return recipients.length === 0;
+    }
+
+    // account is a system account that is not a node, do NOT add
+    if (accountId.num.lt(1000)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function parseTransfers(
+  mirrorTransfers: (HederaMirrorCoinTransfer | HederaMirrorTokenTransfer)[],
+  address: string,
+): Pick<Operation, "type" | "value" | "senders" | "recipients"> {
+  let value = new BigNumber(0);
+  let type: OperationType = "NONE";
+
+  const senders: string[] = [];
+  const recipients: string[] = [];
+
+  for (const transfer of mirrorTransfers) {
+    const amount = new BigNumber(transfer.amount);
+    const accountId = AccountId.fromString(transfer.account);
+
+    if (transfer.account === address) {
+      value = amount.abs();
+      type = amount.isNegative() ? "OUT" : "IN";
+    }
+
+    if (amount.isNegative()) {
+      senders.push(transfer.account);
+    } else if (isValidRecipient(accountId, recipients)) {
+      recipients.push(transfer.account);
+    }
+  }
+
+  // NOTE: earlier addresses are the "fee" addresses
+  senders.reverse();
+  recipients.reverse();
+
+  return {
+    type,
+    value,
+    senders,
+    recipients,
+  };
+}
+
+export async function getOperationsForAccount(
+  ledgerAccountId: string,
+  address: string,
+  latestOperationTimestamp: string | null,
+): Promise<{
+  coinOperations: Operation[];
+  tokenOperations: Operation[];
+}> {
+  const mirrorTransactions = await getAccountTransactions(address, latestOperationTimestamp);
+  const coinOperations: Operation[] = [];
+  const tokenOperations: Operation[] = [];
+
+  for (const rawTx of mirrorTransactions) {
+    const timestamp = new Date(parseInt(rawTx.consensus_timestamp.split(".")[0], 10) * 1000);
+    const hash = base64ToUrlSafeBase64(rawTx.transaction_hash);
+    const fee = new BigNumber(rawTx.charged_tx_fee);
+    const tokenTransfers = rawTx.token_transfers ?? [];
+    const transfers = rawTx.transfers ?? [];
+    const hasFailed = rawTx.result !== "SUCCESS";
+
+    if (tokenTransfers.length > 0) {
+      const tokenId = rawTx.token_transfers[0].token_id;
+      const token = findTokenByAddressInCurrency(tokenId, "hedera");
+      if (!token) continue;
+
+      const encodedTokenId = encodeTokenAccountId(ledgerAccountId, token);
+      const { type, value, senders, recipients } = parseTransfers(rawTx.token_transfers, address);
+
+      tokenOperations.push({
+        id: encodeOperationId(encodedTokenId, hash, type),
+        accountId: encodedTokenId,
+        type,
+        value,
+        recipients,
+        senders,
+        hash,
+        fee,
+        date: timestamp,
+        blockHeight: 5,
+        blockHash: null,
+        hasFailed,
+        extra: { consensusTimestamp: rawTx.consensus_timestamp },
+      });
+    } else if (transfers.length > 0) {
+      const { type, value, senders, recipients } = parseTransfers(rawTx.transfers, address);
+
+      coinOperations.push({
+        id: encodeOperationId(ledgerAccountId, hash, type),
+        accountId: ledgerAccountId,
+        type,
+        value,
+        recipients,
+        senders,
+        hash,
+        fee,
+        date: timestamp,
+        blockHeight: 5,
+        blockHash: null,
+        hasFailed,
+        extra: { consensusTimestamp: rawTx.consensus_timestamp },
+      });
+    }
+  }
+
+  return { coinOperations, tokenOperations };
+}

--- a/libs/coin-modules/coin-hedera/src/bridge/broadcast.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/broadcast.ts
@@ -4,6 +4,7 @@ import { patchOperationWithHash } from "@ledgerhq/coin-framework/operation";
 import { base64ToUrlSafeBase64, patchOperationWithExtra } from "./utils";
 import { HederaOperationExtra, Transaction } from "../types";
 import { broadcastTransaction } from "../api/network";
+import { isValidExtra } from "../logic";
 
 export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({ signedOperation }) => {
   const { signature, operation } = signedOperation;
@@ -16,6 +17,7 @@ export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({ signe
   const base64Hash = Buffer.from(response.transactionHash).toString("base64");
   const base64HashUrlSafe = base64ToUrlSafeBase64(base64Hash);
   const extra: HederaOperationExtra = {
+    ...(isValidExtra(operation.extra) ? operation.extra : {}),
     transactionId: response.transactionId.toString(),
   };
 

--- a/libs/coin-modules/coin-hedera/src/bridge/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/buildOptimisticOperation.ts
@@ -1,21 +1,29 @@
-import { Account, Operation } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import type { Account, Operation, OperationType, TokenAccount } from "@ledgerhq/types-live";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
+import { findSubAccountById, isTokenAccount } from "@ledgerhq/coin-framework/account/helpers";
+import type { Transaction } from "../types";
 import { getEstimatedFees } from "./utils";
-import { Transaction } from "../types";
 
-export const buildOptimisticOperation = async ({
+const buildOptimisticCoinOperation = async ({
   account,
   transaction,
+  transactionType,
 }: {
   account: Account;
   transaction: Transaction;
+  transactionType?: OperationType;
 }): Promise<Operation> => {
+  const estimatedFee = await getEstimatedFees(account, "CryptoTransfer");
+  const value = transaction.amount;
+  const type: OperationType = transactionType ?? "OUT";
+
   const operation: Operation = {
-    id: encodeOperationId(account.id, "", "OUT"),
+    id: encodeOperationId(account.id, "", type),
     hash: "",
-    type: "OUT",
-    value: transaction.amount,
-    fee: await getEstimatedFees(account),
+    type,
+    value,
+    fee: estimatedFee,
     blockHash: null,
     blockHeight: null,
     senders: [account.freshAddress.toString()],
@@ -26,4 +34,67 @@ export const buildOptimisticOperation = async ({
   };
 
   return operation;
+};
+
+const buildOptimisticTokenOperation = async ({
+  account,
+  tokenAccount,
+  transaction,
+}: {
+  account: Account;
+  tokenAccount: TokenAccount;
+  transaction: Transaction;
+}): Promise<Operation> => {
+  const estimatedFee = await getEstimatedFees(account, "TokenTransfer");
+  const value = transaction.amount;
+  const type: OperationType = "OUT";
+
+  const coinOperation = await buildOptimisticCoinOperation({
+    account,
+    transaction: {
+      ...transaction,
+      recipient: tokenAccount.token.contractAddress,
+      amount: new BigNumber(0),
+    },
+    transactionType: "FEES",
+  });
+
+  const operation: Operation = {
+    ...coinOperation,
+    subOperations: [
+      {
+        id: encodeOperationId(tokenAccount.id, "", type),
+        hash: "",
+        type,
+        value,
+        fee: estimatedFee,
+        blockHash: null,
+        blockHeight: null,
+        senders: [account.freshAddress.toString()],
+        recipients: [transaction.recipient],
+        accountId: tokenAccount.id,
+        date: new Date(),
+        extra: {},
+      },
+    ],
+  };
+
+  return operation;
+};
+
+export const buildOptimisticOperation = async ({
+  account,
+  transaction,
+}: {
+  account: Account;
+  transaction: Transaction;
+}): Promise<Operation> => {
+  const subAccount = findSubAccountById(account, transaction.subAccountId || "");
+  const isTokenTransaction = isTokenAccount(subAccount);
+
+  if (isTokenTransaction) {
+    return buildOptimisticTokenOperation({ account, tokenAccount: subAccount, transaction });
+  } else {
+    return buildOptimisticCoinOperation({ account, transaction });
+  }
 };

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
@@ -6,21 +6,30 @@ import {
   RecipientRequired,
 } from "@ledgerhq/errors";
 import { AccountId } from "@hashgraph/sdk";
-import type { AccountBridge } from "@ledgerhq/types-live";
+import type { Account, AccountBridge } from "@ledgerhq/types-live";
 import { calculateAmount, getEstimatedFees } from "./utils";
-import type { Transaction } from "../types";
+import type { HederaOperationType, Transaction, TransactionStatus } from "../types";
+import { findSubAccountById, isTokenAccount } from "@ledgerhq/coin-framework/account";
 
-export const getTransactionStatus: AccountBridge<Transaction>["getTransactionStatus"] = async (
-  account,
-  transaction,
-) => {
+export const getTransactionStatus: AccountBridge<
+  Transaction,
+  Account,
+  TransactionStatus
+>["getTransactionStatus"] = async (account, transaction) => {
   const errors: Record<string, Error> = {};
+  const warnings: Record<string, Error> = {};
+
+  const subAccount = findSubAccountById(account, transaction?.subAccountId || "");
+  const isTokenTransaction = isTokenAccount(subAccount);
+  const operationType: HederaOperationType = isTokenTransaction
+    ? "TokenTransfer"
+    : "CryptoTransfer";
 
   if (!transaction.recipient || transaction.recipient.length === 0) {
-    errors.recipient = new RecipientRequired("");
+    errors.recipient = new RecipientRequired();
   } else {
     if (account.freshAddress === transaction.recipient) {
-      errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource("");
+      errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
     }
 
     try {
@@ -32,24 +41,38 @@ export const getTransactionStatus: AccountBridge<Transaction>["getTransactionSta
     }
   }
 
-  const { amount, totalSpent } = await calculateAmount({
-    transaction,
-    account,
-  });
+  const [calculatedAmount, estimatedFees] = await Promise.all([
+    calculateAmount({ transaction, account }),
+    getEstimatedFees(account, operationType),
+  ]);
 
   if (transaction.amount.eq(0) && !transaction.useAllAmount) {
     errors.amount = new AmountRequired();
-  } else if (account.balance.isLessThan(totalSpent)) {
-    errors.amount = new NotEnoughBalance("");
   }
 
-  const estimatedFees = await getEstimatedFees(account);
+  if (isTokenTransaction) {
+    if (subAccount.balance.isLessThan(calculatedAmount.totalSpent)) {
+      errors.amount = new NotEnoughBalance();
+    }
+
+    if (account.balance.isLessThan(estimatedFees)) {
+      errors.amount = new NotEnoughBalance();
+    }
+  } else {
+    if (transaction.amount.eq(0) && !transaction.useAllAmount) {
+      errors.amount = new AmountRequired();
+    }
+
+    if (account.balance.isLessThan(calculatedAmount.totalSpent)) {
+      errors.amount = new NotEnoughBalance("");
+    }
+  }
 
   return {
-    amount,
+    amount: calculatedAmount.amount,
     errors,
     estimatedFees,
-    totalSpent,
-    warnings: {},
+    totalSpent: calculatedAmount.totalSpent,
+    warnings,
   };
 };

--- a/libs/coin-modules/coin-hedera/src/bridge/js-estimateMaxSpendable.integration.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/js-estimateMaxSpendable.integration.test.ts
@@ -49,7 +49,7 @@ describe("js-estimateMaxSpendable", () => {
   beforeAll(async () => {
     const signer = jest.fn();
     bridge = createBridges(signer);
-    estimatedFees = await getEstimatedFees(account);
+    estimatedFees = await getEstimatedFees(account, "CryptoTransfer");
   });
 
   test("estimateMaxSpendable", async () => {

--- a/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.ts
@@ -9,12 +9,11 @@ import { calculateAmount } from "./utils";
  * Hedera has fully client-side transactions and the fee
  * is not possible to estimate ahead-of-time.
  *
- * @returns  {Transaction}
  */
 export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"] = async (
   account,
   transaction,
-) => {
+): Promise<Transaction> => {
   // explicitly calculate transaction amount to account for `useAllAmount` flag (send max flow)
   // i.e. if `useAllAmount` has been toggled to true, this is where it will update the transaction to reflect that action
   const { amount } = await calculateAmount({ account, transaction });

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.integration.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.integration.test.ts
@@ -53,7 +53,7 @@ describe("utils", () => {
   let estimatedFees = new BigNumber("150200").multipliedBy(2); // 0.001502 ℏ (as of 2023-03-14)
 
   beforeAll(async () => {
-    estimatedFees = await getEstimatedFees(account);
+    estimatedFees = await getEstimatedFees(account, "CryptoTransfer");
   });
 
   test("calculateAmount transaction.useAllAmount = true", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic.ts
+++ b/libs/coin-modules/coin-hedera/src/logic.ts
@@ -1,15 +1,21 @@
-import { ExplorerView } from "@ledgerhq/types-cryptoassets";
-import { Operation } from "@ledgerhq/types-live";
-
-import { HederaOperationExtra } from "./types";
+import type { ExplorerView } from "@ledgerhq/types-cryptoassets";
+import type { Operation } from "@ledgerhq/types-live";
+import type { HederaOperationExtra } from "./types";
 
 const getTransactionExplorer = (
   explorerView: ExplorerView | null | undefined,
   operation: Operation,
 ): string | undefined => {
-  const extra = operation.extra as HederaOperationExtra;
+  const extra = isValidExtra(operation.extra) ? operation.extra : null;
 
-  return explorerView?.tx?.replace("$hash", extra.consensusTimestamp ?? extra.transactionId ?? "0");
+  return explorerView?.tx?.replace(
+    "$hash",
+    extra?.consensusTimestamp ?? extra?.transactionId ?? "0",
+  );
 };
 
-export { getTransactionExplorer };
+const isValidExtra = (extra: unknown): extra is HederaOperationExtra => {
+  return !!extra && typeof extra === "object" && !Array.isArray(extra);
+};
+
+export { getTransactionExplorer, isValidExtra };

--- a/libs/coin-modules/coin-hedera/src/types/bridge.ts
+++ b/libs/coin-modules/coin-hedera/src/types/bridge.ts
@@ -1,4 +1,5 @@
 import type {
+  Operation,
   TransactionCommon,
   TransactionCommonRaw,
   TransactionStatusCommon,
@@ -31,3 +32,7 @@ export type HederaOperationExtra = {
   consensusTimestamp?: string;
   transactionId?: string;
 };
+
+export type HederaOperationType = "CryptoTransfer" | "TokenTransfer";
+
+export type HederaOperation = Operation<HederaOperationExtra>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3000,6 +3000,9 @@ importers:
       expect:
         specifier: ^27.4.6
         version: 27.5.1
+      imurmurhash:
+        specifier: ^0.1.4
+        version: 0.1.4
       invariant:
         specifier: ^2.2.2
         version: 2.2.4
@@ -3016,6 +3019,9 @@ importers:
       '@ledgerhq/types-cryptoassets':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/types-cryptoassets
+      '@types/imurmurhash':
+        specifier: ^0.1.4
+        version: 0.1.4
       '@types/invariant':
         specifier: ^2.2.2
         version: 2.2.37
@@ -23008,13 +23014,10 @@ packages:
     resolution: {integrity: sha512-TL60LmMBGVzs3NQcO8ylWqBumMh4sx0lmeJsn7+9C88fylGDhyyVnKZ1PyTXo9CVDBkndutZx2JUEQWM9BaiXw==}
     peerDependencies:
       expo: '*'
-      expo-constants: '*'
       expo-modules-core: '*'
       react: '*'
       react-native: '*'
     peerDependenciesMeta:
-      expo-constants:
-        optional: true
       expo-modules-core:
         optional: true
 
@@ -23317,6 +23320,7 @@ packages:
     peerDependencies:
       '@expo/dom-webview': '*'
       '@expo/metro-runtime': '*'
+      expo-modules-autolinking: '*'
       expo-modules-core: '*'
       react: '*'
       react-native: '*'
@@ -23325,6 +23329,8 @@ packages:
       '@expo/dom-webview':
         optional: true
       '@expo/metro-runtime':
+        optional: true
+      expo-modules-autolinking:
         optional: true
       expo-modules-core:
         optional: true
@@ -39114,7 +39120,7 @@ snapshots:
       '@expo/image-utils': 0.6.5
       '@expo/json-file': 9.1.4
       '@react-native/normalize-colors': 0.76.9
-      debug: 4.4.0
+      debug: 4.3.4
       fs-extra: 9.1.0
       resolve-from: 5.0.0
       semver: 7.7.1
@@ -41128,7 +41134,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.0
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -41533,7 +41539,7 @@ snapshots:
       uuid: 8.3.2
     optionalDependencies:
       '@multiversx/sdk-bls-wasm': 0.3.5
-      axios: 1.7.9
+      axios: 1.8.4
       bip39: 3.1.0
 
   '@multiversx/sdk-transaction-decoder@1.0.2':
@@ -46052,7 +46058,7 @@ snapshots:
   '@stellar/stellar-sdk@11.3.0':
     dependencies:
       '@stellar/stellar-base': 11.0.1
-      axios: 1.8.3
+      axios: 1.8.4
       bignumber.js: 9.1.2
       eventsource: 2.0.2
       randombytes: 2.1.0
@@ -47932,7 +47938,7 @@ snapshots:
     dependencies:
       '@ton/core': 0.60.1(patch_hash=lboaji3braahojqczblp7nlo7m)(@ton/crypto@3.3.0)
       '@ton/crypto': 3.3.0
-      axios: 1.8.3
+      axios: 1.8.4
       dataloader: 2.2.2
       symbol.inspect: 1.0.1
       teslabot: 1.5.0
@@ -47970,7 +47976,7 @@ snapshots:
 
   '@types/axios@0.14.0':
     dependencies:
-      axios: 1.8.3
+      axios: 1.8.4
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -49003,7 +49009,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.30.1
       '@typescript-eslint/visitor-keys': 8.30.1
-      debug: 4.4.0
+      debug: 4.3.4
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -49930,7 +49936,7 @@ snapshots:
     dependencies:
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
       '@zondax/ledger-js': 0.8.2
-      axios: 1.8.3
+      axios: 1.8.4
 
   JSONStream@1.3.5:
     dependencies:
@@ -50311,7 +50317,7 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.2
       es-errors: 1.3.0
-      es-object-atoms: 1.0.0
+      es-object-atoms: 1.1.1
       es-shim-unscopables: 1.0.2
 
   array.prototype.flat@1.3.2:
@@ -50506,7 +50512,7 @@ snapshots:
   axios@1.7.7:
     dependencies:
       follow-redirects: 1.15.6
-      form-data: 4.0.0
+      form-data: 4.0.2
       proxy-from-env: 1.1.0
 
   axios@1.7.9:
@@ -53324,7 +53330,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.0
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -55102,18 +55108,6 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  expo-asset@11.0.5(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@expo/image-utils': 0.6.5
-      expo: 52.0.46(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(expo-modules-core@2.2.3)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
-      invariant: 2.2.4
-      md5-file: 3.2.3
-      react: 18.3.1
-      react-native: 0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1)
-    optionalDependencies:
-      expo-constants: 17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
-      expo-modules-core: 2.2.3(expo-constants@17.1.6)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
-
   expo-asset@11.0.5(expo-modules-core@2.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1))(react@18.3.1))(expo@52.0.46(cco7moedcz4q7tdej7fmgu5jaq))(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@expo/image-utils': 0.6.5
@@ -55125,6 +55119,20 @@ snapshots:
       react-native: 0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1)
     optionalDependencies:
       expo-modules-core: 2.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-asset@11.0.5(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@expo/image-utils': 0.6.5
+      expo: 52.0.46(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(expo-modules-core@2.2.3)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
+      expo-constants: 17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
+      invariant: 2.2.4
+      md5-file: 3.2.3
+      react: 18.3.1
+      react-native: 0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1)
+    optionalDependencies:
+      expo-modules-core: 2.2.3(expo-constants@17.1.6)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -55314,22 +55322,6 @@ snapshots:
       expo-modules-core: 2.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1))(react@18.3.1)
       react-native: 0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1)
 
-  expo-modules-autolinking@2.0.8(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@expo/spawn-async': 1.7.2
-      chalk: 4.1.2
-      commander: 7.2.0
-      fast-glob: 3.3.2
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      require-from-string: 2.0.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      expo-constants: 17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
-      expo-modules-core: 2.2.3(expo-constants@17.1.6)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-native: 0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1)
-
   expo-modules-autolinking@2.0.8(expo-modules-core@2.2.3(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1))(react@18.3.1))(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(react@18.3.1))(react@18.3.1):
     dependencies:
       '@expo/spawn-async': 1.7.2
@@ -55393,12 +55385,11 @@ snapshots:
       '@expo/metro-config': 0.19.12
       '@expo/vector-icons': 14.0.4
       babel-preset-expo: 12.0.11(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))
-      expo-asset: 11.0.5(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
+      expo-asset: 11.0.5(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
       expo-constants: 17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
       expo-file-system: 18.0.12(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
       expo-font: 13.0.4(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
       expo-keep-awake: 14.0.3(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
-      expo-modules-autolinking: 2.0.8(expo-constants@17.0.8(expo-modules-core@2.2.3)(expo@52.0.46)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1))(expo-modules-core@2.2.3)(react-native@0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1))(react@18.3.1)
       fbemitter: 3.0.0
       react: 18.3.1
       react-native: 0.77.2(@babel/core@7.27.1)(@babel/preset-env@7.27.1(@babel/core@7.27.1))(@react-native-community/cli@15.1.0(typescript@5.4.3))(@types/react@18.2.73)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@18.3.1)
@@ -56934,7 +56925,7 @@ snapshots:
   https-proxy-agent@4.0.0:
     dependencies:
       agent-base: 5.1.1
-      debug: 4.4.0
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -64302,7 +64293,7 @@ snapshots:
   puppeteer-core@2.1.1:
     dependencies:
       '@types/mime-types': 2.1.4
-      debug: 4.4.0
+      debug: 4.3.4
       extract-zip: 1.7.0
       https-proxy-agent: 4.0.0
       mime: 2.6.0
@@ -66796,7 +66787,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.0
+      debug: 4.3.4
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -67761,7 +67752,7 @@ snapshots:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.94.0(webpack-cli@4.10.0)
+      webpack: 5.94.0
     transitivePeerDependencies:
       - metro
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` will be attached in last part of the feature
- [ ] Automatic tests will be attached in last part of the feature
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - better `coin-hedera` structure that should be easier to read and maintain
  - enabled sub accounts
  - synchronisation should be way faster

### 📝 Description

This PR introduces the core logic needed for send/receive HTS tokens integration in both LLD and LLM. It also includes a small refactor of the coin-hedera module.

The main improvement is faster synchronization. Previously, the account balance was fetched using @hashgraph/sdk and AccountBalanceQuery. With the DEV_TOOLS=1 env enabled, numerous retries were clearly visible in the Network tab, significantly impacting sync time. Right now this is based on the mirror node and should work way better.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
