### PR TITLE
:bug: (lld) pluralization issue my ledger

### DIFF
--- a/.changeset/odd-maps-return.md
+++ b/.changeset/odd-maps-return.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+MYLedger pluralization issue

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/InstallSuccessBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/AppsList/InstallSuccessBanner.tsx
@@ -85,6 +85,8 @@ const InstallSuccessBanner = ({ state, addAccount, disabled }: Props) => {
   }, [addAccount, installedSupportedApps]);
   const onClose = useCallback(() => setHasBeenShown(true), []);
   const visible = !hasBeenShown && installedSupportedApps.length > 0;
+  const numberOfApps = installedSupportedApps.length;
+  const appNameToDisplay = numberOfApps === 1 && installedSupportedApps[0].name;
   return (
     <Container ref={cardRef}>
       <FadeInOutBox in={visible} timing={800} color="palette.primary.contrastText">
@@ -105,16 +107,13 @@ const InstallSuccessBanner = ({ state, addAccount, disabled }: Props) => {
             <Box flex={1} justifyContent="space-between">
               <Box mb={3}>
                 <Text ff="Inter|SemiBold" fontSize={6} color="palette.primary.contrastText">
-                  {installedSupportedApps.length === 1 ? (
-                    <Trans
-                      i18nKey="manager.applist.installSuccess.title"
-                      values={{
-                        app: installedSupportedApps[0].name,
-                      }}
-                    />
-                  ) : (
-                    <Trans i18nKey="manager.applist.installSuccess.title_plural" />
-                  )}
+                  <Trans
+                    i18nKey="manager.applist.installSuccess.title"
+                    values={{
+                      app: appNameToDisplay,
+                    }}
+                    count={numberOfApps}
+                  />
                 </Text>
               </Box>
               <Box horizontal>


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - my ledger / i18next

### 📝 Description

During add account rework, we changed all the _plural key to _other key as _plural isn't supported by i18next. We missed this one so this PR fixes the issue

![image](https://github.com/user-attachments/assets/d04ac2aa-5379-4302-9f6a-35c57a861fba)

![image](https://github.com/user-attachments/assets/fff789a1-e2d6-46f5-add7-051dd035be25)

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-19917](https://ledgerhq.atlassian.net/browse/LIVE-19917)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19917]: https://ledgerhq.atlassian.net/browse/LIVE-19917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ