### PR TITLE
chore(cryptoassets): update TRON block average time

### DIFF
--- a/.changeset/eighty-vans-flash.md
+++ b/.changeset/eighty-vans-flash.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/cryptoassets": minor
+"ledger-live-desktop": minor
+---
+
+chore(cryptoassets): update TRON `blockAvgTime` to 9

--- a/apps/ledger-live-desktop/src/renderer/components/StepperNumber.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/StepperNumber.tsx
@@ -3,6 +3,8 @@ import styled from "styled-components";
 import debounce from "lodash/debounce";
 import noop from "lodash/noop";
 import Box from "~/renderer/components/Box";
+import Input from "~/renderer/components/Input";
+
 const Container = styled(Box).attrs(() => ({
   horizontal: true,
   flow: 1,
@@ -12,11 +14,12 @@ const Container = styled(Box).attrs(() => ({
   ff: "Inter",
   color: "palette.text.shade80",
 }))`
-  background-color: rgba(138, 128, 219, 0.1);
   border-radius: 12px;
   display: inline-flex;
   height: 24px;
-  padding: 0 3px;
+`;
+const Num = styled(Input)`
+  max-width: 50px;
 `;
 const Btn = styled(Box).attrs<{ disabled?: boolean }>(p => ({
   bg: p.disabled ? "rgba(138, 128, 219, 0.5)" : "wallet",
@@ -28,12 +31,6 @@ const Btn = styled(Box).attrs<{ disabled?: boolean }>(p => ({
   cursor: ${p => (p.disabled ? "default" : "pointer")};
   height: 18px;
   width: 18px;
-`;
-const Num = styled(Box).attrs(() => ({
-  alignItems: "center",
-  justifyContent: "center",
-}))`
-  min-width: 20px;
 `;
 const DELAY_CLICK = 150;
 const DEBOUNCE_ON_CHANGE = 250;
@@ -122,6 +119,16 @@ class StepperNumber extends PureComponent<Props, State> {
     document.removeEventListener("mouseup", this.handleMouseUp);
   };
 
+  onChange = (input: string) => {
+    const newValue = parseInt(input) || 0;
+    const v = this.isMax(newValue)
+      ? this.props.max
+      : this.isMin(newValue)
+        ? this.props.min
+        : newValue;
+    this.emitChange(v);
+  };
+
   render() {
     const { value } = this.state;
     const isMin = this.isMin(value);
@@ -131,7 +138,7 @@ class StepperNumber extends PureComponent<Props, State> {
         <Btn onMouseDown={!isMin ? this.handleMouseDown("decrement") : undefined} disabled={isMin}>
           {"-"}
         </Btn>
-        <Num>{value}</Num>
+        <Num value={value.toString()} onChange={this.onChange} />
         <Btn onMouseDown={!isMax ? this.handleMouseDown("increment") : undefined} disabled={isMax}>
           {"+"}
         </Btn>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/CurrencyRows.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/CurrencyRows.tsx
@@ -62,13 +62,15 @@ function CurrencyRows({ currency }: Props) {
         >
           <Track onUpdate event="ConfirmationsNb" confirmationsNb={confirmationsNb} />
           {defaults.confirmationsNb ? (
-            <StepperNumber
-              min={defaults.confirmationsNb.min}
-              max={defaults.confirmationsNb.max}
-              step={1}
-              onChange={handleChangeConfirmationsNb}
-              value={confirmationsNb}
-            />
+            <Box width={150}>
+              <StepperNumber
+                min={defaults.confirmationsNb.min}
+                max={defaults.confirmationsNb.max}
+                step={1}
+                onChange={handleChangeConfirmationsNb}
+                value={confirmationsNb}
+              />
+            </Box>
           ) : null}
         </Row>
       ) : (
@@ -82,11 +84,7 @@ function CurrencyRows({ currency }: Props) {
       <Row title={t("account.settings.unit.title")} desc={t("account.settings.unit.desc")} inset>
         <Track onUpdate event="unit" unit={unit} />
 
-        <Box
-          style={{
-            width: 150,
-          }}
-        >
+        <Box width={150}>
           <Select
             isSearchable={false}
             onChange={handleChangeUnit}

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -2899,7 +2899,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "tron",
     color: "#D9012C",
     family: "tron",
-    blockAvgTime: 3,
+    blockAvgTime: 9,
     units: [
       {
         name: "TRX",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The default block confirmation number is computed with the following formula
```
(30 * 60) / blockAvgTime
```
Let's ensure 200 as the default to match what is done on Tronscan, since this is the explorer of choice in LL for TRON.

Also allow to input confirmation number directly, passing by
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/62c57ede-cb2f-4b95-bfb6-c0df918ae09d" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
