### PR TITLE
fix(LLD): account selection prevent double render

### DIFF
--- a/.changeset/light-colts-pretend.md
+++ b/.changeset/light-colts-pretend.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Drawer transition ID should not use map index

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/ConnectYourDevice/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/ConnectYourDevice/index.tsx
@@ -42,9 +42,4 @@ export const ConnectYourDevice = ({
   );
 };
 
-export default React.memo(ConnectYourDevice, (prevProps, nextProps) => {
-  return (
-    prevProps.currency.id === nextProps.currency.id &&
-    prevProps.analyticsPropertyFlow === nextProps.analyticsPropertyFlow
-  );
-});
+export default React.memo(ConnectYourDevice);

--- a/apps/ledger-live-desktop/src/renderer/drawers/Drawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/Drawer.tsx
@@ -78,14 +78,14 @@ export const Drawer = () => {
     >
       <>
         <TransitionGroup>
-          {queue.map(({ Component, props }, index) => (
+          {queue.map(({ Component, props, id }, index) => (
             <Transition
               timeout={{
                 appear: DURATION,
                 enter: DURATION,
                 exit: DURATION * 2,
               }}
-              key={index}
+              key={id}
             >
               {s => (
                 <Bar

--- a/apps/ledger-live-desktop/src/renderer/drawers/Provider.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/Provider.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useReducer, useEffect, useCallback, useState, useContext } from "react";
 import { DrawerProps as SideDrawerProps } from "~/renderer/components/SideDrawer";
+import { v4 as uuid } from "uuid";
 
 type ExtractProps<TComponent> =
   TComponent extends React.ComponentType<infer TProps> ? TProps : undefined;
@@ -12,6 +13,7 @@ export type State<
   props: ExtractProps<C> & {
     onRequestBack?: (a: React.MouseEvent<Element, MouseEvent> | KeyboardEvent) => void;
   };
+  id: string;
   open: boolean;
   options: Omit<SideDrawerProps, "children" | "isOpen" | "onRequestBack">;
 }; // actions
@@ -32,6 +34,7 @@ const reducer = (state: State, update: Partial<State>) => {
 };
 const initialState: State = {
   Component: undefined,
+  id: "",
   props: null,
   open: false,
   options: {},
@@ -60,8 +63,10 @@ const DrawerProvider = ({ children }: { children: React.ReactNode }) => {
   const _setDrawer: typeof setDrawer = useCallback(
     (Component, props, options = {}) => {
       setAnalyticsDrawerName(undefined);
+      const id = uuid();
       dispatch({
         Component,
+        id,
         props,
         open: !!Component,
         options,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Prevents the drawer rendering a component twice, fixing issues with animation retriggers and LDMK initialisation issues

Before:

https://github.com/user-attachments/assets/5ac5d960-0861-45ef-8d42-15b9abe09226



After:

https://github.com/user-attachments/assets/6f316da0-0569-47e4-b9e3-3248295d8621 


### ❓ Context

- **JIRA or GitHub link**: [LIVE-19919](https://ledgerhq.atlassian.net/browse/LIVE-19919)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-19919]: https://ledgerhq.atlassian.net/browse/LIVE-19919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ