### PR TITLE
fix: update tiny-secp256k1 to 1.1.7

### DIFF
--- a/libs/ledgerjs/packages/hw-app-btc/package.json
+++ b/libs/ledgerjs/packages/hw-app-btc/package.json
@@ -70,7 +70,7 @@
     "ripemd160": "2",
     "semver": "^7.3.5",
     "sha.js": "2",
-    "tiny-secp256k1": "1.1.6",
+    "tiny-secp256k1": "1.1.7",
     "varuint-bitcoin": "1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Same as #10717, but for `develop` branch

See https://github.com/bitcoinjs/tiny-secp256k1/pull/140 (full thread)

Note: it doesn't look like that hw-app-btc was affected, the usage seems safe