### PR TITLE
Fix Japanese i18n translation for discreet mode

### DIFF
--- a/.changeset/tricky-islands-fail.md
+++ b/.changeset/tricky-islands-fail.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix japanese i18n translation for discreet mode

--- a/apps/ledger-live-desktop/static/i18n/ja/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ja/app.json
@@ -4168,7 +4168,7 @@
   },
   "settings" : {
     "title" : "設定",
-    "discreet" : "ダークモードに切り替える",
+    "discreet" : "非表示モードに切り替える",
     "helpButton" : "ヘルプ",
     "tabs" : {
       "display" : "一般",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No changed behavior (Only i18n translation is changed)

### 📝 Description
The tooltip for "discreet mode" was originally translated to "ダークモードに切り替える" (It means "Switch to dark mode" in Japanese).
Since official documents is translated to "非表示モードに切り替える" (It means "Switch to invisible mode" in Japanese), so I think this one is better than original.

| Before        | After         |
| ------------- | ------------- |
|  ダークモードに切り替える | 非表示モードに切り替える |

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
