### PR TITLE
:sparkles: (MAD-AA) UX quick wins

### DIFF
--- a/.changeset/nice-grapes-joke.md
+++ b/.changeset/nice-grapes-joke.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+MAD & AA quick wins

--- a/apps/ledger-live-desktop/src/newArch/components/GenericEmptyList.tsx
+++ b/apps/ledger-live-desktop/src/newArch/components/GenericEmptyList.tsx
@@ -1,11 +1,23 @@
 import React from "react";
 import { Flex, Icons, Text } from "@ledgerhq/react-ui/index";
 import { useTranslation } from "react-i18next";
+import styled from "styled-components";
 
 type GenericEmptyListProps = {
   translationKey?: string;
   icon?: React.ReactNode;
 };
+
+const CircleWrapper = styled.div`
+  background-color: ${p => p.theme.colors.opacityDefault.c05};
+  border-radius: 50%;
+  padding: 16px;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
 const GenericEmptyList = ({ translationKey, icon }: GenericEmptyListProps) => {
   const { t } = useTranslation();
@@ -20,7 +32,7 @@ const GenericEmptyList = ({ translationKey, icon }: GenericEmptyListProps) => {
       height="80%"
       rowGap="16px"
     >
-      {Icon}
+      <CircleWrapper>{Icon}</CircleWrapper>
       <Text variant="body" fontWeight="600" lineHeight="24px" fontSize="16px">
         {text}
       </Text>

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
@@ -59,10 +59,6 @@ export const useSearch = ({
         return;
       }
 
-      if (query.length < 2 && prevQuery.length < 2) {
-        return;
-      }
-
       trackModularDrawerEvent(
         "asset_searched",
         {
@@ -76,10 +72,9 @@ export const useSearch = ({
         },
       );
 
-      const results =
-        query.trim().length < 2
-          ? originalAssets
-          : fuse.search(query).map((result: Fuse.FuseResult<CryptoOrTokenCurrency>) => result.item);
+      const results = fuse
+        .search(query)
+        .map((result: Fuse.FuseResult<CryptoOrTokenCurrency>) => result.item);
 
       setItemsToDisplay(results);
     },

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -39,12 +39,15 @@ const AssetSelection = ({
   const [shouldScrollToTop, setShouldScrollToTop] = useState(false);
 
   useEffect(() => {
-    if (defaultSearchValue !== undefined && defaultSearchValue.length >= 2) {
-      const timeout = setTimeout(() => {
-        setShouldScrollToTop(true);
-      }, 100);
-      return () => clearTimeout(timeout);
+    if (defaultSearchValue === undefined) {
+      return;
     }
+
+    const timeout = setTimeout(() => {
+      setShouldScrollToTop(true);
+    }, 100);
+
+    return () => clearTimeout(timeout);
   }, [defaultSearchValue]);
 
   return (

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/FundAccount/components/ActionsContainer.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/FundAccount/components/ActionsContainer.tsx
@@ -101,7 +101,7 @@ const ActionsContainer = ({ account, currencyId }: Props) => {
       height="100%"
       flex={1}
     >
-      <Flex flexDirection="column" width="100%" paddingX={24} paddingTop={24} rowGap={12}>
+      <Flex flexDirection="column" width="100%" paddingX={24} paddingTop={24}>
         {actions.map((action, index) => (
           <ActionItem
             key={index}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - MAD and AA

### 📝 Description

UI and UX quick wins: 
- remove gap between quick actions
- circle icon on empty list
- trigger search even with one char

https://github.com/user-attachments/assets/2b0a3669-9fe9-481e-81a2-9838676dc279



<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20039](https://ledgerhq.atlassian.net/browse/LIVE-20039)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20039]: https://ledgerhq.atlassian.net/browse/LIVE-20039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ