### PR TITLE
feat: add eslint rule to warn about type assertion

### DIFF
--- a/.changeset/hungry-mails-melt.md
+++ b/.changeset/hungry-mails-melt.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Added eslint rule '@typescript-eslint/consistent-type-assertions' to warn against dangerous practices. Fixes some instances in code and disabled warnings for existing cases

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,12 @@ module.exports = {
         ],
       },
     ],
+    "@typescript-eslint/consistent-type-assertions": [
+      "warn",
+      {
+        assertionStyle: "never",
+      },
+    ],
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/screens/DeviceHowTo2.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/screens/DeviceHowTo2.tsx
@@ -45,9 +45,7 @@ const DeviceHowTo2Animation = () => {
   return (
     <AnimationContainer>
       {deviceModelId && (
-        <Animation
-          animation={getDeviceAnimation(deviceModelId, theme, "plugAndPinCode") as object}
-        />
+        <Animation animation={getDeviceAnimation(deviceModelId, theme, "plugAndPinCode")} />
       )}
     </AnimationContainer>
   );

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/screens/PinCodeHowTo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/screens/PinCodeHowTo.tsx
@@ -46,9 +46,7 @@ const PinCodeHowToAnimation = () => {
   return (
     deviceModelId && (
       <AnimationContainer>
-        <Animation
-          animation={getDeviceAnimation(deviceModelId, theme, "plugAndPinCode") as object}
-        />
+        <Animation animation={getDeviceAnimation(deviceModelId, theme, "plugAndPinCode")} />
       </AnimationContainer>
     )
   );

--- a/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/screens/RecoveryHowTo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Onboarding/Screens/Tutorial/screens/RecoveryHowTo3.tsx
@@ -41,9 +41,7 @@ const RecoveryHowTo3Animation = () => {
 
   return (
     <AnimationContainer>
-      <Animation
-        animation={getDeviceAnimation(deviceModelId!, theme, "plugAndPinCode") as object}
-      />
+      <Animation animation={getDeviceAnimation(deviceModelId!, theme, "plugAndPinCode")} />
     </AnimationContainer>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/AddressCell.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/AddressCell.tsx
@@ -98,6 +98,7 @@ class AddressCell extends PureComponent<Props> {
   render() {
     const { operation } = this.props;
     const lense =
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       perOperationType[operation.type as keyof typeof perOperationType] || perOperationType._;
     const value = lense(operation);
     return value ? (

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/ConfirmationCheck.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/ConfirmationCheck.tsx
@@ -59,7 +59,8 @@ export const Container = styled(Box).attrs<ContainerProps>(p => ({
   bg: p.hasFailed
     ? mix(p.theme.colors.alertRed, p.theme.colors.palette.background.paper, 0.95)
     : p.isConfirmed
-      ? mix(inferColor(p) as string, p.theme.colors.palette.background.paper, 0.8)
+      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        mix(inferColor(p) as string, p.theme.colors.palette.background.paper, 0.8)
       : p.theme.colors.palette.background.paper,
   color: p.hasFailed ? p.theme.colors.alertRed : inferColor(p),
   alignItems: "center",

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/EditOperationPanel.tsx
@@ -1,6 +1,5 @@
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
-import { CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import React, { memo, useCallback } from "react";
@@ -22,7 +21,7 @@ const EditOperationPanel = (props: Props) => {
   const { enabled: isEditEvmTxEnabled, params } = useFeature("editEvmTx") ?? {};
   const mainAccount = getMainAccount(account, parentAccount);
   const isCurrencySupported =
-    params?.supportedCurrencyIds?.includes(mainAccount.currency.id as CryptoCurrencyId) || false;
+    params?.supportedCurrencyIds?.includes(mainAccount.currency.id) || false;
 
   const handleOpenEditModal = useCallback(() => {
     invariant(operation.transactionRaw, "operation.transactionRaw is required");

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV1/index.tsx
@@ -114,6 +114,7 @@ export class OperationsList extends PureComponent<Props, State> {
         : undefined;
 
     const all = flattenAccounts(accounts || []).concat(
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       [account as AccountLike, parentAccount as AccountLike].filter(Boolean),
     );
     const accountsMap = keyBy(all, "id");

--- a/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV2/useOperationsList.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/OperationsList/OperationsListV2/useOperationsList.ts
@@ -60,6 +60,7 @@ export function useOperationsList({
   const spamOpsCache = useRef<string[]>([]);
 
   const all = flattenAccounts(accounts || []).concat(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     [account as AccountLike, parentAccount as AccountLike].filter(Boolean),
   );
   const accountsMap = keyBy(all, "id");
@@ -95,6 +96,7 @@ export function useOperationsList({
 
   previousFilteredNftData.current = {
     ...previousFilteredNftData.current,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     ...keyBy(filteredNftData as OrderedOperation[], "id"),
   };
 
@@ -119,6 +121,7 @@ export function useOperationsList({
 
   useEffect(() => {
     spamOps.forEach(op => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       markNftAsSpam(op.collectionId, op.currencyId as SupportedBlockchain, op.spamScore);
     });
   }, [spamOps, markNftAsSpam, nftCollectionsStatusByNetwork]);

--- a/apps/ledger-live-desktop/src/renderer/components/SelectAccount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SelectAccount.tsx
@@ -311,12 +311,14 @@ export const RawSelectAccount = ({
         );
         if (display) {
           result.push({
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             matched: match && !isDisabledOption(option as { disabled?: boolean }),
             account: option,
             accountName,
           });
         }
         return result;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       }, [] as Option[]),
     [searchInputValue, all, withSubAccounts, enforceHideEmptySubAccounts, walletState],
   );

--- a/apps/ledger-live-desktop/src/renderer/components/Stepper/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Stepper/index.tsx
@@ -113,6 +113,7 @@ const Stepper = <T, StepProps>({
     <ModalBody
       refocusWhenChange={stepId}
       onClose={hideCloseButton || deviceBlocked ? undefined : onClose}
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       onBack={onBack && !deviceBlocked ? () => onBack(stepProps as StepProps) : undefined}
       backButtonComponent={backButtonComponent}
       title={title}
@@ -128,18 +129,31 @@ const Stepper = <T, StepProps>({
               stepsErrors={errorSteps}
             />
           )}
-          <StepComponent {...(stepProps as React.PropsWithChildren<StepProps>)} />
+          <StepComponent
+            {
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              ...(stepProps as React.PropsWithChildren<StepProps>)
+            }
+          />
           {children}
         </>
       )}
       renderFooter={
         StepFooter
-          ? () => <StepFooter {...(stepProps as React.PropsWithChildren<StepProps>)} />
+          ? () => (
+              <StepFooter
+                {
+                  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                  ...(stepProps as React.PropsWithChildren<StepProps>)
+                }
+              />
+            )
           : undefined
       }
     />
   );
 };
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export default withTranslation()(Stepper) as <T, StepProps>(
   props: OwnProps<T, StepProps>,
 ) => JSX.Element; // to preserve the generic types

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/AccountHeaderManageActions.ts
@@ -21,10 +21,12 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const mainAccount = getMainAccount(account, parentAccount);
   const label = useGetStakeLabelLocaleBased();
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { cardanoResources } = mainAccount as CardanoAccount;
   invariant(cardanoResources, "cardano account expected");
 
   const disableStakeButton =
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     !canStake(account as CardanoAccount) || isAlreadyStaking(account as CardanoAccount);
 
   const disabledLabel =
@@ -37,6 +39,7 @@ const AccountHeaderActions = ({ account, parentAccount }: Props) => {
   const onClick = useCallback(() => {
     dispatch(
       openModal("MODAL_CARDANO_REWARDS_INFO", {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         account: account as CardanoAccount,
       }),
     );

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/Delegation/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/Delegation/index.tsx
@@ -34,6 +34,7 @@ const Delegation = ({ account }: Props) => {
   const { t } = useTranslation();
 
   if (account.type !== "Account") return null;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { cardanoResources } = account as CardanoAccount;
   invariant(cardanoResources, "cardano account expected");
   const delegation = cardanoResources.delegation;
@@ -48,7 +49,13 @@ const Delegation = ({ account }: Props) => {
       {delegation && delegation.poolId ? (
         <>
           <Header />
-          <Row delegation={delegation} account={account as CardanoAccount} />
+          <Row
+            delegation={delegation}
+            account={
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              account as CardanoAccount
+            }
+          />
         </>
       ) : (
         <Wrapper horizontal>
@@ -76,6 +83,7 @@ const Delegation = ({ account }: Props) => {
               onClick={() => {
                 dispatch(
                   openModal("MODAL_CARDANO_REWARDS_INFO", {
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     account: account as CardanoAccount,
                   }),
                 );

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorField.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/fields/ValidatorField.test.ts
@@ -8,6 +8,7 @@ import {
 import { StakePool } from "@ledgerhq/live-common/families/cardano/staking";
 
 function stackPool(id: string): StakePool {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return { poolId: id } as StakePool;
 }
 

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/steps/StepDelegation.tsx
@@ -36,6 +36,7 @@ export default function StepDelegation({
     setSelectedPool(stakePool);
     const bridge: AccountBridge<CardanoTransaction> = getAccountBridge(account);
     onUpdateTransaction(() => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const updatedTransaction = bridge.updateTransaction(transaction as CardanoTransaction, {
         mode: "delegate",
         poolId: stakePool.poolId,
@@ -44,6 +45,7 @@ export default function StepDelegation({
     });
   };
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const selectedPoolId = (transaction as CardanoTransaction).poolId;
 
   return (
@@ -56,6 +58,7 @@ export default function StepDelegation({
         t={t}
         delegation={delegation}
         onChangeValidator={selectPool}
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         selectedPoolId={selectedPoolId as string}
       />
       {displayError ? (

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/steps/StepClaimRewards.tsx
@@ -44,6 +44,7 @@ export default function StepClaimRewards({
     (mode: string) => {
       updateClaimRewards({
         ...transaction,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         mode: mode as CosmosLikeTransaction["mode"],
       });
     },

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/__tests__/Delegations.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/Delegation/__tests__/Delegations.test.tsx
@@ -13,10 +13,12 @@ jest.mock("@ledgerhq/live-common/config/index", () => ({
 }));
 
 describe("Cosmos Delegations Component", () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const mockCosmosAccount = {
     type: "Account",
     currency: CURRENCIES_LIST.find(c => c.id === "cosmos")!,
     spendableBalance: BigNumber(0),
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     cosmosResources: {
       delegations: [],
       pendingRewardsBalance: BigNumber(0),
@@ -31,6 +33,7 @@ describe("Cosmos Delegations Component", () => {
   });
 
   it("should render Delegations component when we do not configure disable delegations", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (getCurrencyConfiguration as jest.Mock).mockReturnValue({});
 
     render(<Delegations account={mockCosmosAccount} />, {
@@ -44,6 +47,7 @@ describe("Cosmos Delegations Component", () => {
   });
 
   it("should render Delegations component when we do not disable delegations", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (getCurrencyConfiguration as jest.Mock).mockReturnValue({ disableDelegation: false });
 
     render(<Delegations account={mockCosmosAccount} />, {
@@ -57,10 +61,12 @@ describe("Cosmos Delegations Component", () => {
   });
 
   it("should not render Delegations component when we disable delegations", async () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (getCurrencyConfiguration as jest.Mock).mockReturnValue({
       disableDelegation: true,
     });
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const { container } = render(<Delegations account={mockCosmosAccount} />, {
       initialState: { ...INITIAL_STATE },
     }) as unknown as RenderResult;

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
@@ -86,7 +86,9 @@ const SimpleList = styled.ul`
 
 // returns the first error
 function getStatusError(status: TransactionStatus, type = "errors"): Error | undefined | null {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   if (!status || !status[type as keyof TransactionStatus]) return null;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const firstKey = Object.keys(status[type as keyof TransactionStatus]!)[0];
   // @ts-expect-error This is complicated to prove that type / firstKey are the right keys
   return firstKey ? status[type][firstKey] : null;

--- a/apps/ledger-live-desktop/src/renderer/families/solana/Token2022/TokenTransferFeesWarning.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/Token2022/TokenTransferFeesWarning.test.tsx
@@ -8,6 +8,7 @@ describe("TokenTransferFeesWarning", () => {
     render(
       <TokenTransferFeesWarning
         tokenAccount={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             token: {
               units: [{ code: "FAKE", magnitude: 8 }],
@@ -15,6 +16,7 @@ describe("TokenTransferFeesWarning", () => {
           } as unknown as SolanaTokenAccount
         }
         transaction={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             model: {
               commandDescriptor: {
@@ -43,6 +45,7 @@ describe("TokenTransferFeesWarning", () => {
     render(
       <TokenTransferFeesWarning
         tokenAccount={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             token: {
               units: [{ code: "FAKE", magnitude: 8 }],
@@ -50,6 +53,7 @@ describe("TokenTransferFeesWarning", () => {
           } as unknown as SolanaTokenAccount
         }
         transaction={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             model: {
               commandDescriptor: {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -59,6 +59,7 @@ export const mapAsActionContentCard = (card: ClassicCard): ActionContentCard => 
   location: LocationContentCard.Action,
   image: card.extras?.image,
   link: card.extras?.link,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   created: card.created as Date,
   mainCta: card.extras?.mainCta,
   secondaryCta: card.extras?.secondaryCta,
@@ -75,6 +76,7 @@ export const mapAsPortfolioContentCard = (card: ClassicCard): PortfolioContentCa
   image: card.extras?.image,
   url: card.extras?.url,
   path: card.extras?.path,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   created: card.created as Date,
   order: parseInt(card.extras?.order) ? parseInt(card.extras?.order) : undefined,
 });
@@ -87,6 +89,7 @@ export const mapAsNotificationContentCard = (card: ClassicCard): NotificationCon
   url: card.extras?.url,
   path: card.extras?.path,
   cta: card.extras?.cta,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   created: card.created as Date,
   viewed: card.viewed,
   order: parseInt(card.extras?.order) ? parseInt(card.extras?.order) : undefined,
@@ -161,10 +164,12 @@ export async function useBraze() {
       );
 
       const portfolioCards = filterByPage(filteredDesktopCards, LocationContentCard.Portfolio)
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         .map(card => mapAsPortfolioContentCard(card as ClassicCard))
         .sort(compareCards);
 
       const actionCards = filterByPage(filteredDesktopCards, LocationContentCard.Action)
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         .map(card => mapAsActionContentCard(card as ClassicCard))
         .sort(compareCards);
 
@@ -172,6 +177,7 @@ export async function useBraze() {
         filteredDesktopCards,
         LocationContentCard.NotificationCenter,
       )
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         .map(card => mapAsNotificationContentCard(card as ClassicCard))
         .sort(compareCards);
 

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/useDeepLinkHandler.ts
@@ -141,6 +141,7 @@ export function useDeepLinkHandler() {
           const { address, currency } = query;
 
           if (!currency || typeof currency !== "string") return;
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const c = findCryptoCurrencyByKeyword(currency.toUpperCase()) as Currency;
           if (!c || c.type === "FiatCurrency") return;
           const foundAccounts = getAccountsOrSubAccountsByCurrency(c, accounts || []);
@@ -172,6 +173,7 @@ export function useDeepLinkHandler() {
         case "add-account": {
           const { currency } = query;
 
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const foundCurrency = findCryptoCurrencyByKeyword(
             typeof currency === "string" ? currency?.toUpperCase() : "",
           ) as Currency;
@@ -246,6 +248,7 @@ export function useDeepLinkHandler() {
 
           if (url === "delegate" && currency !== "tezos") return;
 
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           const foundCurrency = findCryptoCurrencyByKeyword(
             typeof currency === "string" ? currency.toUpperCase() : "",
           ) as Currency;

--- a/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useNotifications.ts
@@ -71,7 +71,7 @@ export function useNotifications() {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         currentCard.url = currentCard.id;
-        isTrackedUser && braze.logContentCardClick(currentCard as braze.ClassicCard);
+        isTrackedUser && braze.logContentCardClick(currentCard);
       }
 
       track("contentcard_clicked", {

--- a/apps/ledger-live-desktop/src/renderer/icons/device/interactions/Blue/Screen.tsx
+++ b/apps/ledger-live-desktop/src/renderer/icons/device/interactions/Blue/Screen.tsx
@@ -89,7 +89,10 @@ const BlueScreen = ({ active, display, error, ...props }: Props) => {
           rx="2"
         />
         <g id="Blue-screen-content" opacity={active ? 1 : 0}>
-          {display ? screens[display as keyof typeof screens] : null}
+          {display
+            ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              screens[display as keyof typeof screens]
+            : null}
         </g>
       </g>
     </ScreenSVG>

--- a/apps/ledger-live-desktop/src/renderer/icons/device/interactions/NanoS/Screen.tsx
+++ b/apps/ledger-live-desktop/src/renderer/icons/device/interactions/NanoS/Screen.tsx
@@ -92,7 +92,10 @@ const NanoSScreen = ({ active, display, error, ...props }: Props) => {
           transform="translate(-40 -6)"
         />
         <g id="NanoSScreen-screen-content" opacity={active ? 1 : 0}>
-          {display ? screens[display as keyof typeof screens] : null}
+          {display
+            ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              screens[display as keyof typeof screens]
+            : null}
         </g>
       </g>
     </ScreenSVG>

--- a/apps/ledger-live-desktop/src/renderer/icons/device/interactions/NanoX/Screen.tsx
+++ b/apps/ledger-live-desktop/src/renderer/icons/device/interactions/NanoX/Screen.tsx
@@ -93,7 +93,10 @@ const NanoXScreen = ({ active, display, error, ...props }: Props) => {
           transform="translate(-40 -6)"
         />
         <g id="NanoXScreen-screen-content" opacity={active ? 1 : 0}>
-          {display ? screens[display as keyof typeof screens] : null}
+          {display
+            ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              screens[display as keyof typeof screens]
+            : null}
         </g>
       </g>
     </ScreenSVG>

--- a/apps/ledger-live-desktop/src/renderer/icons/device/interactions/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/icons/device/interactions/index.tsx
@@ -60,6 +60,7 @@ const Interactions = ({
   const props = {
     error: !!error,
     screen: error ? "fail" : screen,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     usb: wire && (usbMap[wire] as React.ComponentProps<typeof Device>["usb"]),
     leftHint: action === "left" || (type === "nanoX" && action === "accept"),
     rightHint: action === "accept",

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -204,6 +204,7 @@ async function init() {
   window.addEventListener("keydown", (e: KeyboardEvent) => {
     if (e.which === TAB_KEY) {
       if (!isGlobalTabEnabled()) enableGlobalTab();
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       logger.onTabKey(document.activeElement as HTMLElement);
     }
   });

--- a/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
+++ b/apps/ledger-live-desktop/src/renderer/live-common-setup.ts
@@ -124,9 +124,12 @@ export function registerTransportModules(store: Store) {
       setDeviceMode("polling");
       const params = new URLSearchParams(id.split(vaultTransportPrefixID)[1]);
       return retry(() =>
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         VaultTransport.open(params.get("host") as string).then(transport => {
           transport.setData({
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             token: params.get("token") as string,
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             workspace: params.get("workspace") as string,
           });
           return Promise.resolve(transport);

--- a/apps/ledger-live-desktop/src/renderer/logger/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/index.ts
@@ -343,6 +343,7 @@ export default {
   },
   add,
   onLog: (log: LogEntry | string) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     logger.log(log as LogEntry);
   },
 };

--- a/apps/ledger-live-desktop/src/renderer/logger/summarize.ts
+++ b/apps/ledger-live-desktop/src/renderer/logger/summarize.ts
@@ -21,8 +21,11 @@ function summarizeAccount(argument: Account | TokenAccount) {
     index,
     freshAddress,
     freshAddressPath,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     opsL: undefined as number | undefined,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     pendingOpsL: undefined as number | undefined,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     subA: undefined as unknown[] | undefined,
   };
   if (operations && typeof operations === "object" && Array.isArray(operations)) {
@@ -58,10 +61,12 @@ const recSummarize = (
         return obj.map(o => recSummarize(o, undefined, references));
       }
       if (
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         (obj as { type: string }).type === "Account" ||
         // AccountRaw
         ("seedIdentifier" in obj && "freshAddressPath" in obj && "operations" in obj)
       ) {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         return summarizeAccount(obj as Account);
       }
       const copy = {};

--- a/apps/ledger-live-desktop/src/renderer/middlewares/analytics.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/analytics.ts
@@ -10,6 +10,7 @@ const analyticsMiddleware: Middleware<{}, State> = store => next => action => {
   next(action);
   if (!isAnalyticsStarted) {
     isAnalyticsStarted = true;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     start(store as ReduxStore);
   }
 };

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/index.tsx
@@ -111,6 +111,7 @@ const createSteps = (skipChooseCurrencyStep?: boolean | null): St[] => {
   if (skipChooseCurrencyStep) {
     steps.shift();
   }
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return steps as St[];
 };
 type State = {

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.tsx
@@ -221,9 +221,9 @@ const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
   );
 
   const currencies = useMemo(() => {
-    const supportedCurrenciesAndTokens = (
-      listSupportedCurrencies() as CryptoOrTokenCurrency[]
-    ).concat(listSupportedTokens());
+    const supportedCurrenciesAndTokens =
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      (listSupportedCurrencies() as CryptoOrTokenCurrency[]).concat(listSupportedTokens());
 
     const deactivatedCurrencyIds = new Set(
       mock
@@ -242,7 +242,8 @@ const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
 
   const url =
     currency && currency.type === "TokenCurrency"
-      ? supportLinkByTokenType[currency.tokenType as keyof typeof supportLinkByTokenType]
+      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        supportLinkByTokenType[currency.tokenType as keyof typeof supportLinkByTokenType]
       : null;
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/steps/StepImport.tsx
@@ -43,9 +43,12 @@ const statusCodeErrorMap = new Map<number, (appName: string) => Error>([
 ]);
 
 const remapTransportError = (err: unknown, appName: string): Error => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   if (!err || typeof err !== "object") return err as Error;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { statusCode } = err as { name: string; statusCode: number };
   const errorFromStatusCode = statusCodeErrorMap.get(statusCode)?.(appName);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return errorFromStatusCode || (err as Error);
 };
 const LoadingRow = styled(Box).attrs(() => ({
@@ -172,12 +175,13 @@ class StepImport extends PureComponent<
           error: err => {
             logger.critical(err);
             const error = remapTransportError(err, currency.name);
-            setScanStatus("error", error as Error);
+            setScanStatus("error", error);
           },
         });
     } catch (err) {
       logger.critical(err);
       const { setScanStatus } = this.props;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       setScanStatus("error", err as Error);
     }
   }
@@ -343,6 +347,7 @@ class StepImport extends PureComponent<
                 title={t(`addAccounts.sections.${id}.title`, {
                   count: data.length,
                 })}
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 emptyText={emptyTexts[id as keyof typeof emptyTexts]}
                 accounts={data}
                 autoFocusFirstInput={selectable && i === 0}

--- a/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/FormLiveAppArraySelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/FormLiveAppArraySelect.tsx
@@ -86,6 +86,7 @@ function FormLiveAppArraySelect({
         <Select
           blurInputOnSelect={true}
           onKeyDown={e => {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             const target = e.target as HTMLTextAreaElement;
             if (e.keyCode === 13 && target.value !== "") {
               e.preventDefault();
@@ -95,6 +96,7 @@ function FormLiveAppArraySelect({
           }}
           error={parseCheck ? null : new Error()}
           onChange={(option: unknown) => {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             handleOnChange(option as Option);
           }}
           value={null}

--- a/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/defaultValues.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/defaultValues.tsx
@@ -23,7 +23,7 @@ export const DEFAULT_VALUES = {
   currencies: [""],
 };
 
-export const DEFAULT_FORM: LiveAppManifest = {
+export const DEFAULT_FORM = {
   id: "ReplaceAppName",
   author: "",
   private: false,
@@ -60,7 +60,7 @@ export const DEFAULT_FORM: LiveAppManifest = {
       },
     ],
   },
-};
+} as const satisfies LiveAppManifest;
 
 export const DESCRIPTIONS: Record<string, string> = {
   name: "Live App name as it will appear in the Discover section.",

--- a/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/CreateLocalManifest/index.tsx
@@ -10,7 +10,6 @@ import {
   LiveAppManifest,
   LiveAppManifestSchema,
   LiveAppManifestDappSchema,
-  LiveAppManifestDapp,
   LiveAppManifestParamsNetwork,
   LiveAppManifestSchemaType,
 } from "@ledgerhq/live-common/platform/types";
@@ -64,9 +63,7 @@ function FormLocalManifest({
   const handleSwitchEthDapp = () => {
     setIsDapp(prevState => !prevState);
     setForm((prevState: LiveAppManifest) => {
-      !isDapp
-        ? (prevState.dapp = cloneDeep(DEFAULT_FORM.dapp) as LiveAppManifestDapp)
-        : delete prevState.dapp;
+      !isDapp ? (prevState.dapp = cloneDeep(DEFAULT_FORM.dapp)) : delete prevState.dapp;
       return prevState;
     });
   };
@@ -96,13 +93,13 @@ function FormLocalManifest({
         en: value,
       }).success;
       const optional = LiveAppManifestSchema.shape.content.shape[contentKey].isOptional();
-      const path = `content.${contentKey as string}.en`;
+      const path = `content.${contentKey}.en`;
 
       return (
         <FormLiveAppInput
-          key={contentKey as string}
+          key={contentKey}
           type={typeof value}
-          fieldName={contentKey as string}
+          fieldName={contentKey}
           value={value}
           optional={optional}
           parseCheck={parseCheck}
@@ -138,13 +135,13 @@ function FormLocalManifest({
 
                       const optional = networkKeySchema.isOptional();
                       const parseCheck = networkKeySchema.safeParse(value).success;
-                      const path = `dapp.${dappKey}.${index}.${networkKey as string}`;
+                      const path = `dapp.${dappKey}.${index}.${networkKey}`;
 
                       return (
                         <FormLiveAppInput
-                          key={networkKey as string}
+                          key={networkKey}
                           type={typeof value}
-                          fieldName={networkKey as string}
+                          fieldName={networkKey}
                           value={value}
                           optional={optional}
                           parseCheck={parseCheck}
@@ -159,7 +156,7 @@ function FormLocalManifest({
             }
 
             const value = form.dapp![dappKey];
-            const path = `dapp.${dappKey as string}`;
+            const path = `dapp.${dappKey}`;
             const shape = LiveAppManifestDappSchema.shape[dappKey];
             const parseCheck = shape.safeParse(value).success;
             const optional = shape.isOptional();
@@ -181,9 +178,9 @@ function FormLocalManifest({
 
             return (
               <FormLiveAppInput
-                key={dappKey as string}
+                key={dappKey}
                 type={typeof value}
-                fieldName={dappKey as string}
+                fieldName={dappKey}
                 value={value}
                 optional={optional}
                 parseCheck={parseCheck}
@@ -199,13 +196,16 @@ function FormLocalManifest({
               small
               primary
               onClick={() => {
-                setForm((prevState: LiveAppManifest) => {
-                  const newNetwork = [...prevState.dapp!.networks];
-                  newNetwork.push({ ...DEFAULT_FORM.dapp!.networks[0] });
+                setForm((prevState): LiveAppManifest => {
+                  if (!prevState.dapp) {
+                    return prevState;
+                  }
+                  const networks = [...prevState.dapp.networks];
+                  networks.push({ ...DEFAULT_FORM.dapp.networks[0] });
                   return {
                     ...prevState,
-                    dapp: { ...prevState.dapp, networks: newNetwork },
-                  } as LiveAppManifest;
+                    dapp: { ...prevState.dapp, networks },
+                  };
                 });
               }}
             >
@@ -216,13 +216,16 @@ function FormLocalManifest({
               danger
               disabled={form.dapp?.networks.length === 1}
               onClick={() => {
-                setForm((prevState: LiveAppManifest) => {
-                  const newNetwork = [...prevState.dapp!.networks];
-                  newNetwork.pop();
+                setForm(prevState => {
+                  if (!prevState.dapp) {
+                    return prevState;
+                  }
+                  const networks = [...prevState.dapp.networks];
+                  networks.pop();
                   return {
                     ...prevState,
-                    dapp: { ...prevState.dapp, networks: newNetwork },
-                  } as LiveAppManifest;
+                    dapp: { ...prevState.dapp, networks: networks },
+                  };
                 });
               }}
             >
@@ -266,10 +269,11 @@ function FormLocalManifest({
                   const value = form[key];
                   const isArray = Array.isArray(value);
                   const formKeySchema =
+                    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                     LiveAppManifestSchema.shape[key as keyof LiveAppManifestSchemaType];
                   const parseCheck = formKeySchema.safeParse(value).success;
                   const optional = formKeySchema.isOptional();
-                  const path = `${key as string}`;
+                  const path = `${key}`;
 
                   if (key === "platforms") {
                     return (
@@ -308,9 +312,9 @@ function FormLocalManifest({
                   if (key === "permissions" || key === "categories" || key === "currencies") {
                     return (
                       <FormLiveAppArraySelect
-                        key={key as string}
+                        key={key}
                         options={[...DEFAULT_VALUES[key]]}
-                        fieldName={key as string}
+                        fieldName={key}
                         initialValue={value as string[]}
                         optional={optional}
                         parseCheck={parseCheck}
@@ -325,8 +329,8 @@ function FormLocalManifest({
                   if (isArray) {
                     return (
                       <FormLiveAppArrayInput
-                        key={key as string}
-                        fieldName={key as string}
+                        key={key}
+                        fieldName={key}
                         initialValue={[...value]}
                         optional={optional}
                         parseCheck={parseCheck}
@@ -338,9 +342,9 @@ function FormLocalManifest({
 
                   return (
                     <FormLiveAppInput
-                      key={key as string}
+                      key={key}
                       type={typeof value}
-                      fieldName={key as string}
+                      fieldName={key}
                       value={value}
                       optional={optional}
                       parseCheck={parseCheck}

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -164,6 +164,7 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
     }) => {
       const params = getUpdateAccountWithUpdaterParams({
         result: inputs.result,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         exchange: exchange as ExchangeSwap,
         transaction: transactionParams,
         magnitudeAwareRate: inputs.magnitudeAwareRate,
@@ -184,12 +185,15 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
           swapId,
           mode: ExchangeModeEnum.Swap,
           provider,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           sourceCurrency: sourceCurrency as Currency,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           targetCurrency: targetCurrency as Currency,
         }
       : {
           provider,
           mode: ExchangeModeEnum.Sell,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           sourceCurrency: sourceCurrency as Currency,
         };
   };
@@ -203,11 +207,13 @@ const Body = ({ data, onClose }: { data: Data; onClose?: () => void | undefined 
   const handleSwapTransaction = (operation: Operation, result: ResultsState) => {
     const newResult = {
       operation,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       swapId: swapId as string,
     };
 
     updateAccount({
       result: newResult,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       magnitudeAwareRate: magnitudeAwareRate as BigNumber,
     });
 

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
@@ -11,7 +11,7 @@ type DomainErrorsProps = {
 };
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
-  if ((domainError.error as Error) instanceof InvalidDomain) {
+  if (domainError.error instanceof InvalidDomain) {
     return (
       <div data-testid="domain-error-invalid-domain">
         <Alert
@@ -27,6 +27,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
     return (
       <div data-testid="domain-error-no-resolution">

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
@@ -120,6 +120,7 @@ const baseMockStatus: TransactionStatus = {
   totalSpent: new BigNumber("0"),
 };
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockTFunction: jest.Mock<TFunction> = jest.fn(key => key) as unknown as jest.Mock<TFunction>;
 
 const setup = (
@@ -131,8 +132,9 @@ const setup = (
     <DomainServiceProvider>
       <RecipientField
         account={account}
-        transaction={{ ...baseMockTransaction, ...mockTransaction } as Transaction}
+        transaction={{ ...baseMockTransaction, ...mockTransaction }}
         // tslint:disable-next-line
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         t={mockTFunction as unknown as TFunction}
         onChangeTransaction={mockedOnChangeTransaction}
         status={{ ...baseMockStatus, ...mockStatus }}

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
@@ -72,7 +72,9 @@ const RecipientFieldDomainService = <T extends Transaction, TS extends Transacti
       }
 
       if (
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         (domainError.error as Error) instanceof NoResolution ||
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         (domainError.error as Error) instanceof InvalidDomain
       ) {
         return true;

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepRecipient.test.tsx
@@ -5,6 +5,7 @@ import { TFunction } from "i18next";
 import { SolanaAccount, SolanaTokenAccount } from "@ledgerhq/live-common/families/solana/types";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockTFunction: jest.Mock<TFunction> = jest.fn(key => key) as unknown as jest.Mock<TFunction>;
 
 describe("StepRecipient", () => {
@@ -14,17 +15,20 @@ describe("StepRecipient", () => {
   ])("displays a warning when the token embeds the %s extension", (_s, extension) => {
     render(
       <StepRecipient
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         t={mockTFunction as unknown as TFunction<"translation", undefined>}
         transitionTo={() => {}}
         openedFromAccount={true}
         device={null}
         parentAccount={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             type: "Account",
             currency: {},
           } as unknown as SolanaAccount
         }
         account={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             type: "TokenAccount",
             extensions: {
@@ -33,6 +37,7 @@ describe("StepRecipient", () => {
           } as unknown as SolanaTokenAccount
         }
         transaction={null}
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         status={{} as unknown as TransactionStatus}
         bridgePending={false}
         error={null}
@@ -66,23 +71,27 @@ describe("StepRecipient", () => {
   it("does not display any warning with no problematic token extensions", () => {
     render(
       <StepRecipient
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         t={mockTFunction as unknown as TFunction<"translation", undefined>}
         transitionTo={() => {}}
         openedFromAccount={true}
         device={null}
         parentAccount={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             type: "Account",
             currency: {},
           } as unknown as SolanaAccount
         }
         account={
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             type: "TokenAccount",
             extensions: {},
           } as unknown as SolanaTokenAccount
         }
         transaction={null}
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         status={{} as unknown as TransactionStatus}
         bridgePending={false}
         error={null}

--- a/apps/ledger-live-desktop/src/renderer/reducers/modals.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/modals.ts
@@ -89,6 +89,7 @@ export const getModalData = <Name extends keyof ModalData>(
 // Exporting reducer
 
 export default handleActions<ModalsState, HandlersPayloads[keyof HandlersPayloads]>(
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   handlers as unknown as ModalsHandlers<false>,
   state,
 );

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.test.ts
@@ -23,6 +23,7 @@ describe("lastSeenDeviceSelector", () => {
         apps: [],
       };
       const state = {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         ...({} as State),
         settings: {
           ...SETTINGS_INITIAL_STATE,
@@ -36,11 +37,13 @@ describe("lastSeenDeviceSelector", () => {
   it("should return null if the deviceModelId is invalid", () => {
     invalidDeviceModelIds.forEach(deviceModelId => {
       const lastSeenDevice: State["settings"]["lastSeenDevice"] = {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         modelId: deviceModelId as DeviceModelId, // We might have invalid values in the store
         deviceInfo: aDeviceInfoBuilder(),
         apps: [],
       };
       const state = {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         ...({} as State),
         settings: {
           ...SETTINGS_INITIAL_STATE,
@@ -54,6 +57,7 @@ describe("lastSeenDeviceSelector", () => {
 
   it("should return en-US when the locale is not set", () => {
     const state = {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ...({} as State),
       settings: {
         ...SETTINGS_INITIAL_STATE,
@@ -64,6 +68,7 @@ describe("lastSeenDeviceSelector", () => {
 
   it("should return fr-FR when the locale is set", () => {
     const state = {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ...({} as State),
       settings: {
         ...SETTINGS_INITIAL_STATE,
@@ -75,6 +80,7 @@ describe("lastSeenDeviceSelector", () => {
 
   it("should return en-US when the locale is set to OFAC locale", () => {
     const state = {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       ...({} as State),
       settings: {
         ...SETTINGS_INITIAL_STATE,

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -26,7 +26,6 @@ import {
   Locale,
   DEFAULT_LANGUAGE,
   OFAC_LOCALES,
-  Locales,
 } from "~/config/languages";
 import { State } from ".";
 import regionsByKey from "~/renderer/screens/settings/sections/General/regions.json";
@@ -150,7 +149,7 @@ export const getInitialLanguageAndLocale = (): { language: Language; locale: Loc
   if (languageId) {
     // const localeId = Languages[languageId].locales.find(lang => systemLocal.startsWith(lang));
     // TODO Hack because the typing on the commented line above doesn't work
-    const languageLocales = Languages[languageId].locales as Locales;
+    const languageLocales = Languages[languageId].locales;
 
     const localeId = languageLocales.find(lang => systemLocal.startsWith(lang));
 
@@ -205,6 +204,7 @@ export const INITIAL_STATE: SettingsState = {
   },
   latestFirmware: null,
   blacklistedTokenIds: [],
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   nftCollectionsStatusByNetwork: {} as Record<SupportedBlockchain, Record<string, NftStatus>>,
   hiddenOrdinalsAsset: [],
   deepLinkUrl: null,
@@ -224,12 +224,14 @@ export const INITIAL_STATE: SettingsState = {
     acceptedProviders: [],
     selectableCurrencies: [],
   },
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   overriddenFeatureFlags: {} as Record<FeatureId, Feature>,
   featureFlagsButtonVisible: false,
 
   // Vault
   vaultSigner: { enabled: false, host: "", token: "", workspace: "" },
   supportedCounterValues: [],
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   dismissedContentCards: {} as Record<string, number>,
   anonymousBrazeId: null,
 
@@ -337,6 +339,7 @@ const handlers: SettingsHandlers = {
   },
   SAVE_SETTINGS: (state, { payload }) => {
     if (!payload) return state;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const changed = (Object.keys(payload) as (keyof typeof payload)[]).some(
       key => payload[key] !== state[key],
     );
@@ -386,6 +389,7 @@ const handlers: SettingsHandlers = {
 
   [RESET_HIDDEN_NFT_COLLECTIONS]: state => ({
     ...state,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     nftCollectionsStatusByNetwork: {} as Record<SupportedBlockchain, Record<string, NftStatus>>,
   }),
 
@@ -571,6 +575,7 @@ const handlers: SettingsHandlers = {
   }),
   [UPDATE_ANONYMOUS_USER_NOTIFICATIONS]: (state: SettingsState, { payload }) => {
     const { anonymousUserNotifications: prev } = state;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const next = {
       ...(payload.purgeState ? { LNSUpsell: prev.LNSUpsell } : prev),
       ...payload.notifications,
@@ -580,6 +585,7 @@ const handlers: SettingsHandlers = {
 };
 
 export default handleActions<SettingsState, HandlersPayloads[keyof HandlersPayloads]>(
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   handlers as unknown as SettingsHandlers<false>,
   INITIAL_STATE,
 );
@@ -691,6 +697,7 @@ export const developerModeSelector = (state: State): boolean => state.settings.d
 export const lastUsedVersionSelector = (state: State): string => state.settings.lastUsedVersion;
 export const userThemeSelector = (state: State): "dark" | "light" | undefined | null => {
   const savedVal = state.settings.theme;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return ["dark", "light"].includes(savedVal as string) ? (savedVal as "dark" | "light") : "dark";
 };
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/swap.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/swap.ts
@@ -64,6 +64,7 @@ const options = {
 };
 
 export default handleActions<SwapStateType, HandlersPayloads[keyof HandlersPayloads]>(
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   handlers as unknown as SwapHandlers<false>,
   initialState,
   options,

--- a/apps/ledger-live-desktop/src/renderer/reducers/trustchain.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/trustchain.ts
@@ -10,4 +10,5 @@ import { handleActions } from "redux-actions";
 export default handleActions<
   TrustchainStore,
   TrustchainHandlersPayloads[keyof TrustchainHandlersPayloads]
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 >(trustchainHandlers as unknown as TrustchainHandlers<false>, getInitialStore());

--- a/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
@@ -54,6 +54,7 @@ export const useAccountName = (account: AccountLike) => {
 };
 
 export default handleActions<WalletState, HandlersPayloads[keyof HandlersPayloads]>(
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   handlers as unknown as WalletHandlers<false>,
   initialState,
 );

--- a/apps/ledger-live-desktop/src/renderer/reducers/walletSync.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/walletSync.ts
@@ -185,6 +185,7 @@ export const walletSyncQrCodePinCodeSelector = (state: { walletSync: WalletSyncS
   state.walletSync.qrCodePinCode;
 
 export default handleActions<WalletSyncState, HandlersPayloads[keyof HandlersPayloads]>(
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   handlers as unknown as WalletSyncHandlers<false>,
   initialStateWalletSync,
 );

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshooting.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshooting.tsx
@@ -33,6 +33,7 @@ const USBTroubleshooting = ({ onboarding = false }: { onboarding?: boolean }) =>
   const fallBackUSBTroubleshootingIndex = useSelector(USBTroubleshootingIndexSelector);
 
   // Maybe extract an index from the state, fallback to selector
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   let { USBTroubleshootingIndex } = (locationState || {}) as { USBTroubleshootingIndex?: number };
   USBTroubleshootingIndex = USBTroubleshootingIndex ?? fallBackUSBTroubleshootingIndex;
 
@@ -45,6 +46,7 @@ const USBTroubleshooting = ({ onboarding = false }: { onboarding?: boolean }) =>
   });
   const { context } = state || {};
   const { currentIndex, solutions, SolutionComponent, platform, done } = context;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const platformSolutions = solutions[platform as keyof typeof solutions];
   const isLastStep = useMemo(() => SolutionComponent === RepairFunnel, [SolutionComponent]);
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshootingMachine.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/USBTroubleshooting/USBTroubleshootingMachine.ts
@@ -12,6 +12,7 @@ import UpdateUSBDeviceDrivers from "./solutions/UpdateUSBDeviceDrivers";
 import EnableFullDiskAccess from "./solutions/EnableFullDiskAccess";
 import ResetNVRAM from "./solutions/ResetNVRAM";
 import RepairFunnel from "./solutions/RepairFunnel";
+
 const commonSolutions = [
   DifferentPort,
   ChangeUSBCable,
@@ -19,10 +20,12 @@ const commonSolutions = [
   TurnOffAntivirus,
   TryAnotherComputer,
 ];
+
 const detectedPlatform =
   process.platform === "darwin" ? "mac" : process.platform === "win32" ? "windows" : "linux";
 export default setup({
   types: {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     input: {} as {
       currentIndex: number | undefined;
     },
@@ -33,12 +36,15 @@ export default setup({
   actions: {
     load: assign(({ context }) => {
       const { platform, currentIndex, solutions } = context;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       if (!solutions[platform as keyof typeof solutions])
         throw new Error(`Unknown platform ${platform}`);
       const index =
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         !currentIndex || currentIndex >= solutions[platform as keyof typeof solutions].length
           ? 0
           : currentIndex;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const SolutionComponent = solutions[platform as keyof typeof solutions][index];
       return {
         currentIndex: index,
@@ -53,6 +59,7 @@ export default setup({
     next: assign(({ context }) => {
       const { platform, currentIndex: i, solutions } = context;
       const currentIndex =
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         solutions[platform as keyof typeof solutions].length > i! + 1 ? i! + 1 : i;
       return {
         currentIndex,
@@ -61,6 +68,7 @@ export default setup({
     // Move back to a previous solution.
     previous: assign(({ context }) => {
       const { platform, currentIndex: i, solutions } = context;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const currentIndex = solutions[platform as keyof typeof solutions].length <= 0 ? 0 : i! - 1;
       return {
         currentIndex,
@@ -81,6 +89,7 @@ export default setup({
   context: ({ input }) => ({
     opened: true,
     done: false,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     SolutionComponent: (() => null) as React.ComponentType<{
       number: number;
       sendEvent: (event: AnyEventObject) => unknown;

--- a/apps/ledger-live-desktop/src/renderer/screens/account/BalanceSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/BalanceSummary.tsx
@@ -138,6 +138,7 @@ export default function AccountBalanceSummary({
             magnitude={chartMagnitude}
             color={chartColor}
             // TODO we need to make Date non optional in live-common
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             data={history as Data}
             height={200}
             tickXScale={range}

--- a/apps/ledger-live-desktop/src/renderer/screens/account/TokensList.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/account/TokensList.tsx
@@ -22,9 +22,11 @@ import TableContainer, { TableHeader } from "~/renderer/components/TableContaine
 import AngleDown from "~/renderer/icons/AngleDown";
 import { getLLDCoinFamily } from "~/renderer/families";
 import { blacklistedTokenIdsSelector } from "~/renderer/reducers/settings";
+
 type Props = {
   account: Account;
 };
+
 export default memo<Props>(TokensList);
 function TokensList({ account }: Props) {
   const { t } = useTranslation();
@@ -68,7 +70,8 @@ function TokensList({ account }: Props) {
   if (!isTokenAccount && isEmpty) return null;
   const url =
     currency && currency.type && tokenTypes && tokenTypes.length > 0
-      ? supportLinkByTokenType[tokenTypes[0] as keyof typeof supportLinkByTokenType]
+      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        supportLinkByTokenType[tokenTypes[0] as keyof typeof supportLinkByTokenType]
       : null;
   const specific = getLLDCoinFamily(family)?.tokenList;
   const hasSpecificTokenWording = specific?.hasSpecificTokenWording;

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountGridItem/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountGridItem/Body.tsx
@@ -9,10 +9,12 @@ import CounterValue from "~/renderer/components/CounterValue";
 import Chart from "~/renderer/components/ChartPreview";
 import useTheme from "~/renderer/hooks/useTheme";
 import { Data } from "~/renderer/components/Chart/types";
+
 type Props = {
   account: AccountLike;
   range: PortfolioRange;
 };
+
 function Body({ account, range }: Props) {
   const { history, countervalueAvailable, countervalueChange } = useBalanceHistoryWithCountervalue({
     account,
@@ -47,6 +49,7 @@ function Body({ account, range }: Props) {
       </Box>
       <Chart
         // TODO make date non optional
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         data={history as Data}
         color={color}
         valueKey={countervalueAvailable ? "countervalue" : "value"}
@@ -55,5 +58,6 @@ function Body({ account, range }: Props) {
     </Box>
   );
 }
+
 const MemoedBody: React.ComponentType<Props> = React.memo(Body);
 export default MemoedBody;

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountList/ListBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountList/ListBody.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Account, PortfolioRange, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import { Account, PortfolioRange, AccountLike } from "@ledgerhq/types-live";
 import Box from "~/renderer/components/Box";
 import AccountItem from "../AccountRowItem";
 import AccountItemPlaceholder from "../AccountRowItem/Placeholder";
+
 type Props = {
   visibleAccounts: AccountLike[];
   hiddenAccounts: AccountLike[];
@@ -13,6 +14,7 @@ type Props = {
   horizontal: boolean;
   search?: string;
 };
+
 const ListBody = ({
   visibleAccounts,
   showNewAccount,
@@ -30,7 +32,7 @@ const ListBody = ({
         <AccountItem
           hidden={i >= visibleAccounts.length}
           key={account.id}
-          account={account as TokenAccount | Account}
+          account={account}
           search={search}
           parentAccount={account.type !== "Account" ? lookupParentAccount(account.parentId) : null}
           range={range}
@@ -40,4 +42,5 @@ const ListBody = ({
     )}
   </Box>
 );
+
 export default ListBody;

--- a/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountList/SearchBox.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/accounts/AccountList/SearchBox.tsx
@@ -11,6 +11,7 @@ type Props = {
   autoFocus?: boolean;
   id?: string;
 };
+
 const SearchInput = styled.input`
   border: none;
   background: transparent;
@@ -26,6 +27,7 @@ const SearchInput = styled.input`
     font-weight: 500;
   }
 `;
+
 const SearchIconContainer = styled(Box).attrs<{
   focused?: boolean;
 }>(p => ({
@@ -62,4 +64,6 @@ const SearchBox = forwardRef<HTMLInputElement, Props>(function Search(
     </>
   );
 });
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export default React.memo(SearchBox) as typeof SearchBox; // to preserve the ref forwarding prop

--- a/apps/ledger-live-desktop/src/renderer/screens/asset/BalanceSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/asset/BalanceSummary.tsx
@@ -26,6 +26,7 @@ type Props = {
   countervalueFirst: boolean;
   account: AccountLike;
 };
+
 export default function BalanceSummary({
   unit,
   counterValue,
@@ -116,6 +117,7 @@ export default function BalanceSummary({
             magnitude={chartMagnitude}
             color={chartColor}
             // TODO make date non optional
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             data={history as Data}
             height={200}
             tickXScale={range}

--- a/apps/ledger-live-desktop/src/renderer/screens/card/CardPlatformApp.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/card/CardPlatformApp.tsx
@@ -32,6 +32,7 @@ export default function CardPlatformApp() {
           manifest={manifest}
           inputs={{
             theme: themeType,
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             ...(urlParams as Record<string, string>),
           }}
         />

--- a/apps/ledger-live-desktop/src/renderer/screens/card/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/card/index.tsx
@@ -57,7 +57,7 @@ const LiveAppCard = ({ appId }: { appId: string }) => {
           manifest={manifest}
           inputs={{
             theme: themeType,
-            ...(urlParams as Record<string, string>),
+            ...urlParams,
             lang: language,
             locale: locale,
             devMode,

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step1ChooseImage.tsx
@@ -40,6 +40,7 @@ const extractNftBase64 = (metadata: NFTMetadata) => {
     : null;
   const customImageUri =
     (mediaSizeForCustomImage &&
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       metadata?.medias?.[mediaSizeForCustomImage as keyof NFTMedias]?.uri) ||
     null;
   return customImageUri;
@@ -98,7 +99,7 @@ const StepChooseImage: React.FC<Props> = props => {
             setTimeout(
               () => {
                 if (!isMounted()) return;
-                setSelectedNftBase64({ imageBase64DataUri: res as string });
+                setSelectedNftBase64({ imageBase64DataUri: res });
               },
               Math.max(0, 400 - (Date.now() - t1)),
             );

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
@@ -50,6 +50,7 @@ const StepTransfer: React.FC<Props> = props => {
 
   const isRefusedOnStaxError =
     error instanceof ImageLoadRefusedOnDevice ||
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (error as unknown) instanceof ImageCommitRefusedOnDevice;
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/BuySell/ProviderInterstitial.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/BuySell/ProviderInterstitial.test.tsx
@@ -7,6 +7,7 @@ import { useShowProviderLoadingTransition } from "@ledgerhq/live-common/hooks/us
 import { render, screen } from "tests/testSetup";
 import { ProviderInterstitial } from "./ProviderInterstitial";
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const mockManifest = {
   id: BUY_SELL_UI_APP_ID,
   name: "Moonpay",
@@ -18,12 +19,14 @@ jest.mock("@ledgerhq/live-common/hooks/useShowProviderLoadingTransition", () => 
 
 describe("ProviderInterstitial", () => {
   it("renders nothing if transition hook returns false", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (useShowProviderLoadingTransition as jest.Mock).mockReturnValue(false);
     render(<ProviderInterstitial manifest={mockManifest} isLoading={false} />);
     expect(screen.queryByTestId("custom-buy-sell-loader")).toBeNull();
   });
 
   it("renders loader when transition hook returns true", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (useShowProviderLoadingTransition as jest.Mock).mockReturnValue(true);
     render(<ProviderInterstitial manifest={mockManifest} isLoading={true} />);
 

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/FeesDrawerLiveApp/index.tsx
@@ -132,7 +132,7 @@ export default function FeesDrawerLiveApp({
       <Box mt={3} flow={4} mx={3} flex="1">
         {transaction && mainAccount && (
           <SendAmountFields
-            account={parentAccount || (mainAccount as Account)}
+            account={parentAccount || mainAccount}
             parentAccount={parentAccount}
             status={transactionStatus}
             transaction={transaction}

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/SwapWebViewDemo3.tsx
@@ -530,6 +530,7 @@ const SwapWebView = ({ manifest }: SwapWebProps) => {
           }}
           onStateChange={onStateChange}
           ref={webviewAPIRef}
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           customHandlers={customHandlers as never}
         />
       </SwapWebAppWrapper>

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/utils/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/utils/index.ts
@@ -72,6 +72,7 @@ export function transformToBigNumbers(obj: TransformableObject): TransformableOb
   for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       const value = obj[key];
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       if (typeof value === "string" && !isNaN(value as unknown as number)) {
         transformedObj[key] = new BigNumber(value);
       } else if (typeof value === "object") {

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceIllustration.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceIllustration.tsx
@@ -43,6 +43,7 @@ export const DeviceIllustration = styled.img.attrs<{
   deviceModel: DeviceModel;
 }>(p => ({
   src: illustrations[
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     (process.env.OVERRIDE_MODEL_ID || p.deviceModel.id) as keyof typeof illustrations
   ][p.theme.colors.palette.type || "light"],
 }))<{

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceLanguageInstallation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceLanguageInstallation.tsx
@@ -42,7 +42,7 @@ const DeviceLanguageInstallation: React.FC<Props> = ({
 
   const sortedAvailableLanguages = useMemo(
     () =>
-      (availableLanguages as string[]).sort((a, b) =>
+      availableLanguages.sort((a, b) =>
         t(`deviceLocalization.languages.${a}`).localeCompare(
           t(`deviceLocalization.languages.${b}`),
         ),
@@ -61,6 +61,7 @@ const DeviceLanguageInstallation: React.FC<Props> = ({
 
   const onChange = useCallback(
     (radioValue?: string | number | readonly string[] | undefined) =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       setSelectedLanguage(radioValue as Language),
     [setSelectedLanguage],
   );

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/DeviceName.tsx
@@ -36,6 +36,7 @@ const DeviceName: React.FC<Props> = ({
   onRefreshDeviceInfo,
   setPreventResetOnDeviceChange,
 }: Props) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const model = identifyTargetId(deviceInfo.targetId as number);
   const editSupported = model?.id && isEditDeviceNameSupported(model.id);
   const editEnabled = !disabled && editSupported;

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/StorageBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/StorageBar.tsx
@@ -72,6 +72,7 @@ const StorageBarItem = styled.div.attrs<{
 }>(props => ({
   style: {
     backgroundColor: props.installing ? props.theme.colors.palette.text.shade30 : props.color,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     ...transitionStyles[props.state as keyof typeof transitionStyles](
       `${(props.ratio * 1e2).toFixed(3)}%`,
     ),
@@ -141,6 +142,7 @@ const getAppStorageBarColor = ({
 }: {
   currency: CryptoCurrency | undefined | null;
   name: string;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 }) => (name in appDataColors ? appDataColors[name as keyof typeof appDataColors] : currency?.color);
 
 /**

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/Disconnected.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/Disconnected.tsx
@@ -75,13 +75,10 @@ const Illustration = styled.div<{
   modelId: DeviceModelId;
 }>`
   // prettier-ignore
-  background: url('${p =>
-    illustrations[p.modelId as keyof typeof illustrations][
-      p.theme.colors.palette.type || "light"
-    ]}')
+  background: url('${p => illustrations[p.modelId][p.theme.colors.palette.type || "light"]}')
     no-repeat top right;
-  width: ${p => illustrations[p.modelId as keyof typeof illustrations].width}px;
-  height: ${p => illustrations[p.modelId as keyof typeof illustrations].height}px;
+  width: ${p => illustrations[p.modelId].width}px;
+  height: ${p => illustrations[p.modelId].height}px;
   background-size: contain;
 `;
 const Disconnected = ({ onTryAgain }: { onTryAgain: (a: boolean) => void }) => {

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketCoinChart.tsx
@@ -36,6 +36,7 @@ const transitionStyles = {
 };
 
 const FadeIn = styled.div.attrs<{ state: string }>(p => ({
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   style: transitionStyles[p.state as keyof typeof transitionStyles],
 }))<{
   state: string;

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/components/MarketInfo.tsx
@@ -126,6 +126,7 @@ function MarketInfo({
   const athText = useDateFormatted(athDateD, dayAndHourFormat);
   const atlText = useDateFormatted(atlDateD, dayAndHourFormat);
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const currentPriceChangePercentage = priceChangePercentage?.[range as KeysPriceChange];
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketCoin/index.tsx
@@ -72,6 +72,7 @@ export default function MarketCoinScreen() {
 
   const { name, ticker, image, internalCurrency, price } = currency || {};
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const currentPriceChangePercentage = currency?.priceChangePercentage[range as KeysPriceChange];
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/screens/market/MarketList/components/MarketRowItem.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/MarketList/components/MarketRowItem.tsx
@@ -85,6 +85,7 @@ export const MarketRow = memo<Props>(function MarketRowItem({
   const hasActions =
     currency?.internalCurrency && (availableOnBuy || availableOnSwap || availableOnStake);
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const currentPriceChangePercentage = currency?.priceChangePercentage[range as KeysPriceChange];
 
   return (

--- a/apps/ledger-live-desktop/src/renderer/screens/market/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/index.tsx
@@ -81,8 +81,7 @@ export default function Market() {
    */
   useEffect(() => {
     const intervalId = setInterval(() => refetchData(marketCurrentPage ?? 1), refreshRate);
-
-    return () => clearInterval(intervalId as unknown as number);
+    return () => clearInterval(intervalId);
   }, [marketCurrentPage, refetchData, refreshRate]);
 
   const { order, range, counterCurrency, search = "", liveCompatible } = marketParams;

--- a/apps/ledger-live-desktop/src/renderer/screens/market/utils/market.utils.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/market/utils/market.utils.test.ts
@@ -77,7 +77,9 @@ describe("Market utils", () => {
 
       it("Should return true when internalCurrency.id is available and isCurrencyAvailable returns true", () => {
         const isAvailable = isAvailableOnBuy(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             internalCurrency: { id: "btc" } as CryptoOrTokenCurrency,
             ledgerIds: ["btc"],
           } as CurrencyData,
@@ -88,7 +90,9 @@ describe("Market utils", () => {
 
       it("Should return false when internalCurrency.id is available but isCurrencyAvailable returns false", () => {
         const isAvailable = isAvailableOnBuy(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             internalCurrency: { id: "btc" } as CryptoOrTokenCurrency,
             ledgerIds: ["btc"],
           } as CurrencyData,
@@ -99,6 +103,7 @@ describe("Market utils", () => {
 
       it("Should return true when one of the ledgerIds is available and isCurrencyAvailable returns true", () => {
         const isAvailable = isAvailableOnBuy(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             ledgerIds: ["btc"],
           } as CurrencyData,
@@ -109,6 +114,7 @@ describe("Market utils", () => {
 
       it("Should return false when neither internalCurrency nor ledgerIds are available", () => {
         const isAvailable = isAvailableOnBuy(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             ledgerIds: ["ltc"],
           } as CurrencyData,
@@ -127,7 +133,9 @@ describe("Market utils", () => {
 
       it("Should return true when internalCurrency.id is in the swap set", () => {
         const isAvailable = isAvailableOnSwap(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             internalCurrency: { id: "btc" } as CryptoOrTokenCurrency,
             ledgerIds: ["btc"],
           } as CurrencyData,
@@ -138,7 +146,9 @@ describe("Market utils", () => {
 
       it("Should return false when internalCurrency.id is not in the swap set", () => {
         const isAvailable = isAvailableOnSwap(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             internalCurrency: { id: "btc" } as CryptoOrTokenCurrency,
             ledgerIds: ["btc"],
           } as CurrencyData,
@@ -149,6 +159,7 @@ describe("Market utils", () => {
 
       it("Should return true when one of the ledgerIds is in the swap set", () => {
         const isAvailable = isAvailableOnSwap(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             ledgerIds: ["btc"],
           } as CurrencyData,
@@ -159,6 +170,7 @@ describe("Market utils", () => {
 
       it("Should return false when neither internalCurrency.id nor any ledgerIds are in the swap set", () => {
         const isAvailable = isAvailableOnSwap(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           {
             ledgerIds: ["ltc"],
           } as CurrencyData,

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Collections/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Collections/Row.tsx
@@ -8,6 +8,7 @@ import { Account, NFT, NFTMetadata, ProtoNFT } from "@ledgerhq/types-live";
 import NFTCollectionContextMenu from "~/renderer/components/ContextMenu/NFTCollectionContextMenu";
 import Media from "~/renderer/components/Nft/Media";
 import Skeleton from "~/renderer/components/Nft/Skeleton";
+
 const Container = styled(Box)`
   &.disabled {
     pointer-events: none;
@@ -21,12 +22,14 @@ const Container = styled(Box)`
     background: ${p => rgba(p.theme.colors.wallet, 0.04)};
   }
 `;
+
 type Props = {
   nfts: (ProtoNFT | NFT)[];
   contract: string;
   account: Account;
   onClick: () => void;
 };
+
 const Row = ({ nfts, contract, account, onClick }: Props) => {
   const [nft] = nfts;
   const { status: collectionStatus, metadata: collectionMetadata } = useNftCollectionMetadata(
@@ -60,6 +63,7 @@ const Row = ({ nfts, contract, account, onClick }: Props) => {
       >
         <Skeleton width={32} minHeight={32} show={loading}>
           <Media
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             metadata={nftMetadata as NFTMetadata}
             tokenId={nft?.tokenId}
             mediaFormat="preview"

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Gallery/Collection.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Gallery/Collection.tsx
@@ -56,6 +56,7 @@ const Collection = () => {
   );
   const history = useHistory();
   const nfts = useMemo<(ProtoNFT | NFT)[]>(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     () => (nftsByCollections(account?.nfts, collectionAddress) as (ProtoNFT | NFT)[]) || [],
     [account?.nfts, collectionAddress],
   );
@@ -105,6 +106,7 @@ const Collection = () => {
         <Skeleton width={40} minHeight={40} show={show}>
           <Media
             size={40}
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             metadata={metadata as NFTMetadata}
             tokenId={nft?.tokenId}
             mediaFormat="preview"

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Gallery/TokensList/Item.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Gallery/TokensList/Item.tsx
@@ -15,6 +15,7 @@ import NFTViewerDrawer from "~/renderer/drawers/NFTViewerDrawer";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { State } from "~/renderer/reducers";
 import { IconsLegacy } from "@ledgerhq/react-ui";
+
 const Wrapper = styled(Card)`
   &.disabled {
     pointer-events: none;
@@ -63,6 +64,7 @@ const NftCard = ({ id, mode, account, withContextMenu = false, onHideCollection 
     }),
   );
   const { status, metadata } = useNftMetadata(nft?.contract, nft?.tokenId, nft?.currencyId);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { nftName } = (metadata as NFTMetadata) || {};
   const show = useMemo(() => status === "loading", [status]);
   const isGrid = mode === "grid";
@@ -79,6 +81,7 @@ const NftCard = ({ id, mode, account, withContextMenu = false, onHideCollection 
   }, [id, account]);
   const MaybeContext = ({ children }: { children: React.ReactNode }) =>
     withContextMenu && nft && metadata ? (
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       <NFTContextMenu key={id} nft={nft} account={account} metadata={metadata as NFTMetadata}>
         {children}
       </NFTContextMenu>
@@ -98,6 +101,7 @@ const NftCard = ({ id, mode, account, withContextMenu = false, onHideCollection 
       >
         <Skeleton width={40} minHeight={40} full={isGrid} show={show}>
           <Media
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             metadata={metadata as NFTMetadata}
             tokenId={nft?.tokenId}
             size={40}
@@ -145,6 +149,7 @@ const NftCard = ({ id, mode, account, withContextMenu = false, onHideCollection 
                 key={id}
                 nft={nft}
                 account={account}
+                // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                 metadata={metadata as NFTMetadata}
                 leftClick={true}
                 onHideCollection={onHideCollection}

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Send/Option.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Send/Option.tsx
@@ -19,21 +19,18 @@ type OptionProps = {
 const Option = ({ data: { tokenId, amount, contract, standard, currencyId } }: OptionProps) => {
   const { status, metadata } = useNftMetadata(contract, tokenId, currencyId);
   const show = useMemo(() => status === "loading", [status]);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const nftMetadata = metadata as NFTMetadata;
   return (
     <Box horizontal>
       <Skeleton width={30} minHeight={30} show={show}>
-        <Media
-          metadata={metadata as NFTMetadata}
-          tokenId={tokenId}
-          size={30}
-          mediaFormat="preview"
-        />
+        <Media metadata={nftMetadata} tokenId={tokenId} size={30} mediaFormat="preview" />
       </Skeleton>
       <Box horizontal alignItems="center" justifyContent="space-between" flex={1}>
         <Box ml={3}>
           <Skeleton width={142} minHeight={15} barHeight={8} show={show}>
             <Text ff="Inter|Medium" color="palette.text.shade100" fontSize={2}>
-              {(metadata as NFTMetadata)?.nftName || "-"}
+              {nftMetadata?.nftName || "-"}
             </Text>
           </Skeleton>
           <Skeleton width={80} minHeight={15} barHeight={8} show={show}>

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Send/SelectNFT.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Send/SelectNFT.tsx
@@ -22,7 +22,8 @@ const SelectNFT = ({
   const filteredNFTs = useMemo(
     () =>
       maybeNFTCollection
-        ? (nftsByCollections(account.nfts, maybeNFTCollection) as (ProtoNFT | NFT)[])
+        ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          (nftsByCollections(account.nfts, maybeNFTCollection) as (ProtoNFT | NFT)[])
         : account.nfts?.filter(
             nft => !hiddenNftCollections.includes(`${account.id}|${nft.contract}`),
           ) || [],

--- a/apps/ledger-live-desktop/src/renderer/screens/nft/Send/Summary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/nft/Send/Summary.tsx
@@ -19,14 +19,17 @@ type Props = {
   currency: CryptoCurrency;
 };
 const Summary = ({ transaction }: Props) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const allNfts = useSelector(getAllNFTs) as ProtoNFT[];
   const specific = getLLDCoinFamily(transaction.family);
   const { contract, tokenId, quantity } = useMemo(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     () => specific?.nft?.getNftTransactionProperties(transaction) || ({} as Record<string, never>),
     [specific?.nft, transaction],
   );
   const nft = useMemo(() => getNFT(contract, tokenId, allNfts), [allNfts, contract, tokenId]);
   const { status, metadata } = useNftMetadata(nft?.contract, nft?.tokenId, nft?.currencyId);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { nftName } = status === "loaded" ? metadata : ({} as Record<string, never>);
   const show = useMemo(() => status === "loading", [status]);
 
@@ -60,7 +63,7 @@ const Summary = ({ transaction }: Props) => {
                 color="palette.text.shade100"
                 fontSize={4}
               >
-                {(nftName as string) || "-"}
+                {nftName || "-"}
               </Text>
             </Skeleton>
             <Skeleton width={42} minHeight={18} barHeight={6} show={show}>
@@ -72,6 +75,7 @@ const Summary = ({ transaction }: Props) => {
           </Box>
           <Skeleton width={48} minHeight={48} show={show}>
             <Media
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
               metadata={metadata as NFTMetadata}
               tokenId={tokenId || ""}
               size={48}

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/LiveApp.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/LiveApp.tsx
@@ -36,6 +36,7 @@ export function LiveApp({ match, appId: propsAppId, location }: LiveAppProps) {
   const track = useTrack();
   const swapTrackingProperties = useGetSwapTrackingProperties();
   const { params: internalParams, search } = location;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { state: urlParams, customDappUrl } = useLocation() as ReturnType<typeof useLocation> &
     LiveAppProps["location"] & {
       state: {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/Currencies.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/Currencies.tsx
@@ -9,6 +9,7 @@ import Box from "~/renderer/components/Box";
 import { SettingsSectionBody as Body, SettingsSectionRow as Row } from "../../SettingsSection";
 import CurrencyRows from "./CurrencyRows";
 import Track from "~/renderer/analytics/Track";
+
 export default function Currencies() {
   const { t } = useTranslation();
   const currencies = useSelector(cryptoCurrenciesSelector);
@@ -51,7 +52,12 @@ export default function Currencies() {
       </Row>
       {currency && (
         <Body>
-          <CurrencyRows currency={currency as CryptoCurrency} />
+          <CurrencyRows
+            currency={
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              currency as CryptoCurrency
+            }
+          />
         </Body>
       )}
     </Box>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/CurrencyRows.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/CurrencyRows.tsx
@@ -34,7 +34,7 @@ function CurrencyRows({ currency }: Props) {
   const updateCurrencySettings = (key: Key, val?: number | Unit | null) => {
     const newCurrencySettings = {
       ...currencySettings,
-      [key as keyof CurrencySettings]: val,
+      [key]: val,
     };
 
     dispatch(

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenNFTCollections/row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Accounts/HiddenNFTCollections/row.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { useNftMetadata, useNftCollectionMetadata } from "@ledgerhq/live-nft-react";
 import { accountSelector } from "~/renderer/reducers/accounts";
 import { State } from "~/renderer/reducers";
-import { NFTMetadata } from "@ledgerhq/types-live";
 import { clipboard } from "electron";
 
 import Text from "~/renderer/components/Text";
@@ -64,11 +63,7 @@ export const HiddenNftCollectionRow = ({
       <Flex>
         <Skeleton width={32} minHeight={32} show={loading}>
           {nftMetadata && firstNft && (
-            <Media
-              metadata={nftMetadata as NFTMetadata}
-              tokenId={firstNft?.tokenId}
-              mediaFormat="preview"
-            />
+            <Media metadata={nftMetadata} tokenId={firstNft?.tokenId} mediaFormat="preview" />
           )}
         </Skeleton>
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/FeatureFlagDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/FeatureFlagDetails.tsx
@@ -29,7 +29,7 @@ export const Row: StyledComponent<"div", DefaultTheme, FlexBoxProps> = styled(Fl
 const FeatureFlagDetails: React.FC<Props> = props => {
   const { flagName, focused, setFocusedName } = props;
   const { getFeature } = useFeatureFlags();
-  const flagValue = getFeature(flagName as FeatureId);
+  const flagValue = getFeature(flagName);
   const { t } = useTranslation();
 
   const {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/GroupedFeatures.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/GroupedFeatures.tsx
@@ -4,7 +4,6 @@ import {
 } from "@ledgerhq/live-common/featureFlags/groupedFeatures";
 import { useFeatureFlags } from "@ledgerhq/live-common/featureFlags/FeatureFlagsContext";
 import { Flex, Link, Tag, Box, Switch, Text } from "@ledgerhq/react-ui";
-import { FeatureId } from "@ledgerhq/types-live";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import FeatureFlagDetails, { Row } from "./FeatureFlagDetails";
@@ -28,7 +27,7 @@ const GroupedFeatures = ({ groupName, focused, setFocusedGroupName }: Props) => 
         <FeatureFlagDetails
           key={flagName}
           focused={focusedName === flagName}
-          flagName={flagName as FeatureId}
+          flagName={flagName}
           setFocusedName={setFocusedName}
         />
       )),

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/FeatureFlagsSettings/index.tsx
@@ -75,6 +75,7 @@ export const FeatureFlagContent = withV3StyleProvider((props: { expanded?: boole
         <FeatureFlagDetails
           key={flagName}
           focused={focusedName === flagName}
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           flagName={flagName as FeatureId}
           setFocusedName={setFocusedName}
         />
@@ -100,9 +101,7 @@ export const FeatureFlagContent = withV3StyleProvider((props: { expanded?: boole
   const config = useFeature("firebaseEnvironmentReadOnly");
   const params = config?.params;
   const project =
-    params !== null && typeof params === "object" && "project" in params
-      ? (params as { project: string }).project
-      : "";
+    params !== null && typeof params === "object" && "project" in params ? params.project : "";
 
   const handleChangeTab = useCallback((index: number) => {
     setActiveTabIndex(index);

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/OnboardingAppInstallDebug.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/OnboardingAppInstallDebug.tsx
@@ -15,6 +15,7 @@ type Step = Steps[number] & { key: number };
 
 const defaultDeviceToRestore: DeviceModelInfo = {
   modelId: DeviceModelId.nanoX,
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   deviceInfo: {} as DeviceInfo,
   apps: [
     { name: "Ethereum", version: "" },
@@ -53,11 +54,12 @@ const OnboardingAppInstallDebugScreen = () => {
 
   useEffect(() => {
     if (selectedDeviceToRestoreOption) {
-      setRestore(selectedDeviceToRestoreOption.value !== null);
-      if (selectedDeviceToRestoreOption.value) {
+      const modelId = selectedDeviceToRestoreOption.value;
+      setRestore(modelId !== null);
+      if (modelId) {
         setDeviceToRestore(prev => ({
           ...prev,
-          modelId: selectedDeviceToRestoreOption.value as DeviceModelId,
+          modelId,
         }));
       }
     }

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/RunLocalAppButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/RunLocalAppButton.tsx
@@ -122,6 +122,7 @@ const RunLocalAppButton = () => {
         </Flex>
       </Row>
       {localLiveApps.map((manifest: LiveAppManifest) => (
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         <Row key={manifest.id} title={manifest.name} desc={manifest.url as string}>
           <ButtonContainer>
             <Button small primary onClick={() => history.push(`/platform/${manifest.id}`)}>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/SimpleHashTools/RefreshMetadata/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/SimpleHashTools/RefreshMetadata/index.tsx
@@ -40,6 +40,7 @@ export function useHook(): HookResult {
   const handleChainIdChange = (option: SelectOption) => setChainId(option.value);
   const handleTokenIdChange = (value: string) => setTokenId(value);
   const handleRefreshTypeChange = (option: SelectOption) =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     setRefreshType(option.value as RefreshOption);
 
   const onClick = () => {
@@ -92,6 +93,7 @@ export default function RefreshMetadata(props: HookResult) {
       if (error instanceof LedgerAPI4xx) {
         return t("settings.developer.debugSimpleHash.debugRefreshMetadata.error");
       }
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return (error as Error).message;
     };
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/SimpleHashTools/SpamReportNtf/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/SimpleHashTools/SpamReportNtf/index.tsx
@@ -46,8 +46,10 @@ export function useHook(): HookResult {
   const handleContractAddressChange = (value: string) => setContractAddress(value);
   const handleChainIdChange = (option: SelectOption) => setChainId(option.value);
   const handleTokenIdChange = (value: string) => setTokenId(value);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const handleReportChange = (option: SelectOption) => setReport(option.value as EventType);
   const handleReportTypeChange = (option: SelectOption) =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     setReportType(option.value as ReportOption);
 
   const onClick = () => {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/SimpleHashTools/SpamScore/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/SimpleHashTools/SpamScore/index.tsx
@@ -69,6 +69,7 @@ export default function SpamScore(props: HookResult) {
       if (error instanceof LedgerAPI4xx) {
         return t("settings.developer.debugSimpleHash.debugCheckSpamScore.error");
       }
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return (error as Error).message;
     };
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletSync/Generator/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/WalletSync/Generator/index.tsx
@@ -38,6 +38,7 @@ export function GeneratorLedgerSync() {
 
   const flowsOptions = Object.keys(FlowOptions).map(flow => ({
     label: flow,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     value: flow as Flow,
   }));
 
@@ -75,12 +76,11 @@ export function GeneratorLedgerSync() {
     }
     const instances = Array.from(
       { length: Math.floor(Math.random() * 5) },
-      (_, index) =>
-        ({
-          id: String(index),
-          name: index % 2 === 0 ? `Iphone ${index + 1}` : "macOS",
-          permissions: index % 2 === 0 ? 1 : 2,
-        }) as TrustchainMember,
+      (_, index): TrustchainMember => ({
+        id: String(index),
+        name: index % 2 === 0 ? `Iphone ${index + 1}` : "macOS",
+        permissions: index % 2 === 0 ? 1 : 2,
+      }),
     );
 
     setState({ ...state, instances });
@@ -95,6 +95,7 @@ export function GeneratorLedgerSync() {
           isSearchable={false}
           onChange={option => {
             if (option) {
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
               setState({ ...state, flow: option.value as Flow, step: null });
             }
           }}
@@ -110,6 +111,7 @@ export function GeneratorLedgerSync() {
           isSearchable={false}
           onChange={option => {
             if (option) {
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
               setState({ ...state, step: option.value as Step });
             }
           }}

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Experimental/index.tsx
@@ -47,6 +47,7 @@ const BaseExperimentalFeatureRow = ({
         isDefault={isDefault}
         onChange={onChange}
         {...rest}
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         value={envValue as number}
       />
     </Row>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/LanguageSelect.tsx
@@ -55,17 +55,18 @@ const LanguageSelectComponent: React.FC<Props> = ({ disableLanguagePrompt }) => 
 
   const languages = useMemo(
     () =>
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       [{ value: null as Language | null, label: t(`language.system`) }].concat(
-        (Object.keys(supportedLanguages) as Array<keyof typeof Languages>).map(language => {
-          return {
-            value: language,
-            label: Languages[language].label,
-          };
-        }),
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        (Object.keys(supportedLanguages) as Array<keyof typeof Languages>).map(language => ({
+          value: language,
+          label: Languages[language].label,
+        })),
       ),
     [supportedLanguages, t],
   );
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const selectedLanguage = useMemo(
     () => (useSystem ? languages[0] : languages.find(l => l.value === language)),
     [language, languages, useSystem],

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ThemeSelect.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ThemeSelect.tsx
@@ -27,23 +27,21 @@ const ThemeSelect = () => {
     },
     [dispatch],
   );
-  const options = useMemo(
-    () =>
-      (
-        [
-          {
-            value: null,
-            label: t("theme.system"),
-          },
-        ] as ThemeSelectOption[]
-      ).concat(
-        Object.keys(themeLabels).map(key => ({
-          value: key,
-          label: t(themeLabels[key as keyof typeof themeLabels]),
-        })),
-      ),
-    [t],
-  );
+  const options = useMemo(() => {
+    const xs: ThemeSelectOption[] = [
+      {
+        value: null,
+        label: t("theme.system"),
+      },
+    ];
+    return xs.concat(
+      Object.keys(themeLabels).map(key => ({
+        value: key,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        label: t(themeLabels[key as keyof typeof themeLabels]),
+      })),
+    );
+  }, [t]);
   const currentTheme = options.find(option => option.value === theme);
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/CleanButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/CleanButton.tsx
@@ -7,11 +7,14 @@ import ConfirmModal from "~/renderer/modals/ConfirmModal";
 import ResetFallbackModal from "~/renderer/modals/ResetFallbackModal";
 import { ActionModalReducer, ActionModalState, useActionModal } from "./logic";
 import { useSoftReset } from "~/renderer/reset";
+
 export default function CleanButton() {
   const { t } = useTranslation();
   const softReset = useSoftReset();
   const [state, actions] = useActionModal();
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { opened, pending, fallbackOpened } = state as ActionModalState;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { open, close, closeFallback, handleConfirm, handleError } = actions as ActionModalReducer;
   const onConfirm = useCallback(async () => {
     if (pending) return;

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/ResetButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Help/ResetButton.tsx
@@ -11,11 +11,14 @@ import Button from "~/renderer/components/Button";
 import Alert from "~/renderer/components/Alert";
 import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 import { ActionModalReducer, ActionModalState, useActionModal } from "./logic";
+
 export default function ResetButton() {
   const { t } = useTranslation();
   const hardReset = useHardReset();
   const [state, actions] = useActionModal();
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { opened, pending, fallbackOpened } = state as ActionModalState;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const { open, close, closeFallback, handleConfirm, handleError } = actions as ActionModalReducer;
   const onConfirm = useCallback(async () => {
     if (pending) return;

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -129,6 +129,7 @@ export const getKey = async <
     keyPath,
     defaultValue,
   });
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const transform = transforms[keyPath as keyof Transforms];
   if (transform) {
     data = transform.get(data);
@@ -148,10 +149,12 @@ if (getEnv("PLAYWRIGHT_RUN")) {
 const debouncedSetKey = memoize(
   <K extends keyof DatabaseValues, V = DatabaseValue<K>>(ns: string, keyPath: K) =>
     debounceToUse((value: V) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const transform = transforms[keyPath as keyof Transforms];
       ipcRenderer.invoke("setKey", {
         ns,
         keyPath,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         value: transform ? transform.set(value as Parameters<typeof transform.set>[0]) : value,
       });
     }, 1000),

--- a/apps/ledger-live-desktop/src/renderer/store.ts
+++ b/apps/ledger-live-desktop/src/renderer/store.ts
@@ -8,6 +8,7 @@ const store = new ElectronStore({
 
 export function getStoreValue<T>(key: string, storeId: string): T | undefined {
   const value = store.get(`${storeId}-${key}`);
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return isEmpty(value) ? undefined : (value as T);
 }
 

--- a/apps/ledger-live-desktop/src/renderer/styles/StyleProvider.tsx
+++ b/apps/ledger-live-desktop/src/renderer/styles/StyleProvider.tsx
@@ -45,7 +45,7 @@ const StyleProvider = ({ children, selectedPalette }: Props) => {
 };
 export const withV2StyleProvider = <T,>(Component: React.ComponentType<T>) => {
   const WrappedComponent = (props: T & { children?: React.ReactNode }) => {
-    const selectedPalette = (useSelector(themeSelector) || "light") as "light" | "dark";
+    const selectedPalette = useSelector(themeSelector) || "light";
     return (
       <StyleProvider selectedPalette={selectedPalette}>
         <Component {...props} />

--- a/apps/ledger-live-desktop/src/renderer/styles/StyleProviderV3.tsx
+++ b/apps/ledger-live-desktop/src/renderer/styles/StyleProviderV3.tsx
@@ -44,6 +44,7 @@ export const withV3StyleProvider = <T,>(Component: React.ComponentType<T>) => {
     const theme = useTheme();
 
     return (
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       <StyleProviderV3 selectedPalette={theme.colors.type as "light" | "dark"}>
         <Component {...props} />
       </StyleProviderV3>

--- a/apps/ledger-live-desktop/src/renderer/styles/palettes/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/styles/palettes/index.ts
@@ -47,11 +47,13 @@ const enrichPalette = (rawPalette: RawPalette): Theme => {
     ...rawPalette,
     text: shades.reduce(
       (acc, value) => {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         acc[`shade${value}` as keyof Theme["text"]] = Color(rawPalette.secondary.main)
           .alpha(value / 100)
           .toString();
         return acc;
       },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       {} as Theme["text"],
     ),
   };
@@ -64,10 +66,13 @@ const palettes: {
   dark,
 }).reduce(
   (acc, [name, value]) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const rawPalette: RawPalette = value as RawPalette;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     acc[name as "dark" | "light"] = enrichPalette(rawPalette);
     return acc;
   },
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   {} as {
     dark: Theme;
     light: Theme;

--- a/apps/ledger-live-desktop/src/sentry/anonymizer.ts
+++ b/apps/ledger-live-desktop/src/sentry/anonymizer.ts
@@ -44,6 +44,7 @@ function filepathReplace(path: string): string {
 
   if (!homeDir || !configDir) return ""; // empty everything because we don't know the paths yet
   if (!path || path.startsWith("app://")) return path;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const replaced = (Object.keys(basePaths) as (keyof typeof basePaths)[]).reduce((path, name) => {
     const p: string = basePaths[name];
     return path
@@ -77,10 +78,12 @@ function filepathRecursiveReplacer(obj: ReplacerArgument, seen: Set<ReplacerArgu
         // eslint-disable-next-line no-prototype-builtins
         if (typeof obj.hasOwnProperty === "function" && obj.hasOwnProperty(k)) {
           const value = obj[k];
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           if (seen.has(value as ReplacerArgument)) continue;
           if (typeof value === "string") {
             obj[k] = filepathReplace(value);
           } else {
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             filepathRecursiveReplacer(value as ReplacerArgument, seen);
           }
         }

--- a/apps/ledger-live-desktop/src/sentry/install.ts
+++ b/apps/ledger-live-desktop/src/sentry/install.ts
@@ -142,6 +142,7 @@ export function init(Sentry: typeof SentryMainModule, opts?: Partial<ElectronMai
 
       delete data.server_name; // hides the user machine name
       try {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         anonymizer.filepathRecursiveReplacer(data as unknown as Record<string, unknown>);
       } catch (e) {
         console.error("can't anonymize", e);

--- a/apps/ledger-live-desktop/src/storyly/StorylyProvider.tsx
+++ b/apps/ledger-live-desktop/src/storyly/StorylyProvider.tsx
@@ -23,6 +23,7 @@ const StorylyContext = createContext<StorylyContextType | undefined>(undefined);
 type StoriesType = Feature_Storyly["params"] extends { stories: infer S } ? S : never;
 
 const getTokenForInstanceId = (stories: StoriesType, targetInstanceId: string): string | null => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const foundStory = Object.values(stories) as StorylyInstanceType[];
   const matchingStory = foundStory.find(story => story.instanceId === targetInstanceId);
   return matchingStory ? matchingStory?.token : null;
@@ -52,7 +53,7 @@ const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
 
     storylyRef.current?.on("actionClicked", (story: Story) => {
       if (!story.actionUrl) return;
-      openURL(story.actionUrl as string);
+      openURL(story.actionUrl);
       storylyRef.current?.close?.();
       dispatch(closeAllModal());
       setDrawer();
@@ -77,6 +78,7 @@ const StorylyProvider: React.FC<StorylyProviderProps> = ({ children }) => {
       const storylyQuery = Object.fromEntries(searchParams);
       setQuery(storylyQuery);
       if (storylyQuery?.instance)
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         setToken(getTokenForInstanceId(stories as StoriesType, storylyQuery?.instance));
     }
   }, [stories, url]);

--- a/apps/ledger-live-desktop/tests/featureFlags.ts
+++ b/apps/ledger-live-desktop/tests/featureFlags.ts
@@ -14,6 +14,7 @@ export const getFeature = <T extends FeatureId>({
   allowOverride?: boolean;
   localOverrides?: { [key in FeatureId]?: Feature | undefined };
 }): Features[T] => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   if (localOverrides?.[key]) return localOverrides?.[key] as Features[T];
   return DEFAULT_FEATURES[key];
 };

--- a/apps/ledger-live-desktop/tests/fixtures/common.ts
+++ b/apps/ledger-live-desktop/tests/fixtures/common.ts
@@ -1,4 +1,4 @@
-import { test as base, Page, ElectronApplication, ChromiumBrowserContext } from "@playwright/test";
+import { test as base, Page, ElectronApplication } from "@playwright/test";
 import fsPromises from "fs/promises";
 import merge from "lodash/merge";
 import * as path from "path";
@@ -117,7 +117,7 @@ export const test = base.extend<TestFixtures>({
     page.setDefaultTimeout(120000);
 
     if (process.env.PLAYWRIGHT_CPU_THROTTLING_RATE) {
-      const client = await (page.context() as ChromiumBrowserContext).newCDPSession(page);
+      const client = await page.context().newCDPSession(page);
       await client.send("Emulation.setCPUThrottlingRate", {
         rate: parseInt(process.env.PLAYWRIGHT_CPU_THROTTLING_RATE),
       });

--- a/apps/ledger-live-desktop/tests/misc/reporters/step.ts
+++ b/apps/ledger-live-desktop/tests/misc/reporters/step.ts
@@ -23,7 +23,8 @@ export function step<This, Args extends any[], Return>(message?: string) {
     function replacementMethod(this: any, ...args: Args) {
       const name = message
         ? message.replace(/\$(\d+)/g, (_, index) => args[Number(index)].toString())
-        : `${this.constructor.name}.${context.name as string}`;
+        : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          `${this.constructor.name}.${context.name as string}`;
 
       return test.step(name, async () => target.call(this, ...args), { box: true });
     }

--- a/apps/ledger-live-desktop/tests/mocks/countervalues.mock.ts
+++ b/apps/ledger-live-desktop/tests/mocks/countervalues.mock.ts
@@ -1,6 +1,8 @@
 import { CounterValuesStateRaw, CounterValuesStatus } from "@ledgerhq/live-countervalues/types";
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 export const initialCountervaluesMock = {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   status: {
     "USD ethereum": {
       oldestDateRequested: "2020-04-22T11:51:36.000Z",

--- a/apps/ledger-live-desktop/tests/mocks/serviceStatusHelpers.ts
+++ b/apps/ledger-live-desktop/tests/mocks/serviceStatusHelpers.ts
@@ -3,6 +3,7 @@ import {
   ServiceStatusSummary,
   Incident,
 } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/types";
+
 const statuses = {
   page: {
     id: "767c5rcj7z12",
@@ -463,6 +464,7 @@ const statuses = {
       only_show_if_degraded: false,
     },
   ],
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   incidents: [] as Incident[],
   scheduled_maintenances: [],
   status: {
@@ -470,6 +472,7 @@ const statuses = {
     description: "All Systems Operational",
   },
 };
+
 const mockedIncidents: Incident[] = [
   {
     created_at: "2021-02-22T17:58:18.792+02:00",

--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -243,6 +243,7 @@ export class LiveAppWebview {
     `;
 
     return this.page.evaluate(functionToExecute => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const webview = document.querySelector("webview") as WebviewTag;
       return webview.executeJavaScript(functionToExecute);
     }, sendFunction);

--- a/apps/ledger-live-desktop/tests/specs/syncOnboarding/manual.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/syncOnboarding/manual.spec.ts
@@ -34,6 +34,7 @@ for (const modelId of modelIds) {
       });
 
       await test.step(`[${modelId}] Select stax device`, async () => {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         await onboardingPage.selectDevice(modelId as "nanoS" | "nanoX" | "nanoSP" | "stax");
       });
 

--- a/apps/ledger-live-desktop/tests/testSetup.tsx
+++ b/apps/ledger-live-desktop/tests/testSetup.tsx
@@ -124,6 +124,7 @@ function renderWithMockedCounterValuesProvider(
 ): RenderReturn {
   const {
     initialState = {},
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     store = createStore({ state: initialState as State, dbMiddleware }),
     userEventOptions = {},
     ...renderOptions
@@ -157,6 +158,7 @@ function renderWithMockedCounterValuesProvider(
 function render(ui: JSX.Element, options: ExtraOptions = {}): RenderReturn {
   const {
     initialState = {},
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     store = createStore({ state: initialState as State, dbMiddleware }),
     userEventOptions = {},
     ...renderOptions
@@ -197,6 +199,7 @@ function renderHook<Result, Props>(
   const {
     initialProps,
     initialState = {},
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     store = createStore({ state: initialState as State, dbMiddleware }),
   } = options;
 
@@ -224,6 +227,7 @@ function renderHookWithLiveAppProvider<Result, Props>(
   const {
     initialProps,
     initialState = {},
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     store = createStore({ state: initialState as State, dbMiddleware }),
   } = options;
 

--- a/apps/ledger-live-desktop/tests/utils/customJsonReporter.ts
+++ b/apps/ledger-live-desktop/tests/utils/customJsonReporter.ts
@@ -2,8 +2,8 @@ import { Reporter, TestCase, TestResult } from "@playwright/test/reporter";
 import * as fs from "fs";
 import * as path from "path";
 
-export function getDescription(annotations: any, type: "TMS" | "BUG") {
-  const annotation = annotations.find((ann: any) => ann.type === type);
+export function getDescription(annotations: TestCase["annotations"], type: "TMS" | "BUG") {
+  const annotation = annotations.find(ann => ann.type === type);
   return annotation ? annotation.description : "Type not found";
 }
 
@@ -31,7 +31,7 @@ class JsonReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult): void {
-    const testKeys = getDescription(test.annotations, "TMS").split(", ");
+    const testKeys = getDescription(test.annotations, "TMS")?.split(", ") ?? [];
     const status = result.status.toUpperCase();
 
     for (const testKey of testKeys) {

--- a/apps/ledger-live-desktop/tests/utils/fileUtils.ts
+++ b/apps/ledger-live-desktop/tests/utils/fileUtils.ts
@@ -3,7 +3,7 @@ import { appendFile } from "fs/promises";
 export async function safeAppendFile(filePath: string, data: string) {
   try {
     await appendFile(filePath, data);
-  } catch (e: any) {
+  } catch (e) {
     if (e) console.error("couldn't append file", e);
   }
 }

--- a/apps/ledger-live-desktop/tests/utils/waitFor.ts
+++ b/apps/ledger-live-desktop/tests/utils/waitFor.ts
@@ -13,13 +13,13 @@ export async function waitFor(
     const interval = setInterval(async () => {
       const condition = await predicate();
       if (condition) {
-        clearInterval(interval as unknown as number);
+        clearInterval(interval);
         resolve(true);
       }
     }, intervalMs);
 
     setTimeout(() => {
-      clearInterval(interval as unknown as number);
+      clearInterval(interval);
       reject(new Error("waitFor timeout"));
     }, timeout);
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New eslint rule to warn against type assertions.

### 📝 Description

Type assertions are dangerous because they bypass TypeScript’s type safety, allowing you to tell the compiler “trust me” even if the value doesn’t actually match the asserted type. This can lead to runtime errors, hidden bugs, and broken assumptions during refactoring, especially when asserting from `unknown` or `any`.

### ❓ Context

- **JIRA**: [LIVE-20071](https://ledgerhq.atlassian.net/browse/LIVE-20071)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20071]: https://ledgerhq.atlassian.net/browse/LIVE-20071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ