### PR TITLE
fix: Sui alpaca integration

### DIFF
--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -10,9 +10,6 @@ describe("Sui Api", () => {
 
   beforeAll(() => {
     module = createApi({
-      status: {
-        type: "active",
-      },
       node: {
         url: getEnv("API_SUI_NODE_PROXY"),
       },

--- a/libs/coin-modules/coin-sui/src/api/index.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.ts
@@ -1,4 +1,4 @@
-import coinConfig, { type SuiCoinConfig } from "../config";
+import coinConfig, { type SuiConfig } from "../config";
 import {
   estimateFees,
   combine,
@@ -15,7 +15,7 @@ import type {
   TransactionIntent,
 } from "@ledgerhq/coin-framework/api/index";
 
-export function createApi(config: SuiCoinConfig): AlpacaApi<SuiAsset> {
+export function createApi(config: SuiConfig): AlpacaApi<SuiAsset> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
 
   return {


### PR DESCRIPTION
### 📝 Description

To allow Aplaca to integrate with the SUI coin-module, a slight change in the config is needed. It's now the same as other alpaca coins like Tron or Tezos.
