### PR TITLE
chore(e2e): remove hardcoded ptxSwapLiveAppMobile feature flag from E…

### DIFF
--- a/.changeset/happy-sloths-itch.md
+++ b/.changeset/happy-sloths-itch.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-mobile-e2e-tests": minor
+---
+
+remove hardcoded ptxSwapLiveAppMobile feature flag from E2E mobile tests

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -21,14 +21,6 @@ async function beforeAllFunction(options: ApplicationOptions) {
   await app.init({
     userdata: options.userdata,
     speculosApp: options.speculosApp,
-    featureFlags: {
-      ptxSwapLiveAppMobile: {
-        enabled: true,
-        params: {
-          manifest_id: "swap-live-app-demo-3-stg",
-        },
-      },
-    },
     cliCommandsOnApp: options.cliCommandsOnApp,
   });
   await app.portfolio.waitForPortfolioPageToLoad();

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -9,14 +9,6 @@ const beforeAllFunction = async (swap: SwapType) => {
   await app.speculos.setExchangeDependencies(swap);
   await app.init({
     speculosApp: AppInfos.EXCHANGE,
-    featureFlags: {
-      ptxSwapLiveAppMobile: {
-        enabled: true,
-        params: {
-          manifest_id: "swap-live-app-demo-3-stg",
-        },
-      },
-    },
     cliCommandsOnApp: [
       {
         app: swap.accountToDebit.currency.speculosApp,


### PR DESCRIPTION
…2E mobile tests

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
