### PR TITLE
bugfix(🐛): improve legacy QRcode import detection and address scan handling

### DIFF
--- a/.changeset/rare-meals-flash.md
+++ b/.changeset/rare-meals-flash.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": minor
+---
+
+🔍✨ Improve detection of legacy import base64 strings and invalid address scans
+
+- Better handling of legacy `Qrcode` base64 imports using stricter format and header checks
+- Improved error resilience when scanning addresses (ETH, BTC, etc.) instead of base64
+- Ignores invalid or malformed input early, reducing false positives

--- a/libs/ledger-key-ring-protocol/src/qrcode/index.test.ts
+++ b/libs/ledger-key-ring-protocol/src/qrcode/index.test.ts
@@ -4,51 +4,93 @@ import { convertKeyPairToLiveCredentials } from "../sdk";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { ScannedInvalidQrCode, ScannedOldImportQrCode } from "../errors";
 
+// Test data constants
+const MOCK_TRUSTCHAIN = {
+  rootId: "test-root-id",
+  walletSyncEncryptionKey: "test-wallet-sync-encryption-key",
+  applicationPath: "m/0'/16'/0'",
+} as const;
+
+const LEGACY_IMPORT_QR_CODE =
+  "ZAADAAIAAAAEd2JXMpuoYdzvkNzFTlmQLPcGf2LSjDOgqaB3nQoZqlimcCX6HNkescWKyT1DCGuwO7IesD7oYg+fdZPkiIfFL3V9swfZRePkaNN09IjXsWLsim9hK/qi/RC1/ofX3hYNKUxUAgYVVG82WKXIk47siWfUlRZsCYSAARQ6ASpUgidPjMHaOMK6w53wTZplwo7Zjv1HrIyKwr3Ci8OmrFye5g==";
+
+const CRYPTO_ADDRESSES = {
+  ethereum: "0x6fC39c0C6D379d8D168e9EFD90C4B55Fc1Bb1fF2",
+  solana: "5eMHnPQa4vHP6oFbydZx6RjzGvZR2qZtCQ7E8yrFw93n",
+  ripple: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
+  cardano:
+    "addr1q9dduxx8zhp4vq4rkfsl8gk0wnwhkyd4shzdc3u9jxuw8c3af2cqpjnhx8yqz3sjdf8ttf5htp2v07ah3ts2mtfzw46qqj7kzw",
+  bitcoin: "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh",
+  cosmos: "cosmos1h9w6z0sgp2k4z6qzwk0jhp5a5rz87vt4l25fsl",
+} as const;
+
 describe("Trustchain QR Code", () => {
-  let server;
-  let a;
-  let b;
+  let server: WebSocket.Server;
+  let wsA: WebSocket | null = null;
+  let wsB: WebSocket | null = null;
 
   beforeAll(() => {
     server = new WebSocket.Server({ port: 1234 });
     server.on("connection", ws => {
-      if (!a) {
-        a = ws;
-      } else if (!b) {
-        b = ws;
+      if (!wsA) {
+        wsA = ws;
+      } else if (!wsB) {
+        wsB = ws;
       }
       ws.on("message", message => {
-        if (ws === a && b) {
-          b.send(message);
-        } else if (ws === b && a) {
-          a.send(message);
+        if (ws === wsA && wsB) {
+          wsB.send(message);
+        } else if (ws === wsB && wsA) {
+          wsA.send(message);
         }
       });
     });
   });
 
-  afterAll(() => {
-    server.close();
+  afterAll(async () => {
+    if (wsA) {
+      wsA.terminate();
+      wsA = null;
+    }
+    if (wsB) {
+      wsB.terminate();
+      wsB = null;
+    }
+    if (server) {
+      await new Promise<void>(resolve => {
+        server.close(() => resolve());
+      });
+    }
   });
 
-  test("digits matching scenario", async () => {
-    const onDisplayDigits = jest.fn();
-    const trustchain = {
-      rootId: "test-root-id",
-      walletSyncEncryptionKey: "test-wallet-sync-encryption-key",
-      applicationPath: "m/0'/16'/0'",
-    };
-    const addMember = jest.fn(() => Promise.resolve(trustchain));
+  /**
+   * Helper function to create common test setup
+   */
+  const createTestSetup = async () => {
     const memberCredentials = convertKeyPairToLiveCredentials(await crypto.randomKeypair());
-    const memberName = "foo";
+    const addMember = jest.fn(() => Promise.resolve(MOCK_TRUSTCHAIN));
+    const onRequestQRCodeInput = jest.fn();
+    return {
+      memberCredentials,
+      addMember,
+      onRequestQRCodeInput,
+      memberName: "foo",
+    };
+  };
+
+  test("digits matching scenario", async () => {
+    const { memberCredentials, addMember, memberName } = await createTestSetup();
+    const onDisplayDigits = jest.fn();
 
     let scannedUrlResolve: (url: string) => void;
     const scannedUrlPromise = new Promise<string>(resolve => {
       scannedUrlResolve = resolve;
     });
+
     const onDisplayQRCode = (url: string) => {
       scannedUrlResolve(url);
     };
+
     const onRequestQRCodeInput = jest.fn((config, callback) =>
       callback(onDisplayDigits.mock.calls[0][0]),
     );
@@ -60,7 +102,7 @@ describe("Trustchain QR Code", () => {
       addMember,
       memberCredentials,
       memberName,
-      initialTrustchainId: trustchain.rootId,
+      initialTrustchainId: MOCK_TRUSTCHAIN.rootId,
     });
 
     const scannedUrl = await scannedUrlPromise;
@@ -82,20 +124,12 @@ describe("Trustchain QR Code", () => {
       { digits: 3, connected: false },
       expect.any(Function),
     );
-    expect(res).toEqual(trustchain);
+    expect(res).toEqual(MOCK_TRUSTCHAIN);
   });
+
   test("invalid qr code scanned", async () => {
-    const trustchain = {
-      rootId: "test-root-id",
-      walletSyncEncryptionKey: "test-wallet-sync-encryption-key",
-      applicationPath: "m/0'/16'/0'",
-    };
-    const addMember = jest.fn(() => Promise.resolve(trustchain));
-    const memberCredentials = convertKeyPairToLiveCredentials(await crypto.randomKeypair());
-    const memberName = "foo";
-
-    const onRequestQRCodeInput = jest.fn();
-
+    const { memberCredentials, addMember, onRequestQRCodeInput, memberName } =
+      await createTestSetup();
     const scannedUrl = "https://example.com";
 
     const candidateP = createQRCodeCandidateInstance({
@@ -109,30 +143,39 @@ describe("Trustchain QR Code", () => {
 
     await expect(candidateP).rejects.toThrow(new ScannedInvalidQrCode());
   });
+
   test("old accounts export qr code scanned", async () => {
-    const trustchain = {
-      rootId: "test-root-id",
-      walletSyncEncryptionKey: "test-wallet-sync-encryption-key",
-      applicationPath: "m/0'/16'/0'",
-    };
-    const addMember = jest.fn(() => Promise.resolve(trustchain));
-    const memberCredentials = convertKeyPairToLiveCredentials(await crypto.randomKeypair());
-    const memberName = "foo";
-
-    const onRequestQRCodeInput = jest.fn();
-
-    const scannedUrl =
-      "ZAADAAIAAAAEd2JXMpuoYdzvkNzFTlmQLPcGf2LSjDOgqaB3nQoZqlimcCX6HNkescWKyT1DCGuwO7IesD7oYg+fdZPkiIfFL3V9swfZRePkaNN09IjXsWLsim9hK/qi/RC1/ofX3hYNKUxUAgYVVG82WKXIk47siWfUlRZsCYSAARQ6ASpUgidPjMHaOMK6w53wTZplwo7Zjv1HrIyKwr3Ci8OmrFye5g==";
+    const { memberCredentials, addMember, onRequestQRCodeInput, memberName } =
+      await createTestSetup();
 
     const candidateP = createQRCodeCandidateInstance({
       memberCredentials,
       memberName,
       initialTrustchainId: undefined,
       addMember,
-      scannedUrl,
+      scannedUrl: LEGACY_IMPORT_QR_CODE,
       onRequestQRCodeInput,
     });
 
     await expect(candidateP).rejects.toThrow(new ScannedOldImportQrCode());
   });
+
+  it.each(Object.entries(CRYPTO_ADDRESSES))(
+    "should reject cryptocurrency address (%s) as invalid QR code",
+    async (_, address) => {
+      const { memberCredentials, addMember, onRequestQRCodeInput, memberName } =
+        await createTestSetup();
+
+      const candidateP = createQRCodeCandidateInstance({
+        memberCredentials,
+        memberName,
+        initialTrustchainId: undefined,
+        addMember,
+        scannedUrl: address,
+        onRequestQRCodeInput,
+      });
+
+      await expect(candidateP).rejects.toThrow(new ScannedInvalidQrCode());
+    },
+  );
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR improves the detection of legacy base64-encoded QRcode imports by enforcing stricter format validation and checking for a specific binary header.

It also enhances error handling when scanning inputs that are not base64 (e.g., ETH, BTC addresses), providing clearer error messages and reducing false positives.

https://github.com/user-attachments/assets/e9917cd4-401c-42db-af33-23893f0310af



### ❓ Context

- **JIRA or GitHub link**: [LIVE-20105](https://ledgerhq.atlassian.net/browse/LIVE-20105) 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20105]: https://ledgerhq.atlassian.net/browse/LIVE-20105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ