### PR TITLE
fix: [xrp] getbalance returns early if new account + fix integ tests

### DIFF
--- a/.changeset/tall-pots-thank.md
+++ b/.changeset/tall-pots-thank.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-xrp": minor
+---
+
+fix: getbalance returns 0 locked for new accounts

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -117,7 +117,7 @@ describe("Xrp Api", () => {
         },
       });
       // Then
-      expect(result.length).toEqual(162);
+      expect(result.length).toEqual(178);
     });
 
     it("should use default fees when user does not provide them for crafting a transaction", async () => {

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -96,7 +96,7 @@ describe("Xrp Api", () => {
       const result = await api.getBalance(SENDER_WITH_NO_TRANSACTION);
 
       // Then
-      expect(result).toEqual([{ value: BigInt(0), asset: { type: "native" } }]);
+      expect(result).toEqual([{ value: BigInt(0), locked: BigInt(0), asset: { type: "native" } }]);
     });
   });
 

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -113,6 +113,23 @@ describe("Xrp Api", () => {
         amount: BigInt(10),
         memo: {
           type: "map",
+          memos: new Map(),
+        },
+      });
+      // Then
+      expect(result.length).toEqual(162);
+    });
+
+    it("returns a raw transaction, (memo)", async () => {
+      // When
+      const result = await api.craftTransaction({
+        asset: { type: "native" },
+        type: "send",
+        sender: SENDER,
+        recipient: RECIPIENT,
+        amount: BigInt(10),
+        memo: {
+          type: "map",
           memos: new Map([["memos", ["testdata"]]]),
         },
       });

--- a/libs/coin-modules/coin-xrp/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/getBalance.test.ts
@@ -40,4 +40,79 @@ describe("getBalance", () => {
     expect(mockGetAccountInfo.mock.lastCall[0]).toEqual(address);
     expect(result).toEqual([{ value: balance, asset: { type: "native" }, locked: 23000000n }]);
   });
+
+  it("returns 0 balance and no locked amount for a new (inactive) account", async () => {
+    mockGetAccountInfo.mockResolvedValue({
+      isNewAccount: true,
+      balance: "0",
+      ownerCount: 0,
+      sequence: 0,
+    });
+
+    const result = await getBalance("NEW_XRP_ACCOUNT");
+
+    expect(mockGetAccountInfo).toHaveBeenCalledTimes(1);
+    expect(mockGetServerInfos).not.toHaveBeenCalled(); // important!
+    expect(result).toEqual([{ value: 0n, locked: 0n, asset: { type: "native" } }]);
+  });
+
+  it("calculates locked amount correctly with trustlines", async () => {
+    mockGetServerInfos.mockResolvedValue({
+      info: {
+        validated_ledger: {
+          reserve_base_xrp: 20,
+          reserve_inc_xrp: 5,
+        },
+      },
+    });
+
+    const balance = 100_000_000n;
+    const trustlines = 3;
+
+    mockGetAccountInfo.mockResolvedValue({
+      isNewAccount: false,
+      balance,
+      ownerCount: trustlines,
+      sequence: 1,
+    });
+
+    const result = await getBalance("ACCOUNT_WITH_TRUSTLINES");
+
+    // Locked = 20 + (5 * 3) = 35 XRP = 35_000_000 drops
+    expect(result).toEqual([
+      {
+        value: balance,
+        asset: { type: "native" },
+        locked: 35_000_000n,
+      },
+    ]);
+  });
+
+  it("returns 0 value with locked amount for an active account with 0 balance", async () => {
+    mockGetServerInfos.mockResolvedValue({
+      info: {
+        validated_ledger: {
+          reserve_base_xrp: 10,
+          reserve_inc_xrp: 2,
+        },
+      },
+    });
+
+    mockGetAccountInfo.mockResolvedValue({
+      isNewAccount: false,
+      balance: "0",
+      ownerCount: 0,
+      sequence: 5,
+    });
+
+    const result = await getBalance("ZERO_BALANCE_ACTIVE_ACCOUNT");
+
+    expect(result).toEqual([
+      {
+        value: 0n,
+        asset: { type: "native" },
+        locked: 10_000_000n,
+      },
+    ]);
+  });
 });

--- a/libs/coin-modules/coin-xrp/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/getBalance.ts
@@ -5,6 +5,17 @@ import { parseAPIValue } from "./common";
 
 export async function getBalance(address: string): Promise<Balance<XrpAsset>[]> {
   const accountInfo = await getAccountInfo(address);
+
+  if (accountInfo.isNewAccount) {
+    return [
+      {
+        value: 0n,
+        locked: 0n,
+        asset: { type: "native" },
+      },
+    ];
+  }
+
   const serverInfo = await getServerInfos();
 
   const reserveMinXRP = parseAPIValue(serverInfo.info.validated_ledger.reserve_base_xrp.toString());


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Previously, the getBalance function always computed a locked balance based on XRP reserve rules — even for accounts that were inactive (not yet created on-chain). This led to confusing or incorrect results in cases like:

`{ value: 0n, locked: 1_000_000n }`

when the account had no transaction history and wasn't funded.

#### What the PR Does

- Adds a check in `getBalance.ts`:

If `accountInfo.isNewAccount` is `true` (account doesn't exist):

Return `value: 0n, locked: 0n`

- Updates the integration test:

Adjusts the expected output to include `locked: 0n` explicitly

Fixes the test asserting `result.length` to match actual behavior



### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
