### PR TITLE
ci: add dry_run option to skip upload

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -40,6 +40,14 @@ def trim_version_number(version)
   SemVer.parse(version).format "%M.%m.%p"
 end
 
+def handle_dry_run(options, action_name)
+  if options[:dry_run]
+    UI.important "🔍 DRY RUN MODE - #{action_name} will be skipped"
+    return true
+  end
+  false
+end
+
 lane :beta do |options|
   ensure_git_status_clean
 
@@ -359,22 +367,34 @@ platform :ios do
 
   desc "ci: create testflight version"
   lane :ci_testflight do |options|
+    if options[:dry_run]
+      UI.important "🔍 DRY RUN MODE - No actual upload will be performed"
+    end
+    
     setup_ios_ci
     build(ci: true)
-    upload(
-      prerelease: true,
-      ci: true
-    )
+    
+    unless options[:dry_run]
+      upload(
+        prerelease: true,
+        ci: true
+      )
+    else
+      UI.success "✅ DRY RUN: Build completed successfully (upload skipped)"
+    end
   end
 
   desc "ci: create nightly version"
   lane :ci_nightly do |options|
     setup_ios_ci
     build(ci: true)
-    upload(
-      nightly: true,
-      ci: true
-    )
+    
+    unless handle_dry_run(options, "nightly upload")
+      upload(
+        nightly: true,
+        ci: true
+      )
+    end
   end
 
   desc "ci: create adhoc version"
@@ -531,28 +551,40 @@ platform :android do
   end
 
   desc "build APKs + AAB and send the AAB to the Google Play Store "
-  lane :ci_playstore do
+  lane :ci_playstore do |options|
+    if options[:dry_run]
+      UI.important "🔍 DRY RUN MODE - No actual upload will be performed"
+    end
+    
     prepare_android_internal
     build(
       type: "Release",
       ci: true,
       apk_and_aab: true
     )
-    upload(ci: true)
+    
+    unless options[:dry_run]
+      upload(ci: true)
+    else
+      UI.success "✅ DRY RUN: Build completed successfully (upload skipped)"
+    end
   end
 
   desc "build nightly version"
-  lane :ci_nightly do
+  lane :ci_nightly do |options|
     prepare_android_internal
     build(
       type: "Release",
       ci: true,
       apk_and_aab: true
     )
-    upload(
-      nightly: true,
-      ci: true
-    )
+    
+    unless handle_dry_run(options, "nightly upload")
+      upload(
+        nightly: true,
+        ci: true
+      )
+    end
   end
 
   desc "build recover version"


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

  Add `dry_run` option to fastlane to be able to test easily modifications for `nightly`, `pre-release`, and `release` workflows. It allows us to add a `dry-run` option to these workflows and refactor the build command call very simply and easily.

From 
```
pnpm mobile android:ci:nightly
```
To 
```
pnpm mobile android:ci:nightly ${{ github.event.inputs.dry-run == 'true' && 'dry_run:true' || '' }}
```

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
