### PR TITLE
Fix: send modal ETH ENS resolution

### DIFF
--- a/.changeset/green-students-shout.md
+++ b/.changeset/green-students-shout.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix: ETH ENS Resolution

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.tsx
@@ -46,7 +46,7 @@ const RecipientField = <T extends Transaction, TS extends TransactionStatus>({
       onChangeTransaction(bridge.updateTransaction(transaction, { recipient: value }));
       resetInitValue && resetInitValue();
     }
-  }, [transaction]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [account]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onChange = useCallback(
     async (recipient: string, maybeExtra?: OnChangeExtra | null) => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** 
  - Send Modal Flow

### 📝 Description

This PR fixes a bug introduced by this PR: https://github.com/LedgerHQ/ledger-live/pull/10781

#### 🐛 Why the bug?

I hadn't tested with an ENS address.

With an ENS, for example `vitalik.eth`, the transaction recipient was set to `"vitalik.eth"`. Then, once the ENS resolution logic ran, it updated the recipient again to the resolved address (e.g. `0x...`).  
After that, the first `useEffect` triggered again because the transaction had changed — creating an infinite loop.  
This loop prevented the transaction checks from completing properly.

#### ✅ Solution

Instead of updating the transaction recipient every time the transaction changes, we now only do it when the selected account changes.

https://github.com/user-attachments/assets/784fa32a-35d5-4df7-a6ef-aba2c2a55d11


### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-20137

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
