### PR TITLE
Feat/live 20011 receive flow post onboarding add accounts

### DIFF
--- a/.changeset/clean-spies-agree.md
+++ b/.changeset/clean-spies-agree.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+trigger receive flow after add accounts flow in post onboarding

--- a/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/AddAccounts/index.tsx
@@ -10,7 +10,7 @@ import logger from "~/renderer/logger";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { accountsSelector } from "~/renderer/reducers/accounts";
-import { closeModal } from "~/renderer/actions/modals";
+import { closeModal, openModal } from "~/renderer/actions/modals";
 import Track from "~/renderer/analytics/Track";
 import Stepper, { Step } from "~/renderer/components/Stepper";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -28,6 +28,7 @@ export type Props = {
   existingAccounts: Account[];
   closeModal: (a: string) => void;
   addAccountsAction: typeof addAccountsAction;
+  openModal: (a: string, options: { isFromPostOnboardingEntryPoint?: boolean }) => void;
   blacklistedTokenIds?: string[];
 } & UserProps;
 
@@ -37,6 +38,7 @@ export type UserProps = {
   flow?: string | null;
   onClose?: () => void;
   preventSkippingCurrencySelection?: boolean | undefined | null;
+  isFromPostOnboardingEntryPoint?: boolean;
 };
 
 type StepId = "chooseCurrency" | "connectDevice" | "import" | "finish";
@@ -134,6 +136,7 @@ const mapStateToProps = createStructuredSelector({
 const mapDispatchToProps = {
   addAccountsAction,
   closeModal,
+  openModal,
 };
 const INITIAL_STATE: State = {
   stepId: "chooseCurrency",
@@ -230,6 +233,13 @@ class AddAccounts extends PureComponent<Props, State> {
     }));
   };
 
+  handleReopenReceive = () => {
+    const { openModal, isFromPostOnboardingEntryPoint } = this.props;
+    if (isFromPostOnboardingEntryPoint && this.state.scannedAccounts.length > 0) {
+      openModal("MODAL_RECEIVE", { isFromPostOnboardingEntryPoint: true });
+    }
+  };
+
   render() {
     const {
       device,
@@ -281,6 +291,7 @@ class AddAccounts extends PureComponent<Props, State> {
           const handleCloseModal = () => {
             this.props.onClose?.();
             onClose && onClose();
+            this.handleReopenReceive();
           };
           return (
             <Stepper

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/index.tsx
@@ -21,7 +21,11 @@ const INITIAL_STATE = {
   isAddressVerified: null,
   verifyAddressError: null,
 };
-const ReceiveModal = () => {
+interface ReceiveModalProps {
+  isFromPostOnboardingEntryPoint?: boolean;
+}
+
+const ReceiveModal = (props: ReceiveModalProps) => {
   const [state, setState] = useState<State>(INITIAL_STATE);
 
   const { stepId, isAddressVerified, verifyAddressError } = state;
@@ -69,12 +73,14 @@ const ReceiveModal = () => {
 
   const openAddAccounts = useCallback(() => {
     dispatch(closeModal("MODAL_RECEIVE"));
+
     dispatch(
       openModal("MODAL_ADD_ACCOUNTS", {
         currency: null,
+        isFromPostOnboardingEntryPoint: props.isFromPostOnboardingEntryPoint,
       }),
     );
-  }, [dispatch]);
+  }, [dispatch, props.isFromPostOnboardingEntryPoint]);
 
   useEffect(() => {
     if (!hasAccounts) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In post onboarding currently when pressing "Transfer your assets to Ledger" it triggers the add accounts flow and once complete it does not trigger the receive flow to open.  This PR adds logic to open the receive flow once an account has been added.

<img width="1008" alt="Screenshot 2025-07-07 at 10 27 13" src="https://github.com/user-attachments/assets/6e8fdbba-bcb5-453a-990a-3866120297a6" />
<img width="1010" alt="Screenshot 2025-07-07 at 10 27 24" src="https://github.com/user-attachments/assets/002abfcd-5ddf-4c08-97b5-4d2a979a5757" />
<img width="1004" alt="Screenshot 2025-07-07 at 10 28 01" src="https://github.com/user-attachments/assets/442d56fb-c1ea-48fd-ba79-61db983a1bcc" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20011


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
