### PR TITLE
:bug: (llc) [LIVE-20196]: Charon onboarding status parser should ignore update status

### DIFF
--- a/.changeset/odd-pens-thank.md
+++ b/.changeset/odd-pens-thank.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Charon onboarding status parser should ignore update status

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
@@ -35,6 +35,15 @@ describe("@hw/extractOnboardingState", () => {
             expect(onboardingState?.currentOnboardingStep).toBe(OnboardingStep.Ready);
             expect(onboardingState?.charonStatus).toBeNull();
           });
+
+          it("should ignore charon update status", () => {
+            const charonState = Buffer.from([0x20]);
+            const onboardingState = extractOnboardingState(flagsBytes, charonState);
+
+            expect(onboardingState).not.toBeNull();
+            expect(onboardingState?.currentOnboardingStep).toBe(OnboardingStep.Ready);
+            expect(onboardingState?.charonStatus).toBeNull();
+          });
         });
 
         describe("and the user refuse to backup the charon", () => {

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.ts
@@ -137,6 +137,14 @@ export const extractOnboardingState = (
 
   const currentSeedWordIndex = flagsBytes[2] & currentSeedWordIndexMask;
 
+  const charonSupported = charonState !== undefined && charonState.length > 0;
+  const charonOnboardingBits = charonSupported ? charonState[0] & 0xf : 0;
+  //const charonUpdateBits = charonSupported ? (charonState[0] & 0x30) >> 4 : 0;
+  const charonStatus =
+    charonSupported && fromBitsToCharonStatusMap.has(charonOnboardingBits)
+      ? fromBitsToCharonStatusMap.get(charonOnboardingBits)!
+      : null;
+
   /*
    * Once the device is seeded, there are some additional states for backing up with Charon (for devices that support it)
    * There are 2 scenarios:
@@ -148,9 +156,11 @@ export const extractOnboardingState = (
   if (
     isOnboarded &&
     [OnboardingStep.Ready, OnboardingStep.WelcomeScreen1].includes(currentOnboardingStep) &&
-    charonState !== undefined
+    charonSupported
   ) {
-    currentOnboardingStep = fromBitsToOnboardingStep.get(charonState[0] + CHARON_STEP_BIT_MASK);
+    currentOnboardingStep = fromBitsToOnboardingStep.get(
+      charonOnboardingBits + CHARON_STEP_BIT_MASK,
+    );
 
     if (!currentOnboardingStep) {
       throw new DeviceExtractOnboardingStateError(
@@ -158,12 +168,6 @@ export const extractOnboardingState = (
       );
     }
   }
-
-  const charonSupported = charonState !== undefined && charonState.length > 0;
-  const charonStatus =
-    charonSupported && fromBitsToCharonStatusMap.has(charonState[0])
-      ? fromBitsToCharonStatusMap.get(charonState[0])!
-      : null;
 
   return {
     isOnboarded,


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Charon status byte are not correctly parsed: onboarding status bits and update status bits are "merged"...

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20196


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
