### PR TITLE
fix: Sui listOperation uses minHeight

### DIFF
--- a/.changeset/wild-kangaroos-nail.md
+++ b/.changeset/wild-kangaroos-nail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+Coin:SUI listOperation uses minHeight parameter

--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -5,7 +5,7 @@ import { createApi } from ".";
 
 describe("Sui Api", () => {
   let module: AlpacaApi<SuiAsset>;
-  const SENDER = "0x67b511de2697e4567e41a4477a3abccd4c7c00f4c59b45ab8c72d1544f58ceb8";
+  const SENDER = "0xc6dcb5b920f2fdb751b4a8bad800a4ee04257020d8d6e493c8103b760095016e";
   const RECIPIENT = "0xba7080172a6d957b9ed2e3eb643529860be963cf4af896fb84f1cde00f46b561";
 
   beforeAll(() => {
@@ -65,6 +65,11 @@ describe("Sui Api", () => {
     it("at least operation should be OUT", async () => {
       expect(txs.length).toBeGreaterThanOrEqual(10);
       expect(txs.some(t => t.type === "OUT")).toBeTruthy();
+    });
+
+    it("uses the minHeight to filter", async () => {
+      const minHeightTxs = await module.listOperations(SENDER, { minHeight: 154925948 });
+      expect(txs.length).toBeGreaterThanOrEqual(minHeightTxs.length);
     });
   });
 

--- a/libs/coin-modules/coin-sui/src/api/index.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.ts
@@ -9,11 +9,13 @@ import {
   craftTransaction,
 } from "../logic";
 import type { SuiAsset } from "./types";
-import type {
+import {
   AlpacaApi,
-  FeeEstimation,
-  TransactionIntent,
+  FeeEstimation, Operation, Pagination,
+  TransactionIntent
 } from "@ledgerhq/coin-framework/api/index";
+import errors_1 from "@ledgerhq/errors";
+import logs_1 from "@ledgerhq/logs";
 
 export function createApi(config: SuiConfig): AlpacaApi<SuiAsset> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
@@ -25,7 +27,7 @@ export function createApi(config: SuiConfig): AlpacaApi<SuiAsset> {
     estimateFees: estimate,
     getBalance,
     lastBlock,
-    listOperations,
+    listOperations: list,
   };
 }
 
@@ -38,4 +40,41 @@ async function craft(transactionIntent: TransactionIntent<SuiAsset>): Promise<st
 async function estimate(transactionIntent: TransactionIntent<SuiAsset>): Promise<FeeEstimation> {
   const fees = await estimateFees(transactionIntent);
   return { value: fees };
+}
+
+async function list(address: string, pagination: Pagination): Promise<[Operation<SuiAsset>[], string]> {
+  return operationsFromHeight(address, pagination.minHeight)
+}
+
+type PaginationState = {
+  readonly heightLimit: number;
+  continueIterations: boolean;
+  apiNextCursor?: string;
+  accumulator: Operation<SuiAsset>[];
+};
+
+async function operationsFromHeight(
+  address: string,
+  minHeight: number,
+): Promise<[Operation<SuiAsset>[], string]> {
+  const state: PaginationState = {
+    heightLimit: minHeight,
+    continueIterations: true,
+    accumulator: [],
+  };
+
+  while (state.continueIterations) {
+    const option = state.apiNextCursor
+      ? { minHeight: minHeight, cursor: state.apiNextCursor }
+      : { minHeight: minHeight };
+    const [operations, nextCursor] = await listOperations(address, option);
+    const opsFromHeight = operations.filter(op => op.tx.block.height >= minHeight);
+    state.accumulator.push(...opsFromHeight);
+    state.apiNextCursor = nextCursor;
+    // The API makes 2 calls "IN" and "OUT" so even if we started filtering a few elements, we may still have more txs to fetch on one of the two calls.
+    // We can only stop when we've filtered all txs.
+    state.continueIterations = nextCursor !== "" && opsFromHeight.length > 0;
+  }
+
+  return [state.accumulator, state.apiNextCursor ? state.apiNextCursor : ""];
 }

--- a/libs/coin-modules/coin-sui/src/api/index.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.ts
@@ -14,8 +14,6 @@ import {
   FeeEstimation, Operation, Pagination,
   TransactionIntent
 } from "@ledgerhq/coin-framework/api/index";
-import errors_1 from "@ledgerhq/errors";
-import logs_1 from "@ledgerhq/logs";
 
 export function createApi(config: SuiConfig): AlpacaApi<SuiAsset> {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));

--- a/libs/coin-modules/coin-sui/src/api/index.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.ts
@@ -11,8 +11,10 @@ import {
 import type { SuiAsset } from "./types";
 import {
   AlpacaApi,
-  FeeEstimation, Operation, Pagination,
-  TransactionIntent
+  FeeEstimation,
+  Operation,
+  Pagination,
+  TransactionIntent,
 } from "@ledgerhq/coin-framework/api/index";
 
 export function createApi(config: SuiConfig): AlpacaApi<SuiAsset> {
@@ -40,8 +42,11 @@ async function estimate(transactionIntent: TransactionIntent<SuiAsset>): Promise
   return { value: fees };
 }
 
-async function list(address: string, pagination: Pagination): Promise<[Operation<SuiAsset>[], string]> {
-  return operationsFromHeight(address, pagination.minHeight)
+async function list(
+  address: string,
+  pagination: Pagination,
+): Promise<[Operation<SuiAsset>[], string]> {
+  return operationsFromHeight(address, pagination.minHeight);
 }
 
 type PaginationState = {


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - SUI listOperation alpaca API behavior

### 📝 Description

SUI listOperations never used the minHeight parameter, so alpaca api was not respected and it-tests failed
This PR fixes this in the api folder as to not change the logic, and potentially impact ledger-live.
Now the listOperation with the cursor is called until no new transaction is found after filtering with minHeight

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-9292


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
