### PR TITLE
[E2E] Add missing app.json for swap test

### DIFF
--- a/.changeset/purple-spies-think.md
+++ b/.changeset/purple-spies-think.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Add missing app.json for swap test

--- a/e2e/desktop/tests/userdata/speculos-sanctioned-eth.json
+++ b/e2e/desktop/tests/userdata/speculos-sanctioned-eth.json
@@ -1,0 +1,86 @@
+{
+  "data": {
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "counterValue": "USD",
+      "language": "en",
+      "theme": null,
+      "region": null,
+      "locale": "en-US",
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "month",
+      "marketIndicator": "western",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": true,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoSP",
+      "hasInstalledApps": true,
+      "hasAcceptedSwapKYC": false,
+      "lastSeenDevice": null,
+      "blacklistedTokenIds": [],
+      "swapAcceptedProviderIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "swapProviders": [],
+      "showClearCacheBanner": false,
+      "starredAccountIds": [],
+      "hasPassword": false
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [{
+      "data": {
+        "id": "mock:1:ethereum:true_ethereum_0:",
+        "seedIdentifier": "mock",
+        "name": "Ethereum 1",
+        "starred": false,
+        "derivationMode": "",
+        "index": 0,
+        "freshAddress": "0xB9051f83AC6e147924377BBEebd1Aa7aB43a67F6",
+        "freshAddressPath": "44'/60'/0'/0/0",
+        "freshAddresses": [
+          {
+            "derivationPath": "44'/60'/0'/0/0",
+            "address": "0xB9051f83AC6e147924377BBEebd1Aa7aB43a67F6"
+          }
+        ],
+        "blockHeight": 20133303,
+        "syncHash": "0x19813580",
+        "creationDate": "2024-04-10T12:19:59.000Z",
+        "operationsCount": 10,
+        "operations": [],
+        "pendingOperations": [],
+        "currencyId": "ethereum",
+        "unitMagnitude": 18,
+        "lastSyncDate": "2024-06-20T13:41:52.259Z",
+        "balance": "23405814577004878",
+        "spendableBalance": "23405814577004878",
+        "nfts": [],
+        "balanceHistoryCache": {},
+        "subAccounts": [],
+        "swapHistory": []
+      },
+      "version": 1
+    }
+    ],
+    "countervalues": {}
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - E2E Speculos > Swap test

### 📝 Description

Add missing app.json for swap test

In the [PR blacklisted addresses](https://github.com/LedgerHQ/ledger-live/pull/10365), we did not put the file `speculos-sanctioned-eth.json`
 It’s missing from the userdata used in the e2e swap test: https://github.com/LedgerHQ/ledger-live/blob/develop/e2e/desktop/tests/specs/swap.other.spec.ts#L976

It is failing : https://ledger-live.allure.green.ledgerlabs.net/allure/reports/d2788296-0ede-4291-96e1-82535c3ec8a6/#suites/500d8b838dcfa96d72c7a263e6dc8783/62329b7134cff156/

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-20226


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
