### PR TITLE
fix: disable broadcast for LLM swap max test

### DIFF
--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -1,5 +1,4 @@
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
-import { setupEnv } from "../../../utils/swapUtils";
 import { swapSetup, waitSwapReady } from "../../../bridge/server";
 import { SwapType } from "@ledgerhq/live-common/lib/e2e/models/Swap";
 import {
@@ -10,6 +9,9 @@ import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { ApplicationOptions } from "page";
 import { Provider } from "@ledgerhq/live-common/e2e/enum/Provider";
 import { ABTestingVariants } from "@ledgerhq/types-live";
+import { setEnv } from "@ledgerhq/live-env";
+
+setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
 const liveDataCommand = (currencyApp: { name: string }, index: number) => (userdataPath?: string) =>
   CLI.liveData({
@@ -69,8 +71,6 @@ export function runSwapWithoutAccountTest(
   };
 
   describe("Swap a coin for which you have no account yet", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await beforeAllFunction({
         userdata: "skip-onboarding",
@@ -110,8 +110,6 @@ export function runSwapWithDifferentSeedTest(
   tags: string[],
 ) {
   describe("Swap - Using different seed", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(swap);
       await beforeAllFunction({
@@ -148,8 +146,6 @@ export function runSwapLandingPageTest(
   tags: string[],
 ) {
   describe("Swap - Landing page", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunction({
@@ -195,8 +191,6 @@ export function runTooLowAmountForQuoteSwapsTest(
   tags: string[],
 ) {
   describe("Swap - with too low amount (throwing UI errors)", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(swap);
       await beforeAllFunction({
@@ -257,8 +251,6 @@ export function runUserRefusesTransactionTest(
   tags: string[],
 ) {
   describe("Swap - Rejected on device", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunction({
@@ -307,8 +299,6 @@ export function runSwapHistoryOperationsTest(
   tags: string[],
 ) {
   describe("Swap history", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(swap);
       await beforeAllFunction({
@@ -336,8 +326,6 @@ export function runExportSwapHistoryOperationsTest(
   tags: string[],
 ) {
   describe("Swap history", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(swap);
       await beforeAllFunction({
@@ -363,8 +351,6 @@ export function runSwapWithSendMaxTest(
   tags: string[],
 ) {
   describe("Swap - Send Max", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunction({
@@ -421,8 +407,6 @@ export function runSwapSwitchSendAndReceiveCurrenciesTest(
   tags: string[],
 ) {
   describe("Swap - Switch You send and You receive currency", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(swap);
       await beforeAllFunction({
@@ -455,8 +439,6 @@ export function runSwapCheckProvider(
   tags: string[],
 ) {
   describe("Swap - Provider redirection", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunction({
@@ -502,8 +484,6 @@ export function runSwapEntryPoints(account: Account, tmsLinks: string[], tags: s
   };
 
   describe("Swap - Entry Points - LLM", () => {
-    setupEnv(true);
-
     beforeAll(async () => {
       await beforeAllFunction({
         userdata: "speculos-tests-app",

--- a/e2e/mobile/utils/swapUtils.ts
+++ b/e2e/mobile/utils/swapUtils.ts
@@ -1,22 +1,6 @@
 import { SwapType } from "@ledgerhq/live-common/lib/e2e/models/Swap";
 import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 
-export function setupEnv(disableBroadcast?: boolean) {
-  const originalBroadcastValue = process.env.DISABLE_TRANSACTION_BROADCAST;
-  beforeAll(async () => {
-    process.env.SWAP_DISABLE_APPS_INSTALL = "true";
-    if (disableBroadcast) process.env.DISABLE_TRANSACTION_BROADCAST = "1";
-  });
-  afterAll(async () => {
-    delete process.env.SWAP_DISABLE_APPS_INSTALL;
-    if (originalBroadcastValue !== undefined) {
-      process.env.DISABLE_TRANSACTION_BROADCAST = originalBroadcastValue;
-    } else {
-      delete process.env.DISABLE_TRANSACTION_BROADCAST;
-    }
-  });
-}
-
 export async function performSwapUntilQuoteSelectionStep(
   accountToDebit: Account,
   accountToCredit: Account,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adding setEnv("DISABLE_TRANSACTION_BROADCAST", true) at the begging of the test ([same method on swap.ts test](https://github.com/LedgerHQ/ledger-live/blob/develop/e2e/mobile/specs/swap/swap.ts#L7))
Original value for DISABLE_TRANSACTION_BROADCAST is set again on the [afterAll](https://github.com/LedgerHQ/ledger-live/blob/38f0a9dcbb129e7fc72cbf484ba6a69582b84927/e2e/mobile/setup.ts#L27)

CI run (only swapWithSendMaxUSDTtoBTC.spec.ts) with broadcast on: 
https://github.com/LedgerHQ/ledger-live/actions/runs/16251255082
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
