### PR TITLE
fix: earn back button tracking

### DIFF
--- a/.changeset/wicked-foxes-cough.md
+++ b/.changeset/wicked-foxes-cough.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add tracking of webview back button - in-line with swap live app


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - analytics when user presses native "back" button on /deposit or /withdraw flows on earn live app (stablecoins)

### 📝 Description

Add analytics when user presses native "back" button on /deposit or /withdraw flows on earn live app (stablecoins) - in line with the same implementation on swap live app webveiw back navigation.


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20207

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
