### PR TITLE
fix(dot): use reserved balance for unbonding logic

### DIFF
--- a/.changeset/neat-carrots-collect.md
+++ b/.changeset/neat-carrots-collect.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-polkadot": patch
+---
+
+unbonding blocked due to empty locks array, now using reserved field for locked and spendable balance calculations

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -314,7 +314,10 @@ export const getBalances = async (addr: string) => {
   const frozenBalance = new BigNumber(balanceInfo.frozen || "0");
 
   const frozenMinusReserved = frozenBalance.minus(reservedBalance);
-  const spendableBalance = balance.minus(BigNumber.max(frozenMinusReserved, EXISTENTIAL_DEPOSIT));
+  const spendableBalance = BigNumber.max(
+    balance.minus(BigNumber.max(frozenMinusReserved, EXISTENTIAL_DEPOSIT)),
+    new BigNumber(0),
+  );
 
   return {
     blockHeight: Number(balanceInfo.at.height),

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -4,6 +4,7 @@ import { Extrinsics } from "@polkadot/types/metadata/decorate/types";
 import network from "@ledgerhq/live-network";
 import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
 import coinConfig from "../config";
+import { EXISTENTIAL_DEPOSIT } from "../bridge/utils";
 import type {
   PolkadotValidator,
   PolkadotStakingProgress,
@@ -307,24 +308,20 @@ export const getAccount = async (addr: string) => {
  */
 export const getBalances = async (addr: string) => {
   const balanceInfo = await fetchBalanceInfo(addr);
-  // Locked is the highest value among locks
-  const totalLocked = balanceInfo.locks.reduce((total, lock) => {
-    const amount = new BigNumber(lock.amount);
 
-    if (amount.gt(total)) {
-      return amount;
-    }
-
-    return total;
-  }, new BigNumber(0));
   const balance = new BigNumber(balanceInfo.free);
-  const spendableBalance = totalLocked.gt(balance) ? new BigNumber(0) : balance.minus(totalLocked);
+  const reservedBalance = new BigNumber(balanceInfo.reserved || "0");
+  const frozenBalance = new BigNumber(balanceInfo.frozen || "0");
+
+  const frozenMinusReserved = frozenBalance.minus(reservedBalance);
+  const spendableBalance = balance.minus(BigNumber.max(frozenMinusReserved, EXISTENTIAL_DEPOSIT));
+
   return {
     blockHeight: Number(balanceInfo.at.height),
     balance,
     spendableBalance,
     nonce: Number(balanceInfo.nonce),
-    lockedBalance: new BigNumber(totalLocked),
+    lockedBalance: reservedBalance,
   };
 };
 

--- a/libs/coin-modules/coin-polkadot/src/network/types.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/types.ts
@@ -7,6 +7,7 @@ interface IAt {
 interface IBalanceLock {
   id: string;
   amount: string;
+  reasons: string;
 }
 interface IPallet {
   at: IAt;
@@ -64,12 +65,13 @@ interface IChainProperties {
 }
 export interface SidecarAccountBalanceInfo {
   at: IAt;
-  tokenSymbol: string;
   nonce: string;
+  tokenSymbol: string;
   free: string;
   reserved: string;
   miscFrozen: string;
   feeFrozen: string;
+  frozen: string;
   locks: IBalanceLock[];
 }
 export interface SidecarPallet {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Polkadot Staking related actions (Unbonding, Nominating, Chill)

### 📝 Description

Users were unable to unbond their staked DOT tokens, receiving PolkadotUnauthorizedOperation errors. The lockedBalance was incorrectly showing as 0 despite having staked funds.

The balance calculation was using the balanceInfo.locks array from the sidecar API, which now returns empty arrays. The actual staking balance data is in the reserved field.

**Solution**

- Fixed locked balance: Use reserved field instead of empty locks array
- Fixed spendable balance: Implement correct Polkadot formula: free - max(frozen - reserved, ED


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

We are from Yield.xyz (formerly StakeKit), we power the Earn infra in Ledger Live. We monitor on-chain actions and user activity across all supported networks and reported this issue after receiving feedback from users attempting to unbond staked DOT.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
