### PR TITLE
Feat/live 20010 recover upsell postonboarding redirect

### DIFF
--- a/.changeset/thin-mayflies-grin.md
+++ b/.changeset/thin-mayflies-grin.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+add direct redirect to recover upsell on onboarding completion. Add option of avoiding navigation update on useStartPostOnboardingCallback.

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding.ts
@@ -45,14 +45,16 @@ export function useOpenRecoverUpsellPostOnboarding() {
   }, [redirectionStarted, isFocused, dispatch]);
 
   return useCallback(async () => {
-    const internetConnected = await internetReachable();
+    const internetConnected = (await internetReachable()) ?? false;
     if (internetConnected && recoverFeature?.enabled) {
       const redirect = (url?: string) => {
-        // Set correct post onboarding state
-        startPostOnboarding({
-          deviceModelId: lastConnectedDevice.modelId,
-          disableNavigation: true,
-        });
+        if (lastConnectedDevice !== null) {
+          // Set correct post onboarding state
+          startPostOnboarding({
+            deviceModelId: lastConnectedDevice.modelId,
+            disableNavigation: true,
+          });
+        }
 
         const routes: PartialRoute<Route<string, object | undefined>>[] = [
           {

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding.ts
@@ -16,6 +16,7 @@ import { lastConnectedDeviceSelector, onboardingTypeSelector } from "~/reducers/
 import { OnboardingType } from "~/reducers/types";
 import { RootNavigation } from "~/components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
+import { useStartPostOnboardingCallback } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 
 /**
  * Returns a callback to set the navigation state for the Ledger Recover upsell post onboarding
@@ -35,6 +36,7 @@ export function useOpenRecoverUpsellPostOnboarding() {
   const dispatch = useDispatch();
   const [redirectionStarted, setRedirectionStarted] = useState(false);
   const isFocused = useIsFocused();
+  const startPostOnboarding = useStartPostOnboardingCallback();
 
   useEffect(() => {
     if (redirectionStarted && !isFocused) {
@@ -46,9 +48,18 @@ export function useOpenRecoverUpsellPostOnboarding() {
     const internetConnected = await internetReachable();
     if (internetConnected && recoverFeature?.enabled) {
       const redirect = (url?: string) => {
+        // Set correct post onboarding state
+        startPostOnboarding({
+          deviceModelId: lastConnectedDevice.modelId,
+          disableNavigation: true,
+        });
+
         const routes: PartialRoute<Route<string, object | undefined>>[] = [
           {
-            name: NavigatorName.Main,
+            name: NavigatorName.PostOnboarding,
+            state: {
+              routes: [{ name: ScreenName.PostOnboardingHub }],
+            },
           },
         ];
 
@@ -98,5 +109,6 @@ export function useOpenRecoverUpsellPostOnboarding() {
     recoverPostOnboardingURI,
     touchScreenURI,
     navigation,
+    startPostOnboarding,
   ]);
 }

--- a/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding.ts
+++ b/apps/ledger-live-mobile/src/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding.ts
@@ -1,0 +1,102 @@
+import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
+import {
+  Source,
+  useAlreadyOnboardedURI,
+  useHomeURI,
+  usePostOnboardingURI,
+  useTouchScreenOnboardingUpsellURI,
+} from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { PartialRoute, Route, useIsFocused, useNavigation } from "@react-navigation/core";
+import { useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { setHasBeenUpsoldProtect } from "~/actions/settings";
+import { internetReachable } from "~/logic/internetReachable";
+import { lastConnectedDeviceSelector, onboardingTypeSelector } from "~/reducers/settings";
+import { OnboardingType } from "~/reducers/types";
+import { RootNavigation } from "~/components/RootNavigator/types/helpers";
+import { NavigatorName, ScreenName } from "~/const";
+
+/**
+ * Returns a callback to set the navigation state for the Ledger Recover upsell post onboarding
+ * */
+export function useOpenRecoverUpsellPostOnboarding() {
+  const navigation = useNavigation<RootNavigation>();
+  const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
+  const onboardingType = useSelector(onboardingTypeSelector);
+  const recoverFeature = useFeature("protectServicesMobile");
+  const recoverAlreadyOnboardedURI = useAlreadyOnboardedURI(recoverFeature);
+  const recoverPostOnboardingURI = usePostOnboardingURI(recoverFeature);
+  const touchScreenURI = useTouchScreenOnboardingUpsellURI(
+    recoverFeature,
+    Source.LLM_ONBOARDING_24,
+  );
+  const recoverHomeURI = useHomeURI(recoverFeature);
+  const dispatch = useDispatch();
+  const [redirectionStarted, setRedirectionStarted] = useState(false);
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (redirectionStarted && !isFocused) {
+      dispatch(setHasBeenUpsoldProtect(true));
+    }
+  }, [redirectionStarted, isFocused, dispatch]);
+
+  return useCallback(async () => {
+    const internetConnected = await internetReachable();
+    if (internetConnected && recoverFeature?.enabled) {
+      const redirect = (url?: string) => {
+        const routes: PartialRoute<Route<string, object | undefined>>[] = [
+          {
+            name: NavigatorName.Main,
+          },
+        ];
+
+        if (url) {
+          const params = new URLSearchParams(url.split("?")[1]);
+          routes.push({
+            name: ScreenName.Recover,
+            params: Object.fromEntries(params.entries()),
+          });
+          setRedirectionStarted(true);
+        }
+
+        navigation.reset({
+          index: 1,
+          routes: [
+            {
+              name: NavigatorName.Base,
+              state: {
+                routes,
+              },
+            },
+          ],
+        });
+      };
+      if (
+        lastConnectedDevice &&
+        touchScreenURI &&
+        [DeviceModelId.stax, DeviceModelId.europa].includes(lastConnectedDevice.modelId)
+      ) {
+        redirect(touchScreenURI);
+      } else if (recoverPostOnboardingURI && onboardingType === OnboardingType.restore) {
+        redirect(recoverPostOnboardingURI);
+      } else if (recoverHomeURI && onboardingType === OnboardingType.setupNew) {
+        redirect(recoverHomeURI);
+      } else if (recoverAlreadyOnboardedURI) {
+        redirect(recoverAlreadyOnboardedURI);
+      } else {
+        redirect();
+      }
+    }
+  }, [
+    lastConnectedDevice,
+    onboardingType,
+    recoverFeature?.enabled,
+    recoverAlreadyOnboardedURI,
+    recoverHomeURI,
+    recoverPostOnboardingURI,
+    touchScreenURI,
+    navigation,
+  ]);
+}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/CompletionScreen.tsx
@@ -3,9 +3,9 @@ import { Flex } from "@ledgerhq/native-ui";
 import { StackScreenProps } from "@react-navigation/stack";
 import { TouchableWithoutFeedback } from "react-native-gesture-handler";
 
-import { NavigatorName, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { SyncOnboardingStackParamList } from "~/components/RootNavigator/types/SyncOnboardingNavigator";
-import { BaseComposite, RootNavigation } from "~/components/RootNavigator/types/helpers";
+import { BaseComposite } from "~/components/RootNavigator/types/helpers";
 import { DeviceModelId } from "@ledgerhq/devices";
 import EuropaCompletionView from "./EuropaCompletionView";
 import StaxCompletionView from "./StaxCompletionView";
@@ -17,17 +17,18 @@ import {
   setOnboardingHasDevice,
 } from "~/actions/settings";
 import { hasCompletedOnboardingSelector } from "~/reducers/settings";
-import { useIsFocused, useNavigation } from "@react-navigation/core";
+import { useIsFocused } from "@react-navigation/core";
+import { useOpenRecoverUpsellPostOnboarding } from "~/hooks/useAutoRedirectToPostOnboarding/useOpenRecoverUpsellPostOnboarding";
 
 type Props = BaseComposite<
   StackScreenProps<SyncOnboardingStackParamList, ScreenName.SyncOnboardingCompletion>
 >;
 
 const CompletionScreen = ({ route }: Props) => {
-  const navigation = useNavigation<RootNavigation>();
   const { device } = route.params;
   const dispatch = useDispatch();
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const handleRedirect = useOpenRecoverUpsellPostOnboarding();
 
   useEffect(() => {
     if (!hasCompletedOnboarding) {
@@ -42,22 +43,8 @@ const CompletionScreen = ({ route }: Props) => {
 
   const redirectToMainScreen = useCallback(() => {
     if (!isFocused) return;
-    navigation.reset({
-      index: 0,
-      routes: [
-        {
-          name: NavigatorName.Base,
-          state: {
-            routes: [
-              {
-                name: NavigatorName.Main,
-              },
-            ],
-          },
-        },
-      ],
-    });
-  }, [isFocused, navigation]);
+    handleRedirect();
+  }, [isFocused, handleRedirect]);
 
   return (
     <TouchableWithoutFeedback onPress={redirectToMainScreen}>

--- a/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
+++ b/libs/ledger-live-common/src/postOnboarding/hooks/useStartPostOnboardingCallback.ts
@@ -10,6 +10,7 @@ type StartPostOnboardingOptions = {
   mock?: boolean;
   fallbackIfNoAction?: () => void;
   resetNavigationStack?: boolean;
+  disableNavigation?: boolean;
 };
 
 /**
@@ -30,7 +31,13 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
 
   return useCallback(
     (options: StartPostOnboardingOptions) => {
-      const { deviceModelId, mock = false, fallbackIfNoAction, resetNavigationStack } = options;
+      const {
+        deviceModelId,
+        mock = false,
+        fallbackIfNoAction,
+        resetNavigationStack,
+        disableNavigation,
+      } = options;
       const actions = getPostOnboardingActionsForDevice(deviceModelId, mock).filter(
         actionWithState =>
           !actionWithState.featureFlagId || getFeature(actionWithState.featureFlagId)?.enabled,
@@ -47,7 +54,7 @@ export function useStartPostOnboardingCallback(): (options: StartPostOnboardingO
         if (fallbackIfNoAction) fallbackIfNoAction();
         return;
       }
-      navigateToPostOnboardingHub(resetNavigationStack);
+      if (!disableNavigation) navigateToPostOnboardingHub(resetNavigationStack);
     },
     [dispatch, getFeature, getPostOnboardingActionsForDevice, navigateToPostOnboardingHub],
   );


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Overview:
On LLM adds redirection to recover upsell and postonboarding on completion screen for europa and stax. Previously there was a small glitch where the home screen (portfolio screen) was seen for a second before redirection to upsell and also for postonboarding screen after the video animation finished on the onboarding completion screen. Now the redirect happens directly so user goes direct to these screens.

In-depth details:
Used logic from useOpenRecoverUpsellCallback to do a direct navigation state change when completing the animation of the completion screen.  This means that the recover upsell and postonboarding are not opened via deeplink any more when coming from the onboarding. This now means we're not relying on a deeplink call on main page to set the navigation state for postonboarding flow when coming from onboarding and setting it directly.  The deeplink hook to trigger this flow is still present as it accounts for states where the user has closed the app before being rerouted to postonboarding flows.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20010


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
