### PR TITLE
fix: sui swap device disconnected

### DIFF
--- a/.changeset/thirty-icons-search.md
+++ b/.changeset/thirty-icons-search.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": minor
+---
+
+Fix sui swap device disconnected error

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
@@ -3,15 +3,12 @@ import { Observable } from "rxjs";
 import { SignerContext } from "@ledgerhq/coin-framework/signer";
 import { FeeNotLoaded } from "@ledgerhq/errors";
 import type { AccountBridge } from "@ledgerhq/types-live";
-import { Ed25519PublicKey } from "@mysten/sui/keypairs/ed25519";
-import { verifyTransactionSignature } from "@mysten/sui/verify";
 import { LedgerSigner } from "@mysten/signers/ledger";
 import type { SuiClient } from "@mysten/sui/client";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";
 import { buildTransaction } from "./buildTransaction";
 import { calculateAmount } from "./utils";
 import type { SuiAccount, SuiSigner, Transaction } from "../types";
-import { ensureAddressFormat } from "../utils";
 import { withApi } from "../network/sdk";
 
 /**
@@ -52,19 +49,6 @@ export const buildSignOperation = (
             return ledgerSigner.signTransaction(unsigned);
           }),
         );
-
-        if (!transaction.skipVerify) {
-          const publicKeyResult = await signerContext(deviceId, signer =>
-            signer.getPublicKey(account.freshAddressPath),
-          );
-          const publicKey = new Ed25519PublicKey(publicKeyResult.publicKey);
-          const verify = await verifyTransactionSignature(unsigned, signed.signature, {
-            address: ensureAddressFormat(account.freshAddress),
-          });
-          if (!verify.equals(publicKey)) {
-            throw new Error("verifyTransactionSignature failed");
-          }
-        }
 
         subscriber.next({
           type: "device-signature-granted",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
