### PR TITLE
feat(LLD): edit account name on MAD existing new account

### DIFF
--- a/.changeset/wise-cooks-love.md
+++ b/.changeset/wise-cooks-love.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+edit account name on MAD already existing new account

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/ModularDrawerAddAccountFlowManager.tsx
@@ -142,6 +142,7 @@ const ModularDrawerAddAccountFlowManager = ({
               warningReason={warningReason}
               currency={cryptoCurrency}
               emptyAccount={emptyAccount}
+              navigateToEditAccountName={navigateToEditAccountName}
               navigateToFundAccount={navigateToFundAccount}
               source={source}
             />

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/addAccountFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/addAccountFlow.test.tsx
@@ -328,6 +328,27 @@ describe("ModularDrawerAddAccountFlowManager", () => {
     expectTrackPage(3, "cant add new account", { reason: "ALREADY_EMPTY_ACCOUNT" });
   });
 
+  it("should allow name edit on already imported empty account", async () => {
+    const OLD_NAME = "Arbitrum 2";
+    const NEW_NAME = "My Edited Account";
+
+    setup(arbitrumCurrency, { accounts: [ARB_ACCOUNT, NEW_ARB_ACCOUNT] } as State);
+
+    await mockScanAccountsSubscription([ARB_ACCOUNT, NEW_ARB_ACCOUNT]);
+    await userEvent.click(screen.getByRole("button", { name: /Edit account item/i }));
+
+    expect(screen.getByText(/Edit account name/i)).toBeInTheDocument();
+
+    const input = screen.getByRole("textbox", { name: "account name" });
+    expect(input).toHaveValue(OLD_NAME);
+    await userEvent.clear(input);
+    await userEvent.type(input, NEW_NAME);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByText(NEW_NAME)).toBeInTheDocument();
+  });
+
   it("should error on a Hedera account with no associated accounts", async () => {
     setup(hederaCurrency);
 

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AccountsWarning/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AccountsWarning/index.tsx
@@ -11,11 +11,13 @@ const AccountsWarning = ({
   warningReason,
   currency,
   emptyAccount,
+  navigateToEditAccountName,
   navigateToFundAccount,
   source,
 }: AccountsWarningProps) => {
   const { emptyAccountWarning, noAssociatedAccountsWarning } = useWarningConfig(
     currency,
+    navigateToEditAccountName,
     navigateToFundAccount,
     emptyAccount,
   );

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AccountsWarning/types.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AccountsWarning/types.ts
@@ -16,6 +16,7 @@ export interface ActionButtonsProps {
 export interface AccountsWarningProps {
   warningReason: WarningReason;
   currency: CryptoCurrency;
+  navigateToEditAccountName: (account: Account) => void;
   navigateToFundAccount: (account: Account) => void;
   emptyAccount?: Account;
   source: string;

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AccountsWarning/useWarningConfig.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AccountsWarning/useWarningConfig.tsx
@@ -15,6 +15,7 @@ import { openURL } from "~/renderer/linking";
 
 export const useWarningConfig = (
   currency: CryptoCurrency,
+  navigateToEditAccountName: (account: Account) => void,
   navigateToFundAccount: (account: Account) => void,
   emptyAccount?: Account,
 ) => {
@@ -50,13 +51,18 @@ export const useWarningConfig = (
     description: t("modularAssetDrawer.scanAccounts.warning.description", {
       account: emptyAccountName,
     }),
-    accountRow: formattedAccount ? (
-      <AccountItem
-        account={formattedAccount}
-        onClick={() => handleAccountClick(formattedAccount.id)}
-        backgroundColor={colors.opacityDefault.c05}
-      />
-    ) : null,
+    accountRow:
+      formattedAccount && emptyAccount ? (
+        <AccountItem
+          account={formattedAccount}
+          onClick={() => handleAccountClick(formattedAccount.id)}
+          backgroundColor={colors.opacityDefault.c05}
+          rightElement={{
+            type: "edit",
+            onClick: () => navigateToEditAccountName(emptyAccount),
+          }}
+        />
+      ) : null,
     primaryAction: {
       text: t("modularAssetDrawer.scanAccounts.warning.cta"),
       onClick: handleFundAccount,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Adds edit account name button to account in empty account warning


| Before        | After         |
| ------------- | ------------- |
| <img width="500" height="376" alt="image" src="https://github.com/user-attachments/assets/1045dd50-3c39-40c0-8631-0aeb5e9c9693" /> | <img width="501" height="430" alt="image" src="https://github.com/user-attachments/assets/819d4380-37b2-42be-ab6f-4afe4cd84eb9" /> |


### ❓ Context

- **JIRA or GitHub link**: [LIVE-20093](https://ledgerhq.atlassian.net/browse/LIVE-20093)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20093]: https://ledgerhq.atlassian.net/browse/LIVE-20093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ