### PR TITLE
chore(BACK-9383): [alpaca][xrp] fix impossibility to craft a XRP transaction without memos

### DIFF
--- a/.changeset/modern-chairs-tease.md
+++ b/.changeset/modern-chairs-tease.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-xrp": patch
+---
+
+[alpaca][xrp] fix impossibility to craft a XRP without memos

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -343,6 +343,38 @@ describe("Testing craftTransaction function", () => {
     );
   });
 
+  it("should not pass memos when user does not provide it for crafting a transaction", async () => {
+    await api.craftTransaction({
+      sender: "foo",
+    } as TransactionIntent<XrpAsset, XrpMapMemo>);
+
+    expect(logicCraftTransactionSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        memos: undefined,
+      }),
+      undefined,
+    );
+  });
+
+  it("should not pass memos when user provides an empty memo list it for crafting a transaction", async () => {
+    await api.craftTransaction({
+      sender: "foo",
+      memo: {
+        type: "map",
+        memos: new Map(),
+      },
+    } as TransactionIntent<XrpAsset, XrpMapMemo>);
+
+    expect(logicCraftTransactionSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        memos: undefined,
+      }),
+      undefined,
+    );
+  });
+
   it("should pass destination tag when user provides it for crafting a transaction", async () => {
     await api.craftTransaction({
       sender: "foo",

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -18,6 +18,7 @@ import {
   lastBlock,
   listOperations,
   getTransactionStatus,
+  MemoInput,
 } from "../logic";
 import { ListOperationsOptions, XrpAsset, XrpMapMemo } from "../types";
 
@@ -53,7 +54,7 @@ async function craft(
 
   const memoStrings = memosMap.get("memos") as string[] | undefined;
 
-  let memoEntries: { type: string; data: string }[] = [];
+  let memoEntries: MemoInput[] | undefined = undefined;
 
   if (Array.isArray(memoStrings) && memoStrings.length > 0) {
     memoEntries = memoStrings.map(value => ({ type: "memo", data: value }));


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ALPACA API only

### 📝 Description

When omitting memos or passing an empty list, transaction is currently always crafted with an empty `Memos: []` field. But currently B2B HSM parser does not support it, so we need to be able to craft transactions without `Memos` field.

=> omit the field unless we have a non-empty list of memos

Note: should not be related to https://ledgerhq.atlassian.net/browse/TSD-6153, impacts only ALPACA API code path, but  please be cautious

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-9383

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
