### PR TITLE
LLM: fix swap failures & ledger sync

### DIFF
--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountsListView/components/AccountItem/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/components/AccountsListView/components/AccountItem/index.tsx
@@ -20,7 +20,7 @@ const View: React.FC<ViewProps> = ({
   withPlaceholder,
   accountId,
 }) => (
-  <>
+  <Flex testID={`account-item-container-${accountId}`}>
     <Flex flex={1} rowGap={2} flexShrink={1} testID={`account-item-${accountId}`}>
       <Flex flexDirection="row" columnGap={8} alignItems="center" maxWidth="70%">
         <Text
@@ -65,7 +65,7 @@ const View: React.FC<ViewProps> = ({
         )}
       </Flex>
     )}
-  </>
+  </Flex>
 );
 
 const AccountItem: React.FC<AccountItemProps> = props => <View {...useAccountItemModel(props)} />;

--- a/e2e/mobile/page/accounts/accounts.page.ts
+++ b/e2e/mobile/page/accounts/accounts.page.ts
@@ -4,6 +4,7 @@ import CommonPage from "../common.page";
 export default class AccountsPage extends CommonPage {
   private baseLink = "accounts";
   private listTitle = "accounts-list-title";
+  private accountItemContainerRegExp = new RegExp("account-item-container-.*");
 
   emptyAccountDisplay = () => getElementById("empty-accounts-component");
 
@@ -19,20 +20,10 @@ export default class AccountsPage extends CommonPage {
 
   @Step("Expect accounts number")
   async expectAccountsNumber(expected: number) {
-    const listEl = getElementsById(this.accountItemRegExp());
-    const attrs = await listEl.getAttributes();
+    const accountItemElements = getElementsById(this.accountItemContainerRegExp);
+    const attrs = await accountItemElements.getAttributes();
     if ("elements" in attrs) {
-      // Count unique account names to handle duplicates in view hierarchy
-      const uniqueLabels = new Set();
-      attrs.elements.forEach((element: { label?: string }) => {
-        if (element.label) {
-          // Extract the account name from the label (before the address part)
-          const accountName = element.label.split(" ")[0] + " " + element.label.split(" ")[1];
-          uniqueLabels.add(accountName);
-        }
-      });
-
-      jestExpect(uniqueLabels.size).toBe(expected);
+      jestExpect(attrs.elements.length).toBe(expected);
     } else {
       jestExpect(1).toBe(expected);
     }

--- a/e2e/mobile/page/accounts/accounts.page.ts
+++ b/e2e/mobile/page/accounts/accounts.page.ts
@@ -22,7 +22,17 @@ export default class AccountsPage extends CommonPage {
     const listEl = getElementsById(this.accountItemRegExp());
     const attrs = await listEl.getAttributes();
     if ("elements" in attrs) {
-      jestExpect(attrs.elements.length).toBe(expected);
+      // Count unique account names to handle duplicates in view hierarchy
+      const uniqueLabels = new Set();
+      attrs.elements.forEach((element: { label?: string }) => {
+        if (element.label) {
+          // Extract the account name from the label (before the address part)
+          const accountName = element.label.split(" ")[0] + " " + element.label.split(" ")[1];
+          uniqueLabels.add(accountName);
+        }
+      });
+
+      jestExpect(uniqueLabels.size).toBe(expected);
     } else {
       jestExpect(1).toBe(expected);
     }

--- a/e2e/mobile/page/common.page.ts
+++ b/e2e/mobile/page/common.page.ts
@@ -120,6 +120,7 @@ export default class CommonPage {
   @Step("Select a known device")
   async selectKnownDevice(index = 0) {
     if (isIos()) await device.disableSynchronization();
+    await waitForElementById(this.deviceRowRegex);
     await tapById(this.deviceRowRegex, index);
   }
 

--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -394,7 +394,8 @@ export function runSwapWithSendMaxTest(
       const swap = new Swap(fromAccount, toAccount, amountToSend);
       await checkSwapInfosOnDeviceVerificationStep(swap, selectedProvider, amountToSend);
 
-      await app.speculos.verifyAmountsAndAcceptSwap(swap, amountToSend);
+      await app.swap.verifyAmountsAndAcceptSwap(swap, amountToSend);
+      await app.swap.verifyDeviceActionLoadingNotVisible();
       await app.swap.waitForSuccessAndContinue();
     });
   });


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
