### PR TITLE
feat: auto focus pin input when using LedgerSync PIN validation

### DIFF
--- a/.changeset/fair-onions-share.md
+++ b/.changeset/fair-onions-share.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+auto focus pin input when using LedgerSync validation

--- a/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/StepFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Accounts/screens/AddAccount/components/StepFlow.tsx
@@ -102,7 +102,7 @@ const StepFlow = ({
 
       case Steps.PinInput:
         return nbDigits ? (
-          <PinCodeInput handleSendDigits={handlePinCodeSubmit} nbDigits={nbDigits} />
+          <PinCodeInput handleSendDigits={handlePinCodeSubmit} nbDigits={nbDigits} focusOnMount />
         ) : null;
 
       case Steps.SyncError:

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/components/Activation/ActivationFlow.tsx
@@ -106,7 +106,7 @@ const ActivationFlow = ({
 
       case Steps.PinInput:
         return nbDigits ? (
-          <PinCodeInput handleSendDigits={handlePinCodeSubmit} nbDigits={nbDigits} />
+          <PinCodeInput handleSendDigits={handlePinCodeSubmit} nbDigits={nbDigits} focusOnMount />
         ) : null;
 
       case Steps.SyncError:

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/PinCodeInput.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/Synchronize/PinCodeInput.tsx
@@ -9,9 +9,10 @@ import { NativeSyntheticEvent, TextInput, TextInputKeyPressEventData } from "rea
 type Props = {
   handleSendDigits: (input: string) => void;
   nbDigits: number;
+  focusOnMount?: boolean;
 };
 
-export default function PinCodeInput({ nbDigits, handleSendDigits }: Props) {
+export default function PinCodeInput({ nbDigits, handleSendDigits, focusOnMount = false }: Props) {
   const { t } = useTranslation();
 
   // Dynamically create refs based on the number of digits
@@ -23,6 +24,12 @@ export default function PinCodeInput({ nbDigits, handleSendDigits }: Props) {
       handleSendDigits(digits.join(""));
     }
   }, [digits, handleSendDigits]);
+
+  useEffect(() => {
+    if (focusOnMount) {
+      inputRefs.current[0]?.focus();
+    }
+  }, [focusOnMount]);
 
   const handleChange = (value: string, index: number) => {
     const newDigits = [...digits];
@@ -82,7 +89,7 @@ const DigitInput = forwardRef<TextInput, DigitInputProps>(
     const [isFocused, setIsFocused] = useState(false);
     const inputRef = useRef<TextInput>(null);
 
-    useImperativeHandle(forwardedRef, () => inputRef.current as TextInput);
+    useImperativeHandle(forwardedRef, () => inputRef.current!);
 
     const handleChange = (text: string) => {
       if (text.length <= 1 && /^\d*$/.test(text)) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** Add new trivial behavior

### 📝 Description

Focus the first digit input of the PIN code validation when using LedgerSync

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20379

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
