### PR TITLE
fix(coin-modules): fallback on empty xpub

### DIFF
--- a/.changeset/thin-swans-unite.md
+++ b/.changeset/thin-swans-unite.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-modules-monitoring": minor
+---
+
+fix(coin-modules-monitoring): fallback on empty xpub

--- a/libs/coin-modules-monitoring/src/index.test.ts
+++ b/libs/coin-modules-monitoring/src/index.test.ts
@@ -40,6 +40,7 @@ describe("Coin Modules Monitoring", () => {
           };
           const xPubs: Record<string, string> = {
             "0x9abc": "0xpub",
+            "0x5678": "",
           };
           return {
             xpub: xPubs[info.address],

--- a/libs/coin-modules-monitoring/src/index.ts
+++ b/libs/coin-modules-monitoring/src/index.ts
@@ -69,7 +69,7 @@ export async function monitor<A extends Account>(
         operationType: "scan",
         accountType: accountType as LogEntry["accountType"],
         transactions: initialAccount.operationsCount,
-        accountAddressOrXpub: initialAccount.xpub ?? accountAddress.address,
+        accountAddressOrXpub: initialAccount.xpub || accountAddress.address,
       },
       {
         duration: endSync - startSync,
@@ -78,7 +78,7 @@ export async function monitor<A extends Account>(
         operationType: "sync",
         accountType: accountType as LogEntry["accountType"],
         transactions: initialAccount.operationsCount,
-        accountAddressOrXpub: initialAccount.xpub ?? accountAddress.address,
+        accountAddressOrXpub: initialAccount.xpub || accountAddress.address,
       },
     );
   }


### PR DESCRIPTION
Ensure fallback to account address for empty xpub in scan and sync logs.

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

In case of empty string in xPub, the prop accountAddressOrXpub returned an empty string instead of the address

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
