### PR TITLE
fix: Add extra check to make sure the swap execute button is displaye…

### DIFF
--- a/e2e/mobile/page/discover/discover.page.ts
+++ b/e2e/mobile/page/discover/discover.page.ts
@@ -15,7 +15,7 @@ export default class DiscoverPage {
     { name: "Bitrefill", url: " https://bitrefill.com" },
     { name: "Zerion", url: " https://zerion.io/" },
     { name: "Rainbow", url: " https://rainbow.me" },
-    { name: "POAP", url: " https://app.poap.xyz/" },
+    { name: "POAP", url: " https://app.poap.xyz" },
     { name: "Yearn", url: " https://beta.yearn.fi" },
     { name: "ChangeNOW", url: " https://changenow.io/" },
     { name: "Transak", url: " https://transak.com" },

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -16,7 +16,6 @@ export default class SwapLiveAppPage {
   quotesCountDown = "quotes-countdown";
   quoteProviderName = "quote-card-provider-name";
   executeSwapButton = "execute-button";
-  executeSwapButtonDisabled = "execute-button-disabled";
   deviceActionErrorDescriptionId = "error-description-deviceAction";
   fromAccountErrorId = "from-account-error";
   showDetailslink = "show-details-link";
@@ -110,7 +109,7 @@ export default class SwapLiveAppPage {
 
   @Step("Tap execute swap button")
   async tapExecuteSwap() {
-    await detoxExpect(getWebElementByTestId(this.executeSwapButtonDisabled)).not.toExist();
+    await waitWebElementByTestId(this.executeSwapButton);
     await tapWebElementByTestId(this.executeSwapButton, 1);
   }
 
@@ -178,6 +177,7 @@ export default class SwapLiveAppPage {
       ? `Continue with ${provider}`
       : `Swap with ${provider}`;
 
+    await waitWebElementByTestId(this.executeSwapButton);
     const actualButtonText = await getWebElementText(this.executeSwapButton);
     jestExpect(actualButtonText).toEqual(expectedButtonText);
   }

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -3,6 +3,7 @@ import { swapSetup, waitSwapReady } from "../../bridge/server";
 import { setEnv } from "@ledgerhq/live-env";
 import { performSwapUntilQuoteSelectionStep } from "../../utils/swapUtils";
 import { ABTestingVariants } from "@ledgerhq/types-live";
+import { Account } from "@ledgerhq/live-common/e2e/enum/Account";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -71,17 +72,23 @@ export function runSwapTest(swap: SwapType, tmsLinks: string[], tags: string[]) 
         swap.accountToDebit,
         swap.accountToCredit,
       );
+      const swapAmount =
+        swap.accountToDebit.currency.name === Account.XRP_1.currency.name
+          ? parseFloat(Number(minAmount).toFixed(6)).toString()
+          : minAmount;
+
       await performSwapUntilQuoteSelectionStep(
         swap.accountToDebit,
         swap.accountToCredit,
-        minAmount,
+        swapAmount,
       );
+
       const { providerName } = await app.swapLiveApp.selectExchange();
       await app.swapLiveApp.checkExchangeButtonHasProviderName(providerName);
       await app.swapLiveApp.tapExecuteSwap();
       await app.common.selectKnownDevice();
 
-      await app.swap.verifyAmountsAndAcceptSwap(swap, minAmount);
+      await app.swap.verifyAmountsAndAcceptSwap(swap, swapAmount);
       await app.swap.verifyDeviceActionLoadingNotVisible();
       await app.swap.waitForSuccessAndContinue();
     });


### PR DESCRIPTION
…d and fix wrong discovery url

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
