### PR TITLE
:sparkles: (MAD-LLM) empty assets list fallback

### DIFF
--- a/.changeset/shaggy-jars-sit.md
+++ b/.changeset/shaggy-jars-sit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add generic assetsEmptyList fallback component (use for the MAD)

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -7783,7 +7783,8 @@
     "selectAsset": "Select asset",
     "selectNetwork": "Select network",
     "selectAccount": "Select account",
-    "searchPlaceholder": "Search"
+    "searchPlaceholder": "Search",
+    "emptyAssetList": "No assets found"
   },
   "swapErrors": {
     "incorrectCommandData": {

--- a/apps/ledger-live-mobile/src/newArch/components/EmptyList/AssetsEmptyList/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/components/EmptyList/AssetsEmptyList/index.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Flex, Icons, Text } from "@ledgerhq/native-ui";
+import styled from "styled-components/native";
+import { useTranslation } from "react-i18next";
+
+const CircleWrapper = styled.View`
+  background-color: ${p => p.theme.colors.opacityDefault.c05};
+  border-radius: 999px;
+  padding: 16px;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const AssetsEmptyList = () => {
+  const { t } = useTranslation();
+  return (
+    <Flex
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      minHeight="328px"
+      flex={1}
+      rowGap={24}
+    >
+      <CircleWrapper>
+        <Icons.Search size="L" />
+      </CircleWrapper>
+      <Text
+        variant="h3Inter"
+        fontWeight="semiBold"
+        lineHeight="28px"
+        fontSize="20px"
+        textAlign="center"
+      >
+        {t("modularDrawer.emptyAssetList")}
+      </Text>
+    </Flex>
+  );
+};

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -65,4 +65,21 @@ describe("ModularDrawer integration", () => {
 
     expect(getByText(/arbitrum/i)).toBeVisible();
   });
+
+  it("should show the empty state when no assets are found", async () => {
+    const { getByText, queryByText, getByPlaceholderText, user } = render(
+      <ModularDrawerSharedNavigator />,
+    );
+
+    await user.press(getByText(/open drawer/i));
+
+    const searchInput = getByPlaceholderText(/search/i);
+    expect(searchInput).toBeVisible();
+
+    await user.type(searchInput, "ttttttt");
+
+    await waitFor(() => {
+      expect(queryByText(/no assets found/i)).toBeVisible();
+    });
+  });
 });

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -15,6 +15,7 @@ import {
   useBottomSheetInternal,
   useBottomSheet,
 } from "@gorhom/bottom-sheet";
+import { AssetsEmptyList } from "LLM/components/EmptyList/AssetsEmptyList";
 
 export type AssetSelectionStepProps = {
   isOpen: boolean;
@@ -142,6 +143,7 @@ const AssetSelection = ({
         getItem={(itemsToDisplay, index) => itemsToDisplay[index]}
         renderItem={renderItem}
         showsVerticalScrollIndicator={false}
+        ListEmptyComponent={<AssetsEmptyList />}
         contentContainerStyle={{
           paddingBottom: MARGIN_BOTTOM,
           marginTop: 16,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - asset Selection MAD

### 📝 Description

Add empty asset list fallback. I've added it inside a generic folder. My idea is to centralize every lists fallbacks so it's easy to use


<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-28 at 15 23 44" src="https://github.com/user-attachments/assets/c8492716-5b8b-4778-bb2b-ddb4cdbbe654" />

https://github.com/user-attachments/assets/a374527c-a944-4644-9bb3-f73c5d419346


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20600](https://ledgerhq.atlassian.net/browse/LIVE-20600)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20600]: https://ledgerhq.atlassian.net/browse/LIVE-20600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ