### PR TITLE
[Fix] Fix a tracking issue during Recovery Key onboarding

### DIFF
--- a/.changeset/angry-poets-cover.md
+++ b/.changeset/angry-poets-cover.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix a tracking issue during Recovery Key onboarding

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/SyncOnboardingCompanion.tsx
@@ -213,8 +213,10 @@ const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = ({
         titleCompleted: t("syncOnboarding.manual.seedContent.titleCompleted"),
         background:
           seedPathStatus === "new_seed" ? (
+            // Secret Phrase screen
             <SetupBackground />
           ) : seedPathStatus === "backup_charon" ? (
+            // Recovery Key screen
             <BackupBackground />
           ) : null,
         renderBody: () => (
@@ -326,8 +328,18 @@ const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = ({
       lastCompanionStepKey.current <= StepKey.Seed &&
       stepKey === StepKey.Seed &&
       !analyticsSeedingTracked.current &&
-      seedPathStatus === "backup_charon"
+      (seedPathStatus === "backup_charon" ||
+        (seedPathStatus === "restore_charon" && deviceOnboardingState?.isOnboarded))
     ) {
+      /**
+       * Now we have four ways to seed a device:
+       * - new seed => Backup Recovery Key
+       * - restore using Secret Recovery Phrase => Backup Recovery Key
+       * - restore using Recovery Key => Next step
+       * - restore using Recover subscription => Backup Recovery Key
+       * Three of them will trigger the Backup Recovery Key step, but the last one
+       * will trigger directly the install apps step, so its tracking is treated separately.
+       */
       trackPage(
         `Set up ${productName}: Step 3 Seed Success`,
         undefined,
@@ -344,7 +356,7 @@ const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = ({
       analyticsSeedingTracked.current = true;
     }
     lastCompanionStepKey.current = stepKey;
-  }, [productName, seedPathStatus, stepKey]);
+  }, [deviceOnboardingState?.isOnboarded, productName, seedPathStatus, stepKey]);
 
   useEffect(() => {
     if (lockedDevice) {

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/SyncOnboardingCompanion.tsx
@@ -371,8 +371,18 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
       lastCompanionStepKey.current <= CompanionStepKey.Seed &&
       companionStepKey === CompanionStepKey.Seed &&
       !analyticsSeedingTracked.current &&
-      seedPathStatus === "backup_charon"
+      (seedPathStatus === "backup_charon" ||
+        (seedPathStatus === "restore_charon" && deviceOnboardingState?.isOnboarded))
     ) {
+      /**
+       * Now we have four ways to seed a device:
+       * - new seed => Backup Recovery Key
+       * - restore using Secret Recovery Phrase => Backup Recovery Key
+       * - restore using Recovery Key => Next step
+       * - restore using Recover subscription => Backup Recovery Key
+       * Three of them will trigger the Backup Recovery Key step, but the last one
+       * will trigger directly the install apps step, so its tracking is treated separately.
+       */
       screen(
         "Set up device: Step 3 Seed Success",
         undefined,
@@ -389,7 +399,7 @@ export const SyncOnboardingCompanion: React.FC<SyncOnboardingCompanionProps> = (
       analyticsSeedingTracked.current = true;
     }
     lastCompanionStepKey.current = companionStepKey;
-  }, [companionStepKey, productName, seedPathStatus]);
+  }, [companionStepKey, deviceOnboardingState?.isOnboarded, productName, seedPathStatus]);
 
   const seededDeviceHandled = useRef(false);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Now we have four ways to seed a device:
- new seed => Backup Recovery Key 🔑
- restore using Secret Recovery Phrase => Backup Recovery Key 🔑
- restore using Recovery Key => Next step ‼️
- restore using Recover subscription => Backup Recovery Key 🔑

Three of them except Recovery Key seed will trigger the Backup Recovery Key step, but the Recovery Key seed will pass directly to the install apps step, so its tracking should be treated separately. With this fix the tracking event can be correctly triggered after the Recovery Key seed on both LLM and LLD.

Demo with LLD:

https://github.com/user-attachments/assets/0a32a7eb-c1fe-4bf6-b838-f05ef2ff235d




<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20605](https://ledgerhq.atlassian.net/browse/LIVE-20605)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20605]: https://ledgerhq.atlassian.net/browse/LIVE-20605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ