### PR TITLE
fix: display native drawer for scy flow

### DIFF
--- a/.changeset/gold-yaks-own.md
+++ b/.changeset/gold-yaks-own.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix info drawer not displaying content

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnInfoDrawer.tsx
@@ -9,11 +9,13 @@ import { Track } from "~/analytics";
 import Circle from "~/components/Circle";
 import QueuedDrawer from "~/components/QueuedDrawer";
 import { earnInfoModalSelector } from "~/reducers/earn";
+import { useIsFocused } from "@react-navigation/core";
 
 export function EarnInfoDrawer() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [modalOpened, setModalOpened] = useState(false);
+  const isFocused = useIsFocused();
 
   const openModal = useCallback(() => setModalOpened(true), []);
 
@@ -24,10 +26,10 @@ export function EarnInfoDrawer() {
   const { message, messageTitle, learnMoreLink } = useSelector(earnInfoModalSelector);
 
   useEffect(() => {
-    if (!modalOpened && (message || messageTitle)) {
+    if (isFocused && !modalOpened && (message || messageTitle)) {
       openModal();
     }
-  }, [openModal, message, messageTitle, modalOpened]);
+  }, [isFocused, openModal, message, messageTitle, modalOpened]);
 
   const onLearnMorePress = useCallback(() => {
     if (learnMoreLink) {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Nav to earn from within earn --> select 'earn more' --> deposit flow --> info modal on providers screen

### 📝 Description
Information modal regarding DeFi protocol is not displaying any information while native SCY workflow. 

Screenshot before:
<img width="966" height="1420" alt="image" src="https://github.com/user-attachments/assets/2ac37f47-ab61-4cb8-a84b-ad95389a7347" />

Screenshot after:
<img width="515" height="764" alt="image" src="https://github.com/user-attachments/assets/b4215d8d-9ce2-49f5-b0c9-d8236b085fa4" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20598](https://ledgerhq.atlassian.net/browse/LIVE-20598)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20238]: https://ledgerhq.atlassian.net/browse/LIVE-20238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-20598]: https://ledgerhq.atlassian.net/browse/LIVE-20598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ