### PR TITLE
fix(LLM) rerendering with use db save effect

### DIFF
--- a/.changeset/smooth-dogs-battle.md
+++ b/.changeset/smooth-dogs-battle.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+move useDBSaveEffect usage away from LLM root App


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Moves calls to useDBSaveEffect away from LLM root \<App\> to prevent rerenders on every redux state change.

| Before        | After         |
| ------------- | ------------- |
| ![Kapture 2025-07-29 at 17 18 24](https://github.com/user-attachments/assets/17766e51-23c5-46b4-bb1c-eaec43e9ea74) Starts off with 20 rerenders in root App. Further redux store updates (with toast) trigger rerenders  |  ![Kapture 2025-07-29 at 17 15 48](https://github.com/user-attachments/assets/7f8f6ac3-2283-49c9-b26b-579aaa2b064c)   starts off with 15 rerenders. Further redux store updates (with toast) do not trigger rerenders |
| <img width="270" height="153" alt="image" src="https://github.com/user-attachments/assets/a48ce528-3d3b-468a-affc-916907e891c7" />  Navigation around the app can easily rerender the root App over 50 times  | <img width="207" height="95" alt="image" src="https://github.com/user-attachments/assets/875fbb6f-db20-4475-8ef4-a1ba4803e375" /> Navigation around the app keeps the root App rerenders to ~15 | 


### ❓ Context

- **JIRA or GitHub link**: [LIVE-20627](https://ledgerhq.atlassian.net/browse/LIVE-20627)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20627]: https://ledgerhq.atlassian.net/browse/LIVE-20627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ