### PR TITLE
core(coin-framework): pass `FeeEstimation` to `craftTransaction`

### DIFF
--- a/.changeset/proud-suits-occur.md
+++ b/.changeset/proud-suits-occur.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-stellar": major
+"@ledgerhq/coin-aptos": major
+"@ledgerhq/coin-tezos": major
+"@ledgerhq/coin-tron": major
+"@ledgerhq/coin-xrp": major
+"@ledgerhq/coin-framework": major
+---
+
+core(coin-framework): pass `FeeEstimation` to `craftTransaction`

--- a/libs/coin-framework/src/api/types.ts
+++ b/libs/coin-framework/src/api/types.ts
@@ -202,12 +202,7 @@ export type TransactionValidation = {
 
 export type FeeEstimation = {
   value: bigint;
-  parameters?: {
-    storageLimit: bigint;
-    gasLimit: bigint;
-    // Optional gas price, only for Aptos (need to improve)
-    gasPrice?: bigint;
-  };
+  parameters?: Record<string, unknown>;
 };
 
 // TODO rename start to minHeight
@@ -231,7 +226,7 @@ export type AlpacaApi<MemoType extends Memo = MemoNotSupported> = {
   estimateFees: (transactionIntent: TransactionIntent<MemoType>) => Promise<FeeEstimation>;
   craftTransaction: (
     transactionIntent: TransactionIntent<MemoType>,
-    customFees?: bigint,
+    customFees?: FeeEstimation,
   ) => Promise<string>;
   getBalance: (address: string) => Promise<Balance[]>;
   lastBlock: () => Promise<BlockInfo>;

--- a/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
@@ -115,7 +115,7 @@ describe("createApi", () => {
           type: "send",
           asset: { type: "native" },
         },
-        0n,
+        { value: 0n },
       );
 
       const rawTx = RawTransaction.deserialize(
@@ -141,7 +141,7 @@ describe("createApi", () => {
               "0x50788befc1107c0cc4473848a92e5c783c635866ce3c98de71d2eeb7d2a34f85::aptos_coin::AptosCoin",
           },
         },
-        0n,
+        { value: 0n },
       );
 
       const rawTx = RawTransaction.deserialize(
@@ -167,7 +167,7 @@ describe("createApi", () => {
               "0x50788befc1107c0cc4473848a92e5c783c635866ce3c98de71d2eeb7d2a34f85::aptos_coin::AptosCoin",
           },
         },
-        0n,
+        { value: 0n },
       );
 
       const rawTx = RawTransaction.deserialize(
@@ -194,7 +194,7 @@ describe("createApi", () => {
             assetReference: "0x2ebb2ccac5e027a87fa0e2e5f656a3a4238d6a48d93ec9b610d570fc0aa0df12",
           },
         },
-        0n,
+        { value: 0n },
       );
 
       const rawTx = RawTransaction.deserialize(

--- a/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.integ.test.ts
@@ -140,7 +140,7 @@ describe.skip("Stellar Api", () => {
           amount: AMOUNT,
           memo: { type: "NO_MEMO" },
         },
-        customFees,
+        { value: customFees },
       );
 
       const fees = readFees(transactionXdr);

--- a/libs/coin-modules/coin-stellar/src/api/index.test.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.test.ts
@@ -111,7 +111,7 @@ describe("Testing craftTransaction function", () => {
   it.each([[1n], [50n], [99n]])(
     "should use custom user fees when user provide them for crafting a transaction",
     async (fees: bigint) => {
-      await api.craftTransaction({ asset: {} } as TransactionIntent<StellarMemo>, fees);
+      await api.craftTransaction({ asset: {} } as TransactionIntent<StellarMemo>, { value: fees });
       expect(estimateFeesMock).toHaveBeenCalledTimes(0);
       expect(logicCraftTransactionMock).toHaveBeenCalledWith(
         expect.any(Object),

--- a/libs/coin-modules/coin-stellar/src/api/index.ts
+++ b/libs/coin-modules/coin-stellar/src/api/index.ts
@@ -45,9 +45,9 @@ export function createApi(config: StellarConfig): AlpacaApi<StellarMemo> {
 
 async function craft(
   transactionIntent: TransactionIntent<StellarMemo>,
-  customFees?: bigint,
+  customFees?: FeeEstimation,
 ): Promise<string> {
-  const fees = customFees !== undefined ? customFees : await estimateFees();
+  const fees = customFees?.value ?? (await estimateFees());
 
   // NOTE: check how many memos, throw if more than one?
   // if (transactionIntent.memos && transactionIntent.memos.length > 1) {

--- a/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.integ.test.ts
@@ -162,7 +162,7 @@ describe("Tezos Api", () => {
             recipient: "tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9",
             amount: BigInt(10),
           },
-          customFees,
+          { value: customFees },
         );
 
         const decodedTransaction = await decode(encodedTransaction);

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -111,10 +111,9 @@ describe("Testing craftTransaction function", () => {
         gasLimit: DEFAULT_GAS_LIMIT,
         storageLimit: DEFAULT_STORAGE_LIMIT,
       });
-      await api.craftTransaction(
-        { type: "send", sender: {} } as TezosTransactionIntent,
-        customFees,
-      );
+      await api.craftTransaction({ type: "send", sender: {} } as TezosTransactionIntent, {
+        value: customFees,
+      });
       expect(logicEstimateFees).toHaveBeenCalledTimes(1);
       expect(logicCraftTransactionMock).toHaveBeenCalledWith(
         expect.any(Object),

--- a/libs/coin-modules/coin-tezos/src/api/index.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.ts
@@ -19,9 +19,9 @@ import {
   rawEncode,
 } from "../logic";
 import api from "../network/tzkt";
-import type { TezosOperationMode } from "../types";
 import type { TezosApi, TezosFeeEstimation } from "./types";
-import { TransactionIntent } from "@ledgerhq/coin-framework/api/types";
+import { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-framework/api/types";
+import { TezosOperationMode } from "../types";
 
 export function createApi(config: TezosConfig): TezosApi {
   coinConfig.setCoinConfig(() => ({ ...config, status: { type: "active" } }));
@@ -57,14 +57,17 @@ async function balance(address: string): Promise<Balance[]> {
   ];
 }
 
-async function craft(transactionIntent: TransactionIntent, customFees?: bigint): Promise<string> {
+async function craft(
+  transactionIntent: TransactionIntent,
+  customFees?: FeeEstimation,
+): Promise<string> {
   if (!isTezosTransactionType(transactionIntent.type)) {
     throw new IncorrectTypeError(transactionIntent.type);
   }
 
   // note that an estimation is always necessary to get gasLimit and storageLimit, if even using custom fees
   const fee = await estimate(transactionIntent).then(fees => ({
-    fees: (customFees ?? fees.value).toString(),
+    fees: (customFees?.value ?? fees.value).toString(),
     gasLimit: fees.parameters?.gasLimit?.toString(),
     storageLimit: fees.parameters?.storageLimit?.toString(),
   }));

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.integ.test.ts
@@ -140,7 +140,7 @@ describe("Testing craftTransaction function", () => {
         recipient,
         amount,
       },
-      customFees,
+      { value: customFees },
     );
 
     const decodeResult = await decodeTransaction(result);

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.test.ts
@@ -98,7 +98,7 @@ describe("craftTransaction", () => {
       raw_data_hex: "extendedRawDataHex",
     });
 
-    await craftTransaction(transactionIntent, customFees);
+    await craftTransaction(transactionIntent, { value: customFees });
     expect(craftTrc20Transaction).toHaveBeenCalledWith(
       "contractAddress",
       undefined,
@@ -146,7 +146,7 @@ describe("craftTransaction", () => {
               assetReference: "contractAddress",
             },
           } as TransactionIntent,
-          customFees,
+          { value: customFees },
         );
       } catch (error) {
         expect((error as Error).message).toEqual(

--- a/libs/coin-modules/coin-tron/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-tron/src/logic/craftTransaction.ts
@@ -1,4 +1,4 @@
-import { TransactionIntent } from "@ledgerhq/coin-framework/api/index";
+import { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-framework/api/index";
 import BigNumber from "bignumber.js";
 import { craftStandardTransaction, craftTrc20Transaction } from "../network";
 import { decode58Check } from "../network/format";
@@ -7,7 +7,7 @@ import { feesToNumber } from "./utils";
 
 export async function craftTransaction(
   transactionIntent: TransactionIntent<TronMemo>,
-  customFees?: bigint,
+  customFees?: FeeEstimation,
 ): Promise<string> {
   const { asset, recipient, sender, amount, expiration } = transactionIntent;
   const rawMemo = "memo" in transactionIntent ? transactionIntent.memo : undefined;
@@ -17,7 +17,8 @@ export async function craftTransaction(
   const senderAddress = decode58Check(sender);
 
   if (asset.type === "trc20" && asset.assetReference) {
-    if (customFees !== undefined && (customFees <= 0 || customFees > Number.MAX_SAFE_INTEGER)) {
+    const fees = customFees?.value;
+    if (fees !== undefined && (fees <= 0 || fees > Number.MAX_SAFE_INTEGER)) {
       throw new Error(
         `fees must be between 0 and ${Number.MAX_SAFE_INTEGER} (Typescript Number type value limit)`,
       );
@@ -32,7 +33,7 @@ export async function craftTransaction(
       recipientAddress,
       senderAddress,
       new BigNumber(amount.toString()),
-      feesToNumber(customFees),
+      feesToNumber(fees),
       expiration,
     );
     return rawDataHex as string;

--- a/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.integ.test.ts
@@ -152,7 +152,7 @@ describe("Xrp Api", () => {
             memos: new Map(),
           },
         },
-        customFees,
+        { value: customFees },
       );
 
       expect(decode(result)).toMatchObject({

--- a/libs/coin-modules/coin-xrp/src/api/index.test.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.test.ts
@@ -284,7 +284,9 @@ describe("Testing craftTransaction function", () => {
 
   it("should use custom user fees when user provides it for crafting a transaction", async () => {
     const customFees = 99n;
-    await api.craftTransaction({ sender: "foo" } as TransactionIntent<XrpMapMemo>, customFees);
+    await api.craftTransaction({ sender: "foo" } as TransactionIntent<XrpMapMemo>, {
+      value: customFees,
+    });
 
     expect(logicCraftTransactionSpy).toHaveBeenCalledWith(
       expect.any(Object),

--- a/libs/coin-modules/coin-xrp/src/api/index.ts
+++ b/libs/coin-modules/coin-xrp/src/api/index.ts
@@ -48,10 +48,10 @@ export function createApi(config: XrpConfig): Api<XrpMapMemo> {
 
 async function craft(
   transactionIntent: TransactionIntent<XrpMapMemo>,
-  customFees?: bigint,
+  customFees?: FeeEstimation,
 ): Promise<string> {
   const nextSequenceNumber = await getNextValidSequence(transactionIntent.sender);
-  const estimatedFees = customFees !== undefined ? customFees : (await estimateFees()).fee;
+  const estimatedFees = customFees?.value ?? (await estimateFees()).fee;
 
   const memosMap =
     transactionIntent.memo?.type === "map" ? transactionIntent.memo.memos : new Map();


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Pass `FeeEstimation` to `craftTransaction`, so we can directly forward the output of `estimateFees`. Also make `FeeEstimation` more flexible.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
