### PR TITLE
Fix/Temp fix to skip first provider card to ignore the compact card

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -139,7 +139,7 @@ export class SwapPage extends AppPage {
         const providerLocator = webview
           .getByTestId(this.quoteCardProviderName)
           .getByText(providerName)
-          .first();
+          .nth(1);
 
         await providerLocator.isVisible();
         await providerLocator.click();
@@ -165,7 +165,7 @@ export class SwapPage extends AppPage {
       const providerLocator = webview
         .getByTestId(this.quoteCardProviderName)
         .getByText(providerName)
-        .first();
+        .nth(1);
 
       if (await providerLocator.isVisible()) {
         await providerLocator.click();

--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -254,7 +254,7 @@ export const WebElementHelpers = {
     while (Date.now() - start < timeout) {
       try {
         const elem = WebElementHelpers.getWebElementByTestId(id);
-        await retryUntilTimeout(() => elem.runScript(el => el.innerText), 1000, 200);
+        await retryUntilTimeout(() => elem.runScript(el => el.innerText), timeout);
         return elem;
       } catch (e) {
         lastErr = e instanceof Error ? e : new Error(String(e));

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -82,7 +82,7 @@ export default class SwapLiveAppPage {
 
   @Step("Select available provider")
   async selectExchange() {
-    let index = 0;
+    let index = 1;
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -124,7 +124,7 @@ export default class SwapLiveAppPage {
     await detoxExpect(getWebElementByTestId(this.quotesCountDown)).toExist();
     const providerList = await getWebElementsText(this.quoteProviderName);
     const numberOfQuotesText: string = await getWebElementText(this.numberOfQuotes);
-    jestExpect(numberOfQuotesText).toEqual(`${providerList.length} quotes found`);
+    jestExpect(numberOfQuotesText).toEqual(`${providerList.length - 1} quotes found`);
     return providerList;
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

the compact card seems to be hidden on the provider select screen but hence showing as the first card with test-id=quote-card-provider-name

<img width="334" height="720" alt="image" src="https://github.com/user-attachments/assets/a541c7d1-f96a-495a-bb23-cce75ba858e2" />
<img width="340" height="720" alt="image" src="https://github.com/user-attachments/assets/1a0c72d5-e8c8-446f-a3ed-983c079754bb" />

12:42:28.945 detox[24679] i [ 'Changelly', 'Changelly', 'Changelly', 'Velora', '1inch' ]


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
