### PR TITLE
Bugfix/live-20586 fix send small DOT amount when total balance < 2 DOTs

### DIFF
--- a/.changeset/clean-ties-chew.md
+++ b/.changeset/clean-ties-chew.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-polkadot": minor
+---
+
+[bugfix] fix send small DOT amount when total balance < 2 DOTs

--- a/libs/coin-modules/coin-polkadot/package.json
+++ b/libs/coin-modules/coin-polkadot/package.json
@@ -117,6 +117,7 @@
     "lint": "eslint ./src --no-error-on-unmatched-pattern --ext .ts,.tsx --cache",
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
+    "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
     "test-integ": "jest --config=jest.integ.config.js",
     "typecheck": "tsc --noEmit",
     "unimported": "unimported"

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.test.ts
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";
 import getTransactionStatus from "./getTransactionStatus";
 
@@ -37,6 +38,22 @@ describe("getTransactionStatus", () => {
       expect(stubIsElectionClosed).not.toHaveBeenCalled();
       expect(stubIsControllerAddress).not.toHaveBeenCalled();
       expect(stubVerifyValidatorAddresses).not.toHaveBeenCalled();
+    });
+
+    it("[Bug Polkadot] should have no amount error when user have a valid spendable balance", async () => {
+      const account = createFixtureAccount({
+        spendableBalance: new BigNumber(6705569396),
+        balance: new BigNumber(16705569396),
+      });
+      const transaction = createFixtureTransaction({
+        mode: "send",
+        fees: new BigNumber(158612606),
+        useAllAmount: false,
+        amount: new BigNumber(10000000),
+      });
+
+      const status = await getTransactionStatus(account, transaction);
+      expect(status.errors.amount).toBeUndefined();
     });
   });
 });

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
@@ -35,7 +35,6 @@ import {
   calculateAmount,
   getMinimumAmountToBond,
   getMinimumBalance,
-  EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN,
 } from "./utils";
 import { isValidAddress } from "../common";
 import { getCurrentPolkadotPreloadData } from "./state";
@@ -85,11 +84,7 @@ const getSendTransactionStatus: AccountBridge<
         showCode: true,
       }),
     });
-  } else if (
-    !errors.amount &&
-    !transaction.useAllAmount &&
-    account.spendableBalance.lte(EXISTENTIAL_DEPOSIT.plus(EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN))
-  ) {
+  } else if (!errors.amount && !transaction.useAllAmount && account.spendableBalance.isZero()) {
     errors.amount = new NotEnoughBalance();
   } else if (totalSpent.gt(account.spendableBalance)) {
     errors.amount = new NotEnoughBalance();

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -4,7 +4,7 @@ import { Extrinsics } from "@polkadot/types/metadata/decorate/types";
 import network from "@ledgerhq/live-network";
 import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
 import coinConfig from "../config";
-import { EXISTENTIAL_DEPOSIT } from "../bridge/utils";
+import { EXISTENTIAL_DEPOSIT, EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN } from "../bridge/utils";
 import type {
   PolkadotValidator,
   PolkadotStakingProgress,
@@ -315,7 +315,12 @@ export const getBalances = async (addr: string) => {
 
   const frozenMinusReserved = frozenBalance.minus(reservedBalance);
   const spendableBalance = BigNumber.max(
-    balance.minus(BigNumber.max(frozenMinusReserved, EXISTENTIAL_DEPOSIT)),
+    balance.minus(
+      BigNumber.max(
+        frozenMinusReserved,
+        EXISTENTIAL_DEPOSIT.plus(EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN),
+      ),
+    ),
     new BigNumber(0),
   );
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact

### 📝 Description

#### Context
Bug on Polkadot: User with a balance between 1 and 2 DOT can not send
Fix was merge on `release` branch but not on `develop`
Commits were cherry-pick from the `release`branch

#### What have changed
- Check spendable balance to be superior to zero on `getTransactionStatus`
- `EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN` used to compute spendable balance

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-20586?atlOrigin=eyJpIjoiYWNhNmYwZjA4YTY2NDUwMGIzZDhiYWQxOGE4NWNiZTAiLCJwIjoiaiJ9


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
