### PR TITLE
feat(LIVE-20549): fix mobile export logs error and upgrade swap error

### DIFF
--- a/.changeset/brown-dogs-appear.md
+++ b/.changeset/brown-dogs-appear.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix mobile export error and swap custom error consistency

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
@@ -5,7 +5,10 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 import { Trans, useTranslation } from "react-i18next";
 import { Icons } from "@ledgerhq/native-ui";
+import { useHeaderHeight } from "@react-navigation/elements";
 import { SwapCustomErrorProps } from "../types";
+import Button from "~/components/Button";
+import useExportLogs from "~/components/useExportLogs";
 
 export default function SwapCustomError({ route }: SwapCustomErrorProps) {
   const { t } = useTranslation();
@@ -13,6 +16,8 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
   const titleKey = error && "title" in error ? error.title : undefined;
   const nameKey =
     error && "name" in error && error.name !== "CompleteExchangeError" ? error.name : undefined;
+  const onExport = useExportLogs();
+  const headerHeight = useHeaderHeight();
 
   const { title, description } = useMemo(() => {
     if (titleKey || nameKey) {
@@ -34,18 +39,13 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
   }, [error, nameKey, t, titleKey]);
 
   return (
-    <SafeAreaView style={styles.root}>
-      <Flex justifyContent="center" alignItems="center" flex={1}>
-        <Icons.Close color="red" size="L" />
-        <Text variant="h3Inter" fontWeight="bold" fontSize={25} textAlign={"center"}>
+    <SafeAreaView style={[styles.root, { bottom: headerHeight }]}>
+      <Flex justifyContent="center" alignItems="center">
+        <Icons.DeleteCircleFill color="red" size="XXL" />
+        <Text variant="h3Inter" fontWeight="bold" fontSize={25} textAlign={"center"} mt={24}>
           {title}
         </Text>
-        <Text
-          variant="body"
-          textAlign={"center"}
-          testID="error-description-deviceAction"
-          mt={"32px"}
-        >
+        <Text variant="body" textAlign={"center"} testID="error-description-deviceAction" mt={16}>
           {description}
 
           {error && "cause" in error && error.cause?.swapCode && (
@@ -55,6 +55,14 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
             />
           )}
         </Text>
+        <Button
+          type="main"
+          size="medium"
+          onPress={onExport}
+          alignSelf="stretch"
+          title={t("common.saveLogs")}
+          mt={32}
+        />
       </Flex>
     </SafeAreaView>
   );
@@ -62,7 +70,9 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
 
 const styles = StyleSheet.create({
   root: {
+    display: "flex",
     flex: 1,
-    padding: 32,
+    justifyContent: "center",
+    alignItems: "center",
   },
 });


### PR DESCRIPTION
fix mobile export logs error and upgrade swap error for screen for consistency

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

https://ledgerhq.atlassian.net/browse/LIVE-20549

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
