### PR TITLE
feat(coin-monitoring): monitor tier two adresses

### DIFF
--- a/.changeset/quiet-llamas-scream.md
+++ b/.changeset/quiet-llamas-scream.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/coin-filecoin": minor
+"@ledgerhq/coin-hedera": minor
+"@ledgerhq/coin-modules-monitoring": minor
+"@ledgerhq/coin-tezos": minor
+"@ledgerhq/coin-near": minor
+---
+
+feat(coin-monitoring): monitor tier two adresses

--- a/libs/coin-modules-monitoring/src/currencies.ts
+++ b/libs/coin-modules-monitoring/src/currencies.ts
@@ -38,6 +38,153 @@ const info: Record<string, { accounts: Partial<Record<AccountType, AccountInfo>>
         pristine: { address: "Hbac8tM3SMbua9ZBqPRbEJ2n3FtikRJc7wFmZzpqbtBv" },
       },
     },
+    sui: {
+      accounts: {
+        pristine: { address: "0x285836edd88055191e2448ac81d00786dc33de570bcfdf96fed3e39747449fdc" },
+        average: { address: "0x085f6362077282f861abe75151ba3ec6df1dbb82291369f9a06da135ac156c15" },
+        big: { address: "0x15610fa7ee546b96cb580be4060fae1c4bb15eca87f9a0aa931512bad445fc76" },
+      },
+      skip: "403 issue",
+    },
+    polkadot: {
+      accounts: {
+        pristine: { address: "5HEDGMG7mYqh18Xs4BZpYZ3u7EPWUJ8hPDTJhq3cDZh1ztRW" },
+        average: { address: "1zugcabYjgfQdMLC3cAzQ8tJZMo45tMnGpivpAzpxB4CZyK" },
+        big: { address: "15K6nb2qhMorgiaavGZPPKCzcyrWFiWaSZM15UjqEn8C4yLn" },
+      },
+    },
+    elrond: {
+      // multiversx
+      accounts: {
+        pristine: { address: "erd1s4pulht4wn96swcwel64624l40h5lyxfnl9cejwy27kvwvqayuvq2y7klj" },
+        average: { address: "erd1trwn89w64n88xhl76y8rfzj4r59h2fc8u03mg0tzjh8r3lmwq0lsa3q0yk" },
+        big: { address: "erd17l22xekj5lvfulatz20xr0llxky6c8zr923r95qg3pfx668m862skjdveh" },
+      },
+    },
+    filecoin: {
+      accounts: {
+        pristine: { address: "f02901126" },
+        average: { address: "f1dyqj5drgs4jjjkhddix2pptiwg2cjioyv4x4gli" },
+        big: { address: "f1khdd2v7il7lxn4zjzzrqwceh466mq5k333ktu7q" },
+      },
+    },
+    mina: {
+      accounts: {
+        pristine: { address: "B62qoBXNhc6YqTa86zzniBjNTyshkM7NjGf1Z1uBJJXjSTdYK1qyKr6" },
+        average: { address: "B62qja3UzWbWrJU6gHbdASQyVdMtxcGwPhxaWDiSrT6892ovCqsR6f6" },
+        big: { address: "B62qoErNk7pK8BPtbx1eKoa4GURxvyB65hJNXmeRyk56TeB26zqosvw" },
+      },
+    },
+    hedera: {
+      accounts: {
+        pristine: { address: "0.0.433" },
+        average: { address: "0.0.1000" },
+        big: { address: "0.0.652978" },
+      },
+    },
+    aptos: {
+      accounts: {
+        pristine: { address: "0x404ccbd2acb6208effa69c100849feff040cec697d06f745152bdb3aa3a70614" },
+        average: { address: "0x201cf09644cd5d88aa6db2d1670011325eea2c3198ddfd0c1aa549be0003bb24" },
+        big: { address: "0xb8922507317d85197d70c2bc1afc949c759fd0a62c8841a4300d1e2b63649bf6" },
+      },
+      skip: "403 issue",
+    },
+    celo: {
+      accounts: {
+        pristine: { address: "0x64947cDB38d9d364eD5Ab78bfa23b29DE2ecdF7b" },
+        average: { address: "0x709fcCB2141EddCd95A4d618e82a9E895792055d" },
+        big: { address: "0xA5c453BC33FD9C5C798Ac24F666fa2B49E0a87fe" },
+      },
+    },
+    algorand: {
+      accounts: {
+        pristine: { address: "JHCRLKUBKMRUUHJFYCBYOVQRTSRHSSL6P376LNDQJSVLM7IQI2EUH6S4ZU" },
+        average: { address: "EZ6UMFSEAURIYP2E7KI4BUAERRASJM233XLFBO3ZOQYOQOHYL6FRPTYCEI" },
+        big: { address: "KJOLZZ55JVCXTXDEVFSPUSKGP7SCQDEURMAMEBJEPXRLIQBQDTVD4NO7GQ" },
+      },
+    },
+    near: {
+      accounts: {
+        pristine: { address: "test-pristine.testnet" },
+        average: { address: "nearkat.near" },
+        big: { address: "relay.aurora" },
+      },
+    },
+    cosmos: {
+      accounts: {
+        pristine: { address: "cosmos1cc3h49u9thwtvz4rlx9pf4kwycczx36q46rp59" },
+        average: { address: "cosmos1gs72s636mzfnc0re2qrvupz0daytv4057y30g6" },
+        big: { address: "cosmos18ejqp3d6yejcq3rxj4z6fsne63uj23cykw92pp" },
+      },
+      skip: "invalid url issue",
+    },
+    vechain: {
+      accounts: {
+        pristine: { address: "0x5034aa590125b64023a0262112b98d72e3c8e40e" },
+        average: { address: "0x23a93f95b5bafbf063cf63a129deca068de23288" },
+        big: { address: "0xb0894ec7992e2ca4322dbd2eb99fa39448fe2d72" },
+      },
+    },
+    icon: {
+      accounts: {
+        pristine: { address: "hx4d932cbcffcc95fbac52fcb388fa20c868673a96" },
+        average: { address: "hx2124c477a48c589f377aebfd8028bd4a8d7c0d2d" },
+        big: { address: "hxd75467e3e4ce64e3424c747dfb71503017440433" },
+      },
+      skip: "indexer issue (404)",
+    },
+    stellar: {
+      accounts: {
+        pristine: { address: "GDO2OB4MWX4ZHDFGEHDTV6YB5TZY5MT2F5HEJ7UYR2JY3NTNNDOHA7AV" },
+        average: { address: "GA6QQ7GWNAH7CW42IWV653UAERLQH3G2FDW76ZVL6KWJEZ37JTFH27ET" },
+        big: { address: "GB6YM6S6NW5UDYQASFDFXHCIVLY7BEPRLYVUBXWME6K7YZKKA4VE2Q7C" },
+      },
+    },
+    tezos: {
+      accounts: {
+        pristine: { address: "0082c6dcd37e14f83e852c8d3d21bc39289598f94cdd5800f6e4a9a8a5adfe3beb" },
+        average: { address: "0019b730b7b55718272cd409ca3480ff07c848579cfa65c41a57d50398098c50b2" },
+        big: { address: "007caac43b092bc041b15ca917c63ff7e721db93a16ace333c834fdcc1000884d2" },
+      },
+    },
+    tron: {
+      accounts: {
+        pristine: { address: "TKttnV3NSMA8AqZKpnjFAUFsWsAGdgT5YG" },
+        average: { address: "TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7" },
+        big: { address: "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH" },
+      },
+    },
+    ripple: {
+      accounts: {
+        pristine: { address: "rMQ98K56yXJbDGv49ZSmW51sLn94Xe1mu1" },
+        average: { address: "rPdvC6ccq8hCdPKSPJkPmyZ4Mi1oG2FFkT" },
+        big: { address: "rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY" },
+      },
+    },
+    casper: {
+      accounts: {
+        pristine: {
+          address: "020319d3ace178361daf4a2438faa00ccacad7bd531c93173c1fc30ecc8173ef0f76",
+        },
+        average: { address: "015febf058ea3d58e62363c0f5b546d4cb1a4439fc439dc3d333db192606e6defa" },
+        big: {
+          address: "8c15bba2d147859c7b7a8f43028eeb4d3c9571c6e36dfecc97c77463d3af08cd",
+          xpub: "02024c5e3ba7b1da49cda950319aec914cd3c720fbec3dcf25aa4add631e28f70aa9",
+        },
+      },
+      skip: "xpub issues",
+    },
+    internet_computer: {
+      accounts: {
+        pristine: {
+          address: "020319d3ace178361daf4a2438faa00ccacad7bd531c93173c1fc30ecc8173ef0f76",
+        },
+        average: { address: "015febf058ea3d58e62363c0f5b546d4cb1a4439fc439dc3d333db192606e6defa" },
+        big: { address: "015febf058ea3d58e62363c0f5b546d4cb1a4439fc439dc3d333db192606e6defa" },
+      },
+      skip: "500 issue",
+    },
   };
 
 export default info;

--- a/libs/coin-modules/coin-filecoin/src/common-logic/utils.ts
+++ b/libs/coin-modules/coin-filecoin/src/common-logic/utils.ts
@@ -200,15 +200,17 @@ export const getAccountShape: GetAccountShape = async info => {
   const balance = await fetchBalances(address);
   const rawTxs = await fetchTxs(address);
   const tokenAccounts = await buildTokenAccounts(address, accountId, info.initialAccount);
+  const operations = flatMap(processTxs(rawTxs), mapTxToOps(accountId, info)).sort(
+    (a, b) => b.date.getTime() - a.date.getTime(),
+  );
 
   const result: Partial<Account> = {
     id: accountId,
     subAccounts: tokenAccounts,
     balance: new BigNumber(balance.total_balance),
     spendableBalance: new BigNumber(balance.spendable_balance),
-    operations: flatMap(processTxs(rawTxs), mapTxToOps(accountId, info)).sort(
-      (a, b) => b.date.getTime() - a.date.getTime(),
-    ),
+    operations,
+    operationsCount: operations.length,
     blockHeight: blockHeight.current_block_identifier.index,
   };
   return result;

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -53,6 +53,7 @@ export const getAccountShape: GetAccountShape<Account> = async (
     balance: accountBalance.balance,
     spendableBalance: accountBalance.balance,
     operations,
+    operationsCount: operations.length,
     // NOTE: there are no "blocks" in hedera
     // Set a value just so that operations are considered confirmed according to isConfirmedOperation
     blockHeight: 10,

--- a/libs/coin-modules/coin-near/src/api/indexer.ts
+++ b/libs/coin-modules/coin-near/src/api/indexer.ts
@@ -45,7 +45,7 @@ function getOperationType(transaction: NearTransaction, address: string): Operat
 }
 
 function getOperationValue(transaction: NearTransaction, type: OperationType): BigNumber {
-  const amount = transaction.actions[0].data.deposit || 0;
+  const amount = transaction.actions[0]?.data?.deposit || 0;
 
   if (type === "OUT") {
     return new BigNumber(amount).plus(transaction.fee);

--- a/libs/coin-modules/coin-tezos/src/bridge/synchronization.ts
+++ b/libs/coin-modules/coin-tezos/src/bridge/synchronization.ts
@@ -85,6 +85,7 @@ export const getAccountShape: GetAccountShape<TezosAccount> = async ({
     xpub: publicKey,
     freshAddress: address,
     operations,
+    operationsCount: operations.length,
     balance,
     subAccounts,
     spendableBalance: balance,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->

### 📝 Description

Add  datadog monitoring for tier two coins, exceptions are coins needing additionnal configurations to get the account shape (essentially cosmos)

⚠️ Mina is very slow

ℹ️ filecoin - hedera - tezos - near getAccountShape now returns a operationsCount property

### ❓ Context

- https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/465?selectedIssue=LIVE-20288


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
