### PR TITLE
ci: Migration of AVD storage

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -564,27 +564,22 @@ jobs:
         env:
           PRODUCTION: ${{ inputs.production_firebase }}
 
-      - name: cache android emulator
-        timeout-minutes: 10
-        uses: tespkg/actions-cache@v1
+      - name: Download android emulator
+        timeout-minutes: 5
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         id: detox-avd
         with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-            /usr/local/lib/android/sdk/system-images/android-${{ env.AVD_API }}/${{ env.AVD_TARGET }}/${{ env.AVD_ARCH }}/*
-            /usr/local/lib/android/sdk/emulator/*
-          key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}
-          accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
-          secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          sessionToken: ${{ env.AWS_SESSION_TOKEN }}
-          bucket: ${{ env.cache-bucket }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
+          key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-r2-v8
+          accessKey: "${{ secrets.R2_ACCESS_KEY_ID }}"
+          secretKey: "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          bucket: ledger-live-cache
+          endpoint: ${{ secrets.R2_ENDPOINT }}
+          region: auto
 
       - name: create AVD and generate snapshot for caching
         if: steps.detox-avd.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
+        id: create-avd
         with:
           api-level: ${{ env.AVD_API }}
           arch: ${{ env.AVD_ARCH }}
@@ -597,6 +592,21 @@ jobs:
           disable-linux-hw-accel: false
           emulator-options: ${{ env.AVD_OPTIONS }}
           script: ./tools/scripts/wait_emulator_idle.sh
+
+      - name: Cache android emulator
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        if: steps.detox-avd.outputs.cache-hit != 'true'
+        with:
+          path: |
+            /home/runner/.android/
+            /usr/local/lib/android/sdk/emulator/
+            /usr/local/lib/android/sdk/system-images/android-${{ env.AVD_API }}/${{ env.AVD_TARGET }}/${{ env.AVD_ARCH }}/
+          key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-r2-v8
+          accessKey: "${{ secrets.R2_ACCESS_KEY_ID }}"
+          secretKey: "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          bucket: ledger-live-cache
+          endpoint: ${{ secrets.R2_ENDPOINT }}
+          region: auto
 
       - name: Setup Speculos image and Coin Apps
         id: setup-speculos

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   determine-builds:
     name: "Determine Builds"
-    runs-on: ledger-live-medium
+    runs-on: ubuntu-22.04
     outputs:
       ios_native_exists: ${{ steps.check-ios-native.outputs.cache-hit }}
       ios_js_exists: ${{ steps.check-ios-js.outputs.cache-hit }}
@@ -74,6 +74,7 @@ jobs:
       android_native_key: ${{ steps.cache-keys.outputs.android_native_key }}
       android_js_key: ${{ steps.cache-keys.outputs.android_js_key }}
     steps:
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
@@ -91,7 +92,7 @@ jobs:
       - name: Determine cache keys
         id: cache-keys
         run: |
-          echo "ios_native_key=${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios" >> $GITHUB_OUTPUT
+          echo "ios_native_key=${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-2" >> $GITHUB_OUTPUT
           echo "android_native_key=${{ hashFiles('apps/ledger-live-mobile/android') }}-detox-native-android" >> $GITHUB_OUTPUT
           echo "ios_js_key=${{ inputs.ref || github.sha }}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${{ inputs.ref || github.sha }}-detox-js-android" >> $GITHUB_OUTPUT
@@ -380,7 +381,7 @@ jobs:
           mv ${{ env.ANDROID_JSBUNDLE_PATH }} /tmp/apk/assets/index.android.bundle
           mv ${{ env.ANDROID_APK_PATH }} /tmp/apk/tmp.apk
           (cd /tmp/apk/; zip -r tmp.apk assets/index.android.bundle)
-          /usr/local/lib/android/sdk/build-tools/34.0.0/zipalign -p -v 4 /tmp/apk/tmp.apk ${{ env.ANDROID_APK_PATH }}
+          /usr/local/lib/android/sdk/build-tools/34.0.0/zipalign -p 4 /tmp/apk/tmp.apk ${{ env.ANDROID_APK_PATH }}
           /usr/local/lib/android/sdk/build-tools/34.0.0/apksigner sign --ks ${{ secrets.ANDROID_KEYSTORE_PATH }} --ks-pass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }} --ks-key-alias staging --key-pass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }} ${{ env.ANDROID_APK_PATH }}
 
       - name: Setup the caches
@@ -428,27 +429,22 @@ jobs:
           turbo_port: ${{ steps.setup-caches.outputs.port }}
           disable_cache: ${{ inputs.disable-turbo-cache || false }}
 
-      - name: cache android emulator
+      - name: Download android emulator
         timeout-minutes: 5
-        uses: tespkg/actions-cache@v1
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         id: detox-avd
         with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-            /usr/local/lib/android/sdk/system-images/android-${{ env.AVD_API }}/${{ env.AVD_TARGET }}/${{ env.AVD_ARCH }}/*
-            /usr/local/lib/android/sdk/emulator/*
-          key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}
-          accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
-          secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
-          sessionToken: ${{ env.AWS_SESSION_TOKEN }}
-          bucket: ${{ env.cache-bucket }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-          use-fallback: false
+          key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-r2-v8
+          accessKey: "${{ secrets.R2_ACCESS_KEY_ID }}"
+          secretKey: "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          bucket: ledger-live-cache
+          endpoint: ${{ secrets.R2_ENDPOINT }}
+          region: auto
 
       - name: create AVD and generate snapshot for caching
         if: steps.detox-avd.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
+        id: create-avd
         with:
           api-level: ${{ env.AVD_API }}
           arch: ${{ env.AVD_ARCH }}
@@ -461,6 +457,21 @@ jobs:
           disable-linux-hw-accel: false
           emulator-options: ${{ env.AVD_OPTIONS }}
           script: ./tools/scripts/wait_emulator_idle.sh
+
+      - name: Cache android emulator
+        uses: LedgerHQ/ledger-live/tools/actions/composites/cache/upload@develop
+        if: steps.detox-avd.outputs.cache-hit != 'true'
+        with:
+          path: |
+            /home/runner/.android/
+            /usr/local/lib/android/sdk/emulator/
+            /usr/local/lib/android/sdk/system-images/android-${{ env.AVD_API }}/${{ env.AVD_TARGET }}/${{ env.AVD_ARCH }}/
+          key: ${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-r2-v8
+          accessKey: "${{ secrets.R2_ACCESS_KEY_ID }}"
+          secretKey: "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          bucket: ledger-live-cache
+          endpoint: ${{ secrets.R2_ENDPOINT }}
+          region: auto
 
       - name: Run Android Tests
         id: detox

--- a/tools/actions/composites/cache/download/action.yml
+++ b/tools/actions/composites/cache/download/action.yml
@@ -1,0 +1,61 @@
+name: "Cache Download"
+description: "Download and uncompress cache files to S3"
+inputs:
+  endpoint:
+    description: the S3 endpoint URL, e.g., 's3.amazonaws.com'
+    type: string
+    required: false
+    default: 's3.amazonaws.com'
+  key:
+    type: string
+    required: true
+  accessKey:
+    type: string
+    required: true
+  secretKey:
+    type: string
+    required: true
+  sessionToken:
+    type: string
+    required: false
+  bucket:
+    type: string
+    required: true
+  region:
+    type: string
+    required: true
+outputs:
+  cache-hit:
+    description: "Indicates if the cache was successfully downloaded"
+    value: ${{ steps.download-cache.outcome == 'success' }}
+runs:
+  using: "composite"
+  steps:
+    - name: Downloading files
+      id: download-cache
+      shell: bash
+      continue-on-error: true
+      run: |
+        aws s3 cp s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst /tmp/cache.tzst --endpoint-url https://${{ inputs.endpoint }} --region ${{ inputs.region }} --no-progress
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.accessKey }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.secretKey }}
+        AWS_SESSION_TOKEN: ${{ inputs.sessionToken }}
+
+    - name: Un-Compress files (Linux)
+      if: runner.os == 'Linux' && steps.download-cache.outcome == 'success'
+      shell: bash
+      run: |
+        tar -xf /tmp/cache.tzst -P -C ${{ github.workspace }} --use-compress-program unzstd
+
+    - name: Un-Compress files (macOS)
+      if: runner.os == 'macOS' && steps.download-cache.outcome == 'success'
+      shell: bash
+      run: |
+        gtar -xf /tmp/cache.tzst -P -C ${{ github.workspace }} --use-compress-program unzstd
+
+    - name: Cleanup
+      shell: bash
+      if: steps.download-cache.outcome == 'success'
+      run: |
+          rm -f /tmp/cache.tzst

--- a/tools/actions/composites/cache/upload/action.yml
+++ b/tools/actions/composites/cache/upload/action.yml
@@ -2,7 +2,7 @@ name: "Cache upload"
 description: "Compress and upload cache files to S3"
 inputs:
   endpoint:
-    description: true if you want the runner to be paused, preserving state for investigation
+    description: the S3 endpoint URL, e.g., 's3.amazonaws.com'
     type: string
     required: false
     default: 's3.amazonaws.com'
@@ -20,22 +20,48 @@ inputs:
     required: true
   sessionToken:
     type: string
-    required: true
+    required: false
   bucket:
     type: string
     required: true
   region:
     type: string
     required: true
-
 runs:
   using: "composite"
   steps:
-    - name: Compressing files
+    - name: Create tempfile
+      shell: bash
+      id: create_tempfile
+      run: |
+        export FILE_LIST=$(mktemp /tmp/file-list.XXXXXX)
+        echo "Temporary file created at $FILE_LIST"
+        echo "file-list=$FILE_LIST" >> $GITHUB_OUTPUT
+        
+    - name: Compile file list
       shell: bash
       run: |
-        echo "Compressing files in ${{ inputs.path }}"
-        gtar --posix --delay-directory-restore --use-compress-program zstdmt -P -C ${{ github.workspace }} -cf /tmp/cache.tzst ${{ inputs.path }}
+        touch /tmp/cache-path.txt
+
+        echo "${{ inputs.path }}" | while IFS= read -r filePath; do
+          if [ -d "$filePath" ] || [ -f "$filePath" ]; then
+              find $filePath -type f >> ${{ steps.create_tempfile.outputs.file-list }}
+          else
+            echo "Warning: Path $filePath not found, skipping."
+          fi
+        done
+
+    - name: Compressing files (Linux)
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        /usr/bin/tar --posix -cf /tmp/cache.tzst --exclude cache.tzst -P -C ${{ github.workspace }} --files-from ${{ steps.create_tempfile.outputs.file-list }} --use-compress-program zstdmt
+
+    - name: Compressing files (macOS)
+      shell: bash
+      if: runner.os == 'macOS'
+      run: |
+        gtar --posix --delay-directory-restore --use-compress-program zstdmt -P -C ${{ github.workspace }} -cf /tmp/cache.tzst -T ${{ steps.create_tempfile.outputs.file-list }}
 
     - name: Uploading to S3
       shell: bash
@@ -43,8 +69,15 @@ runs:
         echo "Uploading files to S3 bucket ${{ inputs.bucket }}"
         aws configure set default.s3.max_concurrent_requests 240
         aws configure set default.s3.multipart_chunksize 2MB
-        aws s3 cp /tmp/cache.tzst s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst --endpoint-url https://${{ inputs.endpoint }} --region ${{ inputs.region }}
+        aws s3 cp /tmp/cache.tzst s3://${{ inputs.bucket }}/${{ inputs.key }}/cache.tzst --endpoint-url https://${{ inputs.endpoint }} --region ${{ inputs.region }}  --no-progress
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.accessKey }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.secretKey }}
         AWS_SESSION_TOKEN: ${{ inputs.sessionToken }}
+
+    - name: Cleanup
+      shell: bash
+      run: |
+          echo "Cleaning up temporary files"
+          rm -f /tmp/cache.tzst
+          rm -f ${{ steps.create_tempfile.outputs.file-list }}


### PR DESCRIPTION
This PR migrates the frequently accessed / infrequently wrote AVD snapshot to a new storage mechanism.

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-20305

Green mock run: https://github.com/LedgerHQ/ledger-live/actions/runs/16672701074/job/47193207921
"Green" e2e run: https://github.com/LedgerHQ/ledger-live/actions/runs/16673247899 - note stopped during run following successful test to avoid wasted compute