### PR TITLE
bugfix: remove the send max error on Polkadot

### DIFF
--- a/.changeset/silly-moles-tie.md
+++ b/.changeset/silly-moles-tie.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-polkadot": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"ledger-live-desktop-e2e-tests": minor
+---
+
+bugfix: remove send max error on Polkadot

--- a/apps/ledger-live-desktop/static/i18n/ar/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ar/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "تأكد أن لديك رصيد كافي متبقي لرسوم المعاملات المستقبلية"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "لا يمكن للرصيد أن يقل عن {{minimumBalance}} أرسل الحد الأقصى الى حساب خالي."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "يجب عليك تقييد على الأقل {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/de/app.json
+++ b/apps/ledger-live-desktop/static/i18n/de/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Stellen Sie sicher, dass Sie genug Guthaben für zukünftige Transaktionsgebühren übrig haben"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Kontostand darf nicht unter {{minimumBalance}} liegen. Maximalbetrag zu leerem Konto senden."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Sie müssen eine Kaution von mindestens {{minimumBondAmount}} hinterlegen."
     },

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6546,9 +6546,6 @@
     "PolkadotAllFundsWarning": {
       "title": "Ensure you have enough balance left for future transaction fees"
     },
-    "PolkadotDoMaxSendInstead": {
-      "title": "Balance cannot be below {{minimumBalance}}. Send max to empty account."
-    },
     "PolkadotBondMinimumAmount": {
       "title": "You must bond at least {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/es/app.json
+++ b/apps/ledger-live-desktop/static/i18n/es/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Asegúrate de que tienes un saldo restante suficiente para cubrir las tarifas de transacciones futuras"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "El saldo no puede ser inferior a {{minimumBalance}} Envía el máximo a una cuenta vacía."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Tienes que vincular al menos {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/fr/app.json
+++ b/apps/ledger-live-desktop/static/i18n/fr/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Assurez-vous que votre solde disponible est suffisant pour couvrir vos futurs frais de transaction."
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Le solde ne peut pas être inférieur à {{minimumBalance}}. Pour vider : Max."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Vous devez lier au moins {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/ja/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ja/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "今後のトランザクション手数料に十分な残高を、確保しておいてください。"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "残高が{{minimumBalance}} を下回ることはできません。空のアカウントに最大額を送金してください。"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "{{minimumBondAmount}}以上ボンドする必要があります。"
     },

--- a/apps/ledger-live-desktop/static/i18n/ko/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ko/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "향후 트랜잭션 수수료 지불에 필요한 잔금을 충분히 남겨 두세요"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "잔액은 {{minimumBalance}} 미만일 수 없습니다 최대 금액을 전송하여 계정을 비우세요."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "적어도 {{minimumBondAmount}} 이상 본딩해야 합니다."
     },

--- a/apps/ledger-live-desktop/static/i18n/pt-BR/app.json
+++ b/apps/ledger-live-desktop/static/i18n/pt-BR/app.json
@@ -6190,9 +6190,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Certifique-se de ter saldo suficiente para futuras taxas de transação"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "O saldo não pode ser inferior a {{minimumBalance}}. Enviar máximo para conta vazia."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Você deve vincular pelo menos {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/pt/app.json
+++ b/apps/ledger-live-desktop/static/i18n/pt/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Certifique-se de ter saldo suficiente para futuras taxas de transação"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "O saldo não pode ser inferior a {{minimumBalance}}. Enviar máximo para conta vazia."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Você deve vincular pelo menos {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/ru/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ru/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Не забудьте оставить немного средств на потенциальные комиссии."
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Баланс не может быть ниже {{minimumBalance}}. Отправьте всю сумму, чтобы аннулировать счёт."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Вы должны заблокировать не менее {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-desktop/static/i18n/th-TH/app.json
+++ b/apps/ledger-live-desktop/static/i18n/th-TH/app.json
@@ -6203,9 +6203,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "ตรวจสอบให้แน่ใจว่าคุณมียอดคงเหลือในบัญชีเพียงพอสำหรับค่าธรรมเนียมธุรกรรมในอนาคต"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "ยอดคงเหลือในบัญชีต้องไม่ต่ำกว่า {{minimumBalance}} ส่งสูงสุดไปยังบัญชีที่ว่างเปล่า"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "คุณต้องผูกมัดอย่างน้อย {{minimumBondAmount}}"
     },

--- a/apps/ledger-live-desktop/static/i18n/th/app.json
+++ b/apps/ledger-live-desktop/static/i18n/th/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "ตรวจสอบให้แน่ใจว่าคุณมียอดคงเหลือในบัญชีเพียงพอสำหรับค่าธรรมเนียมธุรกรรมในอนาคต"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "ยอดคงเหลือในบัญชีต้องไม่ต่ำกว่า {{minimumBalance}} ส่งสูงสุดไปยังบัญชีที่ว่างเปล่า"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "คุณต้องผูกมัดอย่างน้อย {{minimumBondAmount}}"
     },

--- a/apps/ledger-live-desktop/static/i18n/tr/app.json
+++ b/apps/ledger-live-desktop/static/i18n/tr/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Gelecekteki işlem ücretleri için yeterli bakiyenin kaldığından emin olun"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Bakiye {{minimumBalance}} altında olamaz Maksimum miktarı bir boş hesaba gönder."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Bağlanılacak tutar en az {{minimumBondAmount}} olmalıdır."
     },

--- a/apps/ledger-live-desktop/static/i18n/zh/app.json
+++ b/apps/ledger-live-desktop/static/i18n/zh/app.json
@@ -6514,9 +6514,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "确保您留有足够的余额，以便缴纳未来的交易费"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "余额不能少于 {{minimumBalance}}发送最大值以清空账户。"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "您必须至少绑定 {{minimumBondAmount}}。"
     },

--- a/apps/ledger-live-mobile/src/locales/ar/common.json
+++ b/apps/ledger-live-mobile/src/locales/ar/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "تأكد أن لديك رصيد كافي متبقي لرسوم المعاملات المستقبلية"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "لا يمكن للرصيد أن يقل عن {{minimumBalance}} أرسل الحد الأقصى الى حساب خالي."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "يجب عليك تقييد على الأقل {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/de/common.json
+++ b/apps/ledger-live-mobile/src/locales/de/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Stellen Sie sicher, dass Sie genug Guthaben für zukünftige Transaktionsgebühren übrig haben"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Kontostand darf nicht unter {{minimumBalance}} liegen. Maximalbetrag zu leerem Konto senden."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Sie müssen eine Kaution von mindestens {{minimumBondAmount}} hinterlegen."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning": {
       "title": "Ensure you have enough balance left for future transaction fees"
     },
-    "PolkadotDoMaxSendInstead": {
-      "title": "Balance cannot be below {{minimumBalance}}. Send max to empty account."
-    },
     "PolkadotBondMinimumAmount": {
       "title": "You must bond at least {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/es/common.json
+++ b/apps/ledger-live-mobile/src/locales/es/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Asegúrate de que tienes un saldo restante suficiente para cubrir las tarifas de transacciones futuras"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "El saldo no puede ser inferior a {{minimumBalance}} Envía el máximo a una cuenta vacía."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Tienes que vincular al menos {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/fr/common.json
+++ b/apps/ledger-live-mobile/src/locales/fr/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Assurez-vous que votre solde disponible est suffisant pour couvrir vos futurs frais de transaction."
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Le solde ne peut pas être inférieur à {{minimumBalance}}. Pour vider : Max."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Vous devez lier au moins {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/ja/common.json
+++ b/apps/ledger-live-mobile/src/locales/ja/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "今後のトランザクション手数料に十分な残高を、確保しておいてください。"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "残高が{{minimumBalance}} を下回ることはできません。空のアカウントに最大額を送金してください。"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "{{minimumBondAmount}}以上ボンドする必要があります。"
     },

--- a/apps/ledger-live-mobile/src/locales/ko/common.json
+++ b/apps/ledger-live-mobile/src/locales/ko/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "향후 트랜잭션 수수료 지불에 필요한 잔금을 충분히 남겨 두세요"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "잔액은 {{minimumBalance}} 미만일 수 없습니다 최대 금액을 전송하여 계정을 비우세요."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "적어도 {{minimumBondAmount}} 이상 본딩해야 합니다."
     },

--- a/apps/ledger-live-mobile/src/locales/pt-BR/common.json
+++ b/apps/ledger-live-mobile/src/locales/pt-BR/common.json
@@ -762,9 +762,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Certifique-se de ter saldo suficiente para futuras taxas de transação"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "O saldo não pode ser inferior a {{minimumBalance}}. Enviar máximo para conta vazia."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Você deve vincular pelo menos {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/pt/common.json
+++ b/apps/ledger-live-mobile/src/locales/pt/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Certifique-se de ter saldo suficiente para futuras taxas de transação"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "O saldo não pode ser inferior a {{minimumBalance}}. Enviar máximo para conta vazia."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Você deve vincular pelo menos {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/ru/common.json
+++ b/apps/ledger-live-mobile/src/locales/ru/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Не забудьте оставить немного средств на потенциальные комиссии."
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Баланс не может быть ниже {{minimumBalance}}. Отправьте всю сумму, чтобы аннулировать счёт."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Вы должны заблокировать не менее {{minimumBondAmount}}."
     },

--- a/apps/ledger-live-mobile/src/locales/th-TH/common.json
+++ b/apps/ledger-live-mobile/src/locales/th-TH/common.json
@@ -762,9 +762,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "ตรวจสอบให้แน่ใจว่าคุณมียอดคงเหลือในบัญชีเพียงพอสำหรับค่าธรรมเนียมธุรกรรมในอนาคต"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "ยอดคงเหลือในบัญชีต้องไม่ต่ำกว่า {{minimumBalance}} ส่งสูงสุดไปยังบัญชีที่ว่างเปล่า"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "คุณต้องผูกมัดอย่างน้อย {{minimumBondAmount}}"
     },

--- a/apps/ledger-live-mobile/src/locales/th/common.json
+++ b/apps/ledger-live-mobile/src/locales/th/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "ตรวจสอบให้แน่ใจว่าคุณมียอดคงเหลือในบัญชีเพียงพอสำหรับค่าธรรมเนียมธุรกรรมในอนาคต"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "ยอดคงเหลือในบัญชีต้องไม่ต่ำกว่า {{minimumBalance}} ส่งสูงสุดไปยังบัญชีที่ว่างเปล่า"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "คุณต้องผูกมัดอย่างน้อย {{minimumBondAmount}}"
     },

--- a/apps/ledger-live-mobile/src/locales/tr/common.json
+++ b/apps/ledger-live-mobile/src/locales/tr/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "Gelecekteki işlem ücretleri için yeterli bakiyenin kaldığından emin olun"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "Bakiye {{minimumBalance}} altında olamaz Maksimum miktarı bir boş hesaba gönder."
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "Bağlanılacak tutar en az {{minimumBondAmount}} olmalıdır."
     },

--- a/apps/ledger-live-mobile/src/locales/zh/common.json
+++ b/apps/ledger-live-mobile/src/locales/zh/common.json
@@ -897,9 +897,6 @@
     "PolkadotAllFundsWarning" : {
       "title" : "确保您留有足够的余额，以便缴纳未来的交易费"
     },
-    "PolkadotDoMaxSendInstead" : {
-      "title" : "余额不能少于 {{minimumBalance}}发送最大值以清空账户。"
-    },
     "PolkadotBondMinimumAmount" : {
       "title" : "您必须至少绑定 {{minimumBondAmount}}。"
     },

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -27,11 +27,6 @@ const transactionsAmountInvalid = [
     xrayTicket: "B2CQA-2571",
   },
   {
-    transaction: new Transaction(Account.DOT_1, Account.DOT_2, "1"),
-    expectedErrorMessage: "Balance cannot be below 1 DOT. Send max to empty account.",
-    xrayTicket: "B2CQA-2567",
-  },
-  {
     transaction: new Transaction(Account.DOT_1, Account.DOT_3, "0.5"),
     expectedErrorMessage: "Recipient address is inactive. Send at least 1 DOT to activate it",
     xrayTicket: "B2CQA-2570",

--- a/e2e/mobile/specs/send/sendInvalid/sendInvalidAmountDOT.spec.ts
+++ b/e2e/mobile/specs/send/sendInvalid/sendInvalidAmountDOT.spec.ts
@@ -1,6 +1,0 @@
-import { runSendInvalidAmountTest } from "../send";
-
-const transaction = new Transaction(Account.DOT_1, Account.DOT_2, "1.2");
-runSendInvalidAmountTest(transaction, "Balance cannot be below 1 DOT. Send max to empty account.", [
-  "B2CQA-2567",
-]);

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
@@ -22,7 +22,6 @@ import {
   PolkadotBondMinimumAmountWarning,
   PolkadotMaxUnbonding,
   PolkadotValidatorsRequired,
-  PolkadotDoMaxSendInstead,
 } from "../types";
 import {
   EXISTENTIAL_DEPOSIT,
@@ -34,7 +33,6 @@ import {
   hasMaxUnlockings,
   calculateAmount,
   getMinimumAmountToBond,
-  getMinimumBalance,
 } from "./utils";
 import { isValidAddress } from "../common";
 import { getCurrentPolkadotPreloadData } from "./state";
@@ -75,16 +73,7 @@ const getSendTransactionStatus: AccountBridge<
     errors.amount = new AmountRequired();
   }
 
-  const minimumBalanceExistential = getMinimumBalance(account);
-  const leftover = account.spendableBalance.minus(totalSpent);
-
-  if (minimumBalanceExistential.gt(0) && leftover.lt(minimumBalanceExistential) && leftover.gt(0)) {
-    errors.amount = new PolkadotDoMaxSendInstead("", {
-      minimumBalance: formatCurrencyUnit(account.currency.units[0], EXISTENTIAL_DEPOSIT, {
-        showCode: true,
-      }),
-    });
-  } else if (!errors.amount && !transaction.useAllAmount && account.spendableBalance.isZero()) {
+  if (!errors.amount && !transaction.useAllAmount && account.spendableBalance.isZero()) {
     errors.amount = new NotEnoughBalance();
   } else if (totalSpent.gt(account.spendableBalance)) {
     errors.amount = new NotEnoughBalance();

--- a/libs/coin-modules/coin-polkadot/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/utils.ts
@@ -250,10 +250,3 @@ export const calculateAmount = ({
 
   return amount.lt(0) ? new BigNumber(0) : amount;
 };
-
-export const getMinimumBalance = (a: Account): BigNumber => {
-  const lockedBalance = a.balance.minus(a.spendableBalance);
-  return lockedBalance.lte(EXISTENTIAL_DEPOSIT)
-    ? EXISTENTIAL_DEPOSIT.minus(lockedBalance)
-    : new BigNumber(0);
-};

--- a/libs/coin-modules/coin-polkadot/src/test/bot-specs.ts
+++ b/libs/coin-modules/coin-polkadot/src/test/bot-specs.ts
@@ -20,7 +20,6 @@ import {
   canNominate,
   isFirstBond,
   hasMinimumBondBalance,
-  getMinimumBalance,
 } from "../bridge/utils";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { acceptTransaction } from "./bot-deviceActions";
@@ -81,16 +80,6 @@ const polkadot: AppSpec<Transaction> = {
             "send is too low to activate account",
           );
           amount = EXISTENTIAL_DEPOSIT;
-        }
-
-        const minimumBalanceExistential = getMinimumBalance(account);
-        const leftover = account.spendableBalance.minus(amount.plus(POLKADOT_MIN_SAFE));
-        if (
-          minimumBalanceExistential.gt(0) &&
-          leftover.lt(minimumBalanceExistential) &&
-          leftover.gt(0)
-        ) {
-          throw new Error("risk of PolkadotDoMaxSendInstead");
         }
 
         return {

--- a/libs/coin-modules/coin-polkadot/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-polkadot/src/test/bridgeDatasetTest.ts
@@ -14,7 +14,6 @@ import {
   PolkadotBondMinimumAmount,
   PolkadotValidatorsRequired,
   PolkadotAllFundsWarning,
-  PolkadotDoMaxSendInstead,
 } from "../types";
 
 import { fromTransactionRaw } from "../bridge/transaction";
@@ -505,26 +504,6 @@ const polkadot: CurrenciesData<Transaction> = {
           expectedStatus: {
             errors: {
               amount: new NotEnoughBalance(),
-            },
-            warnings: {},
-          },
-        },
-        {
-          name: "[send] Do Max Send Instead error",
-          transaction: fromTransactionRaw({
-            family: "polkadot",
-            recipient: ACCOUNT_SAME_STASHCONTROLLER,
-            amount: "5000000000",
-            mode: "send",
-            era: null,
-            validators: [],
-            fees: null,
-            rewardDestination: null,
-            numSlashingSpans: 0,
-          }),
-          expectedStatus: {
-            errors: {
-              amount: new PolkadotDoMaxSendInstead(),
             },
             warnings: {},
           },

--- a/libs/coin-modules/coin-polkadot/src/types/errors.ts
+++ b/libs/coin-modules/coin-polkadot/src/types/errors.ts
@@ -16,4 +16,3 @@ export const PolkadotBondMinimumAmountWarning = createCustomErrorClass(
 
 export const PolkadotMaxUnbonding = createCustomErrorClass("PolkadotMaxUnbonding");
 export const PolkadotValidatorsRequired = createCustomErrorClass("PolkadotValidatorsRequired");
-export const PolkadotDoMaxSendInstead = createCustomErrorClass("PolkadotDoMaxSendInstead");


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact

### 📝 Description

#### Context
We have updated the balance computation on Polkadot to match the new system on this [commit](https://github.com/LedgerHQ/ledger-live/commit/79f0f2aa911cbb53e9ee78cc504963da6ff9042a). Thus, the spendable balance is computed to never allow a balance below 1 DOT (as required by Polkadot). The error `PolkadotDoMaxSendInstead` then can not be displayed anymore:
```
Balance cannot be below 1 DOT. Send max to empty account.
```

#### What have changed
- `PolkadotDoMaxSendInstead` error removed
- Check in Polkadot `getTransactionStatus` for `PolkadotDoMaxSendInstead` removed (and linked code, like `getMinimumBalance` function)
- E2E test for `PolkadotDoMaxSendInstead` removed

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-20586


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
