### PR TITLE
fix: fetch Hedera account balance from mirror node

### DIFF
--- a/libs/coin-modules/coin-hedera/src/api/mirror.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/mirror.test.ts
@@ -1,5 +1,5 @@
 import network from "@ledgerhq/live-network/network";
-import { getAccountTransactions } from "./mirror";
+import { getAccount, getAccountTransactions } from "./mirror";
 
 jest.mock("@ledgerhq/live-network/network");
 const mockedNetwork = jest.mocked(network);
@@ -70,5 +70,32 @@ describe("getAccountTransactions", () => {
     expect(result).toHaveLength(2);
     expect(result.map(tx => tx.consensus_timestamp)).toEqual(["1", "3"]);
     expect(mockedNetwork).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("getAccount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call the correct endpoint and return account data", async () => {
+    mockedNetwork.mockResolvedValueOnce(
+      makeMockResponse({
+        account: "0.0.1234",
+        max_automatic_token_associations: 0,
+        balance: {
+          balance: 1000,
+          timestamp: "1749047764.000113442",
+          tokens: [],
+        },
+      }),
+    );
+
+    const result = await getAccount("0.0.1234");
+    const requestUrl = mockedNetwork.mock.calls[0][0].url;
+
+    expect(result.account).toEqual("0.0.1234");
+    expect(requestUrl).toContain("/api/v1/accounts/0.0.1234");
+    expect(mockedNetwork).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/api/types.ts
+++ b/libs/coin-modules/coin-hedera/src/api/types.ts
@@ -1,0 +1,20 @@
+interface HederaMirrorTransfer {
+  account: string;
+  amount: number;
+}
+
+export interface HederaMirrorTransaction {
+  transfers: HederaMirrorTransfer[];
+  charged_tx_fee: string;
+  transaction_hash: string;
+  consensus_timestamp: string;
+  transaction_id: string;
+}
+
+export interface HederaMirrorAccount {
+  account: string;
+  balance: {
+    balance: number;
+    timestamp: string;
+  };
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - account balance is fetched from mirror node, not RPC
  - synchronization process should work faster and be more stable

### 📝 Description

This PR should fix "HederaAddAccountError" and make synchronisation process faster. Previously, the account balance was fetched using @hashgraph/sdk and AccountBalanceQuery. With the DEV_TOOLS=1 env enabled, numerous retries were clearly visible in the Network tab, significantly impacting sync time. Right now this is based on the mirror node and should work way better.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
