### PR TITLE
Wrong balance for Polkadot accounts

### DIFF
--- a/.changeset/tall-dodos-rule.md
+++ b/.changeset/tall-dodos-rule.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-polkadot": minor
+---
+
+Wrong balance for Polkadot accounts

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.ts
@@ -4,7 +4,6 @@ import { Extrinsics } from "@polkadot/types/metadata/decorate/types";
 import network from "@ledgerhq/live-network";
 import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
 import coinConfig from "../config";
-import { EXISTENTIAL_DEPOSIT, EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN } from "../bridge/utils";
 import type {
   PolkadotValidator,
   PolkadotStakingProgress,
@@ -297,7 +296,12 @@ export const getAccount = async (addr: string) => {
   const stakingInfo = await getStakingInfo(addr);
   const nominations = await getNominations(addr);
 
-  return { ...balances, ...stakingInfo, nominations };
+  const account = { ...balances, ...stakingInfo, nominations };
+  account.balance = account.balance
+    .plus(account.lockedBalance.minus(account.unlockingBalance))
+    .plus(account.unlockingBalance.minus(account.unlockedBalance));
+
+  return account;
 };
 
 /**
@@ -309,27 +313,12 @@ export const getAccount = async (addr: string) => {
 export const getBalances = async (addr: string) => {
   const balanceInfo = await fetchBalanceInfo(addr);
 
-  const balance = new BigNumber(balanceInfo.free);
-  const reservedBalance = new BigNumber(balanceInfo.reserved || "0");
-  const frozenBalance = new BigNumber(balanceInfo.frozen || "0");
-
-  const frozenMinusReserved = frozenBalance.minus(reservedBalance);
-  const spendableBalance = BigNumber.max(
-    balance.minus(
-      BigNumber.max(
-        frozenMinusReserved,
-        EXISTENTIAL_DEPOSIT.plus(EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN),
-      ),
-    ),
-    new BigNumber(0),
-  );
-
   return {
     blockHeight: Number(balanceInfo.at.height),
-    balance,
-    spendableBalance,
+    balance: new BigNumber(balanceInfo.free),
+    spendableBalance: new BigNumber(balanceInfo.transferable || "0"),
     nonce: Number(balanceInfo.nonce),
-    lockedBalance: reservedBalance,
+    lockedBalance: new BigNumber(balanceInfo.reserved || "0"),
   };
 };
 

--- a/libs/coin-modules/coin-polkadot/src/network/sidecar.unit.test.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/sidecar.unit.test.ts
@@ -1,8 +1,10 @@
 import BigNumber from "bignumber.js";
 import { HttpResponse, http } from "msw";
 import coinConfig from "../config";
-import { getAccount, getRegistry } from "./sidecar";
+import { getAccount, getBalances, getRegistry } from "./sidecar";
 import mockServer, { SIDECAR_BASE_URL_TEST } from "./sidecar.mock";
+import * as node from "./node";
+import { SidecarAccountBalanceInfo, SidecarStakingInfo } from "./types";
 
 jest.mock("./node", () => ({
   fetchConstants: jest.fn(),
@@ -12,7 +14,7 @@ jest.mock("./node", () => ({
 }));
 
 describe("getAccount", () => {
-  let balanceResponseStub = {};
+  let balanceResponseStub: Partial<SidecarAccountBalanceInfo> = {};
 
   beforeAll(() => {
     coinConfig.setCoinConfig(() => ({
@@ -49,47 +51,243 @@ describe("getAccount", () => {
     mockServer.close();
   });
 
-  it("should estimate lockedBalance correctly with 1 locked balance type", async () => {
+  it("should return no staking info when no controller found", async () => {
     balanceResponseStub = {
       at: {
         height: "0",
+        hash: "",
       },
-      locks: [
-        {
-          amount: "60000000000",
-          reasons: "All",
-        },
-      ],
-      targets: [],
+      nonce: "1",
+      transferable: "10000000000",
+      reserved: "220000000000", // bonded
+      free: "30000000000",
     };
 
-    const { lockedBalance } = await getAccount("addr");
-    expect(lockedBalance).toEqual(new BigNumber("60000000000"));
+    mockServer.use(
+      http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/activeEra`, () => {
+        return HttpResponse.json(undefined);
+      }),
+    );
+
+    const lockedBalance = new BigNumber(balanceResponseStub.reserved!);
+    const computedBalance = new BigNumber(balanceResponseStub.free!).plus(lockedBalance);
+
+    const account = await getAccount("addr");
+    expect(account).toMatchObject({
+      blockHeight: Number(balanceResponseStub.at!.height),
+      balance: computedBalance,
+      spendableBalance: new BigNumber(balanceResponseStub.transferable!),
+      nonce: Number(balanceResponseStub.nonce!),
+      lockedBalance: lockedBalance,
+      controller: null,
+      stash: null,
+      unlockedBalance: new BigNumber(0),
+      unlockingBalance: new BigNumber(0),
+    });
   });
 
-  it("should estimate lockedBalance when one locked balance is higher than others", async () => {
+  it("should return no staking info when account is not a stash", async () => {
     balanceResponseStub = {
       at: {
         height: "0",
+        hash: "",
       },
-      locks: [
-        {
-          amount: "1",
-          reasons: "reason 1",
-        },
-        {
-          amount: "5",
-          reasons: "reason 2",
-        },
-        {
-          amount: "3",
-          reasons: "reason 3",
-        },
-      ],
-      targets: [],
+      nonce: "1",
+      transferable: "10000000000",
+      reserved: "220000000000", // bonded
+      free: "30000000000",
     };
-    const { lockedBalance } = await getAccount("addr");
-    expect(lockedBalance).toEqual(new BigNumber("5"));
+
+    jest
+      .spyOn(node.default, "fetchStakingInfo")
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      .mockResolvedValue(undefined as unknown as SidecarStakingInfo);
+
+    mockServer.use(
+      http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/bonded`, ({ request }) => {
+        const url = new URL(request.url);
+        const keys = url.searchParams.get("keys[]");
+        const key1 = url.searchParams.get("key1");
+
+        if (keys === "addr" && key1 === "addr") {
+          return HttpResponse.json({ value: {} });
+        }
+
+        return HttpResponse.json(undefined);
+      }),
+    );
+
+    mockServer.use(
+      http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/activeEra`, () => {
+        return HttpResponse.json({});
+      }),
+    );
+
+    const lockedBalance = new BigNumber(balanceResponseStub.reserved!);
+    const computedBalance = new BigNumber(balanceResponseStub.free!).plus(lockedBalance);
+
+    const account = await getAccount("addr");
+    expect(account).toMatchObject({
+      blockHeight: Number(balanceResponseStub.at!.height),
+      balance: computedBalance,
+      spendableBalance: new BigNumber(balanceResponseStub.transferable!),
+      nonce: Number(balanceResponseStub.nonce!),
+      lockedBalance: lockedBalance,
+      controller: {},
+      stash: null,
+      unlockedBalance: new BigNumber(0),
+      unlockingBalance: new BigNumber(0),
+    });
+  });
+
+  it("should correctly set balance and staking info of the account", async () => {
+    balanceResponseStub = {
+      at: {
+        height: "0",
+        hash: "",
+      },
+      nonce: "1",
+      transferable: "10000000000",
+      reserved: "220000000000", // bonded
+      free: "30000000000",
+    };
+
+    const now = new Date();
+    // Here, we count the number of day for the new year, to keep unlocking not unlocked yet
+    // An estimation completion date is generated from this
+    // So for unlocked, we put 1 to make them outdated
+    // And for others, we put a number of day to make a completion date for next year (test will pass, nevermind the current date)
+    const daysCountForNextYear = (now.getFullYear() + 2 - 1970) * 365;
+    const stakingInfoResponseStub = {
+      staking: {
+        unlocking: [
+          {
+            // unbonded
+            value: "40000000000",
+            era: "1",
+          },
+          {
+            // unbonded
+            value: "50000000000",
+            era: "1",
+          },
+          {
+            // unbonding
+            value: "60000000000",
+            era: daysCountForNextYear,
+          },
+          {
+            // unbonding
+            value: "70000000000",
+            era: daysCountForNextYear,
+          },
+        ],
+      },
+    };
+
+    jest
+      .spyOn(node.default, "fetchStakingInfo")
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      .mockResolvedValue(stakingInfoResponseStub as SidecarStakingInfo);
+
+    mockServer.use(
+      http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/bonded`, ({ request }) => {
+        const url = new URL(request.url);
+        const keys = url.searchParams.get("keys[]");
+        const key1 = url.searchParams.get("key1");
+
+        if (keys === "addr" && key1 === "addr") {
+          return HttpResponse.json({ value: {} });
+        }
+
+        return HttpResponse.json(undefined);
+      }),
+    );
+    mockServer.use(
+      http.get(`${SIDECAR_BASE_URL_TEST}/pallets/staking/storage/activeEra`, () => {
+        return HttpResponse.json({});
+      }),
+    );
+
+    const lockedBalance = new BigNumber(balanceResponseStub.reserved!);
+    const unlockedBalance = new BigNumber(stakingInfoResponseStub.staking.unlocking[0].value).plus(
+      new BigNumber(stakingInfoResponseStub.staking.unlocking[1].value),
+    );
+    const unlockingBalance = new BigNumber(
+      stakingInfoResponseStub.staking.unlocking
+        .map(u => u.value)
+        .reduce((value, newValue) => value + Number(newValue), 0),
+    );
+    const computedBalance = new BigNumber(balanceResponseStub.free!)
+      .plus(lockedBalance.minus(unlockingBalance))
+      .plus(unlockingBalance.minus(unlockedBalance));
+
+    const account = await getAccount("addr");
+    expect(account).toMatchObject({
+      blockHeight: Number(balanceResponseStub.at!.height),
+      balance: computedBalance,
+      spendableBalance: new BigNumber(balanceResponseStub.transferable!),
+      nonce: Number(balanceResponseStub.nonce!),
+      lockedBalance: lockedBalance,
+      controller: {},
+      stash: null,
+      unlockedBalance: unlockedBalance,
+      unlockingBalance: unlockingBalance,
+    });
+  });
+});
+
+describe("getBalances", () => {
+  beforeAll(() => {
+    coinConfig.setCoinConfig(() => ({
+      status: {
+        type: "active",
+      },
+      node: {
+        url: "https://httpbin.org/",
+      },
+      sidecar: {
+        url: SIDECAR_BASE_URL_TEST,
+      },
+      metadataShortener: {
+        url: "",
+      },
+      metadataHash: {
+        url: "",
+      },
+    }));
+
+    mockServer.listen({ onUnhandledRequest: "error" });
+  });
+
+  beforeEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  it("should have no spendable balance nor locked balance when API does not return them", async () => {
+    const balanceResponseStub = {
+      at: {
+        height: "0",
+        hash: "",
+      },
+      nonce: "1",
+      free: "30000000000",
+    };
+
+    mockServer.use(
+      http.get(`${SIDECAR_BASE_URL_TEST}/accounts/:addr/balance-info`, () => {
+        return HttpResponse.json(balanceResponseStub);
+      }),
+    );
+
+    const account = await getBalances("addr");
+    expect(account).toMatchObject({
+      blockHeight: Number(balanceResponseStub.at!.height),
+      balance: new BigNumber(balanceResponseStub.free!),
+      spendableBalance: new BigNumber(0),
+      nonce: Number(balanceResponseStub.nonce!),
+      lockedBalance: new BigNumber(0),
+    });
   });
 });
 

--- a/libs/coin-modules/coin-polkadot/src/network/types.ts
+++ b/libs/coin-modules/coin-polkadot/src/network/types.ts
@@ -71,6 +71,7 @@ export interface SidecarAccountBalanceInfo {
   reserved: string;
   miscFrozen: string;
   feeFrozen: string;
+  transferable: string;
   frozen: string;
   locks: IBalanceLock[];
 }

--- a/libs/coin-tester-modules/coin-tester-polkadot/src/scenarii/Polkadot.ts
+++ b/libs/coin-tester-modules/coin-tester-polkadot/src/scenarii/Polkadot.ts
@@ -74,10 +74,7 @@ const getTransactions = () => {
         ).toFixed(),
       ).toBe("50000000000000000000000");
       expect(currentAccount.balance.toFixed()).toBe(
-        previousAccount.balance
-          .minus(latestOperation.value)
-          .minus(new BigNumber("5000000000000"))
-          .toFixed(),
+        previousAccount.balance.minus(latestOperation.value).toFixed(),
       );
     },
   };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - `Balance` on the balance account dashboard should be correctly displayed

### 📝 Description

Wrong balance for Polkadot accounts

#### Context
Users were not able to see their full `balance` on the account. `Bounded` and `unbonding` are missing on the computation.

#### What have changed
- `Balance` updated with the correct computation, adding unbonded and unbonding value
- `Spendable balance` need no more computation, Sidecar provide a computed value `transferable`
- Unit tests on the `getBalances`function

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-20643?atlOrigin=eyJpIjoiMDM1Y2QwYzBiM2Y5NGI1ZDhkYzQ4MDIwMzgzYmNmZDciLCJwIjoiaiJ9


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
