### PR TITLE
ci: enable manual sonar scan in github actions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,6 +3,7 @@ name: "[All Platforms] - SonarQube Scan - Scheduled"
 on:
   schedule:
     - cron: "0 2 * * 1-5" # every working day at 2am we will do a daily scan on develop
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Currently Sonar Scan cannot be manually triggered. This PR allows manual workflow triggers and supports this [ticket](https://ledgerhq.atlassian.net/browse/LIVE-20559)