### PR TITLE
fix(BACK-9348): stellar operation details UI fixes

### DIFF
--- a/.changeset/nine-foxes-flash.md
+++ b/.changeset/nine-foxes-flash.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"@ledgerhq/live-common": patch
+---
+
+fix some UI regressions on stellar detailed operations display introduced in #11120

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/operationDetails.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/operationDetails.tsx
@@ -19,24 +19,37 @@ const OperationDetailsExtra = ({
   return (
     <>
       {Object.keys(extra).map(key => {
-        if (["assetCode", "assetIssuer", "memo"].includes(key)) {
+        let details: React.JSX.Element | undefined = undefined;
+        switch (key) {
+          case "assetCode": {
+            details = <Ellipsis>{extra[key]}</Ellipsis>;
+            break;
+          }
+          case "assetIssuer": {
+            details = (
+              <HashContainer>
+                <SplitAddress value={extra[key] ?? ""} />
+              </HashContainer>
+            );
+            break;
+          }
+          case "memo": {
+            const label = formatMemo(extra);
+            if (label) details = <Ellipsis>{label}</Ellipsis>;
+            break;
+          }
+        }
+
+        if (details)
           return (
             <OpDetailsSection key={key}>
               <OpDetailsTitle>
                 <Trans i18nKey={`families.stellar.${key}`} defaults={key} />
               </OpDetailsTitle>
-              <OpDetailsData>
-                {key === "assetIssuer" ? (
-                  <HashContainer>
-                    <SplitAddress value={extra[key] ?? ""} />
-                  </HashContainer>
-                ) : null}
-                {key === "assetCode" ? <Ellipsis>{extra[key]}</Ellipsis> : null}
-                {key === "memo" ? <Ellipsis>{formatMemo(extra)}</Ellipsis> : null}
-              </OpDetailsData>
+              <OpDetailsData>{details}</OpDetailsData>
             </OpDetailsSection>
           );
-        }
+
         return null;
       })}
     </>

--- a/libs/ledger-live-common/src/families/stellar/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/stellar/__snapshots__/bridge.integration.test.ts.snap
@@ -3,17 +3,17 @@
 exports[`stellar currency bridge scanAccounts stellar seed 1 1`] = `
 [
   {
-    "balance": "341064673",
+    "balance": "341064683",
     "currencyId": "stellar",
     "derivationMode": "sep5",
     "freshAddress": "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
     "freshAddressPath": "44'/148'/0'",
     "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
     "index": 0,
-    "operationsCount": 116,
+    "operationsCount": 126,
     "pendingOperations": [],
     "seedIdentifier": "27c586f8499294c64d57f8d7956eef4431de58ab20e1c88001f6cf131c97d6f3",
-    "spendableBalance": "311064573",
+    "spendableBalance": "311064583",
     "subAccounts": [],
     "swapHistory": [],
     "syncHash": undefined,
@@ -444,6 +444,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
     },
     {
       "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "0b101bc4656b48063383c8c7957eb756df6daee9f10f2d89125f2ec176d28f84",
+      "blockHeight": 58324373,
+      "extra": {
+        "blockTime": 2025-08-05T04:22:10.000Z,
+        "index": "250501274594967553",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "50% CASHBACK ON yStorm & XLM",
+        },
+        "pagingToken": "250501274594967553",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "10264d8b4e71eee96b3972b99c3ccff8a6b2840232d93126df6014ad236183d2",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-10264d8b4e71eee96b3972b99c3ccff8a6b2840232d93126df6014ad236183d2-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316409700,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
       "blockHash": "de91876967432c18db672925858963de846140dc7cbfc8e73e016a09bec9f719",
       "blockHeight": 55972081,
       "extra": {
@@ -857,6 +885,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
         "GDVDHOAN7AFU2ZVJHUHSC7MCF756FINXPHKMXVXLUO2BLRVCBCHPYVIA",
       ],
       "transactionSequenceNumber": 242646183137249660,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "28cd3dca0bcb5ff7d3fe6378c0dde4749dfd6e6cc5722c9f26440c4ffc740fc5",
+      "blockHeight": 58285530,
+      "extra": {
+        "blockTime": 2025-08-02T14:24:45.000Z,
+        "index": "250334445180477441",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy yStorm Earn Native XLM!",
+        },
+        "pagingToken": "250334445180477441",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "2fc357f2119d08873c8eadba23577052b952f8a136b8f283842f8ba1beb23a26",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-2fc357f2119d08873c8eadba23577052b952f8a136b8f283842f8ba1beb23a26-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316403330,
       "type": "IN",
       "value": "1",
     },
@@ -1578,6 +1634,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
     },
     {
       "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "e03520700e06dc2c1bfae2f0b4a94490277088becb48ea306264fdd8dfd1df62",
+      "blockHeight": 58334484,
+      "extra": {
+        "blockTime": 2025-08-05T20:35:01.000Z,
+        "index": "250544701009068033",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy yStorm Earn Native XLM!",
+        },
+        "pagingToken": "250544701009068033",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "6be42b9b39e7f99a20f4df57b8513c881caf1de5279b573c262f6e32425d4e25",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-6be42b9b39e7f99a20f4df57b8513c881caf1de5279b573c262f6e32425d4e25-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316411780,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
       "blockHash": "025bb8acb9b78ff008daf0b6ffad07bdcc64dc5dfc64605189c3fd4a5fac499c",
       "blockHeight": 56641142,
       "extra": {
@@ -1878,6 +1962,62 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
         "GB7T62LJPM7RAQOILVX6DDPVNJQLMIBKGV6SJGXUWOB7IAFGR5US6WS3",
       ],
       "transactionSequenceNumber": 247017862844121600,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "09fd06182f1e9bb78ff2f53e4556aa512d9f13f971d71906a9f91453239eeed9",
+      "blockHeight": 58311936,
+      "extra": {
+        "blockTime": 2025-08-04T08:29:31.000Z,
+        "index": "250447858087116801",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "50% CASHBACK ON yStorm & XLM",
+        },
+        "pagingToken": "250447858087116801",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "83c0c4837794746edc769650209596d2b10a163ffaa012942cc49b72cd3e201b",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-83c0c4837794746edc769650209596d2b10a163ffaa012942cc49b72cd3e201b-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316407580,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "1a5bfecea672170945dcefce62af99913290d3696d2b5fe8b3c40e756bbe2f04",
+      "blockHeight": 58270682,
+      "extra": {
+        "blockTime": 2025-08-01T14:41:57.000Z,
+        "index": "250270673506594817",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy yStorm Earn Native XLM!",
+        },
+        "pagingToken": "250270673506594817",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "86cc5be8b2e5e3ac6fe4ee1d0ace67d6dcee9682c428b2df08e90758583666e1",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-86cc5be8b2e5e3ac6fe4ee1d0ace67d6dcee9682c428b2df08e90758583666e1-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316400540,
       "type": "IN",
       "value": "1",
     },
@@ -2326,6 +2466,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
     },
     {
       "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "4d4da61e0ebfb43089bbb1be529d164db5b47a3e74c7ea2471af6dc4d7e222b8",
+      "blockHeight": 58270696,
+      "extra": {
+        "blockTime": 2025-08-01T14:43:15.000Z,
+        "index": "250270733635469313",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy yStorm Earn Native XLM!",
+        },
+        "pagingToken": "250270733635469313",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "9e29dcd7a4535b565c78cf9984e3b5bc4e45f8789d0c73ba7e95c7f0a2be9be0",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-9e29dcd7a4535b565c78cf9984e3b5bc4e45f8789d0c73ba7e95c7f0a2be9be0-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316400540,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
       "blockHash": "54c972c8c8433729c52ca13f65d26ec45388e7ee280986de4c6cf5a6dfc4f5f9",
       "blockHeight": 29206206,
       "extra": {
@@ -2350,6 +2518,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
       "transactionSequenceNumber": 116917835954913330,
       "type": "OUT",
       "value": "1000",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "ffe2e9c1e5439c3bb5f96db7389fb12c32cfe7709dfda017e42462bd9cc132ab",
+      "blockHeight": 58370660,
+      "extra": {
+        "blockTime": 2025-08-08T06:51:44.000Z,
+        "index": "250700075746578433",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy RFL & Earn Native XLM",
+        },
+        "pagingToken": "250700075746578433",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "a287cdbdcce41744f541d7fe2771a13addfaf00325720cc1ab2226c13439ce5a",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-a287cdbdcce41744f541d7fe2771a13addfaf00325720cc1ab2226c13439ce5a-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GC5MXBUKMFBOASOJUKKZUI7TOVI7AM6T3DYU27VS3OSQP5ODGVDGEXLE",
+      ],
+      "transactionSequenceNumber": 250653093098686850,
+      "type": "IN",
+      "value": "1",
     },
     {
       "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
@@ -2488,6 +2684,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
         "GAJSV2O545Z6ZK7FTPW2GOYNKMYJMP2REUJV4AW6DSYTYUHVI3N2DA6B",
       ],
       "transactionSequenceNumber": 224182342070056600,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "4f1ce00a5d3eac5bdb41cf0fd0b81cdb369bfb349884c44d3e2240a70d37f9d7",
+      "blockHeight": 58363096,
+      "extra": {
+        "blockTime": 2025-08-07T18:34:27.000Z,
+        "index": "250667588613849089",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy RFL & Earn Native XLM",
+        },
+        "pagingToken": "250667588613849089",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "b1a4b775747d4a70444a313f61e7050b804c49ecccc409f8a7ebabd553c66df5",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-b1a4b775747d4a70444a313f61e7050b804c49ecccc409f8a7ebabd553c66df5-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GC5MXBUKMFBOASOJUKKZUI7TOVI7AM6T3DYU27VS3OSQP5ODGVDGEXLE",
+      ],
+      "transactionSequenceNumber": 250653093098684700,
       "type": "IN",
       "value": "1",
     },
@@ -2825,6 +3049,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
     },
     {
       "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "2220076b8d57bd2e0ce2e70ba0765145d47ecf07d06aa67c1999550a85842949",
+      "blockHeight": 58343922,
+      "extra": {
+        "blockTime": 2025-08-06T11:43:04.000Z,
+        "index": "250585236911091713",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy yStorm Earn Native XLM!",
+        },
+        "pagingToken": "250585236911091713",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "d7156608ccfa85496429722fedfc7b1928b4964ea87bac94a42bf753bbe9794b",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-d7156608ccfa85496429722fedfc7b1928b4964ea87bac94a42bf753bbe9794b-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316413820,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
       "blockHash": "348700d9be98e1df277bdad085c71626843870bd80aec3f428aeb06a2519ee43",
       "blockHeight": 37735917,
       "extra": {
@@ -3069,6 +3321,34 @@ exports[`stellar currency bridge scanAccounts stellar seed 1 2`] = `
         "GBLYYM2TF6MTXS52QXGZAEDKB6WGQWBH3Y6WJANED4O7KBYU7SCGZGCA",
       ],
       "transactionSequenceNumber": 243671000988782800,
+      "type": "IN",
+      "value": "1",
+    },
+    {
+      "accountId": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5",
+      "blockHash": "d1709d056a6ee5ef255a9734a3b8a00e2ff86220abea02ca7ecae078fd3150b2",
+      "blockHeight": 58299775,
+      "extra": {
+        "blockTime": 2025-08-03T13:02:48.000Z,
+        "index": "250395626989236225",
+        "ledgerOpType": "IN",
+        "memo": {
+          "type": "MEMO_TEXT",
+          "value": "Buy yStorm Earn Native XLM!",
+        },
+        "pagingToken": "250395626989236225",
+      },
+      "fee": "10000",
+      "hasFailed": false,
+      "hash": "f034bf4a1d9eb1d2660beb03b691de981e01a587ba1377d6ce682142a28c9d48",
+      "id": "js:2:stellar:GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV:sep5-f034bf4a1d9eb1d2660beb03b691de981e01a587ba1377d6ce682142a28c9d48-IN",
+      "recipients": [
+        "GAT4LBXYJGJJJRSNK74NPFLO55CDDXSYVMQODSEAAH3M6EY4S7LPH5GV",
+      ],
+      "senders": [
+        "GBCTYLNHE5XJNGD76R7EVQSMFXMT4SC5PD4XKT2P4LBN2BBB42BKC5EA",
+      ],
+      "transactionSequenceNumber": 250201623316405470,
       "type": "IN",
       "value": "1",
     },

--- a/libs/ledger-live-common/src/families/stellar/ui.ts
+++ b/libs/ledger-live-common/src/families/stellar/ui.ts
@@ -1,15 +1,22 @@
-import { StellarOperationExtra } from "./types";
+import { StellarMemo, StellarOperationExtra } from "./types";
 
 /**
  * Format stellar memo value for display.
  */
 export const formatMemo = (extra: StellarOperationExtra): string | undefined => {
-  switch (extra?.memo?.type) {
+  const memo: StellarMemo | string | undefined = extra.memo;
+
+  // for backward compatibility for previous operation structure, as there is no
+  // data migration system in place
+  // noinspection SuspiciousTypeOfGuard
+  if (typeof memo == "string") return memo;
+
+  switch (memo?.type) {
     case "MEMO_ID":
     case "MEMO_TEXT":
     case "MEMO_HASH":
     case "MEMO_RETURN":
-      return extra?.memo.value;
+      return memo?.value;
   }
   return undefined;
 };


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD stellar transaction details

### 📝 Description

This fixes some UI regressions introduced in #11120:
 - make operation display backward compatible with old structure, to avoid having to reindex all accounts
 - don't show memo row in details when memo is unset/NO_MEMO/unknown type

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- BACK-9348


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
