### PR TITLE
Feature/live 19996

### DIFF
--- a/.changeset/modern-needles-cough.md
+++ b/.changeset/modern-needles-cough.md
@@ -1,0 +1,16 @@
+---
+"@ledgerhq/coin-tester-evm": minor
+"@ledgerhq/types-live": minor
+"@ledgerhq/coin-bitcoin": minor
+"@ledgerhq/coin-evm": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/live-countervalues": minor
+"@ledgerhq/coin-framework": minor
+"@ledgerhq/live-config": minor
+"@ledgerhq/live-wallet": minor
+"@ledgerhq/live-cli": minor
+---
+
+Update EVM createBridge function signature for CAL lazy loading

--- a/apps/cli/src/live-common-setup.ts
+++ b/apps/cli/src/live-common-setup.ts
@@ -18,7 +18,7 @@ import SpeculosHttpTransport, {
   SpeculosHttpTransportOpts,
 } from "@ledgerhq/hw-transport-node-speculos-http";
 import * as legacy from "@ledgerhq/cryptoassets/tokens";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 
 let idCounter = 0;

--- a/apps/ledger-live-desktop/src/newArch/hooks/useStake.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/hooks/useStake.test.ts
@@ -8,7 +8,7 @@ import { AccountRaw, TokenAccount } from "@ledgerhq/types-live";
 
 import { fromAccountRaw } from "@ledgerhq/coin-framework/serialization/account";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 
 const raw: AccountRaw = {

--- a/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.test.ts
+++ b/apps/ledger-live-mobile/src/newArch/hooks/useStake/useStake.test.ts
@@ -10,7 +10,7 @@ import { AccountRaw, TokenAccount } from "@ledgerhq/types-live";
 import { fromAccountRaw } from "@ledgerhq/coin-framework/serialization/account";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 const raw: AccountRaw = {
   id: "js:2:ethereum:0x01:",

--- a/libs/coin-framework/src/account/accountId.test.ts
+++ b/libs/coin-framework/src/account/accountId.test.ts
@@ -7,7 +7,7 @@ import {
 import tokenData from "./__fixtures__/binance-peg_dai_token.json";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import * as cryptoAssets from "../crypto-assets";
-import { CryptoAssetsStore } from "../crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const TOKEN = tokenData as TokenCurrency;

--- a/libs/coin-framework/src/crypto-assets/index.ts
+++ b/libs/coin-framework/src/crypto-assets/index.ts
@@ -1,4 +1,4 @@
-import { CryptoAssetsStore } from "./type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 let cryptoAssetsStore: CryptoAssetsStore | undefined = undefined;
 

--- a/libs/coin-modules/coin-bitcoin/src/descriptor.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/descriptor.test.ts
@@ -5,8 +5,8 @@ import { fromAccountRaw } from "@ledgerhq/coin-framework/serialization/index";
 import { inferDescriptorFromDeviceInfo, inferDescriptorFromAccount } from "./descriptor";
 import bitcoinDatasets from "./datasets/bitcoin";
 import { assignFromAccountRaw } from "./serialization";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 setCryptoAssetsStore({} as CryptoAssetsStore);

--- a/libs/coin-modules/coin-evm/package.json
+++ b/libs/coin-modules/coin-evm/package.json
@@ -55,7 +55,7 @@
     "lint:fix": "pnpm lint --fix",
     "typecheck": "tsc --noEmit",
     "test": "jest",
-    "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand",
+    "test:debug": "node --inspect-wait ./node_modules/jest/bin/jest.js --runInBand",
     "test-integ": "jest --config=jest.integ.config.js",
     "unimported": "unimported"
   },

--- a/libs/coin-modules/coin-evm/src/__fixtures__/cardano-native-8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552.json
+++ b/libs/coin-modules/coin-evm/src/__fixtures__/cardano-native-8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552.json
@@ -1,0 +1,52 @@
+{
+    "type": "TokenCurrency",
+    "id": "cardano/native/8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552",
+    "contractAddress": "8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552",
+    "parentCurrency": {
+      "type": "CryptoCurrency",
+      "id": "cardano",
+      "coinType": 1815,
+      "name": "Cardano",
+      "managerAppName": "Cardano ADA",
+      "ticker": "ADA",
+      "scheme": "cardano",
+      "color": "#0A1D2C",
+      "family": "cardano",
+      "blockAvgTime": 20,
+      "units": [
+        {
+          "name": "ada",
+          "code": "ADA",
+          "magnitude": 6
+        },
+        {
+          "name": "Lovelace",
+          "code": "Lovelace",
+          "magnitude": 0
+        }
+      ],
+      "explorerViews": [
+        {
+          "tx": "https://cardanoscan.io/transaction/$hash",
+          "address": "https://cardanoscan.io/address/$address",
+          "stakePool": "https://cardanoscan.io/pool/$poolId"
+        }
+      ],
+      "keywords": [
+        "ada",
+        "cardano"
+      ]
+    },
+    "tokenType": "native",
+    "name": "LOBSTER",
+    "ticker": "$LOBSTER",
+    "delisted": false,
+    "disableCountervalue": false,
+    "units": [
+      {
+        "name": "LOBSTER",
+        "code": "$LOBSTER",
+        "magnitude": 0
+      }
+    ]
+  }

--- a/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-usd__coin-0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf-IN-i0.json
+++ b/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-usd__coin-0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf-IN-i0.json
@@ -1,0 +1,20 @@
+{
+    "accountId": "js:2:ethereum:0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d:+ethereum%2Ferc20%2Fusd~!underscore!~~!underscore!~coin",
+    "blockHash": "0x58ee7556044cd139e569c87c173a6dedbfbeb9ada6693ee6090fd510acee9c21",
+    "blockHeight": 16240731,
+    "contract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "date": "2022-12-22T14:06:23.000Z",
+    "extra": {},
+    "fee": "1595338583295225",
+    "hash": "0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf",
+    "id": "js:2:ethereum:0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d:+js%3A2%3Aethereum%3A0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d%3A%2Bethereum%252Ferc20%252Fusd~!underscore!~~!underscore!~coin~!dash!~0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf~!dash!~OUT~!dash!~i0-0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf-IN-i0",
+    "recipients": [
+      "0xC2907EFccE4011C491BbedA8A0fA63BA7aab596C"
+    ],
+    "senders": [
+      "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"
+    ],
+    "transactionSequenceNumber": 53,
+    "type": "OUT",
+    "value": "2000000"
+  }

--- a/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-usd__coin-0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf-OUT-i0.json
+++ b/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-usd__coin-0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf-OUT-i0.json
@@ -1,0 +1,19 @@
+{
+  "accountId": "js:2:ethereum:0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d:+js%3A2%3Aethereum%3A0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d%3A%2Bethereum%252Ferc20%252Fusd~!underscore!~~!underscore!~coin~!dash!~0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf~!dash!~OUT~!dash!~i0",
+  "blockHash": "0x58ee7556044cd139e569c87c173a6dedbfbeb9ada6693ee6090fd510acee9c21",
+  "blockHeight": 16240731,
+  "date": "2022-12-22T14:06:23.000Z",
+  "extra": {},
+  "fee": "1595338583295225",
+  "hash": "0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf",
+  "id": "js:2:ethereum:0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d:+js%3A2%3Aethereum%3A0x6cbcd73cd8e8a42844662f0a0e76d7f79afd933d%3A%2Bethereum%252Ferc20%252Fusd~!underscore!~~!underscore!~coin~!dash!~0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf~!dash!~OUT~!dash!~i0-0x02b972f304dc24c9bc362e6435c4ad654241f9af916689a4790145c9bcbdf4cf-OUT-i0",
+  "recipients": [
+    "0xC2907EFccE4011C491BbedA8A0fA63BA7aab596C"
+  ],
+  "senders": [
+    "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d"
+  ],
+  "transactionSequenceNumber": 53,
+  "type": "OUT",
+  "value": "2000000"
+}

--- a/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-usd__coin-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.json
+++ b/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-usd__coin-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.json
@@ -1,0 +1,73 @@
+{
+  type: "TokenCurrency",
+  id: "ethereum/erc20/usd__coin",
+  ledgerSignature: "3045022100b2e358726e4e6a6752cf344017c0e9d45b9a904120758d45f61b2804f9ad5299022015161ef28d8c4481bd9432c13562def9cce688bcfec896ef244c9a213f106cdd",
+  contractAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  parentCurrency: {
+    type: "CryptoCurrency",
+    id: "ethereum",
+    coinType: 60,
+    name: "Ethereum",
+    managerAppName: "Ethereum",
+    ticker: "ETH",
+    scheme: "ethereum",
+    color: "#0ebdcd",
+    symbol: "Ξ",
+    family: "evm",
+    blockAvgTime: 15,
+    units: [
+      {
+        name: "ether",
+        code: "ETH",
+        magnitude: 18,
+      },
+      {
+        name: "Gwei",
+        code: "Gwei",
+        magnitude: 9,
+      },
+      {
+        name: "Mwei",
+        code: "Mwei",
+        magnitude: 6,
+      },
+      {
+        name: "Kwei",
+        code: "Kwei",
+        magnitude: 3,
+      },
+      {
+        name: "wei",
+        code: "wei",
+        magnitude: 0,
+      },
+    ],
+    ethereumLikeInfo: {
+      chainId: 1,
+    },
+    explorerViews: [
+      {
+        tx: "https://etherscan.io/tx/$hash",
+        address: "https://etherscan.io/address/$address",
+        token: "https://etherscan.io/token/$contractAddress?a=$address",
+      },
+    ],
+    keywords: [
+      "eth",
+      "ethereum",
+    ],
+    explorerId: "eth",
+  },
+  tokenType: "erc20",
+  name: "USD Coin",
+  ticker: "USDC",
+  delisted: false,
+  disableCountervalue: false,
+  units: [
+    {
+      name: "USD Coin",
+      code: "USDC",
+      magnitude: 6,
+    },
+  ],
+}

--- a/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-weth.json
+++ b/libs/coin-modules/coin-evm/src/__fixtures__/ethereum-erc20-weth.json
@@ -1,0 +1,73 @@
+{
+    "type": "TokenCurrency",
+    "id": "ethereum/erc20/weth",
+    "ledgerSignature": "3045022100b47ee8551c15a2cf681c649651e987d7e527c481d27c38da1f971a8242792bd3022069c3f688ac5493a23dab5798e3c9b07484765069e1d4be14321aae4d92cb8cbe",
+    "contractAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "parentCurrency": {
+      "type": "CryptoCurrency",
+      "id": "ethereum",
+      "coinType": 60,
+      "name": "Ethereum",
+      "managerAppName": "Ethereum",
+      "ticker": "ETH",
+      "scheme": "ethereum",
+      "color": "#0ebdcd",
+      "symbol": "Ξ",
+      "family": "evm",
+      "blockAvgTime": 15,
+      "units": [
+        {
+          "name": "ether",
+          "code": "ETH",
+          "magnitude": 18
+        },
+        {
+          "name": "Gwei",
+          "code": "Gwei",
+          "magnitude": 9
+        },
+        {
+          "name": "Mwei",
+          "code": "Mwei",
+          "magnitude": 6
+        },
+        {
+          "name": "Kwei",
+          "code": "Kwei",
+          "magnitude": 3
+        },
+        {
+          "name": "wei",
+          "code": "wei",
+          "magnitude": 0
+        }
+      ],
+      "ethereumLikeInfo": {
+        "chainId": 1
+      },
+      "explorerViews": [
+        {
+          "tx": "https://etherscan.io/tx/$hash",
+          "address": "https://etherscan.io/address/$address",
+          "token": "https://etherscan.io/token/$contractAddress?a=$address"
+        }
+      ],
+      "keywords": [
+        "eth",
+        "ethereum"
+      ],
+      "explorerId": "eth"
+    },
+    "tokenType": "erc20",
+    "name": "WETH",
+    "ticker": "WETH",
+    "delisted": false,
+    "disableCountervalue": false,
+    "units": [
+      {
+        "name": "WETH",
+        "code": "WETH",
+        "magnitude": 18
+      }
+    ]
+  }

--- a/libs/coin-modules/coin-evm/src/__fixtures__/optimism-erc20-usd_coin.json
+++ b/libs/coin-modules/coin-evm/src/__fixtures__/optimism-erc20-usd_coin.json
@@ -1,0 +1,69 @@
+{
+  "type": "TokenCurrency",
+  "id": "optimism/erc20/usd_coin",
+  "ledgerSignature": "30440220597e4a9911df217d680aa240ca96f7e8fca24c24e7c673c43820c94b08ef69e402206e975e27e82b3370eca40041fca772bd6c4ca7dd087d2bfcc8aa146cb8e1de53",
+  "contractAddress": "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
+  "parentCurrency": {
+    "type": "CryptoCurrency",
+    "id": "optimism",
+    "coinType": 60,
+    "name": "OP Mainnet",
+    "managerAppName": "Ethereum",
+    "ticker": "ETH",
+    "scheme": "optimism",
+    "color": "#FF0421",
+    "family": "evm",
+    "units": [
+      {
+        "name": "ether",
+        "code": "ETH",
+        "magnitude": 18
+      },
+      {
+        "name": "Gwei",
+        "code": "Gwei",
+        "magnitude": 9
+      },
+      {
+        "name": "Mwei",
+        "code": "Mwei",
+        "magnitude": 6
+      },
+      {
+        "name": "Kwei",
+        "code": "Kwei",
+        "magnitude": 3
+      },
+      {
+        "name": "wei",
+        "code": "wei",
+        "magnitude": 0
+      }
+    ],
+    "ethereumLikeInfo": {
+      "chainId": 10
+    },
+    "explorerViews": [
+      {
+        "tx": "https://optimism.blockscout.com/tx/$hash",
+        "address": "https://optimism.blockscout.com/address/$address",
+        "token": "https://optimism.blockscout.com/address/$address?tab=token_transfer&token=$contractAddress"
+      }
+    ],
+    "keywords": [
+      "optimism"
+    ]
+  },
+  "tokenType": "erc20",
+  "name": "USD Coin",
+  "ticker": "USDC",
+  "delisted": false,
+  "disableCountervalue": false,
+  "units": [
+    {
+      "name": "USD Coin",
+      "code": "USDC",
+      "magnitude": 6
+    }
+  ]
+}

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/accounts.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/accounts.fixtures.ts
@@ -1,13 +1,9 @@
 import BigNumber from "bignumber.js";
-import { hashes as localTokensHashesByChainId } from "@ledgerhq/cryptoassets/data/evm/index";
 import { ERC20Token } from "@ledgerhq/cryptoassets/types";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { AccountShapeInfo } from "@ledgerhq/coin-framework/bridge/jsHelpers";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
-import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import usdtTokenData from "../../__fixtures__/scroll_sepolia-erc20-mock_usdt.json";
-import newTokenData from "../../__fixtures__/scroll_sepolia-erc20-new_token_mock.json";
 import { makeOperation } from "./common.fixtures";
+import "./cryptoAssetsStore.fixtures";
 
 export const currency = getCryptoCurrencyById("scroll_sepolia");
 export const fakeToken: ERC20Token = [
@@ -22,10 +18,6 @@ export const fakeToken: ERC20Token = [
   false, // delisted
 ];
 
-export const localCALHash =
-  localTokensHashesByChainId[
-    currency.ethereumLikeInfo!.chainId as keyof typeof localTokensHashesByChainId
-  ];
 export const getAccountShapeParameters: AccountShapeInfo = {
   address: "0xkvn",
   currency,
@@ -33,20 +25,6 @@ export const getAccountShapeParameters: AccountShapeInfo = {
   derivationPath: "44'/60'/0'/0/0",
   index: 0,
 };
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStore({
-  findTokenById: (id: string) => {
-    if (id === "scroll_sepolia/erc20/mock_usdt") {
-      return usdtTokenData;
-    } else if (id === "scroll_sepolia/erc20/new_token_mock") {
-      return newTokenData;
-    }
-
-    return undefined;
-  },
-  findTokenByAddressInCurrency: (_address: string, _currencyId: string) => undefined,
-} as CryptoAssetsStore);
 
 export const TMUSDTTransaction = makeOperation({
   hash: "anyHash",

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/common.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/common.fixtures.ts
@@ -15,6 +15,7 @@ import { encodeNftId } from "@ledgerhq/coin-framework/nft/nftId";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, DerivationMode, Operation, ProtoNFT, TokenAccount } from "@ledgerhq/types-live";
+import "./cryptoAssetsStore.fixtures";
 
 export const makeAccount = (
   address: string,

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/cryptoAssetsStore.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/cryptoAssetsStore.fixtures.ts
@@ -1,0 +1,24 @@
+import * as legacyTokens from "@ledgerhq/cryptoassets/tokens";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
+import { setCryptoAssetsStoreGetter } from "../../cryptoAssetsStore";
+
+/*
+ * TODO change implementation when new CryptoAssesStore implemented with DADA
+ */
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+setCryptoAssetsStoreForCoinFramework({
+  findTokenById: legacyTokens.findTokenById,
+  findTokenByAddressInCurrency: legacyTokens.findTokenByAddressInCurrency,
+} as CryptoAssetsStore);
+
+setCryptoAssetsStoreGetter(
+  () =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    ({
+      findTokenById: legacyTokens.findTokenById,
+      findTokenByAddressInCurrency: legacyTokens.findTokenByAddressInCurrency,
+      findTokenByAddress: legacyTokens.findTokenByAddress,
+    }) as CryptoAssetsStore,
+);

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/prepareTransaction.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/prepareTransaction.fixtures.ts
@@ -1,14 +1,13 @@
 import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { Account } from "@ledgerhq/types-live";
-
 import { EvmNftTransaction, Transaction as EvmTransaction } from "../../types";
 import ERC1155ABI from "../../abis/erc1155.abi.json";
 import ERC721ABI from "../../abis/erc721.abi.json";
 import ERC20ABI from "../../abis/erc20.abi.json";
+import usdtTokenData from "../../__fixtures__/scroll_sepolia-erc20-mock_usdt.json";
 
 import { makeAccount, makeTokenAccount } from "./common.fixtures";
 
@@ -19,7 +18,8 @@ const currency: CryptoCurrency = {
   },
 };
 
-export const tokenAccount = makeTokenAccount("0xkvn", getTokenById("ethereum/erc20/usd__coin"));
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+export const tokenAccount = makeTokenAccount("0xkvn", usdtTokenData as unknown as TokenCurrency);
 export const account = makeAccount("0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d", currency, [
   tokenAccount,
 ]);

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/synchronization.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/synchronization.fixtures.ts
@@ -4,12 +4,9 @@ import BigNumber from "bignumber.js";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 import { encodeSubOperationId } from "@ledgerhq/coin-framework/operation";
-import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
 import * as logic from "../../logic";
 import { getCoinConfig } from "../../config";
-import usdCoinTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
-import usdTetherTokenData from "../../__fixtures__/ethereum-erc20-usd_tether__erc20_.json";
+import { getCryptoAssetsStore } from "../../cryptoAssetsStore";
 import {
   makeAccount,
   makeNft,
@@ -59,9 +56,9 @@ export const swapHistory = [
 
 export const tokenCurrencies = [
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  Object.freeze(usdCoinTokenData as TokenCurrency),
+  getCryptoAssetsStore().findTokenById("ethereum/erc20/usd__coin") as TokenCurrency,
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  Object.freeze(usdTetherTokenData as TokenCurrency),
+  getCryptoAssetsStore().findTokenById("ethereum/erc20/usd_tether__erc20_") as TokenCurrency,
 ];
 
 export const tokenAccount = {
@@ -98,20 +95,6 @@ export const coinOperations = [
     blockHeight: 1000,
   }),
 ];
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-setCryptoAssetsStore({
-  findTokenById: (id: string) => {
-    if (id === "ethereum/erc20/usd__coin") {
-      return usdCoinTokenData;
-    } else if (id === "ethereum/erc20/usd_tether__erc20_") {
-      return usdTetherTokenData;
-    }
-
-    return undefined;
-  },
-  findTokenByAddressInCurrency: (_address: string, _currencyId: string) => undefined,
-} as CryptoAssetsStore);
 
 export const tokenOperations = [
   makeOperation({

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/transaction.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/transaction.fixtures.ts
@@ -1,6 +1,5 @@
 import BigNumber from "bignumber.js";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
 
 import {
@@ -12,6 +11,7 @@ import {
   EvmNftTransactionRaw,
   EvmNftTransaction,
 } from "../../types";
+import usdtTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
 import { makeAccount, makeTokenAccount } from "./common.fixtures";
 
 export const testData = Object.freeze(Buffer.from("testBufferString").toString("hex"));
@@ -217,7 +217,8 @@ export const currency: CryptoCurrency = Object.freeze({
   },
 });
 
-export const tokenCurrency = Object.freeze(getTokenById("ethereum/erc20/usd__coin"));
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+export const tokenCurrency = Object.freeze(usdtTokenData as TokenCurrency);
 export const tokenAccount = makeTokenAccount(
   "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
   tokenCurrency,

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/accounts.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/accounts.unit.test.ts
@@ -4,8 +4,6 @@ import { tokens as localTokensByChainId } from "@ledgerhq/cryptoassets/data/evm/
 import { fromAccountRaw, toAccountRaw } from "@ledgerhq/coin-framework/serialization/account";
 import { decodeTokenAccountId } from "@ledgerhq/coin-framework/account";
 import { __clearAllLists } from "@ledgerhq/cryptoassets/tokens";
-import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
 import * as etherscanAPI from "../../network/explorer/etherscan";
 import { __resetCALHash, getCALHash } from "../../logic";
 import { getAccountShape } from "../../bridge/synchronization";
@@ -19,10 +17,6 @@ import {
   NTMTransaction,
   TMUSDTTransaction,
 } from "../fixtures/accounts.fixtures";
-import usdtTokenData from "../../__fixtures__/scroll_sepolia-erc20-mock_usdt.json";
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const USDT_TOKEN = usdtTokenData as TokenCurrency;
 
 jest.mock("axios");
 const mockedAxios = jest.mocked(axios);
@@ -73,9 +67,6 @@ describe("EVM Family", () => {
     });
 
     it("should add an account and find no token account without a preload first", async () => {
-      const store = getCryptoAssetsStore();
-      jest.spyOn(store, "findTokenById").mockImplementation((_id: string) => undefined);
-
       const { subAccounts } = await getAccountShape(getAccountShapeParameters, {
         paginationConfig: {},
       });
@@ -84,15 +75,6 @@ describe("EVM Family", () => {
     });
 
     it("should preload currency and add an account with 1 token account in it when there is nothing new in remote CAL", async () => {
-      const store = getCryptoAssetsStore();
-      jest.spyOn(store, "findTokenById").mockImplementation((id: string) => {
-        if (id === "scroll_sepolia/erc20/mock_usdt") {
-          return USDT_TOKEN;
-        }
-
-        return undefined;
-      });
-
       mockedAxios.get.mockImplementationOnce(() => {
         throw new axios.AxiosError("", "", undefined, undefined, { status: 304 } as AxiosResponse);
       });
@@ -208,15 +190,6 @@ describe("EVM Family", () => {
     });
 
     it("should preload again a currency and get the same account with 2 tokens accounts even with a failing CAL service", async () => {
-      const store = getCryptoAssetsStore();
-      jest.spyOn(store, "findTokenById").mockImplementation((id: string) => {
-        if (id === "scroll_sepolia/erc20/mock_usdt") {
-          return USDT_TOKEN;
-        }
-
-        return undefined;
-      });
-
       mockedAxios.get.mockImplementationOnce(async (url, { params } = {}) => {
         if (
           url === "https://crypto-assets-service.api.ledger.com/v1/tokens" &&
@@ -267,15 +240,6 @@ describe("EVM Family", () => {
     });
 
     it("should hydrate the tokens necessary to deserialize an account with 1 token account when there is nothing new in remote CAL", async () => {
-      const store = getCryptoAssetsStore();
-      jest.spyOn(store, "findTokenById").mockImplementation((id: string) => {
-        if (id === "scroll_sepolia/erc20/mock_usdt") {
-          return USDT_TOKEN;
-        }
-
-        return undefined;
-      });
-
       const preloaded = await preload(currency);
       await hydrate(preloaded, currency);
       const account = await getAccountShape(getAccountShapeParameters, {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/ledger.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/ledger.unit.test.ts
@@ -1,7 +1,8 @@
 import BigNumber from "bignumber.js";
 import { Operation } from "@ledgerhq/types-live";
 import { encodeAccountId, encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
-import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import {
   ledgerERC1155EventToOperations,
   ledgerERC20EventToOperations,
@@ -16,6 +17,8 @@ import {
   LedgerExplorerInternalTransaction,
   LedgerExplorerOperation,
 } from "../../../types";
+import usdCoinTokenData from "../../../__fixtures__/ethereum-erc20-usd__coin.json";
+import { setCryptoAssetsStoreGetter } from "../../../cryptoAssetsStore";
 
 const accountId = encodeAccountId({
   type: "js",
@@ -728,7 +731,22 @@ describe("EVM Family", () => {
       });
 
       describe("ledgerERC20EventToOperations", () => {
-        const tokenCurrency = getTokenById("ethereum/erc20/usd__coin");
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const tokenCurrency = usdCoinTokenData as TokenCurrency;
+
+        beforeAll(() => {
+          setCryptoAssetsStoreGetter(
+            () =>
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              ({
+                findTokenByAddressInCurrency: (_address: string, _currencyId: string) => {
+                  return _address === "0x000000000000000000000000000000000000dead"
+                    ? undefined
+                    : tokenCurrency;
+                },
+              }) as CryptoAssetsStore,
+          );
+        });
 
         it("should return an empty array for an unknown token", () => {
           const ledgerERC20Event: LedgerExplorerERC20TransferEvent = {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/api/explorer/etherscan.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/api/explorer/etherscan.unit.test.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { delay } from "@ledgerhq/live-promise";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { EtherscanLikeExplorerUsedIncorrectly } from "../../../../errors";
 import * as ETHERSCAN_API from "../../../../network/explorer/etherscan";
 import { makeAccount } from "../../../fixtures/common.fixtures";
@@ -21,6 +22,17 @@ import {
   etherscanOperationToOperations,
 } from "../../../../adapters";
 import { getCoinConfig } from "../../../../config";
+import { setCryptoAssetsStoreGetter } from "../../../../cryptoAssetsStore";
+
+setCryptoAssetsStoreGetter(
+  () =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    ({
+      findTokenByAddressInCurrency: (_address: string, _currencyId: string) => {
+        return undefined;
+      },
+    }) as CryptoAssetsStore,
+);
 
 jest.mock("axios");
 jest.mock("@ledgerhq/live-promise");

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/api/explorer/ledger.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/api/explorer/ledger.unit.test.ts
@@ -6,6 +6,7 @@ import { delay } from "@ledgerhq/live-promise";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
 import { encodeAccountId } from "@ledgerhq/coin-framework/account/index";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { LedgerExplorerUsedIncorrectly } from "../../../../errors";
 import * as LEDGER_API from "../../../../network/explorer/ledger";
 import {
@@ -15,6 +16,21 @@ import {
   coinOperation4,
 } from "../../../fixtures/explorer/ledger.fixtures";
 import { getCoinConfig } from "../../../../config";
+import tokenData from "../../../../__fixtures__/ethereum-erc20-usd__coin.json";
+import { setCryptoAssetsStoreGetter } from "../../../../cryptoAssetsStore";
+
+setCryptoAssetsStoreGetter(
+  () =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    ({
+      findTokenByAddressInCurrency: (_address: string, _currencyId: string) => {
+        if (_address === tokenData.contractAddress.toLowerCase()) {
+          return tokenData;
+        }
+        return undefined;
+      },
+    }) as CryptoAssetsStore,
+);
 
 jest.mock("axios");
 jest.mock("@ledgerhq/live-promise");

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/broadcast.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/broadcast.unit.test.ts
@@ -5,8 +5,8 @@ import {
   encodeERC721OperationId,
 } from "@ledgerhq/coin-framework/nft/nftOperationId";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import axios from "axios";
@@ -23,6 +23,7 @@ import {
 } from "../fixtures/transaction.fixtures";
 import { getCoinConfig } from "../../config";
 import { getEstimatedFees } from "../../utils";
+import usdtTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
 
 jest.useFakeTimers();
 
@@ -44,7 +45,8 @@ const currency: CryptoCurrency = {
     ...getCryptoCurrencyById("ethereum").ethereumLikeInfo,
   } as any,
 };
-const tokenCurrency = getTokenById("ethereum/erc20/usd__coin");
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const tokenCurrency = usdtTokenData as TokenCurrency;
 const tokenAccount: TokenAccount = makeTokenAccount(
   "0x055C1e159E345cB4197e3844a86A61E0a801d856", // jacquie.eth
   tokenCurrency,

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/buildOptimisticOperation.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/buildOptimisticOperation.unit.test.ts
@@ -4,8 +4,9 @@ import {
   encodeERC721OperationId,
 } from "@ledgerhq/coin-framework/nft/nftOperationId";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import BigNumber from "bignumber.js";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import buildOptimisticOperation from "../../bridge/buildOptimisticOperation";
 import { Transaction as EvmTransaction } from "../../types";
 import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
@@ -15,9 +16,11 @@ import {
   erc721TokenTransactionRaw,
 } from "../fixtures/transaction.fixtures";
 import { getEstimatedFees } from "../../utils";
+import usdCoinTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
 
 const currency = getCryptoCurrencyById("ethereum");
-const tokenCurrency = getTokenById("ethereum/erc20/usd__coin");
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const tokenCurrency = usdCoinTokenData as TokenCurrency;
 const tokenAccount = {
   ...makeTokenAccount(
     "0x055C1e159E345cB4197e3844a86A61E0a801d856", // jacquie.eth

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/deviceTransactionConfig.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/deviceTransactionConfig.unit.test.ts
@@ -7,6 +7,7 @@ import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
 import getDeviceTransactionConfig from "../../deviceTransactionConfig";
 import getTransactionStatus from "../../bridge/getTransactionStatus";
 import { Transaction as EvmTransaction } from "../../types";
+import "../fixtures/cryptoAssetsStore.fixtures";
 
 enum NFT_CONTRACTS {
   ERC721 = "0x60F80121C31A0d46B5279700f9DF786054aa5eE5",

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/estimateMaxSpendable.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/estimateMaxSpendable.unit.test.ts
@@ -1,11 +1,12 @@
 import BigNumber from "bignumber.js";
-import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
 import { EvmTransactionEIP1559, EvmTransactionLegacy } from "../../types";
 import { estimateMaxSpendable } from "../../bridge/estimateMaxSpendable";
 import * as nodeApi from "../../network/node/rpc.common";
 import { getCoinConfig } from "../../config";
+import usdCoinTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
 
 jest.mock("../../config");
 const mockGetConfig = jest.mocked(getCoinConfig);
@@ -17,7 +18,8 @@ const currency: CryptoCurrency = {
   } as any,
 };
 const tokenAccount = {
-  ...makeTokenAccount("0xkvn", getTokenById("ethereum/erc20/usd__coin")),
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  ...makeTokenAccount("0xkvn", usdCoinTokenData as TokenCurrency),
   balance: new BigNumber(6969),
 };
 const account = {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import {
   AmountRequired,
   ETHAddressNonEIP,
@@ -18,6 +18,7 @@ import {
 import { ProtoNFT } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import fc from "fast-check";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { NotEnoughNftOwned, NotOwnedNft, QuantityNeedsToBePositive } from "../../errors";
 import * as getTransactionStatusModule from "../../bridge/getTransactionStatus";
 import {
@@ -32,6 +33,7 @@ import {
   getMinEip1559Fees,
   getMinLegacyFees,
 } from "../../editTransaction/getMinEditTransactionFees";
+import usdCoinTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
 
 const {
   default: getTransactionStatus,
@@ -41,7 +43,8 @@ const {
 
 const recipient = "0xe2ca7390e76c5A992749bB622087310d2e63ca29"; // rambo.eth
 const testData = Buffer.from("testBufferString").toString("hex");
-const tokenAccount = makeTokenAccount("0xkvn", getTokenById("ethereum/erc20/usd__coin"));
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const tokenAccount = makeTokenAccount("0xkvn", usdCoinTokenData as TokenCurrency);
 const account = makeAccount("0xkvn", getCryptoCurrencyById("ethereum"), [tokenAccount]);
 const legacyTx: EvmTransactionLegacy = {
   amount: new BigNumber(100),

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/operation.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/operation.test.ts
@@ -1,21 +1,25 @@
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById, getTokenById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import { genAccount, genOperation, genTokenAccount } from "@ledgerhq/coin-framework/mocks/account";
 import { Operation } from "@ledgerhq/types-live";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import Prando from "prando";
 import { getStuckAccountAndOperation, isEditableOperation } from "../../operation";
 import { getCoinConfig } from "../../config";
+import usdCoinTokenData from "../../__fixtures__/ethereum-erc20-usd__coin.json";
+import lobsterTokenData from "../../__fixtures__/cardano-native-8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552.json";
 
 jest.mock("../../config");
 const mockGetConfig = jest.mocked(getCoinConfig);
 
 const ethereum = getCryptoCurrencyById("ethereum");
-const usdc = getTokenById("ethereum/erc20/usd__coin");
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const usdc = usdCoinTokenData as TokenCurrency;
+
 const cardano = getCryptoCurrencyById("cardano");
-const lobster = getTokenById(
-  "cardano/native/8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552",
-);
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const lobster = lobsterTokenData as TokenCurrency;
 
 describe("EVM Family", () => {
   beforeEach(() => {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/prepareTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/prepareTransaction.unit.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
-import { addTokens, convertERC20, getTokenById } from "@ledgerhq/cryptoassets/tokens";
+import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { prepareForSignOperation, prepareTransaction } from "../../bridge/prepareTransaction";
 import { makeAccount, makeTokenAccount } from "../fixtures/common.fixtures";
 import { createTransaction } from "../../bridge/createTransaction";
@@ -18,6 +18,7 @@ import { GasOptions, Transaction as EvmTransaction, EvmNftTransaction } from "..
 import * as nftAPI from "../../network/nft";
 import { getCoinConfig } from "../../config";
 import { DEFAULT_NONCE, getEstimatedFees } from "../../utils";
+import usdCoinTokenData from "../../__fixtures__/optimism-erc20-usd_coin.json";
 
 jest.mock("../../config");
 const mockGetConfig = jest.mocked(getCoinConfig);
@@ -333,22 +334,6 @@ describe("EVM Family", () => {
       });
 
       describe("Tokens", () => {
-        beforeAll(() => {
-          addTokens([
-            convertERC20([
-              "optimism",
-              "usd_coin",
-              "USDC",
-              6,
-              "USD Coin",
-              "30440220597e4a9911df217d680aa240ca96f7e8fca24c24e7c673c43820c94b08ef69e402206e975e27e82b3370eca40041fca772bd6c4ca7dd087d2bfcc8aa146cb8e1de53",
-              "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
-              false,
-              false,
-            ]),
-          ]);
-        });
-
         it("should have a gasLimit = 0 and no data when recipient has an error", async () => {
           jest.spyOn(nodeApi, "getGasEstimation").mockImplementation(async () => {
             throw new Error();
@@ -528,7 +513,8 @@ describe("EVM Family", () => {
           const tokenAccountWithBalance = {
             ...makeTokenAccount(
               "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
-              getTokenById("optimism/erc20/usd_coin"),
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              usdCoinTokenData as TokenCurrency,
             ),
             balance: new BigNumber(200),
           };

--- a/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/etherscan.ts
@@ -6,7 +6,6 @@ import {
 } from "@ledgerhq/coin-framework/nft/nftOperationId";
 import { Operation, OperationType } from "@ledgerhq/types-live";
 import { encodeNftId } from "@ledgerhq/coin-framework/nft/nftId";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { decodeAccountId, encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { encodeOperationId, encodeSubOperationId } from "@ledgerhq/coin-framework/operation";
 import {
@@ -17,6 +16,7 @@ import {
   EtherscanInternalTransaction,
 } from "../types";
 import { safeEncodeEIP55 } from "../utils";
+import { getCryptoAssetsStore } from "../cryptoAssetsStore";
 
 /**
  * Adapter to convert an Etherscan operation into Ledger Live Operations.
@@ -82,7 +82,10 @@ export const etherscanERC20EventToOperations = (
   index = 0,
 ): Operation[] => {
   const { currencyId, xpubOrAddress: address } = decodeAccountId(accountId);
-  const tokenCurrency = findTokenByAddressInCurrency(event.contractAddress, currencyId);
+  const tokenCurrency = getCryptoAssetsStore().findTokenByAddressInCurrency(
+    event.contractAddress,
+    currencyId,
+  );
   if (!tokenCurrency) return [];
 
   const tokenAccountId = encodeTokenAccountId(accountId, tokenCurrency);

--- a/libs/coin-modules/coin-evm/src/adapters/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/ledger.ts
@@ -6,7 +6,6 @@ import {
 } from "@ledgerhq/coin-framework/nft/nftOperationId";
 import { Operation, OperationType } from "@ledgerhq/types-live";
 import { encodeNftId } from "@ledgerhq/coin-framework/nft/nftId";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { decodeAccountId, encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
 import { encodeOperationId, encodeSubOperationId } from "@ledgerhq/coin-framework/operation";
 import {
@@ -17,6 +16,7 @@ import {
   LedgerExplorerInternalTransaction,
 } from "../types";
 import { safeEncodeEIP55 } from "../utils";
+import { getCryptoAssetsStore } from "../cryptoAssetsStore";
 
 /**
  * Adapter to convert a Ledger Explorer operation
@@ -82,7 +82,10 @@ export const ledgerERC20EventToOperations = (
   const { accountId, hash, fee, blockHeight, blockHash, transactionSequenceNumber, date } =
     coinOperation;
   const { currencyId, xpubOrAddress: address } = decodeAccountId(accountId);
-  const tokenCurrency = findTokenByAddressInCurrency(event.contract, currencyId);
+  const tokenCurrency = getCryptoAssetsStore().findTokenByAddressInCurrency(
+    event.contract,
+    currencyId,
+  );
   if (!tokenCurrency) return [];
 
   const tokenAccountId = encodeTokenAccountId(accountId, tokenCurrency);

--- a/libs/coin-modules/coin-evm/src/bridge/js.ts
+++ b/libs/coin-modules/coin-evm/src/bridge/js.ts
@@ -8,10 +8,12 @@ import {
 import { SignerContext } from "@ledgerhq/coin-framework/signer";
 import type { AccountBridge, Bridge, CurrencyBridge } from "@ledgerhq/types-live";
 import getAddressWrapper from "@ledgerhq/coin-framework/bridge/getAddressWrapper";
+import type { CryptoAssetsStoreGetter } from "@ledgerhq/types-live";
 import type { Transaction as EvmTransaction } from "../types/index";
 import { setCoinConfig, type CoinConfig } from "../config";
 import type { EvmSigner } from "../types/signer";
 import resolver from "../hw-getAddress";
+import { setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
 import { getTransactionStatus } from "./getTransactionStatus";
 import { getAccountShape, sync } from "./synchronization";
@@ -66,8 +68,10 @@ export function buildAccountBridge(
 export function createBridges(
   signerContext: SignerContext<EvmSigner>,
   coinConfig: CoinConfig,
+  cryptoAssetsStoreGetter: CryptoAssetsStoreGetter,
 ): Bridge<EvmTransaction> {
   setCoinConfig(coinConfig);
+  setCryptoAssetsStoreGetter(cryptoAssetsStoreGetter);
 
   return {
     currencyBridge: buildCurrencyBridge(signerContext),

--- a/libs/coin-modules/coin-evm/src/cryptoAssetsStore.test.ts
+++ b/libs/coin-modules/coin-evm/src/cryptoAssetsStore.test.ts
@@ -1,0 +1,19 @@
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
+import {
+  CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE,
+  getCryptoAssetsStore,
+  setCryptoAssetsStoreGetter,
+} from "./cryptoAssetsStore";
+
+describe("cryptoAssetsStore", () => {
+  it("should throw an error when CryptoAssetsStoreGetter is not set", () => {
+    expect(() => getCryptoAssetsStore()).toThrow(CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE);
+  });
+
+  it("should return the CryptoAssetsStoreGetter set", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const store = {} as CryptoAssetsStore;
+    setCryptoAssetsStoreGetter(() => store);
+    expect(getCryptoAssetsStore()).toEqual(store);
+  });
+});

--- a/libs/coin-modules/coin-evm/src/cryptoAssetsStore.ts
+++ b/libs/coin-modules/coin-evm/src/cryptoAssetsStore.ts
@@ -1,0 +1,16 @@
+import type { CryptoAssetsStore, CryptoAssetsStoreGetter } from "@ledgerhq/types-live";
+
+export const CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE =
+  "CryptoAssetsStore is not set. Please call setCryptoAssetsStore first on coin EVM";
+
+let getStore: CryptoAssetsStoreGetter;
+export function setCryptoAssetsStoreGetter(cryptoAssetsStoreGetter: CryptoAssetsStoreGetter): void {
+  getStore = cryptoAssetsStoreGetter;
+}
+
+export function getCryptoAssetsStore(): CryptoAssetsStore {
+  if (!getStore) {
+    throw new Error(CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE);
+  }
+  return getStore();
+}

--- a/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
@@ -6,12 +6,12 @@ import {
   ERC1155_CLEAR_SIGNED_SELECTORS,
 } from "@ledgerhq/evm-tools/selectors/index";
 import { Account, AccountLike } from "@ledgerhq/types-live";
-import { findTokenByAddress } from "@ledgerhq/cryptoassets/tokens";
 import { validateDomain } from "@ledgerhq/domain-service/utils/index";
 import { getMainAccount } from "@ledgerhq/coin-framework/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/index";
 import type { CommonDeviceTransactionField } from "@ledgerhq/coin-framework/transaction/common";
 import { Transaction as EvmTransaction, TransactionStatus } from "./types";
+import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 type DeviceTransactionField = CommonDeviceTransactionField;
 
@@ -29,7 +29,8 @@ const inferDeviceTransactionConfigWalletApi = (
   const knownNft = mainAccount.nfts?.find(
     nft => nft.contract.toLowerCase() === transaction.recipient.toLowerCase(),
   );
-  const token = findTokenByAddress(transaction.recipient);
+
+  const token = getCryptoAssetsStore().findTokenByAddress(transaction.recipient);
 
   // ERC20 fields
   if (token && Object.values<string>(ERC20_CLEAR_SIGNED_SELECTORS).includes(selector)) {

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii.test.ts
@@ -7,7 +7,7 @@ import { scenarioScroll } from "./scenarii/scroll";
 import { scenarioBlast } from "./scenarii/blast";
 import { scenarioSonic } from "./scenarii/sonic";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import * as legacy from "@ledgerhq/cryptoassets/tokens";
 
 global.console = require("console");

--- a/libs/ledger-live-common/src/DataModel.test.ts
+++ b/libs/ledger-live-common/src/DataModel.test.ts
@@ -7,7 +7,7 @@ import { accountRawToAccountUserData } from "@ledgerhq/live-wallet/store";
 import { createDataModel } from "./DataModel";
 import { fromAccountRaw, toAccountRaw } from "./account";
 import { getCurrencyConfiguration } from "./config";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
 
 jest.mock("./config", () => ({

--- a/libs/ledger-live-common/src/__tests__/accounts/groupPerDay.ts
+++ b/libs/ledger-live-common/src/__tests__/accounts/groupPerDay.ts
@@ -2,7 +2,7 @@ import flatMap from "lodash/flatMap";
 import { fromAccountRaw, groupAccountOperationsByDay } from "../../account";
 import { TezosAccountRaw } from "../../families/tezos/types";
 import { setSupportedCurrencies } from "../../currencies";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { setup } from "../../bridge/impl";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 setSupportedCurrencies(["tezos"]);

--- a/libs/ledger-live-common/src/__tests__/test-helpers/setup.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/setup.ts
@@ -1,5 +1,5 @@
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import "./environment";
 import BigNumber from "bignumber.js";
 

--- a/libs/ledger-live-common/src/account/serialization.test.ts
+++ b/libs/ledger-live-common/src/account/serialization.test.ts
@@ -4,7 +4,7 @@ import { toAccountRaw, fromAccountRaw } from "./serialization";
 import { setWalletAPIVersion } from "../wallet-api/version";
 import { WALLET_API_VERSION } from "../wallet-api/constants";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import solanaSplTokenData from "../__fixtures__/solana-spl-epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v.json";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.test.ts
@@ -1,7 +1,7 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { getCryptoAssetsStore, setCryptoAssetsStore } from ".";
 import * as legacy from "@ledgerhq/cryptoassets/tokens";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 describe("Testing CryptoAssetStore", () => {
   it("should return the default methods from cryptoassets libs when feature flag does not exists", () => {

--- a/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
+++ b/libs/ledger-live-common/src/bridge/crypto-assets/index.ts
@@ -1,6 +1,6 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
 import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 const legacyStore: CryptoAssetsStore = {
   findTokenByAddress: legacy.findTokenByAddress,
@@ -17,7 +17,8 @@ export function setCryptoAssetsStore(store: CryptoAssetsStore) {
 }
 
 export function getCryptoAssetsStore(): CryptoAssetsStore {
-  const featureEnabled = LiveConfig.getValueByKey("feature_cal_lazy_loading");
+  const featureEnabled =
+    LiveConfig.isConfigSet() && LiveConfig.getValueByKey("feature_cal_lazy_loading");
   if (!featureEnabled) {
     return legacyStore;
   }

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -20,7 +20,7 @@ import {
 import { getAlpacaAccountBridge } from "./generic-alpaca/accountBridge";
 import { getAlpacaCurrencyBridge } from "./generic-alpaca/currencyBridge";
 import { AddressesSanctionedError } from "@ledgerhq/coin-framework/sanction/errors";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
 import { getCryptoAssetsStore, setCryptoAssetsStore } from "./crypto-assets";
 

--- a/libs/ledger-live-common/src/currencies/sortByMarketcap.test.ts
+++ b/libs/ledger-live-common/src/currencies/sortByMarketcap.test.ts
@@ -3,7 +3,7 @@ import { findCurrencyByTicker, listCryptoCurrencies, listTokens } from ".";
 import { getBTCValues } from "@ledgerhq/live-countervalues/mock";
 import { CURRENCIES_LIST, IDS } from "./mock";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 setCryptoAssetsStoreForCoinFramework({

--- a/libs/ledger-live-common/src/families/bitcoin/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/bitcoin/__snapshots__/bridge.integration.test.ts.snap
@@ -2646,6 +2646,7 @@ exports[`bitcoin currency bridge scanAccounts bitcoin seed 1 2`] = `
       "senders": [
         "bc1qtc9gkextz267qgaupcmqpz9hl64nwqn6y4t0qk",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "2717",
     },
@@ -15474,6 +15475,7 @@ exports[`decred currency bridge scanAccounts decred seed 1 2`] = `
       "senders": [
         "DskW13e355a7M3kmhBjZrSGrGYTYn9T4dbk",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "621400",
     },
@@ -18429,6 +18431,7 @@ exports[`decred currency bridge scanAccounts decred seed 1 2`] = `
       "senders": [
         "Dshb98SrdLmgDoy3PRouifMYCERdDYuCcEM",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "625888",
     },
@@ -19077,6 +19080,7 @@ exports[`decred currency bridge scanAccounts decred seed 1 2`] = `
       "senders": [
         "DseydKh2Cgzht5dwbSgXBDLLDNdjcSu8Qu2",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "623776",
     },
@@ -21359,6 +21363,7 @@ exports[`dogecoin currency bridge scanAccounts dogecoin seed 1 2`] = `
       "senders": [
         "DCTZJgCwmkTko41GXvWF4BrutEY5NSr1hC",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "4988700000",
     },
@@ -21825,6 +21830,7 @@ exports[`litecoin currency bridge scanAccounts litecoin seed 1 2`] = `
       "senders": [
         "ltc1qmynthzpjrtdwp87anmwqc9mam0wjn0nuskm43r",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "100283",
     },
@@ -22879,6 +22885,7 @@ exports[`litecoin currency bridge scanAccounts litecoin seed 1 2`] = `
       "senders": [
         "MSyowFrsqmk9MjgAQerz5HAQjHAcDGM8aV",
       ],
+      "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "100323",
     },

--- a/libs/ledger-live-common/src/families/bitcoin/satstack.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/satstack.test.ts
@@ -19,7 +19,7 @@ import { setEnv } from "@ledgerhq/live-env";
 import { fromAccountRaw } from "../../account";
 import { setSupportedCurrencies } from "../../currencies";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 setSupportedCurrencies(["bitcoin"]);
 jest.setTimeout(10000);

--- a/libs/ledger-live-common/src/families/evm/setup.ts
+++ b/libs/ledger-live-common/src/families/evm/setup.ts
@@ -19,7 +19,8 @@ import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { EvmConfigInfo } from "@ledgerhq/coin-evm/config";
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import { DmkSignerEth, LegacySignerEth } from "@ledgerhq/live-signer-evm";
-import { EvmSigner } from "@ledgerhq/coin-evm/lib/types/signer";
+import { EvmSigner } from "@ledgerhq/coin-evm/types/signer";
+import { getCryptoAssetsStore } from "../../bridge/crypto-assets";
 
 const createSigner: CreateSigner<EvmSigner> = (transport: Transport) => {
   if (isDmkTransport(transport)) {
@@ -47,6 +48,7 @@ const getCurrencyConfig = (currency: CryptoCurrency) => {
 const bridge: Bridge<EvmTransaction> = createBridges(
   executeWithSigner(createSigner),
   getCurrencyConfig,
+  getCryptoAssetsStore,
 );
 
 const messageSigner = {

--- a/libs/ledger-live-common/src/families/tron/data.mock.ts
+++ b/libs/ledger-live-common/src/families/tron/data.mock.ts
@@ -1,7 +1,7 @@
 import { fromAccountRaw } from "../../account/serialization";
 import { TronAccount } from "@ledgerhq/coin-tron/types/index";
 import { setCryptoAssetsStore as setCryptoAssetsStoreForCoinFramework } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 export const __NEXT_REWARD_DATE__ = new Date(Date.now() - 6 * 60 * 60 * 1000);
 

--- a/libs/ledgerjs/packages/types-live/.unimportedrc.json
+++ b/libs/ledgerjs/packages/types-live/.unimportedrc.json
@@ -1,3 +1,10 @@
 {
-  "entry": ["src/index.ts"]
+  "entry": [
+    "src/index.ts"
+  ],
+  "ignoreUnresolved": [],
+  "ignoreUnused": [],
+  "ignoreUnimported": [
+    "src/crypto-assets/type.ts"
+  ]
 }

--- a/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/crypto-assets/index.ts
@@ -7,3 +7,5 @@ export type CryptoAssetsStore = {
   findTokenByAddressInCurrency(address: string, currencyId: string): TokenCurrency | undefined;
   findTokenByTicker(ticker: string): TokenCurrency | undefined;
 };
+
+export type CryptoAssetsStoreGetter = () => CryptoAssetsStore;

--- a/libs/ledgerjs/packages/types-live/src/index.ts
+++ b/libs/ledgerjs/packages/types-live/src/index.ts
@@ -17,3 +17,4 @@ export * from "./messages";
 export * from "./swap";
 export * from "./ABTesting";
 export * from "./walletSync";
+export * from "./crypto-assets";

--- a/libs/live-config/src/LiveConfig.ts
+++ b/libs/live-config/src/LiveConfig.ts
@@ -47,6 +47,10 @@ export class LiveConfig {
     LiveConfig.instance.config = config;
   }
 
+  static isConfigSet() {
+    return Object.keys(LiveConfig.instance.config).length > 0;
+  }
+
   static getValueByKey(key: string) {
     if (Object.keys(LiveConfig.instance.config).length === 0) {
       throw new Error("Config not set");

--- a/libs/live-countervalues/src/mock.test.ts
+++ b/libs/live-countervalues/src/mock.test.ts
@@ -10,7 +10,7 @@ import {
 import { formatCounterValueDay, formatCounterValueHour, parseFormattedDate } from "./helpers";
 import api from "./api";
 import * as cryptoAssets from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 setEnv("MOCK", "1");
 setEnv("MOCK_COUNTERVALUES", "1");

--- a/libs/live-wallet/src/liveqr/importAccounts.test.ts
+++ b/libs/live-wallet/src/liveqr/importAccounts.test.ts
@@ -8,7 +8,7 @@ import { setSupportedCurrencies } from "@ledgerhq/coin-framework/currencies/inde
 import { fromAccountRaw } from "@ledgerhq/coin-framework/serialization/account";
 import { AccountData, accountDataToAccount } from "./cross";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 setSupportedCurrencies(["ethereum"]);
 describe("importAccountsMakeItems", () => {

--- a/libs/live-wallet/src/ordering.test.ts
+++ b/libs/live-wallet/src/ordering.test.ts
@@ -6,7 +6,7 @@ import { setSupportedCurrencies } from "@ledgerhq/coin-framework/currencies/inde
 import { fromAccountRaw } from "@ledgerhq/coin-framework/serialization/account";
 import { WalletState, accountRawToAccountUserData } from "./store";
 import { setCryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/index";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 setSupportedCurrencies(["ethereum"]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - No impact

### 📝 Description

#### Context
To be able to call the CAL dynamically, we need to inject the `CryptoAssetsStore` into concerned module. Implementation will be provided by LiveHub team. This ticket is for the Ethereum coin module.

#### What have changed
- `CryptoAssetsStore` injected into `coin-evm`
- A getter function is used instead of a variable for the `CryptoAssetsStore`, to be able to switch between legacy and new system with feature flag on runtime
- Types are put into `types-live` package 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) --> https://ledgerhq.atlassian.net/browse/LIVE-19996?atlOrigin=eyJpIjoiZjgxYzY0Y2ViZWRkNGVmNjg3MDlmZTNlZWQ3ZTFiODUiLCJwIjoiaiJ9


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
