### PR TITLE
fix(LLM): prevent android locks on transient AppState changes

### DIFF
--- a/.changeset/six-trainers-train.md
+++ b/.changeset/six-trainers-train.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Prevent Android app locks on transient state changes


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Prevent Android locking on false-positive background->active state changes

Before:

https://github.com/user-attachments/assets/c41fb7b9-e01f-4db9-9bcf-f245370b572b

After:

https://github.com/user-attachments/assets/36a04277-4bb8-4f76-8a12-e55e79df4413

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20760](https://ledgerhq.atlassian.net/browse/LIVE-20760)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20760]: https://ledgerhq.atlassian.net/browse/LIVE-20760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ