### PR TITLE
fix: custom close for card

### DIFF
--- a/.changeset/clean-mails-watch.md
+++ b/.changeset/clean-mails-watch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix custom close to work with live app routing

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -59,7 +59,9 @@ export function useCustomExchangeHandlers({
   return useMemo<WalletAPICustomHandlers>(() => {
     const ptxCustomHandlers = {
       "custom.close": () => {
-        navigation.popToTop();
+        navigation.getParent()?.navigate(NavigatorName.Base, {
+          screen: NavigatorName.Main,
+        });
       },
       "custom.getFunds": (request: { params?: { accountId?: string; currencyId?: string } }) => {
         const accountId = request.params?.accountId;


### PR DESCRIPTION
### 📝 Description

Using `navigation.popToTop` works in buy/sell as we have no additional routing within the app so it is not intercepted by this listener and it successfully goes back to the homepage

Swap has additional routing and our history stack can get messy. Doing:

```
navigation.getParent()?.navigate(NavigatorName.Base, {
    screen: NavigatorName.Main,
});
```

Forces us to load the main screen and unload swap 


### ❓ Context

- [LIVE-20692](https://ledgerhq.atlassian.net/browse/LIVE-20692)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20692]: https://ledgerhq.atlassian.net/browse/LIVE-20692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ