### PR TITLE
fix: increase thresold to 0.3 on Search inputs of LLD/LLM

### DIFF
--- a/.changeset/curly-buses-jog.md
+++ b/.changeset/curly-buses-jog.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Make the search threshold more permissive to allow to search Cosmos. Temporary solution before DaDa.

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/test/useSearch.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/test/useSearch.test.ts
@@ -10,11 +10,15 @@ describe("useSearch", () => {
     { name: "Ethereum", ticker: "ETH", id: "ethereum", type: "CryptoCurrency" },
     { name: "Solana", ticker: "SOL", id: "solana", type: "CryptoCurrency" },
     { name: "Tether", ticker: "USDT", id: "tether", type: "TokenCurrency" },
+    { name: "Cosmos", ticker: "ATOM", id: "cosmos", type: "CryptoCurrency" },
+    { name: "Binance-Peg Cosmos Token", ticker: "ATOM", id: "bsc/bep20/binance-peg_cosmos_token", type: "TokenCurrency" },
   ] as CryptoOrTokenCurrency[];
 
   const mockAssetsToDisplay = [
     { name: "Bitcoin", ticker: "BTC", id: "bitcoin", type: "CryptoCurrency" },
     { name: "Ethereum", ticker: "ETH", id: "ethereum", type: "CryptoCurrency" },
+    { name: "Cosmos", ticker: "ATOM", id: "cosmos", type: "CryptoCurrency" },
+    { name: "Binance-Peg Cosmos Token", ticker: "ATOM", id: "bsc/bep20/binance-peg_cosmos_token", type: "TokenCurrency" },
   ] as CryptoOrTokenCurrency[];
 
   const mockSetItemsToDisplay = jest.fn();
@@ -150,5 +154,27 @@ describe("useSearch", () => {
         market_trend: false,
       },
     });
+  });
+
+  it("should match tokens with names containing the search term in the middle", () => {
+    const { result } = renderHook(() => useSearch(defaultProps));
+
+    act(() => {
+      result.current.handleSearch("Cosmos");
+    });
+
+    act(() => {
+      result.current.handleDebouncedChange("Cosmos", "");
+    });
+
+    expect(result.current.displayedValue).toBe("Cosmos");
+    // Verify that both "Cosmos" and "Binance-Peg Cosmos Token" are matched
+    expect(mockSetItemsToDisplay).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Cosmos", ticker: "ATOM" }),
+        expect.objectContaining({ name: "Binance-Peg Cosmos Token", ticker: "ATOM" }),
+      ])
+    );
+    expect(mockSetSearchedValue).toHaveBeenCalledWith("Cosmos");
   });
 });

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
@@ -24,7 +24,7 @@ export type SearchResult = {
 
 const FUSE_OPTIONS = {
   includeScore: false,
-  threshold: 0.1,
+  threshold: 0.3,
   keys: getEnv("CRYPTO_ASSET_SEARCH_KEYS"),
   shouldSort: false,
 };

--- a/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/drawers/DataSelector/SelectAccountAndCurrencyDrawer.tsx
@@ -19,7 +19,7 @@ const TRACK_PAGE_NAME = "Asset/Network selection";
 
 const options = {
   includeScore: false,
-  threshold: 0.1,
+  threshold: 0.3,
   // Search in `ticker`, `name`, `keywords` values
   keys: getEnv("CRYPTO_ASSET_SEARCH_KEYS"),
   shouldSort: false,

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
@@ -31,7 +31,7 @@ export type SearchResult = {
 
 const FUSE_OPTIONS = {
   includeScore: false,
-  threshold: 0.1,
+  threshold: 0.3,
   keys: getEnv("CRYPTO_ASSET_SEARCH_KEYS"),
   shouldSort: false,
 };


### PR DESCRIPTION

### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:** search inputs for assets on **LLD and LLM**

### 📝 Description

As a temporary solution before the migration to API based search (DaDa), we change the threshold to be more permissive in allowing Cosmos to be searchable when its current name is actually `Binance-Peg Cosmos Token` (which in itself is a problem, which should be fixed in future)

| Before        | After         |
| ------------- | ------------- |
|        <img width="359" height="482" alt="Screenshot 2025-08-19 at 11 53 55" src="https://github.com/user-attachments/assets/7dea35c5-b8f7-4057-bda6-830b66e2cfcf" />       |       <img width="474" height="319" alt="Screenshot 2025-08-19 at 11 54 10" src="https://github.com/user-attachments/assets/039aa0d0-e9ba-4021-ae72-d68971721fb9" />        |


### ❓ Context

- **JIRA or GitHub link**: N/A

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
