### PR TITLE
test(aptos): aptos config sets default headers if none are passed + u…

### DIFF
--- a/.changeset/bright-bears-hope.md
+++ b/.changeset/bright-bears-hope.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aptos": patch
+---
+
+(Aptos) Ensure X-Ledger-Client-Version header is always included in API requests.

--- a/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
@@ -1,7 +1,7 @@
 import { Deserializer, Hex, Network, RawTransaction } from "@aptos-labs/ts-sdk";
 import { createApi } from "../../api";
 import { getEnv, setEnvUnsafe } from "@ledgerhq/live-env";
-import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from "../../constants";
+import { DEFAULT_GAS, DEFAULT_GAS_PRICE, TOKEN_TYPE } from "../../constants";
 
 describe("createApi", () => {
   // NOTE: as our aptos nodes and indexer whitelist calls, we need to explicitely set the LEDGER_CLIENT_VERSION
@@ -222,7 +222,7 @@ describe("createApi", () => {
       const balances = await api.getBalance(tokenAccount.freshAddress);
       const tokenBalances = balances.filter(
         b =>
-          b.asset.type === assetTypeToken &&
+          b.asset.type === TOKEN_TYPE.FUNGIBLE_ASSET &&
           b.asset.assetReference ===
             "0x2ebb2ccac5e027a87fa0e2e5f656a3a4238d6a48d93ec9b610d570fc0aa0df12",
       );

--- a/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
@@ -15,7 +15,6 @@ describe("createApi", () => {
     },
   });
   const assetTypeNative = "native";
-  const assetTypeToken = "token";
 
   const sender = {
     xpub: "0x934887885b27a0407bf8a5e0bbc6b6371254bea94de5510e948bcc92dc0a519b",

--- a/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/api/index.integ.test.ts
@@ -1,9 +1,12 @@
 import { Deserializer, Hex, Network, RawTransaction } from "@aptos-labs/ts-sdk";
 import { createApi } from "../../api";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnvUnsafe } from "@ledgerhq/live-env";
 import { DEFAULT_GAS, DEFAULT_GAS_PRICE } from "../../constants";
 
 describe("createApi", () => {
+  // NOTE: as our aptos nodes and indexer whitelist calls, we need to explicitely set the LEDGER_CLIENT_VERSION
+  // in turn it will be used in the headers of those api calls.
+  setEnvUnsafe("LEDGER_CLIENT_VERSION", "lld/2.124.0-dev");
   const api = createApi({
     aptosSettings: {
       network: Network.MAINNET,

--- a/libs/coin-modules/coin-aptos/src/network/client.ts
+++ b/libs/coin-modules/coin-aptos/src/network/client.ts
@@ -84,7 +84,20 @@ export class AptosAPI {
         },
       });
     } else {
-      this.aptosConfig = new AptosConfig(currencyIdOrSettings);
+      // Ensure the header is present when custom settings are provided
+      const settings = { ...currencyIdOrSettings };
+      const existingHeaders = settings.clientConfig?.HEADERS ?? {};
+
+      settings.clientConfig = {
+        ...(settings.clientConfig ?? {}),
+        HEADERS: {
+          ...existingHeaders,
+          // don’t override if caller already provided it
+          "X-Ledger-Client-Version": existingHeaders["X-Ledger-Client-Version"] ?? appVersion,
+        },
+      };
+
+      this.aptosConfig = new AptosConfig(settings);
     }
 
     this.aptosClient = new Aptos(this.aptosConfig);


### PR DESCRIPTION
…pdate integration test to pre-set the ledger version before running

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Our Aptos fullnode/indexer whitelist requires X-Ledger-Client-Version.
When callers pass custom AptosConfig settings, that header wasn’t guaranteed → some requests were rejected.
Tests now explicitly set the env so the header is populated.

#### Key changes

##### AptosAPI (when given a settings object):

Merge/ensure clientConfig.HEADERS["X-Ledger-Client-Version"] is set to appVersion unless already provided.
Preserve any existing headers.

#####  Integration test:

Import `setEnvUnsafe` and set `LEDGER_CLIENT_VERSION` to `lld/2.124.0-dev`.
Use `TOKEN_TYPE.FUNGIBLE_ASSET` instead of assetTypeToken.
index.integ.test.ts updated to supply env + token type, ensuring header is present during real node/indexer calls.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
