### PR TITLE
test(sui): fix integ test relying on proxy to have a version properly…

### DIFF
--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -1,6 +1,6 @@
 import type { AlpacaApi, FeeEstimation, Operation } from "@ledgerhq/coin-framework/api/types";
 import { createApi } from ".";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnvUnsafe } from "@ledgerhq/live-env";
 
 describe("Sui Api", () => {
   let module: AlpacaApi;
@@ -8,6 +8,10 @@ describe("Sui Api", () => {
   const RECIPIENT = "0xba7080172a6d957b9ed2e3eb643529860be963cf4af896fb84f1cde00f46b561";
 
   beforeAll(() => {
+    // NOTE: as our sui proxy whitelists calls, we need to explicitely set the LEDGER_CLIENT_VERSION
+    // in turn it will be used in the headers of those api calls.
+    setEnvUnsafe("LEDGER_CLIENT_VERSION", "lld/2.124.0-dev");
+
     module = createApi({
       node: {
         url: getEnv("API_SUI_NODE_PROXY"),

--- a/libs/coin-modules/coin-sui/src/bridge/buildTransaction.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/buildTransaction.integration.test.ts
@@ -1,21 +1,12 @@
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";
+import { extractCoinTypeFromUnsignedTx, setupSdkTestEnv } from "../test/testUtils";
 
 import { BigNumber } from "bignumber.js";
 import { buildTransaction } from "./buildTransaction";
-import coinConfig from "../config";
-import { getFullnodeUrl } from "@mysten/sui/client";
-import { extractCoinTypeFromUnsignedTx } from "../test/testUtils";
 
 describe("buildTransaction", () => {
   beforeAll(() => {
-    coinConfig.setCoinConfig(() => ({
-      status: {
-        type: "active",
-      },
-      node: {
-        url: getFullnodeUrl("mainnet"),
-      },
-    }));
+    setupSdkTestEnv();
   });
 
   it("returns unsigned tx bytes for given tx with USDT coin type and can decode coinType from unsigned", async () => {

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.integration.test.ts
@@ -1,19 +1,11 @@
 import buildSignOperation from "./signOperation";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";
 import { SuiSigner } from "../types";
-import coinConfig from "../config";
-import { getEnv } from "@ledgerhq/live-env";
+import { setupSdkTestEnv } from "../test/testUtils";
 
 describe("signOperation", () => {
   beforeAll(() => {
-    coinConfig.setCoinConfig(() => ({
-      status: {
-        type: "active",
-      },
-      node: {
-        url: getEnv("API_SUI_NODE_PROXY"),
-      },
-    }));
+    setupSdkTestEnv();
   });
 
   const fakeSignature = new Uint8Array(64).fill(0x42);

--- a/libs/coin-modules/coin-sui/src/network/sdk.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.integration.test.ts
@@ -1,6 +1,5 @@
 import BigNumber from "bignumber.js";
 import type { Operation } from "@ledgerhq/types-live";
-import coinConfig from "../config";
 import {
   createTransaction,
   DEFAULT_COIN_TYPE,
@@ -12,18 +11,11 @@ import {
   getBlockInfo,
   getStakes,
 } from "./sdk";
-import { getEnv } from "@ledgerhq/live-env";
+import { setupSdkTestEnv } from "../test/testUtils";
 
 describe("SUI SDK Integration tests", () => {
   beforeAll(() => {
-    coinConfig.setCoinConfig(() => ({
-      status: {
-        type: "active",
-      },
-      node: {
-        url: getEnv("API_SUI_NODE_PROXY"),
-      },
-    }));
+    setupSdkTestEnv();
   });
 
   describe("getOperations", () => {

--- a/libs/coin-modules/coin-sui/src/test/testUtils.ts
+++ b/libs/coin-modules/coin-sui/src/test/testUtils.ts
@@ -1,5 +1,7 @@
 import { Transaction } from "@mysten/sui/transactions";
 import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import coinConfig from "../config";
+import { getEnv, setEnvUnsafe } from "@ledgerhq/live-env";
 
 export async function extractCoinTypeFromUnsignedTx(
   unsignedTxBytes: Uint8Array,
@@ -35,4 +37,19 @@ export async function extractCoinTypeFromUnsignedTx(
   const coinTypes: string[] = coinObjects.map(obj => (obj.data?.bcs as any).type);
 
   return coinTypes;
+}
+
+export function setupSdkTestEnv() {
+  // NOTE: as our sui proxy whitelists calls, we need to explicitely set the LEDGER_CLIENT_VERSION
+  // in turn it will be used in the headers of those api calls.
+  setEnvUnsafe("LEDGER_CLIENT_VERSION", "lld/2.124.0-dev");
+
+  coinConfig.setCoinConfig(() => ({
+    status: {
+      type: "active",
+    },
+    node: {
+      url: getEnv("API_SUI_NODE_PROXY"),
+    },
+  }));
 }


### PR DESCRIPTION
… set

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description


Our Sui proxy requires the `X-Ledger-Client-Version` header for whitelisted calls.
Previously, integration tests configured this inconsistently (manual coinConfig.setCoinConfig + getEnv).
This PR centralizes setup and ensures the client version is always injected.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
