### PR TITLE
feat: Update Solana createBridge function signature for Lazy CAL

### DIFF
--- a/.changeset/happy-rules-sneeze.md
+++ b/.changeset/happy-rules-sneeze.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-tester-solana": minor
+"@ledgerhq/coin-solana": minor
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-framework": minor
+---
+
+Update Solana createBridge function signature for Lazy CAL

--- a/libs/coin-modules/coin-solana/src/__fixtures__/solana-spl-epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v.json
+++ b/libs/coin-modules/coin-solana/src/__fixtures__/solana-spl-epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v.json
@@ -1,0 +1,50 @@
+{
+  "type": "TokenCurrency",
+  "id": "solana/spl/epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v",
+  "contractAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "parentCurrency": {
+    "type": "CryptoCurrency",
+    "id": "solana",
+    "coinType": 501,
+    "name": "Solana",
+    "managerAppName": "Solana",
+    "ticker": "SOL",
+    "scheme": "solana",
+    "color": "#000",
+    "family": "solana",
+    "units": [
+      {
+        "name": "SOL",
+        "code": "SOL",
+        "magnitude": 9
+      },
+      {
+        "name": "lamports",
+        "code": "lamports",
+        "magnitude": 0
+      }
+    ],
+    "explorerViews": [
+      {
+        "address": "https://explorer.solana.com/address/$address",
+        "tx": "https://explorer.solana.com/tx/$hash"
+      },
+      {
+        "address": "https://solanabeach.io/address/$address",
+        "tx": "https://solanabeach.io/transaction/$hash"
+      }
+    ],
+    "keywords": ["sol", "solana"]
+  },
+  "name": "USD Coin",
+  "tokenType": "spl",
+  "ticker": "USDC",
+  "disableCountervalue": false,
+  "units": [
+    {
+      "name": "USD Coin",
+      "code": "USDC",
+      "magnitude": 6
+    }
+  ]
+}

--- a/libs/coin-modules/coin-solana/src/bridge.integration.test.ts
+++ b/libs/coin-modules/coin-solana/src/bridge.integration.test.ts
@@ -8,7 +8,6 @@ import {
   NotEnoughBalance,
   RecipientRequired,
 } from "@ledgerhq/errors";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AccountRaw, CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import {
@@ -29,6 +28,7 @@ import { assertUnreachable } from "./utils";
 import { getEnv } from "@ledgerhq/live-env";
 import { encodeAccountId } from "@ledgerhq/coin-framework/lib/account/accountId";
 import { testOnChainData } from "./tests/test-onchain-data.fixture";
+import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 const mainAccId = encodeAccountId({
   type: "js",
@@ -43,7 +43,7 @@ const wSolSubAccId = encodeAccountIdWithTokenAccountAddress(
   testOnChainData.wSolSenderAssocTokenAccAddress,
 );
 
-const wSolToken = findTokenByAddressInCurrency(
+const wSolToken = getCryptoAssetsStore().findTokenByAddressInCurrency(
   "So11111111111111111111111111111111111111112",
   "solana",
 ) as TokenCurrency;

--- a/libs/coin-modules/coin-solana/src/bridge/js.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/js.ts
@@ -7,8 +7,8 @@ import { SignerContext } from "@ledgerhq/coin-framework/signer";
 import { SolanaSigner } from "../signer";
 import { CoinConfig } from "@ledgerhq/coin-framework/config";
 import solanaCoinConfig, { SolanaCoinConfig } from "../config";
-import { CryptoAssetsStoreGetter } from "@ledgerhq/coin-framework/crypto-assets/type";
 import { setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
+import { CryptoAssetsStoreGetter } from "@ledgerhq/types-live";
 
 const httpRequestLogger = (url: string, options: any) => {
   log("network", url, {

--- a/libs/coin-modules/coin-solana/src/bridge/js.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/js.ts
@@ -7,6 +7,8 @@ import { SignerContext } from "@ledgerhq/coin-framework/signer";
 import { SolanaSigner } from "../signer";
 import { CoinConfig } from "@ledgerhq/coin-framework/config";
 import solanaCoinConfig, { SolanaCoinConfig } from "../config";
+import { CryptoAssetsStoreGetter } from "@ledgerhq/coin-framework/crypto-assets/type";
+import { setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
 
 const httpRequestLogger = (url: string, options: any) => {
   log("network", url, {
@@ -38,8 +40,10 @@ const getQueuedAndCachedAPI = makeLRUCache(
 export function createBridges(
   signerContext: SignerContext<SolanaSigner>,
   coinConfig: CoinConfig<SolanaCoinConfig>,
+  cryptoAssetsStoreGetter: CryptoAssetsStoreGetter,
 ) {
   solanaCoinConfig.setCoinConfig(coinConfig);
+  setCryptoAssetsStoreGetter(cryptoAssetsStoreGetter);
   return makeBridges({
     getAPI,
     getQueuedAPI,

--- a/libs/coin-modules/coin-solana/src/cli-transaction.ts
+++ b/libs/coin-modules/coin-solana/src/cli-transaction.ts
@@ -1,9 +1,9 @@
-import { findTokenById, findTokenByTicker } from "@ledgerhq/cryptoassets";
 import type { Account, AccountLike, AccountLikeArray } from "@ledgerhq/types-live";
 import invariant from "invariant";
 import { getAccountCurrency } from "@ledgerhq/coin-framework/account/index";
 import { Transaction } from "./types";
 import { assertUnreachable } from "./utils";
+import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 const modes = [
   "send",
@@ -94,7 +94,9 @@ function inferTransactions(
           throw new Error("expected main account");
         }
 
-        const tokenCurrency = findTokenByTicker(token) ?? findTokenById(token);
+        const tokenCurrency =
+          getCryptoAssetsStore().findTokenByTicker(token) ??
+          getCryptoAssetsStore().findTokenById(token);
 
         if (!tokenCurrency) {
           throw new Error(`token <${token}> not found`);

--- a/libs/coin-modules/coin-solana/src/cryptoAssetsStore.test.ts
+++ b/libs/coin-modules/coin-solana/src/cryptoAssetsStore.test.ts
@@ -1,0 +1,20 @@
+import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+
+import {
+  CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE,
+  getCryptoAssetsStore,
+  setCryptoAssetsStoreGetter,
+} from "./cryptoAssetsStore";
+
+describe("cryptoAssetsStore", () => {
+  it("should throw an error when CryptoAssetsStoreGetter is not set", () => {
+    expect(() => getCryptoAssetsStore()).toThrow(CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE);
+  });
+
+  it("should return the CryptoAssetsStoreGetter set", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const store = {} as CryptoAssetsStore;
+    setCryptoAssetsStoreGetter(() => store);
+    expect(getCryptoAssetsStore()).toEqual(store);
+  });
+});

--- a/libs/coin-modules/coin-solana/src/cryptoAssetsStore.test.ts
+++ b/libs/coin-modules/coin-solana/src/cryptoAssetsStore.test.ts
@@ -1,5 +1,4 @@
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
-
+import { CryptoAssetsStore } from "@ledgerhq/types-live";
 import {
   CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE,
   getCryptoAssetsStore,

--- a/libs/coin-modules/coin-solana/src/cryptoAssetsStore.ts
+++ b/libs/coin-modules/coin-solana/src/cryptoAssetsStore.ts
@@ -1,7 +1,4 @@
-import {
-  CryptoAssetsStore,
-  CryptoAssetsStoreGetter,
-} from "@ledgerhq/coin-framework/crypto-assets/type";
+import { CryptoAssetsStore, CryptoAssetsStoreGetter } from "@ledgerhq/types-live";
 
 export const CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE =
   "CryptoAssetsStore is not set. Please call setCryptoAssetsStore first on coin solana";

--- a/libs/coin-modules/coin-solana/src/cryptoAssetsStore.ts
+++ b/libs/coin-modules/coin-solana/src/cryptoAssetsStore.ts
@@ -1,0 +1,19 @@
+import {
+  CryptoAssetsStore,
+  CryptoAssetsStoreGetter,
+} from "@ledgerhq/coin-framework/crypto-assets/type";
+
+export const CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE =
+  "CryptoAssetsStore is not set. Please call setCryptoAssetsStore first on coin solana";
+
+let getStore: CryptoAssetsStoreGetter;
+export function setCryptoAssetsStoreGetter(cryptoAssetsStoreGetter: CryptoAssetsStoreGetter): void {
+  getStore = cryptoAssetsStoreGetter;
+}
+
+export function getCryptoAssetsStore(): CryptoAssetsStore {
+  if (!getStore) {
+    throw new Error(CRYPTO_ASSETS_STORE_NO_SET_ERROR_MESSAGE);
+  }
+  return getStore();
+}

--- a/libs/coin-modules/coin-solana/src/helpers/token.ts
+++ b/libs/coin-modules/coin-solana/src/helpers/token.ts
@@ -1,7 +1,6 @@
 import BigNumber from "bignumber.js";
 import type { PublicKey } from "@solana/web3.js";
 import { TOKEN_2022_PROGRAM_ID, TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { AccountLike } from "@ledgerhq/types-live";
 import {
   SolanaTokenAccount,
@@ -11,9 +10,12 @@ import {
 } from "../types";
 import { TransferFeeConfigExt } from "../network/chain/account/tokenExtensions";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
+import { getCryptoAssetsStore } from "../cryptoAssetsStore";
 
 export function tokenIsListedOnLedger(currencyId: string, mint: string): boolean {
-  return findTokenByAddressInCurrency(mint, currencyId)?.type === "TokenCurrency";
+  return (
+    getCryptoAssetsStore().findTokenByAddressInCurrency(mint, currencyId)?.type === "TokenCurrency"
+  );
 }
 
 export function isTokenAccountFrozen(account: AccountLike): boolean {

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -1,4 +1,3 @@
-import { getTokenById } from "@ledgerhq/cryptoassets";
 import {
   AmountRequired,
   InvalidAddress,
@@ -82,6 +81,7 @@ import { TokenAccountInfo } from "./network/chain/account/token";
 import { deriveRawCommandDescriptor, toLiveTransaction } from "./rawTransaction";
 import BigNumber from "bignumber.js";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
+import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 async function deriveCommandDescriptor(
   mainAccount: SolanaAccount,
@@ -374,7 +374,7 @@ async function deriveCreateAssociatedTokenAccountCommandDescriptor(
 ): Promise<CommandDescriptor> {
   const errors: Record<string, Error> = {};
 
-  const token = getTokenById(model.uiState.tokenId);
+  const token = getCryptoAssetsStore().getTokenById(model.uiState.tokenId);
   const mint = token.contractAddress;
   const tokenProgram = await getMaybeTokenMintProgram(mint, api);
 

--- a/libs/coin-modules/coin-solana/src/synchronization.ts
+++ b/libs/coin-modules/coin-solana/src/synchronization.ts
@@ -10,7 +10,6 @@ import {
   toTokenAccountWithInfo,
   TransactionDescriptor,
 } from "./network/chain/web3";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { encodeOperationId } from "@ledgerhq/coin-framework/operation";
 import { encodeNftId } from "@ledgerhq/coin-framework/nft/nftId";
 import {
@@ -51,6 +50,7 @@ import { getStakeAccounts } from "./network/chain/stake-activation/rpc";
 import { tryParseAsMintAccount } from "./network/chain/account";
 import ky from "ky";
 import { isSignaturesForAddressResponse } from "./utils";
+import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 export async function getAccount(
   address: string,
@@ -438,7 +438,7 @@ async function newSubAcc({
   const creationDate = new Date((lastTx?.info.blockTime ?? Date.now() / 1000) * 1000);
 
   const mint = assocTokenAcc.info.mint.toBase58();
-  const tokenCurrency = findTokenByAddressInCurrency(mint, currencyId);
+  const tokenCurrency = getCryptoAssetsStore().findTokenByAddressInCurrency(mint, currencyId);
 
   if (!tokenCurrency) {
     throw new Error(`token for mint "${mint}" not found`);

--- a/libs/coin-modules/coin-solana/src/tests/tokens-bridge.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/tests/tokens-bridge.unit.test.ts
@@ -10,7 +10,6 @@ import {
   TransactionStatus,
 } from "../types";
 
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import {
@@ -32,6 +31,11 @@ import {
 } from "@solana/spl-token";
 import { calculateToken2022TransferFees } from "../helpers/token";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
+import { getCryptoAssetsStore, setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
+import usdcTokenData from "../__fixtures__/solana-spl-epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v.json";
+import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
+
+const USDC_TOKEN = usdcTokenData as unknown as TokenCurrency;
 
 // fake addresses
 const testData = {
@@ -60,7 +64,23 @@ const mainAccId = encodeAccountId({
 
 const wSolSubAccId = encodeAccountIdWithTokenAccountAddress(mainAccId, testData.ataAddress1);
 
-const wSolToken = findTokenByAddressInCurrency(testData.mintAddress, "solana") as TokenCurrency;
+setCryptoAssetsStoreGetter(
+  () =>
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    ({
+      findTokenByAddressInCurrency: (address: string, _currencyId: string) => {
+        if (address === "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v") {
+          return USDC_TOKEN;
+        }
+        return undefined;
+      },
+    }) as CryptoAssetsStore,
+);
+
+const wSolToken = getCryptoAssetsStore().findTokenByAddressInCurrency(
+  testData.mintAddress,
+  "solana",
+) as TokenCurrency;
 
 const baseAccount = {
   balance: new BigNumber(10000),

--- a/libs/coin-modules/coin-solana/src/tests/tokens-bridge.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/tests/tokens-bridge.unit.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../types";
 
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, CryptoAssetsStore } from "@ledgerhq/types-live";
 import {
   SolanaRecipientMemoIsRequired,
   SolanaTokenAccountFrozen,
@@ -33,7 +33,6 @@ import { calculateToken2022TransferFees } from "../helpers/token";
 import { PARSED_PROGRAMS } from "../network/chain/program/constants";
 import { getCryptoAssetsStore, setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
 import usdcTokenData from "../__fixtures__/solana-spl-epjfwdd5aufqssqem2qn1xzybapc8g4weggkzwytdt1v.json";
-import { CryptoAssetsStore } from "@ledgerhq/coin-framework/crypto-assets/type";
 
 const USDC_TOKEN = usdcTokenData as unknown as TokenCurrency;
 

--- a/libs/coin-modules/coin-solana/src/transaction.ts
+++ b/libs/coin-modules/coin-solana/src/transaction.ts
@@ -22,10 +22,10 @@ import {
   toTransactionStatusRawCommon as toTransactionStatusRaw,
 } from "@ledgerhq/coin-framework/serialization";
 import type { Account } from "@ledgerhq/types-live";
-import { findTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/index";
 import { findSubAccountById, getAccountCurrency } from "@ledgerhq/coin-framework/account";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies";
 import { assertUnreachable } from "./utils";
+import { getCryptoAssetsStore } from "./cryptoAssetsStore";
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -153,7 +153,11 @@ function formatTokenTransfer(mainAccount: Account, tx: Transaction, command: Tok
 }
 
 function formatCreateATA(mainAccount: Account, command: TokenCreateATACommand) {
-  const token = findTokenByAddressInCurrency(command.mint, mainAccount.currency.id);
+  const token = getCryptoAssetsStore().findTokenByAddressInCurrency(
+    command.mint,
+    mainAccount.currency.id,
+  );
+
   if (!token) {
     throw new Error(`token for mint "${command.mint}" not found`);
   }

--- a/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-solana/src/scenarii.test.ts
@@ -2,12 +2,24 @@ import { executeScenario } from "@ledgerhq/coin-tester/main";
 import { killSpeculos } from "@ledgerhq/coin-tester/signers/speculos";
 import { scenarioSolana } from "./scenarii/solana";
 import { killAgave } from "./agave";
+import * as legacy from "@ledgerhq/cryptoassets/tokens";
+import { setCryptoAssetsStoreGetter } from "@ledgerhq/coin-solana/cryptoAssetsStore";
 
 ["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].map(e =>
   process.on(e, async () => {
     await Promise.all([killSpeculos(), killAgave()]);
   }),
 );
+
+//TODO coin tester should not call external endpoints (avoid the error Failed to fetch Figment APY LedgerAPI5xx: Unhandled request)
+//TODO mock call to CAL when available
+setCryptoAssetsStoreGetter(() => ({
+  findTokenByAddress: legacy.findTokenByAddress,
+  getTokenById: legacy.getTokenById,
+  findTokenById: legacy.findTokenById,
+  findTokenByAddressInCurrency: legacy.findTokenByAddressInCurrency,
+  findTokenByTicker: legacy.findTokenByTicker,
+}));
 
 describe("Solana Deterministic Tester", () => {
   it("scenario Solana", async () => {

--- a/libs/ledger-live-common/src/families/solana/setup.ts
+++ b/libs/ledger-live-common/src/families/solana/setup.ts
@@ -19,6 +19,7 @@ import { SolanaCoinConfig } from "@ledgerhq/coin-solana/config";
 import { getCryptoCurrencyById } from "../../currencies";
 import { signMessage } from "@ledgerhq/coin-solana/hw-signMessage";
 import { LegacySignerSolana } from "@ledgerhq/live-signer-solana";
+import { getCryptoAssetsStore } from "../../bridge/crypto-assets";
 
 const createSigner: CreateSigner<SolanaSigner> = (transport: Transport) =>
   new LegacySignerSolana(transport);
@@ -30,6 +31,7 @@ const getCurrencyConfig = () => {
 const bridge: Bridge<Transaction, SolanaAccount, TransactionStatus> = createBridges(
   executeWithSigner(createSigner),
   getCurrencyConfig,
+  getCryptoAssetsStore,
 );
 
 const messageSigner = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Solana Token Retrieval in coin-solana

### 📝 Description

#### Context
To be able to call the CAL dynamically, we need to inject the `CryptoAssetsStore` into concerned module. 
Implementation will be provided by LiveHub team. This ticket is for the Solana coin module.

#### What have changed
- `CryptoAssetsStore` injected into `coin-solana`
- A getter function is used instead of a variable for the `CryptoAssetsStore`, to be able to switch between legacy and new system with feature flag on runtime

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA**: https://ledgerhq.atlassian.net/browse/LIVE-19997
---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
