### PR TITLE
LLM MAD Analytics for Live Apps

### DIFF
--- a/.changeset/ninety-peaches-report.md
+++ b/.changeset/ninety-peaches-report.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat: LLM MAD Analytics for Live Apps

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/NoAccountScreen.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/NoAccountScreen.tsx
@@ -7,6 +7,7 @@ import { CurrentAccountHistDB } from "@ledgerhq/live-common/wallet-api/react";
 import Button from "../Button";
 import { useSelectAccount } from "./helpers";
 import { OpenModularDrawerFunction } from "LLM/features/ModularDrawer/types";
+import { currentRouteNameRef } from "~/analytics/screenRefs";
 type NoAccountScreenProps = {
   manifest: AppManifest;
   currentAccountHistDb?: CurrentAccountHistDB;
@@ -29,6 +30,11 @@ export function NoAccountScreen({
         currencies,
         enableAccountSelection: true,
         onAccountSelected: onSelectAccountSuccess,
+        flow: manifest.name,
+        source:
+          currentRouteNameRef.current === "Platform Catalog"
+            ? "Discover"
+            : currentRouteNameRef.current ?? "Unknown",
       });
     } else {
       onSelectAccount();

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -178,6 +178,11 @@ export const PlatformAPIWebview = forwardRef<WebviewAPI, WebviewProps>(
               currencies: allCurrencies,
               enableAccountSelection: true,
               onAccountSelected: onSuccess,
+              flow: manifest.name,
+              source:
+                currentRouteNameRef.current === "Platform Catalog"
+                  ? "Discover"
+                  : currentRouteNameRef.current ?? "Unknown",
             });
           } else {
             if (currenciesDiff.length === 1) {

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useDrawerLifecycle.ts
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/hooks/useDrawerLifecycle.ts
@@ -70,10 +70,18 @@ export function useDrawerLifecycle({
     navigationStepManager.reset();
     handleKeyboardDismiss();
     onClose?.();
+    const page =
+      navigationStepManager.currentStep === ModularDrawerStep.Network
+        ? "Add Account Select Network"
+        : getCurrentPageName(navigationStepManager.currentStep);
+
+    const flowName =
+      navigationStepManager.currentStep === ModularDrawerStep.Network ? "Add Account" : flow;
+
     trackModularDrawerEvent(EVENTS_NAME.BUTTON_CLICKED, {
       button: "Close",
-      flow,
-      page: getCurrentPageName(navigationStepManager.currentStep),
+      flow: flowName,
+      page,
     });
   }, [trackModularDrawerEvent, flow, navigationStepManager, onClose, resetSelection]);
 

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -124,8 +124,8 @@ const AssetSelection = ({
         />
       )}
       <SearchInputContainer
-        source="modular-drawer"
-        flow="asset-selection"
+        source={source}
+        flow={flow}
         items={availableAssets}
         setItemsToDisplay={setItemsToDisplay}
         assetsToDisplay={itemsToDisplay}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
- LLM modular drawer tracking is now enabled for Live Apps
- Fixes analytics for SearchInput and closeButton in the Network step

### 📝 Description

- Enable LLM modular drawer tracking for Live Apps

- Fix analytics on SearchInput and closeButton in the Network step

Tracking Plan: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/5533728769/MVP+Modular+Drawer-+LLD+Data+Tracking+Plan

### ❓ Context

- **JIRA or GitHub link**: [LIVE-20433]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20433]: https://ledgerhq.atlassian.net/browse/LIVE-20433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ