### PR TITLE
ci: enable turborepo for coverage and testing

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -35,9 +35,11 @@ jobs:
 
     runs-on: [ledger-live-4xlarge]
     steps:
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.sha }}
+
       - name: Setup the caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         id: setup-caches
@@ -48,34 +50,57 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
           turbo-server-token: ${{ secrets.TURBOREPO_SERVER_TOKEN }}
+
       - name: Install dependencies
-        run: pnpm i --filter="!./apps/**"
-      - name: Build and Test affected libraries
-        id: test-libs
+        run: pnpm i --filter="./libs/**"
+
+      - name: Run coverage on appropriate libraries
         run: |
+          
           mkdir -p ${{ github.workspace }}/coverage
-          pnpm build:libs
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+        
+          pnpm turbo run coverage --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" --filter="./libs/**" --concurrency=1 -- --runInBand=1 
+
+      - name: Test libraries without coverage script & Process coverage files
+        id: test-libs
+        run: |
+          
+          echo "::group::Processing coverage files"
+          
+          testCommand=(pnpm turbo test --concurrency=25%)
+          
           for package_json in $(find ./libs -name "package.json"); do
             lib=$(dirname "$package_json")
             echo "Processing library at path: $lib"
             if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json"; then
-              echo "Running coverage script for $lib"
-              pnpm --prefix "$lib" run coverage
               if [ -f "$lib/coverage/lcov.info" ] && [ -f "$lib/coverage/sonar-executionTests-report.xml" ]; then
                 echo "Appending coverage files for $lib"
                 cat "$lib/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
                 cat "$lib/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
               fi
-            elif [ -f "$package_json" ] && jq -e '.scripts.test' "$package_json"; then
-              echo "Coverage script not defined for $lib, running test script."
-              pnpm --prefix "$lib" run test
+            elif [ -f "$package_json" ] && ! jq -e '.scripts.coverage' "$package_json" && jq -e '.scripts.test' "$package_json"; then
+              echo "Coverage script not defined for $lib, adding to testflow."
+              
+              name=$(jq -r '.name' "$package_json")
+              testCommand+=(--filter "$name")
+          
             else
               echo "No coverage or test script found for $lib, skipping."
             fi
+          
           done
+          
+          testCommand+=(--api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}")
+          testCommand+=(--token="${{ secrets.TURBOREPO_SERVER_TOKEN }}")
+          testCommand+=(--team="foo")
+
+          echo "::endgroup::"
+          echo "Running tests for libs without coverage with command: ${testCommand[@]}"
+          "${testCommand[@]}"
         shell: bash
+
       - name: (On Failure) Upload live-common snapshots and source
         uses: actions/upload-artifact@v4
         if: failure()
@@ -83,18 +108,21 @@ jobs:
           name: live-common-src
           path: |
             libs/ledger-live-common/src
+
       - uses: actions/github-script@v7
         if: ${{ !cancelled() }}
         with:
           script: |
             const fs = require("fs");
             fs.writeFileSync("summary-tests.txt", "${{ steps.test-libs.outcome }}", "utf-8");
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         id: generate_coverage
         with:
           name: coverage-libs
           path: ${{ github.workspace }}/coverage
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/libs/coin-modules/coin-celo/package.json
+++ b/libs/coin-modules/coin-celo/package.json
@@ -141,7 +141,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --testPathIgnorePatterns='/bridge.integration.test.ts|node_modules|lib-es|lib/' --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-celo.json",
+    "coverage": "jest --coverage --testPathIgnorePatterns='/bridge.integration.test.ts|node_modules|lib-es|lib/' --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/coin-modules/coin-mina/package.json
+++ b/libs/coin-modules/coin-mina/package.json
@@ -130,7 +130,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-boilerplate.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "doc": "documentation readme src/** --section=API --pe ts --re ts --re d.ts",

--- a/libs/coin-modules/coin-sui/package.json
+++ b/libs/coin-modules/coin-sui/package.json
@@ -112,7 +112,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc --outDir lib --module commonjs --moduleResolution node10 && tsc -m ES6 --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-sui.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m ES6 --outDir lib-es",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -81,7 +81,7 @@
     "test-bridge-update": "UPDATE_BACKEND_MOCKS=1 env-cmd -f .ci.integration.env pnpm jest --ci --updateSnapshot --passWithNoTests",
     "test-account-migration": "tsx src/__tests__/migration/account-migration.ts",
     "unimported": "unimported",
-    "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci --updateSnapshot && git diff --exit-code src"
+    "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci --updateSnapshot"
   },
   "files": [
     "lib",

--- a/libs/ledgerjs/packages/hw-app-algorand/package.json
+++ b/libs/ledgerjs/packages/hw-app-algorand/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-algorand.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-aptos/package.json
+++ b/libs/ledgerjs/packages/hw-app-aptos/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-aptos.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-btc/package.json
+++ b/libs/ledgerjs/packages/hw-app-btc/package.json
@@ -88,7 +88,7 @@
   },
   "scripts": {
     "clean": "rimraf lib lib-es",
-    "coverage": "jest --coverage --testPathIgnorePatterns='/.test.ts.disabled|node_modules|lib-es|lib/' --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-btc.json",
+    "coverage": "jest --coverage --testPathIgnorePatterns='/.test.ts.disabled|node_modules|lib-es|lib/' --passWithNoTests",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",

--- a/libs/ledgerjs/packages/hw-app-canton/package.json
+++ b/libs/ledgerjs/packages/hw-app-canton/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-canton.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-cosmos/package.json
+++ b/libs/ledgerjs/packages/hw-app-cosmos/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-cosmos.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-eth/package.json
+++ b/libs/ledgerjs/packages/hw-app-eth/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-eth.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-exchange/package.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/package.json
@@ -49,7 +49,7 @@
     "clean": "rimraf lib lib-es",
     "prebuild": "pnpm pbjs -t json -r ledger_swap -o src/generate-protocol.json ./protocol.proto",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-exchange.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-hedera/package.json
+++ b/libs/ledgerjs/packages/hw-app-hedera/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-hedera.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-helium/package.json
+++ b/libs/ledgerjs/packages/hw-app-helium/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-helium.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-icon/package.json
+++ b/libs/ledgerjs/packages/hw-app-icon/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-icon.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-multiversx/package.json
+++ b/libs/ledgerjs/packages/hw-app-multiversx/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-multiversx.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-near/package.json
+++ b/libs/ledgerjs/packages/hw-app-near/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-near.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-polkadot/package.json
+++ b/libs/ledgerjs/packages/hw-app-polkadot/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-polkadot.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-solana/package.json
+++ b/libs/ledgerjs/packages/hw-app-solana/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-solana.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-str/package.json
+++ b/libs/ledgerjs/packages/hw-app-str/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-str.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-tezos/package.json
+++ b/libs/ledgerjs/packages/hw-app-tezos/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-tezos.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-trx/package.json
+++ b/libs/ledgerjs/packages/hw-app-trx/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-trx.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-vet/package.json
+++ b/libs/ledgerjs/packages/hw-app-vet/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-vet.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledgerjs/packages/hw-app-xrp/package.json
+++ b/libs/ledgerjs/packages/hw-app-xrp/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage --passWithNoTests && mv coverage/coverage-final.json coverage/coverage-hw-app-xrp.json",
+    "coverage": "jest --coverage --passWithNoTests",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/turbo.json
+++ b/turbo.json
@@ -142,7 +142,8 @@
       "persistent": true
     },
     "coverage": {
-      "cache": false
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/lcov.info", "coverage/sonar-executionTests-report.xml"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
- Enabling turborepo and caching for quicker feedback on library changes
- Adding code coverage files to codecheck output for re-use
- Remove superfluous mv on packages
- Optimising concurrency based on resources available and usage profile of tasks

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-19990
Uncached: https://github.com/LedgerHQ/ledger-live/actions/runs/17153246758/job/48664106376
Cached: https://github.com/LedgerHQ/ledger-live/actions/runs/17153246758/job/48666162957