### PR TITLE
ci: Fix for turbo build order

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -147,7 +147,7 @@
       "persistent": true
     },
     "coverage": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "build"],
       "outputs": ["coverage/lcov.info", "coverage/sonar-executionTests-report.xml"]
     },
     "clean": {


### PR DESCRIPTION
On occasion build of live-common happens after the codecheck of live-common. This change ensures that build is done before codecheck.