### PR TITLE
ci: reduction of android workers to improve ci reliability

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -486,7 +486,7 @@ platform :android do
           "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASS"],
         },
         project_dir: 'android/',
-        flags: ' -Dorg.gradle.workers.max=3 -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=1g"'
+        flags: ' -Dorg.gradle.workers.max=2 -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=750m"'
       )
     end
   end


### PR DESCRIPTION
Memory limitations within the CI cause the Android build process to flake.

By reducing the java workers, memory consumption is reduced with minimal speed impact.

Test runs: https://github.com/LedgerHQ/ledger-live-build/actions/runs/17174797893