### PR TITLE
ci: Fix coverage commands

### DIFF
--- a/libs/coin-framework/package.json
+++ b/libs/coin-framework/package.json
@@ -118,7 +118,7 @@
   "scripts": {
     "clean": "rm -rf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/coin-modules/coin-module-boilerplate/package.json
+++ b/libs/coin-modules/coin-module-boilerplate/package.json
@@ -123,7 +123,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "doc": "documentation readme src/** --section=API --pe ts --re ts --re d.ts",

--- a/libs/coin-modules/coin-polkadot/package.json
+++ b/libs/coin-modules/coin-polkadot/package.json
@@ -109,7 +109,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc --outDir lib --module commonjs --moduleResolution node10 && tsc -m ES6 --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m ES6 --outDir lib-es",

--- a/libs/coin-modules/coin-stellar/package.json
+++ b/libs/coin-modules/coin-stellar/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/coin-modules/coin-tezos/package.json
+++ b/libs/coin-modules/coin-tezos/package.json
@@ -103,7 +103,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/coin-modules/coin-tron/package.json
+++ b/libs/coin-modules/coin-tron/package.json
@@ -123,7 +123,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/coin-modules/coin-xrp/package.json
+++ b/libs/coin-modules/coin-xrp/package.json
@@ -127,7 +127,7 @@
   "scripts": {
     "clean": "rimraf lib lib-es",
     "build": "tsc && tsc -m esnext --moduleResolution bundler --outDir lib-es",
-    "coverage": "jest --coverage || true",
+    "coverage": "jest --coverage",
     "prewatch": "pnpm build",
     "watch": "tsc --watch",
     "watch:es": "tsc --watch -m esnext --moduleResolution bundler --outDir lib-es",

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -81,7 +81,7 @@
     "test-bridge-update": "UPDATE_BACKEND_MOCKS=1 env-cmd -f .ci.integration.env pnpm jest --ci --updateSnapshot --passWithNoTests",
     "test-account-migration": "tsx src/__tests__/migration/account-migration.ts",
     "unimported": "unimported",
-    "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci --updateSnapshot"
+    "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Currently the coverage commands have a "|| true" suffix which causes the test runs to not explicitly fail and subsequently, don't get blocked from merge. This change removes the fallback to ensure that passing tests are required.