### PR TITLE
ci: Resource usage adjustments

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -486,7 +486,7 @@ platform :android do
           "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASS"],
         },
         project_dir: 'android/',
-        flags: ' -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'
+        flags: ' -Dorg.gradle.workers.max=2 -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=750m"'
       )
     end
   end


### PR DESCRIPTION
- Allow JVM to assign relevant container aware limits based on helm changes (rather than hard coded)
- Do not test libs/UI in lib tests (regression from implementation of Sonarcloud)
- Move lib testing to GitHub hosted runner

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-20960
Android build pass: https://github.com/LedgerHQ/ledger-live-build/actions/runs/17265184098/job/48995530881
Test Libraries Pass: https://github.com/LedgerHQ/ledger-live/actions/runs/17266666795/job/49000315088

Note: This required helm charts to be rolled out in advance.