### PR TITLE
:bug: (lld) use lang instead of locale in notif panel

### DIFF
--- a/.changeset/olive-ads-brush.md
+++ b/.changeset/olive-ads-brush.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Force date to lang instead of locale in the notification panel

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/AnnouncementPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/AnnouncementPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import TriangleWarning from "~/renderer/icons/TriangleWarning";
 import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
@@ -17,6 +17,7 @@ import { urls } from "~/config/urls";
 import { useDateFormatted } from "~/renderer/hooks/useDateFormatter";
 import LogContentCardWrapper from "LLD/features/DynamicContent/components/LogContentCardWrapper";
 import { LNSUpsellBanner } from "LLD/features/LNSUpsell";
+import { languageSelector } from "~/renderer/reducers/settings";
 
 const DateRowContainer = styled.div`
   padding: 4px 16px;
@@ -86,7 +87,8 @@ const DateLabel = styled(Text).attrs({
 const dateFull: Intl.DateTimeFormatOptions = { dateStyle: "full" };
 
 function DateRow({ date }: DateRowProps) {
-  const txt = useDateFormatted(date, dateFull);
+  const language = useSelector(languageSelector);
+  const txt = useDateFormatted(date, dateFull, language);
   return (
     <DateRowContainer>
       <DateLabel>{txt}</DateLabel>

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDateFormatter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDateFormatter.test.tsx
@@ -135,12 +135,13 @@ describe("useDateFormatter", () => {
 
     const setLocale_Mock = (
       locale: string,
+      forcedLanguage?: string,
       opts?: {
         intlOpts?: Intl.DateTimeFormatOptions;
       },
     ) => {
       spy.mockReturnValue(locale);
-      const { result } = renderHook(() => useDateFormatter(opts?.intlOpts), {
+      const { result } = renderHook(() => useDateFormatter(opts?.intlOpts, forcedLanguage), {
         wrapper: HookWrapper,
       });
       f = result.current;
@@ -157,6 +158,12 @@ describe("useDateFormatter", () => {
 
       setLocale_Mock("pt-BR");
       expect(f(date)).toEqual("01/02/2000");
+    });
+
+    test("should format date properly with forced language", () => {
+      const date = new Date("February 1, 2000 10:00:00");
+      setLocale_Mock("fr", "en");
+      expect(f(date)).toEqual("2/1/2000");
     });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/useDateFormatter.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useDateFormatter.ts
@@ -58,19 +58,38 @@ export type useDateFormatterOptions = {
 };
 
 /**
- *
+ * @param intlOpts - Intl.DateTimeFormatOptions
+ * @param forcedLanguage - language to force, if not provided, the locale will be used. This should be only used for notifications panel.
  * @returns a function that format a date into a string based on the current
  * locale.
  */
-export const useDateFormatter = (intlOpts?: Intl.DateTimeFormatOptions) => {
+export const useDateFormatter = (
+  intlOpts?: Intl.DateTimeFormatOptions,
+  forcedLanguage?: string,
+) => {
   const locale = useSelector(localeSelector);
-  const format = useMemo(() => new Intl.DateTimeFormat(locale, intlOpts), [locale, intlOpts]);
+  const targetLanguage = forcedLanguage ?? locale;
+  const format = useMemo(
+    () => new Intl.DateTimeFormat(targetLanguage, intlOpts),
+    [targetLanguage, intlOpts],
+  );
   const f = useCallback((date: Date) => format.format(date), [format]);
   return f;
 };
 
-export const useDateFormatted = (date?: Date, intlOpts?: Intl.DateTimeFormatOptions): string => {
-  const dateFormatter = useDateFormatter(intlOpts);
+/**
+ *
+ * @param date - date to format
+ * @param intlOpts - Intl.DateTimeFormatOptions
+ * @param forcedLanguage - language to force, if not provided, the locale will be used. This should be only used for notifications panel.
+ * @returns a formatted date string
+ */
+export const useDateFormatted = (
+  date?: Date,
+  intlOpts?: Intl.DateTimeFormatOptions,
+  forcedLanguage?: string,
+): string => {
+  const dateFormatter = useDateFormatter(intlOpts, forcedLanguage);
   return useMemo(() => (date ? dateFormatter(date) : ""), [date, dateFormatter]);
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Notif panel

### 📝 Description

The notification panel is only used by Braze. Our implementation had a good logic but weird behavior in that case. Because Braze uses the language property to determine the language to use but we displayed the Date with the locale. 
To override this I added a forcedLanguage prop to useDateFormatted

| Before        | After         |
| ------------- | ------------- |
|<img width="482" height="746" alt="Screenshot 2025-08-28 at 5 29 45 PM" src="https://github.com/user-attachments/assets/081083c9-c971-476e-a428-da9c62cf9535" />|<img width="484" height="782" alt="Screenshot 2025-08-28 at 5 29 31 PM" src="https://github.com/user-attachments/assets/8b75d770-9a85-432b-94f5-2f60a711419a" />               |


### ❓ Context

- **JIRA or GitHub link**: [LIVE-20959](https://ledgerhq.atlassian.net/browse/LIVE-20959)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-20959]: https://ledgerhq.atlassian.net/browse/LIVE-20959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ