### PR TITLE
fix: tezos delegate on nano app approval

### DIFF
--- a/e2e/mobile/specs/portfolio/portfolioAccountsTab.spec.ts
+++ b/e2e/mobile/specs/portfolio/portfolioAccountsTab.spec.ts
@@ -1,5 +1,5 @@
 const testConfig = {
-  tmsLinks: ["B2CQA-2871", "B2CQA-2873", "B2CQA-3060"],
+  tmsLinks: ["B2CQA-2871", "B2CQA-2873", "B2CQA-3060", "B2CQA-2873"],
   tags: ["@NanoSP", "@LNS", "@NanoX"],
 };
 

--- a/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
+++ b/e2e/mobile/specs/swap/swapBTC_NATIVE_SEGWIT_ETH.spec.ts
@@ -1,4 +1,4 @@
 import { runSwapTest } from "./swap";
 
 const swap = new Swap(Account.BTC_NATIVE_SEGWIT_1, Account.ETH_1, "0.00067", Fee.MEDIUM);
-runSwapTest(swap, ["B2CQA-2744", "B2CQA-2432"], ["@NanoSP", "@LNS", "@NanoX"]);
+runSwapTest(swap, ["B2CQA-2744", "B2CQA-2432", "B2CQA-620"], ["@NanoSP", "@LNS", "@NanoX"]);

--- a/libs/ledger-live-common/src/e2e/enum/DeviceLabels.ts
+++ b/libs/ledger-live-common/src/e2e/enum/DeviceLabels.ts
@@ -6,6 +6,7 @@ export enum DeviceLabels {
   SIGN = "Sign",
   APPROVE = "Approve",
   ACCEPT = "Accept",
+  ACCEPT_RISK = "Accept risk",
   TRANSFER = "Transfer",
   RECIPIENT = "Recipient",
   DEST = "Dest",

--- a/libs/ledger-live-common/src/e2e/families/tezos.ts
+++ b/libs/ledger-live-common/src/e2e/families/tezos.ts
@@ -3,6 +3,8 @@ import { DeviceLabels } from "../enum/DeviceLabels";
 
 export async function delegateTezos() {
   await waitFor(DeviceLabels.REVIEW_OPERATION);
+  await pressUntilTextFound(DeviceLabels.ACCEPT_RISK);
+  await pressBoth();
   await pressUntilTextFound(DeviceLabels.ACCEPT);
   await pressBoth();
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
