### PR TITLE
feat: add arrow header back button to onboarding navigation

### DIFF
--- a/.changeset/bright-cougars-switch.md
+++ b/.changeset/bright-cougars-switch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Add arrow back header component to all onboarding screens for consistent ux

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/index.tsx
@@ -76,6 +76,11 @@ export type BleDevicePairingFlowProps = {
    * should react to a request from this component to set or to clean its header.
    */
   requestToSetHeaderOptions: (request: SetHeaderOptionsRequest) => void;
+
+  /**
+   * The headers for onboarding are configured to be only back arrows whilst in other flows can be cross icons.
+   */
+  isOnboarding?: boolean;
 };
 
 // A "done" state to avoid having the BLE scanning on the device that we just paired
@@ -93,6 +98,7 @@ const BleDevicePairingFlow: React.FC<BleDevicePairingFlowProps> = ({
   onPairingSuccess,
   onPairingSuccessAddToKnownDevices = false,
   requestToSetHeaderOptions,
+  isOnboarding,
 }) => {
   const dispatchRedux = useDispatch();
 
@@ -191,12 +197,18 @@ const BleDevicePairingFlow: React.FC<BleDevicePairingFlowProps> = ({
       });
     } else if (pairingFlowStep === "pairing") {
       if (!isPaired) {
+        const options = isOnboarding
+          ? {
+              headerLeft: () => <NavigationHeaderBackButton onPress={onRetryPairingFlow} />,
+              headerRight: () => null,
+            }
+          : {
+              headerLeft: () => null,
+              headerRight: () => <NavigationHeaderCloseButton onPress={onRetryPairingFlow} />,
+            };
         requestToSetHeaderOptions({
           type: "set",
-          options: {
-            headerLeft: () => null,
-            headerRight: () => <NavigationHeaderCloseButton onPress={onRetryPairingFlow} />,
-          },
+          options,
         });
       } else {
         // If a device is paired, we still want to display the success component without the screen own header
@@ -223,6 +235,7 @@ const BleDevicePairingFlow: React.FC<BleDevicePairingFlowProps> = ({
     onRetryPairingFlow,
     pairingFlowStep,
     requestToSetHeaderOptions,
+    isOnboarding,
   ]);
 
   return (

--- a/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
+++ b/apps/ledger-live-mobile/src/components/NavigationHeaderCloseButton.tsx
@@ -10,6 +10,7 @@ import Touchable from "./Touchable";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
 import { useNavigateToPostOnboardingHubCallback } from "~/logic/postOnboarding/useNavigateToPostOnboardingHubCallback";
 import { StyleProp, ViewStyle } from "react-native";
+import { NavigationHeaderBackButton } from "./NavigationHeaderBackButton";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const emptyFunction = () => {};
@@ -92,6 +93,9 @@ type AdvancedProps = {
   confirmCTAConfig?: Partial<CtaConfig>;
   confirmButtonText?: React.ReactNode;
   rejectButtonText?: React.ReactNode;
+
+  // All onboarding screens should only use back arrow as navigation to go back or close
+  isOnboarding?: boolean;
 };
 
 /**
@@ -117,6 +121,7 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
     confirmCTAConfig,
     confirmButtonText,
     rejectButtonText,
+    isOnboarding = false,
   }) => {
     const navigation = useNavigation();
     const [isConfirmationModalOpened, setIsConfirmationModalOpened] = useState(false);
@@ -191,9 +196,10 @@ export const NavigationHeaderCloseButtonAdvanced: React.FC<AdvancedProps> = Reac
           </Button>
         );
 
+      if (isOnboarding) return <NavigationHeaderBackButton onPress={onPress} />;
       if (rounded) return <NavigationHeaderCloseButtonRounded onPress={onPress} color={color} />;
       else return <NavigationHeaderCloseButton onPress={onPress} color={color} />;
-    }, [buttonText, showButton, onPress, rounded, color]);
+    }, [buttonText, showButton, onPress, rounded, color, isOnboarding]);
 
     return (
       <>

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseOnboardingNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseOnboardingNavigator.tsx
@@ -58,7 +58,10 @@ export const ErrorHeaderInfo = ({ route, navigation }: ErrorHeaderInfoNavigatorP
 export default function BaseOnboardingNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const stackNavigationConfig = useMemo(() => getStackNavigatorConfig(colors, true), [colors]);
+  const stackNavigationConfig = useMemo(
+    () => getStackNavigatorConfig(colors, true, undefined, true),
+    [colors],
+  );
   return (
     <Stack.Navigator
       screenOptions={{

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SyncOnboardingNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SyncOnboardingNavigator.tsx
@@ -8,13 +8,16 @@ import { SyncOnboardingStackParamList } from "./types/SyncOnboardingNavigator";
 import { SyncOnboarding } from "~/screens/SyncOnboarding";
 import { getStackNavigatorConfig } from "~/navigation/navigatorConfig";
 import FirmwareUpdateScreen from "~/screens/FirmwareUpdate";
-import { Button, IconsLegacy } from "@ledgerhq/native-ui";
+import { NavigationHeaderBackButton } from "../NavigationHeaderBackButton";
 
 const Stack = createStackNavigator<SyncOnboardingStackParamList>();
 
 export const SyncOnboardingNavigator = () => {
   const { colors } = useTheme();
-  const stackNavigatorConfig = useMemo(() => getStackNavigatorConfig(colors), [colors]);
+  const stackNavigatorConfig = useMemo(
+    () => getStackNavigatorConfig(colors, undefined, undefined, true),
+    [colors],
+  );
 
   return (
     <Stack.Navigator
@@ -32,8 +35,8 @@ export const SyncOnboardingNavigator = () => {
           gestureEnabled: false,
           headerShown: true,
           headerTitle: () => null,
-          headerLeft: () => null,
-          headerRight: () => <Button Icon={IconsLegacy.CloseMedium} />,
+          headerLeft: () => <NavigationHeaderBackButton />,
+          headerRight: () => null,
         }}
       />
     </Stack.Navigator>

--- a/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
+++ b/apps/ledger-live-mobile/src/navigation/navigatorConfig.tsx
@@ -22,6 +22,7 @@ export const getStackNavigatorConfig = (
   c: ColorV2 | ColorV3,
   closable = false,
   onClose?: () => void,
+  isOnboarding?: boolean,
 ) => ({
   ...defaultNavigationOptions,
   cardStyle: {
@@ -38,8 +39,13 @@ export const getStackNavigatorConfig = (
   headerTitleStyle: {
     color: (c as ColorV3).neutral?.c100 || (c as ColorV2).darkBlue,
   },
-  headerRight: closable
-    ? () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} />
-    : undefined,
+  headerRight:
+    closable && !isOnboarding
+      ? () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} />
+      : undefined,
+  headerLeft:
+    closable && isOnboarding
+      ? () => <NavigationHeaderCloseButtonAdvanced onClose={onClose} isOnboarding />
+      : undefined,
 });
 export type StackNavigatorConfig = ReturnType<typeof getStackNavigatorConfig>;

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/WalletSyncNavigator.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/WalletSyncNavigator.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
 import { ScreenName } from "~/const";
@@ -19,10 +19,13 @@ import { useClose } from "./hooks/useClose";
 import { track } from "~/analytics";
 import { AnalyticsPage } from "./hooks/useLedgerSyncAnalytics";
 import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
+import { hasCompletedOnboardingSelector } from "~/reducers/settings";
+import { useSelector } from "react-redux";
 
 const Stack = createStackNavigator<WalletSyncNavigatorStackParamList>();
 
 export default function WalletSyncNavigator() {
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const { colors } = useTheme();
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors), [colors]);
   const { t } = useTranslation();
@@ -60,8 +63,12 @@ export default function WalletSyncNavigator() {
         component={ActivationLoading}
         options={{
           title: "",
-          headerLeft: () => null,
-          headerRight: () => <NavigationHeaderCloseButton onPress={close} />,
+          headerLeft: hasCompletedOnboarding
+            ? () => <NavigationHeaderBackButton onPress={close} />
+            : () => null,
+          headerRight: hasCompletedOnboarding
+            ? () => null
+            : () => <NavigationHeaderCloseButton onPress={close} />,
         }}
       />
 

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/index.tsx
@@ -71,6 +71,7 @@ import { setLastConnectedDevice, setLastSeenDeviceInfo } from "~/actions/setting
 import { lastSeenDeviceSelector } from "~/reducers/settings";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { useKeepScreenAwake } from "~/hooks/useKeepScreenAwake";
+import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
 
 const requiredBatteryStatuses = [
   BatteryStatusTypes.BATTERY_PERCENTAGE,
@@ -455,21 +456,36 @@ export const FirmwareUpdate = ({
   ]);
 
   useEffect(() => {
-    navigation.setOptions({
-      headerRight: () => (
-        <Button
-          onPress={() => {
-            if (isAllowedToClose) {
-              quitUpdate();
-            } else {
-              setIsCloseWarningOpen(true);
-            }
-          }}
-          Icon={IconsLegacy.CloseMedium}
-        />
-      ),
-    });
-  }, [navigation, quitUpdate, isAllowedToClose]);
+    const options = isBeforeOnboarding
+      ? {
+          headerLeft: () => (
+            <NavigationHeaderBackButton
+              onPress={() => {
+                if (isAllowedToClose) {
+                  quitUpdate();
+                } else {
+                  setIsCloseWarningOpen(true);
+                }
+              }}
+            />
+          ),
+        }
+      : {
+          headerRight: () => (
+            <Button
+              onPress={() => {
+                if (isAllowedToClose) {
+                  quitUpdate();
+                } else {
+                  setIsCloseWarningOpen(true);
+                }
+              }}
+              Icon={IconsLegacy.CloseMedium}
+            />
+          ),
+        };
+    navigation.setOptions(options);
+  }, [navigation, quitUpdate, isAllowedToClose, isBeforeOnboarding]);
 
   const steps: Item[] = useMemo(() => {
     const newSteps: UpdateSteps = {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/BleDevicePairingFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/BleDevicePairingFlow.tsx
@@ -59,6 +59,7 @@ const OnboardingBleDevicePairingFlow: React.FC<Props> = ({ navigation, route }) 
           filterByDeviceModelId={filterByDeviceModelId}
           onPairingSuccess={onPairingSuccess}
           requestToSetHeaderOptions={requestToSetHeaderOptions}
+          isOnboarding
         />
       </Flex>
     </SafeAreaView>

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -18,6 +18,8 @@ import { NavigationHeaderCloseButton } from "~/components/NavigationHeaderCloseB
 import UnlockDeviceDrawer from "~/components/UnlockDeviceDrawer";
 import AutoRepairDrawer from "./AutoRepairDrawer";
 import { type SyncOnboardingScreenProps } from "./SyncOnboardingScreenProps";
+import { NavigationHeaderBackButton } from "~/components/NavigationHeaderBackButton";
+import { NavigatorName, ScreenName } from "~/const";
 
 const POLLING_PERIOD_MS = 1000;
 const DESYNC_TIMEOUT_MS = 20000;
@@ -63,7 +65,15 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
     if (currentStep === "early-security-check") {
       setIsESCMandatoryDrawerOpen(true);
     } else {
+      // The navigation must be popped to to avoid returning to this screen when pressing back on device selection
       navigation.popToTop();
+      // The navigation goes to an intermediary blank screen if not directly navigated to correct screen after pop
+      navigation.navigate(NavigatorName.BaseOnboarding, {
+        screen: NavigatorName.Onboarding,
+        params: {
+          screen: ScreenName.OnboardingDeviceSelection,
+        },
+      });
     }
   }, [currentStep, navigation]);
 
@@ -74,8 +84,8 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
       header: () => (
         <>
           <SafeAreaView edges={["top", "left", "right"]}>
-            <Flex my={5} flexDirection="row" justifyContent="flex-end" alignItems="center">
-              <NavigationHeaderCloseButton onPress={onCloseButtonPress} />
+            <Flex my={5} flexDirection="row" justifyContent="flex-start" alignItems="center">
+              <NavigationHeaderBackButton onPress={onCloseButtonPress} />
             </Flex>
           </SafeAreaView>
           <PlainOverlay isOpen={isHeaderOverlayOpen} delay={headerOverlayDelayMs} />


### PR DESCRIPTION


<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [X] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [X] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

To make the onboarding experience consistent all the cross icons for closing screens or to go back during the onboarding flows have been changed to arrow buttons in the left hand corner.  I went through all the screens that were in the two main onboarding navigators and replaced where possible with aforementioned back arrow buttons.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20224


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
