### PR TITLE
Support: Adjust JVM args to use container percentages

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -180,6 +180,7 @@ jobs:
             ${{ github.workspace }}/summary-typecheck.txt
             ${{ github.workspace }}/summary-lint.txt
 
+
   test-docs:
     name: "Libraries Documentation Check"
     runs-on: ubuntu-22.04

--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -486,7 +486,7 @@ platform :android do
           "android.injected.signing.key.password" => ENV["ANDROID_KEY_PASS"],
         },
         project_dir: 'android/',
-        flags: ' -Dorg.gradle.workers.max=2 -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxMetaspaceSize=750m"'
+        flags: ' -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2 -Dorg.gradle.jvmargs="-XX:MaxRAMPercentage=15.0"'
       )
     end
   end

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -81,7 +81,7 @@
     "test-bridge-update": "UPDATE_BACKEND_MOCKS=1 env-cmd -f .ci.integration.env pnpm jest --ci --updateSnapshot --passWithNoTests",
     "test-account-migration": "tsx src/__tests__/migration/account-migration.ts",
     "unimported": "unimported",
-    "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci --updateSnapshot"
+    "coverage": "env-cmd -f .ci.unit.env pnpm jest --coverage --ci"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Change JVM args to max ram percentage percentage to allow re-sizing of containers easily

Test runs (attempts 1-8): https://github.com/LedgerHQ/ledger-live-build/actions/runs/17265017874/job/49212699042