### PR TITLE
ci: fix provisioning profile selection by removing extra date param

### DIFF
--- a/apps/ledger-live-mobile/fastlane/Fastfile
+++ b/apps/ledger-live-mobile/fastlane/Fastfile
@@ -156,7 +156,7 @@ platform :ios do
     MY_APP_BUNDLE_ID = ENV["MY_APP_BUNDLE_ID"]
     MY_APP_ID = ENV["APP_IDENTIFIER"]
 
-    MY_PROFILE = (options[:adhoc] ? "match AdHoc #{MY_APP_BUNDLE_ID} 1754305777" : "match AppStore #{MY_APP_BUNDLE_ID}")
+    MY_PROFILE = (options[:adhoc] ? "match AdHoc #{MY_APP_BUNDLE_ID}" : "match AppStore #{MY_APP_BUNDLE_ID}")
     MY_TEAM = ENV["DEVELOPER_TEAM_ID"]
 
     if (!options[:local])


### PR DESCRIPTION
Update naming of provisioning profiles to match those within the developer portal

https://ledger.slack.com/archives/C0308JT8WS2/p1756718987017109