### PR TITLE
Support: Migrate mock test flows to github hosted runners

### DIFF
--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -165,7 +165,7 @@ jobs:
 
   build-android-js:
     name: "Android Build JS"
-    runs-on: [ ledger-live-4xlarge ]
+    runs-on: [ ledger-live-linux-8CPU-32RAM ]
     if: ${{ inputs.build-android-js == true }}
     outputs:
         js-bundle-size: ${{ steps.output-js-bundle-size.outputs.size }}
@@ -190,6 +190,7 @@ jobs:
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
           skip-pnpm-cache: "false"
+          install-proto: "true"
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
@@ -235,6 +236,6 @@ jobs:
   skip-android-js:
     name: "Android Build JS - Skip"
     if: ${{ inputs.build-android-js != true }}
-    runs-on: [ ledger-live-4xlarge ]
+    runs-on: [ ubuntu-22.04 ]
     steps:
       - run: echo "Skipping"

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -179,7 +179,7 @@ jobs:
       LANG: en_US.UTF-8
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
-    runs-on: [ ledger-live-4xlarge ]
+    runs-on: [ ledger-live-linux-8CPU-32RAM ]
     outputs:
       js-bundle-size: ${{ steps.output-js-bundle-size.outputs.size }}
     steps:
@@ -200,6 +200,7 @@ jobs:
         id: setup-caches
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
         with:
+          install-proto: "true"
           skip-pod-cache: "true"
           skip-turbo-cache: "false"
           skip-pnpm-cache: "false"
@@ -247,6 +248,6 @@ jobs:
   skip-ios-js:
     name: "iOS Build JS - Skip"
     if: ${{ inputs.build-ios-js != true }}
-    runs-on: [ ledger-live-4xlarge ]
+    runs-on: [ ubuntu-22.04 ]
     steps:
       - run: echo "Skipping"

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   determine-builds:
     name: "Determine Builds"
-    runs-on: ubuntu-22.04
+    runs-on: [ ubuntu-22.04 ]
     outputs:
       ios_native_exists: ${{ steps.check-ios-native.outputs.cache-hit }}
       ios_js_exists: ${{ steps.check-ios-js.outputs.cache-hit }}
@@ -497,7 +497,7 @@ jobs:
 
   allure-report-ios:
     name: "iOS Detox > Allure Report"
-    runs-on: [ledger-live-medium]
+    runs-on: [ ubuntu-22.04 ]
     if: ${{ !cancelled() && !inputs.speculos_tests && needs.detox-tests-ios.outputs.artifact }}
     needs: [detox-tests-ios]
     outputs:
@@ -505,6 +505,8 @@ jobs:
       result: ${{ steps.summary.outputs.test_result }}
       status: ${{ needs.detox-tests-ios.outputs.status }}
     steps:
+      - name: Install Allure CLI
+        run: npm install -g allure-commandline
       - name: Download Allure Report
         uses: actions/download-artifact@v4
         with:
@@ -529,7 +531,7 @@ jobs:
 
   allure-report-android:
     name: "Android Detox > Allure Report"
-    runs-on: [ledger-live-medium]
+    runs-on: [ ubuntu-22.04 ]
     if: ${{ !cancelled() && needs.detox-tests-android.outputs.artifact }}
     outputs:
       report-url: ${{ steps.upload.outputs.report-url }}
@@ -537,6 +539,8 @@ jobs:
       finalStatus: ${{ steps.aggregate.outputs.finalStatus }}
     needs: [detox-tests-android]
     steps:
+      - name: Install Allure CLI
+        run: npm install -g allure-commandline
       - name: Download Allure Report
         uses: actions/download-artifact@v4
         with:
@@ -561,7 +565,7 @@ jobs:
 
   report-bundle-sizes:
     name: "Build Mobile > Report Bundle Sizes"
-    runs-on: ledger-live-medium
+    runs-on: [ ubuntu-22.04 ]
     if: needs.build-ios.outputs.js-bundle-size != '' && needs.build-android.outputs.js-bundle-size != '' && !inputs.skip-bundle-size-reporting
     needs: [ build-ios, build-android ]
     steps:


### PR DESCRIPTION
Migration of mock test flows to GitHub hosted runners.

Changed from:
iOS build JS: https://github.com/LedgerHQ/ledger-live/actions/runs/17373539621/job/49314747407 - 7m 20s
Android build JS: https://github.com/LedgerHQ/ledger-live/actions/runs/17373539621/job/49314747414 - 7m 19s
Build & Test Mobile / iOS Detox > Allure Report https://github.com/LedgerHQ/ledger-live/actions/runs/17373539621/job/49316798557 - 50s
Build & Test Mobile / Android Detox > Allure Report https://github.com/LedgerHQ/ledger-live/actions/runs/17373539621/job/49316758949 - 53s

to:
iOS build JS: https://github.com/LedgerHQ/ledger-live/actions/runs/17373514130/job/49314603160 - 7m 24s
Android build JS: https://github.com/LedgerHQ/ledger-live/actions/runs/17373514130/job/49314603197 - 7m 11s
Build & Test Mobile / iOS Detox > Allure Report https://github.com/LedgerHQ/ledger-live/actions/runs/17374653793/job/49320004196 - 27s
Build & Test Mobile / Android Detox > Allure Report https://github.com/LedgerHQ/ledger-live/actions/runs/17374653793/job/49319637540 - 32s

Critical path: -19s
