### PR TITLE
fix: update ethers to v6.15.0

### DIFF
--- a/.changeset/chatty-houses-ring.md
+++ b/.changeset/chatty-houses-ring.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-tester-evm": minor
+"@ledgerhq/coin-filecoin": minor
+"@ledgerhq/coin-evm": minor
+---
+
+Update ethers library to v6.15.0

--- a/libs/coin-modules/coin-evm/docs/adapters.md
+++ b/libs/coin-modules/coin-evm/docs/adapters.md
@@ -4,7 +4,7 @@ Set of functions in charge of converting a transaction format specific to a libr
 ## Files
 
 #### ethers.ts
-Functions used to convert transactions for the [ethers.js v5 library](https://docs.ethers.org/v5/)
+Functions used to convert transactions for the [ethers.js v6 library](https://docs.ethers.org/v6/)
 
 #### etherscan.ts
 Functions used to convert transactions coming from the [etherscan-like explorers](https://docs.etherscan.io/api-endpoints/accounts)

--- a/libs/coin-modules/coin-evm/package.json
+++ b/libs/coin-modules/coin-evm/package.json
@@ -74,7 +74,7 @@
     "axios": "1.11.0",
     "bignumber.js": "^9.1.2",
     "eip55": "^2.1.1",
-    "ethers": "5.7.2",
+    "ethers": "6.15.0",
     "expect": "^27.4.6",
     "imurmurhash": "^0.1.4",
     "invariant": "^2.2.2",

--- a/libs/coin-modules/coin-evm/src/__tests__/fixtures/prepareTransaction.fixtures.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/fixtures/prepareTransaction.fixtures.ts
@@ -62,14 +62,14 @@ export const expectedData = (
   switch (type) {
     case "erc20":
       return Buffer.from(
-        new ethers.utils.Interface(ERC20ABI)
+        new ethers.Interface(ERC20ABI)
           .encodeFunctionData("transfer", [transaction.recipient, transaction.amount.toFixed()])
           .slice(2),
         "hex",
       );
     case "erc721":
       return Buffer.from(
-        new ethers.utils.Interface(ERC721ABI)
+        new ethers.Interface(ERC721ABI)
           .encodeFunctionData("safeTransferFrom(address,address,uint256,bytes)", [
             account.freshAddress,
             transaction.recipient,
@@ -81,7 +81,7 @@ export const expectedData = (
       );
     case "erc1155":
       return Buffer.from(
-        new ethers.utils.Interface(ERC1155ABI)
+        new ethers.Interface(ERC1155ABI)
           .encodeFunctionData("safeTransferFrom(address,address,uint256,uint256,bytes)", [
             account.freshAddress,
             transaction.recipient,

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/ethers.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/adapters/ethers.unit.test.ts
@@ -42,31 +42,31 @@ describe("EVM Family", () => {
     describe("ethers", () => {
       describe("transactionToEthersTransaction", () => {
         it("should build convert an EIP1559 ledger live transaction to an ethers transaction", () => {
-          const ethers1559Tx: ethers.Transaction = {
+          const ethers1559Tx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(21000),
+            gasLimit: 21000n,
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: 100n,
+            chainId: 1n,
             type: 2,
-            maxFeePerGas: ethers.BigNumber.from(10000),
-            maxPriorityFeePerGas: ethers.BigNumber.from(10000),
+            maxFeePerGas: 10000n,
+            maxPriorityFeePerGas: 10000n,
           };
 
           expect(transactionToEthersTransaction(eip1559Tx)).toEqual(ethers1559Tx);
         });
 
         it("should build convert an legacy ledger live transaction to an ethers transaction", () => {
-          const legacyEthersTx: ethers.Transaction = {
+          const legacyEthersTx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(21000),
+            gasLimit: 21000n,
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: 100n,
+            chainId: 1n,
             type: 0,
-            gasPrice: ethers.BigNumber.from(10000),
+            gasPrice: 10000n,
           };
 
           expect(transactionToEthersTransaction(legacyTx)).toEqual(legacyEthersTx);
@@ -78,16 +78,16 @@ describe("EVM Family", () => {
             maxFeePerGas: new BigNumber("29625091714.5"),
           };
 
-          const ethers1559Tx: ethers.Transaction = {
+          const ethers1559Tx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(21000),
+            gasLimit: 21000n,
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: 100n,
+            chainId: 1n,
             type: 2,
-            maxFeePerGas: ethers.BigNumber.from("29625091715"),
-            maxPriorityFeePerGas: ethers.BigNumber.from(10000),
+            maxFeePerGas: 29625091715n,
+            maxPriorityFeePerGas: 10000n,
           };
 
           expect(transactionToEthersTransaction(txWithFloatingPoint)).toEqual(ethers1559Tx);
@@ -110,15 +110,15 @@ describe("EVM Family", () => {
             type: 0,
           };
 
-          const ethersTxWithUnrealisticNonce: ethers.Transaction = {
+          const ethersTxWithUnrealisticNonce: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: Number.MAX_SAFE_INTEGER - 1,
-            gasLimit: ethers.BigNumber.from(21000),
+            gasLimit: 21000n,
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: 100n,
+            chainId: 1n,
             type: 0,
-            gasPrice: ethers.BigNumber.from(10000),
+            gasPrice: 10000n,
           };
 
           expect(transactionToEthersTransaction(createdTransactionWithDefaultNonce)).toEqual(

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/broadcast.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/broadcast.unit.test.ts
@@ -33,8 +33,8 @@ const mockGetConfig = jest.mocked(getCoinConfig);
 jest.mock("ethers");
 const mockEthers = jest.mocked(ethers);
 jest
-  .spyOn(mockEthers.providers.StaticJsonRpcProvider.prototype, "sendTransaction")
-  .mockResolvedValue(Promise.resolve({ hash: "0xH4sH" }));
+  .spyOn(mockEthers.JsonRpcProvider.prototype as any, "broadcastTransaction")
+  .mockResolvedValue({ hash: "0xH4sH" } as any);
 
 jest.mock("axios");
 const mockAxios = jest.mocked(axios);
@@ -180,7 +180,7 @@ describe("EVM Family", () => {
             },
           }));
 
-          const providerSpy = jest.spyOn(mockEthers.providers, "StaticJsonRpcProvider");
+          const providerSpy = jest.spyOn(mockEthers, "JsonRpcProvider");
 
           // MEV OFF
           await broadcast({
@@ -195,7 +195,7 @@ describe("EVM Family", () => {
           });
 
           expect(providerSpy).toHaveBeenCalledTimes(1);
-          expect(providerSpy).toHaveBeenNthCalledWith(1, "https://my-rpc.com");
+          expect(providerSpy).toHaveBeenNthCalledWith(1, "https://my-rpc.com", 1);
         });
       });
 

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/hw-signMessage.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/hw-signMessage.unit.test.ts
@@ -7,19 +7,19 @@ import { makeAccount } from "../fixtures/common.fixtures";
 const signPersonalMessage = jest.fn(() =>
   concat(
     of({ type: "signer.evm.signing" }),
-    of({ type: "signer.evm.signed", value: { r: "01", s: "02", v: 3 } }),
+    of({ type: "signer.evm.signed", value: { r: "01", s: "02", v: 27 } }),
   ),
 );
 const signEIP712Message = jest.fn(() =>
   concat(
     of({ type: "signer.evm.signing" }),
-    of({ type: "signer.evm.signed", value: { r: "03", s: "04", v: 6 } }),
+    of({ type: "signer.evm.signed", value: { r: "03", s: "04", v: 28 } }),
   ),
 );
 const signEIP712HashedMessage = jest.fn(() =>
   concat(
     of({ type: "signer.evm.signing" }),
-    of({ type: "signer.evm.signed", value: { r: "07", s: "08", v: 9 } }),
+    of({ type: "signer.evm.signed", value: { r: "07", s: "08", v: 27 } }),
   ),
 );
 
@@ -103,7 +103,7 @@ describe("EVM Family", () => {
           rsv: {
             r: "01",
             s: "02",
-            v: 3,
+            v: 27,
           },
           signature:
             "0x000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000021b",
@@ -122,7 +122,7 @@ describe("EVM Family", () => {
           rsv: {
             r: "03",
             s: "04",
-            v: 6,
+            v: 28,
           },
           signature:
             "0x000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000041c",
@@ -149,7 +149,7 @@ describe("EVM Family", () => {
           rsv: {
             r: "07",
             s: "08",
-            v: 9,
+            v: 27,
           },
           signature:
             "0x000000000000000000000000000000000000000000000000000000000000000700000000000000000000000000000000000000000000000000000000000000081b",

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/prepareTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/prepareTransaction.unit.test.ts
@@ -262,13 +262,13 @@ describe("EVM Family", () => {
           const opAccount = makeAccount("0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d", optimism);
           const opTransaction = {
             ...createTransaction(opAccount),
-            recipient: ethers.constants.AddressZero,
+            recipient: ethers.ZeroAddress,
           };
 
           jest.spyOn(ethers, "Contract").mockImplementationOnce(() => {
             return {
-              getL1Fee: (): ethers.BigNumber => {
-                return ethers.BigNumber.from(1234);
+              getL1Fee: (): BigNumber => {
+                return BigNumber(1234);
               },
             } as any;
           });
@@ -294,14 +294,14 @@ describe("EVM Family", () => {
 
           const opTransaction = {
             ...createTransaction(opAccount),
-            recipient: ethers.constants.AddressZero,
+            recipient: ethers.ZeroAddress,
             additionalFees: new BigNumber(4567),
           };
 
           jest.spyOn(ethers, "Contract").mockImplementationOnce(() => {
             return {
-              getL1Fee: (): ethers.BigNumber => {
-                return ethers.BigNumber.from(1234);
+              getL1Fee: (): BigNumber => {
+                return BigNumber(1234);
               },
             } as any;
           });
@@ -503,8 +503,8 @@ describe("EVM Family", () => {
 
           jest.spyOn(ethers, "Contract").mockImplementationOnce(() => {
             return {
-              getL1Fee: (): ethers.BigNumber => {
-                return ethers.BigNumber.from(1234);
+              getL1Fee: (): BigNumber => {
+                return BigNumber(1234);
               },
             } as any;
           });
@@ -524,7 +524,7 @@ describe("EVM Family", () => {
 
           const opTokenTransaction = {
             ...createTransaction(opAccount),
-            recipient: ethers.constants.AddressZero,
+            recipient: ethers.ZeroAddress,
             additionalFees: new BigNumber(4567),
             amount: new BigNumber(50),
             subAccountId: tokenAccountWithBalance.id,
@@ -700,8 +700,8 @@ describe("EVM Family", () => {
         it("should keep the original transaction `additionalFees` as an addition to the 'on-chain' additionalFees", async () => {
           jest.spyOn(ethers, "Contract").mockImplementationOnce(() => {
             return {
-              getL1Fee: (): ethers.BigNumber => {
-                return ethers.BigNumber.from(1234);
+              getL1Fee: (): BigNumber => {
+                return BigNumber(1234);
               },
             } as any;
           });
@@ -712,7 +712,7 @@ describe("EVM Family", () => {
           const opNftTransaction: EvmTransaction & EvmNftTransaction = {
             ...createTransaction(opAccount),
             mode: "erc721",
-            recipient: ethers.constants.AddressZero,
+            recipient: ethers.ZeroAddress,
             additionalFees: new BigNumber(4567),
             amount: new BigNumber(0),
             nft: {

--- a/libs/coin-modules/coin-evm/src/__tests__/unit/transaction.unit.test.ts
+++ b/libs/coin-modules/coin-evm/src/__tests__/unit/transaction.unit.test.ts
@@ -265,31 +265,31 @@ describe("EVM Family", () => {
     describe("transactionToEthersTransaction", () => {
       describe("without customGasLimit", () => {
         it("should build convert an EIP1559 ledger live transaction to an ethers transaction", () => {
-          const ethers1559Tx: ethers.Transaction = {
+          const ethers1559Tx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(21000),
+            gasLimit: BigInt(21000),
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: BigInt(100),
+            chainId: BigInt(1),
             type: 2,
-            maxFeePerGas: ethers.BigNumber.from(10000),
-            maxPriorityFeePerGas: ethers.BigNumber.from(10000),
+            maxFeePerGas: BigInt(10000),
+            maxPriorityFeePerGas: BigInt(10000),
           };
 
           expect(transactionToEthersTransaction(eip1559Tx)).toEqual(ethers1559Tx);
         });
 
         it("should build convert an legacy ledger live transaction to an ethers transaction", () => {
-          const legacyEthersTx: ethers.Transaction = {
+          const legacyEthersTx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(21000),
+            gasLimit: BigInt(21000),
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: BigInt(100),
+            chainId: BigInt(1),
             type: 0,
-            gasPrice: ethers.BigNumber.from(10000),
+            gasPrice: BigInt(10000),
           };
 
           expect(transactionToEthersTransaction(legacyTx)).toEqual(legacyEthersTx);
@@ -298,16 +298,16 @@ describe("EVM Family", () => {
 
       describe("with customGasLimit", () => {
         it("should build convert an EIP1559 ledger live transaction to an ethers transaction", () => {
-          const ethers1559Tx: ethers.Transaction = {
+          const ethers1559Tx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(22000),
+            gasLimit: BigInt(22000),
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: BigInt(100),
+            chainId: BigInt(1),
             type: 2,
-            maxFeePerGas: ethers.BigNumber.from(10000),
-            maxPriorityFeePerGas: ethers.BigNumber.from(10000),
+            maxFeePerGas: BigInt(10000),
+            maxPriorityFeePerGas: BigInt(10000),
           };
 
           expect(
@@ -316,15 +316,15 @@ describe("EVM Family", () => {
         });
 
         it("should build convert an legacy ledger live transaction to an ethers transaction", () => {
-          const legacyEthersTx: ethers.Transaction = {
+          const legacyEthersTx: ethers.TransactionLike = {
             to: "0xkvn",
             nonce: 0,
-            gasLimit: ethers.BigNumber.from(22000),
+            gasLimit: BigInt(22000),
             data: "0x" + testData,
-            value: ethers.BigNumber.from(100),
-            chainId: 1,
+            value: BigInt(100),
+            chainId: BigInt(1),
             type: 0,
-            gasPrice: ethers.BigNumber.from(10000),
+            gasPrice: BigInt(10000),
           };
 
           expect(

--- a/libs/coin-modules/coin-evm/src/adapters/ethers.ts
+++ b/libs/coin-modules/coin-evm/src/adapters/ethers.ts
@@ -16,25 +16,24 @@ export const transactionToEthersTransaction = (tx: EvmTransaction): ethers.Trans
 
   const ethersTx = {
     to: tx.recipient,
-    value: ethers.BigNumber.from(tx.amount.toFixed(0)),
+    value: BigInt(tx.amount.toFixed(0)),
     data: tx.data ? `0x${tx.data.toString("hex")}` : undefined,
-    gasLimit: ethers.BigNumber.from(gasLimit.toFixed(0)),
+    gasLimit: BigInt(gasLimit.toFixed(0)),
     // When using DEFAULT_NONCE (-1) ethers might break on some methods,
     // therefore we replace this by an unrealisticly high nonce
     // to prevent any valid signature being crafted here
     nonce: tx.nonce === DEFAULT_NONCE ? Number.MAX_SAFE_INTEGER - 1 : tx.nonce,
-    chainId: tx.chainId,
+    chainId: BigInt(tx.chainId),
     type: tx.type,
   } as Partial<ethers.Transaction>;
 
   // is EIP-1559 transaction (type 2)
   if (tx.type === 2) {
-    ethersTx.maxFeePerGas = ethers.BigNumber.from(tx.maxFeePerGas.toFixed(0));
-    ethersTx.maxPriorityFeePerGas = ethers.BigNumber.from(tx.maxPriorityFeePerGas.toFixed(0));
+    ethersTx.maxFeePerGas = BigInt(tx.maxFeePerGas.toFixed(0));
+    ethersTx.maxPriorityFeePerGas = BigInt(tx.maxPriorityFeePerGas.toFixed(0));
   } else {
     // is Legacy transaction (type 0)
-    ethersTx.gasPrice = ethers.BigNumber.from(tx.gasPrice.toFixed(0));
+    ethersTx.gasPrice = BigInt(tx.gasPrice.toFixed(0));
   }
-
   return ethersTx as ethers.Transaction;
 };

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -1,5 +1,5 @@
 import { Api, FeeEstimation } from "@ledgerhq/coin-framework/api/types";
-import { ethers, BigNumber } from "ethers";
+import { ethers } from "ethers";
 import * as legacy from "@ledgerhq/cryptoassets/tokens";
 import { EvmConfig } from "../config";
 import { setCryptoAssetsStoreGetter } from "../cryptoAssetsStore";
@@ -60,24 +60,20 @@ describe.each([
     [
       "legacy",
       (transaction: ethers.Transaction): void => {
-        expect(transaction).toMatchObject({
-          type: null,
-          gasPrice: expect.any(ethers.BigNumber),
-        });
-        expect(transaction.gasPrice?.toBigInt()).toBeGreaterThan(0);
+        expect(transaction.type).toBe(0);
+        expect(typeof transaction.gasPrice).toBe("bigint");
+        expect(transaction.gasPrice).toBeGreaterThan(0);
       },
     ],
     [
       "eip1559",
       (transaction: ethers.Transaction): void => {
-        expect(transaction).toMatchObject({
-          type: 2,
-          gasPrice: null,
-          maxFeePerGas: expect.any(ethers.BigNumber),
-          maxPriorityFeePerGas: expect.any(ethers.BigNumber),
-        });
-        expect(transaction.maxFeePerGas?.toBigInt()).toBeGreaterThan(0);
-        expect(transaction.maxPriorityFeePerGas?.toBigInt()).toBeGreaterThan(0);
+        expect(transaction.type).toBe(2);
+        expect(transaction.gasPrice).toBeNull();
+        expect(typeof transaction.maxFeePerGas).toBe("bigint");
+        expect(typeof transaction.maxPriorityFeePerGas).toBe("bigint");
+        expect(transaction.maxFeePerGas).toBeGreaterThan(0n);
+        expect(transaction.maxPriorityFeePerGas).toBeGreaterThan(0n);
       },
     ],
   ])("craftTransaction", (mode, expectTransactionForMode) => {
@@ -93,11 +89,11 @@ describe.each([
       });
 
       expect(result).toMatch(/^0x[A-Fa-f0-9]+$/);
-      expect(ethers.utils.parseTransaction(result)).toMatchObject({
-        value: BigNumber.from(10),
+      expect(ethers.Transaction.from(result)).toMatchObject({
+        value: 10n,
         to: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
       });
-      expectTransactionForMode(ethers.utils.parseTransaction(result));
+      expectTransactionForMode(ethers.Transaction.from(result));
     });
 
     it("crafts a transaction with the USDC asset", async () => {
@@ -113,11 +109,11 @@ describe.each([
       });
 
       expect(result).toMatch(/^0x[A-Fa-f0-9]+$/);
-      expect(ethers.utils.parseTransaction(result)).toMatchObject({
-        value: BigNumber.from(0),
+      expect(ethers.Transaction.from(result)).toMatchObject({
+        value: 0n,
         to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
       });
-      expectTransactionForMode(ethers.utils.parseTransaction(result));
+      expectTransactionForMode(ethers.Transaction.from(result));
     });
   });
 

--- a/libs/coin-modules/coin-evm/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-evm/src/bridge/getTransactionStatus.ts
@@ -71,7 +71,7 @@ export const validateRecipient = (
     } else {
       // Check if address is respecting EIP-55
       try {
-        const recipientChecksumed = ethers.utils.getAddress(tx.recipient);
+        const recipientChecksumed = ethers.getAddress(tx.recipient);
         if (tx.recipient !== recipientChecksumed) {
           // this case can happen if the user is entering an ICAP address.
           throw new Error();

--- a/libs/coin-modules/coin-evm/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-evm/src/bridge/signOperation.ts
@@ -67,7 +67,7 @@ export const buildSignOperation =
                         const signature = getSerializedTransaction(preparedTransaction, {
                           r: "0x" + sig.r,
                           s: "0x" + sig.s,
-                          v: typeof sig.v === "number" ? sig.v : parseInt(sig.v, 16),
+                          v: (typeof sig.v === "number" ? sig.v : parseInt(sig.v, 16)) as 27 | 28,
                         });
 
                         const operation = buildOptimisticOperation(account, {

--- a/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
+++ b/libs/coin-modules/coin-evm/src/deviceTransactionConfig.ts
@@ -20,6 +20,7 @@ const inferDeviceTransactionConfigWalletApi = (
   mainAccount: Account,
 ): Array<DeviceTransactionField> => {
   if (!transaction.data) throw new Error();
+  const abiCoder = ethers.AbiCoder.defaultAbiCoder();
   const fields: Array<DeviceTransactionField> = [];
 
   const hasValidDomain = validateDomain(transaction.recipientDomain?.domain);
@@ -36,10 +37,10 @@ const inferDeviceTransactionConfigWalletApi = (
   if (token && Object.values<string>(ERC20_CLEAR_SIGNED_SELECTORS).includes(selector)) {
     switch (selector) {
       case ERC20_CLEAR_SIGNED_SELECTORS.TRANSFER: {
-        const [recipient, value] = ethers.utils.defaultAbiCoder.decode(
+        const [recipient, value] = abiCoder.decode(
           ["address", "uint256"],
           argumentsBuffer,
-        ) as [string, ethers.BigNumber];
+        ) as unknown as [string, bigint];
 
         fields.push(
           {
@@ -65,10 +66,10 @@ const inferDeviceTransactionConfigWalletApi = (
         return fields;
       }
       case ERC20_CLEAR_SIGNED_SELECTORS.APPROVE: {
-        const [spender, value] = ethers.utils.defaultAbiCoder.decode(
+        const [spender, value] = abiCoder.decode(
           ["address", "uint256"],
           argumentsBuffer,
-        ) as [string, ethers.BigNumber];
+        ) as unknown as [string, bigint];
 
         const valueAsBN = new BigNumber(value.toString());
         fields.push(
@@ -121,10 +122,10 @@ const inferDeviceTransactionConfigWalletApi = (
       case ERC721_CLEAR_SIGNED_SELECTORS.SAFE_TRANSFER_FROM:
       case ERC721_CLEAR_SIGNED_SELECTORS.SAFE_TRANSFER_FROM_WITH_DATA:
       case ERC721_CLEAR_SIGNED_SELECTORS.TRANSFER_FROM: {
-        const [, recipient, tokenId] = ethers.utils.defaultAbiCoder.decode(
+        const [, recipient, tokenId] = abiCoder.decode(
           ERC721_METHODS_ARGUMENTS[selector],
           argumentsBuffer,
-        ) as [unknown, string, ethers.BigNumber];
+        ) as unknown as [unknown, string, bigint];
 
         fields.push(
           {
@@ -157,10 +158,10 @@ const inferDeviceTransactionConfigWalletApi = (
       }
 
       case ERC721_CLEAR_SIGNED_SELECTORS.APPROVE: {
-        const [spender, tokenId] = ethers.utils.defaultAbiCoder.decode(
+        const [spender, tokenId] = abiCoder.decode(
           ERC721_METHODS_ARGUMENTS[selector],
           argumentsBuffer,
-        ) as [string, ethers.BigNumber];
+        ) as unknown as [string, bigint];
 
         fields.push(
           {
@@ -193,10 +194,10 @@ const inferDeviceTransactionConfigWalletApi = (
       }
 
       case ERC721_CLEAR_SIGNED_SELECTORS.SET_APPROVAL_FOR_ALL: {
-        const [spender, canManageAll] = ethers.utils.defaultAbiCoder.decode(
+        const [spender, canManageAll] = abiCoder.decode(
           ERC721_METHODS_ARGUMENTS[selector],
           argumentsBuffer,
-        ) as [string, boolean];
+        ) as unknown as [string, boolean];
 
         fields.push(
           {
@@ -247,10 +248,10 @@ const inferDeviceTransactionConfigWalletApi = (
 
     switch (selector) {
       case ERC1155_CLEAR_SIGNED_SELECTORS.SAFE_TRANSFER_FROM: {
-        const [, recipient, tokenId, quantity] = ethers.utils.defaultAbiCoder.decode(
+        const [, recipient, tokenId, quantity] = abiCoder.decode(
           ERC1155_METHODS_ARGUMENTS[selector],
           argumentsBuffer,
-        ) as [unknown, string, ethers.BigNumber, ethers.BigNumber];
+        ) as unknown as [unknown, string, bigint, bigint];
 
         fields.push(
           {
@@ -288,10 +289,10 @@ const inferDeviceTransactionConfigWalletApi = (
       }
 
       case ERC1155_CLEAR_SIGNED_SELECTORS.SAFE_BATCH_TRANSFER_FROM: {
-        const [, recipient, tokenIds, quantities] = ethers.utils.defaultAbiCoder.decode(
+        const [, recipient, tokenIds, quantities] = abiCoder.decode(
           ERC1155_METHODS_ARGUMENTS[selector],
           argumentsBuffer,
-        ) as [unknown, string, ethers.BigNumber[], ethers.BigNumber[]];
+        ) as unknown as [unknown, string, bigint[], bigint[]];
 
         const totalQuantity = quantities.reduce(
           (acc, curr) => acc.plus(curr.toString()),
@@ -329,10 +330,10 @@ const inferDeviceTransactionConfigWalletApi = (
       }
 
       case ERC1155_CLEAR_SIGNED_SELECTORS.SET_APPROVAL_FOR_ALL: {
-        const [spender, canManageAll] = ethers.utils.defaultAbiCoder.decode(
+        const [spender, canManageAll] = abiCoder.decode(
           ERC1155_METHODS_ARGUMENTS[selector],
           argumentsBuffer,
-        ) as [string, boolean];
+        ) as unknown as [string, boolean];
 
         fields.push(
           {

--- a/libs/coin-modules/coin-evm/src/hw-signMessage.ts
+++ b/libs/coin-modules/coin-evm/src/hw-signMessage.ts
@@ -17,12 +17,11 @@ export const prepareMessageToSign = ({ message }: { message: string }): TypedEvm
     // With the ethers lib, EIP712Domain type should be removed otherwise
     // you'll end up with a "ambiguous primary types" error
     const { EIP712Domain, ...otherTypes } = parsedMessage.types;
-
     return {
       standard: "EIP712",
       message: parsedMessage,
-      domainHash: ethers.utils._TypedDataEncoder.hashDomain(parsedMessage.domain),
-      hashStruct: ethers.utils._TypedDataEncoder.hashStruct(
+      domainHash: ethers.TypedDataEncoder.hashDomain(parsedMessage.domain),
+      hashStruct: ethers.TypedDataEncoder.hashStruct(
         parsedMessage.primaryType,
         otherTypes,
         parsedMessage.message,
@@ -65,11 +64,11 @@ export const signMessage =
         });
       });
 
-      const signature = ethers.utils.joinSignature({
+      const signature = ethers.Signature.from({
         r: `0x${r}`,
         s: `0x${s}`,
         v: typeof v === "string" ? parseInt(v, 16) : v,
-      });
+      }).serialized;
 
       return { rsv: { r, s, v }, signature };
     }
@@ -113,11 +112,11 @@ export const signMessage =
       }
     });
 
-    const signature = ethers.utils.joinSignature({
+    const signature = ethers.Signature.from({
       r: `0x${r}`,
       s: `0x${s}`,
       v: typeof v === "string" ? parseInt(v, 16) : v,
-    });
+    }).serialized;
 
     return { rsv: { r, s, v }, signature };
   };

--- a/libs/coin-modules/coin-evm/src/logic/combine.ts
+++ b/libs/coin-modules/coin-evm/src/logic/combine.ts
@@ -1,4 +1,4 @@
-import { Signature, Transaction, utils } from "ethers";
+import { Signature, Transaction } from "ethers";
 
 /**
  * Combines a serialized (hex string) Ethereum transaction and a signature to generate a signed transaction.
@@ -7,8 +7,26 @@ import { Signature, Transaction, utils } from "ethers";
  * @returns Signed transaction as a hexadecimal string
  */
 export function combine(tx: string | Transaction, signature: string | Signature): string {
-  const { r, s, v, ...unsignedTx } = typeof tx === "string" ? utils.parseTransaction(tx) : tx;
-  const sig = typeof signature === "string" ? utils.splitSignature(signature) : signature;
+  const txObj = typeof tx === "string" ? Transaction.from(tx) : tx;
+  const sig = typeof signature === "string" ? Signature.from(signature) : signature;
 
-  return utils.serializeTransaction(unsignedTx, sig);
+  // Extract only raw fields manually to avoid class instance issues
+  const unsignedTx = {
+    type: txObj.type,
+    to: txObj.to ?? undefined,
+    nonce: txObj.nonce,
+    gasLimit: txObj.gasLimit,
+    gasPrice: txObj.gasPrice,
+    maxPriorityFeePerGas: txObj.maxPriorityFeePerGas ?? undefined,
+    maxFeePerGas: txObj.maxFeePerGas ?? undefined,
+    data: txObj.data,
+    value: txObj.value,
+    chainId: txObj.chainId,
+    accessList: txObj.accessList ?? undefined,
+  } as Partial<Transaction>;
+
+  return Transaction.from({
+    ...unsignedTx,
+    signature: sig,
+  }).serialized;
 }

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -1,8 +1,7 @@
 import { ethers } from "ethers";
-import { TransactionTypes } from "ethers/lib/utils";
 import { FeeEstimation } from "@ledgerhq/coin-framework/api/types";
 import ERC20ABI from "../abis/erc20.abi.json";
-import { ApiFeeData, ApiGasOptions } from "../types";
+import { ApiFeeData, ApiGasOptions, TransactionTypes } from "../types";
 
 export function isApiGasOptions(options: unknown): options is ApiGasOptions {
   if (!options || typeof options !== "object") return false;
@@ -65,7 +64,7 @@ export function getTransactionType(intentType: string): TransactionTypes {
 }
 
 export function getErc20Data(recipient: string, amount: bigint): Buffer {
-  const contract = new ethers.utils.Interface(ERC20ABI);
+  const contract = new ethers.Interface(ERC20ABI);
   const data = contract.encodeFunctionData("transfer", [recipient, amount]);
   return Buffer.from(data.slice(2), "hex");
 }

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.test.ts
@@ -35,13 +35,13 @@ describe("craftTransaction", () => {
       2,
       {
         gasPrice: null,
-        maxFeePerGas: new BigNumber(4),
-        maxPriorityFeePerGas: new BigNumber(7),
+        maxFeePerGas: new BigNumber(7),
+        maxPriorityFeePerGas: new BigNumber(4),
         nextBaseFee: null,
       },
       {
-        maxFeePerGas: 4,
-        maxPriorityFeePerGas: 7,
+        maxFeePerGas: 7,
+        maxPriorityFeePerGas: 4,
       },
     ],
   ])("%s transaction type", (transactionType, transactionTypeNumber, feeData, expectedFee) => {
@@ -70,16 +70,16 @@ describe("craftTransaction", () => {
           },
         }),
       ).toEqual(
-        ethers.utils.serializeTransaction({
+        ethers.Transaction.from({
           type: transactionTypeNumber,
           to: "0x7b2c7232f9e38f30e2868f0e5bf311cd83554b5a",
           nonce: 18,
           gasLimit: 2300,
-          data: Buffer.from([]),
+          data: "0x",
           value: 10,
           chainId: 42,
           ...expectedFee,
-        }),
+        }).unsignedSerialized,
       );
     });
 
@@ -108,20 +108,25 @@ describe("craftTransaction", () => {
           },
         }),
       ).toEqual(
-        ethers.utils.serializeTransaction({
+        ethers.Transaction.from({
           type: transactionTypeNumber,
           to: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
           nonce: 18,
           gasLimit: 2300,
-          data: Buffer.concat([
-            Buffer.from("a9059cbb000000000000000000000000", "hex"), // transfer selector
-            Buffer.from("7b2c7232f9e38f30e2868f0e5bf311cd83554b5a", "hex"), // recipient
-            Buffer.from("000000000000000000000000000000000000000000000000000000000000000a", "hex"), // amount
-          ]),
+          data:
+            "0x" +
+            Buffer.concat([
+              Buffer.from("a9059cbb000000000000000000000000", "hex"), // transfer selector
+              Buffer.from("7b2c7232f9e38f30e2868f0e5bf311cd83554b5a", "hex"), // recipient
+              Buffer.from(
+                "000000000000000000000000000000000000000000000000000000000000000a",
+                "hex",
+              ), // amount
+            ]).toString("hex"),
           value: 0,
           chainId: 42,
           ...expectedFee,
-        }),
+        }).unsignedSerialized,
       );
     });
   });

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
@@ -1,9 +1,8 @@
 import { FeeEstimation, TransactionIntent } from "@ledgerhq/coin-framework/api/types";
-import { ethers } from "ethers";
+import { Transaction, TransactionLike } from "ethers";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import BigNumber from "bignumber.js";
-import { TransactionTypes } from "ethers/lib/utils";
-import { isNative } from "../types";
+import { isNative, TransactionTypes } from "../types";
 import { getNodeApi } from "../network/node";
 import { getErc20Data, getTransactionType } from "./common";
 import { getSequence } from "./getSequence";
@@ -33,20 +32,18 @@ export async function craftTransaction(
   );
   const fee = await node.getFeeData(currency, { type: transactionType });
 
-  const unsignedTransaction: ethers.utils.UnsignedTransaction = {
+  const unsignedTransaction: TransactionLike = {
     type: transactionType,
     to,
     nonce,
-    gasLimit: ethers.BigNumber.from(gasLimit.toFixed(0)),
-    data,
+    gasLimit: BigInt(gasLimit.toFixed(0)),
+    data: "0x" + data.toString("hex"),
     value,
     chainId,
-    ...(fee.gasPrice ? { gasPrice: ethers.BigNumber.from(fee.gasPrice.toFixed(0)) } : {}),
-    ...(fee.maxFeePerGas
-      ? { maxFeePerGas: ethers.BigNumber.from(fee.maxFeePerGas.toFixed(0)) }
-      : {}),
+    ...(fee.gasPrice ? { gasPrice: BigInt(fee.gasPrice.toFixed(0)) } : {}),
+    ...(fee.maxFeePerGas ? { maxFeePerGas: BigInt(fee.maxFeePerGas.toFixed(0)) } : {}),
     ...(fee.maxPriorityFeePerGas
-      ? { maxPriorityFeePerGas: ethers.BigNumber.from(fee.maxPriorityFeePerGas.toFixed(0)) }
+      ? { maxPriorityFeePerGas: BigInt(fee.maxPriorityFeePerGas.toFixed(0)) }
       : {}),
   };
 
@@ -66,5 +63,5 @@ export async function craftTransaction(
     unsignedTransaction.maxPriorityFeePerGas = customFees.parameters.maxPriorityFeePerGas;
   }
 
-  return ethers.utils.serializeTransaction(unsignedTransaction);
+  return Transaction.from(unsignedTransaction).unsignedSerialized;
 }

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
@@ -5,9 +5,15 @@ import type {
   MemoNotSupported,
   TransactionIntent,
 } from "@ledgerhq/coin-framework/api/index";
-import { TransactionTypes } from "ethers/lib/utils";
 import { getNodeApi } from "../network/node";
-import { ApiFeeData, ApiGasOptions, FeeData, GasOptions, isNative } from "../types";
+import {
+  ApiFeeData,
+  ApiGasOptions,
+  FeeData,
+  GasOptions,
+  isNative,
+  TransactionTypes,
+} from "../types";
 import { getGasTracker } from "../network/gasTracker";
 import { getErc20Data, getTransactionType } from "./common";
 

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -22,10 +22,9 @@ import {
   RecipientRequired,
 } from "@ledgerhq/errors";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { TransactionTypes } from "ethers/lib/utils";
 import { formatCurrencyUnit } from "@ledgerhq/coin-framework/currencies/formatCurrencyUnit";
 import { getFeesUnit } from "@ledgerhq/coin-framework/account/helpers";
-import { isNative } from "../types";
+import { isNative, TransactionTypes } from "../types";
 import { DEFAULT_GAS_LIMIT } from "../utils";
 import { getGasTracker } from "../network/gasTracker";
 import estimateFees from "./estimateFees";
@@ -99,7 +98,7 @@ function validateRecipient(
 
   // Check if address is respecting EIP-55
   try {
-    const recipientChecksumed = ethers.utils.getAddress(intent.recipient);
+    const recipientChecksumed = ethers.getAddress(intent.recipient);
     if (intent.recipient !== recipientChecksumed) {
       // this case can happen if the user is entering an ICAP address.
       throw new Error();

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.ts
@@ -361,7 +361,7 @@ export const getOptimismAdditionalFees: NodeApi["getOptimismAdditionalFees"] = a
       return getSerializedTransaction(transaction, {
         r: "0xffffffffffffffffffffffffffffffffffffffff",
         s: "0xffffffffffffffffffffffffffffffffffffffff",
-        v: 0,
+        v: 27,
       });
     } catch (e) {
       return null;
@@ -371,7 +371,7 @@ export const getOptimismAdditionalFees: NodeApi["getOptimismAdditionalFees"] = a
     return new BigNumber(0);
   }
 
-  const optimismGasOracle = new ethers.utils.Interface(OptimismGasPriceOracleAbi);
+  const optimismGasOracle = new ethers.Interface(OptimismGasPriceOracleAbi);
   const data = optimismGasOracle.encodeFunctionData("getL1Fee(bytes)", [serializedTransaction]);
 
   const [result] = await fetchWithRetries<
@@ -427,7 +427,7 @@ export const getScrollAdditionalFees: NodeApi["getScrollAdditionalFees"] = async
       return getSerializedTransaction(transaction, {
         r: "0xffffffffffffffffffffffffffffffffffffffff",
         s: "0xffffffffffffffffffffffffffffffffffffffff",
-        v: 0,
+        v: 27,
       });
     } catch (e) {
       return null;
@@ -437,7 +437,7 @@ export const getScrollAdditionalFees: NodeApi["getScrollAdditionalFees"] = async
     return new BigNumber(0);
   }
 
-  const optimismGasOracle = new ethers.utils.Interface(OptimismGasPriceOracleAbi);
+  const optimismGasOracle = new ethers.Interface(OptimismGasPriceOracleAbi);
   const data = optimismGasOracle.encodeFunctionData("getL1Fee(bytes)", [serializedTransaction]);
 
   const [result] = await fetchWithRetries<

--- a/libs/coin-modules/coin-evm/src/types/transaction.ts
+++ b/libs/coin-modules/coin-evm/src/types/transaction.ts
@@ -181,3 +181,8 @@ type EvmTransactionNftParamRaw = {
   quantity: ProtoNFTRaw["amount"];
   collectionName: string;
 };
+
+export enum TransactionTypes {
+  legacy = 0,
+  eip1559 = 2,
+}

--- a/libs/coin-modules/coin-filecoin/package.json
+++ b/libs/coin-modules/coin-filecoin/package.json
@@ -104,7 +104,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "@zondax/cbor": "v8.1.0-zondax-no-bigint",
     "bignumber.js": "^9.1.2",
-    "ethers": "5.7.2",
+    "ethers": "6.15.0",
     "invariant": "^2.2.2",
     "iso-filecoin": "^4.1.0",
     "lodash": "^4.17.21",

--- a/libs/coin-modules/coin-filecoin/src/erc20/tokenAccounts.ts
+++ b/libs/coin-modules/coin-filecoin/src/erc20/tokenAccounts.ts
@@ -165,7 +165,7 @@ export const encodeTxnParams = (abiEncodedParams: string) => {
 };
 
 export const abiEncodeTransferParams = (recipient: string, amount: string) => {
-  const contract = new ethers.utils.Interface(contractABI);
+  const contract = new ethers.Interface(contractABI);
   const data = contract.encodeFunctionData("transfer", [recipient, amount]);
   return data;
 };

--- a/libs/coin-tester-modules/coin-tester-evm/package.json
+++ b/libs/coin-tester-modules/coin-tester-evm/package.json
@@ -71,7 +71,7 @@
     "bluebird": "^3.7.2",
     "docker-compose": "^1.1.0",
     "dotenv": "^16.4.5",
-    "ethers": "5.7.2",
+    "ethers": "6.15.0",
     "msw": "^2.2.1"
   },
   "devDependencies": {

--- a/libs/coin-tester-modules/coin-tester-evm/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/helpers.ts
@@ -9,9 +9,9 @@ export const sonic = getCryptoCurrencyById("sonic");
 export const polygon = getCryptoCurrencyById("polygon");
 export const scroll = getCryptoCurrencyById("scroll");
 export const blast = getCryptoCurrencyById("blast");
-export const ERC20Interface = new ethers.utils.Interface(ERC20_ABI);
-export const ERC721Interface = new ethers.utils.Interface(ERC721_ABI);
-export const ERC1155Interface = new ethers.utils.Interface(ERC1155_ABI);
+export const ERC20Interface = new ethers.Interface(ERC20_ABI);
+export const ERC721Interface = new ethers.Interface(ERC721_ABI);
+export const ERC1155Interface = new ethers.Interface(ERC1155_ABI);
 export const VITALIK = "0x6bfD74C0996F269Bcece59191EFf667b3dFD73b9";
 
 export const impersonnateAccount = async ({
@@ -20,24 +20,25 @@ export const impersonnateAccount = async ({
   to,
   data,
 }: {
-  provider: ethers.providers.JsonRpcProvider;
+  provider: ethers.JsonRpcProvider;
   addressToImpersonnate: string;
   to: string;
   data: string;
 }) => {
   await provider.send("anvil_setBalance", [
     addressToImpersonnate,
-    ethers.utils.parseEther("10").toHexString(),
+    ethers.toBeHex(ethers.parseEther("10")),
   ]);
   await provider.send("anvil_impersonateAccount", [addressToImpersonnate]);
+  const feeData = await provider.getFeeData();
   const impersonatedAccount = {
     from: addressToImpersonnate,
     to,
     data,
-    value: ethers.BigNumber.from(0).toHexString(),
-    gas: ethers.BigNumber.from(1_000_000).toHexString(),
+    value: ethers.toBeHex(0n),
+    gas: ethers.toBeHex(1_000_000n),
     type: "0x0",
-    gasPrice: (await provider.getGasPrice()).toHexString(),
+    gasPrice: feeData.gasPrice ? ethers.toBeHex(feeData.gasPrice) : "0x0",
     nonce: "0x" + (await provider.getTransactionCount(addressToImpersonnate)).toString(16),
     chainId: "0x" + (await provider.getNetwork()).chainId.toString(16),
   };
@@ -63,10 +64,10 @@ export const callMyDealer = async ({
   junkie,
   dose,
 }: {
-  provider: ethers.providers.JsonRpcProvider;
+  provider: ethers.JsonRpcProvider;
   drug: Drug;
   junkie: string;
-  dose: ethers.BigNumber;
+  dose: bigint;
 }) => {
   const { contractAddress } = drug;
 
@@ -78,8 +79,8 @@ export const callMyDealer = async ({
         : ERC1155Interface.encodeFunctionData("balanceOf", [DEALER, drug.tokenId]);
   const expectedSlotValue =
     drug.type === "Nft" && drug.standard === "ERC721"
-      ? ethers.utils.hexZeroPad(DEALER, 32)
-      : ethers.utils.hexZeroPad(stash, 32);
+      ? ethers.zeroPadValue(DEALER, 32)
+      : ethers.zeroPadValue(stash, 32);
 
   // Get a list of all storage slots accessed when requesting the balance of the dealer
   const { accessList }: { accessList: { address: string; storageKeys: string[] }[] } =
@@ -134,7 +135,7 @@ export const callMyDealer = async ({
     to: contractAddress,
     data:
       drug.type === "TokenCurrency"
-        ? ERC20Interface.encodeFunctionData("transfer", [junkie, dose.toHexString()])
+        ? ERC20Interface.encodeFunctionData("transfer", [junkie, ethers.toBeHex(dose)])
         : drug.standard === "ERC721"
           ? ERC721Interface.encodeFunctionData("safeTransferFrom(address,address,uint256)", [
               DEALER,
@@ -143,7 +144,7 @@ export const callMyDealer = async ({
             ])
           : ERC1155Interface.encodeFunctionData(
               "safeTransferFrom(address,address,uint256,uint256,bytes)",
-              [DEALER, junkie, drug.tokenId, dose.toHexString(), "0x"],
+              [DEALER, junkie, drug.tokenId, ethers.toBeHex(dose), "0x"],
             ),
   });
 };

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/blast.ts
@@ -1,6 +1,6 @@
 import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { BigNumber } from "bignumber.js";
-import { ethers, providers } from "ethers";
+import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
 import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
@@ -40,9 +40,7 @@ const makeScenarioTransactions = ({ address }: { address: string }): BlastScenar
   const MIM_ON_BLAST = getTokenById(TOKEN_ID);
   const scenarioSendMIMTransaction: BlastScenarioTransaction = {
     name: "Send 80 MIM",
-    amount: new BigNumber(
-      ethers.utils.parseUnits("80", MIM_ON_BLAST.units[0].magnitude).toString(),
-    ),
+    amount: new BigNumber(ethers.parseUnits("80", MIM_ON_BLAST.units[0].magnitude).toString()),
     recipient: VITALIK,
     subAccountId: encodeTokenAccountId(`js:2:blast:${address}:`, MIM_ON_BLAST),
     expect: (previousAccount, currentAccount) => {
@@ -52,10 +50,10 @@ const makeScenarioTransactions = ({ address }: { address: string }): BlastScenar
       expect(latestOperation.value.toFixed()).toBe(latestOperation.fee.toFixed());
       expect(latestOperation.subOperations?.[0].type).toBe("OUT");
       expect(latestOperation.subOperations?.[0].value.toFixed()).toBe(
-        ethers.utils.parseUnits("80", MIM_ON_BLAST.units[0].magnitude).toString(),
+        ethers.parseUnits("80", MIM_ON_BLAST.units[0].magnitude).toString(),
       );
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
-        ethers.utils.parseUnits("20", MIM_ON_BLAST.units[0].magnitude).toString(),
+        ethers.parseUnits("20", MIM_ON_BLAST.units[0].magnitude).toString(),
       );
     },
   };
@@ -71,7 +69,7 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
       spawnAnvil("https://rpc.blast.io"),
     ]);
 
-    const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    const provider = new ethers.JsonRpcProvider("http://127.0.0.1:8545");
     const signerContext: Parameters<typeof resolver>[0] = (deviceId, fn) =>
       fn(new LegacySignerEth(transport));
 
@@ -115,7 +113,7 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
       provider,
       drug: MIM_ON_BLAST,
       junkie: address,
-      dose: ethers.utils.parseUnits("100", MIM_ON_BLAST.units[0].magnitude),
+      dose: ethers.parseUnits("100", MIM_ON_BLAST.units[0].magnitude),
     });
 
     return {
@@ -132,17 +130,17 @@ export const scenarioBlast: Scenario<EvmTransaction, Account> = {
   },
   beforeAll: account => {
     const MIM_ON_BLAST = getTokenById(TOKEN_ID);
-    expect(account.balance.toFixed()).toBe(ethers.utils.parseEther("10000").toString());
+    expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0]?.type).toBe("TokenAccount");
     expect(account.subAccounts?.[0]?.balance?.toFixed()).toBe(
-      ethers.utils.parseUnits("100", MIM_ON_BLAST.units[0].magnitude).toString(),
+      ethers.parseUnits("100", MIM_ON_BLAST.units[0].magnitude).toString(),
     );
   },
   afterAll: account => {
     const MIM_ON_BLAST = getTokenById(TOKEN_ID);
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("20", MIM_ON_BLAST.units[0].magnitude).toString(),
+      ethers.parseUnits("20", MIM_ON_BLAST.units[0].magnitude).toString(),
     );
     expect(account.operations.length).toBe(3);
   },

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/ethereum.ts
@@ -5,7 +5,7 @@ import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { Account } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import { ethers, providers } from "ethers";
+import { ethers } from "ethers";
 import { makeAccount } from "@ledgerhq/coin-evm/__tests__/fixtures/common.fixtures";
 import { buildAccountBridge, buildCurrencyBridge } from "@ledgerhq/coin-evm/bridge/js";
 import { getCoinConfig, setCoinConfig } from "@ledgerhq/coin-evm/config";
@@ -52,9 +52,7 @@ const makeScenarioTransactions = ({
 
   const scenarioSendUSDCTransaction: EthereumScenarioTransaction = {
     name: "Send USDC",
-    amount: new BigNumber(
-      ethers.utils.parseUnits("80", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
-    ),
+    amount: new BigNumber(ethers.parseUnits("80", USDC_ON_ETHEREUM.units[0].magnitude).toString()),
     recipient: VITALIK,
     subAccountId: encodeTokenAccountId(`js:2:ethereum:${address}:`, USDC_ON_ETHEREUM),
     expect: (previousAccount, currentAccount) => {
@@ -64,10 +62,10 @@ const makeScenarioTransactions = ({
       expect(latestOperation.value.toFixed()).toBe(latestOperation.fee.toFixed());
       expect(latestOperation.subOperations?.[0].type).toBe("OUT");
       expect(latestOperation.subOperations?.[0].value.toFixed()).toBe(
-        ethers.utils.parseUnits("80", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
+        ethers.parseUnits("80", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
       );
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
-        ethers.utils.parseUnits("20", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
+        ethers.parseUnits("20", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
       );
     },
   };
@@ -209,7 +207,7 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
 
     const scenarioAccount = makeAccount(address, ethereum);
 
-    const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    const provider = new ethers.JsonRpcProvider("http://127.0.0.1:8545");
 
     const lastBlockNumber = await provider.getBlockNumber();
     // start indexing at next block
@@ -220,7 +218,7 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
       provider,
       drug: USDC_ON_ETHEREUM,
       junkie: address,
-      dose: ethers.utils.parseUnits("100", USDC_ON_ETHEREUM.units[0].magnitude),
+      dose: ethers.parseUnits("100", USDC_ON_ETHEREUM.units[0].magnitude),
     });
 
     // Get a Bored Ape
@@ -233,7 +231,7 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
         standard: "ERC721",
       },
       junkie: address,
-      dose: ethers.BigNumber.from(1),
+      dose: 1n,
     });
 
     // Get 2 CloneX
@@ -246,7 +244,7 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
         standard: "ERC1155",
       },
       junkie: address,
-      dose: ethers.BigNumber.from(2),
+      dose: 2n,
     });
 
     return {
@@ -257,10 +255,10 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
     };
   },
   beforeAll: account => {
-    expect(account.balance.toFixed()).toBe(ethers.utils.parseEther("10000").toString());
+    expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0].type).toBe("TokenAccount");
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("100", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
+      ethers.parseUnits("100", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
     );
     expect(account.nfts?.length).toBe(2);
   },
@@ -271,7 +269,7 @@ export const scenarioEthereum: Scenario<EvmTransaction, Account> = {
   afterAll: account => {
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("20", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
+      ethers.parseUnits("20", USDC_ON_ETHEREUM.units[0].magnitude).toString(),
     );
     expect(account.nfts?.length).toBe(0);
     expect(account.operations.length).toBe(7);

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/polygon.ts
@@ -1,6 +1,6 @@
 import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { BigNumber } from "bignumber.js";
-import { ethers, providers } from "ethers";
+import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
 import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
@@ -30,8 +30,8 @@ const platinumTokenId = "4";
 const makeScenarioTransactions = ({ address }: { address: string }) => {
   const send1MaticTransaction: PolygonScenarioTransaction = {
     name: "Send 1 POL",
-    amount: new BigNumber(ethers.utils.parseEther("1").toString()),
-    recipient: ethers.constants.AddressZero,
+    amount: new BigNumber(ethers.parseEther("1").toString()),
+    recipient: ethers.ZeroAddress,
     expect: (previousAccount, currentAccount) => {
       const [latestOperation] = currentAccount.operations;
       expect(currentAccount.operations.length - previousAccount.operations.length).toBe(1);
@@ -51,9 +51,7 @@ const makeScenarioTransactions = ({ address }: { address: string }) => {
   const send80USDCTransaction: PolygonScenarioTransaction = {
     name: "Send 80 USDC",
     recipient: VITALIK,
-    amount: new BigNumber(
-      ethers.utils.parseUnits("80", USDC_ON_POLYGON.units[0].magnitude).toString(),
-    ),
+    amount: new BigNumber(ethers.parseUnits("80", USDC_ON_POLYGON.units[0].magnitude).toString()),
     subAccountId: encodeTokenAccountId(`js:2:polygon:${address}:`, USDC_ON_POLYGON),
     expect: (previousAccount, currentAccount) => {
       const [latestOperation] = currentAccount.operations;
@@ -61,7 +59,7 @@ const makeScenarioTransactions = ({ address }: { address: string }) => {
       expect(latestOperation.type).toBe("FEES");
       expect(latestOperation.subOperations?.[0].type).toBe("OUT");
       expect(latestOperation.subOperations?.[0].value.toFixed()).toBe(
-        ethers.utils.parseUnits("80", USDC_ON_POLYGON.units[0].magnitude).toString(),
+        ethers.parseUnits("80", USDC_ON_POLYGON.units[0].magnitude).toString(),
       );
     },
   };
@@ -130,7 +128,7 @@ export const scenarioPolygon: Scenario<EvmTransaction, Account> = {
       spawnAnvil("https://polygon-bor-rpc.publicnode.com"),
     ]);
 
-    const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    const provider = new ethers.JsonRpcProvider("http://127.0.0.1:8545");
     const signerContext: Parameters<typeof resolver>[0] = (_, fn) =>
       fn(new LegacySignerEth(transport));
 
@@ -208,7 +206,7 @@ export const scenarioPolygon: Scenario<EvmTransaction, Account> = {
       provider,
       drug: USDC_ON_POLYGON,
       junkie: address,
-      dose: ethers.utils.parseUnits("100", USDC_ON_POLYGON.units[0].magnitude),
+      dose: ethers.parseUnits("100", USDC_ON_POLYGON.units[0].magnitude),
     });
 
     // Get 1 yoot
@@ -221,7 +219,7 @@ export const scenarioPolygon: Scenario<EvmTransaction, Account> = {
         standard: "ERC721",
       },
       junkie: address,
-      dose: ethers.BigNumber.from(1),
+      dose: 1n,
     });
 
     await callMyDealer({
@@ -233,7 +231,7 @@ export const scenarioPolygon: Scenario<EvmTransaction, Account> = {
         standard: "ERC1155",
       },
       junkie: address,
-      dose: ethers.BigNumber.from(10),
+      dose: 10n,
     });
 
     return { currencyBridge, accountBridge, account: scenarioAccount, onSignerConfirmation };
@@ -243,17 +241,17 @@ export const scenarioPolygon: Scenario<EvmTransaction, Account> = {
     await indexBlocks();
   },
   beforeAll: account => {
-    expect(account.balance.toFixed()).toBe(ethers.utils.parseEther("10000").toString());
+    expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0].type).toBe("TokenAccount");
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("100", USDC_ON_POLYGON.units[0].magnitude).toString(),
+      ethers.parseUnits("100", USDC_ON_POLYGON.units[0].magnitude).toString(),
     );
     expect(account.nfts?.length).toBe(2);
   },
   afterAll: account => {
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("20", USDC_ON_POLYGON.units[0].magnitude).toString(),
+      ethers.parseUnits("20", USDC_ON_POLYGON.units[0].magnitude).toString(),
     );
     expect(account.nfts?.length).toBe(0);
     expect(account.operations.length).toBe(7);

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/scroll.ts
@@ -1,6 +1,6 @@
 import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { BigNumber } from "bignumber.js";
-import { ethers, providers } from "ethers";
+import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
 import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
@@ -44,9 +44,7 @@ const makeScenarioTransactions = ({
   const USDC_ON_SCROLL = getTokenById("scroll/erc20/usd_coin");
   const scenarioSendUSDCTransaction: ScrollScenarioTransaction = {
     name: "Send USDC",
-    amount: new BigNumber(
-      ethers.utils.parseUnits("80", USDC_ON_SCROLL.units[0].magnitude).toString(),
-    ),
+    amount: new BigNumber(ethers.parseUnits("80", USDC_ON_SCROLL.units[0].magnitude).toString()),
     recipient: VITALIK,
     subAccountId: encodeTokenAccountId(`js:2:scroll:${address}:`, USDC_ON_SCROLL),
     expect: (previousAccount, currentAccount) => {
@@ -56,10 +54,10 @@ const makeScenarioTransactions = ({
       expect(latestOperation.value.toFixed()).toBe(latestOperation.fee.toFixed());
       expect(latestOperation.subOperations?.[0].type).toBe("OUT");
       expect(latestOperation.subOperations?.[0].value.toFixed()).toBe(
-        ethers.utils.parseUnits("80", USDC_ON_SCROLL.units[0].magnitude).toString(),
+        ethers.parseUnits("80", USDC_ON_SCROLL.units[0].magnitude).toString(),
       );
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
-        ethers.utils.parseUnits("20", USDC_ON_SCROLL.units[0].magnitude).toString(),
+        ethers.parseUnits("20", USDC_ON_SCROLL.units[0].magnitude).toString(),
       );
     },
   };
@@ -75,7 +73,7 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
       spawnAnvil("https://rpc.scroll.io"),
     ]);
 
-    const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    const provider = new ethers.JsonRpcProvider("http://127.0.0.1:8545");
     const signerContext: Parameters<typeof resolver>[0] = (deviceId, fn) =>
       fn(new LegacySignerEth(transport));
 
@@ -119,7 +117,7 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
       provider,
       drug: USDC_ON_SCROLL,
       junkie: address,
-      dose: ethers.utils.parseUnits("100", USDC_ON_SCROLL.units[0].magnitude),
+      dose: ethers.parseUnits("100", USDC_ON_SCROLL.units[0].magnitude),
     });
 
     return {
@@ -136,17 +134,17 @@ export const scenarioScroll: Scenario<EvmTransaction, Account> = {
   },
   beforeAll: account => {
     const USDC_ON_SCROLL = getTokenById(TOKEN_ID);
-    expect(account.balance.toFixed()).toBe(ethers.utils.parseEther("10000").toString());
+    expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0]?.type).toBe("TokenAccount");
     expect(account.subAccounts?.[0]?.balance?.toFixed()).toBe(
-      ethers.utils.parseUnits("100", USDC_ON_SCROLL.units[0].magnitude).toString(),
+      ethers.parseUnits("100", USDC_ON_SCROLL.units[0].magnitude).toString(),
     );
   },
   afterAll: account => {
     const USDC_ON_SCROLL = getTokenById(TOKEN_ID);
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("20", USDC_ON_SCROLL.units[0].magnitude).toString(),
+      ethers.parseUnits("20", USDC_ON_SCROLL.units[0].magnitude).toString(),
     );
     expect(account.operations.length).toBe(3);
   },

--- a/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
+++ b/libs/coin-tester-modules/coin-tester-evm/src/scenarii/sonic.ts
@@ -1,6 +1,6 @@
 import { LegacySignerEth } from "@ledgerhq/live-signer-evm";
 import { BigNumber } from "bignumber.js";
-import { ethers, providers } from "ethers";
+import { ethers } from "ethers";
 import { Account } from "@ledgerhq/types-live";
 import { getTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { encodeTokenAccountId } from "@ledgerhq/coin-framework/account/index";
@@ -43,9 +43,7 @@ const makeScenarioTransactions = ({ address }: { address: string }): SonicScenar
 
   const scenarioSendUSDCTransaction: SonicScenarioTransaction = {
     name: "Send USDC",
-    amount: new BigNumber(
-      ethers.utils.parseUnits("80", USDC_ON_SONIC.units[0].magnitude).toString(),
-    ),
+    amount: new BigNumber(ethers.parseUnits("80", USDC_ON_SONIC.units[0].magnitude).toString()),
     recipient: VITALIK,
     subAccountId: encodeTokenAccountId(`js:2:sonic:${address}:`, USDC_ON_SONIC),
     expect: (previousAccount, currentAccount) => {
@@ -55,10 +53,10 @@ const makeScenarioTransactions = ({ address }: { address: string }): SonicScenar
       expect(latestOperation.value.toFixed()).toBe(latestOperation.fee.toFixed());
       expect(latestOperation.subOperations?.[0].type).toBe("OUT");
       expect(latestOperation.subOperations?.[0].value.toFixed()).toBe(
-        ethers.utils.parseUnits("80", USDC_ON_SONIC.units[0].magnitude).toString(),
+        ethers.parseUnits("80", USDC_ON_SONIC.units[0].magnitude).toString(),
       );
       expect(currentAccount.subAccounts?.[0].balance.toFixed()).toBe(
-        ethers.utils.parseUnits("20", USDC_ON_SONIC.units[0].magnitude).toString(),
+        ethers.parseUnits("20", USDC_ON_SONIC.units[0].magnitude).toString(),
       );
     },
   };
@@ -140,7 +138,7 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
 
     const scenarioAccount = makeAccount(address, sonic);
 
-    const provider = new providers.StaticJsonRpcProvider("http://127.0.0.1:8545");
+    const provider = new ethers.JsonRpcProvider("http://127.0.0.1:8545");
 
     const lastBlockNumber = await provider.getBlockNumber();
     // start indexing at next block
@@ -151,7 +149,7 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
       provider,
       drug: USDC_ON_SONIC,
       junkie: address,
-      dose: ethers.utils.parseUnits("100", USDC_ON_SONIC.units[0].magnitude),
+      dose: ethers.parseUnits("100", USDC_ON_SONIC.units[0].magnitude),
     });
 
     return {
@@ -162,10 +160,10 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
     };
   },
   beforeAll: account => {
-    expect(account.balance.toFixed()).toBe(ethers.utils.parseEther("10000").toString());
+    expect(account.balance.toFixed()).toBe(ethers.parseEther("10000").toString());
     expect(account.subAccounts?.[0].type).toBe("TokenAccount");
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("100", USDC_ON_SONIC.units[0].magnitude).toString(),
+      ethers.parseUnits("100", USDC_ON_SONIC.units[0].magnitude).toString(),
     );
   },
   getTransactions: address => makeScenarioTransactions({ address }),
@@ -175,7 +173,7 @@ export const scenarioSonic: Scenario<EvmTransaction, Account> = {
   afterAll: account => {
     expect(account.subAccounts?.length).toBe(1);
     expect(account.subAccounts?.[0].balance.toFixed()).toBe(
-      ethers.utils.parseUnits("20", USDC_ON_SONIC.units[0].magnitude).toString(),
+      ethers.parseUnits("20", USDC_ON_SONIC.units[0].magnitude).toString(),
     );
     // expect(account.operations.length).toBe(3);
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2941,8 +2941,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       ethers:
-        specifier: 5.7.2
-        version: 5.7.2
+        specifier: 6.15.0
+        version: 6.15.0
       expect:
         specifier: ^27.4.6
         version: 27.5.1
@@ -3053,8 +3053,8 @@ importers:
         specifier: ^9.1.2
         version: 9.1.2
       ethers:
-        specifier: 5.7.2
-        version: 5.7.2
+        specifier: 6.15.0
+        version: 6.15.0
       invariant:
         specifier: ^2.2.2
         version: 2.2.4
@@ -4557,8 +4557,8 @@ importers:
         specifier: ^16.4.5
         version: 16.4.7
       ethers:
-        specifier: 5.7.2
-        version: 5.7.2
+        specifier: 6.15.0
+        version: 6.15.0
       msw:
         specifier: ^2.2.1
         version: 2.7.3(typescript@5.6.3)
@@ -12991,9 +12991,6 @@ packages:
   '@ethersproject/base64@5.7.0':
     resolution: {integrity: sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==}
 
-  '@ethersproject/basex@5.7.0':
-    resolution: {integrity: sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==}
-
   '@ethersproject/bignumber@5.7.0':
     resolution: {integrity: sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==}
 
@@ -13003,17 +13000,8 @@ packages:
   '@ethersproject/constants@5.7.0':
     resolution: {integrity: sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==}
 
-  '@ethersproject/contracts@5.7.0':
-    resolution: {integrity: sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==}
-
   '@ethersproject/hash@5.7.0':
     resolution: {integrity: sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==}
-
-  '@ethersproject/hdnode@5.7.0':
-    resolution: {integrity: sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==}
-
-  '@ethersproject/json-wallets@5.7.0':
-    resolution: {integrity: sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==}
 
   '@ethersproject/keccak256@5.7.0':
     resolution: {integrity: sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==}
@@ -13024,32 +13012,17 @@ packages:
   '@ethersproject/networks@5.7.1':
     resolution: {integrity: sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==}
 
-  '@ethersproject/pbkdf2@5.7.0':
-    resolution: {integrity: sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==}
-
   '@ethersproject/properties@5.7.0':
     resolution: {integrity: sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==}
 
-  '@ethersproject/providers@5.7.2':
-    resolution: {integrity: sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==}
-
-  '@ethersproject/random@5.7.0':
-    resolution: {integrity: sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==}
-
   '@ethersproject/rlp@5.7.0':
     resolution: {integrity: sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==}
-
-  '@ethersproject/sha2@5.7.0':
-    resolution: {integrity: sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==}
 
   '@ethersproject/shims@5.7.0':
     resolution: {integrity: sha512-WeDptc6oAprov5CCN2LJ/6/+dC9gTonnkdAtLepm/7P5Z+3PRxS5NpfVWmOMs1yE4Vitl2cU8bOPWC0GvGSbVg==}
 
   '@ethersproject/signing-key@5.7.0':
     resolution: {integrity: sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==}
-
-  '@ethersproject/solidity@5.7.0':
-    resolution: {integrity: sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==}
 
   '@ethersproject/strings@5.7.0':
     resolution: {integrity: sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==}
@@ -13060,14 +13033,8 @@ packages:
   '@ethersproject/units@5.7.0':
     resolution: {integrity: sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==}
 
-  '@ethersproject/wallet@5.7.0':
-    resolution: {integrity: sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==}
-
   '@ethersproject/web@5.7.1':
     resolution: {integrity: sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==}
-
-  '@ethersproject/wordlists@5.7.0':
-    resolution: {integrity: sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==}
 
   '@exodus/patch-broken-hermes-typed-arrays@1.0.0-alpha.1':
     resolution: {integrity: sha512-oYv+2IJxaNVTnF7lJqS+wrW0JisE9kcKlgQnkrdhtlsfRmFlcYPdPSO8eaIXKHKkzKndy3I+ZzTELg+BVi3vSg==}
@@ -14612,9 +14579,6 @@ packages:
 
   '@noble/curves@1.3.0':
     resolution: {integrity: sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==}
-
-  '@noble/curves@1.4.0':
-    resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
 
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
@@ -23876,15 +23840,12 @@ packages:
     resolution: {integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==}
     engines: {node: '>=10.0.0'}
 
-  ethers@5.7.2:
-    resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
-
-  ethers@6.13.4:
-    resolution: {integrity: sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==}
-    engines: {node: '>=14.0.0'}
-
   ethers@6.14.1:
     resolution: {integrity: sha512-JnFiPFi3sK2Z6y7jZ3qrafDMwiXmU+6cNZ0M+kPq+mTy9skqEzwqAdFW3nb/em2xjlIVXX6Lz8ID6i3LmS4+fQ==}
+    engines: {node: '>=14.0.0'}
+
+  ethers@6.15.0:
+    resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
     engines: {node: '>=14.0.0'}
 
   ethjs-unit@0.1.6:
@@ -39988,11 +39949,6 @@ snapshots:
     dependencies:
       '@ethersproject/bytes': 5.7.0
 
-  '@ethersproject/basex@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/properties': 5.7.0
-
   '@ethersproject/bignumber@5.7.0':
     dependencies:
       '@ethersproject/bytes': 5.7.0
@@ -40007,19 +39963,6 @@ snapshots:
     dependencies:
       '@ethersproject/bignumber': 5.7.0
 
-  '@ethersproject/contracts@5.7.0':
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-
   '@ethersproject/hash@5.7.0':
     dependencies:
       '@ethersproject/abstract-signer': 5.7.0
@@ -40032,37 +39975,6 @@ snapshots:
       '@ethersproject/properties': 5.7.0
       '@ethersproject/strings': 5.7.0
 
-  '@ethersproject/hdnode@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/basex': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/pbkdf2': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/wordlists': 5.7.0
-
-  '@ethersproject/json-wallets@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/hdnode': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/pbkdf2': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      aes-js: 3.0.0
-      scrypt-js: 3.0.1
-
   '@ethersproject/keccak256@5.7.0':
     dependencies:
       '@ethersproject/bytes': 5.7.0
@@ -40074,56 +39986,14 @@ snapshots:
     dependencies:
       '@ethersproject/logger': 5.7.0
 
-  '@ethersproject/pbkdf2@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-
   '@ethersproject/properties@5.7.0':
     dependencies:
-      '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/providers@5.7.2':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/base64': 5.7.0
-      '@ethersproject/basex': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/networks': 5.7.1
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/rlp': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/web': 5.7.1
-      bech32: 1.1.4
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@ethersproject/random@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
 
   '@ethersproject/rlp@5.7.0':
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/logger': 5.7.0
-
-  '@ethersproject/sha2@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      hash.js: 1.1.7
 
   '@ethersproject/shims@5.7.0': {}
 
@@ -40135,15 +40005,6 @@ snapshots:
       bn.js: 5.2.1
       elliptic: 6.6.1
       hash.js: 1.1.7
-
-  '@ethersproject/solidity@5.7.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/strings': 5.7.0
 
   '@ethersproject/strings@5.7.0':
     dependencies:
@@ -40169,36 +40030,10 @@ snapshots:
       '@ethersproject/constants': 5.7.0
       '@ethersproject/logger': 5.7.0
 
-  '@ethersproject/wallet@5.7.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/hdnode': 5.7.0
-      '@ethersproject/json-wallets': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/wordlists': 5.7.0
-
   '@ethersproject/web@5.7.1':
     dependencies:
       '@ethersproject/base64': 5.7.0
       '@ethersproject/bytes': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/strings': 5.7.0
-
-  '@ethersproject/wordlists@5.7.0':
-    dependencies:
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/hash': 5.7.0
       '@ethersproject/logger': 5.7.0
       '@ethersproject/properties': 5.7.0
       '@ethersproject/strings': 5.7.0
@@ -43471,10 +43306,6 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.3
 
-  '@noble/curves@1.4.0':
-    dependencies:
-      '@noble/hashes': 1.4.0
-
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -45913,7 +45744,7 @@ snapshots:
 
   '@scure/bip32@1.4.0':
     dependencies:
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.6
 
@@ -57271,43 +57102,7 @@ snapshots:
       ethereum-cryptography: 0.1.3
       rlp: 2.2.7
 
-  ethers@5.7.2:
-    dependencies:
-      '@ethersproject/abi': 5.7.0
-      '@ethersproject/abstract-provider': 5.7.0
-      '@ethersproject/abstract-signer': 5.7.0
-      '@ethersproject/address': 5.7.0
-      '@ethersproject/base64': 5.7.0
-      '@ethersproject/basex': 5.7.0
-      '@ethersproject/bignumber': 5.7.0
-      '@ethersproject/bytes': 5.7.0
-      '@ethersproject/constants': 5.7.0
-      '@ethersproject/contracts': 5.7.0
-      '@ethersproject/hash': 5.7.0
-      '@ethersproject/hdnode': 5.7.0
-      '@ethersproject/json-wallets': 5.7.0
-      '@ethersproject/keccak256': 5.7.0
-      '@ethersproject/logger': 5.7.0
-      '@ethersproject/networks': 5.7.1
-      '@ethersproject/pbkdf2': 5.7.0
-      '@ethersproject/properties': 5.7.0
-      '@ethersproject/providers': 5.7.2
-      '@ethersproject/random': 5.7.0
-      '@ethersproject/rlp': 5.7.0
-      '@ethersproject/sha2': 5.7.0
-      '@ethersproject/signing-key': 5.7.0
-      '@ethersproject/solidity': 5.7.0
-      '@ethersproject/strings': 5.7.0
-      '@ethersproject/transactions': 5.7.0
-      '@ethersproject/units': 5.7.0
-      '@ethersproject/wallet': 5.7.0
-      '@ethersproject/web': 5.7.1
-      '@ethersproject/wordlists': 5.7.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  ethers@6.13.4:
+  ethers@6.14.1:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -57320,7 +57115,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ethers@6.14.1:
+  ethers@6.15.0:
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.2.0
@@ -70839,7 +70634,7 @@ snapshots:
       axios: 1.11.0
       bignumber.js: 9.1.2
       ethereum-cryptography: 2.2.1
-      ethers: 6.13.4
+      ethers: 6.15.0
       eventemitter3: 3.1.2
       injectpromise: 1.0.0
       lodash: 4.17.21


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - serialization is different
  - No more StaticJsonProvider
  - BigInt is used instead of ethers.BigNumber
 

### 📝 Description

Update ethers v5 to ethers v6.15.0

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-21064](https://ledgerhq.atlassian.net/browse/LIVE-21064)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21064]: https://ledgerhq.atlassian.net/browse/LIVE-21064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ