### PR TITLE
Support/migration sonarcloud to hosted

### DIFF
--- a/.github/workflows/scan-sonar-reusable.yml
+++ b/.github/workflows/scan-sonar-reusable.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   scan-sonar:
     name: "Sonar Cloud"
-    runs-on: [ledger-live-4xlarge]
+    runs-on: [ ubuntu-22.04 ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Migration of Sonar scanning to GitHub hosted runner.

Successful run: https://github.com/LedgerHQ/ledger-live/actions/runs/17398849973/job/49388115234?pr=11592
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-20559