### PR TITLE
Fix (LLM): Market loader replace internet error 

### DIFF
--- a/.changeset/funny-seals-listen.md
+++ b/.changeset/funny-seals-listen.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: loader in market

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/ListEmpty/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/components/ListEmpty/index.tsx
@@ -20,6 +20,7 @@ interface ListEmptyProps {
   hasNoSearchResult: boolean;
   search?: string;
   resetSearch: () => void;
+  isLoading?: boolean;
 }
 
 function ListEmpty({
@@ -27,9 +28,14 @@ function ListEmpty({
   hasNoSearchResult,
   search,
   resetSearch,
+  isLoading = false,
 }: ListEmptyProps) {
   const { t } = useTranslation();
   const { isConnected } = useNetInfo();
+
+  if (isLoading) {
+    return null;
+  }
 
   if (hasNoSearchResult) {
     // No search results

--- a/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/index.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/Market/screens/MarketList/index.tsx
@@ -144,6 +144,7 @@ function View({
         hasEmptyStarredCoins={filterByStarredCurrencies && starredMarketCoins.length <= 0}
         search={search}
         resetSearch={resetSearch}
+        isLoading={loading}
       />
     ),
     refreshControl: (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - In the Market page in LLM when the data is loading we should see the loader and not the connection error view

### 📝 Description

In the LLM market, when data was loading we used to see the connection error view instead of the loader. Now the loader is displayed first and if no data is available the connection error view appears

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21132]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->

https://github.com/user-attachments/assets/7c4aecd4-7f4e-4abe-b83e-b57a98a6902f

https://github.com/user-attachments/assets/e44520c0-38b5-4e9c-a5c9-33c64e2be2d6




---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21132]: https://ledgerhq.atlassian.net/browse/LIVE-21132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ