### PR TITLE
fix: taquito dynamic import using a pnpm patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,7 +266,8 @@
       "react-native-webview": "patches/react-native-webview.patch",
       "detox@20.39.0": "patches/detox@20.39.0.patch",
       "@datadog/datadog-ci@3.11.0": "patches/@datadog__datadog-ci@3.11.0.patch",
-      "@exodus/patch-broken-hermes-typed-arrays": "patches/@exodus__patch-broken-hermes-typed-arrays.patch"
+      "@exodus/patch-broken-hermes-typed-arrays": "patches/@exodus__patch-broken-hermes-typed-arrays.patch",
+      "@taquito/http-utils": "patches/@taquito__http-utils.patch"
     },
     "packageExtensions": {
       "eslint-config-next@*": {

--- a/patches/@taquito__http-utils.patch
+++ b/patches/@taquito__http-utils.patch
@@ -1,0 +1,44 @@
+diff --git a/dist/taquito-http-utils.es6.js b/dist/taquito-http-utils.es6.js
+index 2750d3bce03a6413a83cec1f7bbd5311e30b44f4..afe3c0577b9c478165537bf512a20af73c2ca2e2 100644
+--- a/dist/taquito-http-utils.es6.js
++++ b/dist/taquito-http-utils.es6.js
+@@ -415,13 +415,11 @@ if (isNode) {
+     fetch = require('node-fetch');
+     if (Number(process.versions.node.split('.')[0]) >= 19) {
+         // we need agent with keepalive false for node 19 and above
+-        createAgent = (url) => __awaiter(void 0, void 0, void 0, function* () {
+-            const { Agent: HttpsAgent } = yield import('https');
+-            const { Agent: HttpAgent } = yield import('http');
++        createAgent = (url) => {
+             return url.startsWith('https')
+-                ? new HttpsAgent({ keepAlive: false })
+-                : new HttpAgent({ keepAlive: false });
+-        });
++                ? new require('https').Agent({ keepAlive: false })
++                : new require('http').Agent({ keepAlive: false });
++        };
+     }
+ }
+ class HttpBackend {
+diff --git a/dist/taquito-http-utils.umd.js b/dist/taquito-http-utils.umd.js
+index fa74f64f45c61839ffdcd01169e01a6956a535e3..111c657e76c41bf36eb02403c8b8515c9927671a 100644
+--- a/dist/taquito-http-utils.umd.js
++++ b/dist/taquito-http-utils.umd.js
+@@ -419,13 +419,11 @@
+         fetch = require('node-fetch');
+         if (Number(process.versions.node.split('.')[0]) >= 19) {
+             // we need agent with keepalive false for node 19 and above
+-            createAgent = (url) => __awaiter(void 0, void 0, void 0, function* () {
+-                const { Agent: HttpsAgent } = yield import('https');
+-                const { Agent: HttpAgent } = yield import('http');
++            createAgent = (url) => {
+                 return url.startsWith('https')
+-                    ? new HttpsAgent({ keepAlive: false })
+-                    : new HttpAgent({ keepAlive: false });
+-            });
++                    ? new require('https').Agent({ keepAlive: false })
++                    : new require('http').Agent({ keepAlive: false });
++            };
+         }
+     }
+     class HttpBackend {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ patchedDependencies:
   '@hashgraph/sdk@2.14.2':
     hash: hno7opkpqo3efbuenv6ysglr4m
     path: patches/@hashgraph__sdk@2.14.2.patch
+  '@taquito/http-utils':
+    hash: v4hkik3oiwaypgtnmqvg6j46di
+    path: patches/@taquito__http-utils.patch
   '@ton/core@0.60.1':
     hash: lboaji3braahojqczblp7nlo7m
     path: patches/@ton__core@0.60.1.patch
@@ -36969,13 +36972,13 @@ snapshots:
   '@babel/helper-function-name@7.23.0':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
@@ -36998,7 +37001,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.27.4
-      '@babel/types': 7.27.6
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
@@ -37066,7 +37069,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.22.6':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.2
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -37086,9 +37089,9 @@ snapshots:
 
   '@babel/helpers@7.24.1':
     dependencies:
-      '@babel/template': 7.24.0
+      '@babel/template': 7.27.2
       '@babel/traverse': 7.27.4
-      '@babel/types': 7.24.0
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
@@ -38061,9 +38064,9 @@ snapshots:
 
   '@babel/template@7.24.0':
     dependencies:
-      '@babel/code-frame': 7.24.6
-      '@babel/parser': 7.24.1
-      '@babel/types': 7.24.0
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
 
   '@babel/template@7.27.0':
     dependencies:
@@ -42734,7 +42737,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.1
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -49757,7 +49760,7 @@ snapshots:
     dependencies:
       json-stringify-safe: 5.0.1
 
-  '@taquito/http-utils@23.0.0-beta.1':
+  '@taquito/http-utils@23.0.0-beta.1(patch_hash=v4hkik3oiwaypgtnmqvg6j46di)':
     dependencies:
       '@taquito/core': 23.0.0-beta.1
       node-fetch: 2.7.0
@@ -49799,7 +49802,7 @@ snapshots:
   '@taquito/rpc@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.0.0-beta.1
-      '@taquito/http-utils': 23.0.0-beta.1
+      '@taquito/http-utils': 23.0.0-beta.1(patch_hash=v4hkik3oiwaypgtnmqvg6j46di)
       '@taquito/utils': 23.0.0-beta.1
       bignumber.js: 9.1.2
     transitivePeerDependencies:
@@ -49808,7 +49811,7 @@ snapshots:
   '@taquito/taquito@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.0.0-beta.1
-      '@taquito/http-utils': 23.0.0-beta.1
+      '@taquito/http-utils': 23.0.0-beta.1(patch_hash=v4hkik3oiwaypgtnmqvg6j46di)
       '@taquito/local-forging': 23.0.0-beta.1
       '@taquito/michel-codec': 23.0.0-beta.1
       '@taquito/michelson-encoder': 23.0.0-beta.1
@@ -50067,16 +50070,16 @@ snapshots:
 
   '@types/babel__generator@7.6.8':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.2
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.3
+      '@babel/types': 7.28.2
 
   '@types/babel__traverse@7.20.5':
     dependencies:
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.2
 
   '@types/bchaddrjs@0.4.3': {}
 
@@ -52128,7 +52131,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -70085,7 +70088,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.1
+      debug: 4.3.4
       fast-safe-stringify: 2.1.1
       form-data: 4.0.2
       formidable: 2.1.2


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - All tezos flows

### 📝 Description

This pull request introduces a patch for the `@taquito/http-utils` dependency to improve compatibility with Electron by updating agent creation logic.

We cannot use dynamic imports in Electron with our current setup (nodeIntegration enabled and context isolation disabled), so we need to patch the lib to update the `import` calls to `require` calls

https://www.electronjs.org/docs/latest/tutorial/esm
https://www.electronjs.org/docs/latest/tutorial/esm#esm-preload-scripts-must-be-context-isolated-to-use-dynamic-nodejs-esm-imports

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21271]


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
