### PR TITLE
fix(webhid): prevent InvalidStateError on open

### DIFF
--- a/.changeset/curly-countries-remember.md
+++ b/.changeset/curly-countries-remember.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-transport-webhid": patch
+---
+
+Fixes a thrown InvalidStateError DOMException from being thrown when TransportWebHID.open is called on a device with an already open connection.

--- a/libs/ledgerjs/packages/hw-transport-webhid/src/TransportWebHID.ts
+++ b/libs/ledgerjs/packages/hw-transport-webhid/src/TransportWebHID.ts
@@ -159,7 +159,9 @@ export default class TransportWebHID extends Transport {
    * Create a Ledger transport with a HIDDevice
    */
   static async open(device: HIDDevice) {
-    await device.open();
+    if (!device.opened) {
+      await device.open();
+    }
     const transport = new TransportWebHID(device);
 
     const onDisconnect = e => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.

### 📝 Description

Prevents [InvalidStateError](https://developer.mozilla.org/en-US/docs/Web/API/HIDDevice/open#exceptions) DOMException from being thrown during a TransportWebHID.open() call when the device connection is already open.

It's possible for the device to already have an open connection. Simply wrapping the HIDDevice.open() call in a [HIDDevice.opened](https://developer.mozilla.org/en-US/docs/Web/API/HIDDevice/opened) check fixes the issue.

No existing test coverage to extend.

Re-opening #11300.

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
