### PR TITLE
fix: update Earn app ID to 'earn-stg' for testing environment

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/services/earn.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/earn.spec.ts
@@ -13,7 +13,7 @@ test.beforeAll(async () => {
   // Check that dummy app in tests/dummy-ptx-app has been started successfully
   testServerIsRunning = await LiveAppWebview.startLiveApp("dummy-ptx-app/public", {
     name: "Earn",
-    id: "earn",
+    id: "earn-stg",
     apiVersion: "^2.0.0",
     permissions: ["account.list"],
   });


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. not needed for tests
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - fixes the earn test

### 📝 Description

The FF on firebase testing env was update last week with a different manifest id than the one setup in the test

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
