### PR TITLE
✨  LLM / LLD - Edit Mad default configuration and fallback

### DIFF
--- a/.changeset/six-forks-share.md
+++ b/.changeset/six-forks-share.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+LLD / LLM - Edit default modular configuration of the drawer

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/modules.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/__tests__/modules.test.tsx
@@ -60,7 +60,7 @@ const mockCurrencies = [ethereumCurrency, bitcoinCurrency, arbitrumCurrency];
 
 describe("ModularDrawerFlowManager - Modules configuration", () => {
   // This is tempory as in the future balance will be displayed by default for all assets but right now it's not the case
-  it("shouldn't display balance on the right at assetSelection by default", async () => {
+  it("should display balance on the right at assetSelection by default", async () => {
     const mixedCurrencies = [
       baseCurrency,
       arbitrumCurrency,
@@ -82,8 +82,8 @@ describe("ModularDrawerFlowManager - Modules configuration", () => {
     expect(screen.queryByText(/base/i)).toBeNull();
     expect(screen.queryByText(/scroll/i)).toBeNull();
 
-    expect(screen.queryByText(/\$95,622,923.34/i)).toBeNull();
-    expect(screen.queryByText(/34,478.4 eth/i)).toBeNull();
+    expect(screen.queryByText(/\$95,622,923.34/i)).toBeVisible();
+    expect(screen.queryByText(/34,478.4 eth/i)).toBeVisible();
   });
 
   it("should display balance on the right at assetSelection step", async () => {

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/__tests__/useModularDrawerConfiguration.test.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/__tests__/useModularDrawerConfiguration.test.ts
@@ -103,7 +103,7 @@ describe("useModularDrawerConfiguration", () => {
       const drawerConfiguration: EnhancedModularDrawerConfiguration = {
         assets: {
           rightElement: "balance",
-          leftElement: "priceVariation",
+          leftElement: "marketTrend",
           filter: "topNetworks",
         },
       };

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/__tests__/useOpenAssetFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/__tests__/useOpenAssetFlow.test.tsx
@@ -77,7 +77,7 @@ describe("useOpenAssetFlow", () => {
         currencies: [],
         drawerConfiguration: {
           assets: { leftElement: "undefined", rightElement: "balance" },
-          networks: { leftElement: "undefined", rightElement: "balance" },
+          networks: { leftElement: "numberOfAccounts", rightElement: "balance" },
         },
         flow: "add_account",
         onAssetSelected: expect.any(Function),

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useOpenAssetFlow.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useOpenAssetFlow.tsx
@@ -37,7 +37,7 @@ function selectCurrency(
       flow,
       drawerConfiguration: drawerConfiguration ?? {
         assets: { leftElement: "undefined", rightElement: "balance" },
-        networks: { leftElement: "undefined", rightElement: "balance" },
+        networks: { leftElement: "numberOfAccounts", rightElement: "balance" },
       },
     },
     {

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ModularDrawer/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ModularDrawer/constants.ts
@@ -34,7 +34,7 @@ export const DRAWER_CONFIG_OPTIONS = {
     left: [
       { value: "undefined", label: "Undefined" },
       { value: "apy", label: "Apy" },
-      { value: "priceVariation", label: "Price Variation" },
+      { value: "marketTrend", label: "Market Trend" },
     ],
     right: [
       { value: "undefined", label: "Undefined" },

--- a/libs/ledger-live-common/src/modularDrawer/modules/createAssetConfiguration.ts
+++ b/libs/ledger-live-common/src/modularDrawer/modules/createAssetConfiguration.ts
@@ -6,27 +6,27 @@ import { useLeftApyModule } from "../hooks/modules/useLeftApyModule";
 import { createUseRightBalanceAsset } from "../hooks/useRightBalanceAsset";
 
 const getRightElement =
-  (AssetConfigurationDeps: AssetConfigurationDeps) => (rightElement: string) => {
+  (AssetConfigurationDeps: AssetConfigurationDeps) => (rightElement?: string) => {
     switch (rightElement) {
+      case "undefined":
+        return undefined;
+      case "marketTrend":
       case "balance":
+      default:
         return createUseRightBalanceAsset({
           useBalanceDeps: AssetConfigurationDeps.useBalanceDeps,
           balanceItem: AssetConfigurationDeps.balanceItem,
         });
-      case "marketTrend":
-      case "undefined":
-      default:
-        return undefined;
     }
   };
 
 const getLeftElement =
-  (AssetConfigurationDeps: AssetConfigurationDeps) => (leftElement: string) => {
+  (AssetConfigurationDeps: AssetConfigurationDeps) => (leftElement?: string) => {
     switch (leftElement) {
       case "apy":
         return (assets: CryptoOrTokenCurrency[]) =>
           useLeftApyModule(assets, AssetConfigurationDeps.ApyIndicator);
-      case "priceVariation":
+      case "marketTrend":
       case "undefined":
       default:
         return undefined;
@@ -36,7 +36,7 @@ const getLeftElement =
 const createAssetConfigurationHook: CreateAssetConfigurationHook =
   deps =>
   ({ assetsConfiguration, currenciesByProvider }) => {
-    const { rightElement = "undefined", leftElement = "undefined" } = assetsConfiguration ?? {};
+    const { rightElement, leftElement } = assetsConfiguration ?? {};
 
     const rightHook = getRightElement(deps)(rightElement);
     const leftHook = getLeftElement(deps)(leftElement);

--- a/libs/ledger-live-common/src/modularDrawer/modules/createNetworkConfiguration.ts
+++ b/libs/ledger-live-common/src/modularDrawer/modules/createNetworkConfiguration.ts
@@ -15,13 +15,10 @@ import { composeHooks } from "../../utils/composeHooks";
 
 export const getLeftElement =
   (NetworkConfigurationDeps: NetworkConfigurationDeps) =>
-  (leftElement: LeftElementKind): NetworkHook | undefined => {
+  (leftElement?: LeftElementKind): NetworkHook | undefined => {
     switch (leftElement) {
-      case "numberOfAccounts":
-        return createUseLeftAccountsModule({
-          useAccountData: NetworkConfigurationDeps.useAccountData,
-          accountsCount: NetworkConfigurationDeps.accountsCount,
-        });
+      case "undefined":
+        return undefined;
       case "numberOfAccountsAndApy":
         return (params: AccountModuleParams & { networks: CryptoOrTokenCurrency[] }) =>
           useLeftAccountsApyModule(
@@ -30,24 +27,27 @@ export const getLeftElement =
             NetworkConfigurationDeps.accountsCountAndApy,
             params.networks,
           );
-      case "undefined":
+      case "numberOfAccounts":
       default:
-        return undefined;
+        return createUseLeftAccountsModule({
+          useAccountData: NetworkConfigurationDeps.useAccountData,
+          accountsCount: NetworkConfigurationDeps.accountsCount,
+        });
     }
   };
 
 export const getRightElement =
   (NetworkConfigurationDeps: NetworkConfigurationDeps) =>
-  (rightElement: RightElementKind): NetworkHook | undefined => {
+  (rightElement?: RightElementKind): NetworkHook | undefined => {
     switch (rightElement) {
+      case "undefined":
+        return undefined;
       case "balance":
+      default:
         return createUseRightBalanceNetwork({
           useBalanceDeps: NetworkConfigurationDeps.useBalanceDeps,
           balanceItem: NetworkConfigurationDeps.balanceItem,
         });
-      case "undefined":
-      default:
-        return undefined;
     }
   };
 
@@ -59,7 +59,7 @@ export const createNetworkConfigurationHook =
     currenciesByProvider,
     accounts$,
   }: CreateNetworkConfigurationHookProps) => {
-    const { leftElement = "undefined", rightElement = "undefined" } = networksConfig ?? {};
+    const { leftElement, rightElement } = networksConfig ?? {};
     const leftHook = getLeftElement(NetworkConfigurationDeps)(leftElement);
     const rightHook = getRightElement(NetworkConfigurationDeps)(rightElement);
 

--- a/libs/ledger-live-common/src/wallet-api/ModularDrawer/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/ModularDrawer/types.ts
@@ -13,7 +13,7 @@ export type ModularDrawerConfiguration = {
 };
 
 export const filterOptions = ["topNetworks", "undefined"] as const;
-export const assetsLeftElementOptions = ["apy", "priceVariation", "undefined"] as const;
+export const assetsLeftElementOptions = ["apy", "marketTrend", "undefined"] as const;
 export const assetsRightElementOptions = ["balance", "marketTrend", "undefined"] as const;
 export const networksLeftElementOptions = [
   "numberOfAccounts",


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

The modular drawer now falls back on the default configuration if a wrong one has been sent instead of not displaying anything
Rename the asset left element from `priceVariation` to `marketTrend` to be consistent with the right element
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
