### PR TITLE
feat(BACK-9645): return SUI objects in craftTransaction

### DIFF
--- a/libs/coin-modules/coin-sui/src/api/index.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.ts
@@ -40,9 +40,14 @@ export function createApi(config: SuiConfig): AlpacaApi {
 }
 
 async function craft(transactionIntent: TransactionIntent): Promise<CraftedTransaction> {
-  const { unsigned } = await craftTransaction(transactionIntent);
+  const { unsigned, objects } = await craftTransaction(transactionIntent, true);
 
-  return { transaction: Buffer.from(unsigned).toString("hex") };
+  return {
+    transaction: Buffer.from(unsigned).toString("hex"),
+    details: {
+      objects: objects?.map(obj => Buffer.from(obj).toString("hex")),
+    },
+  };
 }
 
 async function estimate(transactionIntent: TransactionIntent): Promise<FeeEstimation> {

--- a/libs/coin-modules/coin-sui/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-sui/src/logic/craftTransaction.ts
@@ -4,28 +4,33 @@ import type { SuiTransactionMode, CoreTransaction } from "../types";
 import suiAPI from "../network";
 import { DEFAULT_COIN_TYPE } from "../network/sdk";
 
-export async function craftTransaction({
-  amount,
-  asset,
-  recipient,
-  sender,
-  type,
-  ...extra
-}: TransactionIntent & {
-  useAllAmount?: boolean;
-  stakedSuiId?: string;
-}): Promise<CoreTransaction> {
+export async function craftTransaction(
+  {
+    amount,
+    asset,
+    recipient,
+    sender,
+    type,
+    ...extra
+  }: TransactionIntent & {
+    useAllAmount?: boolean;
+    stakedSuiId?: string;
+  },
+  withObjects: boolean = false,
+): Promise<CoreTransaction & { objects?: Uint8Array[] }> {
   let coinType = DEFAULT_COIN_TYPE;
   if (asset.type === "token" && asset.assetReference) {
     coinType = asset.assetReference;
   }
-  const unsigned = await suiAPI.createTransaction(sender, {
-    amount: BigNumber(amount.toString()),
-    coinType,
-    mode: type as SuiTransactionMode,
-    recipient,
-    ...extra,
-  });
-
-  return { unsigned };
+  return suiAPI.createTransaction(
+    sender,
+    {
+      amount: BigNumber(amount.toString()),
+      coinType,
+      mode: type as SuiTransactionMode,
+      recipient,
+      ...extra,
+    },
+    withObjects,
+  );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Add option to return SUI objects in craftTransaction (for clear signing).

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- https://ledgerhq.atlassian.net/browse/BACK-9645

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
