### PR TITLE
Feat: live-20185 Display generic error message

### DIFF
--- a/.changeset/rich-spiders-grin.md
+++ b/.changeset/rich-spiders-grin.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": major
+"live-mobile": major
+---
+
+Display generic error message for suspect users on Changelly

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
@@ -7,6 +7,7 @@ import { useGetSwapTrackingProperties } from "../../utils/index";
 import { BoxedIcon, Text } from "@ledgerhq/react-ui";
 import { SwapLiveError } from "@ledgerhq/live-common/exchange/swap/types";
 import ErrorIcon from "~/renderer/components/ErrorIcon";
+import { track } from "~/renderer/analytics/__mocks__/segment";
 
 const ContentBox = styled(Box)`
   display: flex;
@@ -72,6 +73,10 @@ export default function WebviewErrorDrawer(error?: SwapLiveError) {
   const errorMessage = error?.cause?.response?.data?.error?.message?.toLowerCase();
 
   if (errorMessage?.includes("transaction cannot be created")) {
+    track("error_message", {
+      ...swapDefaultTrack,
+      message: "partner_unavailable",
+    });
     titleKey = "errors.TransactionCannotBeCreated.title";
     descriptionKey = "errors.TransactionCannotBeCreated.description";
     errorCodeSection = null;

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
@@ -72,8 +72,8 @@ export default function WebviewErrorDrawer(error?: SwapLiveError) {
   const errorMessage = error?.cause?.response?.data?.error?.message?.toLowerCase();
 
   if (errorMessage?.includes("transaction cannot be created")) {
-    titleKey = "errors.swapPartnerUnavailableError.title";
-    descriptionKey = "errors.swapPartnerUnavailableError.description";
+    titleKey = "errors.TransactionCannotBeCreated.title";
+    descriptionKey = "errors.TransactionCannotBeCreated.description";
     errorCodeSection = null;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/WebviewErrorDrawer/index.tsx
@@ -68,6 +68,15 @@ export default function WebviewErrorDrawer(error?: SwapLiveError) {
         break;
     }
   }
+
+  const errorMessage = error?.cause?.response?.data?.error?.message?.toLowerCase();
+
+  if (errorMessage?.includes("transaction cannot be created")) {
+    titleKey = "errors.swapPartnerUnavailableError.title";
+    descriptionKey = "errors.swapPartnerUnavailableError.description";
+    errorCodeSection = null;
+  }
+
   switch (error?.cause?.response?.data?.error?.messageKey) {
     case "WRONG_OR_EXPIRED_RATE_ID":
       titleKey = "errors.SwapRateExpiredError.title";

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6340,6 +6340,10 @@
       "title": "Something went wrong",
       "description": "Transaction failed. Please try again."
     },
+    "TransactionCannotBeCreated": {
+      "title": "Partner unavailable",
+      "description": "We cannot complete your swap with this partner. Please try with another one. Error code 8HBBZLP"
+    },
     "TimeoutError": {
       "title": "Sorry, server took too long to respond",
       "description": "Please try again."

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -889,6 +889,10 @@
       "title": "Something went wrong",
       "description": "The exchange transaction did not go through. Please try again or contact support."
     },
+    "SwapPartnerUnavailableError": {
+      "title": "Partner unavailable",
+      "description": "We cannot complete your swap with this partner. Please try with another one. Error code 8HBBZLP"
+    },
     "SwapTimeoutError": {
       "title": "Quotes could not be generated because of technical issues. Try swapping again in a few moments."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -889,10 +889,6 @@
       "title": "Something went wrong",
       "description": "The exchange transaction did not go through. Please try again or contact support."
     },
-    "SwapPartnerUnavailableError": {
-      "title": "Partner unavailable",
-      "description": "We cannot complete your swap with this partner. Please try with another one. Error code 8HBBZLP"
-    },
     "SwapTimeoutError": {
       "title": "Quotes could not be generated because of technical issues. Try swapping again in a few moments."
     },
@@ -8034,6 +8030,10 @@
     "signatureVerificationFail": {
       "title": "Signature verification failed",
       "description": "Please retry or contact Ledger Support if in doubt"
+    },
+    "TransactionCannotBeCreated": {
+      "title": "Partner unavailable",
+      "description": "We cannot complete your swap with this partner. Please try with another one. Error code 8HBBZLP"
     },
     "default": {
       "title": "Something went wrong",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8031,7 +8031,7 @@
       "title": "Signature verification failed",
       "description": "Please retry or contact Ledger Support if in doubt"
     },
-    "TransactionCannotBeCreated": {
+    "transactionCannotBeCreated": {
       "title": "Partner unavailable",
       "description": "We cannot complete your swap with this partner. Please try with another one. Error code 8HBBZLP"
     },

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
@@ -27,8 +27,8 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
 
     if (errorMessage.includes("transaction cannot be created")) {
       return {
-        title: t("swapErrors.TransactionCannotBeCreated.title"),
-        description: t("swapErrors.TransactionCannotBeCreated.description"),
+        title: t("swapErrors.transactionCannotBeCreated.title"),
+        description: t("swapErrors.transactionCannotBeCreated.description"),
       };
     }
 

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
@@ -9,6 +9,8 @@ import { useHeaderHeight } from "@react-navigation/elements";
 import { SwapCustomErrorProps } from "../types";
 import Button from "~/components/Button";
 import useExportLogs from "~/components/useExportLogs";
+import { sharedSwapTracking } from "../utils";
+import { track } from "~/analytics/segment";
 
 export default function SwapCustomError({ route }: SwapCustomErrorProps) {
   const { t } = useTranslation();
@@ -26,6 +28,10 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
         : "";
 
     if (errorMessage.includes("transaction cannot be created")) {
+      track("error_message", {
+        ...sharedSwapTracking,
+        message: "partner_unavailable",
+      });
       return {
         title: t("swapErrors.transactionCannotBeCreated.title"),
         description: t("swapErrors.transactionCannotBeCreated.description"),

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/SwapCustomError.tsx
@@ -20,6 +20,18 @@ export default function SwapCustomError({ route }: SwapCustomErrorProps) {
   const headerHeight = useHeaderHeight();
 
   const { title, description } = useMemo(() => {
+    const errorMessage =
+      error && "message" in error && typeof error.message === "string"
+        ? error.message.toLowerCase()
+        : "";
+
+    if (errorMessage.includes("transaction cannot be created")) {
+      return {
+        title: t("swapErrors.TransactionCannotBeCreated.title"),
+        description: t("swapErrors.TransactionCannotBeCreated.description"),
+      };
+    }
+
     if (titleKey || nameKey) {
       const errorKey = titleKey || nameKey;
       const titleTranslationKey = `swapErrors.${errorKey}.title`;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Implemented a new generic error message - “Partner unavailable: We cannot complete your swap with this partner. Please try with another one._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-20185


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
