### PR TITLE
fix: xrp negative balance

### DIFF
--- a/.changeset/thick-years-boil.md
+++ b/.changeset/thick-years-boil.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-xrp": minor
+---
+
+Prevent negative XRP spendable balance

--- a/libs/coin-modules/coin-xrp/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-xrp/src/logic/getBalance.ts
@@ -1,6 +1,7 @@
 import { Balance } from "@ledgerhq/coin-framework/api/types";
 import { getAccountInfo, getServerInfos } from "../network";
 import { parseAPIValue } from "./common";
+import BigNumber from "bignumber.js";
 
 export async function getBalance(address: string): Promise<Balance[]> {
   const accountInfo = await getAccountInfo(address);
@@ -12,7 +13,10 @@ export async function getBalance(address: string): Promise<Balance[]> {
   );
   const trustlines = accountInfo.ownerCount;
 
-  const locked = reserveMinXRP.plus(reservePerTrustline.times(trustlines));
+  const locked =
+    accountInfo.balance === "0"
+      ? new BigNumber(0)
+      : reserveMinXRP.plus(reservePerTrustline.times(trustlines));
   return [
     {
       value: BigInt(accountInfo.balance),

--- a/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-alpaca/tests/getAccountShape.test.ts
@@ -1,0 +1,173 @@
+import BigNumber from "bignumber.js";
+import { genericGetAccountShape } from "../getAccountShape";
+
+jest.mock("@ledgerhq/coin-framework/account/index", () => ({
+  encodeAccountId: jest.fn(() => "accId"),
+}));
+
+const mergeOpsMock = jest.fn();
+jest.mock("@ledgerhq/coin-framework/bridge/jsHelpers", () => ({
+  mergeOps: (...args: any[]) => mergeOpsMock(...args),
+}));
+
+const listOperationsMock = jest.fn();
+const getBalanceMock = jest.fn();
+const lastBlockMock = jest.fn();
+const getTokenFromAssetMock = jest.fn();
+const chainSpecificGetAccountShapeMock = jest.fn();
+jest.mock("../alpaca", () => ({
+  getAlpacaApi: () => ({
+    lastBlock: (...a: any[]) => lastBlockMock(...a),
+    getBalance: (...a: any[]) => getBalanceMock(...a),
+    listOperations: (...a: any[]) => listOperationsMock(...a),
+    getTokenFromAsset: (...a: any[]) => getTokenFromAssetMock(...a),
+    getChainSpecificRules: () => ({
+      getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),
+    }),
+  }),
+}));
+
+const adaptCoreOperationToLiveOperationMock = jest.fn();
+const extractBalanceMock = jest.fn();
+jest.mock("../utils", () => ({
+  adaptCoreOperationToLiveOperation: (...a: any[]) => adaptCoreOperationToLiveOperationMock(...a),
+  extractBalance: (...a: any[]) => extractBalanceMock(...a),
+}));
+
+const inferSubOperationsMock = jest.fn();
+jest.mock("@ledgerhq/coin-framework/serialization", () => ({
+  inferSubOperations: (...a: any[]) => inferSubOperationsMock(...a),
+}));
+
+const buildSubAccountsMock = jest.fn();
+jest.mock("../buildSubAccounts", () => ({
+  buildSubAccounts: (...a: any[]) => buildSubAccountsMock(...a),
+}));
+
+// Test matrix for Stellar & XRP
+const chains = [
+  { currency: { id: "stellar", name: "Stellar" }, network: "testnet" },
+  { currency: { id: "ripple", name: "XRP" }, network: "mainnet" },
+];
+
+describe("genericGetAccountShape (stellar & xrp)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(chains)("$currency.id", ({ currency, network }) => {
+    test("builds account shape with existing operations, pagination and sub accounts", async () => {
+      const oldOp = {
+        hash: "h1",
+        blockHeight: 10,
+        type: "OPT_IN",
+        extra: { pagingToken: "pt1", assetReference: "ar1", assetOwner: "ow1" },
+      };
+      const initialAccount = { operations: [oldOp], blockHeight: 10 };
+
+      extractBalanceMock.mockReturnValue({ value: "1000", locked: "300" });
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: "1000", locked: "300" },
+        { asset: { type: "token", symbol: "TOK1" }, value: "42" },
+        { asset: { type: "token", symbol: "TOK_IGNORE" }, value: "5" },
+      ]);
+
+      getTokenFromAssetMock.mockImplementation(asset =>
+        asset.symbol === "TOK1" ? { id: `${currency.id}_token1` } : null,
+      );
+
+      const coreOp = { hash: "h2", height: 12 };
+      listOperationsMock.mockResolvedValue([[coreOp]]);
+
+      adaptCoreOperationToLiveOperationMock.mockImplementation((_accId, op) => ({
+        hash: op.hash,
+        type: "IN",
+        blockHeight: 12,
+        extra: { assetReference: "ar2", assetOwner: "ow2" },
+      }));
+
+      mergeOpsMock.mockImplementation((oldOps, newOps) => [...newOps, ...oldOps]);
+
+      buildSubAccountsMock.mockReturnValue([
+        { id: `${currency.id}_subAcc1`, type: "TokenAccount" },
+      ]);
+
+      inferSubOperationsMock.mockImplementation(hash =>
+        hash === "h2" ? [{ id: `${currency.id}_subOp1` }] : [],
+      );
+
+      lastBlockMock.mockResolvedValue({ height: 123 });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr1`,
+          initialAccount,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(chainSpecificGetAccountShapeMock).toHaveBeenCalledWith(`${currency.id}_addr1`);
+
+      expect(listOperationsMock).toHaveBeenCalledWith(`${currency.id}_addr1`, {
+        minHeight: 11,
+        order: "asc",
+        lastPagingToken: "pt1",
+      });
+
+      const assetsBalancePassed = buildSubAccountsMock.mock.calls[0][0].assetsBalance;
+      expect(assetsBalancePassed).toHaveLength(1);
+      expect(assetsBalancePassed[0].asset.symbol).toBe("TOK1");
+
+      const assetOpsPassed = buildSubAccountsMock.mock.calls[0][0].operations;
+      expect(assetOpsPassed).toHaveLength(1);
+      expect(assetOpsPassed[0].hash).toBe("h2");
+
+      expect(result).toMatchObject({
+        balance: new BigNumber(1000),
+        spendableBalance: new BigNumber(700),
+        blockHeight: 123,
+        operationsCount: 2,
+        subAccounts: [{ id: `${currency.id}_subAcc1`, type: "TokenAccount" }],
+        operations: [
+          {
+            hash: "h2",
+            type: "IN",
+            blockHeight: 12,
+            subOperations: [{ id: `${currency.id}_subOp1` }],
+            extra: { assetReference: "ar2", assetOwner: "ow2" },
+          },
+          oldOp,
+        ],
+      });
+    });
+
+    test("handles empty operations (no old ops, no new ops) and blockHeight=0", async () => {
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: "0", locked: "0" }]);
+      extractBalanceMock.mockReturnValue({ value: "0", locked: "0" });
+      listOperationsMock.mockResolvedValue([[]]);
+      buildSubAccountsMock.mockReturnValue([]);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        {
+          address: `${currency.id}_addr2`,
+          initialAccount: undefined,
+          currency,
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+      expect(result).toMatchObject({
+        operations: [], // Empty array check for `operations`
+        blockHeight: 0,
+        operationsCount: 0,
+        subAccounts: [], // Empty array check for `subAccounts`
+        balance: new BigNumber(0),
+        spendableBalance: new BigNumber(0),
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

XRP as locked value set to 1, so if balance is 0 we see a negative value !
To avoid that, if spendable balance is negative then we set it to 0.

<img width="597" height="742" alt="Screenshot 2025-09-11 at 15 37 44" src="https://github.com/user-attachments/assets/2eb4a78d-b19b-465e-83d0-d7ce0bb0e681" />  


### ❓ Context

- **JIRA or GitHub link**: [LIVE-21395](https://ledgerhq.atlassian.net/browse/LIVE-21395)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21395]: https://ledgerhq.atlassian.net/browse/LIVE-21395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ