### PR TITLE
Revert "fix(LIVE-21396): Tab indicator out of sync"

### DIFF
--- a/.changeset/ninety-zoos-happen.md
+++ b/.changeset/ninety-zoos-happen.md
@@ -1,5 +1,0 @@
----
-"ledger-live-desktop": major
----
-
-Fix Tab indicator out of sync bug

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Navbar/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Navbar/index.tsx
@@ -55,11 +55,7 @@ const Navbar = () => {
 
   return (
     <Nav>
-      <Chip
-        onTabChange={onWrappedTabChange}
-        initialActiveIndex={currentIndex}
-        key={`chip-${currentIndex}-${pathname}`}
-      >
+      <Chip onTabChange={onWrappedTabChange} initialActiveIndex={currentIndex}>
         {tabs.map((tab, idx) => (
           <Text key={tab} data-testid={`${tab}-tab-button`} data-active={currentIndex === idx}>
             {tab}


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live#11741