### PR TITLE
fix: Tab Indicator Sync

### DIFF
--- a/.changeset/wise-jokes-wonder.md
+++ b/.changeset/wise-jokes-wonder.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/react-ui": minor
+---
+
+Fix Tab Indicator Sync

--- a/libs/ui/packages/react/src/components/tabs/Chip/index.tsx
+++ b/libs/ui/packages/react/src/components/tabs/Chip/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Flex from "../../layout/Flex";
 
@@ -41,6 +41,11 @@ const Item = styled(Flex).attrs({
 
 export default function BarTabs({ children, onTabChange, initialActiveIndex }: Props): JSX.Element {
   const [activeIndex, setActiveIndex] = useState(initialActiveIndex);
+
+  useEffect(() => {
+    setActiveIndex(initialActiveIndex);
+  }, [initialActiveIndex]);
+
   return (
     <Container>
       {React.Children.toArray(children).map((child, index) => (


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR fixes the Tab indicator sync issue
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._


| Before       
| 
<img width="1624" height="979" alt="Screenshot 2025-09-10 at 11 47 44" src="https://github.com/user-attachments/assets/290ee080-6703-405c-9105-10182e553275" />
 | ------------- |

 | After         |

<img width="1624" height="979" alt="Screenshot 2025-09-10 at 14 55 13" src="https://github.com/user-attachments/assets/be0e6270-4320-4ab1-b1d0-8effa30282cd" />

|               |               |

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-21396


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
