### PR TITLE
feat(LIVE-21429): Update rendering strategy on earn tab navigation

### DIFF
--- a/.changeset/clean-spoons-do.md
+++ b/.changeset/clean-spoons-do.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Change rendering strategy for earn on tab bar navigation

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
@@ -114,7 +114,7 @@ export default function MainNavigator() {
         name={NavigatorName.Earn}
         component={EarnLiveAppNavigator}
         layout={({ children }) => (
-          // never unmount Portfolio on navigation
+          // dont unmount Earn on navigation
           <>{children}</>
         )}
         options={{

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigator.tsx
@@ -113,8 +113,12 @@ export default function MainNavigator() {
       <Tab.Screen
         name={NavigatorName.Earn}
         component={EarnLiveAppNavigator}
-        layout={unmountOnBlur}
+        layout={({ children }) => (
+          // never unmount Portfolio on navigation
+          <>{children}</>
+        )}
         options={{
+          freezeOnBlur: true,
           headerShown: false,
           tabBarIcon: props => (
             <TabIcon


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description
Change rendering strategy for Earn app tab

https://github.com/user-attachments/assets/6383447d-f58a-47f2-8dde-c03679e78712



### ❓ Context

- **JIRA or GitHub link**: [LIVE-21429](https://ledgerhq.atlassian.net/browse/LIVE-21429)
- [Confluence](https://ledgerhq.atlassian.net/wiki/spaces/PTX/pages/6200557585/MOBILE+Rendering+on+Ledger-Live)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21429]: https://ledgerhq.atlassian.net/browse/LIVE-21429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ