### PR TITLE
🐛  LLD - fix accounts added screen on live app flows

### DIFF
--- a/.changeset/nasty-islands-run.md
+++ b/.changeset/nasty-islands-run.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LLD - Fix the accounts added screen on live app flows

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsAdded/components/AccountList.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsAdded/components/AccountList.tsx
@@ -11,16 +11,21 @@ export const AccountList = ({
   accounts,
   formatAccount,
   navigateToEditAccountName,
+  isAccountSelectionFlow,
 }: AccountListProps) => {
   const { colors } = useTheme();
   const history = useHistory();
 
   const handleAccountClick = useCallback(
-    (accountId: string) => {
-      history.push({ pathname: `/account/${accountId}` });
-      setDrawer();
+    (account: Account) => {
+      if (isAccountSelectionFlow) {
+        navigateToEditAccountName(account);
+      } else {
+        history.push({ pathname: `/account/${account.id}` });
+        setDrawer();
+      }
     },
-    [history],
+    [history, isAccountSelectionFlow, navigateToEditAccountName],
   );
 
   const accountItems = useMemo(
@@ -34,9 +39,9 @@ export const AccountList = ({
               aria-label={`account item ${account.id}`}
               account={formattedAccount}
               backgroundColor={colors.opacityDefault.c05}
-              onClick={() => handleAccountClick(account.id)}
+              onClick={() => handleAccountClick(account)}
               rightElement={{
-                type: "edit",
+                type: isAccountSelectionFlow ? "arrow" : "edit",
                 onClick: () => navigateToEditAccountName(account),
               }}
             />
@@ -47,8 +52,9 @@ export const AccountList = ({
       accounts,
       formatAccount,
       colors.opacityDefault.c05,
-      handleAccountClick,
       navigateToEditAccountName,
+      isAccountSelectionFlow,
+      handleAccountClick,
     ],
   );
 

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsAdded/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsAdded/index.tsx
@@ -66,6 +66,7 @@ const AccountsAdded = ({
           accounts={accounts}
           formatAccount={formatAccount}
           navigateToEditAccountName={navigateToEditAccountName}
+          isAccountSelectionFlow={isAccountSelectionFlow}
         />
       </ScrollContainer>
       <ActionButtons

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsAdded/types.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsAdded/types.ts
@@ -15,6 +15,7 @@ export interface AccountListProps {
   accounts: Account[];
   formatAccount: (account: Account) => FormattedAccount;
   navigateToEditAccountName: (account: Account) => void;
+  isAccountSelectionFlow: boolean;
 }
 
 export interface AccountsAddedProps {

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerBackButton.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerBackButton.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { ModularDrawerStep } from "../types";
 import { useSelector } from "react-redux";
-import { modularDrawerStateSelector } from "~/renderer/reducers/modularDrawer";
+import { modularDrawerSearchedSelector } from "~/renderer/reducers/modularDrawer";
 
 interface UseModularDrawerBackButtonProps {
   currentStep: ModularDrawerStep;
@@ -19,7 +19,7 @@ export function useModularDrawerBackButton({
   hasOneCurrency,
   networksToDisplay,
 }: UseModularDrawerBackButtonProps) {
-  const { searchedValue } = useSelector(modularDrawerStateSelector);
+  const searchedValue = useSelector(modularDrawerSearchedSelector);
   const handleBack = useMemo(() => {
     const canGoBackToAsset = !hasOneCurrency || !!searchedValue;
     const canGoBackToNetwork = networksToDisplay && networksToDisplay.length > 1;

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerData.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerData.ts
@@ -3,7 +3,7 @@ import { CurrenciesByProviderId, LoadingStatus } from "@ledgerhq/live-common/dep
 import { getLoadingStatus } from "@ledgerhq/live-common/modularDrawer/utils/getLoadingStatus";
 import { findCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { useAssetsData } from "@ledgerhq/live-common/modularDrawer/hooks/useAssetsData";
-import { modularDrawerStateSelector } from "~/renderer/reducers/modularDrawer";
+import { modularDrawerSearchedSelector } from "~/renderer/reducers/modularDrawer";
 import { useSelector } from "react-redux";
 import { useFeature } from "@ledgerhq/live-common/featureFlags/index";
 
@@ -18,13 +18,13 @@ export function useModularDrawerData({
   useCase,
   areCurrenciesFiltered,
 }: UseModularDrawerDataProps) {
-  const { searchedValue } = useSelector(modularDrawerStateSelector);
   const modularDrawerFeature = useFeature("lldModularDrawer");
 
   const isStaging = useMemo(
     () => modularDrawerFeature?.params?.backendEnvironment === "STAGING",
     [modularDrawerFeature?.params?.backendEnvironment],
   );
+  const searchedValue = useSelector(modularDrawerSearchedSelector);
 
   const { data, isLoading, isSuccess, error, loadNext, refetch } = useAssetsData({
     search: searchedValue,

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerFlowState.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/hooks/useModularDrawerFlowState.ts
@@ -15,7 +15,7 @@ import {
 } from "@ledgerhq/live-common/modularDrawer/utils/index";
 import { findTokenById } from "@ledgerhq/cryptoassets/tokens";
 import { useSelector } from "react-redux";
-import { modularDrawerStateSelector } from "~/renderer/reducers/modularDrawer";
+import { modularDrawerSearchedSelector } from "~/renderer/reducers/modularDrawer";
 
 type Props = {
   currenciesByProvider: CurrenciesByProviderId[];
@@ -41,7 +41,7 @@ export function useModularDrawerFlowState({
   flow,
 }: Props) {
   const { trackModularDrawerEvent } = useModularDrawerAnalytics();
-  const { searchedValue } = useSelector(modularDrawerStateSelector);
+  const searchedValue = useSelector(modularDrawerSearchedSelector);
 
   const [selectedAsset, setSelectedAsset] = useState<CryptoOrTokenCurrency>();
   const [selectedNetwork, setSelectedNetwork] = useState<CryptoOrTokenCurrency>();

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/components/SearchInputContainer/useSearch.ts
@@ -2,8 +2,8 @@ import { ChangeEvent, useCallback } from "react";
 import { useModularDrawerAnalytics } from "LLD/features/ModularDrawer/analytics/useModularDrawerAnalytics";
 import { MODULAR_DRAWER_PAGE_NAME } from "LLD/features/ModularDrawer/analytics/modularDrawer.types";
 import { useDispatch, useSelector } from "react-redux";
-import { modularDrawerStateSelector, setSearchedValue } from "~/renderer/reducers/modularDrawer";
 import { useSearchCommon } from "@ledgerhq/live-common/modularDrawer/hooks/useSearch";
+import { modularDrawerSearchedSelector, setSearchedValue } from "~/renderer/reducers/modularDrawer";
 
 export type SearchProps = {
   source: string;
@@ -18,7 +18,9 @@ export type SearchResult = {
 
 export const useSearch = ({ source, flow }: SearchProps): SearchResult => {
   const dispatch = useDispatch();
-  const { searchedValue } = useSelector(modularDrawerStateSelector);
+
+  const searchedValue = useSelector(modularDrawerSearchedSelector);
+
   const { trackModularDrawerEvent } = useModularDrawerAnalytics();
 
   const onTrackSearch = useCallback(

--- a/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -8,7 +8,7 @@ import TrackDrawerScreen from "../../analytics/TrackDrawerScreen";
 import { CurrenciesByProviderId, LoadingStatus } from "@ledgerhq/live-common/deposit/type";
 import { GenericError } from "../../components/GenericError";
 import { useSelector } from "react-redux";
-import { modularDrawerStateSelector } from "~/renderer/reducers/modularDrawer";
+import { modularDrawerSearchedSelector } from "~/renderer/reducers/modularDrawer";
 
 export type AssetSelectionStepProps = {
   assetsToDisplay: CryptoOrTokenCurrency[];
@@ -37,7 +37,7 @@ const AssetSelection = ({
   error,
   refetch,
 }: Readonly<AssetSelectionStepProps>) => {
-  const { searchedValue } = useSelector(modularDrawerStateSelector);
+  const searchedValue = useSelector(modularDrawerSearchedSelector);
 
   const [shouldScrollToTop, setShouldScrollToTop] = useState(false);
 

--- a/apps/ledger-live-desktop/src/renderer/reducers/modularDrawer.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/modularDrawer.ts
@@ -21,6 +21,8 @@ const modularDrawerSlice = createSlice({
 
 export const modularDrawerStateSelector = (state: State) => state.modularDrawer;
 
+export const modularDrawerSearchedSelector = (state: State) => state.modularDrawer.searchedValue;
+
 export const { setSearchedValue } = modularDrawerSlice.actions;
 
 export default modularDrawerSlice.reducer;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Fix a UX issue when adding accounts from the mad on live app flows

### 📝 Description

Added a selector to access the searchedValue directly instead of the whole modularDrawer slice. This will avoid rerenders when other values than the search change
Display an arrow in the accounts added screen when coming from a live app. Clicking on an account on this screen selects it and sends it to the live app

<img width="587" height="920" alt="Screenshot 2025-09-12 at 17 20 07" src="https://github.com/user-attachments/assets/922e06e3-4226-429f-87cb-24205971b554" />

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21368]<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21368]: https://ledgerhq.atlassian.net/browse/LIVE-21368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ