### PR TITLE
fix(LLD): MAD data hook isloading should exclude next page loads

### DIFF
--- a/.changeset/eighty-apricots-carry.md
+++ b/.changeset/eighty-apricots-carry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+mad hook isLoading should exclude next page loads

--- a/libs/ledger-live-common/src/modularDrawer/hooks/useAssetsData.ts
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/useAssetsData.ts
@@ -34,15 +34,24 @@ export function useAssetsData({
   version: string;
   isStaging?: boolean;
 }) {
-  const { data, isLoading, error, fetchNextPage, isSuccess, refetch, isFetching, isError } =
-    useGetAssetsDataInfiniteQuery({
-      search,
-      useCase,
-      currencyIds: areCurrenciesFiltered ? currencyIds : undefined,
-      product,
-      version,
-      isStaging,
-    });
+  const {
+    data,
+    isLoading,
+    error,
+    fetchNextPage,
+    isSuccess,
+    refetch,
+    isFetching,
+    isError,
+    isFetchingNextPage,
+  } = useGetAssetsDataInfiniteQuery({
+    search,
+    useCase,
+    currencyIds: areCurrenciesFiltered ? currencyIds : undefined,
+    product,
+    version,
+    isStaging,
+  });
 
   const joinedPages = useMemo(() => {
     return data?.pages.reduce<AssetsDataWithPagination>((acc, page) => {
@@ -65,9 +74,11 @@ export function useAssetsData({
 
   const hasMore = Boolean(joinedPages?.pagination.nextCursor);
 
+  const isInitialLoading = isLoading || (isFetching && !isFetchingNextPage);
+
   return {
     data: joinedPages,
-    isLoading: isLoading || isFetching,
+    isLoading: isInitialLoading,
     error,
     loadNext: hasMore ? fetchNextPage : undefined,
     isSuccess,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Fixes infinite scroll

### 📝 Description

Fixes infinite scroll whilst preserving skeleton on search

Before:

https://github.com/user-attachments/assets/c259ab40-b4ab-4974-9632-24d318f4688f

After: 

https://github.com/user-attachments/assets/1e42cce2-34a2-4b16-894b-98956bc4ef42

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21427](https://ledgerhq.atlassian.net/browse/LIVE-21427)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21427]: https://ledgerhq.atlassian.net/browse/LIVE-21427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ