### PR TITLE
[LIVE–21274] Fix(LLM/Sync Onboarding): Onboarding OS update interrupted

### DIFF
--- a/.changeset/ninety-adults-repeat.md
+++ b/.changeset/ninety-adults-repeat.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix OS update closing automatically in sync onboarding


### PR DESCRIPTION
…S Update)

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Onboarding of touchscreen devices

### 📝 Description

The issue is that some polling logic was happening in the background (for another screen) while doing the OS update in the context of an onboarding.
Due to that logic, some `navigation.goBack()` call was triggered at some point from that other screen, causing a closing of the update screen, and the interruption of the update.
 
<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21274] <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21274]: https://ledgerhq.atlassian.net/browse/LIVE-21274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ