### PR TITLE
fix(LLD): change receive assets error icon

### DIFF
--- a/.changeset/fifty-doors-compare.md
+++ b/.changeset/fifty-doors-compare.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+LLD MAD change receive assets error icon

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/ModularDrawerAddAccountFlowManager.tsx
@@ -145,6 +145,7 @@ const ModularDrawerAddAccountFlowManager = ({
               navigateToEditAccountName={navigateToEditAccountName}
               navigateToFundAccount={navigateToFundAccount}
               source={source}
+              isAccountSelectionFlow={isAccountSelectionFlow}
             />
           </StepContainer>
         );

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsWarning/index.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsWarning/index.tsx
@@ -14,11 +14,13 @@ const AccountsWarning = ({
   navigateToEditAccountName,
   navigateToFundAccount,
   source,
+  isAccountSelectionFlow,
 }: AccountsWarningProps) => {
   const { emptyAccountWarning, noAssociatedAccountsWarning } = useWarningConfig(
     currency,
     navigateToEditAccountName,
     navigateToFundAccount,
+    isAccountSelectionFlow,
     emptyAccount,
   );
 

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsWarning/types.ts
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsWarning/types.ts
@@ -20,4 +20,5 @@ export interface AccountsWarningProps {
   navigateToFundAccount: (account: Account) => void;
   emptyAccount?: Account;
   source: string;
+  isAccountSelectionFlow: boolean;
 }

--- a/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsWarning/useWarningConfig.tsx
+++ b/apps/ledger-live-desktop/src/newArch/features/AddAccountDrawer/screens/AccountsWarning/useWarningConfig.tsx
@@ -17,6 +17,7 @@ export const useWarningConfig = (
   currency: CryptoCurrency,
   navigateToEditAccountName: (account: Account) => void,
   navigateToFundAccount: (account: Account) => void,
+  isAccountSelectionFlow: boolean,
   emptyAccount?: Account,
 ) => {
   const { t } = useTranslation();
@@ -58,7 +59,7 @@ export const useWarningConfig = (
           onClick={() => handleAccountClick(formattedAccount.id)}
           backgroundColor={colors.opacityDefault.c05}
           rightElement={{
-            type: "edit",
+            type: isAccountSelectionFlow ? "arrow" : "edit",
             onClick: () => navigateToEditAccountName(emptyAccount),
           }}
         />


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Changes asset needs 

### 📝 Description

Changed edit icon to arrow on MAD account selection flows for empty account error page

| Before        | After         |
| ------------- | ------------- |
| <img width="3022" height="2112" alt="image" src="https://github.com/user-attachments/assets/1611f3f3-6aa7-497f-836a-5339223f8fc2" />  | <img width="3022" height="2112" alt="image" src="https://github.com/user-attachments/assets/fb2a0f6f-cbbb-496b-9847-de4d8e26dcb5" /> |
| <img width="3022" height="2112" alt="image" src="https://github.com/user-attachments/assets/f9e7c6d1-6940-4d12-8465-00dbe7ab1b51" /> | <img width="3022" height="2112" alt="image" src="https://github.com/user-attachments/assets/eb320bd4-c0a2-464c-a534-e9de2f7ab71b" /> |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21368](https://ledgerhq.atlassian.net/browse/LIVE-21368)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21368]: https://ledgerhq.atlassian.net/browse/LIVE-21368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ