### PR TITLE
Remove ripemd160 & sha256 dependency in favor of @noble/hashes

### DIFF
--- a/libs/coin-modules/coin-bitcoin/package.json
+++ b/libs/coin-modules/coin-bitcoin/package.json
@@ -66,10 +66,8 @@
     "expect": "^27.4.6",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "ripemd160": "^2.0.2",
     "rxjs": "^7.8.1",
     "@noble/curves": "^1.9.7",
-    "sha.js": "^2.4.11",
     "utility-types": "^3.10.0",
     "varuint-bitcoin": "1.1.2"
   },

--- a/libs/coin-modules/coin-bitcoin/src/crypto-util.ts
+++ b/libs/coin-modules/coin-bitcoin/src/crypto-util.ts
@@ -1,14 +1,14 @@
-import RIPEMD160 from "ripemd160";
-import sha from "sha.js";
+import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
+import { ripemd160 as nobleRipemd160 } from "@noble/hashes/ripemd160";
 
 export function sha256(buffer: Buffer | string) {
-  return sha("sha256").update(buffer).digest();
+  return Buffer.from(nobleSha256(buffer));
 }
 export function hash256(buffer: Buffer | string) {
   return sha256(sha256(buffer));
 }
 export function ripemd160(buffer: Buffer | string) {
-  return new RIPEMD160().update(buffer).digest();
+  return Buffer.from(nobleRipemd160(buffer));
 }
 export function hash160(buffer: Buffer | string) {
   return ripemd160(sha256(buffer));

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/decred.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/decred.ts
@@ -4,7 +4,7 @@ import * as bjs from "bitcoinjs-lib";
 import bs58checkBase from "bs58check/base";
 import bs58check from "bs58check";
 import { blake256 as nobleBlake256 } from "@noble/hashes/blake1";
-import RIPEMD160 from "ripemd160";
+import { ripemd160 } from "@noble/hashes/ripemd160";
 import bs58 from "bs58";
 import BIP32 from "./bip32";
 
@@ -27,10 +27,7 @@ class Decred extends Base {
   // refer to decred spec https://devdocs.decred.org/developer-guides/addresses/
   static getAddressFromPk(publicKey: Buffer): string {
     const prefix = Buffer.from("073f", "hex");
-    const pkhash = Buffer.concat([
-      prefix,
-      new RIPEMD160().update(Decred.blake256(publicKey)).digest(),
-    ]);
+    const pkhash = Buffer.concat([prefix, Buffer.from(ripemd160(Decred.blake256(publicKey)))]);
     const checksum = Decred._blake256x2(pkhash).slice(0, 4);
     return bs58.encode(Buffer.concat([pkhash, checksum]));
   }

--- a/libs/coin-modules/coin-bitcoin/types.d.ts
+++ b/libs/coin-modules/coin-bitcoin/types.d.ts
@@ -1,3 +1,2 @@
 declare module "coininfo";
-declare module "blake-hash";
 declare module "bs58check/base";

--- a/libs/device-core/package.json
+++ b/libs/device-core/package.json
@@ -25,7 +25,7 @@
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "semver": "^7.3.5",
-    "sha.js": "^2.4.11"
+    "@noble/hashes": "1.8.0"
   },
   "devDependencies": {
     "@testing-library/react": "14",

--- a/libs/device-core/src/managerApi/use-cases/getUserHashes.ts
+++ b/libs/device-core/src/managerApi/use-cases/getUserHashes.ts
@@ -1,7 +1,7 @@
-import sha from "sha.js";
+import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
 
 function sha256(buffer: Buffer | string) {
-  return sha("sha256").update(buffer).digest();
+  return Buffer.from(nobleSha256(buffer));
 }
 
 function userHashesPerUserId(userId: string) {

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -251,7 +251,7 @@
     "rlp": "^3.0.0",
     "rxjs": "^7.8.1",
     "semver": "^7.3.5",
-    "sha.js": "^2.4.11",
+    "@noble/hashes": "1.8.0",
     "triple-beam": "^1.3.0",
     "tsx": "^4.7.1",
     "usehooks-ts": "^2.13.0",

--- a/libs/ledger-live-common/src/bot/index.ts
+++ b/libs/ledger-live-common/src/bot/index.ts
@@ -714,7 +714,7 @@ export async function bot({ disabled, filter }: Arg = {}): Promise<void> {
     const serializedReport: MinimalSerializedReport = {
       results: results.map(convertSpecReport),
       environment: BOT_ENVIRONMENT,
-      seedHash: sha256(getEnv("SEED")),
+      seedHash: sha256(getEnv("SEED")).toString("hex"),
     };
 
     await Promise.all([

--- a/libs/ledger-live-common/src/crypto/index.ts
+++ b/libs/ledger-live-common/src/crypto/index.ts
@@ -1,5 +1,5 @@
-import sha from "sha.js";
+import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
 
 export function sha256(buffer: Buffer | string) {
-  return sha("sha256").update(buffer).digest();
+  return Buffer.from(nobleSha256(buffer));
 }

--- a/libs/ledgerjs/packages/hw-app-btc/package.json
+++ b/libs/ledgerjs/packages/hw-app-btc/package.json
@@ -67,9 +67,8 @@
     "bs58": "^4.0.1",
     "bs58check": "^2.1.2",
     "invariant": "^2.2.4",
-    "ripemd160": "2",
+    "@noble/hashes": "1.8.0",
     "semver": "^7.3.5",
-    "sha.js": "2",
     "@noble/curves": "1.9.7",
     "varuint-bitcoin": "1.1.2"
   },

--- a/libs/ledgerjs/packages/hw-app-btc/src/BtcOld.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/BtcOld.ts
@@ -1,6 +1,6 @@
 import bs58 from "bs58";
-import RIPEMD160 from "ripemd160";
-import sha from "sha.js";
+import { sha256 as nobleSha256 } from "@noble/hashes/sha256";
+import { ripemd160 as nobleRipemd160 } from "@noble/hashes/ripemd160";
 import type Transport from "@ledgerhq/hw-transport";
 import type { CreateTransactionArg } from "./createTransaction";
 import { createTransaction } from "./createTransaction";
@@ -185,13 +185,13 @@ function makeXpub(
 }
 
 function sha256(buffer: Buffer | string) {
-  return sha("sha256").update(buffer).digest();
+  return Buffer.from(nobleSha256(buffer));
 }
 function hash256(buffer: Buffer | string) {
   return sha256(sha256(buffer));
 }
 function ripemd160(buffer: Buffer | string) {
-  return new RIPEMD160().update(buffer).digest();
+  return Buffer.from(nobleRipemd160(buffer));
 }
 function hash160(buffer: Buffer | string) {
   return ripemd160(sha256(buffer));

--- a/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInputBIP143.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/getTrustedInputBIP143.ts
@@ -1,5 +1,5 @@
 import Transport from "@ledgerhq/hw-transport";
-import shajs from "sha.js";
+import { sha256 } from "@noble/hashes/sha256";
 import type { Transaction } from "./types";
 import { serializeTransaction } from "./serializeTransaction";
 export function getTrustedInputBIP143(
@@ -18,9 +18,7 @@ export function getTrustedInputBIP143(
     throw new Error("Decred does not implement BIP143");
   }
 
-  let hash = shajs("sha256")
-    .update(shajs("sha256").update(serializeTransaction(transaction, true)).digest())
-    .digest();
+  let hash = Buffer.from(sha256(sha256(serializeTransaction(transaction, true))));
   const data = Buffer.alloc(4);
   data.writeUInt32LE(indexLookup, 0);
   const { outputs, locktime } = transaction;

--- a/libs/ledgerjs/packages/hw-app-btc/src/hashPublicKey.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/hashPublicKey.ts
@@ -1,5 +1,5 @@
-import RIPEMD160 from "ripemd160";
-import sha from "sha.js";
+import { sha256 } from "@noble/hashes/sha256";
+import { ripemd160 } from "@noble/hashes/ripemd160";
 export function hashPublicKey(buffer: Buffer): Buffer {
-  return new RIPEMD160().update(sha("sha256").update(buffer).digest()).digest();
+  return Buffer.from(ripemd160(sha256(buffer)));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2416,15 +2416,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      ripemd160:
-        specifier: ^2.0.2
-        version: 2.0.2
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
-      sha.js:
-        specifier: ^2.4.11
-        version: 2.4.11
       utility-types:
         specifier: ^3.10.0
         version: 3.11.0
@@ -4846,12 +4840,12 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-live
+      '@noble/hashes':
+        specifier: 1.8.0
+        version: 1.8.0
       semver:
         specifier: ^7.3.5
         version: 7.5.4
-      sha.js:
-        specifier: ^2.4.11
-        version: 2.4.11
     devDependencies:
       '@testing-library/react':
         specifier: '14'
@@ -5449,6 +5443,9 @@ importers:
       '@noble/curves':
         specifier: ^1.9.7
         version: 1.9.7
+      '@noble/hashes':
+        specifier: 1.8.0
+        version: 1.8.0
       '@reduxjs/toolkit':
         specifier: 2.8.2
         version: 2.8.2(react-redux@7.2.9(@types/react@18.2.73)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -5584,9 +5581,6 @@ importers:
       semver:
         specifier: ^7.3.5
         version: 7.5.4
-      sha.js:
-        specifier: ^2.4.11
-        version: 2.4.11
       triple-beam:
         specifier: ^1.3.0
         version: 1.4.1
@@ -6112,6 +6106,9 @@ importers:
       '@noble/curves':
         specifier: 1.9.7
         version: 1.9.7
+      '@noble/hashes':
+        specifier: 1.8.0
+        version: 1.8.0
       bip32-path:
         specifier: ^0.4.2
         version: 0.4.2
@@ -6127,15 +6124,9 @@ importers:
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
-      ripemd160:
-        specifier: '2'
-        version: 2.0.2
       semver:
         specifier: ^7.3.5
         version: 7.5.4
-      sha.js:
-        specifier: '2'
-        version: 2.4.11
       varuint-bitcoin:
         specifier: 1.1.2
         version: 1.1.2


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - bitcoin implementation

### 📝 Description

as a continuation of #11814 we can simplify even more our curves by removing ripemd160 and sha.js dependency, converging all to @noble/hashes @ 1.8.0 on Ledger Live stack.


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
