### PR TITLE
ci: move desktop tests to 16CPU runners and optimize execution

### DIFF
--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -114,7 +114,8 @@ jobs:
           path: ${{ github.workspace }}/apps/ledger-live-desktop/coverage
 
   e2e-tests-linux:
-    name: "Ubuntu E2E"
+    name: "Ubuntu Mock"
+    timeout-minutes: 20
     outputs:
       status: ${{ steps.tests.outcome }}
     env:
@@ -126,7 +127,7 @@ jobs:
       LC_ALL: en_US.UTF-8
       # DEBUG: "pw:browser*"
       # DEBUG_LOGS: 1
-    runs-on: [ ledger-live-linux-8CPU-32RAM ]
+    runs-on: [ ledger-live-linux-16CPU-64RAM ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -145,15 +146,8 @@ jobs:
         id: setup-test-desktop
         with:
           skip_ruby: true
-          install_playwright: true
           turborepo-server-port: ${{ steps.caches.outputs.port }}
-      - name: Install CLI dependencies
-        env:
-          LANG: en_US.UTF-8
-        run: pnpm i --filter="live-cli*..."
-        shell: bash
-      - name: Build CLI
-        run: pnpm build:cli --api="http://127.0.0.1:${{ steps.caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo"
+          install_playwright: true
       - name: Run playwright tests [Linux => xvfb-run]
         id: tests
         run: |

--- a/apps/ledger-live-desktop/scripts/ci-lint.mjs
+++ b/apps/ledger-live-desktop/scripts/ci-lint.mjs
@@ -40,7 +40,7 @@ for (const arg in argv) {
 const output = external ? "lint-desktop-external.json" : "lint-desktop.json";
 const lint = async () => {
   cd("../../");
-  if (typeof port === "string" && typeof token !== "string") {
+  if (port && token) {
     await $`pnpm lint \\
       --filter="ledger-live-desktop" \\
       --api="http://127.0.0.1:${port}" \\

--- a/apps/ledger-live-desktop/tests/playwright.config.ts
+++ b/apps/ledger-live-desktop/tests/playwright.config.ts
@@ -36,7 +36,7 @@ const config: PlaywrightTestConfig = {
   maxFailures: process.env.CI ? 5 : undefined,
   reportSlowTests: process.env.CI ? { max: 0, threshold: 60000 } : null,
   fullyParallel: true,
-  workers: "40%", // NOTE: 'macos-latest' and 'windows-latest' can't run 3 concurrent workers
+  workers: "60%", // NOTE: 'macos-latest' and 'windows-latest' can't run 3 concurrent workers
   retries: 0, // We explicitly want to disable retries to be strict about avoiding flaky tests. (see https://github.com/LedgerHQ/ledger-live/pull/4918)
   reporter: process.env.CI
     ? [

--- a/tools/actions/composites/setup-test-desktop/action.yml
+++ b/tools/actions/composites/setup-test-desktop/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Install dependencies
       env:
         LANG: en_US.UTF-8
-      run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live" --filter="@ledgerhq/dummy-*-app..." --unsafe-perm
+      run: pnpm i --filter="ledger-live-desktop..." --filter="ledger-live" --filter="@ledgerhq/dummy-*-app..." --filter="live-cli*..." --unsafe-perm
       shell: bash
     - name: Install playwright dependencies
       if: ${{ inputs.install_playwright }}
@@ -55,7 +55,7 @@ runs:
     - name: Build dependencies
       if: inputs.turborepo-server-port != ''
       run: |
-        pnpm build:lld:deps --api="http://127.0.0.1:${{ inputs.turborepo-server-port }}" --token="${{ inputs.turbo-server-token }}" --team="foo"
+        pnpm turbo build --filter="ledger-live-desktop^..." --filter=@ledgerhq/live-cli --api="http://127.0.0.1:${{ inputs.turborepo-server-port }}" --token="${{ inputs.turbo-server-token }}" --team="foo"
       shell: bash
     - name: Build dependencies
       if: inputs.turborepo-server-port == ''

--- a/turbo.json
+++ b/turbo.json
@@ -279,7 +279,9 @@
         "CI_OS"
       ],
       "outputs": [
-        "lint.json"
+        "lint.json",
+        "lint-desktop.json",
+        "lint-desktop-external.json"
       ]
     },
     "ledger-live-desktop#test": {


### PR DESCRIPTION
- Use larger Ubuntu runners for mock tests
- Enable turborepo for linting

Ticket: https://ledgerhq.atlassian.net/browse/LIVE-21435
Test flow: https://github.com/LedgerHQ/ledger-live/actions/runs/17712539818