### PR TITLE
Support: Library test parallelisation

### DIFF
--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -61,7 +61,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
         
-          pnpm turbo run coverage --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" --filter="./libs/**" --filter="!./libs/ui/**" --concurrency=1 -- --runInBand=1 
+          pnpm turbo run coverage --api="http://127.0.0.1:${{ steps.setup-caches.outputs.port }}" --token="${{ secrets.TURBOREPO_SERVER_TOKEN }}" --team="foo" --filter="./libs/**" --filter="!./libs/ui/**" --concurrency=4 -- --runInBand=1 
 
       - name: Test libraries without coverage script & Process coverage files
         id: test-libs
@@ -69,7 +69,7 @@ jobs:
           
           echo "::group::Processing coverage files"
           
-          testCommand=(pnpm turbo test --concurrency=25%)
+          testCommand=(pnpm turbo test --concurrency=4)
           
           for package_json in $(find ./libs -name "package.json"); do
             lib=$(dirname "$package_json")

--- a/turbo.json
+++ b/turbo.json
@@ -188,7 +188,7 @@
       "persistent": true
     },
     "coverage": {
-      "cache": false,
+      "cache": true,
       "dependsOn": [
         "^build",
         "build"


### PR DESCRIPTION
- Alter the Lib tests to utilise GHA resources more appropriately
- Enable caching on code coverage

Uncached: https://github.com/LedgerHQ/ledger-live/actions/runs/17762424329/job/50478087815
Cached: http://github.com/LedgerHQ/ledger-live/actions/runs/17762424329/job/50480762178