### PR TITLE
fix(back-9674): cursor on last page + block height type

### DIFF
--- a/.changeset/eight-zebras-end.md
+++ b/.changeset/eight-zebras-end.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-sui": patch
+---
+
+coin:sui fix last page cursor

--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -125,6 +125,10 @@ describe("Sui Api", () => {
       });
       expect(txs.length).toBeGreaterThanOrEqual(minHeightTxs.length);
     });
+
+    it("returns block height as a number", async () => {
+      expect(txs.every(t => typeof t.tx.block.height === "number")).toBeTruthy();
+    });
   });
 
   describe("getBalance", () => {

--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -39,7 +39,7 @@ describe("Sui Api", () => {
     });
   });
 
-  describe("listOperations for big account (testing cursor logic)", () => {
+  describe("listOperations, testing cursor logic", () => {
     // this account has a lot of operations
     const binance = "0x935029ca5219502a47ac9b69f556ccf6e2198b5e7815cf50f68846f723739cbd";
 
@@ -69,6 +69,20 @@ describe("Sui Api", () => {
     });
     it("should fetch operations successfully in default order", async () => {
       await testListOperations(undefined);
+    });
+
+    it("shouldn't return cursor on last page", async () => {
+      const [operations, cursor] = await module.listOperations(
+        "0xd8908c165dee785924e7421a0fd0418a19d5daeec395fd505a92a0fd3117e428",
+        { minHeight: 0, order: "asc" },
+      );
+
+      // assume it has not a lot of operations
+      // at time of writing, it has only 2 operations
+      expect(operations.length).toBeLessThan(10);
+      expect(operations.length).toBeGreaterThan(0);
+
+      expect(cursor).toBe("");
     });
   });
 

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -352,8 +352,7 @@ export function transactionToOp(address: string, transaction: SuiTransactionBloc
       hash,
       fees: BigInt(getOperationFee(transaction).toString()),
       block: {
-        // agreed to return bigint
-        height: BigInt(transaction.checkpoint || "") as unknown as number,
+        height: Number.parseInt(transaction.checkpoint || "0"),
         time: getOperationDate(transaction),
       },
     },

--- a/libs/coin-modules/coin-sui/src/network/sdk.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.ts
@@ -534,8 +534,8 @@ type Cursor = {
   in?: string;
 };
 
-function serializeCursor(cursor: Cursor): string {
-  return bs58.encode(Buffer.from(JSON.stringify(cursor)));
+function serializeCursor(cursor: Cursor): string | undefined {
+  return cursor.in || cursor.out ? bs58.encode(Buffer.from(JSON.stringify(cursor))) : undefined;
 }
 
 function deserializeCursor(b58cursor: string | undefined): Cursor {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:**
	- fix the token on last page (sui list operations)
	- block height is a number, conform to coin-fw api (sui list operations)