### PR TITLE
Support: GHA graphql patch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ pnpmfileChecksum: icbum5fm2zpmtctr4exqaodaui
 
 patchedDependencies:
   '@changesets/get-github-info@0.6.0':
-    hash: 7jzpsqogb5i6art53pk3h33ix4
+    hash: ihbfttx3a3q6odiznwmem6m4ay
     path: patches/@changesets__get-github-info@0.6.0.patch
   '@datadog/datadog-ci@3.11.0':
     hash: hshtsvjisk4nrwuydtrlg3tpk4
@@ -39030,7 +39030,7 @@ snapshots:
 
   '@changesets/changelog-github@0.5.0':
     dependencies:
-      '@changesets/get-github-info': 0.6.0(patch_hash=7jzpsqogb5i6art53pk3h33ix4)
+      '@changesets/get-github-info': 0.6.0(patch_hash=ihbfttx3a3q6odiznwmem6m4ay)
       '@changesets/types': 6.0.0
       dotenv: 8.6.0
     transitivePeerDependencies:
@@ -39093,7 +39093,7 @@ snapshots:
       fs-extra: 7.0.1
       semver: 7.7.1
 
-  '@changesets/get-github-info@0.6.0(patch_hash=7jzpsqogb5i6art53pk3h33ix4)':
+  '@changesets/get-github-info@0.6.0(patch_hash=ihbfttx3a3q6odiznwmem6m4ay)':
     dependencies:
       dataloader: 1.4.0
       node-fetch: 2.7.0


### PR DESCRIPTION
PNPM lock update to enable the patch of the graphql patch adjustments