### PR TITLE
update canton blockavg

### DIFF
--- a/.changeset/hot-rings-fail.md
+++ b/.changeset/hot-rings-fail.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": patch
+---
+
+Update canton blockavg

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -614,7 +614,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "canton_network",
     color: "#F8FFAE",
     family: "canton",
-    blockAvgTime: 20,
+    blockAvgTime: 100,
     units: [
       {
         name: "cc",
@@ -645,7 +645,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "canton_network_localnet",
     color: "#F8FFAE",
     family: "canton",
-    blockAvgTime: 20,
+    blockAvgTime: 100,
     isTestnetFor: "canton_network",
     units: [
       {
@@ -677,7 +677,7 @@ export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
     scheme: "canton_network_devnet",
     color: "#F8FFAE",
     family: "canton",
-    blockAvgTime: 20,
+    blockAvgTime: 100,
     isTestnetFor: "canton_network",
     units: [
       {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** currencies
  - ...

### 📝 Description

Update canton blockavgtime, implies 18 confirmations required instead of 90

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-21545


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
