### PR TITLE
fix: Delegation crashes on Cosmos if no validator data is returned

### DIFF
--- a/.changeset/old-points-bathe.md
+++ b/.changeset/old-points-bathe.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix Delegation crashes on Cosmos if no validator data is returned

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/fields/ValidatorField.tsx
@@ -34,11 +34,13 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr }: Props
     (evt: React.ChangeEvent<HTMLInputElement>) => setSearch(evt.target.value),
     [setSearch],
   );
+
   const chosenValidator = useMemo(() => {
+    if (validators.length === 0) return [];
     return [validators.find(v => v.validatorAddress === chosenVoteAccAddr) || validators[0]];
   }, [validators, chosenVoteAccAddr]);
 
-  if (chosenVoteAccAddr === "") {
+  if (chosenVoteAccAddr === "" && validators.length > 0) {
     onChangeValidator({ address: validators[0].validatorAddress });
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

If a problem happens when trying to retrieve validator.validatorAddress the APP should not crash 

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:  [LIVE-21620](https://ledgerhq.atlassian.net/browse/LIVE-21620)
- [LIVE-22017](https://ledgerhq.atlassian.net/browse/LIVE-22017)


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21620]: https://ledgerhq.atlassian.net/browse/LIVE-21620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-22017]: https://ledgerhq.atlassian.net/browse/LIVE-22017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ