### PR TITLE
feat: 🆕 Add SyncSuccessAllAccounts Mixpanel Tracker

### DIFF
--- a/.changeset/eight-oranges-fetch.md
+++ b/.changeset/eight-oranges-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+add Time to view balance (Sync all accounts on init)

--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
@@ -12,6 +12,7 @@ import type { SyncAction, SyncState, BridgeSyncState } from "./types";
 import { BridgeSyncContext, BridgeSyncStateContext } from "./context";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
+import { createSyncSessionManager } from "../syncSessionManager";
 
 export type Props = {
   // this is a wrapping component that you need to put in your tree
@@ -52,6 +53,7 @@ export const BridgeSync = ({
     accounts,
     hydrateCurrency,
   });
+  const sessionManager = useRef(createSyncSessionManager(trackAnalytics)).current;
   const [syncQueue, syncState] = useSyncQueue({
     accounts,
     prepareCurrency,
@@ -59,10 +61,12 @@ export const BridgeSync = ({
     trackAnalytics,
     updateAccountWithUpdater,
     blacklistedTokenIds,
+    sessionManager,
   });
   const sync = useSync({
     syncQueue,
     accounts,
+    sessionManager,
   });
   useSyncBackground({
     sync,
@@ -111,6 +115,7 @@ function useSyncQueue({
   trackAnalytics,
   updateAccountWithUpdater,
   blacklistedTokenIds,
+  sessionManager,
 }) {
   const [bridgeSyncState, setBridgeSyncState]: [BridgeSyncState, any] = useState({});
   const setAccountSyncState = useCallback((accountId: string, s: SyncState) => {
@@ -204,6 +209,7 @@ function useSyncQueue({
               pending: false,
               error: null,
             });
+            sessionManager.onAccountSyncDone(accountId, accounts);
             next();
           },
           error: (raw: Error) => {
@@ -215,6 +221,7 @@ function useSyncQueue({
                 pending: false,
                 error: null,
               });
+              sessionManager.onAccountSyncDone(accountId, accounts);
               next();
               return;
             }
@@ -223,6 +230,7 @@ function useSyncQueue({
               pending: false,
               error,
             });
+            sessionManager.onAccountSyncDone(accountId, accounts);
             next();
           },
         });
@@ -231,6 +239,7 @@ function useSyncQueue({
           pending: false,
           error,
         });
+        sessionManager.onAccountSyncDone(accountId, accounts);
         next();
       }
     },
@@ -243,6 +252,7 @@ function useSyncQueue({
       trackAnalytics,
       updateAccountWithUpdater,
       blacklistedTokenIds,
+      sessionManager,
     ],
   );
   const synchronizeRef = useRef(synchronize);
@@ -259,7 +269,7 @@ function useSyncQueue({
 }
 
 // useSync: returns a sync function with the syncQueue
-function useSync({ syncQueue, accounts }) {
+function useSync({ syncQueue, accounts, sessionManager }) {
   const skipUnderPriority = useRef(-1);
   const sync = useMemo(() => {
     const schedule = (ids: string[], priority: number, reason: string) => {
@@ -267,6 +277,10 @@ function useSync({ syncQueue, accounts }) {
       // by convention we remove concurrent tasks with same priority
       // FIXME this is somehow a hack. ideally we should just dedup the account ids in the pending queue...
       syncQueue.remove(o => priority === o.priority);
+      // start a global session only if initial + all accounts
+      if (reason === "initial" && ids.length === accounts.length) {
+        sessionManager.start(ids, reason);
+      }
       log("bridge", "schedule " + ids.join(", "));
       syncQueue.push(
         ids.map(accountId => ({
@@ -289,7 +303,7 @@ function useSync({ syncQueue, accounts }) {
       SET_SKIP_UNDER_PRIORITY: ({ priority }: { priority: number }) => {
         if (priority === skipUnderPriority.current) return;
         skipUnderPriority.current = priority;
-        syncQueue.remove(({ priority }) => priority < skipUnderPriority);
+        syncQueue.remove(({ priority }) => priority < skipUnderPriority.current);
 
         if (priority === -1 && !accounts.every(isUpToDateAccount)) {
           // going back to -1 priority => retriggering a background sync if it is "Paused"
@@ -338,7 +352,7 @@ function useSync({ syncQueue, accounts }) {
         });
       }
     };
-  }, [accounts, syncQueue]);
+  }, [accounts, syncQueue, sessionManager]);
   const ref = useRef(sync);
   useEffect(() => {
     ref.current = sync;

--- a/libs/ledger-live-common/src/bridge/syncSessionManager/index.test.ts
+++ b/libs/ledger-live-common/src/bridge/syncSessionManager/index.test.ts
@@ -1,0 +1,107 @@
+import { createSyncSessionManager } from ".";
+import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { setSupportedCurrencies } from "../../currencies";
+import { genAccount } from "../../mock/account";
+
+jest.mock("@ledgerhq/logs", () => ({
+  log: jest.fn(),
+}));
+
+setSupportedCurrencies(["bitcoin", "ethereum"]);
+
+describe("syncSessionManager", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  test("tracks SyncSuccessAllAccounts with correct aggregates when all accounts complete", () => {
+    const trackAnalytics = jest.fn();
+    const session = createSyncSessionManager(trackAnalytics);
+
+    const BTC = getCryptoCurrencyById("bitcoin");
+    const ETH = getCryptoCurrencyById("ethereum");
+    const a1 = genAccount("a1", { currency: BTC, operationsSize: 3 });
+    const a2 = genAccount("a2", { currency: BTC, operationsSize: 5 });
+    const a3 = genAccount("a3", { currency: ETH, operationsSize: 7 });
+    const accounts = [a1, a2, a3];
+
+    const nowSpy = jest
+      .spyOn(Date, "now")
+      // start time
+      .mockReturnValueOnce(1_000)
+      // end time (when last account completes)
+      .mockReturnValueOnce(5_000);
+
+    session.start(["a1", "a2", "a3"], "initial");
+
+    // Completing accounts one by one should only trigger analytics on last one
+    session.onAccountSyncDone("a1", accounts);
+    expect(trackAnalytics).not.toHaveBeenCalled();
+
+    session.onAccountSyncDone("a2", accounts);
+    expect(trackAnalytics).not.toHaveBeenCalled();
+
+    session.onAccountSyncDone("a3", accounts);
+
+    expect(trackAnalytics).toHaveBeenCalledTimes(1);
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      "SyncSuccessAllAccounts",
+      expect.objectContaining({
+        duration: 4, // (5000 - 1000) / 1000
+        accountsCount: accounts.length,
+        operationsCount: a1.operationsCount + a2.operationsCount + a3.operationsCount,
+        chains: ["Bitcoin", "Ethereum"],
+        reason: "initial",
+      }),
+    );
+
+    nowSpy.mockRestore();
+  });
+
+  test("ignores subsequent 'initial' sessions after the first completion", () => {
+    const trackAnalytics = jest.fn();
+    const session = createSyncSessionManager(trackAnalytics);
+
+    const BTC = getCryptoCurrencyById("bitcoin");
+    const ETH = getCryptoCurrencyById("ethereum");
+    const a1 = genAccount("a1", { currency: BTC });
+    const a2 = genAccount("a2", { currency: ETH });
+    a1.operationsCount = 2;
+    a2.operationsCount = 1;
+    const accounts = [a1, a2];
+
+    const nowSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(10_000) // first start
+      .mockReturnValueOnce(14_000); // first completion
+
+    // First initial session completes => tracked once
+    session.start(["a1", "a2"], "initial");
+    session.onAccountSyncDone("a1", accounts);
+    session.onAccountSyncDone("a2", accounts);
+
+    expect(trackAnalytics).toHaveBeenCalledTimes(1);
+    expect(trackAnalytics.mock.calls[0][0]).toBe("SyncSuccessAllAccounts");
+
+    // Next initial session should be ignored entirely
+    session.start(["a1"], "initial");
+    session.onAccountSyncDone("a1", accounts);
+
+    expect(trackAnalytics).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockRestore();
+  });
+
+  test("does nothing if onAccountSyncDone is called without a started session", () => {
+    const trackAnalytics = jest.fn();
+    const session = createSyncSessionManager(trackAnalytics);
+    const BTC = getCryptoCurrencyById("bitcoin");
+    const acc = genAccount("x1", { currency: BTC });
+    acc.operationsCount = 1;
+    const accounts = [acc];
+
+    session.onAccountSyncDone("x1", accounts);
+    expect(trackAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/bridge/syncSessionManager/index.ts
+++ b/libs/ledger-live-common/src/bridge/syncSessionManager/index.ts
@@ -1,0 +1,80 @@
+import { log } from "@ledgerhq/logs";
+import { Account } from "@ledgerhq/types-live";
+import { Props } from "../react/BridgeSync";
+
+type Session = {
+  reason: string;
+  startTime: number;
+  accountIds: string[];
+  remaining: Set<string>;
+};
+
+// Session manager factory to track global sync sessions (Accounts)
+export function createSyncSessionManager(trackAnalytics: Props["trackAnalytics"]) {
+  let current: Session | null = null;
+
+  let hasTrackedInitial = false;
+
+  const start = (ids: string[], reason: string) => {
+    if (reason === "initial" && hasTrackedInitial) return;
+    current = {
+      reason,
+      startTime: Date.now(),
+      accountIds: ids,
+      remaining: new Set(ids),
+    };
+    logSyncSession("started", { reason, accounts: ids.length });
+  };
+
+  const onAccountSyncDone = (accountId: string, accounts: Account[]) => {
+    if (!current) return;
+
+    current.remaining.delete(accountId);
+
+    if (current.remaining.size === 0) {
+      trackSessionAnalytics(trackAnalytics, current, accounts);
+
+      if (current.reason === "initial") {
+        hasTrackedInitial = true;
+      }
+      current = null;
+    }
+  };
+
+  return { start, onAccountSyncDone } as const;
+}
+
+export function getTotalOperations(accounts: Account[]): number {
+  return accounts.reduce((sum, acc) => sum + acc.operationsCount, 0);
+}
+
+export function getUniqueChains(accounts: Account[]): string[] {
+  return [...new Set(accounts.map(acc => acc.currency.name))];
+}
+
+export function trackSessionAnalytics(
+  trackAnalytics: Props["trackAnalytics"],
+  session: Session,
+  accounts: Account[],
+) {
+  const duration = (Date.now() - session.startTime) / 1000;
+  const totalOps = getTotalOperations(accounts);
+  const chains = getUniqueChains(accounts);
+
+  trackAnalytics("SyncSuccessAllAccounts", {
+    duration,
+    accountsCount: accounts.length,
+    operationsCount: totalOps,
+    chains,
+    reason: session.reason,
+  });
+
+  logSyncSession("finished", { reason: session.reason, duration: `${duration}s` });
+}
+
+function logSyncSession(event: "started" | "finished", data: Record<string, string | number>) {
+  const serialized = Object.entries(data)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(", ");
+  log("bridge", `SyncSession ${event} ${serialized}`);
+}


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR introduces a new analytics event `SyncSuccessAllAccounts` with the following dimensions:

* **duration**: Total time (in seconds) taken to sync all accounts.
* **accountsCount**: Number of accounts synced.
* **operationsCount**: Total number of transactions (operations) synced across all accounts.
* **chains**: List of chains (currencies) involved in the sync.
* **reason**: Sync type, reusing the same values as the existing `SyncSuccess` event (e.g., `"initial"`, `"manual"`, `"auto"`). => will be "initial"

The tracker is fired **once per full sync session** when all accounts have been successfully synced.

---

### ⚙️ Implementation

* Added a `createSyncSessionManager` factory to manage sync sessions and track analytics per session.
* Introduced a `trackSessionAnalytics` helper to calculate metrics and call `trackAnalytics` for Mixpanel.
* Added utility functions:

  * `getTotalOperations(accounts: Account[])` → total number of operations.
  * `getUniqueChains(accounts: Account[])` → list of unique chains involved.
* Session lifecycle:

  * `start(ids, reason)` → starts a new sync session.
  * `onAccountSyncDone(accountId, accounts)` → marks an account as synced and triggers analytics when all accounts are done.

---

### 📈 How it works

1. When a sync session starts, we store the list of accounts to sync and the sync reason.
2. Each time an account finishes syncing, it is removed from the session’s `remaining` set.
3. Once all accounts are synced, `SyncSuccessAllAccounts` is sent to Mixpanel with calculated metrics.

---

### ✅ QA / Testing

* Verified that the tracker fires exactly **once per full sync session**.
* Confirmed metrics (`duration`, `accountsCount`, `operationsCount`, `chains`, `reason`) are correctly reported.
* Ensured the tracker does not fire for partial or repeated `"initial"` syncs.

---

### 📌 Notes

* `reason` reuses the existing sync types for consistency.
* Sync session logging (`started` / `finished`) is preserved for debugging purposes.



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-21040


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
