### PR TITLE
:bug: (llm-LS) duplicated screen during navigation

### DIFF
--- a/.changeset/new-walls-peel.md
+++ b/.changeset/new-walls-peel.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix navigation inside the GeneralSettings Navigator

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -80,8 +80,13 @@ import SwiperScreenDebug from "~/screens/Settings/Debug/Features/SwiperScreenDeb
 import { DebugStorageMigration } from "~/screens/Settings/Debug/Debugging/StorageMigration";
 import CustomCALRefInput from "~/screens/Settings/Developer/CustomCALRefInput";
 import ModularDrawerScreenDebug from "LLM/features/ModularDrawer/Debug";
+import { UnmountOnBlur } from "./utils/UnmountOnBlur";
 
 const Stack = createStackNavigator<SettingsNavigatorStackParamList>();
+
+const unmountOnBlur = ({ children }: { children: React.ReactNode }) => (
+  <UnmountOnBlur>{children}</UnmountOnBlur>
+);
 
 export default function SettingsNavigator() {
   const { t } = useTranslation();
@@ -117,6 +122,7 @@ export default function SettingsNavigator() {
       <Stack.Screen
         name={ScreenName.GeneralSettings}
         component={GeneralSettings}
+        layout={unmountOnBlur}
         options={{
           title: t("settings.display.title"),
         }}

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/ManageInstances/DeletionSuccess.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/ManageInstances/DeletionSuccess.tsx
@@ -23,7 +23,7 @@ export function WalletSyncManageInstanceDeletionSuccess({ navigation, route }: P
       button: AnalyticsButton.Close,
       page: AnalyticsPage.RemoveInstanceSuccess,
     });
-    navigation.navigate(NavigatorName.Settings, {
+    navigation.popTo(NavigatorName.Settings, {
       screen: ScreenName.GeneralSettings,
     });
   }

--- a/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/ManageKey/DeletionSuccess.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/WalletSync/screens/ManageKey/DeletionSuccess.tsx
@@ -18,7 +18,7 @@ export function WalletSyncManageKeyDeletionSuccess({ navigation }: Props) {
   const { t } = useTranslation();
 
   function close(): void {
-    navigation.replace(NavigatorName.Settings, {
+    navigation.popTo(NavigatorName.Settings, {
       screen: ScreenName.GeneralSettings,
     });
   }


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

We have some issues caused by the way we handle the navigation in LLM that have been revealed by react navigation v7. The bug was caused by a duplication of the screen. And when we pressed the open drawer it killed it directly as the press was trigger twice

https://github.com/user-attachments/assets/66ab5615-8de8-49fc-a0f1-ec1b38c6d4d5



https://github.com/user-attachments/assets/e48845b0-80e1-4c5c-9232-f629fc51a161


<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**:[LIVE-21665](https://ledgerhq.atlassian.net/browse/LIVE-21665) <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21665]: https://ledgerhq.atlassian.net/browse/LIVE-21665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ