### PR TITLE
:bug: (llm) fix unsupported string property + typing

### DIFF
--- a/.changeset/hip-points-care.md
+++ b/.changeset/hip-points-care.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/native-ui": minor
+---
+
+Fix android crash caused by unexpected string style property

--- a/apps/ledger-live-mobile/android/app/build.gradle
+++ b/apps/ledger-live-mobile/android/app/build.gradle
@@ -126,7 +126,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 36176158
-        versionName "3.91.0"
+        versionName "3.93.0"
         resValue "string", "build_config_package", "com.ledger.live"
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/components/Skeleton/SkeletonList.tsx
+++ b/apps/ledger-live-mobile/src/newArch/features/ModularDrawer/components/Skeleton/SkeletonList.tsx
@@ -6,7 +6,7 @@ interface Props {
   nbItems?: number;
 }
 const SkeletonList = ({ nbItems }: Props) => (
-  <Flex flexDirection="column" flex="1 1 auto" overflow="hidden" rowGap="8px">
+  <Flex flexDirection="column" flex={1} overflow="hidden" rowGap="8px">
     {Array.from({ length: nbItems ?? 10 }, (_, index) => (
       <Skeleton key={index} barHeight={64} minHeight={64} />
     ))}

--- a/libs/ui/packages/native/src/pre-ldls/components/Input/Input.tsx
+++ b/libs/ui/packages/native/src/pre-ldls/components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { TextInput, View } from "react-native";
+import { NativeSyntheticEvent, TextInput, TextInputFocusEventData, View } from "react-native";
 import styled, { DefaultTheme, ThemeContext } from "styled-components/native";
 import { Tokens, useTokens } from "../../libs";
 
@@ -56,12 +56,12 @@ export const Input = React.forwardRef<TextInput, Props>(
 
     const tokens = useTokens(themeType, [...TOKEN_KEYS]);
 
-    const handleFocus = (e: any) => {
+    const handleFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
       setIsFocused(true);
       onFocus?.(e);
     };
 
-    const handleBlur = (e: any) => {
+    const handleBlur = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
       setIsFocused(false);
       onBlur?.(e);
     };


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - SkeletonList LLM MAD
  - SearchInput onBlur/onFocus typing

### 📝 Description

Fix the following error: 

`Error while updating property flex in shadow node of type RCTView java.lang.String cannot be cast to java.lang.Double`

+ remove the "any" in the ui lib to enforce typing


| Before        | After         |
| ------------- | ------------- |
|https://github.com/user-attachments/assets/a8d25797-161f-4965-8eba-5cf23870ae16|https://github.com/user-attachments/assets/516c0c5a-f4c1-45ca-a19f-68c7529ebb33|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-21698](https://ledgerhq.atlassian.net/browse/LIVE-21698)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21698]: https://ledgerhq.atlassian.net/browse/LIVE-21698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ