### PR TITLE
fix: auto close DevTools WebContents when webviews are destroyed

### DIFF
--- a/.changeset/dull-humans-deliver.md
+++ b/.changeset/dull-humans-deliver.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+fix(wallet-api): correct UsedAt type

--- a/.changeset/orange-pumpkins-hug.md
+++ b/.changeset/orange-pumpkins-hug.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+fix: auto close DevTools WebContents when webviews are destroyed

--- a/.changeset/orange-pumpkins-hug.md
+++ b/.changeset/orange-pumpkins-hug.md
@@ -1,5 +1,5 @@
 ---
-"ledger-live-desktop": patch
+"ledger-live-desktop": minor
 ---
 
 fix: auto close DevTools WebContents when webviews are destroyed

--- a/apps/ledger-live-desktop/src/main/window-lifecycle.ts
+++ b/apps/ledger-live-desktop/src/main/window-lifecycle.ts
@@ -79,29 +79,6 @@ export const loadWindow = async () => {
     fullUrl.searchParams.append("appLocale", app.getLocale());
     fullUrl.searchParams.append("systemLocale", app.getSystemLocale());
 
-    if (__DEV__) {
-      const setUserAgent = (webContents: Electron.WebContents) => {
-        webContents.setUserAgent(`${webContents.getUserAgent()} LedgerLive/${__APP_VERSION__}`);
-      };
-      setUserAgent(mainWindow.webContents);
-      mainWindow.webContents.on("did-attach-webview", function (_event, webContents) {
-        setUserAgent(webContents);
-
-        // Track and clean up a webview's DevTools WebContents to avoid orphaned DevTools windows.
-        let devtoolContents: WebContents | null = null;
-        webContents.on("devtools-opened", () => {
-          devtoolContents = webContents.devToolsWebContents;
-          devtoolContents?.on("destroyed", () => {
-            devtoolContents = null;
-          });
-        });
-
-        webContents.on("destroyed", () => {
-          devtoolContents?.close();
-        });
-      });
-    }
-
     await mainWindow.loadURL(fullUrl.href);
   }
 };
@@ -223,6 +200,31 @@ function setupMainWindowHandlers() {
     }
     return false;
   });
+
+  // Track and clean up a webview's DevTools WebContents to avoid orphaned DevTools windows.
+  mainWindow.webContents.on("did-attach-webview", function (_event, webContents) {
+    let devtoolContents: WebContents | null = null;
+    webContents.on("devtools-opened", () => {
+      devtoolContents = webContents.devToolsWebContents;
+      devtoolContents?.on("destroyed", () => {
+        devtoolContents = null;
+      });
+    });
+
+    webContents.on("destroyed", () => {
+      devtoolContents?.close();
+    });
+  });
+
+  if (__DEV__) {
+    const setUserAgent = (webContents: Electron.WebContents) => {
+      webContents.setUserAgent(`${webContents.getUserAgent()} LedgerLive/${__APP_VERSION__}`);
+    };
+    setUserAgent(mainWindow.webContents);
+    mainWindow.webContents.on("did-attach-webview", function (_event, webContents) {
+      setUserAgent(webContents);
+    });
+  }
 }
 
 /**

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/TopBar.tsx
@@ -262,7 +262,7 @@ export const TopBar = ({
       {enablePlatformDevTools ? (
         <>
           <Separator />
-          <ItemContainer isInteractive onClick={onOpenDevTools}>
+          <ItemContainer data-testid="live-app-devtools" isInteractive onClick={onOpenDevTools}>
             <LightBulb size={16} />
             <ItemContent>
               <Trans i18nKey="common.sync.devTools" />
@@ -343,7 +343,7 @@ export const TopBar = ({
         )}
 
         {shouldDisplayClose && (
-          <ItemContainer isInteractive onClick={onClose}>
+          <ItemContainer data-testid="live-app-close" isInteractive onClick={onClose}>
             <IconClose size={16} />
           </ItemContainer>
         )}

--- a/apps/ledger-live-desktop/src/renderer/screens/platform/v2/Catalog/Card/Minimum.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/platform/v2/Catalog/Card/Minimum.tsx
@@ -15,10 +15,10 @@ export function MinimumCard(props: PropsCard<RecentlyUsedManifest | LiveAppManif
 
   const lang = useSelector(languageSelector);
   const usedAt = useMemo(() => {
-    if ("usedAt" in manifest) {
+    if ("usedAt" in manifest && manifest.usedAt.unit) {
       const rtf = new Intl.RelativeTimeFormat(lang);
       return rtf.format(-manifest.usedAt.diff, manifest.usedAt.unit);
-    } else return;
+    }
   }, [lang, manifest]);
 
   return (

--- a/apps/ledger-live-desktop/tests/page/discover.page.ts
+++ b/apps/ledger-live-desktop/tests/page/discover.page.ts
@@ -3,6 +3,11 @@ import { AppPage } from "tests/page/abstractClasses";
 export class DiscoverPage extends AppPage {
   private testAppCatalogItem = this.page.getByTestId("platform-catalog-app-dummy-live-app");
   private disclaimerTitle = this.page.getByTestId("live-app-disclaimer-drawer-title");
+  private discoverTitle = this.page.locator("#page-scroller").getByText("discover");
+
+  async waitForDiscoverVisible() {
+    await this.discoverTitle.waitFor({ state: "visible" });
+  }
 
   async openTestApp() {
     await this.testAppCatalogItem.click();

--- a/apps/ledger-live-desktop/tests/specs/webviewDevTools/webview-dev-tools.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/webviewDevTools/webview-dev-tools.spec.ts
@@ -1,0 +1,92 @@
+import test from "../../fixtures/common";
+import { LiveAppWebview } from "../../models/LiveAppWebview";
+import { DiscoverPage } from "../../page/discover.page";
+import { Layout } from "../../component/layout.component";
+import { Drawer } from "../../component/drawer.component";
+
+test.use({
+  userdata: "skip-onboarding",
+  settings: {
+    enablePlatformDevTools: true,
+  },
+});
+
+let testServerIsRunning = false;
+
+test.beforeAll(async () => {
+  // Check that dummy app in tests/dummy-live-app has been started successfully
+  testServerIsRunning = await LiveAppWebview.startLiveApp("dummy-wallet-app/dist", {
+    name: "Dummy Wallet API Live App",
+    id: "dummy-live-app",
+    apiVersion: "2.0.0",
+    content: {
+      shortDescription: {
+        en: "App to test the Wallet API",
+      },
+      description: {
+        en: "App to test the Wallet API with Playwright",
+      },
+    },
+  });
+
+  if (!testServerIsRunning) {
+    console.warn("Stopping Buy/Sell test setup");
+    return;
+  }
+});
+
+test.afterAll(async () => {
+  if (testServerIsRunning) {
+    await LiveAppWebview.stopLiveApp();
+  }
+});
+
+test("Webview Auto close Dev Tools when leaving", async ({ page, electronApp }) => {
+  if (!testServerIsRunning) {
+    console.warn("Test server not running - Cancelling Wallet API E2E test");
+    return;
+  }
+
+  const layout = new Layout(page);
+  const drawer = new Drawer(page);
+  const discoverPage = new DiscoverPage(page);
+  const liveAppWebview = new LiveAppWebview(page, electronApp);
+
+  await test.step("open live-app", async () => {
+    await layout.goToDiscover();
+    await discoverPage.waitForDiscoverVisible();
+    await discoverPage.openTestApp();
+    await drawer.continue();
+    await drawer.waitForDrawerToDisappear();
+  });
+
+  await test.step("open devtools", async () => {
+    await liveAppWebview.openDevTools();
+    await liveAppWebview.checkDevToolsOpened();
+  });
+
+  await test.step("leave the live-app", async () => {
+    await liveAppWebview.closeLiveApp();
+    await liveAppWebview.checkDevToolsClosed();
+    // Make sure we are back on discover page
+    await discoverPage.waitForDiscoverVisible();
+  });
+
+  await test.step("open live-app second time", async () => {
+    await discoverPage.openTestApp();
+    await drawer.continue();
+    await drawer.waitForDrawerToDisappear();
+  });
+
+  await test.step("open devtools second time", async () => {
+    await liveAppWebview.openDevTools();
+    await liveAppWebview.checkDevToolsOpened();
+  });
+
+  await test.step("leave the live-app second time", async () => {
+    await liveAppWebview.closeLiveApp();
+    await liveAppWebview.checkDevToolsClosed();
+    // Make sure we are back on discover page
+    await discoverPage.waitForDiscoverVisible();
+  });
+});

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -1010,11 +1010,11 @@ export interface RecentlyUsed {
 
 export type RecentlyUsedManifest = AppManifest & { usedAt: UsedAt };
 export type UsedAt = {
-  unit: Intl.RelativeTimeFormatUnit;
+  unit?: Intl.RelativeTimeFormatUnit;
   diff: number;
 };
 
-function calculateTimeDiff(usedAt: string) {
+function calculateTimeDiff(usedAt: string): UsedAt {
   const start = new Date();
   const end = new Date(usedAt);
   const interval = intervalToDuration({ start, end });
@@ -1027,7 +1027,7 @@ function calculateTimeDiff(usedAt: string) {
     "minutes",
     "seconds",
   ];
-  let timeDiff = { unit: units[-1], diff: 0 };
+  let timeDiff: UsedAt = { unit: undefined, diff: 0 };
 
   for (const unit of units) {
     if (interval[unit] > 0) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Any live-app devtools usage

### 📝 Description

This pull request introduces a minor release for both `ledger-live-desktop` and `@ledgerhq/live-common`, focusing on improvements to the DevTools lifecycle in webviews and a fix for the `UsedAt` type. The most significant changes ensure that DevTools windows are automatically closed when their associated webviews are destroyed, preventing orphaned windows, and that the `UsedAt` type is correctly handled throughout the codebase. Additional updates include new E2E tests to verify DevTools behavior and improved test selectors for UI components.

**Webview DevTools lifecycle improvements:**

* Automatically closes DevTools WebContents when webviews are destroyed to prevent orphaned DevTools windows (`window-lifecycle.ts`). [[1]](diffhunk://#diff-1d4cef1f6a4beae303dde15f9b14d0fbea6c5bed667eaa595db6520034860a5eR1-R5) [[2]](diffhunk://#diff-3431fcce1a6127579b271f122ec72b40d05b38f993a307dc822ba1658973b6d3R203-R227)
* Added a comprehensive E2E test (`webview-dev-tools.spec.ts`) to verify that DevTools windows open and close correctly when navigating away from a live app.

**Type and logic fixes:**

* Corrected the `UsedAt` type to allow `unit` to be optional, and updated related logic to handle cases where `unit` may be undefined (`react.ts`, `Minimum.tsx`). [[1]](diffhunk://#diff-8e9ee7517c5ee1c4ba2cb199c0be78b9d2c9c65c1f2ccdf524edf003da3fa893R1-R5) [[2]](diffhunk://#diff-fe605b7a5dd7dcb19f66cdc636ed7c541f084fcf75be1fd8ea1b7361d186303fL1013-R1017) [[3]](diffhunk://#diff-fe605b7a5dd7dcb19f66cdc636ed7c541f084fcf75be1fd8ea1b7361d186303fL1030-R1030) [[4]](diffhunk://#diff-81d1ca2168912613df366519c565c8553b4d8adc64b29a6560fecc1c5395c78bL18-R21)

**Test and UI improvements:**

* Added `data-testid` attributes to DevTools and close buttons in the live app top bar for easier test automation (`TopBar.tsx`). [[1]](diffhunk://#diff-24322eba0b3ade4e812076ed72bb2748e8dd10390059847db3a0e3acfac905e3L265-R265) [[2]](diffhunk://#diff-24322eba0b3ade4e812076ed72bb2748e8dd10390059847db3a0e3acfac905e3L346-R346)
* Updated Playwright test models to interact with new test IDs and verify DevTools lifecycle (`LiveAppWebview.ts`, `discover.page.ts`). [[1]](diffhunk://#diff-109cfcca7dcd84408d8b0dbfc9faafb7285bf034c3422be690dd2b0ba618a0e5R11-R12) [[2]](diffhunk://#diff-109cfcca7dcd84408d8b0dbfc9faafb7285bf034c3422be690dd2b0ba618a0e5R23-R24) [[3]](diffhunk://#diff-109cfcca7dcd84408d8b0dbfc9faafb7285bf034c3422be690dd2b0ba618a0e5R65-R111) [[4]](diffhunk://#diff-694b9ffc18fabc1d980a8b540415d15598aaaf16e1832876c44cf9a77e90e15dR6-R10)

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
