### PR TITLE
test(desktop): refactor LiveAppWebview with unified hover+click helper to reduce e2e flakiness and more modal checks

### DIFF
--- a/apps/ledger-live-desktop/tests/component/modal.component.ts
+++ b/apps/ledger-live-desktop/tests/component/modal.component.ts
@@ -41,6 +41,7 @@ export class Modal extends Component {
 
   @step("Continue to sign transaction")
   async continueToSignTransaction() {
+    await this.continueButton.hover();
     await this.continueButton.click();
   }
 

--- a/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
+++ b/apps/ledger-live-desktop/tests/models/LiveAppWebview.ts
@@ -72,33 +72,27 @@ export class LiveAppWebview {
   }
 
   async getAccountsList() {
-    const webviewPage = await this.getWebView();
-    await webviewPage.getByTestId("get-all-accounts-button").click();
+    await this.clickByTestId("get-all-accounts-button");
   }
 
   async requestAsset() {
-    const webviewPage = await this.getWebView();
-    await webviewPage.getByTestId("request-single-account-button").click();
+    await this.clickByTestId("request-single-account-button");
   }
 
   async verifyAddress() {
-    const webviewPage = await this.getWebView();
-    await webviewPage.getByTestId("verify-address-button").click();
+    await this.clickByTestId("verify-address-button");
   }
 
   async listCurrencies() {
-    const webviewPage = await this.getWebView();
-    await webviewPage.getByTestId("list-currencies-button").click();
+    await this.clickByTestId("list-currencies-button");
   }
 
   async signBitcoinTransaction() {
-    const webviewPage = await this.getWebView();
-    await webviewPage.getByTestId("sign-bitcoin-transaction-button").click();
+    await this.clickByTestId("sign-bitcoin-transaction-button");
   }
 
   async signEthereumTransaction() {
-    const webviewPage = await this.getWebView();
-    await webviewPage.getByTestId("sign-ethereum-transaction-button").click();
+    await this.clickByTestId("sign-ethereum-transaction-button");
   }
 
   async setCurrencyIds(currencies: string[]) {
@@ -127,73 +121,59 @@ export class LiveAppWebview {
   }
 
   async accountRequest() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("account-request").click();
+    return this.clickByTestId("account-request");
   }
 
   async accountReceive() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("account-receive").click();
+    return this.clickByTestId("account-receive");
   }
 
   async accountList() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("account-list").click();
+    return this.clickByTestId("account-list");
   }
 
   async bitcoinGetXPub() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("bitcoin-getXPub").click();
+    return this.clickByTestId("bitcoin-getXPub");
   }
 
   async currencyList() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("currency-list").click();
+    return this.clickByTestId("currency-list");
   }
 
   async storage() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("storage").click();
+    return this.clickByTestId("storage");
   }
 
   async transactionSign() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("transaction-sign").click();
+    return this.clickByTestId("transaction-sign");
   }
 
   async transactionSignSolana() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("transaction-sign-solana").click();
+    return this.clickByTestId("transaction-sign-solana");
   }
 
   async transactionSignRawSolana() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("transaction-sign-raw-solana").click();
+    return this.clickByTestId("transaction-sign-raw-solana");
   }
 
   async transactionSignAndBroadcast() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("transaction-signAndBroadcast").click();
+    return this.clickByTestId("transaction-signAndBroadcast");
   }
 
   async walletCapabilities() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("wallet-capabilities").click();
+    return this.clickByTestId("wallet-capabilities");
   }
 
   async walletUserId() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("wallet-userId").click();
+    return this.clickByTestId("wallet-userId");
   }
 
   async walletInfo() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("wallet-info").click();
+    return this.clickByTestId("wallet-info");
   }
 
   async clearStates() {
-    const webview = await this.getWebView();
-    return webview.getByTestId("clear-states").click();
+    return this.clickByTestId("clear-states");
   }
 
   async getResOutput() {
@@ -252,5 +232,14 @@ export class LiveAppWebview {
       const webview = document.querySelector("webview") as WebviewTag;
       return webview.executeJavaScript(functionToExecute);
     }, sendFunction);
+  }
+
+  async clickByTestId(testId: string) {
+    const page = await this.getWebView();
+    const locator = page.getByTestId(testId);
+    // There is likely some race condition in the page and without hover() you click on the element before all it's event listeners are setup.
+    // https://github.com/microsoft/playwright/issues/20253#issuecomment-1398568789
+    await locator.hover();
+    return locator.click();
   }
 }

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -136,7 +136,7 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
       id: "2d23ca2a-069e-579f-b13d-05bc706c7583",
       address: "1xeyL26EKAAR3pStd7wEveajk4MQcrYezeJ",
       balance: "35688397",
-      blockHeight: 194870,
+      blockHeight: expect.any(Number),
       currency: "bitcoin",
       name: "Bitcoin 1 (legacy)",
       spendableBalance: "35688397",
@@ -150,6 +150,7 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
 
     await liveAppWebview.accountReceive();
 
+    await modal.waitForModalToAppear();
     await deviceAction.openApp();
     await deviceAction.complete();
     await modal.waitForModalToDisappear();
@@ -269,6 +270,8 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setData(data);
     await liveAppWebview.transactionSign();
 
+    await modal.waitForModalToAppear();
+
     // Step Fees
     await expect(page.getByText(/learn more about fees/i)).toBeVisible();
     await modal.continueToSignTransaction();
@@ -279,6 +282,8 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     const res = await liveAppWebview.getResOutput();
     expect(res).toBe("empty response");
@@ -295,12 +300,16 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setAmount(amount);
     await liveAppWebview.transactionSignSolana();
 
+    await modal.waitForModalToAppear();
+
     // Step Recipient
     await expect(page.getByText(recipient)).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     const res = await liveAppWebview.getResOutput();
     expect(res).toMatchObject({
@@ -336,12 +345,16 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setData(rawTx);
     await liveAppWebview.transactionSignRawSolana();
 
+    await modal.waitForModalToAppear();
+
     // Step Recipient
     await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     const res = await liveAppWebview.getResOutput();
     expect(res).toMatchObject({
@@ -380,12 +393,16 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setData(rawTx);
     await liveAppWebview.transactionSignRawSolana();
 
+    await modal.waitForModalToAppear();
+
     // Step Recipient
     await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     const res = await liveAppWebview.getResOutput();
     expect(res).toMatchObject({
@@ -437,12 +454,16 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setData(rawTx);
     await liveAppWebview.transactionSignRawSolana();
 
+    await modal.waitForModalToAppear();
+
     // Step Recipient
     await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     const res = await liveAppWebview.getResOutput();
     expect(res).toMatchObject({
@@ -517,12 +538,16 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setData(rawTx);
     await liveAppWebview.transactionSignRawSolana();
 
+    await modal.waitForModalToAppear();
+
     // Step Recipient
     await expect(page.getByText("Blind signing required")).toBeVisible();
     await modal.continueToSignTransaction();
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     const res = await liveAppWebview.getResOutput();
     expect(res).toMatchObject({
@@ -687,9 +712,11 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setAmount(amount);
     await liveAppWebview.transactionSign();
 
+    await modal.waitForModalToAppear();
     await expect(page.getByText(/keeping you safe/i)).toBeVisible();
     await modal.continueIsDisabled();
     await modal.close();
+    await modal.waitForModalToDisappear();
 
     await resetWebview();
   });
@@ -705,6 +732,8 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     await liveAppWebview.setData(data);
     await liveAppWebview.transactionSignAndBroadcast();
 
+    await modal.waitForModalToAppear();
+
     // Step Fees
     await expect(page.getByText(/learn more about fees/i)).toBeVisible();
     await modal.continueToSignTransaction();
@@ -715,6 +744,8 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
 
     // Step Device
     await deviceAction.silentSign();
+
+    await modal.waitForModalToDisappear();
 
     // Click on notification toaster
     // NOTE: toaster not visible in output, need to find a better way to handle css animations


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. not needed for tests
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - tests e2e wallet-api

### 📝 Description

This pull request improves the reliability and consistency of UI test automation for the wallet API by refactoring click actions and enhancing modal handling. The main changes include centralizing click logic in the `LiveAppWebview` model, ensuring UI elements are properly interacted with, and adding explicit waits for modal dialogs in test flows.

**Test automation improvements**

* Refactored multiple click actions in `LiveAppWebview` methods to use a new `clickByTestId` helper, which ensures elements are hovered before clicking to avoid race conditions during UI interactions. [[1]](diffhunk://#diff-109cfcca7dcd84408d8b0dbfc9faafb7285bf034c3422be690dd2b0ba618a0e5L75-R95) [[2]](diffhunk://#diff-109cfcca7dcd84408d8b0dbfc9faafb7285bf034c3422be690dd2b0ba618a0e5L130-R176) [[3]](diffhunk://#diff-109cfcca7dcd84408d8b0dbfc9faafb7285bf034c3422be690dd2b0ba618a0e5R236-R244)
* Added explicit calls to `modal.waitForModalToAppear()` and `modal.waitForModalToDisappear()` in test flows, improving synchronization and reducing flakiness when waiting for modal dialogs. [[1]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R153) [[2]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R273-R274) [[3]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R286-R287) [[4]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R303-R313) [[5]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R348-R358) [[6]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R396-R406) [[7]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R457-R467) [[8]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R541-R551) [[9]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R715-R719) [[10]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R735-R736) [[11]](diffhunk://#diff-bee0053a7e512efe28e0fdd08ef85386e9f9ec4bd5116eb452dc55906db5c4f2R748-R749)

**Test expectation adjustments**

* Updated the expected value for `blockHeight` in test assertions to use `expect.any(Number)` instead of a fixed value, making the test less brittle to data changes.

**Component interaction reliability**

* Updated `Modal.continueToSignTransaction()` to hover over the continue button before clicking, addressing a potential race condition where click events could be missed.

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
