### PR TITLE
Revert "feat(LIVE-21138): only auto select device if it's available"

### DIFF
--- a/.changeset/late-rats-live.md
+++ b/.changeset/late-rats-live.md
@@ -1,5 +1,0 @@
----
-"live-mobile": minor
----
-
-Only skip select device if it's available

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -13,10 +13,6 @@ import SelectDevice2 from "~/components/SelectDevice2";
 import { ScreenName } from "~/const";
 import { useStartExchangeDeviceAction } from "~/hooks/deviceActions";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
-import SkipSelectDevice from "~/screens/SkipSelectDevice";
-import { lastConnectedDeviceSelector } from "~/reducers/settings";
-import { useSelector } from "react-redux";
-import type { State } from "~/reducers/types";
 
 type Props = StackNavigatorProps<
   PlatformExchangeNavigatorParamList,
@@ -27,9 +23,6 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
   const action = useStartExchangeDeviceAction();
   const [device, setDevice] = useState<Device>();
   const hasPopped = useRef(false);
-  const lastConnectedDevice = useSelector<State, (Device & { available?: boolean }) | null>(
-    lastConnectedDeviceSelector,
-  );
 
   const onClose = useCallback(() => {
     // Prevent onClose being called twice
@@ -45,21 +38,12 @@ export default function PlatformStartExchange({ navigation, route }: Props) {
     },
     [device, route.params],
   );
+
   // Does not react to an header update request, the header stays the same.
   const requestToSetHeaderOptions = useCallback(() => undefined, []);
   const request = useMemo(() => route.params.request, [route.params.request]);
   return (
     <SafeAreaView style={styles.root} edges={["bottom"]}>
-      <SkipSelectDevice
-        route={{
-          ...route,
-          params: {
-            ...route.params,
-            forceSelectDevice: !lastConnectedDevice?.available,
-          },
-        }}
-        onResult={setDevice}
-      />
       <Flex px={16} flex={1} mt={8}>
         <SelectDevice2
           onSelect={setDevice}

--- a/apps/ledger-live-mobile/src/screens/SkipSelectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SkipSelectDevice.tsx
@@ -11,14 +11,12 @@ import { ScreenName } from "~/const";
 import { useDebouncedRequireBluetooth } from "~/components/RequiresBLE/hooks/useRequireBluetooth";
 import RequiresBluetoothDrawer from "~/components/RequiresBLE/RequiresBluetoothDrawer";
 import { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
-import { PlatformExchangeNavigatorParamList } from "~/components/RootNavigator/types/PlatformExchangeNavigator";
 
 type Navigation =
   | StackNavigatorProps<AddAccountsNavigatorParamList, ScreenName.AddAccountsSelectDevice>
   | StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveAddAccountSelectDevice>
   | StackNavigatorProps<ReceiveFundsStackParamList, ScreenName.ReceiveConnectDevice>
-  | StackNavigatorProps<DeviceSelectionNavigatorParamsList, ScreenName.SelectDevice>
-  | StackNavigatorProps<PlatformExchangeNavigatorParamList, ScreenName.PlatformStartExchange>;
+  | StackNavigatorProps<DeviceSelectionNavigatorParamsList, ScreenName.SelectDevice>;
 
 type Props = {
   onResult: (device: Device) => void;


### PR DESCRIPTION
This reverts commit 6cf6b1a775d36e5e935c185ace4e32129dffa7ff.

<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

Revert "feat(LIVE-21138): only auto select device if it's available"

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
