### PR TITLE
ci: move pod lock tests to any available mac runner

### DIFF
--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -662,7 +662,7 @@ jobs:
 
   test-pod-lockfile:
     name: "Test Pod Lockfile"
-    runs-on: [ general-pool, macOS, ARM64 ]
+    runs-on: [ macOS, ARM64 ]
     needs: [ determine-builds ]
     if: needs.determine-builds.outputs.ios_native_exists == 'true'
     steps:


### PR DESCRIPTION
Removal of the pool specificity label to make use of the mac pool and prevent queues

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/18001112770/job/51210427739