### PR TITLE
ci: restrict push flows use of macOS runners

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -36,6 +36,8 @@ jobs:
     with:
       macos-specificity-runner-label: "performance-pool"
       skip-bundle-size-reporting: true
+      max-shards: 1
+      skip-pod-checks: "true"
 
   # Tests
   test-libraries:

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -22,6 +22,16 @@ on:
         required: false
         type: boolean
         default: false
+      max-shards:
+        description: Max number of shards to use for detox tests (both ios and android)
+        required: false
+        type: number
+        default: 2
+      skip-pod-checks:
+        description: Whether to skip the pod lockfile checks
+        required: false
+        type: string
+        default: 'true'
 
   workflow_dispatch:
     inputs:
@@ -46,6 +56,16 @@ on:
         required: false
         type: boolean
         default: false
+      max-shards:
+        description: Max number of shards to use for detox tests (both ios and android)
+        required: false
+        type: number
+        default: 2
+      skip-pod-checks:
+        description: Whether to skip the pod lockfile checks
+        required: false
+        type: string
+        default: 'true'
 
 permissions:
   id-token: write
@@ -75,6 +95,7 @@ jobs:
       android_js_key: ${{ steps.cache-keys.outputs.android_js_key }}
       android_timing_cache_key: ${{ steps.cache-keys.outputs.android_timing_cache_key }}
       ios_timing_cache_key: ${{ steps.cache-keys.outputs.ios_timing_cache_key }}
+      shard_matrix: ${{ steps.generate-shard-matrix.outputs.matrix }}
     steps:
 
       - uses: actions/checkout@v4
@@ -153,6 +174,13 @@ jobs:
           use-fallback: false
           lookup-only: true
 
+      - name: Generate shard matrix
+        id: generate-shard-matrix
+        run: |
+          max_shards=${{ inputs.max-shards || 2 }}
+          shard_indices=$(seq -s ',' 1 $max_shards)
+          echo "matrix={\"shardIndex\":[$shard_indices],\"shardTotal\":[$max_shards]}" >> $GITHUB_OUTPUT
+
   build-ios:
     name: "iOS Build"
     needs: [ determine-builds ]
@@ -186,9 +214,7 @@ jobs:
     runs-on: ["${{ inputs.macos-specificity-runner-label }}", macOS, ARM64]
     strategy:
       fail-fast: false
-      matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
+      matrix: ${{ fromJson(needs.determine-builds.outputs.shard_matrix) }}
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
       LANG: en_US.UTF-8
@@ -360,9 +386,7 @@ jobs:
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
     strategy:
       fail-fast: false
-      matrix:
-        shardIndex: [ 1, 2 ]
-        shardTotal: [ 2 ]
+      matrix: ${{ fromJson(needs.determine-builds.outputs.shard_matrix) }}
 
     steps:
       - uses: actions/checkout@v4
@@ -608,7 +632,7 @@ jobs:
     name: Merge iOS Timing Files
     needs: [ determine-builds, detox-tests-ios ]
     runs-on: ubuntu-24.04
-    if: ${{ !cancelled() && (needs.detox-tests-ios.result == 'success' || needs.detox-tests-ios.result == 'failure') }}
+    if: ${{ !cancelled() && (needs.detox-tests-ios.result == 'success' || needs.detox-tests-ios.result == 'failure')  && inputs.max-shards > 1 }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -636,7 +660,7 @@ jobs:
     name: Merge Android Timing Files
     needs: [ determine-builds, detox-tests-android ]
     runs-on: ubuntu-24.04
-    if: ${{ !cancelled() && (needs.detox-tests-android.result == 'success' || needs.detox-tests-android.result == 'failure') }}
+    if: ${{ !cancelled() && (needs.detox-tests-android.result == 'success' || needs.detox-tests-android.result == 'failure') && inputs.max-shards > 1 }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -664,7 +688,7 @@ jobs:
     name: "Test Pod Lockfile"
     runs-on: [ macOS, ARM64 ]
     needs: [ determine-builds ]
-    if: needs.determine-builds.outputs.ios_native_exists == 'true'
+    if: needs.determine-builds.outputs.ios_native_exists == 'true' && inputs.skip-pod-checks != 'true'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Limited macOS availability is causing congestion. PR flows are more time sensitive and as such should be prioritised.

This PR reduces Push flows to a single runner to prioritise Mock validation before merge. It also disables some steps related to macOS which may be mitigated via a merge queue. E.g. Lockfile checking should be completed pre-merge and shouldn't be necessary post... ish.

Timing file merges are not required as there is one shard

1 shard test: https://github.com/LedgerHQ/ledger-live/actions/runs/18010676461
2 shard test: https://github.com/LedgerHQ/ledger-live/actions/runs/18012284857

Skip lock checks: https://github.com/LedgerHQ/ledger-live/actions/runs/18012652465
Don’t skip lock checks: https://github.com/LedgerHQ/ledger-live/actions/runs/18012698060

Skip timing file merge: https://github.com/LedgerHQ/ledger-live/actions/runs/18012859731
Don’t skip timing file merge: https://github.com/LedgerHQ/ledger-live/actions/runs/18012883708