### PR TITLE
fix(LLD): force MacOS to exit on window close

### DIFF
--- a/.changeset/angry-kangaroos-exist.md
+++ b/.changeset/angry-kangaroos-exist.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Force MacOS to exit on window close

--- a/apps/ledger-live-desktop/src/main/index.ts
+++ b/apps/ledger-live-desktop/src/main/index.ts
@@ -244,6 +244,10 @@ app.on("window-all-closed", () => {
   cleanupTransports();
   if (process.platform !== "darwin") {
     app.quit();
+    // Fallback: force exit if app.quit() doesn't work
+    setTimeout(() => {
+      process.exit(0);
+    }, 3000);
   }
 });
 


### PR DESCRIPTION


### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** not automatically covered. AFAIK we don't have proper E2E environment/test framework to test this on the prod build itself. <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - LLD MacOS
  - on close window

### 📝 Description

For unknown reason, this old bug is back: Ledger Live doesn't want to exit from Dock when you close on Mac OS.

We let 3s to be sure all fs is saved (e.g. app.json saves) and after we force its exit.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21819](https://ledgerhq.atlassian.net/browse/LIVE-21819)

---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21819]: https://ledgerhq.atlassian.net/browse/LIVE-21819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ