### PR TITLE
[LIVE-21230] Added operationId to status request on swap history for nearintents

### DIFF
--- a/.changeset/breezy-queens-agree.md
+++ b/.changeset/breezy-queens-agree.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Added operationId to status request on swap history for nearintents

--- a/libs/ledger-live-common/src/exchange/swap/updateAccountSwapStatus.ts
+++ b/libs/ledger-live-common/src/exchange/swap/updateAccountSwapStatus.ts
@@ -39,14 +39,16 @@ const maybeGetUpdatedSwapHistory = async (
         } else {
           // Collect all others swaps that need status update via getMultipleStatus
           const transactionId =
-            provider === "thorswap" || provider === "lifi"
+            provider === "thorswap" || provider === "lifi" || provider === "nearintents"
               ? operations?.find(o => o.id.includes(operationId))?.hash
               : undefined;
           pendingSwapIds.push({
             provider,
             swapId,
             transactionId,
-            ...((provider === "thorswap" || provider === "lifi") && { operationId }),
+            ...((provider === "thorswap" || provider === "lifi" || provider === "nearintents") && {
+              operationId,
+            }),
           });
         }
       }

--- a/libs/ledger-live-common/src/exchange/swap/updateAccountSwapStatus.ts
+++ b/libs/ledger-live-common/src/exchange/swap/updateAccountSwapStatus.ts
@@ -4,6 +4,8 @@ import type { TokenAccount, Account, SwapOperation, Operation } from "@ledgerhq/
 import type { SwapStatus, SwapStatusRequest, UpdateAccountSwapStatus } from "./types";
 import { log } from "@ledgerhq/logs";
 
+const PROVIDERS_REQUIRING_OPERATION_ID = ["thorswap", "lifi", "nearintents"];
+
 const maybeGetUpdatedSwapHistory = async (
   swapHistory: SwapOperation[] | null | undefined,
   operations: Operation[] | null | undefined,
@@ -38,17 +40,15 @@ const maybeGetUpdatedSwapHistory = async (
           }
         } else {
           // Collect all others swaps that need status update via getMultipleStatus
-          const transactionId =
-            provider === "thorswap" || provider === "lifi" || provider === "nearintents"
-              ? operations?.find(o => o.id.includes(operationId))?.hash
-              : undefined;
+          const requiresOperationId = PROVIDERS_REQUIRING_OPERATION_ID.includes(provider);
+          const relatedTransactionId = requiresOperationId
+            ? operations?.find(op => op.id.includes(operationId))?.hash
+            : undefined;
           pendingSwapIds.push({
             provider,
             swapId,
-            transactionId,
-            ...((provider === "thorswap" || provider === "lifi" || provider === "nearintents") && {
-              operationId,
-            }),
+            transactionId: relatedTransactionId,
+            ...(requiresOperationId && { operationId }),
           });
         }
       }


### PR DESCRIPTION
### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - Added operationId to status request on swap history

### 📝 Description

This PR adds `operationId` to the request to get the transaction status from swap for `nearintents` provider.

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21230](https://ledgerhq.atlassian.net/browse/LIVE-21230) 


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21230]: https://ledgerhq.atlassian.net/browse/LIVE-21230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ