### PR TITLE
:bug: (LLM-E2E) subaccount displayed currency

### DIFF
--- a/libs/ledger-live-common/src/deposit/helper.ts
+++ b/libs/ledger-live-common/src/deposit/helper.ts
@@ -1,4 +1,4 @@
-import { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { CryptoOrTokenCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { MappedAsset, CurrenciesByProviderId, GroupedCurrencies } from "./type";
 import {
   currenciesByMarketcap,
@@ -50,9 +50,22 @@ export const groupCurrenciesByProvider = (
   // So we need to take the first crypto or token currency of each provider to fix that
   for (const [, { currenciesByNetwork }] of assetsByProviderId.entries()) {
     const firstCrypto = currenciesByNetwork.find(c => c.type === "CryptoCurrency");
-    const elem = firstCrypto ?? currenciesByNetwork.find(c => c.type === "TokenCurrency");
-    if (elem) {
-      sortedCryptoCurrencies.push(elem);
+    if (firstCrypto) {
+      sortedCryptoCurrencies.push(firstCrypto);
+      continue;
+    }
+
+    const tokens = currenciesByNetwork.filter(
+      (c): c is TokenCurrency => c.type === "TokenCurrency",
+    );
+
+    let preferredToken = tokens.find(t => t.parentCurrency?.id === "ethereum");
+    if (!preferredToken) {
+      preferredToken = tokens[0];
+    }
+
+    if (preferredToken) {
+      sortedCryptoCurrencies.push(preferredToken);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR is a test to fix e2E subaccount test. The issue is that we use https://countervalues.live.ledger.com/v3/supported/crypto endpoint to have the list of crypto. But it doesn't have any data about networks' MC. This means Celo USDT will be the represented usdt in the asset list.

To mitigate this issue, we can have a logic that says if there is a token on eth then display the one on eth otherwise, take the first one. 

I think this is ok as it's just user-facing and e2e. Plus, it will be removed for DADA 


before:

<img width="484" height="785" alt="image" src="https://github.com/user-attachments/assets/e5cf703d-1e1e-409b-bccb-c9652c485c11" />



after: 

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e4d627a6-6db5-4868-8164-c1054cead736" />


### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
