### PR TITLE
:bug: (LLD) remove shared securely during receive flow if bypass

### DIFF
--- a/.changeset/twenty-books-pull.md
+++ b/.changeset/twenty-books-pull.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Don't display 'shared securely' during receive flow if the user didn't use his device

--- a/apps/ledger-live-desktop/src/renderer/families/canton/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/StepReceiveFunds.tsx
@@ -288,10 +288,7 @@ const StepReceiveFunds = ({
                 />
               </Alert>
               <Separator2 />
-              <Receive2NoDevice
-                onVerify={onVerify}
-                onContinue={() => onChangeAddressVerified(true)}
-              />
+              <Receive2NoDevice onVerify={onVerify} onContinue={onFinishReceiveFlow} />
             </>
           ) : device ? (
             // verification with device

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -366,10 +366,7 @@ const StepReceiveFunds = (props: StepProps) => {
                 />
               </Alert>
               <Separator2 />
-              <Receive2NoDevice
-                onVerify={onVerify}
-                onContinue={() => onChangeAddressVerified(true)}
-              />
+              <Receive2NoDevice onVerify={onVerify} onContinue={onFinishReceiveFlow} />
             </>
           ) : device ? (
             // verification with device


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - receive flow normal & canton

### 📝 Description

We don't want to display "shared securely" if the user bypass the device check 
We should trigger onFinishReceiveFlow instead of updating the verify state


https://github.com/user-attachments/assets/b20c76c1-7415-4dd1-96b8-0c56927a6797



### ❓ Context

- **JIRA or GitHub link**: [LIVE-21351](https://ledgerhq.atlassian.net/browse/LIVE-21351)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-21351]: https://ledgerhq.atlassian.net/browse/LIVE-21351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ