### PR TITLE
feat: (LIVE-21558) Add A/B test for desktop ‘Confirm on Device’ flow (details vs no-details)

### DIFF
--- a/.changeset/forty-boats-taste.md
+++ b/.changeset/forty-boats-taste.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Introduced A/B test for the Swap desktop Confirm on Device flow.

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -6,6 +6,7 @@ import { connect, useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import { ABTestingVariants } from "@ledgerhq/types-live";
 import ProviderIcon from "~/renderer/components/ProviderIcon";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
@@ -1170,9 +1171,19 @@ const SwapDeviceConfirmation: React.FC<SwapConfirmationProps> = ({
   stateSettings,
   walletState,
 }) => {
-  const isDetailedViewEnabled = useFeature("ptxSwapDetailedView")?.enabled;
+  const ptxSwapDetailedView = useFeature("ptxSwapDetailedView");
+  const isDetailedViewEnabled = !!ptxSwapDetailedView?.enabled;
+  const variant = ptxSwapDetailedView?.params?.variant ?? ABTestingVariants.variantA;
   const sourceAccountCurrency = exchange.fromCurrency;
   const targetAccountCurrency = exchange.toCurrency;
+
+  useEffect(() => {
+    track("PTX Swap Confirmation Viewed", {
+      ptxSwapDetailedViewVariant: isDetailedViewEnabled ? variant : null,
+      view: isDetailedViewEnabled ? "ptxdrawerdetails" : "ptxnodrawerdetails",
+    });
+  }, [variant, isDetailedViewEnabled]);
+
   const sourceAccountName =
     accountNameSelector(walletState, {
       accountId:

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -1174,15 +1174,10 @@ const SwapDeviceConfirmation: React.FC<SwapConfirmationProps> = ({
   const ptxSwapDetailedView = useFeature("ptxSwapDetailedView");
   const isDetailedViewEnabled = !!ptxSwapDetailedView?.enabled;
   const variant = ptxSwapDetailedView?.params?.variant ?? ABTestingVariants.variantA;
+  const variantViewName =
+    variant === ABTestingVariants.variantA ? "ptxDrawerDetails" : "ptxNoDrawerDetails";
   const sourceAccountCurrency = exchange.fromCurrency;
   const targetAccountCurrency = exchange.toCurrency;
-
-  useEffect(() => {
-    track("PTX Swap Confirmation Viewed", {
-      ptxSwapDetailedViewVariant: isDetailedViewEnabled ? variant : null,
-      view: isDetailedViewEnabled ? "ptxdrawerdetails" : "ptxnodrawerdetails",
-    });
-  }, [variant, isDetailedViewEnabled]);
 
   const sourceAccountName =
     accountNameSelector(walletState, {
@@ -1294,6 +1289,7 @@ const SwapDeviceConfirmation: React.FC<SwapConfirmationProps> = ({
           sourcecurrency={sourceAccountCurrency?.name}
           targetcurrency={targetAccountCurrency?.name}
           provider={exchangeRate.provider}
+          ptxSwapDetailedViewVariant={variantViewName}
           {...swapDefaultTrack}
         />
         {isDetailedViewEnabled ? (

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/DrawerFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/Swap2/Form/DrawerFooter.tsx
@@ -32,7 +32,8 @@ export function DrawerFooter({ provider }: { provider: string }) {
   const ptxSwapLiveAppKycWarning = useFeature("ptxSwapLiveAppKycWarning");
   const url = providerData?.termsOfUseUrl;
   const providerName = getProviderName(provider);
-  const isDetailedViewEnabled = useFeature("ptxSwapDetailedView");
+  const ptxSwapDetailedView = useFeature("ptxSwapDetailedView");
+  const isDetailedViewEnabled = !!ptxSwapDetailedView?.enabled;
 
   const { acceptTerms, urls } = useMemo(() => {
     if (!ptxSwapLiveAppKycWarning?.enabled) {
@@ -51,7 +52,7 @@ export function DrawerFooter({ provider }: { provider: string }) {
           urls: [url],
         };
       case "Changelly": {
-        if (isDetailedViewEnabled?.enabled) {
+        if (isDetailedViewEnabled) {
           return {
             acceptTerms: "DeviceAction.swap.changellyAcceptTerms",
             urls: providerData?.usefulUrls,
@@ -79,7 +80,7 @@ export function DrawerFooter({ provider }: { provider: string }) {
     providerName,
     ptxSwapLiveAppKycWarning?.enabled,
     url,
-    isDetailedViewEnabled?.enabled,
+    isDetailedViewEnabled,
   ]);
 
   if (!url) {

--- a/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
+++ b/libs/ledger-live-common/src/featureFlags/defaultFeatures.ts
@@ -113,7 +113,6 @@ export const DEFAULT_FEATURES: Features = {
   ptxServiceCtaExchangeDrawer: DEFAULT_FEATURE,
   ptxServiceCtaScreens: DEFAULT_FEATURE,
   ptxSwapReceiveTRC20WithoutTrx: DEFAULT_FEATURE,
-  ptxSwapDetailedView: DEFAULT_FEATURE,
   disableNftLedgerMarket: DEFAULT_FEATURE,
   disableNftRaribleOpensea: DEFAULT_FEATURE,
   disableNftSend: DEFAULT_FEATURE,
@@ -127,6 +126,12 @@ export const DEFAULT_FEATURES: Features = {
   brazePushNotifications: initFeature(),
   stakeAccountBanner: initFeature(),
 
+  ptxSwapDetailedView: initFeature({
+    enabled: false,
+    params: {
+      variant: ABTestingVariants.variantA,
+    },
+  }),
   buyDeviceFromLive: {
     enabled: false,
     params: { debug: false, url: null },

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -188,7 +188,7 @@ export type Features = CurrencyFeatures & {
   ptxSwapLiveAppMobile: Feature_PtxSwapLiveApp;
   ptxSwapLiveAppKycWarning: DefaultFeature;
   ptxSwapLiveApp: Feature_PtxSwapLiveApp;
-  ptxSwapDetailedView: DefaultFeature;
+  ptxSwapDetailedView: Feature_PtxSwapDetailedView;
   ptxEarnLiveApp: Feature_PtxEarnLiveApp;
   ptxSwapReceiveTRC20WithoutTrx: Feature_PtxSwapReceiveTRC20WithoutTrx;
   flexibleContentCards: Feature_FlexibleContentCards;
@@ -675,6 +675,10 @@ export type Feature_web3hub = DefaultFeature;
 export type Feature_MemoTag = DefaultFeature;
 export type Feature_PtxSwapMoonpayProvider = DefaultFeature;
 export type Feature_PtxSwapExodusProvider = DefaultFeature;
+
+export type Feature_PtxSwapDetailedView = Feature<{
+  variant: ABTestingVariants;
+}>;
 
 export type Feature_LlmRebornLP = Feature<{
   variant: ABTestingVariants;


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

This PR Implements A/B test: transaction details vs simplified confirm prompt (desktop)
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-21558


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
