### PR TITLE
ci: enable pod file checks on pr flows

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -77,6 +77,7 @@ jobs:
     secrets: inherit
     with:
       macos-specificity-runner-label: "performance-pool"
+      skip-pod-checks: "false"
 
   # Tests
   test-libraries:


### PR DESCRIPTION
Enable pod sync checks within the PR flows to avoid repo health issues caused by mismatching lock files