### PR TITLE
ci: ensure desktop failure reporting always runs

### DIFF
--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -191,10 +191,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: "download linter results"
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: lint-desktop
       - name: download images artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: images
       - name: parse images
@@ -241,7 +243,7 @@ jobs:
               linux: {
                 symbol: "🐧",
                 name: "Linux",
-                jobUrl: jobs.find(job => job.name == `Ubuntu E2E`)?.html_url
+                jobUrl: jobs.find(job => job.name == `Ubuntu Mock`)?.html_url
               },
             };
 
@@ -367,31 +369,25 @@ jobs:
                     "emoji": true
                   }
                 },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "header",
+              {
+                  "type": "section",
                   "text": {
-                    "type": "plain_text",
-                    "text": "Checks"
+                    "type": "mrkdwn",
+                    "text": `Code Checks: ${typecheck.pass ? "✅" : "❌"}\n`
                   }
                 },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "header",
+              {
+                  "type": "section",
                   "text": {
-                    "type": "plain_text",
-                    "text": "E2E Tests"
+                    "type": "mrkdwn",
+                    "text": `Unit Tests: ${unitTests.pass ? "✅" : "❌"}\n`
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": `- 🐧 linux: ${report.linux.pass ? "✅" : "❌"}\n`
+                    "text": `🐧 linux Mock: ${report.linux.pass ? "✅" : "❌"}\n`
                   }
                 },
                 {


### PR DESCRIPTION
Fix the desktop reporting step so that it successfully reports various failures

Full fail: https://github.com/LedgerHQ/ledger-live/actions/runs/18093265314
Notification: https://ledger.slack.com/archives/C08JQKWS9KK/p1759140396350139

Codececk Success: https://github.com/LedgerHQ/ledger-live/actions/runs/18093330600/job/51478903544
Notification: https://ledger.slack.com/archives/C08JQKWS9KK/p1759140770397359 

Unit Test Success: https://github.com/LedgerHQ/ledger-live/actions/runs/18093531008/job/51479560160?pr=12050
Notification: https://ledger.slack.com/archives/C08JQKWS9KK/p1759141413781289

All pass: https://github.com/LedgerHQ/ledger-live/actions/runs/18093784878