### PR TITLE
fix: self send makes 2 ops

### DIFF
--- a/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.integration.test.ts
@@ -124,6 +124,23 @@ describe("Sui Api", () => {
       expect(txs.some(t => t.type === "OUT")).toBeTruthy();
     });
 
+    it("should return 2 operations in case of a self send", async () => {
+      const [selfTxs] = await module.listOperations(
+        "0xb37b298c9164c28c8aaf989a49416e3c323b67bc2b96a54501b524419ebb4ead",
+        { minHeight: 0, order: "asc" },
+      );
+      expect(selfTxs.length).toBeGreaterThanOrEqual(4);
+      // https://suiscan.xyz/mainnet/tx/9vtfErSE4xpL89QAg6sppveJruNj6vY76AvmLhYNmx8R
+      const selfSend = selfTxs.filter(
+        tx => tx.id === "9vtfErSE4xpL89QAg6sppveJruNj6vY76AvmLhYNmx8R",
+      );
+      expect(selfSend.length).toBe(2);
+      expect(selfSend.filter(t => t.type === "IN")[0].value).toBe(5);
+      expect(selfSend.filter(t => t.type === "IN")[0].tx.fees).toBe(495000);
+      expect(selfSend.filter(t => t.type === "OUT")[0].value).toBe(-5);
+      expect(selfSend.filter(t => t.type === "OUT")[0].tx.fees).toBe(495000);
+    });
+
     it("uses the minHeight to filter", async () => {
       const minHeightTxs = await module.listOperations(SENDER, {
         minHeight: 154925948,


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [ ] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [ ] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - ...

### 📝 Description

_Replace this text by a clear and concise description of what this pull request is about and why it is needed. Be sure to explain the problem you're addressing and the solution you're proposing._
_For libraries, you can add a code sample of how to use it._
_For bug fixes, you can explain the previous behaviour and how it was fixed._
_In case of visual features, please attach screenshots or video recordings to demonstrate the changes._

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: <!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
