### PR TITLE
:bug: (LLM) Cannot read property 'params' of undefined sentry

### DIFF
--- a/.changeset/tough-months-check.md
+++ b/.changeset/tough-months-check.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix sentry error

--- a/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/AccountsNavigator.tsx
@@ -37,6 +37,11 @@ type ParamsType = {
   params?: { specificAccounts?: object[] };
 };
 
+const isParamsType = (value: unknown): value is ParamsType =>
+  typeof value === "object" &&
+  value !== null &&
+  Object.prototype.hasOwnProperty.call(value, "params");
+
 export default function AccountsNavigator() {
   const { colors } = useTheme();
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors), [colors]);
@@ -50,8 +55,10 @@ export default function AccountsNavigator() {
   const onPressBack = useCallback(
     (nav: NavType) => {
       // Needed since we use the same screen for different purposes
-      const params: ParamsType = navigation.getState()?.routes[1].params || {};
-      const screenName = params?.params?.specificAccounts
+      const maybeParams = navigation.getState()?.routes?.[1]?.params;
+      const hasSpecificAccounts =
+        isParamsType(maybeParams) && Boolean(maybeParams.params?.specificAccounts);
+      const screenName = hasSpecificAccounts
         ? TrackingEvent.AccountListSummary
         : TrackingEvent.AccountsList;
       track("button_clicked", {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Please make sure to read CONTRIBUTING.md if you have not already. Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### ✅ Checklist

<!-- Pull Requests must pass the CI and be code reviewed. Set as Draft if the PR is not ready. -->

- [x] `npx changeset` was attached.
- [] **Covered by automatic tests.** <!-- if not, please explain. (Feature must be tested / Bug fix must bring non-regression) -->
- [x] **Impact of the changes:** <!-- Please take some time to list the impact & what specific areas Quality Assurance (QA) should focus on -->
  - accountsNavigator

### 📝 Description

I'm not able to repro nor find a common behavior. It looks like it happens only on android
I've added a typeguard so we don't throw this error. 
As the error mentions params undefined, it shouldn't be an issue in prod it will just change the navigation

<!--
| Before        | After         |
| ------------- | ------------- |
|               |               |
-->

### ❓ Context

- **JIRA or GitHub link**: [LIVE-21864](https://ledgerhq.atlassian.net/browse/LIVE-21864)<!-- Attach the relevant ticket number if applicable. (e.g., [JIRA-123] for Jira or #123 for a Github issue) -->


---

### 🧐 Checklist for the PR Reviewers

<!-- Please do not edit this if you are the PR author -->

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
